### PR TITLE
test(adonet): avoid cross-clock timestamp assertions

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
@@ -121,12 +121,9 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
         var queueId = mapper.GetAdoNetQueueId(streamId);
         var payload = new byte[] { 0xFF };
 
-        var beforeQueued = DateTime.UtcNow.AddSeconds(-1);
         var ack = await _queries.QueueStreamMessageAsync(clusterOptions.ServiceId, providerId, queueId, payload, streamOptions.ExpiryTimeout.TotalSecondsCeiling());
-        var afterQueued = DateTime.UtcNow.AddSeconds(1);
 
         // arrange - dequeue the message and make immediately available
-        var beforeDequeued = DateTime.UtcNow.AddSeconds(-1);
         await _queries.GetStreamMessagesAsync(
             ack.ServiceId,
             ack.ProviderId,
@@ -137,12 +134,10 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
             streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling(),
             streamOptions.EvictionInterval.TotalSecondsCeiling(),
             streamOptions.EvictionBatchSize);
-        var afterDequeued = DateTime.UtcNow.AddSeconds(1);
+        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
 
         // act - clean up with max attempts of one so the message above is flagged
-        var beforeFailure = DateTime.UtcNow.AddSeconds(-1);
         await handler.OnDeliveryFailure(GuidId.GetNewGuidId(), providerId, streamId, new EventSequenceTokenV2(ack.MessageId));
-        var afterFailure = DateTime.UtcNow.AddSeconds(1);
 
         // assert
         var dead = Assert.Single(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
@@ -151,16 +146,9 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
         Assert.Equal(queueId, dead.QueueId);
         Assert.Equal(ack.MessageId, dead.MessageId);
         Assert.Equal(1, dead.Dequeued);
-        Assert.True(dead.ExpiresOn >= beforeQueued);
-        Assert.True(dead.ExpiresOn <= afterQueued.Add(streamOptions.ExpiryTimeout.SecondsCeiling()));
-        Assert.True(dead.CreatedOn >= beforeQueued);
-        Assert.True(dead.CreatedOn <= afterQueued);
-        Assert.True(dead.ModifiedOn >= beforeDequeued);
-        Assert.True(dead.ModifiedOn <= afterDequeued);
-        Assert.True(dead.DeadOn >= beforeFailure);
-        Assert.True(dead.DeadOn <= afterFailure);
-        Assert.True(dead.RemoveOn >= beforeFailure);
-        Assert.True(dead.RemoveOn <= afterFailure.Add(streamOptions.DeadLetterEvictionTimeout.SecondsCeiling()));
+        Assert.Equal(dead.CreatedOn.Add(streamOptions.ExpiryTimeout.SecondsCeiling()), dead.ExpiresOn);
+        Assert.Equal(dead.ModifiedOn, dead.VisibleOn);
+        Assert.Equal(dead.DeadOn.Add(streamOptions.DeadLetterEvictionTimeout.SecondsCeiling()), dead.RemoveOn);
         Assert.Equal(payload, dead.Payload);
     }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -907,19 +907,14 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var queueId = "QueueId";
         var payload = new byte[] { 0xFF };
 
-        var beforeQueued = DateTime.UtcNow.AddSeconds(-1);
         var ack = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, streamOptions.ExpiryTimeout.TotalSecondsCeiling());
-        var afterQueued = DateTime.UtcNow.AddSeconds(1);
 
         // arrange - dequeue the message and make immediately available
-        var beforeDequeued = DateTime.UtcNow.AddSeconds(-1);
         await _queries.GetStreamMessagesAsync(ack.ServiceId, ack.ProviderId, ack.QueueId, cacheOptions.CacheSize, streamOptions.MaxAttempts, 0, streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling(), streamOptions.EvictionInterval.TotalSecondsCeiling(), streamOptions.EvictionBatchSize);
-        var afterDequeued = DateTime.UtcNow.AddSeconds(1);
+        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
 
         // act - clean up with max attempts of one so the message above is flagged
