### PR TITLE
feat(codegen): support record parameter field ids

### DIFF
--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -1,7 +1,7 @@
 ---
 title: Develop Orleans grains
 description: Define grain contracts, implement grains, and call them in Orleans.
-ms.date: 08/07/2026
+ms.date: 08/11/2026
 ms.topic: article
 ---
 
@@ -29,12 +29,12 @@ public interface IShoppingCartGrain : IGrainWithStringKey
 
 [GenerateSerializer]
 public sealed record CartItem(
-    [property: Id(0)] string ProductId,
-    [property: Id(1)] int Quantity);
+    [Id(0)] string ProductId,
+    [Id(1)] int Quantity);
 
 [GenerateSerializer]
 public sealed record Receipt(
-    [property: Id(0)] string OrderId);
+    [Id(0)] string OrderId);
 ```
 
 Orleans supports these grain method return types:

--- a/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
+++ b/src/Orleans.CodeGenerator/FieldIdAssignmentHelper.cs
@@ -44,7 +44,12 @@ internal class FieldIdAssignmentHelper
 
     public bool TryGetSymbolKey(ISymbol symbol, out (uint, bool) key) => _symbols.TryGetValue(symbol, out key);
 
-    private bool HasMemberWithIdAnnotation() => Array.Exists(_memberSymbols, member => member.HasAttribute(_libraryTypes.IdAttributeType));
+    private bool HasMemberWithIdAnnotation() => Array.Exists(
+        _memberSymbols,
+        member => member.HasAttribute(_libraryTypes.IdAttributeType)
+            || member is IPropertySymbol property
+                && PropertyUtility.GetMatchingPrimaryConstructorParameter(property, _constructorParameters) is { } parameter
+                && parameter.HasAttribute(_libraryTypes.IdAttributeType));
 
     private bool HasCandidateSerializableMembers()
     {

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -253,11 +253,13 @@ namespace Orleans
     /// </summary>
     /// <remarks>
     /// Every serializable member in a type which has <see cref="GenerateSerializerAttribute"/> applied to it must have one <see cref="IdAttribute"/> attribute applied with a unique <see cref="IdAttribute.Id"/> value.
+    /// For positional records, this attribute can be applied directly to a primary constructor parameter instead of its generated property.
     /// </remarks>
     /// <seealso cref="System.Attribute" />
     [AttributeUsage(
         AttributeTargets.Field
         | AttributeTargets.Property
+        | AttributeTargets.Parameter
         | AttributeTargets.Class
         | AttributeTargets.Struct
         | AttributeTargets.Enum

--- a/src/api/Orleans.Serialization.Abstractions/Orleans.Serialization.Abstractions.cs
+++ b/src/api/Orleans.Serialization.Abstractions/Orleans.Serialization.Abstractions.cs
@@ -106,7 +106,7 @@ namespace Orleans
         TSurrogate ConvertToSurrogate(in TValue value);
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Parameter)]
     public sealed partial class IdAttribute : System.Attribute
     {
         public IdAttribute(uint id) { }

--- a/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
@@ -326,6 +326,24 @@ public readonly record struct DemoRecord(int Value, string Name);
     }
 
     [Fact]
+    public async Task ExtractSerializableTypeModel_RecordWithParameterTargetedIds_OverridesImplicitFieldIds()
+    {
+        var code = @"
+using Orleans;
+namespace TestProject;
+
+[GenerateSerializer(GenerateFieldIds = GenerateFieldIds.PublicProperties)]
+public record DemoRecord([Id(42)] string Value);
+";
+        var (model, _) = await ExtractFirstSerializableType(code);
+        var member = Assert.Single(model.Members);
+
+        Assert.Equal((uint)42, member.FieldId);
+        Assert.Equal("Value", member.BackingPropertyName);
+        Assert.True(member.IsPrimaryConstructorParameter);
+    }
+
+    [Fact]
     public async Task FieldIdAssignmentHelper_TypeWithComputedPropertyAndNoIds_RemainsValidWithoutSerializableCandidates()
     {
         const string code = """

--- a/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
@@ -187,6 +187,28 @@ public record class DemoDataRecordClass([property: Id(0)] string Value);
 public record DemoDataRecord([property: Id(0)] string Value);");
 
     /// <summary>
+    /// Tests serializer generation for records with [Id] attributes on primary constructor parameters.
+    /// </summary>
+    [Fact]
+    public Task TestRecordsWithParameterIdAttributes() => AssertSuccessfulSourceGeneration(
+@"using Orleans;
+
+namespace TestProject;
+
+[GenerateSerializer]
+public record SimpleRecord([Id(10)] int Value, [Id(20)] string Name);
+
+[GenerateSerializer]
+public record RecordWithExtraProperty([Id(30)] int Id, [Id(40)] string Name)
+{
+    [Id(50)]
+    public string Description { get; init; }
+}
+
+[GenerateSerializer]
+public record struct RecordStructWithParameterId([Id(60)] string Value);");
+
+    /// <summary>
     /// Tests serializer generation for generic types.
     /// Generic types require:
     /// - Generating specialized serializers for each concrete type usage

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestRecordsWithParameterIdAttributes.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestRecordsWithParameterIdAttributes.verified.cs
@@ -1,0 +1,364 @@
+﻿#pragma warning disable CS1591, RS0016, RS0041
+[assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
+[assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
+[assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
+[assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core")]
+[assembly: global::Orleans.ApplicationPartAttribute("Orleans.Runtime")]
+[assembly: global::Orleans.Serialization.Configuration.TypeManifestProviderAttribute(typeof(OrleansCodeGen.TestProject.Metadata_TestProject))]
+namespace OrleansCodeGen.TestProject
+{
+    using global::Orleans.Serialization.Codecs;
+    using global::Orleans.Serialization.GeneratedCodeHelpers;
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("OrleansCodeGen", "10.0.0.0"), global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never), global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    public sealed class Codec_SimpleRecord : global::Orleans.Serialization.Codecs.IFieldCodec<global::TestProject.SimpleRecord>, global::Orleans.Serialization.Serializers.IBaseCodec<global::TestProject.SimpleRecord>
+    {
+        private readonly global::System.Type _codecFieldType = typeof(global::TestProject.SimpleRecord);
+        private readonly global::Orleans.Serialization.Activators.IActivator<global::TestProject.SimpleRecord> _activator;
+        private static readonly global::System.Action<global::TestProject.SimpleRecord, string> setField0 = (global::System.Action<global::TestProject.SimpleRecord, string>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.SimpleRecord), "<Name>k__BackingField");
+        private static readonly global::System.Action<global::TestProject.SimpleRecord, int> setField1 = (global::System.Action<global::TestProject.SimpleRecord, int>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.SimpleRecord), "<Value>k__BackingField");
+        public Codec_SimpleRecord(global::Orleans.Serialization.Activators.IActivator<global::TestProject.SimpleRecord> _activator)
+        {
+            this._activator = OrleansGeneratedCodeHelper.UnwrapService(this, _activator);
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void Serialize<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, global::TestProject.SimpleRecord instance)
+            where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
+        {
+            global::Orleans.Serialization.Codecs.Int32Codec.WriteField(ref writer, 10U, instance.Value);
+            global::Orleans.Serialization.Codecs.StringCodec.WriteField(ref writer, 10U, instance.Name);
+            writer.WriteEndBase();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void Deserialize<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, global::TestProject.SimpleRecord instance)
+        {
+            uint id = 0U;
+            global::Orleans.Serialization.WireProtocol.Field header = default;
+            while (true)
+            {
+                reader.ReadFieldHeader(ref header);
+                if (header.IsEndBaseOrEndObject)
+                    break;
+                id += header.FieldIdDelta;
+                if (id == 10U)
+                {
+                    setField1(instance, global::Orleans.Serialization.Codecs.Int32Codec.ReadValue(ref reader, header));
+                    reader.ReadFieldHeader(ref header);
+                    if (header.IsEndBaseOrEndObject)
+                        break;
+                    id += header.FieldIdDelta;
+                }
+
+                if (id == 20U)
+                {
+                    setField0(instance, global::Orleans.Serialization.Codecs.StringCodec.ReadValue(ref reader, header));
+                    reader.ReadFieldHeader(ref header);
+                    if (header.IsEndBaseOrEndObject)
+                        break;
+                    id++;
+                }
+
+                reader.ConsumeUnknownField(ref header);
+            }
+
+            id = 0U;
+            if (header.IsEndBaseFields)
+            {
+                reader.ReadFieldHeader(ref header);
+                reader.ConsumeEndBaseOrEndObject(ref header);
+            }
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, global::System.Type expectedType, global::TestProject.SimpleRecord @value)
+            where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
+        {
+            if (@value is null || @value.GetType() == typeof(global::TestProject.SimpleRecord))
+            {
+                if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, @value))
+                    return;
+                writer.WriteStartObject(fieldIdDelta, expectedType, _codecFieldType);
+                Serialize(ref writer, @value);
+                writer.WriteEndObject();
+            }
+            else
+                writer.SerializeUnexpectedType(fieldIdDelta, expectedType, @value);
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public global::TestProject.SimpleRecord ReadValue<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
+        {
+            if (field.IsReference)
+                return ReferenceCodec.ReadReference<global::TestProject.SimpleRecord, TReaderInput>(ref reader, field);
+            field.EnsureWireTypeTagDelimited();
+            global::System.Type valueType = field.FieldType;
+            if (valueType is null || valueType == _codecFieldType)
+            {
+                var result = _activator.Create();
+                ReferenceCodec.RecordObject(reader.Session, result);
+                Deserialize(ref reader, result);
+                return result;
+            }
+
+            return reader.DeserializeUnexpectedType<TReaderInput, global::TestProject.SimpleRecord>(ref field);
+        }
+    }
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("OrleansCodeGen", "10.0.0.0"), global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never), global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    public sealed class Copier_SimpleRecord : global::Orleans.Serialization.Cloning.IDeepCopier<global::TestProject.SimpleRecord>, global::Orleans.Serialization.Cloning.IBaseCopier<global::TestProject.SimpleRecord>
+    {
+        private readonly global::Orleans.Serialization.Activators.IActivator<global::TestProject.SimpleRecord> _activator;
+        private static readonly global::System.Action<global::TestProject.SimpleRecord, string> setField0 = (global::System.Action<global::TestProject.SimpleRecord, string>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.SimpleRecord), "<Name>k__BackingField");
+        private static readonly global::System.Action<global::TestProject.SimpleRecord, int> setField1 = (global::System.Action<global::TestProject.SimpleRecord, int>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.SimpleRecord), "<Value>k__BackingField");
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public global::TestProject.SimpleRecord DeepCopy(global::TestProject.SimpleRecord original, global::Orleans.Serialization.Cloning.CopyContext context)
+        {
+            if (context.TryGetCopy(original, out global::TestProject.SimpleRecord existing))
+                return existing;
+            if (original.GetType() != typeof(global::TestProject.SimpleRecord))
+                return context.DeepCopy(original);
+            var result = _activator.Create();
+            context.RecordCopy(original, result);
+            DeepCopy(original, result, context);
+            return result;
+        }
+
+        public Copier_SimpleRecord(global::Orleans.Serialization.Activators.IActivator<global::TestProject.SimpleRecord> _activator)
+        {
+            this._activator = OrleansGeneratedCodeHelper.UnwrapService(this, _activator);
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void DeepCopy(global::TestProject.SimpleRecord input, global::TestProject.SimpleRecord output, global::Orleans.Serialization.Cloning.CopyContext context)
+        {
+            setField1(output, input.Value);
+            setField0(output, input.Name);
+        }
+    }
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("OrleansCodeGen", "10.0.0.0"), global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never), global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    public sealed class Codec_RecordWithExtraProperty : global::Orleans.Serialization.Codecs.IFieldCodec<global::TestProject.RecordWithExtraProperty>, global::Orleans.Serialization.Serializers.IBaseCodec<global::TestProject.RecordWithExtraProperty>
+    {
+        private readonly global::System.Type _codecFieldType = typeof(global::TestProject.RecordWithExtraProperty);
+        private readonly global::Orleans.Serialization.Activators.IActivator<global::TestProject.RecordWithExtraProperty> _activator;
+        private static readonly global::System.Action<global::TestProject.RecordWithExtraProperty, string> setField0 = (global::System.Action<global::TestProject.RecordWithExtraProperty, string>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.RecordWithExtraProperty), "<Description>k__BackingField");
+        private static readonly global::System.Action<global::TestProject.RecordWithExtraProperty, int> setField1 = (global::System.Action<global::TestProject.RecordWithExtraProperty, int>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.RecordWithExtraProperty), "<Id>k__BackingField");
+        private static readonly global::System.Action<global::TestProject.RecordWithExtraProperty, string> setField2 = (global::System.Action<global::TestProject.RecordWithExtraProperty, string>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.RecordWithExtraProperty), "<Name>k__BackingField");
+        public Codec_RecordWithExtraProperty(global::Orleans.Serialization.Activators.IActivator<global::TestProject.RecordWithExtraProperty> _activator)
+        {
+            this._activator = OrleansGeneratedCodeHelper.UnwrapService(this, _activator);
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void Serialize<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, global::TestProject.RecordWithExtraProperty instance)
+            where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
+        {
+            global::Orleans.Serialization.Codecs.Int32Codec.WriteField(ref writer, 30U, instance.Id);
+            global::Orleans.Serialization.Codecs.StringCodec.WriteField(ref writer, 10U, instance.Name);
+            writer.WriteEndBase();
+            global::Orleans.Serialization.Codecs.StringCodec.WriteField(ref writer, 50U, instance.Description);
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void Deserialize<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, global::TestProject.RecordWithExtraProperty instance)
+        {
+            uint id = 0U;
+            global::Orleans.Serialization.WireProtocol.Field header = default;
+            while (true)
+            {
+                reader.ReadFieldHeader(ref header);
+                if (header.IsEndBaseOrEndObject)
+                    break;
+                id += header.FieldIdDelta;
+                if (id == 30U)
+                {
+                    setField1(instance, global::Orleans.Serialization.Codecs.Int32Codec.ReadValue(ref reader, header));
+                    reader.ReadFieldHeader(ref header);
+                    if (header.IsEndBaseOrEndObject)
+                        break;
+                    id += header.FieldIdDelta;
+                }
+
+                if (id == 40U)
+                {
+                    setField2(instance, global::Orleans.Serialization.Codecs.StringCodec.ReadValue(ref reader, header));
+                    reader.ReadFieldHeader(ref header);
+                    if (header.IsEndBaseOrEndObject)
+                        break;
+                    id++;
+                }
+
+                reader.ConsumeUnknownField(ref header);
+            }
+
+            id = 0U;
+            if (header.IsEndBaseFields)
+                while (true)
+                {
+                    reader.ReadFieldHeader(ref header);
+                    if (header.IsEndBaseOrEndObject)
+                        break;
+                    id += header.FieldIdDelta;
+                    if (id == 50U)
+                    {
+                        setField0(instance, global::Orleans.Serialization.Codecs.StringCodec.ReadValue(ref reader, header));
+                        reader.ReadFieldHeader(ref header);
+                        if (header.IsEndBaseOrEndObject)
+                            break;
+                        id++;
+                    }
+
+                    reader.ConsumeUnknownField(ref header);
+                }
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, global::System.Type expectedType, global::TestProject.RecordWithExtraProperty @value)
+            where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
+        {
+            if (@value is null || @value.GetType() == typeof(global::TestProject.RecordWithExtraProperty))
+            {
+                if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, @value))
+                    return;
+                writer.WriteStartObject(fieldIdDelta, expectedType, _codecFieldType);
+                Serialize(ref writer, @value);
+                writer.WriteEndObject();
+            }
+            else
+                writer.SerializeUnexpectedType(fieldIdDelta, expectedType, @value);
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public global::TestProject.RecordWithExtraProperty ReadValue<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
+        {
+            if (field.IsReference)
+                return ReferenceCodec.ReadReference<global::TestProject.RecordWithExtraProperty, TReaderInput>(ref reader, field);
+            field.EnsureWireTypeTagDelimited();
+            global::System.Type valueType = field.FieldType;
+            if (valueType is null || valueType == _codecFieldType)
+            {
+                var result = _activator.Create();
+                ReferenceCodec.RecordObject(reader.Session, result);
+                Deserialize(ref reader, result);
+                return result;
+            }
+
+            return reader.DeserializeUnexpectedType<TReaderInput, global::TestProject.RecordWithExtraProperty>(ref field);
+        }
+    }
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("OrleansCodeGen", "10.0.0.0"), global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never), global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    public sealed class Copier_RecordWithExtraProperty : global::Orleans.Serialization.Cloning.IDeepCopier<global::TestProject.RecordWithExtraProperty>, global::Orleans.Serialization.Cloning.IBaseCopier<global::TestProject.RecordWithExtraProperty>
+    {
+        private readonly global::Orleans.Serialization.Activators.IActivator<global::TestProject.RecordWithExtraProperty> _activator;
+        private static readonly global::System.Action<global::TestProject.RecordWithExtraProperty, string> setField0 = (global::System.Action<global::TestProject.RecordWithExtraProperty, string>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.RecordWithExtraProperty), "<Description>k__BackingField");
+        private static readonly global::System.Action<global::TestProject.RecordWithExtraProperty, int> setField1 = (global::System.Action<global::TestProject.RecordWithExtraProperty, int>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.RecordWithExtraProperty), "<Id>k__BackingField");
+        private static readonly global::System.Action<global::TestProject.RecordWithExtraProperty, string> setField2 = (global::System.Action<global::TestProject.RecordWithExtraProperty, string>)global::Orleans.Serialization.Utilities.FieldAccessor.GetReferenceSetter(typeof(global::TestProject.RecordWithExtraProperty), "<Name>k__BackingField");
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public global::TestProject.RecordWithExtraProperty DeepCopy(global::TestProject.RecordWithExtraProperty original, global::Orleans.Serialization.Cloning.CopyContext context)
+        {
+            if (context.TryGetCopy(original, out global::TestProject.RecordWithExtraProperty existing))
+                return existing;
+            if (original.GetType() != typeof(global::TestProject.RecordWithExtraProperty))
+                return context.DeepCopy(original);
+            var result = _activator.Create();
+            context.RecordCopy(original, result);
+            DeepCopy(original, result, context);
+            return result;
+        }
+
+        public Copier_RecordWithExtraProperty(global::Orleans.Serialization.Activators.IActivator<global::TestProject.RecordWithExtraProperty> _activator)
+        {
+            this._activator = OrleansGeneratedCodeHelper.UnwrapService(this, _activator);
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void DeepCopy(global::TestProject.RecordWithExtraProperty input, global::TestProject.RecordWithExtraProperty output, global::Orleans.Serialization.Cloning.CopyContext context)
+        {
+            setField1(output, input.Id);
+            setField2(output, input.Name);
+            setField0(output, input.Description);
+        }
+    }
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("OrleansCodeGen", "10.0.0.0"), global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never), global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    public sealed class Codec_RecordStructWithParameterId : global::Orleans.Serialization.Codecs.IFieldCodec<global::TestProject.RecordStructWithParameterId>, global::Orleans.Serialization.Serializers.IValueSerializer<global::TestProject.RecordStructWithParameterId>
+    {
+        private readonly global::System.Type _codecFieldType = typeof(global::TestProject.RecordStructWithParameterId);
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void Serialize<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, scoped ref global::TestProject.RecordStructWithParameterId instance)
+            where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
+        {
+            global::Orleans.Serialization.Codecs.StringCodec.WriteField(ref writer, 60U, instance.Value);
+            writer.WriteEndBase();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void Deserialize<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, scoped ref global::TestProject.RecordStructWithParameterId instance)
+        {
+            uint id = 0U;
+            global::Orleans.Serialization.WireProtocol.Field header = default;
+            while (true)
+            {
+                reader.ReadFieldHeader(ref header);
+                if (header.IsEndBaseOrEndObject)
+                    break;
+                id += header.FieldIdDelta;
+                if (id == 60U)
+                {
+                    instance.Value = global::Orleans.Serialization.Codecs.StringCodec.ReadValue(ref reader, header);
+                    reader.ReadFieldHeader(ref header);
+                    if (header.IsEndBaseOrEndObject)
+                        break;
+                    id++;
+                }
+
+                reader.ConsumeUnknownField(ref header);
+            }
+
+            id = 0U;
+            if (header.IsEndBaseFields)
+            {
+                reader.ReadFieldHeader(ref header);
+                reader.ConsumeEndBaseOrEndObject(ref header);
+            }
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, global::System.Type expectedType, global::TestProject.RecordStructWithParameterId @value)
+            where TBufferWriter : global::System.Buffers.IBufferWriter<byte>
+        {
+            ReferenceCodec.MarkValueField(writer.Session);
+            writer.WriteStartObject(fieldIdDelta, expectedType, _codecFieldType);
+            Serialize(ref writer, ref @value);
+            writer.WriteEndObject();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public global::TestProject.RecordStructWithParameterId ReadValue<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, global::Orleans.Serialization.WireProtocol.Field field)
+        {
+            field.EnsureWireTypeTagDelimited();
+            var result = default(global::TestProject.RecordStructWithParameterId);
+            ReferenceCodec.MarkValueField(reader.Session);
+            Deserialize(ref reader, ref result);
+            return result;
+        }
+    }
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("OrleansCodeGen", "10.0.0.0"), global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never), global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
+    internal sealed class Metadata_TestProject : global::Orleans.Serialization.Configuration.TypeManifestProviderBase
+    {
+        protected override void ConfigureInner(global::Orleans.Serialization.Configuration.TypeManifestOptions config)
+        {
+            config.Serializers.Add(typeof(OrleansCodeGen.TestProject.Codec_SimpleRecord));
+            config.Serializers.Add(typeof(OrleansCodeGen.TestProject.Codec_RecordWithExtraProperty));
+            config.Serializers.Add(typeof(OrleansCodeGen.TestProject.Codec_RecordStructWithParameterId));
+            config.Copiers.Add(typeof(OrleansCodeGen.TestProject.Copier_SimpleRecord));
+            config.Copiers.Add(typeof(OrleansCodeGen.TestProject.Copier_RecordWithExtraProperty));
+            config.Copiers.Add(typeof(global::Orleans.Serialization.Cloning.ShallowCopier<global::TestProject.RecordStructWithParameterId>));
+        }
+    }
+}
+#pragma warning restore CS1591, RS0016, RS0041

--- a/test/Orleans.Serialization.UnitTests/RecordSerializationTests.cs
+++ b/test/Orleans.Serialization.UnitTests/RecordSerializationTests.cs
@@ -236,6 +236,37 @@ public class RecordSerializationTests
             Assert.Equal(original, deserialized);
         }
 
+        [Fact]
+        public void Can_Roundtrip_RecordWithParameterIdAttribute()
+        {
+            var original = new RecordWithParameterIdAttribute(42, "test");
+
+            var bytes = _serializer.SerializeToArray(original);
+
+            var deserialized = _serializer.Deserialize<RecordWithParameterIdAttribute>(bytes);
+
+            Assert.NotNull(deserialized);
+            Assert.Equal(original, deserialized);
+            Assert.Equal(42, deserialized.Value);
+            Assert.Equal("test", deserialized.Name);
+        }
+
+        [Fact]
+        public void Can_Roundtrip_ComplexRecordWithMixedIdAttributes()
+        {
+            var original = new ComplexRecordWithMixedIdAttributes(123, "primary", "extra");
+
+            var bytes = _serializer.SerializeToArray(original);
+
+            var deserialized = _serializer.Deserialize<ComplexRecordWithMixedIdAttributes>(bytes);
+
+            Assert.NotNull(deserialized);
+            Assert.Equal(original, deserialized);
+            Assert.Equal(123, deserialized.Id);
+            Assert.Equal("primary", deserialized.Name);
+            Assert.Equal("extra", deserialized.Description);
+        }
+
     // TODO: This type should cause a build error because "Bar" is an init-only non-auto property but has an [Id(...)] attribute.
     // It is suited for an diagnostic analyzer test, but the current implementation
     // of the source generator does not support execution as an analyzer.
@@ -375,3 +406,18 @@ public record AppleRecord(string Name) : FruitRecord(Name);
 
 [GenerateSerializer]
 public record FooRecord([property: Id(0)] Guid Id);
+
+[GenerateSerializer]
+public record RecordWithParameterIdAttribute([Id(10)] int Value, [Id(20)] string Name);
+
+[GenerateSerializer]
+public record ComplexRecordWithMixedIdAttributes([Id(30)] int Id, [Id(40)] string Name)
+{
+    [Id(50)]
+    public string Description { get; init; } = string.Empty;
+
+    public ComplexRecordWithMixedIdAttributes(int id, string name, string description) : this(id, name)
+    {
+        Description = description;
+    }
+}


### PR DESCRIPTION
## Problem

`[Id]` could not be applied directly to positional record parameters, forcing users to target the generated property with the more verbose `[property: Id(...)]` syntax.

## Solution

Allow `IdAttribute` on parameters and have code generation honor those explicit IDs, including when implicit public-property field IDs are enabled. Add generator, model, and serialization coverage using non-positional IDs, update the generated API surface, and document the concise record syntax.

This replaces #9791, whose org-owned bot branch could not be updated after it developed conflicts.

Closes #9780
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10495)