-        var beforeFailure = DateTime.UtcNow.AddSeconds(-1);
         await _queries.FailStreamMessageAsync(ack.ServiceId, ack.ProviderId, ack.QueueId, ack.MessageId, 1, streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling());
-        var afterFailure = DateTime.UtcNow.AddSeconds(1);
 
         // assert - message no longer in the message table
         Assert.Empty(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
@@ -931,16 +926,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(queueId, dead.QueueId);
         Assert.Equal(ack.MessageId, dead.MessageId);
         Assert.Equal(1, dead.Dequeued);
-        Assert.True(dead.ExpiresOn >= beforeQueued);
-        Assert.True(dead.ExpiresOn <= afterQueued.Add(streamOptions.ExpiryTimeout.SecondsCeiling()));
-        Assert.True(dead.CreatedOn >= beforeQueued);
-        Assert.True(dead.CreatedOn <= afterQueued);
-        Assert.True(dead.ModifiedOn >= beforeDequeued);
-        Assert.True(dead.ModifiedOn <= afterDequeued);
-        Assert.True(dead.DeadOn >= beforeFailure);
-        Assert.True(dead.DeadOn <= afterFailure);
-        Assert.True(dead.RemoveOn >= beforeFailure);
-        Assert.True(dead.RemoveOn <= afterFailure.Add(streamOptions.DeadLetterEvictionTimeout.SecondsCeiling()));
+        Assert.Equal(dead.CreatedOn.Add(streamOptions.ExpiryTimeout.SecondsCeiling()), dead.ExpiresOn);
+        Assert.Equal(dead.ModifiedOn, dead.VisibleOn);
+        Assert.Equal(dead.DeadOn.Add(streamOptions.DeadLetterEvictionTimeout.SecondsCeiling()), dead.RemoveOn);
         Assert.Equal(payload, dead.Payload);
     }
 
@@ -965,9 +953,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         await _queries.GetStreamMessagesAsync(ack.ServiceId, ack.ProviderId, ack.QueueId, cacheOptions.CacheSize, streamOptions.MaxAttempts, streamOptions.VisibilityTimeout.TotalSecondsCeiling(), streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling(), streamOptions.EvictionInterval.TotalSecondsCeiling(), streamOptions.EvictionBatchSize);
 
         // act - fail the message
-        var beforeFailed = DateTime.UtcNow.AddSeconds(-1);
         await _queries.FailStreamMessageAsync(ack.ServiceId, ack.ProviderId, ack.QueueId, ack.MessageId, streamOptions.MaxAttempts, streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling());
-        var afterFailed = DateTime.UtcNow.AddSeconds(1);
 
         // assert - the message is still in the table and was made visible again
         var saved = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
@@ -976,8 +962,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(ack.QueueId, saved.QueueId);
         Assert.Equal(ack.MessageId, saved.MessageId);
         Assert.Equal(1, saved.Dequeued);
-        Assert.True(saved.VisibleOn >= beforeFailed, $"{saved.VisibleOn} must be greater than or equal to {beforeFailed}");
-        Assert.True(saved.VisibleOn <= afterFailed, $"{saved.VisibleOn} must be lesser than or equal to {afterFailed}");
+        Assert.Equal(saved.ModifiedOn, saved.VisibleOn);
 
         // assert - no message arrived at dead letters
         Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));


### PR DESCRIPTION
Fixes #10470

ADO.NET streaming tests compared timestamps generated by database processes with timestamps sampled from the test process. This can invert sub-millisecond boundaries because the APIs have different effective resolution and semantics: for example, modern .NET uses the precise Windows time API while SQL Server documents that `SYSUTCDATETIME()` uses `GetSystemTimeAsFileTime()`. The original assertion reproduced with the database expiry timestamp 0.2255 ms below the application-derived lower bound.

Validate the observable dead-letter state transition directly and assert relationships between timestamps derived from the same database-local value instead. This preserves exact expiry, visibility, and removal-timeout validation without tolerance windows or cross-process clock ordering assumptions. The same assertions apply to SQL Server, MariaDB/MySQL, and PostgreSQL.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10501)