### PR TITLE
feat(membership): retain local health history

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -123,9 +123,11 @@ namespace Orleans.Configuration
         internal static TimeSpan ClusteringShutdownGracePeriod => TimeSpan.FromSeconds(5);
 
         /// <summary>
-        /// Gets or sets the period between self-tests to log local health degradation status.
+        /// Gets or sets the minimum period between logs reporting local health degradation.
         /// </summary>
-        /// <value>The local host will perform a self-test every ten seconds by default.</value>
+        /// <value>
+        /// Local health is sampled every second and detected degradation is logged no more than once every ten seconds by default.
+        /// </value>
         public TimeSpan LocalHealthDegradationMonitoringPeriod { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>

--- a/src/Orleans.Core/Timers/TimeProviderValueStopwatch.cs
+++ b/src/Orleans.Core/Timers/TimeProviderValueStopwatch.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Orleans.Runtime;
+
+/// <summary>
+/// A non-allocating stopwatch backed by a <see cref="TimeProvider"/>.
+/// </summary>
+internal readonly struct TimeProviderValueStopwatch
+{
+    private readonly TimeProvider _timeProvider;
+
+    private TimeProviderValueStopwatch(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+        StartTimestamp = timeProvider.GetTimestamp();
+    }
+
+    /// <summary>
+    /// Gets the timestamp captured when this stopwatch started.
+    /// </summary>
+    public long StartTimestamp { get; }
+
+    /// <summary>
+    /// Starts a new stopwatch.
+    /// </summary>
+    public static TimeProviderValueStopwatch StartNew(TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        return new(timeProvider);
+    }
+
+    /// <summary>
+    /// Gets the elapsed duration and returns the timestamp used as the endpoint.
+    /// </summary>
+    public TimeSpan GetElapsedTime(out long endTimestamp)
+    {
+        endTimestamp = _timeProvider.GetTimestamp();
+        return _timeProvider.GetElapsedTime(StartTimestamp, endTimestamp);
+    }
+}

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -192,6 +192,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<IProbeHealthMonitor, ProbingSiloHealthMonitor>();
             services.AddSingleton<LocalSiloHealthMonitor>();
             services.AddFromExisting<ILocalSiloHealthMonitor, LocalSiloHealthMonitor>();
+            services.AddFromExisting<ILocalSiloHealthEventRecorder, LocalSiloHealthMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, LocalSiloHealthMonitor>();
             services.AddSingleton<MembershipAgent>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, MembershipAgent>();

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -31,6 +31,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILogger<ClusterHealthMonitor> log;
         private readonly IFatalErrorHandler fatalErrorHandler;
         private readonly IOptionsMonitor<ClusterMembershipOptions> clusterMembershipOptions;
+        private readonly TimeProvider timeProvider;
         private ImmutableDictionary<SiloAddress, SiloHealthMonitor> monitoredSilos = ImmutableDictionary<SiloAddress, SiloHealthMonitor>.Empty;
         private MembershipVersion observedMembershipVersion;
         private Func<SiloAddress, SiloHealthMonitor> createMonitor;
@@ -54,7 +55,8 @@ namespace Orleans.Runtime.MembershipService
             IOptionsMonitor<ClusterMembershipOptions> clusterMembershipOptions,
             IFatalErrorHandler fatalErrorHandler,
             IServiceProvider serviceProvider,
-            ConnectionManager connectionManager)
+            ConnectionManager connectionManager,
+            [FromKeyedServices(TimeProviderNames.Membership)] TimeProvider timeProvider)
         {
             this.localSiloDetails = localSiloDetails;
             this.serviceProvider = serviceProvider;
@@ -63,6 +65,7 @@ namespace Orleans.Runtime.MembershipService
             this.log = log;
             this.fatalErrorHandler = fatalErrorHandler;
             this.clusterMembershipOptions = clusterMembershipOptions;
+            this.timeProvider = timeProvider;
             this.onProbeResult = this.OnProbeResultInternal;
             Func<SiloHealthMonitor, ProbeResult, Task> onProbeResultFunc = (siloHealthMonitor, probeResult) => this.onProbeResult(siloHealthMonitor, probeResult);
             this.createMonitor = silo => ActivatorUtilities.CreateInstance<SiloHealthMonitor>(serviceProvider, silo, onProbeResultFunc);
@@ -85,7 +88,7 @@ namespace Orleans.Runtime.MembershipService
                 LogDebugStartingToProcessMembershipUpdates(log);
                 await foreach (var tableSnapshot in this.membershipManager.MembershipUpdates.WithCancellation(this.shutdownCancellation.Token))
                 {
-                    var utcNow = DateTime.UtcNow;
+                    var utcNow = this.timeProvider.GetUtcNow().UtcDateTime;
 
                     var newMonitoredSilos = this.UpdateMonitoredSilos(tableSnapshot, this.monitoredSilos, utcNow);
 
@@ -98,7 +101,9 @@ namespace Orleans.Runtime.MembershipService
                     {
                         if (!newMonitoredSilos.ContainsKey(pair.Key))
                         {
-                            using var cancellation = new CancellationTokenSource(this.clusterMembershipOptions.CurrentValue.ProbeTimeout);
+                            using var cancellation = new CancellationTokenSource(
+                                this.clusterMembershipOptions.CurrentValue.ProbeTimeout,
+                                this.timeProvider);
                             await pair.Value.StopAsync(cancellation.Token);
                         }
                     }
@@ -291,7 +296,10 @@ namespace Orleans.Runtime.MembershipService
 
             Task OnValidateInitialConnectivityStart(CancellationToken ct)
             {
-                this.monitoredSilos = this.UpdateMonitoredSilos(this.membershipManager.CurrentSnapshot, this.monitoredSilos, DateTime.UtcNow);
+                this.monitoredSilos = this.UpdateMonitoredSilos(
+                    this.membershipManager.CurrentSnapshot,
+                    this.monitoredSilos,
+                    this.timeProvider.GetUtcNow().UtcDateTime);
                 tasks.Add(Task.Run(() => this.ProcessMembershipUpdates()));
                 return Task.CompletedTask;
             }
@@ -308,7 +316,9 @@ namespace Orleans.Runtime.MembershipService
                 this.monitoredSilos = ImmutableDictionary<SiloAddress, SiloHealthMonitor>.Empty;
 
                 // Allow some minimum time for graceful shutdown.
-                var shutdownGracePeriod = Task.WhenAll(Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod), ct.WhenCancelled());
+                var shutdownGracePeriod = Task.WhenAll(
+                    Task.Delay(ClusterMembershipOptions.ClusteringShutdownGracePeriod, this.timeProvider),
+                    ct.WhenCancelled());
                 await Task.WhenAny(shutdownGracePeriod, Task.WhenAll(tasks));
             }
         }

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthEventHistory.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthEventHistory.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+
+namespace Orleans.Runtime.MembershipService;
+
+internal sealed class LocalSiloHealthEventHistory
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _retentionPeriod;
+    private readonly long _bucketTimestampLength;
+    private readonly Bucket[] _buckets;
+    private readonly Dictionary<HealthEventIdentity, AggregateEntry> _candidates = [];
+    private readonly List<LocalSiloHealthEvent> _selected = [];
+    private int _count;
+    private int _occupiedBucketCount;
+
+    public LocalSiloHealthEventHistory(
+        TimeProvider timeProvider,
+        TimeSpan retentionPeriod,
+        TimeSpan bucketDuration)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(retentionPeriod, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(bucketDuration, TimeSpan.Zero);
+
+        _timeProvider = timeProvider;
+        _retentionPeriod = retentionPeriod;
+        _bucketTimestampLength = GetTimestampLength(bucketDuration);
+        _buckets = new Bucket[checked((int)Math.Ceiling(retentionPeriod / bucketDuration) + 1)];
+    }
+
+    internal int Count => _count;
+
+    internal int OccupiedBucketCount => _occupiedBucketCount;
+
+    public void Add(LocalSiloHealthEvent healthEvent)
+    {
+        RemoveExpired(healthEvent.Timestamp);
+        AddCore(healthEvent);
+    }
+
+    public void AddRange(List<LocalSiloHealthEvent> healthEvents, long nowTimestamp)
+    {
+        RemoveExpired(nowTimestamp);
+        foreach (var healthEvent in healthEvents)
+        {
+            AddCore(healthEvent);
+        }
+    }
+
+    public LocalSiloHealthStatus Aggregate(
+        long startTimestamp,
+        long endTimestamp,
+        long nowTimestamp,
+        LocalSiloHealthCheckCategory categories,
+        int maxScore)
+    {
+        RemoveExpired(nowTimestamp);
+        if (categories == LocalSiloHealthCheckCategory.None)
+        {
+            return new(0, []);
+        }
+
+        try
+        {
+            foreach (var bucket in _buckets)
+            {
+                if (bucket.Events is not { Count: > 0 } events)
+                {
+                    continue;
+                }
+
+                foreach (var healthEvent in events)
+                {
+                    if ((healthEvent.Category & categories) == 0)
+                    {
+                        continue;
+                    }
+
+                    var isPriorState = healthEvent.Timestamp < startTimestamp
+                        && IsStateful(healthEvent.Kind);
+                    if (!isPriorState && !Overlaps(healthEvent, startTimestamp, endTimestamp))
+                    {
+                        continue;
+                    }
+
+                    var identity = new HealthEventIdentity(healthEvent.Kind, healthEvent.Source);
+                    ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(_candidates, identity, out _);
+                    if (isPriorState)
+                    {
+                        if (!entry.HasPriorState || healthEvent.Timestamp > entry.PriorState.Timestamp)
+                        {
+                            entry.PriorState = healthEvent;
+                            entry.HasPriorState = true;
+                        }
+
+                        continue;
+                    }
+
+                    entry.HasBoundaryState |= healthEvent.Timestamp == startTimestamp && IsStateful(healthEvent.Kind);
+                    if (!entry.HasIntervalEvent || IsBetter(healthEvent, entry.IntervalEvent))
+                    {
+                        entry.IntervalEvent = healthEvent;
+                        entry.HasIntervalEvent = true;
+                    }
+                }
+            }
+
+            _selected.EnsureCapacity(_candidates.Count);
+            var score = 0;
+            foreach (var entry in _candidates.Values)
+            {
+                LocalSiloHealthEvent healthEvent;
+                if (!entry.HasIntervalEvent)
+                {
+                    healthEvent = entry.PriorState;
+                }
+                else if (entry.HasPriorState
+                    && !entry.HasBoundaryState
+                    && IsBetter(entry.PriorState, entry.IntervalEvent))
+                {
+                    healthEvent = entry.PriorState;
+                }
+                else
+                {
+                    healthEvent = entry.IntervalEvent;
+                }
+
+                _selected.Add(healthEvent);
+                score = (int)Math.Min(maxScore, (long)score + healthEvent.Score);
+            }
+
+            _selected.Sort(static (left, right) =>
+            {
+                var kindComparison = left.Kind.CompareTo(right.Kind);
+                return kindComparison != 0
+                    ? kindComparison
+                    : string.CompareOrdinal(left.Source, right.Source);
+            });
+            return new(score, ImmutableArray.CreateRange(_selected));
+        }
+        finally
+        {
+            _candidates.Clear();
+            _selected.Clear();
+        }
+    }
+
+    private void AddCore(LocalSiloHealthEvent healthEvent)
+    {
+        var bucketIndex = GetBucketIndex(healthEvent.Timestamp);
+        ref var bucket = ref _buckets[GetSlot(bucketIndex)];
+        if (!bucket.IsOccupied)
+        {
+            bucket.IsOccupied = true;
+            bucket.Index = bucketIndex;
+            bucket.Events ??= [];
+            _occupiedBucketCount++;
+        }
+        else if (bucket.Index != bucketIndex)
+        {
+            if (bucket.Index > bucketIndex)
+            {
+                return;
+            }
+
+            _count -= bucket.Events!.Count;
+            bucket.Events.Clear();
+            bucket.Index = bucketIndex;
+        }
+
+        bucket.Events!.Add(healthEvent);
+        _count++;
+    }
+
+    private void RemoveExpired(long nowTimestamp)
+    {
+        var oldestTimestamp = SubtractTimestamp(nowTimestamp, _retentionPeriod);
+        var oldestBucketIndex = GetBucketIndex(oldestTimestamp);
+        foreach (ref var bucket in _buckets.AsSpan())
+        {
+            if (!bucket.IsOccupied)
+            {
+                continue;
+            }
+
+            if (bucket.Index < oldestBucketIndex)
+            {
+                Clear(ref bucket);
+            }
+            else if (bucket.Index == oldestBucketIndex)
+            {
+                var events = bucket.Events!;
+                var writeIndex = 0;
+                for (var readIndex = 0; readIndex < events.Count; readIndex++)
+                {
+                    var healthEvent = events[readIndex];
+                    if (healthEvent.Timestamp >= oldestTimestamp)
+                    {
+                        events[writeIndex++] = healthEvent;
+                    }
+                }
+
+                var removedCount = events.Count - writeIndex;
+                if (removedCount > 0)
+                {
+                    events.RemoveRange(writeIndex, removedCount);
+                    _count -= removedCount;
+                }
+
+                if (events.Count == 0)
+                {
+                    Clear(ref bucket);
+                }
+            }
+        }
+    }
+
+    private void Clear(ref Bucket bucket)
+    {
+        _count -= bucket.Events!.Count;
+        bucket.Events.Clear();
+        bucket.IsOccupied = false;
+        _occupiedBucketCount--;
+    }
+
+    private bool Overlaps(LocalSiloHealthEvent healthEvent, long startTimestamp, long endTimestamp)
+    {
+        if (healthEvent.Timestamp < startTimestamp)
+        {
+            return false;
+        }
+
+        return healthEvent.Timestamp <= endTimestamp
+            || healthEvent.Duration is { } duration
+                && duration > TimeSpan.Zero
+                && _timeProvider.GetElapsedTime(endTimestamp, healthEvent.Timestamp) <= duration;
+    }
+
+    private static bool IsStateful(LocalSiloHealthCheckKind kind)
+        => kind is LocalSiloHealthCheckKind.MembershipStatus
+            or LocalSiloHealthCheckKind.HealthCheckParticipant
+            or LocalSiloHealthCheckKind.ThreadPoolQueueDelay
+            or LocalSiloHealthCheckKind.ProbeRequests
+            or LocalSiloHealthCheckKind.ProbeResponses;
+
+    private static bool IsBetter(
+        LocalSiloHealthEvent candidate,
+        LocalSiloHealthEvent current)
+        => candidate.Score > current.Score
+            || candidate.Score == current.Score && candidate.Timestamp > current.Timestamp;
+
+    private long GetBucketIndex(long timestamp) => timestamp / _bucketTimestampLength;
+
+    private int GetSlot(long bucketIndex)
+    {
+        var slot = bucketIndex % _buckets.Length;
+        return (int)(slot >= 0 ? slot : slot + _buckets.Length);
+    }
+
+    private long GetTimestampLength(TimeSpan duration)
+        => checked((long)Math.Ceiling(duration.TotalSeconds * _timeProvider.TimestampFrequency));
+
+    private long SubtractTimestamp(long timestamp, TimeSpan duration)
+        => timestamp - GetTimestampLength(duration);
+
+    private readonly record struct HealthEventIdentity(
+        LocalSiloHealthCheckKind Kind,
+        string? Source);
+
+    private struct AggregateEntry
+    {
+        public LocalSiloHealthEvent PriorState;
+        public LocalSiloHealthEvent IntervalEvent;
+        public bool HasPriorState;
+        public bool HasIntervalEvent;
+        public bool HasBoundaryState;
+    }
+
+    private struct Bucket
+    {
+        public long Index;
+        public List<LocalSiloHealthEvent>? Events;
+        public bool IsOccupied;
+    }
+}

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -13,19 +13,67 @@ using Orleans.Internal;
 
 namespace Orleans.Runtime.MembershipService
 {
+    [Flags]
+    internal enum LocalSiloHealthCheckCategory
+    {
+        None = 0,
+        Local = 1,
+        Network = 2,
+        All = Local | Network,
+    }
+
+    internal enum LocalSiloHealthCheckKind
+    {
+        MembershipStatus,
+        SiloSuspected,
+        HealthCheckParticipant,
+        ThreadPoolQueueDelay,
+        ProbeRequests,
+        ProbeResponses,
+        GarbageCollectionPause,
+        RuntimeStall,
+        ComponentHealthCheckStall,
+    }
+
+    internal readonly record struct LocalSiloHealthEvent(
+        DateTimeOffset Timestamp,
+        LocalSiloHealthCheckKind Kind,
+        LocalSiloHealthCheckCategory Category,
+        string? Source,
+        int Score,
+        string? Complaint,
+        TimeSpan? Duration);
+
+    internal readonly record struct LocalSiloHealthStatus(int Score, ImmutableArray<LocalSiloHealthEvent> Events)
+    {
+        public ImmutableArray<string> Complaints
+            => [.. Events.Where(static status => status.Complaint is not null).Select(static status => status.Complaint!)];
+    }
+
     internal interface ILocalSiloHealthMonitor
     {
         /// <summary>
-        /// Returns the local health degradation score, which is a value between 0 (healthy) and <see cref="LocalSiloHealthMonitor.MaxScore"/> (unhealthy).
+        /// Returns the aggregate local health status over the provided period.
         /// </summary>
-        /// <param name="checkTime">The time which the check is taking place.</param>
-        /// <returns>The local health degradation score, which is a value between 0 (healthy) and <see cref="LocalSiloHealthMonitor.MaxScore"/> (unhealthy).</returns>
-        int GetLocalHealthDegradationScore(DateTime checkTime);
+        /// <param name="period">The period ending at the current time to aggregate.</param>
+        /// <param name="categories">The categories of health checks to include.</param>
+        /// <returns>The aggregate health status.</returns>
+        LocalSiloHealthStatus GetLocalHealthStatus(TimeSpan period, LocalSiloHealthCheckCategory categories);
 
         /// <summary>
         /// The most recent list of detected health issues.
         /// </summary>
         ImmutableArray<string> Complaints { get; }
+    }
+
+    internal interface ILocalSiloHealthEventRecorder
+    {
+        void RecordHealthEvent(
+            LocalSiloHealthCheckKind kind,
+            int score,
+            string? complaint,
+            TimeSpan? duration = null,
+            string? source = null);
     }
 
     /// <summary>
@@ -48,10 +96,17 @@ namespace Orleans.Runtime.MembershipService
     ///   <item><description>Check that local async timers have been firing on-time (within 3 seconds of their due time).</description></item>
     /// </list>
     /// </remarks>
-    internal partial class LocalSiloHealthMonitor : ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver, ILocalSiloHealthMonitor
+    internal partial class LocalSiloHealthMonitor :
+        ILifecycleParticipant<ISiloLifecycle>,
+        ILifecycleObserver,
+        ILocalSiloHealthMonitor,
+        ILocalSiloHealthEventRecorder
     {
-        private const int MaxScore = 8;
+        internal const int MaxScore = 8;
+        private static readonly TimeSpan HistoryDuration = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan MinimumCheckPeriod = TimeSpan.FromSeconds(1);
         private readonly List<IHealthCheckParticipant> _healthCheckParticipants;
+        private readonly List<LocalSiloHealthEvent> _healthEvents = [];
         private readonly IMembershipManager _membershipManager;
         private readonly IProbeHealthMonitor _probeHealthMonitor;
         private readonly ILocalSiloDetails _localSiloDetails;
@@ -59,10 +114,20 @@ namespace Orleans.Runtime.MembershipService
         private readonly ClusterMembershipOptions _clusterMembershipOptions;
         private readonly IAsyncTimer _degradationCheckTimer;
         private readonly ThreadPoolMonitor _threadPoolMonitor;
-        private ValueStopwatch _clusteredDuration;
+        private readonly TimeProvider _timeProvider;
+#if NET9_0_OR_GREATER
+        private readonly Lock _historyLock = new();
+        private readonly Lock _samplingLock = new();
+#else
+        private readonly object _historyLock = new();
+        private readonly object _samplingLock = new();
+#endif
         private Task? _runTask;
         private bool _isActive;
         private DateTime _lastHealthCheckTime;
+        private long? _clusteredSinceTimestamp;
+        private long? _lastHealthCheckTimestamp;
+        private LocalSiloHealthStatus _latestStatus;
 
         public LocalSiloHealthMonitor(
             IEnumerable<IHealthCheckParticipant> healthCheckParticipants,
@@ -81,89 +146,157 @@ namespace Orleans.Runtime.MembershipService
             _localSiloDetails = localSiloDetails;
             _log = log;
             _clusterMembershipOptions = clusterMembershipOptions.Value;
+            _timeProvider = timeProvider;
             _degradationCheckTimer = timerFactory.Create(
                 _clusterMembershipOptions.LocalHealthDegradationMonitoringPeriod,
                 nameof(LocalSiloHealthMonitor),
                 timeProvider);
-            _threadPoolMonitor = new ThreadPoolMonitor(loggerFactory.CreateLogger<ThreadPoolMonitor>());
+            _threadPoolMonitor = new ThreadPoolMonitor(loggerFactory.CreateLogger<ThreadPoolMonitor>(), timeProvider);
         }
 
         /// <inheritdoc />
-        public ImmutableArray<string> Complaints { get; private set; } = ImmutableArray<string>.Empty;
+        public ImmutableArray<string> Complaints { get; private set; } = [];
 
         /// <inheritdoc />
-        public int GetLocalHealthDegradationScore(DateTime checkTime) => GetLocalHealthDegradationScore(checkTime, null);
-
-        /// <summary>
-        /// Returns the local health degradation score, which is a value between 0 (healthy) and <see cref="MaxScore"/> (unhealthy).
-        /// </summary>
-        /// <param name="checkTime">The time which the check is taking place.</param>
-        /// <param name="complaints">If not null, will be populated with the current set of detected health issues.</param>
-        /// <returns>The local health degradation score, which is a value between 0 (healthy) and <see cref="MaxScore"/> (unhealthy).</returns>
-        public int GetLocalHealthDegradationScore(DateTime checkTime, List<string>? complaints)
+        /// <remarks>Periods longer than the one-minute retention window are limited to the retained history.</remarks>
+        public LocalSiloHealthStatus GetLocalHealthStatus(TimeSpan period, LocalSiloHealthCheckCategory categories)
         {
-            var score = 0;
-            score += CheckSuspectingNodes(checkTime, complaints);
-            score += CheckLocalHealthCheckParticipants(checkTime, complaints);
-            score += CheckThreadPoolQueueDelay(checkTime, complaints);
+            if (period < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(period), period, "The aggregation period must not be negative.");
+            }
+
+            DateTimeOffset now;
+            lock (_samplingLock)
+            {
+                EnsureHealthCheck(_timeProvider.GetUtcNow(), _timeProvider.GetTimestamp());
+                now = _timeProvider.GetUtcNow();
+            }
+
+            lock (_historyLock)
+            {
+                RemoveExpiredEvents(now);
+                var lookback = period > HistoryDuration ? HistoryDuration : period;
+                return AggregateHealthStatus(now - lookback, now, categories);
+            }
+        }
+
+        void ILocalSiloHealthEventRecorder.RecordHealthEvent(
+            LocalSiloHealthCheckKind kind,
+            int score,
+            string? complaint,
+            TimeSpan? duration,
+            string? source)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(score);
+            var now = _timeProvider.GetUtcNow();
+            lock (_historyLock)
+            {
+                _healthEvents.Add(new(now, kind, GetCategory(kind), source, score, complaint, duration));
+                RemoveExpiredEvents(now);
+            }
+        }
+
+        private LocalSiloHealthStatus EnsureHealthCheck(DateTimeOffset now, long timestamp)
+        {
+            if (_lastHealthCheckTimestamp is { } lastCheck
+                && _timeProvider.GetElapsedTime(lastCheck, timestamp) < MinimumCheckPeriod)
+            {
+                return _latestStatus;
+            }
+
+            var events = new List<LocalSiloHealthEvent>(_healthCheckParticipants.Count + 6);
+            var complaints = new List<string>();
+            CheckMembershipStatus(now.UtcDateTime, events, complaints);
+            CheckLocalHealthCheckParticipants(now, events, complaints);
+            CheckThreadPoolQueueDelay(now, events, complaints);
 
             if (_isActive)
             {
                 var membershipSnapshot = _membershipManager.CurrentSnapshot;
                 if (membershipSnapshot.ActiveNodeCount <= 1)
                 {
-                    _clusteredDuration.Reset();
+                    _clusteredSinceTimestamp = null;
                 }
-                else if (!_clusteredDuration.IsRunning)
+                else
                 {
-                    _clusteredDuration.Restart();
+                    _clusteredSinceTimestamp ??= timestamp;
                 }
 
                 // Only consider certain checks if the silo has been a member of a multi-silo cluster for a certain period.
                 var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
-                if (_clusteredDuration.Elapsed > recencyWindow)
+                if (_clusteredSinceTimestamp is { } clusteredSince
+                    && _timeProvider.GetElapsedTime(clusteredSince, timestamp) > recencyWindow)
                 {
-                    score += CheckReceivedProbeResponses(checkTime, complaints);
-                    score += CheckReceivedProbeRequests(checkTime, complaints);
+                    CheckReceivedProbeResponses(now, events, complaints);
+                    CheckReceivedProbeRequests(now, events, complaints);
                 }
             }
 
-            // Clamp the score between 0 and the maximum allowed score.
-            score = Math.Max(0, Math.Min(MaxScore, score));
-            return score;
-        }
-
-        private int CheckThreadPoolQueueDelay(DateTime checkTime, List<string>? complaints)
-        {
-            var threadPoolDelaySeconds = _threadPoolMonitor.MeasureQueueDelay().TotalSeconds;
-
-            if ((int)threadPoolDelaySeconds >= 1)
+            _lastHealthCheckTimestamp = _timeProvider.GetTimestamp();
+            lock (_historyLock)
             {
-                // Log as an error if the delay is massive.
-                var logLevel = (int)threadPoolDelaySeconds >= 10 ? LogLevel.Error : LogLevel.Warning;
-                LogThreadPoolDelay(logLevel, threadPoolDelaySeconds);
-
-                complaints?.Add(
-                    $".NET Thread Pool is exhibiting delays of {threadPoolDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.");
+                _healthEvents.AddRange(events);
+                RemoveExpiredEvents(now);
             }
 
-            // Each second of delay contributes to the score.
-            return (int)threadPoolDelaySeconds;
+            var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
+            Complaints = [.. complaints];
+            return _latestStatus = new(score, [.. events]);
         }
 
-        private int CheckSuspectingNodes(DateTime now, List<string>? complaints)
+        private void CheckThreadPoolQueueDelay(
+            DateTimeOffset now,
+            List<LocalSiloHealthEvent> events,
+            List<string> complaints)
         {
-            var score = 0;
+            var delay = _threadPoolMonitor.MeasureQueueDelay();
+            var score = (int)delay.TotalSeconds;
+            string? complaint = null;
+            if (score >= 1)
+            {
+                var logLevel = score >= 10 ? LogLevel.Error : LogLevel.Warning;
+                LogThreadPoolDelay(logLevel, delay.TotalSeconds);
+                complaint = $".NET Thread Pool is exhibiting delays of {delay.TotalSeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.";
+                complaints.Add(complaint);
+            }
+
+            events.Add(new(
+                now,
+                LocalSiloHealthCheckKind.ThreadPoolQueueDelay,
+                GetCategory(LocalSiloHealthCheckKind.ThreadPoolQueueDelay),
+                Source: null,
+                score,
+                complaint,
+                delay));
+        }
+
+        private void CheckMembershipStatus(
+            DateTime now,
+            List<LocalSiloHealthEvent> events,
+            List<string> complaints)
+        {
             var membershipSnapshot = _membershipManager.CurrentSnapshot;
             if (membershipSnapshot.Entries.TryGetValue(_localSiloDetails.SiloAddress, out var membershipEntry))
             {
+                var statusScore = 0;
+                string? statusComplaint = null;
                 if (membershipEntry.Status != SiloStatus.Active)
                 {
                     LogSiloNotActive(membershipEntry.Status);
-                    complaints?.Add($"This silo is not active (Status: {membershipEntry.Status}) and is therefore not healthy.");
-
-                    score = MaxScore;
+                    statusComplaint = $"This silo is not active (Status: {membershipEntry.Status}) and is therefore not healthy.";
+                    complaints.Add(statusComplaint);
+                    statusScore = MaxScore;
                 }
+
+                events.Add(new(
+                    now,
+                    LocalSiloHealthCheckKind.MembershipStatus,
+                    GetCategory(LocalSiloHealthCheckKind.MembershipStatus),
+                    Source: null,
+                    statusScore,
+                    statusComplaint,
+                    Duration: null));
 
                 // Check if there are valid votes against this node.
                 var expiration = _clusterMembershipOptions.DeathVoteExpirationTimeout;
@@ -173,76 +306,171 @@ namespace Orleans.Runtime.MembershipService
                     if (membershipSnapshot.GetSiloStatus(vote.Item1) == SiloStatus.Active)
                     {
                         LogSiloSuspected(vote.Item1, vote.Item2);
-                        complaints?.Add($"Silo {vote.Item1} recently suspected this silo is dead at {vote.Item2}.");
-
-                        ++score;
+                        var complaint = $"Silo {vote.Item1} recently suspected this silo is dead at {vote.Item2}.";
+                        complaints.Add(complaint);
+                        events.Add(new(
+                            now,
+                            LocalSiloHealthCheckKind.SiloSuspected,
+                            GetCategory(LocalSiloHealthCheckKind.SiloSuspected),
+                            vote.Item1.ToParsableString(),
+                            Score: 1,
+                            complaint,
+                            Duration: null));
                     }
                 }
             }
             else
             {
                 LogMembershipEntryNotFound();
-                complaints?.Add("Could not find a membership entry for this silo");
-
-                score = MaxScore;
+                const string Complaint = "Could not find a membership entry for this silo";
+                complaints.Add(Complaint);
+                events.Add(new(
+                    now,
+                    LocalSiloHealthCheckKind.MembershipStatus,
+                    GetCategory(LocalSiloHealthCheckKind.MembershipStatus),
+                    Source: null,
+                    Score: MaxScore,
+                    Complaint,
+                    Duration: null));
             }
-
-            return score;
         }
 
-        private int CheckReceivedProbeRequests(DateTime now, List<string>? complaints)
+        private void CheckReceivedProbeRequests(
+            DateTimeOffset now,
+            List<LocalSiloHealthEvent> events,
+            List<string> complaints)
         {
             var membershipSnapshot = _membershipManager.CurrentSnapshot;
-            var score = _probeHealthMonitor.CheckReceivedProbeRequests(now, membershipSnapshot.ActiveNodeCount, out var complaint);
+            var score = _probeHealthMonitor.CheckReceivedProbeRequests(now.UtcDateTime, membershipSnapshot.ActiveNodeCount, out var complaint);
             if (complaint is not null)
             {
-                complaints?.Add(complaint);
+                complaints.Add(complaint);
             }
 
-            return score;
+            events.Add(new(
+                now,
+                LocalSiloHealthCheckKind.ProbeRequests,
+                GetCategory(LocalSiloHealthCheckKind.ProbeRequests),
+                Source: null,
+                score,
+                complaint,
+                Duration: null));
         }
 
-        private int CheckReceivedProbeResponses(DateTime now, List<string>? complaints)
+        private void CheckReceivedProbeResponses(
+            DateTimeOffset now,
+            List<LocalSiloHealthEvent> events,
+            List<string> complaints)
         {
             var membershipSnapshot = _membershipManager.CurrentSnapshot;
             // Use ActiveNodeCount - 1 as a proxy for monitored node count (we don't monitor ourselves)
             var monitoredNodeCount = Math.Max(0, membershipSnapshot.ActiveNodeCount - 1);
-            var score = _probeHealthMonitor.CheckReceivedProbeResponses(now, monitoredNodeCount, out var complaint);
+            var score = _probeHealthMonitor.CheckReceivedProbeResponses(now.UtcDateTime, monitoredNodeCount, out var complaint);
             if (complaint is not null)
             {
-                complaints?.Add(complaint);
+                complaints.Add(complaint);
             }
 
-            return score;
+            events.Add(new(
+                now,
+                LocalSiloHealthCheckKind.ProbeResponses,
+                GetCategory(LocalSiloHealthCheckKind.ProbeResponses),
+                Source: null,
+                score,
+                complaint,
+                Duration: null));
         }
 
-        private int CheckLocalHealthCheckParticipants(DateTime now, List<string>? complaints)
+        private void CheckLocalHealthCheckParticipants(
+            DateTimeOffset now,
+            List<LocalSiloHealthEvent> events,
+            List<string> complaints)
         {
-            // Check for execution delays and other local health warning signs.
-            var score = 0;
-            foreach (var participant in _healthCheckParticipants)
+            for (var i = 0; i < _healthCheckParticipants.Count; i++)
             {
+                var participant = _healthCheckParticipants[i];
+                var score = 0;
+                string? complaint = null;
                 try
                 {
                     if (!participant.CheckHealth(_lastHealthCheckTime, out var reason))
                     {
                         LogHealthCheckParticipantUnhealthy(participant.GetType(), reason);
-                        complaints?.Add($"Health check participant {participant.GetType()} is reporting that it is unhealthy with complaint: {reason}");
-
-                        ++score;
+                        complaint = $"Health check participant {participant.GetType()} is reporting that it is unhealthy with complaint: {reason}";
+                        complaints.Add(complaint);
+                        score = 1;
                     }
                 }
                 catch (Exception exception)
                 {
                     LogHealthCheckParticipantError(exception, participant.GetType());
-                    complaints?.Add($"Error checking health for participant {participant.GetType()}: {LogFormatter.PrintException(exception)}");
-
-                    ++score;
+                    complaint = $"Error checking health for participant {participant.GetType()}: {LogFormatter.PrintException(exception)}";
+                    complaints.Add(complaint);
+                    score = 1;
                 }
+
+                events.Add(new(
+                    now,
+                    LocalSiloHealthCheckKind.HealthCheckParticipant,
+                    GetCategory(LocalSiloHealthCheckKind.HealthCheckParticipant),
+                    $"{participant.GetType().FullName}[{i}]",
+                    score,
+                    complaint,
+                    Duration: null));
             }
 
-            _lastHealthCheckTime = now;
-            return score;
+            _lastHealthCheckTime = now.UtcDateTime;
+        }
+
+        private LocalSiloHealthStatus AggregateHealthStatus(
+            DateTimeOffset start,
+            DateTimeOffset end,
+            LocalSiloHealthCheckCategory categories)
+        {
+            if (categories == LocalSiloHealthCheckCategory.None)
+            {
+                return new(0, []);
+            }
+
+            var events = _healthEvents
+                .Where(status => status.Timestamp >= start
+                    && status.Timestamp <= end
+                    && (status.Category & categories) != 0)
+                .GroupBy(static status => (status.Kind, status.Source))
+                .Select(static statuses => statuses
+                    .OrderByDescending(static status => status.Score)
+                    .ThenByDescending(static status => status.Timestamp)
+                    .First())
+                .OrderBy(static status => status.Kind)
+                .ThenBy(static status => status.Source, StringComparer.Ordinal)
+                .ToImmutableArray();
+            var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
+            return new(score, events);
+        }
+
+        private void RemoveExpiredEvents(DateTimeOffset now)
+        {
+            var oldestRetained = now - HistoryDuration;
+            _healthEvents.RemoveAll(status => status.Timestamp < oldestRetained);
+        }
+
+        private static LocalSiloHealthCheckCategory GetCategory(LocalSiloHealthCheckKind kind)
+            => kind switch
+            {
+                LocalSiloHealthCheckKind.MembershipStatus
+                    or LocalSiloHealthCheckKind.SiloSuspected
+                    or LocalSiloHealthCheckKind.ProbeRequests
+                    or LocalSiloHealthCheckKind.ProbeResponses => LocalSiloHealthCheckCategory.Network,
+                _ => LocalSiloHealthCheckCategory.Local,
+            };
+
+        private LocalSiloHealthStatus GetLatestHealthStatus()
+        {
+            var now = _timeProvider.GetUtcNow();
+            lock (_samplingLock)
+            {
+                return EnsureHealthCheck(now, _timeProvider.GetTimestamp());
+            }
         }
 
         private async Task Run()
@@ -251,16 +479,12 @@ namespace Orleans.Runtime.MembershipService
             {
                 try
                 {
-                    var complaints = new List<string>();
-                    var now = DateTime.UtcNow;
-                    var score = GetLocalHealthDegradationScore(now, complaints);
-                    if (score > 0)
+                    var status = GetLatestHealthStatus();
+                    if (status.Score > 0)
                     {
-                        var complaintsString = string.Join("\n", complaints);
-                        LogSelfMonitoringDegraded(score, MaxScore, complaintsString);
+                        var complaintsString = string.Join("\n", status.Complaints);
+                        LogSelfMonitoringDegraded(status.Score, MaxScore, complaintsString);
                     }
-
-                    this.Complaints = ImmutableArray.CreateRange(complaints);
                 }
                 catch (Exception exception)
                 {
@@ -304,13 +528,15 @@ namespace Orleans.Runtime.MembershipService
             private readonly object _lockObj = new();
 #endif
             private readonly ILogger<ThreadPoolMonitor> _log;
+            private readonly TimeProvider _timeProvider;
             private bool _scheduled;
             private TimeSpan _lastQueueDelay;
-            private ValueStopwatch _queueDelay;
+            private long _queueDelayTimestamp;
 
-            public ThreadPoolMonitor(ILogger<ThreadPoolMonitor> log)
+            public ThreadPoolMonitor(ILogger<ThreadPoolMonitor> log, TimeProvider timeProvider)
             {
                 _log = log;
+                _timeProvider = timeProvider;
             }
 
             public TimeSpan MeasureQueueDelay()
@@ -319,14 +545,14 @@ namespace Orleans.Runtime.MembershipService
                 TimeSpan delay;
                 lock (_lockObj)
                 {
-                    var currentQueueDelay = _queueDelay.Elapsed;
+                    var currentQueueDelay = _scheduled ? _timeProvider.GetElapsedTime(_queueDelayTimestamp) : TimeSpan.Zero;
                     delay = currentQueueDelay > _lastQueueDelay ? currentQueueDelay : _lastQueueDelay;
 
                     if (!_scheduled)
                     {
                         _scheduled = true;
                         shouldSchedule = true;
-                        _queueDelay.Restart();
+                        _queueDelayTimestamp = _timeProvider.GetTimestamp();
                     }
                     else
                     {
@@ -349,8 +575,7 @@ namespace Orleans.Runtime.MembershipService
                     lock (_lockObj)
                     {
                         _scheduled = false;
-                        _queueDelay.Stop();
-                        _lastQueueDelay = _queueDelay.Elapsed;
+                        _lastQueueDelay = _timeProvider.GetElapsedTime(_queueDelayTimestamp);
                     }
                 }
                 catch (Exception exception)

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -115,7 +115,7 @@ namespace Orleans.Runtime.MembershipService
         private static readonly TimeSpan HistoryDuration = TimeSpan.FromMinutes(1);
         private static readonly TimeSpan MinimumCheckPeriod = TimeSpan.FromSeconds(1);
         private readonly List<IHealthCheckParticipant> _healthCheckParticipants;
-        private readonly List<LocalSiloHealthEvent> _healthEvents = [];
+        private readonly LocalSiloHealthEventHistory _healthHistory;
         private readonly IMembershipManager _membershipManager;
         private readonly IProbeHealthMonitor _probeHealthMonitor;
         private readonly ILocalSiloDetails _localSiloDetails;
@@ -161,6 +161,7 @@ namespace Orleans.Runtime.MembershipService
             _log = log;
             _clusterMembershipOptions = clusterMembershipOptions.Value;
             _timeProvider = timeProvider;
+            _healthHistory = new(timeProvider, HistoryDuration, MinimumCheckPeriod);
             _degradationCheckTimer = timerFactory.Create(
                 MinimumCheckPeriod,
                 nameof(LocalSiloHealthMonitor),
@@ -200,8 +201,12 @@ namespace Orleans.Runtime.MembershipService
 
             lock (_historyLock)
             {
-                RemoveExpiredEvents(_timeProvider.GetTimestamp());
-                return AggregateHealthStatus(startTimestamp, endTimestamp, categories);
+                return _healthHistory.Aggregate(
+                    startTimestamp,
+                    endTimestamp,
+                    _timeProvider.GetTimestamp(),
+                    categories,
+                    MaxScore);
             }
         }
 
@@ -233,8 +238,7 @@ namespace Orleans.Runtime.MembershipService
             var timestamp = _timeProvider.GetTimestamp();
             lock (_historyLock)
             {
-                _healthEvents.Add(new(timestamp, kind, GetCategory(kind), source, score, complaint, duration));
-                RemoveExpiredEvents(timestamp);
+                _healthHistory.Add(new(timestamp, kind, GetCategory(kind), source, score, complaint, duration));
             }
         }
 
@@ -264,7 +268,7 @@ namespace Orleans.Runtime.MembershipService
                 CheckThreadPoolQueueDelay(timestamp, events, complaints);
                 AddEvents(timestamp, events);
 
-                var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
+                var score = GetScore(events);
                 Complaints = [.. complaints];
                 localStatus = _latestStatus = new(score, [.. events]);
                 Interlocked.Increment(ref _healthCheckVersion);
@@ -332,7 +336,7 @@ namespace Orleans.Runtime.MembershipService
             }
 
             AddEvents(timestamp, events);
-            var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
+            var score = GetScore(events);
             var result = _latestNetworkStatus = new(score, [.. events]);
             Interlocked.Increment(ref _networkHealthCheckVersion);
             return result;
@@ -342,8 +346,7 @@ namespace Orleans.Runtime.MembershipService
         {
             lock (_historyLock)
             {
-                _healthEvents.AddRange(events);
-                RemoveExpiredEvents(timestamp);
+                _healthHistory.AddRange(events, timestamp);
             }
         }
 
@@ -526,69 +529,6 @@ namespace Orleans.Runtime.MembershipService
             _lastHealthCheckTime = now;
         }
 
-        private LocalSiloHealthStatus AggregateHealthStatus(
-            long startTimestamp,
-            long endTimestamp,
-            LocalSiloHealthCheckCategory categories)
-        {
-            if (categories == LocalSiloHealthCheckCategory.None)
-            {
-                return new(0, []);
-            }
-
-            var intervalEvents = _healthEvents
-                .Where(status => Overlaps(status, startTimestamp, endTimestamp)
-                    && (status.Category & categories) != 0)
-                .ToList();
-            var stateAtStart = _healthEvents
-                .Where(status => status.Timestamp < startTimestamp
-                    && (status.Category & categories) != 0
-                    && IsStateful(status.Kind))
-                .GroupBy(static status => (status.Kind, status.Source))
-                .Select(static statuses => statuses.MaxBy(static status => status.Timestamp))
-                .Where(status => !intervalEvents.Any(candidate =>
-                    candidate.Timestamp == startTimestamp
-                    && candidate.Kind == status.Kind
-                    && candidate.Source == status.Source));
-            var events = intervalEvents
-                .Concat(stateAtStart)
-                .GroupBy(static status => (status.Kind, status.Source))
-                .Select(static statuses => statuses
-                    .OrderByDescending(static status => status.Score)
-                    .ThenByDescending(static status => status.Timestamp)
-                    .First())
-                .OrderBy(static status => status.Kind)
-                .ThenBy(static status => status.Source, StringComparer.Ordinal)
-                .ToImmutableArray();
-            var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
-            return new(score, events);
-
-            bool Overlaps(LocalSiloHealthEvent status, long start, long end)
-            {
-                if (status.Timestamp < start)
-                {
-                    return false;
-                }
-
-                return status.Timestamp <= end
-                    || status.Duration is { } duration
-                        && duration > TimeSpan.Zero
-                        && _timeProvider.GetElapsedTime(end, status.Timestamp) <= duration;
-            }
-
-            static bool IsStateful(LocalSiloHealthCheckKind kind)
-                => kind is LocalSiloHealthCheckKind.MembershipStatus
-                    or LocalSiloHealthCheckKind.HealthCheckParticipant
-                    or LocalSiloHealthCheckKind.ThreadPoolQueueDelay
-                    or LocalSiloHealthCheckKind.ProbeRequests
-                    or LocalSiloHealthCheckKind.ProbeResponses;
-        }
-
-        private void RemoveExpiredEvents(long now)
-        {
-            _healthEvents.RemoveAll(status => _timeProvider.GetElapsedTime(status.Timestamp, now) > HistoryDuration);
-        }
-
         private long SubtractTimestamp(long timestamp, TimeSpan duration)
             => timestamp - (long)(duration.TotalSeconds * _timeProvider.TimestampFrequency);
 
@@ -601,6 +541,17 @@ namespace Orleans.Runtime.MembershipService
                     or LocalSiloHealthCheckKind.ProbeResponses => LocalSiloHealthCheckCategory.Network,
                 _ => LocalSiloHealthCheckCategory.Local,
             };
+
+        private static int GetScore(List<LocalSiloHealthEvent> events)
+        {
+            var score = 0;
+            foreach (var healthEvent in events)
+            {
+                score = (int)Math.Min(MaxScore, (long)score + healthEvent.Score);
+            }
+
+            return score;
+        }
 
         private async Task Run()
         {

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -42,7 +42,8 @@ namespace Orleans.Runtime.MembershipService
         string? Source,
         int Score,
         string? Complaint,
-        TimeSpan? Duration);
+        TimeSpan? Duration,
+        LogLevel LogLevel = LogLevel.Warning);
 
     internal readonly record struct LocalSiloHealthStatus(int Score, ImmutableArray<LocalSiloHealthEvent> Events)
     {
@@ -53,12 +54,16 @@ namespace Orleans.Runtime.MembershipService
     internal interface ILocalSiloHealthMonitor
     {
         /// <summary>
-        /// Returns the aggregate local health status over the provided period.
+        /// Returns the aggregate local health status over the provided interval.
         /// </summary>
-        /// <param name="period">The period ending at the current time to aggregate.</param>
+        /// <param name="start">The inclusive start of the interval to aggregate.</param>
+        /// <param name="end">The inclusive end of the interval to aggregate.</param>
         /// <param name="categories">The categories of health checks to include.</param>
         /// <returns>The aggregate health status.</returns>
-        LocalSiloHealthStatus GetLocalHealthStatus(TimeSpan period, LocalSiloHealthCheckCategory categories);
+        LocalSiloHealthStatus GetLocalHealthStatus(
+            DateTimeOffset start,
+            DateTimeOffset end,
+            LocalSiloHealthCheckCategory categories);
 
         /// <summary>
         /// The most recent list of detected health issues.
@@ -127,7 +132,12 @@ namespace Orleans.Runtime.MembershipService
         private DateTime _lastHealthCheckTime;
         private long? _clusteredSinceTimestamp;
         private long? _lastHealthCheckTimestamp;
+        private long? _lastNetworkHealthCheckTimestamp;
+        private long? _lastDegradationLogTimestamp;
+        private int _healthCheckVersion;
+        private int _networkHealthCheckVersion;
         private LocalSiloHealthStatus _latestStatus;
+        private LocalSiloHealthStatus _latestNetworkStatus;
 
         public LocalSiloHealthMonitor(
             IEnumerable<IHealthCheckParticipant> healthCheckParticipants,
@@ -148,7 +158,7 @@ namespace Orleans.Runtime.MembershipService
             _clusterMembershipOptions = clusterMembershipOptions.Value;
             _timeProvider = timeProvider;
             _degradationCheckTimer = timerFactory.Create(
-                _clusterMembershipOptions.LocalHealthDegradationMonitoringPeriod,
+                MinimumCheckPeriod,
                 nameof(LocalSiloHealthMonitor),
                 timeProvider);
             _threadPoolMonitor = new ThreadPoolMonitor(loggerFactory.CreateLogger<ThreadPoolMonitor>(), timeProvider);
@@ -158,27 +168,48 @@ namespace Orleans.Runtime.MembershipService
         public ImmutableArray<string> Complaints { get; private set; } = [];
 
         /// <inheritdoc />
-        /// <remarks>Periods longer than the one-minute retention window are limited to the retained history.</remarks>
-        public LocalSiloHealthStatus GetLocalHealthStatus(TimeSpan period, LocalSiloHealthCheckCategory categories)
+        public LocalSiloHealthStatus GetLocalHealthStatus(
+            DateTimeOffset start,
+            DateTimeOffset end,
+            LocalSiloHealthCheckCategory categories)
+        {
+            if (end < start)
+            {
+                throw new ArgumentOutOfRangeException(nameof(end), end, "The interval end must not precede its start.");
+            }
+
+            var healthCheckVersion = Volatile.Read(ref _healthCheckVersion);
+            var networkHealthCheckVersion = Volatile.Read(ref _networkHealthCheckVersion);
+            lock (_samplingLock)
+            {
+                EnsureHealthCheck(
+                    end,
+                    _timeProvider.GetTimestamp(),
+                    includeNetworkChecks: (categories & LocalSiloHealthCheckCategory.Network) != 0,
+                    healthCheckVersion,
+                    networkHealthCheckVersion,
+                    out _);
+            }
+
+            lock (_historyLock)
+            {
+                RemoveExpiredEvents(_timeProvider.GetUtcNow());
+                return AggregateHealthStatus(start, end, categories);
+            }
+        }
+
+        internal LocalSiloHealthStatus GetLocalHealthStatus(
+            TimeSpan period,
+            LocalSiloHealthCheckCategory categories)
         {
             if (period < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(period), period, "The aggregation period must not be negative.");
             }
 
-            DateTimeOffset now;
-            lock (_samplingLock)
-            {
-                EnsureHealthCheck(_timeProvider.GetUtcNow(), _timeProvider.GetTimestamp());
-                now = _timeProvider.GetUtcNow();
-            }
-
-            lock (_historyLock)
-            {
-                RemoveExpiredEvents(now);
-                var lookback = period > HistoryDuration ? HistoryDuration : period;
-                return AggregateHealthStatus(now - lookback, now, categories);
-            }
+            var end = _timeProvider.GetUtcNow();
+            var lookback = period > HistoryDuration ? HistoryDuration : period;
+            return GetLocalHealthStatus(end - lookback, end, categories);
         }
 
         void ILocalSiloHealthEventRecorder.RecordHealthEvent(
@@ -197,19 +228,76 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        private LocalSiloHealthStatus EnsureHealthCheck(DateTimeOffset now, long timestamp)
+        private LocalSiloHealthStatus EnsureHealthCheck(
+            DateTimeOffset now,
+            long timestamp,
+            bool includeNetworkChecks,
+            int healthCheckVersion,
+            int networkHealthCheckVersion,
+            out bool sampled)
         {
-            if (_lastHealthCheckTimestamp is { } lastCheck
-                && _timeProvider.GetElapsedTime(lastCheck, timestamp) < MinimumCheckPeriod)
+            LocalSiloHealthStatus localStatus;
+            var sampledLocalHealth = false;
+            if (Volatile.Read(ref _healthCheckVersion) != healthCheckVersion
+                || (_lastHealthCheckTimestamp is { } lastCheck
+                    && _timeProvider.GetElapsedTime(lastCheck, timestamp) < MinimumCheckPeriod))
             {
-                return _latestStatus;
+                localStatus = _latestStatus;
+            }
+            else
+            {
+                sampledLocalHealth = true;
+                _lastHealthCheckTimestamp = timestamp;
+                var events = new List<LocalSiloHealthEvent>(_healthCheckParticipants.Count + 1);
+                var complaints = new List<string>();
+                CheckLocalHealthCheckParticipants(now, events, complaints);
+                CheckThreadPoolQueueDelay(now, events, complaints);
+                AddEvents(now, events);
+
+                var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
+                Complaints = [.. complaints];
+                localStatus = _latestStatus = new(score, [.. events]);
+                Interlocked.Increment(ref _healthCheckVersion);
             }
 
-            var events = new List<LocalSiloHealthEvent>(_healthCheckParticipants.Count + 6);
+            if (!includeNetworkChecks)
+            {
+                sampled = sampledLocalHealth;
+                return localStatus;
+            }
+
+            var networkStatus = EnsureNetworkHealthCheck(
+                now,
+                timestamp,
+                networkHealthCheckVersion,
+                out var sampledNetworkHealth);
+            sampled = sampledLocalHealth || sampledNetworkHealth;
+            var combined = new LocalSiloHealthStatus(
+                Math.Clamp(localStatus.Score + networkStatus.Score, 0, MaxScore),
+                [.. localStatus.Events, .. networkStatus.Events]);
+            Complaints = combined.Complaints;
+            return combined;
+        }
+
+        private LocalSiloHealthStatus EnsureNetworkHealthCheck(
+            DateTimeOffset now,
+            long timestamp,
+            int networkHealthCheckVersion,
+            out bool sampled)
+        {
+            if (Volatile.Read(ref _networkHealthCheckVersion) != networkHealthCheckVersion
+                || (_lastNetworkHealthCheckTimestamp is { } lastCheck
+                    && _timeProvider.GetElapsedTime(lastCheck, timestamp) < MinimumCheckPeriod))
+            {
+                sampled = false;
+                return _latestNetworkStatus;
+            }
+
+            sampled = true;
+            _lastNetworkHealthCheckTimestamp = timestamp;
+            var events = new List<LocalSiloHealthEvent>(4);
             var complaints = new List<string>();
             CheckMembershipStatus(now.UtcDateTime, events, complaints);
-            CheckLocalHealthCheckParticipants(now, events, complaints);
-            CheckThreadPoolQueueDelay(now, events, complaints);
 
             if (_isActive)
             {
@@ -233,16 +321,20 @@ namespace Orleans.Runtime.MembershipService
                 }
             }
 
-            _lastHealthCheckTimestamp = _timeProvider.GetTimestamp();
+            AddEvents(now, events);
+            var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
+            var result = _latestNetworkStatus = new(score, [.. events]);
+            Interlocked.Increment(ref _networkHealthCheckVersion);
+            return result;
+        }
+
+        private void AddEvents(DateTimeOffset now, List<LocalSiloHealthEvent> events)
+        {
             lock (_historyLock)
             {
                 _healthEvents.AddRange(events);
                 RemoveExpiredEvents(now);
             }
-
-            var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
-            Complaints = [.. complaints];
-            return _latestStatus = new(score, [.. events]);
         }
 
         private void CheckThreadPoolQueueDelay(
@@ -255,8 +347,6 @@ namespace Orleans.Runtime.MembershipService
             string? complaint = null;
             if (score >= 1)
             {
-                var logLevel = score >= 10 ? LogLevel.Error : LogLevel.Warning;
-                LogThreadPoolDelay(logLevel, delay.TotalSeconds);
                 complaint = $".NET Thread Pool is exhibiting delays of {delay.TotalSeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses.";
                 complaints.Add(complaint);
             }
@@ -268,7 +358,8 @@ namespace Orleans.Runtime.MembershipService
                 Source: null,
                 score,
                 complaint,
-                delay));
+                delay,
+                score >= 10 ? LogLevel.Error : LogLevel.Warning));
         }
 
         private void CheckMembershipStatus(
@@ -283,7 +374,6 @@ namespace Orleans.Runtime.MembershipService
                 string? statusComplaint = null;
                 if (membershipEntry.Status != SiloStatus.Active)
                 {
-                    LogSiloNotActive(membershipEntry.Status);
                     statusComplaint = $"This silo is not active (Status: {membershipEntry.Status}) and is therefore not healthy.";
                     complaints.Add(statusComplaint);
                     statusScore = MaxScore;
@@ -305,7 +395,6 @@ namespace Orleans.Runtime.MembershipService
                 {
                     if (membershipSnapshot.GetSiloStatus(vote.Item1) == SiloStatus.Active)
                     {
-                        LogSiloSuspected(vote.Item1, vote.Item2);
                         var complaint = $"Silo {vote.Item1} recently suspected this silo is dead at {vote.Item2}.";
                         complaints.Add(complaint);
                         events.Add(new(
@@ -321,7 +410,6 @@ namespace Orleans.Runtime.MembershipService
             }
             else
             {
-                LogMembershipEntryNotFound();
                 const string Complaint = "Could not find a membership entry for this silo";
                 complaints.Add(Complaint);
                 events.Add(new(
@@ -331,7 +419,8 @@ namespace Orleans.Runtime.MembershipService
                     Source: null,
                     Score: MaxScore,
                     Complaint,
-                    Duration: null));
+                    Duration: null,
+                    LogLevel: LogLevel.Error));
             }
         }
 
@@ -390,12 +479,12 @@ namespace Orleans.Runtime.MembershipService
             {
                 var participant = _healthCheckParticipants[i];
                 var score = 0;
+                var logLevel = LogLevel.Warning;
                 string? complaint = null;
                 try
                 {
                     if (!participant.CheckHealth(_lastHealthCheckTime, out var reason))
                     {
-                        LogHealthCheckParticipantUnhealthy(participant.GetType(), reason);
                         complaint = $"Health check participant {participant.GetType()} is reporting that it is unhealthy with complaint: {reason}";
                         complaints.Add(complaint);
                         score = 1;
@@ -403,7 +492,7 @@ namespace Orleans.Runtime.MembershipService
                 }
                 catch (Exception exception)
                 {
-                    LogHealthCheckParticipantError(exception, participant.GetType());
+                    logLevel = LogLevel.Error;
                     complaint = $"Error checking health for participant {participant.GetType()}: {LogFormatter.PrintException(exception)}";
                     complaints.Add(complaint);
                     score = 1;
@@ -416,7 +505,8 @@ namespace Orleans.Runtime.MembershipService
                     $"{participant.GetType().FullName}[{i}]",
                     score,
                     complaint,
-                    Duration: null));
+                    Duration: null,
+                    LogLevel: logLevel));
             }
 
             _lastHealthCheckTime = now.UtcDateTime;
@@ -432,10 +522,22 @@ namespace Orleans.Runtime.MembershipService
                 return new(0, []);
             }
 
-            var events = _healthEvents
-                .Where(status => status.Timestamp >= start
-                    && status.Timestamp <= end
+            var intervalEvents = _healthEvents
+                .Where(status => Overlaps(status, start, end)
                     && (status.Category & categories) != 0)
+                .ToList();
+            var stateAtStart = _healthEvents
+                .Where(status => status.Timestamp < start
+                    && (status.Category & categories) != 0
+                    && IsStateful(status.Kind))
+                .GroupBy(static status => (status.Kind, status.Source))
+                .Select(static statuses => statuses.MaxBy(static status => status.Timestamp))
+                .Where(status => !intervalEvents.Any(candidate =>
+                    candidate.Timestamp == start
+                    && candidate.Kind == status.Kind
+                    && candidate.Source == status.Source));
+            var events = intervalEvents
+                .Concat(stateAtStart)
                 .GroupBy(static status => (status.Kind, status.Source))
                 .Select(static statuses => statuses
                     .OrderByDescending(static status => status.Score)
@@ -446,6 +548,21 @@ namespace Orleans.Runtime.MembershipService
                 .ToImmutableArray();
             var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
             return new(score, events);
+
+            static bool Overlaps(LocalSiloHealthEvent status, DateTimeOffset start, DateTimeOffset end)
+            {
+                var eventStart = status.Duration is { } duration && duration > TimeSpan.Zero
+                    ? status.Timestamp - duration
+                    : status.Timestamp;
+                return eventStart <= end && status.Timestamp >= start;
+            }
+
+            static bool IsStateful(LocalSiloHealthCheckKind kind)
+                => kind is LocalSiloHealthCheckKind.MembershipStatus
+                    or LocalSiloHealthCheckKind.HealthCheckParticipant
+                    or LocalSiloHealthCheckKind.ThreadPoolQueueDelay
+                    or LocalSiloHealthCheckKind.ProbeRequests
+                    or LocalSiloHealthCheckKind.ProbeResponses;
         }
 
         private void RemoveExpiredEvents(DateTimeOffset now)
@@ -464,24 +581,31 @@ namespace Orleans.Runtime.MembershipService
                 _ => LocalSiloHealthCheckCategory.Local,
             };
 
-        private LocalSiloHealthStatus GetLatestHealthStatus()
-        {
-            var now = _timeProvider.GetUtcNow();
-            lock (_samplingLock)
-            {
-                return EnsureHealthCheck(now, _timeProvider.GetTimestamp());
-            }
-        }
-
         private async Task Run()
         {
             while (await _degradationCheckTimer.NextTick())
             {
                 try
                 {
-                    var status = GetLatestHealthStatus();
-                    if (status.Score > 0)
+                    var logDegradation = CanLogDegradation();
+                    LocalSiloHealthStatus status;
+                    var healthCheckVersion = Volatile.Read(ref _healthCheckVersion);
+                    var networkHealthCheckVersion = Volatile.Read(ref _networkHealthCheckVersion);
+                    lock (_samplingLock)
                     {
+                        status = EnsureHealthCheck(
+                            _timeProvider.GetUtcNow(),
+                            _timeProvider.GetTimestamp(),
+                            includeNetworkChecks: logDegradation,
+                            healthCheckVersion,
+                            networkHealthCheckVersion,
+                            out _);
+                    }
+
+                    if (status.Score > 0 && logDegradation)
+                    {
+                        _lastDegradationLogTimestamp = _timeProvider.GetTimestamp();
+                        LogHealthDetails(status.Events);
                         var complaintsString = string.Join("\n", status.Complaints);
                         LogSelfMonitoringDegraded(status.Score, MaxScore, complaintsString);
                     }
@@ -489,6 +613,38 @@ namespace Orleans.Runtime.MembershipService
                 catch (Exception exception)
                 {
                     LogErrorMonitoringLocalSiloHealth(exception);
+                }
+            }
+
+            bool CanLogDegradation()
+            {
+                var now = _timeProvider.GetTimestamp();
+                if (_lastDegradationLogTimestamp is not { } lastLog
+                    || _timeProvider.GetElapsedTime(lastLog, now) >= _clusterMembershipOptions.LocalHealthDegradationMonitoringPeriod)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        private void LogHealthDetails(ImmutableArray<LocalSiloHealthEvent> events)
+        {
+            foreach (var healthEvent in events)
+            {
+                if (healthEvent.Score <= 0 || healthEvent.Complaint is not { } complaint)
+                {
+                    continue;
+                }
+
+                if (healthEvent.Kind == LocalSiloHealthCheckKind.ThreadPoolQueueDelay)
+                {
+                    LogThreadPoolDelay(healthEvent.LogLevel, healthEvent.Duration?.TotalSeconds ?? 0);
+                }
+                else
+                {
+                    LogRecordedHealthIssue(healthEvent.LogLevel, healthEvent.Kind, healthEvent.Source, complaint);
                 }
             }
         }
@@ -589,6 +745,15 @@ namespace Orleans.Runtime.MembershipService
             Message = ".NET Thread Pool is exhibiting delays of {ThreadPoolQueueDelaySeconds}s. This can indicate .NET Thread Pool starvation, very long .NET GC pauses, or other runtime or machine pauses."
         )]
         private partial void LogThreadPoolDelay(LogLevel logLevel, double threadPoolQueueDelaySeconds);
+
+        [LoggerMessage(
+            Message = "{Kind} health check for {Source} reported: {Complaint}"
+        )]
+        private partial void LogRecordedHealthIssue(
+            LogLevel logLevel,
+            LocalSiloHealthCheckKind kind,
+            string? source,
+            string complaint);
 
         [LoggerMessage(
             Level = LogLevel.Warning,

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -36,7 +36,7 @@ namespace Orleans.Runtime.MembershipService
     }
 
     internal readonly record struct LocalSiloHealthEvent(
-        DateTimeOffset Timestamp,
+        long Timestamp,
         LocalSiloHealthCheckKind Kind,
         LocalSiloHealthCheckCategory Category,
         string? Source,
@@ -56,13 +56,17 @@ namespace Orleans.Runtime.MembershipService
         /// <summary>
         /// Returns the aggregate local health status over the provided interval.
         /// </summary>
-        /// <param name="start">The inclusive start of the interval to aggregate.</param>
-        /// <param name="end">The inclusive end of the interval to aggregate.</param>
+        /// <param name="startTimestamp">The inclusive start of the interval to aggregate.</param>
+        /// <param name="endTimestamp">The inclusive end of the interval to aggregate.</param>
         /// <param name="categories">The categories of health checks to include.</param>
         /// <returns>The aggregate health status.</returns>
         LocalSiloHealthStatus GetLocalHealthStatus(
-            DateTimeOffset start,
-            DateTimeOffset end,
+            long startTimestamp,
+            long endTimestamp,
+            LocalSiloHealthCheckCategory categories);
+
+        LocalSiloHealthStatus GetLocalHealthStatus(
+            TimeSpan period,
             LocalSiloHealthCheckCategory categories);
 
         /// <summary>
@@ -169,13 +173,16 @@ namespace Orleans.Runtime.MembershipService
 
         /// <inheritdoc />
         public LocalSiloHealthStatus GetLocalHealthStatus(
-            DateTimeOffset start,
-            DateTimeOffset end,
+            long startTimestamp,
+            long endTimestamp,
             LocalSiloHealthCheckCategory categories)
         {
-            if (end < start)
+            if (endTimestamp < startTimestamp)
             {
-                throw new ArgumentOutOfRangeException(nameof(end), end, "The interval end must not precede its start.");
+                throw new ArgumentOutOfRangeException(
+                    nameof(endTimestamp),
+                    endTimestamp,
+                    "The interval end must not precede its start.");
             }
 
             var healthCheckVersion = Volatile.Read(ref _healthCheckVersion);
@@ -183,8 +190,8 @@ namespace Orleans.Runtime.MembershipService
             lock (_samplingLock)
             {
                 EnsureHealthCheck(
-                    end,
-                    _timeProvider.GetTimestamp(),
+                    _timeProvider.GetUtcNow(),
+                    endTimestamp,
                     includeNetworkChecks: (categories & LocalSiloHealthCheckCategory.Network) != 0,
                     healthCheckVersion,
                     networkHealthCheckVersion,
@@ -193,12 +200,12 @@ namespace Orleans.Runtime.MembershipService
 
             lock (_historyLock)
             {
-                RemoveExpiredEvents(_timeProvider.GetUtcNow());
-                return AggregateHealthStatus(start, end, categories);
+                RemoveExpiredEvents(_timeProvider.GetTimestamp());
+                return AggregateHealthStatus(startTimestamp, endTimestamp, categories);
             }
         }
 
-        internal LocalSiloHealthStatus GetLocalHealthStatus(
+        public LocalSiloHealthStatus GetLocalHealthStatus(
             TimeSpan period,
             LocalSiloHealthCheckCategory categories)
         {
@@ -207,9 +214,12 @@ namespace Orleans.Runtime.MembershipService
                 throw new ArgumentOutOfRangeException(nameof(period), period, "The aggregation period must not be negative.");
             }
 
-            var end = _timeProvider.GetUtcNow();
+            var endTimestamp = _timeProvider.GetTimestamp();
             var lookback = period > HistoryDuration ? HistoryDuration : period;
-            return GetLocalHealthStatus(end - lookback, end, categories);
+            return GetLocalHealthStatus(
+                SubtractTimestamp(endTimestamp, lookback),
+                endTimestamp,
+                categories);
         }
 
         void ILocalSiloHealthEventRecorder.RecordHealthEvent(
@@ -220,11 +230,11 @@ namespace Orleans.Runtime.MembershipService
             string? source)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(score);
-            var now = _timeProvider.GetUtcNow();
+            var timestamp = _timeProvider.GetTimestamp();
             lock (_historyLock)
             {
-                _healthEvents.Add(new(now, kind, GetCategory(kind), source, score, complaint, duration));
-                RemoveExpiredEvents(now);
+                _healthEvents.Add(new(timestamp, kind, GetCategory(kind), source, score, complaint, duration));
+                RemoveExpiredEvents(timestamp);
             }
         }
 
@@ -250,9 +260,9 @@ namespace Orleans.Runtime.MembershipService
                 _lastHealthCheckTimestamp = timestamp;
                 var events = new List<LocalSiloHealthEvent>(_healthCheckParticipants.Count + 1);
                 var complaints = new List<string>();
-                CheckLocalHealthCheckParticipants(now, events, complaints);
-                CheckThreadPoolQueueDelay(now, events, complaints);
-                AddEvents(now, events);
+                CheckLocalHealthCheckParticipants(now.UtcDateTime, timestamp, events, complaints);
+                CheckThreadPoolQueueDelay(timestamp, events, complaints);
+                AddEvents(timestamp, events);
 
                 var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
                 Complaints = [.. complaints];
@@ -297,7 +307,7 @@ namespace Orleans.Runtime.MembershipService
             _lastNetworkHealthCheckTimestamp = timestamp;
             var events = new List<LocalSiloHealthEvent>(4);
             var complaints = new List<string>();
-            CheckMembershipStatus(now.UtcDateTime, events, complaints);
+            CheckMembershipStatus(now.UtcDateTime, timestamp, events, complaints);
 
             if (_isActive)
             {
@@ -316,29 +326,29 @@ namespace Orleans.Runtime.MembershipService
                 if (_clusteredSinceTimestamp is { } clusteredSince
                     && _timeProvider.GetElapsedTime(clusteredSince, timestamp) > recencyWindow)
                 {
-                    CheckReceivedProbeResponses(now, events, complaints);
-                    CheckReceivedProbeRequests(now, events, complaints);
+                    CheckReceivedProbeResponses(now.UtcDateTime, timestamp, events, complaints);
+                    CheckReceivedProbeRequests(now.UtcDateTime, timestamp, events, complaints);
                 }
             }
 
-            AddEvents(now, events);
+            AddEvents(timestamp, events);
             var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
             var result = _latestNetworkStatus = new(score, [.. events]);
             Interlocked.Increment(ref _networkHealthCheckVersion);
             return result;
         }
 
-        private void AddEvents(DateTimeOffset now, List<LocalSiloHealthEvent> events)
+        private void AddEvents(long timestamp, List<LocalSiloHealthEvent> events)
         {
             lock (_historyLock)
             {
                 _healthEvents.AddRange(events);
-                RemoveExpiredEvents(now);
+                RemoveExpiredEvents(timestamp);
             }
         }
 
         private void CheckThreadPoolQueueDelay(
-            DateTimeOffset now,
+            long timestamp,
             List<LocalSiloHealthEvent> events,
             List<string> complaints)
         {
@@ -352,7 +362,7 @@ namespace Orleans.Runtime.MembershipService
             }
 
             events.Add(new(
-                now,
+                timestamp,
                 LocalSiloHealthCheckKind.ThreadPoolQueueDelay,
                 GetCategory(LocalSiloHealthCheckKind.ThreadPoolQueueDelay),
                 Source: null,
@@ -364,6 +374,7 @@ namespace Orleans.Runtime.MembershipService
 
         private void CheckMembershipStatus(
             DateTime now,
+            long timestamp,
             List<LocalSiloHealthEvent> events,
             List<string> complaints)
         {
@@ -380,7 +391,7 @@ namespace Orleans.Runtime.MembershipService
                 }
 
                 events.Add(new(
-                    now,
+                    timestamp,
                     LocalSiloHealthCheckKind.MembershipStatus,
                     GetCategory(LocalSiloHealthCheckKind.MembershipStatus),
                     Source: null,
@@ -398,7 +409,7 @@ namespace Orleans.Runtime.MembershipService
                         var complaint = $"Silo {vote.Item1} recently suspected this silo is dead at {vote.Item2}.";
                         complaints.Add(complaint);
                         events.Add(new(
-                            now,
+                            timestamp,
                             LocalSiloHealthCheckKind.SiloSuspected,
                             GetCategory(LocalSiloHealthCheckKind.SiloSuspected),
                             vote.Item1.ToParsableString(),
@@ -413,7 +424,7 @@ namespace Orleans.Runtime.MembershipService
                 const string Complaint = "Could not find a membership entry for this silo";
                 complaints.Add(Complaint);
                 events.Add(new(
-                    now,
+                    timestamp,
                     LocalSiloHealthCheckKind.MembershipStatus,
                     GetCategory(LocalSiloHealthCheckKind.MembershipStatus),
                     Source: null,
@@ -425,19 +436,20 @@ namespace Orleans.Runtime.MembershipService
         }
 
         private void CheckReceivedProbeRequests(
-            DateTimeOffset now,
+            DateTime now,
+            long timestamp,
             List<LocalSiloHealthEvent> events,
             List<string> complaints)
         {
             var membershipSnapshot = _membershipManager.CurrentSnapshot;
-            var score = _probeHealthMonitor.CheckReceivedProbeRequests(now.UtcDateTime, membershipSnapshot.ActiveNodeCount, out var complaint);
+            var score = _probeHealthMonitor.CheckReceivedProbeRequests(now, membershipSnapshot.ActiveNodeCount, out var complaint);
             if (complaint is not null)
             {
                 complaints.Add(complaint);
             }
 
             events.Add(new(
-                now,
+                timestamp,
                 LocalSiloHealthCheckKind.ProbeRequests,
                 GetCategory(LocalSiloHealthCheckKind.ProbeRequests),
                 Source: null,
@@ -447,21 +459,22 @@ namespace Orleans.Runtime.MembershipService
         }
 
         private void CheckReceivedProbeResponses(
-            DateTimeOffset now,
+            DateTime now,
+            long timestamp,
             List<LocalSiloHealthEvent> events,
             List<string> complaints)
         {
             var membershipSnapshot = _membershipManager.CurrentSnapshot;
             // Use ActiveNodeCount - 1 as a proxy for monitored node count (we don't monitor ourselves)
             var monitoredNodeCount = Math.Max(0, membershipSnapshot.ActiveNodeCount - 1);
-            var score = _probeHealthMonitor.CheckReceivedProbeResponses(now.UtcDateTime, monitoredNodeCount, out var complaint);
+            var score = _probeHealthMonitor.CheckReceivedProbeResponses(now, monitoredNodeCount, out var complaint);
             if (complaint is not null)
             {
                 complaints.Add(complaint);
             }
 
             events.Add(new(
-                now,
+                timestamp,
                 LocalSiloHealthCheckKind.ProbeResponses,
                 GetCategory(LocalSiloHealthCheckKind.ProbeResponses),
                 Source: null,
@@ -471,7 +484,8 @@ namespace Orleans.Runtime.MembershipService
         }
 
         private void CheckLocalHealthCheckParticipants(
-            DateTimeOffset now,
+            DateTime now,
+            long timestamp,
             List<LocalSiloHealthEvent> events,
             List<string> complaints)
         {
@@ -499,7 +513,7 @@ namespace Orleans.Runtime.MembershipService
                 }
 
                 events.Add(new(
-                    now,
+                    timestamp,
                     LocalSiloHealthCheckKind.HealthCheckParticipant,
                     GetCategory(LocalSiloHealthCheckKind.HealthCheckParticipant),
                     $"{participant.GetType().FullName}[{i}]",
@@ -509,12 +523,12 @@ namespace Orleans.Runtime.MembershipService
                     LogLevel: logLevel));
             }
 
-            _lastHealthCheckTime = now.UtcDateTime;
+            _lastHealthCheckTime = now;
         }
 
         private LocalSiloHealthStatus AggregateHealthStatus(
-            DateTimeOffset start,
-            DateTimeOffset end,
+            long startTimestamp,
+            long endTimestamp,
             LocalSiloHealthCheckCategory categories)
         {
             if (categories == LocalSiloHealthCheckCategory.None)
@@ -523,17 +537,17 @@ namespace Orleans.Runtime.MembershipService
             }
 
             var intervalEvents = _healthEvents
-                .Where(status => Overlaps(status, start, end)
+                .Where(status => Overlaps(status, startTimestamp, endTimestamp)
                     && (status.Category & categories) != 0)
                 .ToList();
             var stateAtStart = _healthEvents
-                .Where(status => status.Timestamp < start
+                .Where(status => status.Timestamp < startTimestamp
                     && (status.Category & categories) != 0
                     && IsStateful(status.Kind))
                 .GroupBy(static status => (status.Kind, status.Source))
                 .Select(static statuses => statuses.MaxBy(static status => status.Timestamp))
                 .Where(status => !intervalEvents.Any(candidate =>
-                    candidate.Timestamp == start
+                    candidate.Timestamp == startTimestamp
                     && candidate.Kind == status.Kind
                     && candidate.Source == status.Source));
             var events = intervalEvents
@@ -549,12 +563,17 @@ namespace Orleans.Runtime.MembershipService
             var score = Math.Clamp(events.Sum(static status => status.Score), 0, MaxScore);
             return new(score, events);
 
-            static bool Overlaps(LocalSiloHealthEvent status, DateTimeOffset start, DateTimeOffset end)
+            bool Overlaps(LocalSiloHealthEvent status, long start, long end)
             {
-                var eventStart = status.Duration is { } duration && duration > TimeSpan.Zero
-                    ? status.Timestamp - duration
-                    : status.Timestamp;
-                return eventStart <= end && status.Timestamp >= start;
+                if (status.Timestamp < start)
+                {
+                    return false;
+                }
+
+                return status.Timestamp <= end
+                    || status.Duration is { } duration
+                        && duration > TimeSpan.Zero
+                        && _timeProvider.GetElapsedTime(end, status.Timestamp) <= duration;
             }
 
             static bool IsStateful(LocalSiloHealthCheckKind kind)
@@ -565,11 +584,13 @@ namespace Orleans.Runtime.MembershipService
                     or LocalSiloHealthCheckKind.ProbeResponses;
         }
 
-        private void RemoveExpiredEvents(DateTimeOffset now)
+        private void RemoveExpiredEvents(long now)
         {
-            var oldestRetained = now - HistoryDuration;
-            _healthEvents.RemoveAll(status => status.Timestamp < oldestRetained);
+            _healthEvents.RemoveAll(status => _timeProvider.GetElapsedTime(status.Timestamp, now) > HistoryDuration);
         }
+
+        private long SubtractTimestamp(long timestamp, TimeSpan duration)
+            => timestamp - (long)(duration.TotalSeconds * _timeProvider.TimestampFrequency);
 
         private static LocalSiloHealthCheckCategory GetCategory(LocalSiloHealthCheckKind kind)
             => kind switch

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -81,11 +81,10 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber)
         {
-            IndirectProbeResponse result;
-            var healthScore = this.ActivationServices.GetRequiredService<ILocalSiloHealthMonitor>()
-                .GetLocalHealthStatus(probeTimeout, LocalSiloHealthCheckCategory.Local)
-                .Score;
+            var probeStartTime = _timeProvider.GetUtcNow();
             var probeResponseTimestamp = _timeProvider.GetTimestamp();
+            var succeeded = false;
+            string? failureMessage = null;
             try
             {
                 var probeTask = this.ProbeInternal(target, probeNumber);
@@ -99,25 +98,25 @@ namespace Orleans.Runtime.MembershipService
                     throw;
                 }
 
-                result = new IndirectProbeResponse
-                {
-                    Succeeded = true,
-                    IntermediaryHealthScore = healthScore,
-                    ProbeResponseTime = _timeProvider.GetElapsedTime(probeResponseTimestamp),
-                };
+                succeeded = true;
             }
             catch (Exception exception)
             {
-                result = new IndirectProbeResponse
-                {
-                    Succeeded = false,
-                    IntermediaryHealthScore = healthScore,
-                    FailureMessage = $"Encountered exception {LogFormatter.PrintException(exception)}",
-                    ProbeResponseTime = _timeProvider.GetElapsedTime(probeResponseTimestamp),
-                };
+                failureMessage = $"Encountered exception {LogFormatter.PrintException(exception)}";
             }
 
-            return result;
+            var probeResponseTime = _timeProvider.GetElapsedTime(probeResponseTimestamp);
+            var probeEndTime = probeStartTime + probeResponseTime;
+            var healthScore = this.ActivationServices.GetRequiredService<ILocalSiloHealthMonitor>()
+                .GetLocalHealthStatus(probeStartTime, probeEndTime, LocalSiloHealthCheckCategory.Local)
+                .Score;
+            return new IndirectProbeResponse
+            {
+                Succeeded = succeeded,
+                IntermediaryHealthScore = healthScore,
+                FailureMessage = failureMessage,
+                ProbeResponseTime = probeResponseTime,
+            };
         }
 
         public Task GossipToRemoteSilos(

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -14,19 +14,22 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILogger<MembershipSystemTarget> log;
         private readonly IInternalGrainFactory grainFactory;
         private readonly MessagingInstruments _messagingInstruments;
+        private readonly TimeProvider _timeProvider;
 
         public MembershipSystemTarget(
             IMembershipManager membershipManager,
             ILogger<MembershipSystemTarget> log,
             IInternalGrainFactory grainFactory,
             MessagingInstruments messagingInstruments,
-            SystemTargetShared shared)
+            SystemTargetShared shared,
+            [FromKeyedServices(TimeProviderNames.Membership)] TimeProvider timeProvider)
             : base(Constants.MembershipServiceType, shared)
         {
             this.membershipManager = membershipManager;
             this.log = log;
             this.grainFactory = grainFactory;
             _messagingInstruments = messagingInstruments;
+            _timeProvider = timeProvider;
             shared.ActivationDirectory.RecordNewTarget(this);
         }
 
@@ -79,14 +82,16 @@ namespace Orleans.Runtime.MembershipService
         public async Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber)
         {
             IndirectProbeResponse result;
-            var healthScore = this.ActivationServices.GetRequiredService<LocalSiloHealthMonitor>().GetLocalHealthDegradationScore(DateTime.UtcNow);
-            var probeResponseTimer = ValueStopwatch.StartNew();
+            var healthScore = this.ActivationServices.GetRequiredService<ILocalSiloHealthMonitor>()
+                .GetLocalHealthStatus(probeTimeout, LocalSiloHealthCheckCategory.Local)
+                .Score;
+            var probeResponseTimestamp = _timeProvider.GetTimestamp();
             try
             {
                 var probeTask = this.ProbeInternal(target, probeNumber);
                 try
                 {
-                    await probeTask.WaitAsync(probeTimeout);
+                    await probeTask.WaitAsync(probeTimeout, _timeProvider);
                 }
                 catch (TimeoutException exception)
                 {
@@ -98,7 +103,7 @@ namespace Orleans.Runtime.MembershipService
                 {
                     Succeeded = true,
                     IntermediaryHealthScore = healthScore,
-                    ProbeResponseTime = probeResponseTimer.Elapsed,
+                    ProbeResponseTime = _timeProvider.GetElapsedTime(probeResponseTimestamp),
                 };
             }
             catch (Exception exception)
@@ -108,7 +113,7 @@ namespace Orleans.Runtime.MembershipService
                     Succeeded = false,
                     IntermediaryHealthScore = healthScore,
                     FailureMessage = $"Encountered exception {LogFormatter.PrintException(exception)}",
-                    ProbeResponseTime = probeResponseTimer.Elapsed,
+                    ProbeResponseTime = _timeProvider.GetElapsedTime(probeResponseTimestamp),
                 };
             }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -81,8 +81,7 @@ namespace Orleans.Runtime.MembershipService
 
         public async Task<IndirectProbeResponse> ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber)
         {
-            var probeStartTime = _timeProvider.GetUtcNow();
-            var probeResponseTimestamp = _timeProvider.GetTimestamp();
+            var probeTimer = TimeProviderValueStopwatch.StartNew(_timeProvider);
             var succeeded = false;
             string? failureMessage = null;
             try
@@ -105,10 +104,9 @@ namespace Orleans.Runtime.MembershipService
                 failureMessage = $"Encountered exception {LogFormatter.PrintException(exception)}";
             }
 
-            var probeResponseTime = _timeProvider.GetElapsedTime(probeResponseTimestamp);
-            var probeEndTime = probeStartTime + probeResponseTime;
+            var probeResponseTime = probeTimer.GetElapsedTime(out var probeEndTimestamp);
             var healthScore = this.ActivationServices.GetRequiredService<ILocalSiloHealthMonitor>()
-                .GetLocalHealthStatus(probeStartTime, probeEndTime, LocalSiloHealthCheckCategory.Local)
+                .GetLocalHealthStatus(probeTimer.StartTimestamp, probeEndTimestamp, LocalSiloHealthCheckCategory.Local)
                 .Score;
             return new IndirectProbeResponse
             {

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -27,6 +27,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly IMembershipManager _membershipService;
         private readonly MessagingInstruments? _messagingInstruments;
         private readonly ILocalSiloDetails _localSiloDetails;
+        private readonly TimeProvider _timeProvider;
         private readonly CancellationTokenSource _stoppingCancellation = new();
 #if NET9_0_OR_GREATER
         private readonly Lock _lockObj = new();
@@ -34,7 +35,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly object _lockObj = new();
 #endif
         private readonly IAsyncTimer _pingTimer;
-        private ValueStopwatch _elapsedSinceLastSuccessfulResponse;
+        private long? _lastSuccessfulResponseTimestamp;
         private readonly Func<SiloHealthMonitor, ProbeResult, Task> _onProbeResult;
         private Task? _runTask;
 
@@ -51,7 +52,8 @@ namespace Orleans.Runtime.MembershipService
         /// <summary>
         /// The time since the last ping response was received from either the node being monitored or an intermediary.
         /// </summary>
-        public TimeSpan? ElapsedSinceLastResponse => _elapsedSinceLastSuccessfulResponse.IsRunning ? (TimeSpan?)_elapsedSinceLastSuccessfulResponse.Elapsed : null;
+        public TimeSpan? ElapsedSinceLastResponse
+            => _lastSuccessfulResponseTimestamp is { } timestamp ? _timeProvider.GetElapsedTime(timestamp) : null;
 
         /// <summary>
         /// The duration of time measured from just prior to sending the last probe which received a response until just after receiving and processing the response.
@@ -78,13 +80,14 @@ namespace Orleans.Runtime.MembershipService
             _membershipService = membershipService;
             _messagingInstruments = messagingInstruments;
             _localSiloDetails = localSiloDetails;
+            _timeProvider = timeProvider;
             _log = loggerFactory.CreateLogger<SiloHealthMonitor>();
             _pingTimer = asyncTimerFactory.Create(
                 _clusterMembershipOptions.CurrentValue.ProbeTimeout,
                 nameof(SiloHealthMonitor),
                 timeProvider);
             _onProbeResult = onProbeResult;
-            _elapsedSinceLastSuccessfulResponse = ValueStopwatch.StartNew();
+            _lastSuccessfulResponseTimestamp = _timeProvider.GetTimestamp();
         }
 
         internal interface ITestAccessor
@@ -172,7 +175,7 @@ namespace Orleans.Runtime.MembershipService
             {
                 ProbeResult probeResult;
                 overrideDelay = default;
-                var now = DateTime.UtcNow;
+                var now = _timeProvider.GetUtcNow().UtcDateTime;
 
                 try
                 {
@@ -192,7 +195,7 @@ namespace Orleans.Runtime.MembershipService
 
                     var isDirectProbe = !options.EnableIndirectProbes || _failedProbes < options.NumMissedProbesLimit - 1 || otherNodes.Length == 0;
                     var timeout = GetTimeout(isDirectProbe);
-                    using var cancellation = new CancellationTokenSource(timeout);
+                    using var cancellation = new CancellationTokenSource(timeout, _timeProvider);
 
                     if (isDirectProbe)
                     {
@@ -237,8 +240,10 @@ namespace Orleans.Runtime.MembershipService
                 if (options.ExtendProbeTimeoutDuringDegradation)
                 {
                     // Attempt to account for local health degradation by extending the timeout period.
-                    var localDegradationScore = _localSiloHealthMonitor.GetLocalHealthDegradationScore(DateTime.UtcNow);
-                    additionalTimeout += localDegradationScore;
+                    var localHealth = _localSiloHealthMonitor.GetLocalHealthStatus(
+                        options.ProbeTimeout,
+                        LocalSiloHealthCheckCategory.Local);
+                    additionalTimeout += localHealth.Score;
                 }
 
                 if (!isDirectProbe)
@@ -268,7 +273,7 @@ namespace Orleans.Runtime.MembershipService
             var id = ++_nextProbeId;
             LogTraceGoingToSendPing(_log, id, TargetSiloAddress);
 
-            var roundTripTimer = ValueStopwatch.StartNew();
+            var roundTripTimestamp = _timeProvider.GetTimestamp();
             ProbeResult probeResult;
             Exception? failureException;
             try
@@ -278,26 +283,25 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (OperationCanceledException exception)
             {
-                failureException = new OperationCanceledException($"The ping attempt was cancelled after {roundTripTimer.Elapsed}. Ping #{id}", exception);
+                failureException = new OperationCanceledException(
+                    $"The ping attempt was cancelled after {_timeProvider.GetElapsedTime(roundTripTimestamp)}. Ping #{id}",
+                    exception);
             }
             catch (Exception exception)
             {
                 failureException = exception;
             }
-            finally
-            {
-                roundTripTimer.Stop();
-            }
+            var roundTripTime = _timeProvider.GetElapsedTime(roundTripTimestamp);
 
             if (failureException is null)
             {
                 _messagingInstruments?.OnPingReplyReceived(TargetSiloAddress);
 
-                LogTraceGotSuccessfulPingResponse(_log, id, TargetSiloAddress, roundTripTimer.Elapsed);
+                LogTraceGotSuccessfulPingResponse(_log, id, TargetSiloAddress, roundTripTime);
 
                 _failedProbes = 0;
-                _elapsedSinceLastSuccessfulResponse.Restart();
-                LastRoundTripTime = roundTripTimer.Elapsed;
+                _lastSuccessfulResponseTimestamp = _timeProvider.GetTimestamp();
+                LastRoundTripTime = roundTripTime;
                 probeResult = ProbeResult.CreateDirect(0, ProbeResultStatus.Succeeded);
             }
             else
@@ -305,7 +309,7 @@ namespace Orleans.Runtime.MembershipService
                 _messagingInstruments?.OnPingReplyMissed(TargetSiloAddress);
 
                 var failedProbes = ++_failedProbes;
-                LogWarningDidNotGetResponseForProbe(_log, failureException, id, TargetSiloAddress, roundTripTimer.Elapsed, failedProbes);
+                LogWarningDidNotGetResponseForProbe(_log, failureException, id, TargetSiloAddress, roundTripTime, failedProbes);
 
                 probeResult = ProbeResult.CreateDirect(failedProbes, ProbeResultStatus.Failed);
             }
@@ -325,22 +329,22 @@ namespace Orleans.Runtime.MembershipService
             var id = ++_nextProbeId;
             LogTraceGoingToSendIndirectPing(_log, id, TargetSiloAddress, intermediary);
 
-            var roundTripTimer = ValueStopwatch.StartNew();
+            var roundTripTimestamp = _timeProvider.GetTimestamp();
             ProbeResult probeResult;
             try
             {
                 using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, _stoppingCancellation.Token);
                 var indirectResult = await _prober.ProbeIndirectly(intermediary, TargetSiloAddress, directProbeTimeout, id, cancellationSource.Token).WaitAsync(cancellationSource.Token);
-                roundTripTimer.Stop();
-                var roundTripTime = roundTripTimer.Elapsed - indirectResult.ProbeResponseTime;
+                var elapsed = _timeProvider.GetElapsedTime(roundTripTimestamp);
+                var roundTripTime = elapsed - indirectResult.ProbeResponseTime;
 
                 // Record timing regardless of the result.
-                _elapsedSinceLastSuccessfulResponse.Restart();
+                _lastSuccessfulResponseTimestamp = _timeProvider.GetTimestamp();
                 LastRoundTripTime = roundTripTime;
 
                 if (indirectResult.Succeeded)
                 {
-                    LogInformationIndirectProbeSucceeded(_log, id, TargetSiloAddress, intermediary, roundTripTimer.Elapsed, indirectResult.ProbeResponseTime);
+                    LogInformationIndirectProbeSucceeded(_log, id, TargetSiloAddress, intermediary, elapsed, indirectResult.ProbeResponseTime);
 
                     _messagingInstruments?.OnPingReplyReceived(TargetSiloAddress);
 
@@ -358,7 +362,7 @@ namespace Orleans.Runtime.MembershipService
                     }
                     else
                     {
-                        LogWarningIndirectProbeFailed(_log, id, TargetSiloAddress, intermediary, roundTripTimer.Elapsed, indirectResult.ProbeResponseTime, indirectResult.FailureMessage, indirectResult.IntermediaryHealthScore);
+                        LogWarningIndirectProbeFailed(_log, id, TargetSiloAddress, intermediary, elapsed, indirectResult.ProbeResponseTime, indirectResult.FailureMessage, indirectResult.IntermediaryHealthScore);
 
                         var missed = ++_failedProbes;
                         probeResult = ProbeResult.CreateIndirect(missed, ProbeResultStatus.Failed, indirectResult, intermediary);

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -241,10 +241,8 @@ namespace Orleans.Runtime.MembershipService
                 {
                     // This query must happen before the probe because its result determines the probe timeout.
                     // Outcome-reporting health checks, such as an intermediary's health score, run after probing.
-                    var end = _timeProvider.GetUtcNow();
                     var localHealth = _localSiloHealthMonitor.GetLocalHealthStatus(
-                        end - options.ProbeTimeout,
-                        end,
+                        options.ProbeTimeout,
                         LocalSiloHealthCheckCategory.Local);
                     additionalTimeout += localHealth.Score;
                 }
@@ -276,7 +274,7 @@ namespace Orleans.Runtime.MembershipService
             var id = ++_nextProbeId;
             LogTraceGoingToSendPing(_log, id, TargetSiloAddress);
 
-            var roundTripTimestamp = _timeProvider.GetTimestamp();
+            var roundTripTimer = TimeProviderValueStopwatch.StartNew(_timeProvider);
             ProbeResult probeResult;
             Exception? failureException;
             try
@@ -287,14 +285,14 @@ namespace Orleans.Runtime.MembershipService
             catch (OperationCanceledException exception)
             {
                 failureException = new OperationCanceledException(
-                    $"The ping attempt was cancelled after {_timeProvider.GetElapsedTime(roundTripTimestamp)}. Ping #{id}",
+                    $"The ping attempt was cancelled after {roundTripTimer.GetElapsedTime(out _)}. Ping #{id}",
                     exception);
             }
             catch (Exception exception)
             {
                 failureException = exception;
             }
-            var roundTripTime = _timeProvider.GetElapsedTime(roundTripTimestamp);
+            var roundTripTime = roundTripTimer.GetElapsedTime(out _);
 
             if (failureException is null)
             {
@@ -332,13 +330,13 @@ namespace Orleans.Runtime.MembershipService
             var id = ++_nextProbeId;
             LogTraceGoingToSendIndirectPing(_log, id, TargetSiloAddress, intermediary);
 
-            var roundTripTimestamp = _timeProvider.GetTimestamp();
+            var roundTripTimer = TimeProviderValueStopwatch.StartNew(_timeProvider);
             ProbeResult probeResult;
             try
             {
                 using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation, _stoppingCancellation.Token);
                 var indirectResult = await _prober.ProbeIndirectly(intermediary, TargetSiloAddress, directProbeTimeout, id, cancellationSource.Token).WaitAsync(cancellationSource.Token);
-                var elapsed = _timeProvider.GetElapsedTime(roundTripTimestamp);
+                var elapsed = roundTripTimer.GetElapsedTime(out _);
                 var roundTripTime = elapsed - indirectResult.ProbeResponseTime;
 
                 // Record timing regardless of the result.

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -239,9 +239,12 @@ namespace Orleans.Runtime.MembershipService
 
                 if (options.ExtendProbeTimeoutDuringDegradation)
                 {
-                    // Attempt to account for local health degradation by extending the timeout period.
+                    // This query must happen before the probe because its result determines the probe timeout.
+                    // Outcome-reporting health checks, such as an intermediary's health score, run after probing.
+                    var end = _timeProvider.GetUtcNow();
                     var localHealth = _localSiloHealthMonitor.GetLocalHealthStatus(
-                        options.ProbeTimeout,
+                        end - options.ProbeTimeout,
+                        end,
                         LocalSiloHealthCheckCategory.Local);
                     additionalTimeout += localHealth.Score;
                 }

--- a/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
+++ b/src/Orleans.Runtime/Networking/ProbeRequestMonitor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans.Runtime.Messaging
 {
@@ -13,7 +14,13 @@ namespace Orleans.Runtime.Messaging
 #else
         private readonly object _lock = new();
 #endif
-        private ValueStopwatch _probeRequestStopwatch;
+        private readonly TimeProvider _timeProvider;
+        private long? _lastProbeRequestTimestamp;
+
+        public ProbeRequestMonitor([FromKeyedServices(TimeProviderNames.Membership)] TimeProvider timeProvider)
+        {
+            _timeProvider = timeProvider;
+        }
 
         /// <summary>
         /// Called when this silo receives a health probe request.
@@ -22,13 +29,22 @@ namespace Orleans.Runtime.Messaging
         {
             lock (_lock)
             {
-                _probeRequestStopwatch.Restart();
+                _lastProbeRequestTimestamp = _timeProvider.GetTimestamp();
             }
         }
 
         /// <summary>
         /// The duration which has elapsed since the most recently received health probe request.
         /// </summary>
-        public TimeSpan? ElapsedSinceLastProbeRequest => _probeRequestStopwatch.IsRunning ? (Nullable<TimeSpan>)_probeRequestStopwatch.Elapsed : null;
+        public TimeSpan? ElapsedSinceLastProbeRequest
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _lastProbeRequestTimestamp is { } timestamp ? _timeProvider.GetElapsedTime(timestamp) : null;
+                }
+            }
+        }
     }
 }

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -4,9 +4,11 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Runtime.MembershipService;
 
 namespace Orleans.Runtime
 {
@@ -17,7 +19,9 @@ namespace Orleans.Runtime
         IOptions<ClusterMembershipOptions> clusterMembershipOptions,
         IEnumerable<IHealthCheckParticipant> participants,
         ILogger<Watchdog> logger,
-        OrleansInstruments orleansInstruments) : IDisposable
+        OrleansInstruments orleansInstruments,
+        ILocalSiloHealthEventRecorder healthEventRecorder,
+        [FromKeyedServices(TimeProviderNames.Membership)] TimeProvider timeProvider) : IDisposable
     {
         private static readonly TimeSpan PlatformWatchdogHeartbeatPeriod = TimeSpan.FromMilliseconds(1000);
         private readonly CancellationTokenSource _cancellation = new();
@@ -25,8 +29,10 @@ namespace Orleans.Runtime
         private readonly List<IHealthCheckParticipant> _participants = participants.ToList();
         private readonly ILogger _logger = logger;
         private readonly WatchdogInstruments _watchdogInstruments = new(orleansInstruments);
-        private ValueStopwatch _platformWatchdogStopwatch;
-        private ValueStopwatch _componentWatchdogStopwatch;
+        private readonly ILocalSiloHealthEventRecorder _healthEventRecorder = healthEventRecorder;
+        private readonly TimeProvider _timeProvider = timeProvider;
+        private long _platformWatchdogTimestamp;
+        private long _componentWatchdogTimestamp;
 
         // GC pause duration since process start.
         private TimeSpan _cumulativeGCPauseDuration;
@@ -44,8 +50,7 @@ namespace Orleans.Runtime
                 throw new InvalidOperationException("Watchdog.Start may not be called more than once");
             }
 
-            var now = DateTime.UtcNow;
-            _platformWatchdogStopwatch = ValueStopwatch.StartNew();
+            _platformWatchdogTimestamp = _timeProvider.GetTimestamp();
             _cumulativeGCPauseDuration = GC.GetTotalPauseDuration();
 
             _platformWatchdogThread = new Thread(RunPlatformWatchdog)
@@ -55,8 +60,8 @@ namespace Orleans.Runtime
             };
             _platformWatchdogThread.Start();
 
-            _componentWatchdogStopwatch = ValueStopwatch.StartNew();
-            _lastComponentHealthCheckTime = DateTime.UtcNow;
+            _componentWatchdogTimestamp = _timeProvider.GetTimestamp();
+            _lastComponentHealthCheckTime = _timeProvider.GetUtcNow().UtcDateTime;
 
             _componentWatchdogThread = new Thread(RunComponentWatchdog)
             {
@@ -87,7 +92,7 @@ namespace Orleans.Runtime
                     LogErrorPlatformWatchdogInternalError(_logger, exc);
                 }
 
-                _platformWatchdogStopwatch.Restart();
+                _platformWatchdogTimestamp = _timeProvider.GetTimestamp();
                 _cumulativeGCPauseDuration = GC.GetTotalPauseDuration();
                 _cancellation.Token.WaitHandle.WaitOne(PlatformWatchdogHeartbeatPeriod);
             }
@@ -101,16 +106,35 @@ namespace Orleans.Runtime
             }
 
             var pauseDurationSinceLastTick = GC.GetTotalPauseDuration() - _cumulativeGCPauseDuration;
-            var timeSinceLastTick = _platformWatchdogStopwatch.Elapsed;
+            var timeSinceLastTick = _timeProvider.GetElapsedTime(_platformWatchdogTimestamp);
+            if (pauseDurationSinceLastTick > TimeSpan.Zero)
+            {
+                _healthEventRecorder.RecordHealthEvent(
+                    LocalSiloHealthCheckKind.GarbageCollectionPause,
+                    score: 0,
+                    complaint: $"The .NET runtime paused for garbage collection for {pauseDurationSinceLastTick}.",
+                    duration: pauseDurationSinceLastTick);
+            }
+
             if (timeSinceLastTick > PlatformWatchdogHeartbeatPeriod.Multiply(2))
             {
                 var gc = new[] { GC.CollectionCount(0), GC.CollectionCount(1), GC.CollectionCount(2) };
+                _healthEventRecorder.RecordHealthEvent(
+                    LocalSiloHealthCheckKind.RuntimeStall,
+                    score: 1,
+                    complaint: $".NET Runtime Platform stalled for {timeSinceLastTick}. Memory: {GC.GetTotalMemory(false) / (1024 * 1024)}MB. Collection counts: 0: {gc[0]}, 1: {gc[1]}, 2: {gc[2]}.",
+                    duration: timeSinceLastTick);
                 LogWarningSiloHeartbeatTimerStalled(_logger, timeSinceLastTick, pauseDurationSinceLastTick, GC.GetTotalMemory(false) / (1024 * 1024), gc[0], gc[1], gc[2]);
             }
 
-            var timeSinceLastParticipantCheck = _componentWatchdogStopwatch.Elapsed;
+            var timeSinceLastParticipantCheck = _timeProvider.GetElapsedTime(_componentWatchdogTimestamp);
             if (timeSinceLastParticipantCheck > _componentHealthCheckPeriod.Multiply(2))
             {
+                _healthEventRecorder.RecordHealthEvent(
+                    LocalSiloHealthCheckKind.ComponentHealthCheckStall,
+                    score: 1,
+                    complaint: $"Participant check thread has not completed for {timeSinceLastParticipantCheck}.",
+                    duration: timeSinceLastParticipantCheck);
                 LogWarningParticipantCheckThreadStalled(_logger, timeSinceLastParticipantCheck);
             }
         }
@@ -128,7 +152,7 @@ namespace Orleans.Runtime
                     LogErrorComponentHealthCheckInternalError(_logger, exc);
                 }
 
-                _componentWatchdogStopwatch.Restart();
+                _componentWatchdogTimestamp = _timeProvider.GetTimestamp();
                 _cancellation.Token.WaitHandle.WaitOne(_componentHealthCheckPeriod);
             }
         }
@@ -140,7 +164,7 @@ namespace Orleans.Runtime
             StringBuilder? complaints = null;
 
             // Restart the timer before the check to reduce false positives for the stall checker.
-            _componentWatchdogStopwatch.Restart();
+            _componentWatchdogTimestamp = _timeProvider.GetTimestamp();
             foreach (var participant in _participants)
             {
                 try
@@ -170,7 +194,7 @@ namespace Orleans.Runtime
                 LogWarningHealthCheckFailure(_logger, numFailedChecks, _participants.Count, complaints);
             }
 
-            _lastComponentHealthCheckTime = DateTime.UtcNow;
+            _lastComponentHealthCheckTime = _timeProvider.GetUtcNow().UtcDateTime;
         }
 
         public void Dispose()

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -1,8 +1,11 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Threading.Channels;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using NonSilo.Tests.Utilities;
 using NSubstitute;
 using Orleans.Configuration;
@@ -76,7 +79,7 @@ namespace NonSilo.Tests.Membership
                 });
 
             this.localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
-            this.localSiloHealthMonitor.GetLocalHealthDegradationScore(default).ReturnsForAnyArgs(0);
+            this.localSiloHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
 
             this.prober = Substitute.For<IRemoteSiloProber>();
             this.membershipTable = new InMemoryMembershipTable(new TableVersion(1, "1"));
@@ -859,7 +862,8 @@ namespace NonSilo.Tests.Membership
                 optionsMonitor,
                 this.fatalErrorHandler,
                 null!,
-                connManager);
+                connManager,
+                TimeProvider.System);
 
             ((ILifecycleParticipant<ISiloLifecycle>)monitor).Participate(this.lifecycle);
 
@@ -926,6 +930,158 @@ namespace NonSilo.Tests.Membership
             protected override void OnSendMessageFailure(Message message, string error) { }
             protected override void RetryMessage(Message msg, Exception? ex = null) { }
             public void SimulateMessageReceived() => MarkMessageReceived();
+        }
+
+        [Fact]
+        public async Task ClusterHealthMonitor_StaleJoinEvictionUsesInjectedTimeProvider()
+        {
+            var start = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+            var maxJoinAttemptTime = TimeSpan.FromMinutes(5);
+            var timeProvider = new FakeTimeProvider(start);
+            var updates = new ControlledMembershipUpdateStream();
+            var manager = Substitute.For<IMembershipManager>();
+            manager.CurrentSnapshot.Returns(new MembershipTableSnapshot(
+                MembershipVersion.MinValue,
+                ImmutableDictionary<SiloAddress, MembershipEntry>.Empty));
+            manager.MembershipUpdates.Returns(updates);
+            manager.TrySuspectSilo(default!, default, default).ReturnsForAnyArgs(true);
+            var options = new ClusterMembershipOptions
+            {
+                EvictWhenMaxJoinAttemptTimeExceeded = true,
+                MaxJoinAttemptTime = maxJoinAttemptTime,
+            };
+            var optionsMonitor = Substitute.For<IOptionsMonitor<ClusterMembershipOptions>>();
+            optionsMonitor.CurrentValue.Returns(options);
+            var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
+            using var services = new ServiceCollection().BuildServiceProvider();
+            await using var monitor = new ClusterHealthMonitor(
+                this.localSiloDetails,
+                manager,
+                this.loggerFactory.CreateLogger<ClusterHealthMonitor>(),
+                optionsMonitor,
+                this.fatalErrorHandler,
+                services,
+                this.connectionManager,
+                timeProvider);
+            ((ILifecycleParticipant<ISiloLifecycle>)monitor).Participate(lifecycle);
+            var accessor = (ClusterHealthMonitor.ITestAccessor)monitor;
+            var joiningSilo = Silo("127.0.0.200:111@100");
+            var joiningEntry = Entry(joiningSilo, SiloStatus.Joining, start);
+
+            await lifecycle.OnStart();
+            try
+            {
+                await updates.WaitForReadAsync(1);
+                timeProvider.Advance(maxJoinAttemptTime);
+                updates.Publish(CreateSnapshot(1, joiningEntry));
+                await updates.WaitForReadAsync(2);
+
+                Assert.Equal(new MembershipVersion(1), accessor.ObservedVersion);
+                await manager.DidNotReceive().TrySuspectSilo(
+                    Arg.Any<SiloAddress>(),
+                    Arg.Any<SiloAddress?>(),
+                    Arg.Any<CancellationToken>());
+
+                timeProvider.Advance(TimeSpan.FromTicks(1));
+                updates.Publish(CreateSnapshot(2, joiningEntry));
+                await updates.WaitForReadAsync(3);
+
+                Assert.Equal(new MembershipVersion(2), accessor.ObservedVersion);
+                await manager.Received(1).TrySuspectSilo(
+                    joiningSilo,
+                    null,
+                    Arg.Is<CancellationToken>(token => token.CanBeCanceled && !token.IsCancellationRequested));
+            }
+            finally
+            {
+                var stopTask = lifecycle.OnStop();
+                updates.Complete();
+                await stopTask;
+                await updates.Completed;
+            }
+
+            static MembershipTableSnapshot CreateSnapshot(long version, MembershipEntry joiningEntry)
+                => new(
+                    new MembershipVersion(version),
+                    ImmutableDictionary<SiloAddress, MembershipEntry>.Empty.Add(joiningEntry.SiloAddress, joiningEntry));
+        }
+
+        private sealed class ControlledMembershipUpdateStream : IAsyncEnumerable<MembershipTableSnapshot>
+        {
+            private readonly Channel<MembershipTableSnapshot> _updates = Channel.CreateUnbounded<MembershipTableSnapshot>();
+            private readonly Dictionary<int, TaskCompletionSource> _readWaiters = [];
+            private readonly TaskCompletionSource _completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly object _lock = new();
+            private int _readCount;
+
+            public Task Completed => _completed.Task;
+
+            public void Publish(MembershipTableSnapshot snapshot) => Assert.True(_updates.Writer.TryWrite(snapshot));
+
+            public void Complete() => _updates.Writer.TryComplete();
+
+            public Task WaitForReadAsync(int readCount)
+            {
+                lock (_lock)
+                {
+                    if (_readCount >= readCount)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    if (!_readWaiters.TryGetValue(readCount, out var waiter))
+                    {
+                        waiter = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                        _readWaiters.Add(readCount, waiter);
+                    }
+
+                    return waiter.Task;
+                }
+            }
+
+            public IAsyncEnumerator<MembershipTableSnapshot> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+                => new Enumerator(this, _updates.Reader, cancellationToken);
+
+            private void OnReadStarted()
+            {
+                TaskCompletionSource? waiter;
+                lock (_lock)
+                {
+                    _readCount++;
+                    _readWaiters.Remove(_readCount, out waiter);
+                }
+
+                waiter?.TrySetResult();
+            }
+
+            private sealed class Enumerator(
+                ControlledMembershipUpdateStream owner,
+                ChannelReader<MembershipTableSnapshot> reader,
+                CancellationToken cancellationToken) : IAsyncEnumerator<MembershipTableSnapshot>
+            {
+                public MembershipTableSnapshot Current { get; private set; } = null!;
+
+                public async ValueTask<bool> MoveNextAsync()
+                {
+                    owner.OnReadStarted();
+                    while (await reader.WaitToReadAsync(cancellationToken))
+                    {
+                        if (reader.TryRead(out var item))
+                        {
+                            Current = item;
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                public ValueTask DisposeAsync()
+                {
+                    owner._completed.TrySetResult();
+                    return ValueTask.CompletedTask;
+                }
+            }
         }
     }
 }

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -79,7 +79,7 @@ namespace NonSilo.Tests.Membership
                 });
 
             this.localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
-            this.localSiloHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
+            this.localSiloHealthMonitor.GetLocalHealthStatus(default, default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
 
             this.prober = Substitute.For<IRemoteSiloProber>();
             this.membershipTable = new InMemoryMembershipTable(new TableVersion(1, "1"));

--- a/test/Orleans.Core.Tests/Membership/LocalSiloHealthEventHistoryTests.cs
+++ b/test/Orleans.Core.Tests/Membership/LocalSiloHealthEventHistoryTests.cs
@@ -1,0 +1,196 @@
+using Microsoft.Extensions.Time.Testing;
+using Orleans.Runtime.MembershipService;
+using TestExtensions;
+using Xunit;
+
+namespace NonSilo.Tests.Membership;
+
+[TestCategory("BVT"), TestCategory("Membership")]
+public class LocalSiloHealthEventHistoryTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+    private readonly FakeTimeProvider _timeProvider = new(Start);
+    private readonly long _startTimestamp;
+
+    public LocalSiloHealthEventHistoryTests()
+    {
+        _startTimestamp = _timeProvider.GetTimestamp();
+    }
+
+    [Fact]
+    public void Add_GroupsReportsBySecond()
+    {
+        var history = CreateHistory();
+        var start = _timeProvider.GetTimestamp();
+
+        history.Add(Event(start, LocalSiloHealthCheckKind.RuntimeStall, source: "first"));
+        history.Add(Event(TimestampAt(TimeSpan.FromMilliseconds(500)), LocalSiloHealthCheckKind.RuntimeStall, source: "second"));
+
+        Assert.Equal(2, history.Count);
+        Assert.Equal(1, history.OccupiedBucketCount);
+
+        history.Add(Event(TimestampAt(TimeSpan.FromSeconds(1)), LocalSiloHealthCheckKind.RuntimeStall, source: "third"));
+
+        Assert.Equal(3, history.Count);
+        Assert.Equal(2, history.OccupiedBucketCount);
+    }
+
+    [Fact]
+    public void Aggregate_ReusesExpiredBucketSlots()
+    {
+        var history = CreateHistory();
+        var start = _timeProvider.GetTimestamp();
+        history.Add(Event(start, LocalSiloHealthCheckKind.RuntimeStall, source: "expired"));
+
+        _timeProvider.Advance(TimeSpan.FromSeconds(61));
+        var now = _timeProvider.GetTimestamp();
+        history.Add(Event(now, LocalSiloHealthCheckKind.RuntimeStall, source: "current"));
+
+        var status = history.Aggregate(
+            TimestampAt(TimeSpan.FromSeconds(1)),
+            now,
+            now,
+            LocalSiloHealthCheckCategory.Local,
+            LocalSiloHealthMonitor.MaxScore);
+
+        var healthEvent = Assert.Single(status.Events);
+        Assert.Equal("current", healthEvent.Source);
+        Assert.Equal(1, history.Count);
+        Assert.Equal(1, history.OccupiedBucketCount);
+    }
+
+    [Fact]
+    public void Aggregate_CompactsPartiallyExpiredBucketWithUnorderedReports()
+    {
+        var history = CreateHistory();
+        history.Add(Event(
+            TimestampAt(TimeSpan.FromMilliseconds(500)),
+            LocalSiloHealthCheckKind.RuntimeStall,
+            source: "retained"));
+        history.Add(Event(
+            TimestampAt(TimeSpan.FromMilliseconds(100)),
+            LocalSiloHealthCheckKind.RuntimeStall,
+            source: "expired"));
+
+        var now = TimestampAt(TimeSpan.FromSeconds(60.25));
+        var status = history.Aggregate(
+            TimestampAt(TimeSpan.FromMilliseconds(250)),
+            now,
+            now,
+            LocalSiloHealthCheckCategory.Local,
+            LocalSiloHealthMonitor.MaxScore);
+
+        var healthEvent = Assert.Single(status.Events);
+        Assert.Equal("retained", healthEvent.Source);
+        Assert.Equal(1, history.Count);
+    }
+
+    [Fact]
+    public void Aggregate_SelectsWorstReportPerIdentityAcrossBuckets()
+    {
+        var history = CreateHistory();
+        history.Add(Event(
+            TimestampAt(TimeSpan.Zero),
+            LocalSiloHealthCheckKind.RuntimeStall,
+            score: 1,
+            source: "runtime"));
+        history.Add(Event(
+            TimestampAt(TimeSpan.FromSeconds(1)),
+            LocalSiloHealthCheckKind.RuntimeStall,
+            score: 4,
+            source: "runtime"));
+        history.Add(Event(
+            TimestampAt(TimeSpan.FromSeconds(2)),
+            LocalSiloHealthCheckKind.RuntimeStall,
+            score: 2,
+            source: "runtime"));
+
+        var end = TimestampAt(TimeSpan.FromSeconds(2));
+        var status = history.Aggregate(
+            TimestampAt(TimeSpan.Zero),
+            end,
+            end,
+            LocalSiloHealthCheckCategory.Local,
+            LocalSiloHealthMonitor.MaxScore);
+
+        var healthEvent = Assert.Single(status.Events);
+        Assert.Equal(4, status.Score);
+        Assert.Equal(TimestampAt(TimeSpan.FromSeconds(1)), healthEvent.Timestamp);
+    }
+
+    [Fact]
+    public void Aggregate_CarriesStateButNotIncidentsIntoInterval()
+    {
+        var history = CreateHistory();
+        history.Add(Event(
+            TimestampAt(TimeSpan.Zero),
+            LocalSiloHealthCheckKind.HealthCheckParticipant,
+            score: 1,
+            source: "participant"));
+        history.Add(Event(
+            TimestampAt(TimeSpan.Zero),
+            LocalSiloHealthCheckKind.RuntimeStall,
+            score: 2,
+            source: "runtime"));
+
+        var start = TimestampAt(TimeSpan.FromMilliseconds(500));
+        var end = TimestampAt(TimeSpan.FromSeconds(1));
+        var status = history.Aggregate(
+            start,
+            end,
+            end,
+            LocalSiloHealthCheckCategory.Local,
+            LocalSiloHealthMonitor.MaxScore);
+
+        var healthEvent = Assert.Single(status.Events);
+        Assert.Equal(LocalSiloHealthCheckKind.HealthCheckParticipant, healthEvent.Kind);
+        Assert.Equal(1, status.Score);
+    }
+
+    [Fact]
+    public void Aggregate_ClampsWithoutOverflow()
+    {
+        var history = CreateHistory();
+        var timestamp = TimestampAt(TimeSpan.Zero);
+        history.Add(Event(
+            timestamp,
+            LocalSiloHealthCheckKind.RuntimeStall,
+            score: int.MaxValue,
+            source: "runtime"));
+        history.Add(Event(
+            timestamp,
+            LocalSiloHealthCheckKind.ComponentHealthCheckStall,
+            score: 1,
+            source: "component"));
+
+        var status = history.Aggregate(
+            timestamp,
+            timestamp,
+            timestamp,
+            LocalSiloHealthCheckCategory.Local,
+            LocalSiloHealthMonitor.MaxScore);
+
+        Assert.Equal(LocalSiloHealthMonitor.MaxScore, status.Score);
+    }
+
+    private LocalSiloHealthEventHistory CreateHistory()
+        => new(_timeProvider, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(1));
+
+    private LocalSiloHealthEvent Event(
+        long timestamp,
+        LocalSiloHealthCheckKind kind,
+        int score = 1,
+        string? source = null)
+        => new(
+            timestamp,
+            kind,
+            LocalSiloHealthCheckCategory.Local,
+            source,
+            score,
+            Complaint: null,
+            Duration: null);
+
+    private long TimestampAt(TimeSpan elapsed)
+        => _startTimestamp
+            + (long)(elapsed.TotalSeconds * _timeProvider.TimestampFrequency);
+}

--- a/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
@@ -53,6 +53,22 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public void GetLocalHealthStatus_RejectsReversedInterval()
+        {
+            var participant = new TestHealthCheckParticipant(_ => (true, null));
+            var monitor = CreateMonitor(participant);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => monitor.GetLocalHealthStatus(
+                    Start,
+                    Start - TimeSpan.FromTicks(1),
+                    LocalSiloHealthCheckCategory.All));
+
+            Assert.Equal("end", exception.ParamName);
+            Assert.Equal(0, participant.CallCount);
+        }
+
+        [Fact]
         public void GetLocalHealthStatus_RetentionAndQueryBoundsAreInclusive()
         {
             var monitor = CreateMonitor();
@@ -210,6 +226,58 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public void GetLocalHealthStatus_LocalCacheDoesNotSuppressNetworkCheck()
+        {
+            var monitor = CreateMonitor();
+            _ = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+
+            var network = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Network);
+
+            var membershipEvent = Assert.Single(
+                network.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.MembershipStatus);
+            Assert.Equal(LocalSiloHealthCheckCategory.Network, membershipEvent.Category);
+            Assert.Equal(0, membershipEvent.Score);
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_MembershipRecoveryReplacesPriorState()
+        {
+            var localSilo = _localSiloDetails.SiloAddress;
+            var membershipEntry = new MembershipEntry
+            {
+                SiloAddress = localSilo,
+                Status = SiloStatus.Joining,
+                StartTime = Start.UtcDateTime,
+                IAmAliveTime = Start.UtcDateTime,
+            };
+            _membershipManager.CurrentSnapshot.Returns(new MembershipTableSnapshot(
+                new MembershipVersion(1),
+                ImmutableDictionary<SiloAddress, MembershipEntry>.Empty.Add(localSilo, membershipEntry)));
+            var monitor = CreateMonitor();
+            var joining = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Network);
+            Assert.Equal(LocalSiloHealthMonitor.MaxScore, joining.Score);
+
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+            membershipEntry.Status = SiloStatus.Active;
+            var active = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Network);
+            Assert.Equal(0, active.Score);
+
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(500));
+            var carried = monitor.GetLocalHealthStatus(
+                Start.AddSeconds(1),
+                Start.AddSeconds(1.5),
+                LocalSiloHealthCheckCategory.Network);
+            Assert.Equal(0, carried.Score);
+            var membershipStatus = Assert.Single(
+                carried.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.MembershipStatus);
+            Assert.Equal(0, membershipStatus.Score);
+            Assert.Null(membershipStatus.Source);
+            Assert.Null(membershipStatus.Complaint);
+        }
+
+        [Fact]
         public void GetLocalHealthStatus_PreservesDistinctStallKinds()
         {
             var monitor = CreateMonitor();
@@ -262,6 +330,74 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public void GetLocalHealthStatus_IncludesDurationEventWhichOverlapsInterval()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            _timeProvider.Advance(TimeSpan.FromSeconds(3));
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.RuntimeStall,
+                score: 2,
+                complaint: "overlapping runtime stall",
+                duration: TimeSpan.FromSeconds(2));
+
+            var status = monitor.GetLocalHealthStatus(
+                Start,
+                Start.AddSeconds(2),
+                LocalSiloHealthCheckCategory.Local);
+
+            var healthEvent = Assert.Single(
+                status.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall);
+            Assert.Equal(2, status.Score);
+            Assert.Equal(Start.AddSeconds(3), healthEvent.Timestamp);
+            Assert.Equal(TimeSpan.FromSeconds(2), healthEvent.Duration);
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_CarriesStateSampleIntoInterval()
+        {
+            var participant = new TestHealthCheckParticipant(_ => (false, "persistently unhealthy"));
+            var monitor = CreateMonitor(participant);
+            _ = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(500));
+
+            var status = monitor.GetLocalHealthStatus(
+                Start.AddMilliseconds(250),
+                Start.AddMilliseconds(500),
+                LocalSiloHealthCheckCategory.Local);
+
+            var participantEvent = Assert.Single(
+                status.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.HealthCheckParticipant);
+            Assert.Equal(1, status.Score);
+            Assert.Equal(Start, participantEvent.Timestamp);
+            Assert.Contains("persistently unhealthy", participantEvent.Complaint, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_DoesNotCarryIncidentIntoLaterInterval()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.RuntimeStall,
+                score: 2,
+                complaint: "completed runtime stall",
+                duration: TimeSpan.FromSeconds(1));
+            _timeProvider.Advance(TimeSpan.FromSeconds(2));
+
+            var status = monitor.GetLocalHealthStatus(
+                Start.AddSeconds(1),
+                Start.AddSeconds(2),
+                LocalSiloHealthCheckCategory.Local);
+
+            Assert.DoesNotContain(
+                status.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall);
+        }
+
+        [Fact]
         public void GetLocalHealthStatus_UsesOneSecondOnDemandCacheCadence()
         {
             var participant = new TestHealthCheckParticipant(_ => (true, null));
@@ -284,6 +420,22 @@ namespace NonSilo.Tests.Membership
 
             static bool IsParticipantEvent(LocalSiloHealthEvent item)
                 => item.Kind == LocalSiloHealthCheckKind.HealthCheckParticipant;
+        }
+
+        [Fact]
+        public void LocalSiloHealthMonitor_SchedulesHealthChecksOncePerSecond()
+        {
+            TimeSpan? period = null;
+            var timerFactory = new DelegateAsyncTimerFactory(
+                (value, _) =>
+                {
+                    period = value;
+                    return new DelegateAsyncTimer(_ => Task.FromResult(false));
+                });
+
+            _ = CreateMonitor(timerFactory);
+
+            Assert.Equal(TimeSpan.FromSeconds(1), period);
         }
 
         [Fact]
@@ -331,6 +483,7 @@ namespace NonSilo.Tests.Membership
                 Assert.Equal(1, Volatile.Read(ref activeCalls));
                 Assert.Equal(1, Volatile.Read(ref maximumActiveCalls));
                 Assert.All(workers, worker => Assert.False(worker.IsCompleted));
+                _timeProvider.Advance(TimeSpan.FromSeconds(2));
             }
             finally
             {
@@ -442,6 +595,13 @@ namespace NonSilo.Tests.Membership
         {
             var timerFactory = new DelegateAsyncTimerFactory(
                 (_, _) => new DelegateAsyncTimer(_ => Task.FromResult(false)));
+            return CreateMonitor(timerFactory, participants);
+        }
+
+        private LocalSiloHealthMonitor CreateMonitor(
+            IAsyncTimerFactory timerFactory,
+            params IHealthCheckParticipant[] participants)
+        {
             return new LocalSiloHealthMonitor(
                 participants,
                 _membershipManager,

--- a/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
@@ -484,7 +484,6 @@ namespace NonSilo.Tests.Membership
                 Assert.Equal(1, Volatile.Read(ref activeCalls));
                 Assert.Equal(1, Volatile.Read(ref maximumActiveCalls));
                 Assert.All(workers, worker => Assert.False(worker.IsCompleted));
-                _timeProvider.Advance(TimeSpan.FromSeconds(2));
             }
             finally
             {

--- a/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
@@ -1,0 +1,488 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using NonSilo.Tests.Utilities;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.Runtime.MembershipService;
+using TestExtensions;
+using Xunit;
+
+namespace NonSilo.Tests.Membership
+{
+    [TestCategory("BVT"), TestCategory("Membership")]
+    public class LocalSiloHealthMonitorTests
+    {
+        private static readonly DateTimeOffset Start = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        private readonly FakeTimeProvider _timeProvider = new(Start);
+        private readonly IMembershipManager _membershipManager;
+        private readonly IProbeHealthMonitor _probeHealthMonitor = Substitute.For<IProbeHealthMonitor>();
+        private readonly ILocalSiloDetails _localSiloDetails = Substitute.For<ILocalSiloDetails>();
+
+        public LocalSiloHealthMonitorTests()
+        {
+            var localSilo = SiloAddress.FromParsableString("127.0.0.1:100@100");
+            _localSiloDetails.SiloAddress.Returns(localSilo);
+            _membershipManager = Substitute.For<IMembershipManager>();
+            _membershipManager.CurrentSnapshot.Returns(new MembershipTableSnapshot(
+                new MembershipVersion(1),
+                ImmutableDictionary<SiloAddress, MembershipEntry>.Empty.Add(
+                    localSilo,
+                    new MembershipEntry
+                    {
+                        SiloAddress = localSilo,
+                        Status = SiloStatus.Active,
+                        StartTime = Start.UtcDateTime,
+                        IAmAliveTime = Start.UtcDateTime,
+                    })));
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_RejectsNegativePeriod()
+        {
+            var participant = new TestHealthCheckParticipant(_ => (true, null));
+            var monitor = CreateMonitor(participant);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => monitor.GetLocalHealthStatus(TimeSpan.FromTicks(-1), LocalSiloHealthCheckCategory.All));
+
+            Assert.Equal("period", exception.ParamName);
+            Assert.Equal(0, participant.CallCount);
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_RetentionAndQueryBoundsAreInclusive()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.RuntimeStall,
+                score: 3,
+                complaint: "runtime stalled",
+                duration: TimeSpan.FromSeconds(3),
+                source: "retention-boundary");
+
+            var atRecordedTime = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+            Assert.Contains(atRecordedTime.Events, IsRetentionEvent);
+
+            _timeProvider.Advance(TimeSpan.FromMinutes(1));
+            var atRetentionBoundary = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
+            Assert.Contains(atRetentionBoundary.Events, IsRetentionEvent);
+
+            _timeProvider.Advance(TimeSpan.FromTicks(1));
+            var afterRetentionBoundary = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
+            Assert.DoesNotContain(afterRetentionBoundary.Events, IsRetentionEvent);
+
+            static bool IsRetentionEvent(LocalSiloHealthEvent item)
+                => item.Kind == LocalSiloHealthCheckKind.RuntimeStall
+                    && item.Source == "retention-boundary"
+                    && item.Timestamp == Start;
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_LimitsLookbackToRetainedHistory()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.RuntimeStall,
+                score: 2,
+                complaint: "retained",
+                duration: TimeSpan.FromSeconds(2));
+            _timeProvider.Advance(TimeSpan.FromSeconds(59));
+
+            var status = monitor.GetLocalHealthStatus(TimeSpan.MaxValue, LocalSiloHealthCheckCategory.Local);
+
+            Assert.Contains(
+                status.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall
+                    && item.Complaint == "retained");
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_SelectsWorstEventPerKindAndSource()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            recorder.RecordHealthEvent(LocalSiloHealthCheckKind.RuntimeStall, 1, "alpha-low", TimeSpan.FromSeconds(1), "alpha");
+            recorder.RecordHealthEvent(LocalSiloHealthCheckKind.RuntimeStall, 4, "alpha-high", TimeSpan.FromSeconds(4), "alpha");
+            recorder.RecordHealthEvent(LocalSiloHealthCheckKind.RuntimeStall, 2, "alpha-later-low", TimeSpan.FromSeconds(2), "alpha");
+            recorder.RecordHealthEvent(LocalSiloHealthCheckKind.RuntimeStall, 3, "beta-high", TimeSpan.FromSeconds(3), "beta");
+
+            var status = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+            var selected = status.Events.Where(item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall).ToArray();
+
+            Assert.Equal(7, status.Score);
+            Assert.Collection(
+                selected,
+                item =>
+                {
+                    Assert.Equal("alpha", item.Source);
+                    Assert.Equal(4, item.Score);
+                    Assert.Equal("alpha-high", item.Complaint);
+                    Assert.Equal(TimeSpan.FromSeconds(4), item.Duration);
+                },
+                item =>
+                {
+                    Assert.Equal("beta", item.Source);
+                    Assert.Equal(3, item.Score);
+                    Assert.Equal("beta-high", item.Complaint);
+                    Assert.Equal(TimeSpan.FromSeconds(3), item.Duration);
+                });
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_EqualScoresSelectLatestEvent()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.RuntimeStall,
+                score: 3,
+                complaint: "earlier",
+                duration: TimeSpan.FromSeconds(1),
+                source: "equal-score");
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.RuntimeStall,
+                score: 3,
+                complaint: "later",
+                duration: TimeSpan.FromSeconds(2),
+                source: "equal-score");
+
+            var status = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
+            var selected = Assert.Single(status.Events, item => item.Source == "equal-score");
+
+            Assert.Equal(3, status.Score);
+            Assert.Equal(Start.AddSeconds(1), selected.Timestamp);
+            Assert.Equal("later", selected.Complaint);
+            Assert.Equal(TimeSpan.FromSeconds(2), selected.Duration);
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_FiltersCategoriesAndClampsAggregateScore()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            var allKinds = Enum.GetValues<LocalSiloHealthCheckKind>();
+            foreach (var kind in allKinds)
+            {
+                recorder.RecordHealthEvent(kind, score: 2, complaint: kind.ToString(), source: $"recorded-{kind}");
+            }
+
+            var network = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Network);
+            var local = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+            var none = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.None);
+            var all = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.All);
+
+            LocalSiloHealthCheckKind[] networkKinds =
+            [
+                LocalSiloHealthCheckKind.MembershipStatus,
+                LocalSiloHealthCheckKind.SiloSuspected,
+                LocalSiloHealthCheckKind.ProbeRequests,
+                LocalSiloHealthCheckKind.ProbeResponses,
+            ];
+            var localKinds = allKinds.Except(networkKinds).ToArray();
+
+            Assert.Equal(networkKinds, RecordedKinds(network));
+            Assert.All(network.Events, item => Assert.Equal(LocalSiloHealthCheckCategory.Network, item.Category));
+            Assert.Equal(LocalSiloHealthMonitor.MaxScore, network.Score);
+
+            Assert.Equal(localKinds, RecordedKinds(local));
+            Assert.All(local.Events, item => Assert.Equal(LocalSiloHealthCheckCategory.Local, item.Category));
+            Assert.Equal(LocalSiloHealthMonitor.MaxScore, local.Score);
+
+            Assert.Equal(0, none.Score);
+            Assert.Empty(none.Events);
+
+            Assert.Equal(allKinds, RecordedKinds(all));
+            Assert.Equal(LocalSiloHealthMonitor.MaxScore, all.Score);
+            Assert.Contains(all.Events, item => item.Category == LocalSiloHealthCheckCategory.Local);
+            Assert.Contains(all.Events, item => item.Category == LocalSiloHealthCheckCategory.Network);
+
+            static LocalSiloHealthCheckKind[] RecordedKinds(LocalSiloHealthStatus status)
+                => status.Events
+                    .Where(item => item.Source?.StartsWith("recorded-", StringComparison.Ordinal) == true)
+                    .Select(item => item.Kind)
+                    .ToArray();
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_PreservesDistinctStallKinds()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.GarbageCollectionPause,
+                score: 1,
+                complaint: "gc pause",
+                duration: TimeSpan.FromSeconds(1));
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.RuntimeStall,
+                score: 2,
+                complaint: "runtime stall",
+                duration: TimeSpan.FromSeconds(2));
+            recorder.RecordHealthEvent(
+                LocalSiloHealthCheckKind.ComponentHealthCheckStall,
+                score: 3,
+                complaint: "component stall",
+                duration: TimeSpan.FromSeconds(3));
+
+            var status = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+            var stalls = status.Events
+                .Where(item => item.Kind is LocalSiloHealthCheckKind.GarbageCollectionPause
+                    or LocalSiloHealthCheckKind.RuntimeStall
+                    or LocalSiloHealthCheckKind.ComponentHealthCheckStall)
+                .ToArray();
+
+            Assert.Equal(6, status.Score);
+            Assert.Collection(
+                stalls,
+                item => AssertStall(item, LocalSiloHealthCheckKind.GarbageCollectionPause, 1, "gc pause", TimeSpan.FromSeconds(1)),
+                item => AssertStall(item, LocalSiloHealthCheckKind.RuntimeStall, 2, "runtime stall", TimeSpan.FromSeconds(2)),
+                item => AssertStall(item, LocalSiloHealthCheckKind.ComponentHealthCheckStall, 3, "component stall", TimeSpan.FromSeconds(3)));
+            Assert.Equal(new[] { "gc pause", "runtime stall", "component stall" }, status.Complaints);
+
+            static void AssertStall(
+                LocalSiloHealthEvent item,
+                LocalSiloHealthCheckKind kind,
+                int score,
+                string complaint,
+                TimeSpan duration)
+            {
+                Assert.Equal(kind, item.Kind);
+                Assert.Equal(LocalSiloHealthCheckCategory.Local, item.Category);
+                Assert.Null(item.Source);
+                Assert.Equal(score, item.Score);
+                Assert.Equal(complaint, item.Complaint);
+                Assert.Equal(duration, item.Duration);
+            }
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_UsesOneSecondOnDemandCacheCadence()
+        {
+            var participant = new TestHealthCheckParticipant(_ => (true, null));
+            var monitor = CreateMonitor(participant);
+
+            var first = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
+            Assert.Equal(1, participant.CallCount);
+
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(999));
+            var cached = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
+            Assert.Equal(1, participant.CallCount);
+
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+            var refreshed = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
+            Assert.Equal(2, participant.CallCount);
+
+            Assert.Equal(Start, Assert.Single(first.Events, IsParticipantEvent).Timestamp);
+            Assert.Equal(Start, Assert.Single(cached.Events, IsParticipantEvent).Timestamp);
+            Assert.Equal(Start.AddSeconds(1), Assert.Single(refreshed.Events, IsParticipantEvent).Timestamp);
+
+            static bool IsParticipantEvent(LocalSiloHealthEvent item)
+                => item.Kind == LocalSiloHealthCheckKind.HealthCheckParticipant;
+        }
+
+        [Fact]
+        public async Task GetLocalHealthStatus_ConcurrentCallersShareOneNonOverlappingParticipantPass()
+        {
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var activeCalls = 0;
+            var maximumActiveCalls = 0;
+            var participant = new TestHealthCheckParticipant(_ =>
+            {
+                var active = Interlocked.Increment(ref activeCalls);
+                UpdateMaximum(ref maximumActiveCalls, active);
+                entered.TrySetResult();
+                try
+                {
+                    release.Task.GetAwaiter().GetResult();
+                    return (true, null);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref activeCalls);
+                }
+            });
+            var monitor = CreateMonitor(participant);
+            var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var ready = Enumerable.Range(0, 8)
+                .Select(_ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))
+                .ToArray();
+            var workers = Enumerable.Range(0, ready.Length)
+                .Select(index => Task.Run(async () =>
+                {
+                    ready[index].SetResult();
+                    await start.Task;
+                    return monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+                }))
+                .ToArray();
+
+            await Task.WhenAll(ready.Select(item => item.Task));
+            start.SetResult();
+            await entered.Task;
+            try
+            {
+                Assert.Equal(1, participant.CallCount);
+                Assert.Equal(1, Volatile.Read(ref activeCalls));
+                Assert.Equal(1, Volatile.Read(ref maximumActiveCalls));
+                Assert.All(workers, worker => Assert.False(worker.IsCompleted));
+            }
+            finally
+            {
+                release.TrySetResult();
+            }
+
+            var results = await Task.WhenAll(workers);
+            var expected = results[0];
+            var expectedEvents = expected.Events
+                .Select(item => (item.Timestamp, item.Kind, item.Category, item.Source, item.Score, item.Complaint, item.Duration))
+                .ToArray();
+
+            Assert.Equal(1, participant.CallCount);
+            Assert.Equal(0, Volatile.Read(ref activeCalls));
+            Assert.Equal(1, Volatile.Read(ref maximumActiveCalls));
+            Assert.All(results, result =>
+            {
+                Assert.Equal(expected.Score, result.Score);
+                Assert.Equal(
+                    expectedEvents,
+                    result.Events.Select(item => (item.Timestamp, item.Kind, item.Category, item.Source, item.Score, item.Complaint, item.Duration)));
+                var participantEvent = Assert.Single(result.Events, item => item.Kind == LocalSiloHealthCheckKind.HealthCheckParticipant);
+                Assert.Equal(Start, participantEvent.Timestamp);
+                Assert.Equal(0, participantEvent.Score);
+                Assert.Null(participantEvent.Complaint);
+            });
+        }
+
+        [Fact]
+        public async Task RecordHealthEvent_DoesNotWaitForHealthCheckParticipants()
+        {
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var participant = new TestHealthCheckParticipant(_ =>
+            {
+                entered.TrySetResult();
+                release.Task.GetAwaiter().GetResult();
+                return (true, null);
+            });
+            var monitor = CreateMonitor(participant);
+            var checkTask = Task.Run(
+                () => monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local));
+
+            await entered.Task;
+            try
+            {
+                var recordTask = Task.Run(
+                    () => ((ILocalSiloHealthEventRecorder)monitor).RecordHealthEvent(
+                        LocalSiloHealthCheckKind.ComponentHealthCheckStall,
+                        score: 1,
+                        complaint: "participant check stalled",
+                        duration: TimeSpan.FromSeconds(2)));
+
+                await recordTask.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.False(checkTask.IsCompleted);
+            }
+            finally
+            {
+                release.TrySetResult();
+            }
+
+            await checkTask;
+            var status = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+            Assert.Contains(
+                status.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.ComponentHealthCheckStall
+                    && item.Complaint == "participant check stalled");
+        }
+
+        [Fact]
+        public void GetLocalHealthStatus_EmitsTypedThreadPoolQueueDelayEvent()
+        {
+            var monitor = CreateMonitor();
+
+            var status = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
+            var threadPoolEvent = Assert.Single(
+                status.Events,
+                item => item.Kind == LocalSiloHealthCheckKind.ThreadPoolQueueDelay);
+
+            Assert.Equal(Start, threadPoolEvent.Timestamp);
+            Assert.Equal(LocalSiloHealthCheckCategory.Local, threadPoolEvent.Category);
+            Assert.Null(threadPoolEvent.Source);
+            Assert.True(threadPoolEvent.Score >= 0);
+            Assert.NotNull(threadPoolEvent.Duration);
+            Assert.True(threadPoolEvent.Duration >= TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void RecordHealthEvent_RejectsNegativeScore()
+        {
+            var monitor = CreateMonitor();
+            var recorder = (ILocalSiloHealthEventRecorder)monitor;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => recorder.RecordHealthEvent(
+                    LocalSiloHealthCheckKind.RuntimeStall,
+                    score: -1,
+                    complaint: "rejected",
+                    duration: TimeSpan.FromSeconds(1),
+                    source: "negative-score"));
+            var status = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.All);
+
+            Assert.Equal("score", exception.ParamName);
+            Assert.DoesNotContain(status.Events, item => item.Source == "negative-score");
+            Assert.DoesNotContain(status.Complaints, complaint => complaint == "rejected");
+        }
+
+        private LocalSiloHealthMonitor CreateMonitor(params IHealthCheckParticipant[] participants)
+        {
+            var timerFactory = new DelegateAsyncTimerFactory(
+                (_, _) => new DelegateAsyncTimer(_ => Task.FromResult(false)));
+            return new LocalSiloHealthMonitor(
+                participants,
+                _membershipManager,
+                _probeHealthMonitor,
+                _localSiloDetails,
+                NullLogger<LocalSiloHealthMonitor>.Instance,
+                Options.Create(new ClusterMembershipOptions()),
+                timerFactory,
+                NullLoggerFactory.Instance,
+                _timeProvider);
+        }
+
+        private static void UpdateMaximum(ref int maximum, int candidate)
+        {
+            var observed = Volatile.Read(ref maximum);
+            while (candidate > observed)
+            {
+                var prior = Interlocked.CompareExchange(ref maximum, candidate, observed);
+                if (prior == observed)
+                {
+                    return;
+                }
+
+                observed = prior;
+            }
+        }
+
+        private sealed class TestHealthCheckParticipant(
+            Func<DateTime, (bool IsHealthy, string? Reason)> check) : IHealthCheckParticipant
+        {
+            private int _callCount;
+
+            public int CallCount => Volatile.Read(ref _callCount);
+
+            public bool CheckHealth(DateTime lastCheckTime, [NotNullWhen(false)] out string? reason)
+            {
+                Interlocked.Increment(ref _callCount);
+                var result = check(lastCheckTime);
+                reason = result.Reason;
+                return result.IsHealthy;
+            }
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
@@ -17,12 +17,14 @@ namespace NonSilo.Tests.Membership
     {
         private static readonly DateTimeOffset Start = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
         private readonly FakeTimeProvider _timeProvider = new(Start);
+        private readonly long _startTimestamp;
         private readonly IMembershipManager _membershipManager;
         private readonly IProbeHealthMonitor _probeHealthMonitor = Substitute.For<IProbeHealthMonitor>();
         private readonly ILocalSiloDetails _localSiloDetails = Substitute.For<ILocalSiloDetails>();
 
         public LocalSiloHealthMonitorTests()
         {
+            _startTimestamp = _timeProvider.GetTimestamp();
             var localSilo = SiloAddress.FromParsableString("127.0.0.1:100@100");
             _localSiloDetails.SiloAddress.Returns(localSilo);
             _membershipManager = Substitute.For<IMembershipManager>();
@@ -60,11 +62,11 @@ namespace NonSilo.Tests.Membership
 
             var exception = Assert.Throws<ArgumentOutOfRangeException>(
                 () => monitor.GetLocalHealthStatus(
-                    Start,
-                    Start - TimeSpan.FromTicks(1),
+                    _startTimestamp,
+                    _startTimestamp - 1,
                     LocalSiloHealthCheckCategory.All));
 
-            Assert.Equal("end", exception.ParamName);
+            Assert.Equal("endTimestamp", exception.ParamName);
             Assert.Equal(0, participant.CallCount);
         }
 
@@ -81,7 +83,7 @@ namespace NonSilo.Tests.Membership
                 source: "retention-boundary");
 
             var atRecordedTime = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
-            Assert.Contains(atRecordedTime.Events, IsRetentionEvent);
+            Assert.Equal(_startTimestamp, Assert.Single(atRecordedTime.Events, IsRetentionEvent).Timestamp);
 
             _timeProvider.Advance(TimeSpan.FromMinutes(1));
             var atRetentionBoundary = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
@@ -93,8 +95,7 @@ namespace NonSilo.Tests.Membership
 
             static bool IsRetentionEvent(LocalSiloHealthEvent item)
                 => item.Kind == LocalSiloHealthCheckKind.RuntimeStall
-                    && item.Source == "retention-boundary"
-                    && item.Timestamp == Start;
+                    && item.Source == "retention-boundary";
         }
 
         [Fact]
@@ -172,7 +173,7 @@ namespace NonSilo.Tests.Membership
             var selected = Assert.Single(status.Events, item => item.Source == "equal-score");
 
             Assert.Equal(3, status.Score);
-            Assert.Equal(Start.AddSeconds(1), selected.Timestamp);
+            Assert.Equal(TimestampAt(TimeSpan.FromSeconds(1)), selected.Timestamp);
             Assert.Equal("later", selected.Complaint);
             Assert.Equal(TimeSpan.FromSeconds(2), selected.Duration);
         }
@@ -265,8 +266,8 @@ namespace NonSilo.Tests.Membership
 
             _timeProvider.Advance(TimeSpan.FromMilliseconds(500));
             var carried = monitor.GetLocalHealthStatus(
-                Start.AddSeconds(1),
-                Start.AddSeconds(1.5),
+                TimestampAt(TimeSpan.FromSeconds(1)),
+                TimestampAt(TimeSpan.FromSeconds(1.5)),
                 LocalSiloHealthCheckCategory.Network);
             Assert.Equal(0, carried.Score);
             var membershipStatus = Assert.Single(
@@ -342,15 +343,15 @@ namespace NonSilo.Tests.Membership
                 duration: TimeSpan.FromSeconds(2));
 
             var status = monitor.GetLocalHealthStatus(
-                Start,
-                Start.AddSeconds(2),
+                _startTimestamp,
+                TimestampAt(TimeSpan.FromSeconds(2)),
                 LocalSiloHealthCheckCategory.Local);
 
             var healthEvent = Assert.Single(
                 status.Events,
                 item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall);
             Assert.Equal(2, status.Score);
-            Assert.Equal(Start.AddSeconds(3), healthEvent.Timestamp);
+            Assert.Equal(TimestampAt(TimeSpan.FromSeconds(3)), healthEvent.Timestamp);
             Assert.Equal(TimeSpan.FromSeconds(2), healthEvent.Duration);
         }
 
@@ -363,15 +364,15 @@ namespace NonSilo.Tests.Membership
             _timeProvider.Advance(TimeSpan.FromMilliseconds(500));
 
             var status = monitor.GetLocalHealthStatus(
-                Start.AddMilliseconds(250),
-                Start.AddMilliseconds(500),
+                TimestampAt(TimeSpan.FromMilliseconds(250)),
+                TimestampAt(TimeSpan.FromMilliseconds(500)),
                 LocalSiloHealthCheckCategory.Local);
 
             var participantEvent = Assert.Single(
                 status.Events,
                 item => item.Kind == LocalSiloHealthCheckKind.HealthCheckParticipant);
             Assert.Equal(1, status.Score);
-            Assert.Equal(Start, participantEvent.Timestamp);
+            Assert.Equal(_startTimestamp, participantEvent.Timestamp);
             Assert.Contains("persistently unhealthy", participantEvent.Complaint, StringComparison.Ordinal);
         }
 
@@ -388,8 +389,8 @@ namespace NonSilo.Tests.Membership
             _timeProvider.Advance(TimeSpan.FromSeconds(2));
 
             var status = monitor.GetLocalHealthStatus(
-                Start.AddSeconds(1),
-                Start.AddSeconds(2),
+                TimestampAt(TimeSpan.FromSeconds(1)),
+                TimestampAt(TimeSpan.FromSeconds(2)),
                 LocalSiloHealthCheckCategory.Local);
 
             Assert.DoesNotContain(
@@ -414,9 +415,9 @@ namespace NonSilo.Tests.Membership
             var refreshed = monitor.GetLocalHealthStatus(TimeSpan.FromMinutes(1), LocalSiloHealthCheckCategory.Local);
             Assert.Equal(2, participant.CallCount);
 
-            Assert.Equal(Start, Assert.Single(first.Events, IsParticipantEvent).Timestamp);
-            Assert.Equal(Start, Assert.Single(cached.Events, IsParticipantEvent).Timestamp);
-            Assert.Equal(Start.AddSeconds(1), Assert.Single(refreshed.Events, IsParticipantEvent).Timestamp);
+            Assert.Equal(_startTimestamp, Assert.Single(first.Events, IsParticipantEvent).Timestamp);
+            Assert.Equal(_startTimestamp, Assert.Single(cached.Events, IsParticipantEvent).Timestamp);
+            Assert.Equal(TimestampAt(TimeSpan.FromSeconds(1)), Assert.Single(refreshed.Events, IsParticipantEvent).Timestamp);
 
             static bool IsParticipantEvent(LocalSiloHealthEvent item)
                 => item.Kind == LocalSiloHealthCheckKind.HealthCheckParticipant;
@@ -506,7 +507,7 @@ namespace NonSilo.Tests.Membership
                     expectedEvents,
                     result.Events.Select(item => (item.Timestamp, item.Kind, item.Category, item.Source, item.Score, item.Complaint, item.Duration)));
                 var participantEvent = Assert.Single(result.Events, item => item.Kind == LocalSiloHealthCheckKind.HealthCheckParticipant);
-                Assert.Equal(Start, participantEvent.Timestamp);
+                Assert.Equal(_startTimestamp, participantEvent.Timestamp);
                 Assert.Equal(0, participantEvent.Score);
                 Assert.Null(participantEvent.Complaint);
             });
@@ -563,7 +564,7 @@ namespace NonSilo.Tests.Membership
                 status.Events,
                 item => item.Kind == LocalSiloHealthCheckKind.ThreadPoolQueueDelay);
 
-            Assert.Equal(Start, threadPoolEvent.Timestamp);
+            Assert.Equal(_startTimestamp, threadPoolEvent.Timestamp);
             Assert.Equal(LocalSiloHealthCheckCategory.Local, threadPoolEvent.Category);
             Assert.Null(threadPoolEvent.Source);
             Assert.True(threadPoolEvent.Score >= 0);
@@ -613,6 +614,9 @@ namespace NonSilo.Tests.Membership
                 NullLoggerFactory.Instance,
                 _timeProvider);
         }
+
+        private long TimestampAt(TimeSpan elapsed)
+            => _startTimestamp + (long)(elapsed.TotalSeconds * _timeProvider.TimestampFrequency);
 
         private static void UpdateMaximum(ref int maximum, int candidate)
         {

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -101,14 +101,15 @@ namespace NonSilo.Tests.Membership
                 new ConnectionManager(
                     Options.Create(new ConnectionOptions()),
                     null!,
-                    this.loggerFactory.CreateLogger<ConnectionManager>()));
+                    this.loggerFactory.CreateLogger<ConnectionManager>()),
+                TimeProvider.System);
             ((ILifecycleParticipant<ISiloLifecycle>)this.clusterHealthMonitor).Participate(this.lifecycle);
 
             this.remoteSiloProber = Substitute.For<IRemoteSiloProber>();
             remoteSiloProber.Probe(default!, default).ReturnsForAnyArgs(Task.CompletedTask);
 
             this.localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
-            this.localSiloHealthMonitor.GetLocalHealthDegradationScore(default).ReturnsForAnyArgs(0);
+            this.localSiloHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
 
             this.onProbeResult = (Func<SiloHealthMonitor, SiloHealthMonitor.ProbeResult, Task>)((siloHealthMonitor, probeResult) => Task.CompletedTask);
 

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -109,7 +109,7 @@ namespace NonSilo.Tests.Membership
             remoteSiloProber.Probe(default!, default).ReturnsForAnyArgs(Task.CompletedTask);
 
             this.localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
-            this.localSiloHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
+            this.localSiloHealthMonitor.GetLocalHealthStatus(default, default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
 
             this.onProbeResult = (Func<SiloHealthMonitor, SiloHealthMonitor.ProbeResult, Task>)((siloHealthMonitor, probeResult) => Task.CompletedTask);
 

--- a/test/Orleans.Core.Tests/Membership/MembershipSystemTargetTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipSystemTargetTests.cs
@@ -1,0 +1,203 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.Runtime.MembershipService;
+using TestExtensions;
+using Xunit;
+
+namespace NonSilo.Tests.Membership
+{
+    [TestCategory("BVT"), TestCategory("Membership")]
+    public class MembershipSystemTargetTests
+    {
+        private static readonly DateTimeOffset Start = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+        [Fact]
+        public async Task ProbeIndirectly_QueriesLocalHealthAndReportsProviderElapsedTime()
+        {
+            var probeTimeout = TimeSpan.FromSeconds(10);
+            var elapsed = TimeSpan.FromMilliseconds(3_250);
+            const int ProbeNumber = 17;
+            var targetSilo = SiloAddress.FromParsableString("127.0.0.1:200@100");
+            var healthStatus = CreateDistinctStallStatus();
+            using var rig = CreateTestRig(healthStatus);
+
+            var responseTask = rig.Target.ProbeIndirectly(targetSilo, probeTimeout, ProbeNumber);
+            await rig.PingEntered.Task;
+
+            Assert.False(responseTask.IsCompleted);
+            rig.TimeProvider.Advance(elapsed);
+            rig.PingRelease.SetResult();
+
+            var response = await responseTask;
+
+            Assert.True(response.Succeeded);
+            Assert.Equal(healthStatus.Score, response.IntermediaryHealthScore);
+            Assert.Equal(elapsed, response.ProbeResponseTime);
+            Assert.Null(response.FailureMessage);
+            rig.LocalHealthMonitor.Received(1).GetLocalHealthStatus(
+                probeTimeout,
+                LocalSiloHealthCheckCategory.Local);
+            rig.GrainFactory.Received(1).GetSystemTarget<IMembershipService>(
+                Constants.MembershipServiceType,
+                targetSilo);
+            await rig.RemoteMembershipService.Received(1).Ping(ProbeNumber);
+            Assert.Same(rig.Target, rig.ActivationDirectory.FindTarget(rig.Target.GrainId));
+        }
+
+        [Fact]
+        public async Task ProbeIndirectly_TimesOutUsingInjectedProvider()
+        {
+            var probeTimeout = TimeSpan.FromSeconds(5);
+            const int ProbeNumber = 23;
+            var targetSilo = SiloAddress.FromParsableString("127.0.0.1:300@100");
+            var healthStatus = CreateDistinctStallStatus();
+            using var rig = CreateTestRig(healthStatus);
+
+            try
+            {
+                var responseTask = rig.Target.ProbeIndirectly(targetSilo, probeTimeout, ProbeNumber);
+                await rig.PingEntered.Task;
+
+                rig.TimeProvider.Advance(probeTimeout - TimeSpan.FromTicks(1));
+                Assert.False(responseTask.IsCompleted);
+
+                rig.TimeProvider.Advance(TimeSpan.FromTicks(1));
+                var response = await responseTask;
+
+                Assert.False(response.Succeeded);
+                Assert.Equal(healthStatus.Score, response.IntermediaryHealthScore);
+                Assert.Equal(probeTimeout, response.ProbeResponseTime);
+                Assert.Contains(nameof(TimeoutException), response.FailureMessage, StringComparison.Ordinal);
+                rig.LocalHealthMonitor.Received(1).GetLocalHealthStatus(
+                    probeTimeout,
+                    LocalSiloHealthCheckCategory.Local);
+                rig.GrainFactory.Received(1).GetSystemTarget<IMembershipService>(
+                    Constants.MembershipServiceType,
+                    targetSilo);
+                await rig.RemoteMembershipService.Received(1).Ping(ProbeNumber);
+            }
+            finally
+            {
+                rig.PingRelease.TrySetResult();
+            }
+        }
+
+        private static LocalSiloHealthStatus CreateDistinctStallStatus() => new(
+            Score: 6,
+            Events:
+            [
+                new(
+                    Start,
+                    LocalSiloHealthCheckKind.GarbageCollectionPause,
+                    LocalSiloHealthCheckCategory.Local,
+                    Source: null,
+                    Score: 1,
+                    Complaint: "gc pause",
+                    Duration: TimeSpan.FromSeconds(1)),
+                new(
+                    Start,
+                    LocalSiloHealthCheckKind.RuntimeStall,
+                    LocalSiloHealthCheckCategory.Local,
+                    Source: null,
+                    Score: 2,
+                    Complaint: "runtime stall",
+                    Duration: TimeSpan.FromSeconds(2)),
+                new(
+                    Start,
+                    LocalSiloHealthCheckKind.ComponentHealthCheckStall,
+                    LocalSiloHealthCheckCategory.Local,
+                    Source: null,
+                    Score: 3,
+                    Complaint: "component stall",
+                    Duration: TimeSpan.FromSeconds(3)),
+            ]);
+
+        private static MembershipSystemTargetTestRig CreateTestRig(LocalSiloHealthStatus healthStatus)
+        {
+            var timeProvider = new FakeTimeProvider(Start);
+            var localHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
+            localHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(healthStatus);
+            var services = new ServiceCollection();
+            services.AddSingleton(localHealthMonitor);
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<CatalogInstruments>();
+            services.AddSingleton<SchedulerInstruments>();
+            services.AddSingleton<GrainInstruments>();
+            services.AddSingleton<MessagingInstruments>();
+            services.AddSingleton<MessagingProcessingInstruments>();
+            var serviceProvider = services.BuildServiceProvider();
+
+            var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+            localSiloDetails.SiloAddress.Returns(SiloAddress.FromParsableString("127.0.0.1:100@100"));
+            var activationDirectory = new ActivationDirectory(serviceProvider.GetRequiredService<CatalogInstruments>());
+            var runtimeClient = (InsideRuntimeClient)RuntimeHelpers.GetUninitializedObject(typeof(InsideRuntimeClient));
+            typeof(InsideRuntimeClient)
+                .GetField("<ServiceProvider>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(runtimeClient, serviceProvider);
+            var shared = new SystemTargetShared(
+                runtimeClient,
+                localSiloDetails,
+                NullLoggerFactory.Instance,
+                Options.Create(new SchedulingOptions()),
+                grainReferenceActivator: null!,
+                timerRegistry: null!,
+                activationDirectory,
+                serviceProvider.GetRequiredService<SchedulerInstruments>(),
+                serviceProvider.GetRequiredService<GrainInstruments>(),
+                serviceProvider.GetRequiredService<MessagingInstruments>(),
+                serviceProvider.GetRequiredService<MessagingProcessingInstruments>());
+
+            var pingEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pingRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var remoteMembershipService = Substitute.For<IMembershipService>();
+            remoteMembershipService.Ping(Arg.Any<int>()).Returns(_ =>
+            {
+                pingEntered.TrySetResult();
+                return pingRelease.Task;
+            });
+            var grainFactory = Substitute.For<IInternalGrainFactory>();
+            grainFactory
+                .GetSystemTarget<IMembershipService>(Constants.MembershipServiceType, Arg.Any<SiloAddress>())
+                .Returns(remoteMembershipService);
+            var target = new MembershipSystemTarget(
+                Substitute.For<IMembershipManager>(),
+                NullLogger<MembershipSystemTarget>.Instance,
+                grainFactory,
+                serviceProvider.GetRequiredService<MessagingInstruments>(),
+                shared,
+                timeProvider);
+
+            return new(
+                serviceProvider,
+                timeProvider,
+                localHealthMonitor,
+                grainFactory,
+                remoteMembershipService,
+                activationDirectory,
+                target,
+                pingEntered,
+                pingRelease);
+        }
+
+        private sealed record MembershipSystemTargetTestRig(
+            ServiceProvider ServiceProvider,
+            FakeTimeProvider TimeProvider,
+            ILocalSiloHealthMonitor LocalHealthMonitor,
+            IInternalGrainFactory GrainFactory,
+            IMembershipService RemoteMembershipService,
+            ActivationDirectory ActivationDirectory,
+            MembershipSystemTarget Target,
+            TaskCompletionSource PingEntered,
+            TaskCompletionSource PingRelease) : IDisposable
+        {
+            public void Dispose() => ServiceProvider.Dispose();
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Membership/MembershipSystemTargetTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipSystemTargetTests.cs
@@ -26,6 +26,7 @@ namespace NonSilo.Tests.Membership
             var targetSilo = SiloAddress.FromParsableString("127.0.0.1:200@100");
             var healthStatus = CreateDistinctStallStatus();
             using var rig = CreateTestRig(healthStatus);
+            var startTimestamp = rig.TimeProvider.GetTimestamp();
 
             var responseTask = rig.Target.ProbeIndirectly(targetSilo, probeTimeout, ProbeNumber);
             await rig.PingEntered.Task;
@@ -42,8 +43,8 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(elapsed, response.ProbeResponseTime);
             Assert.Null(response.FailureMessage);
             rig.LocalHealthMonitor.Received(1).GetLocalHealthStatus(
-                Start,
-                Start + elapsed,
+                startTimestamp,
+                rig.TimeProvider.GetTimestamp(),
                 LocalSiloHealthCheckCategory.Local);
             rig.GrainFactory.Received(1).GetSystemTarget<IMembershipService>(
                 Constants.MembershipServiceType,
@@ -60,6 +61,7 @@ namespace NonSilo.Tests.Membership
             var targetSilo = SiloAddress.FromParsableString("127.0.0.1:300@100");
             var healthStatus = CreateDistinctStallStatus();
             using var rig = CreateTestRig(healthStatus);
+            var startTimestamp = rig.TimeProvider.GetTimestamp();
 
             try
             {
@@ -78,8 +80,8 @@ namespace NonSilo.Tests.Membership
                 Assert.Equal(probeTimeout, response.ProbeResponseTime);
                 Assert.Contains(nameof(TimeoutException), response.FailureMessage, StringComparison.Ordinal);
                 rig.LocalHealthMonitor.Received(1).GetLocalHealthStatus(
-                    Start,
-                    Start + probeTimeout,
+                    startTimestamp,
+                    rig.TimeProvider.GetTimestamp(),
                     LocalSiloHealthCheckCategory.Local);
                 rig.GrainFactory.Received(1).GetSystemTarget<IMembershipService>(
                     Constants.MembershipServiceType,
@@ -97,7 +99,7 @@ namespace NonSilo.Tests.Membership
             Events:
             [
                 new(
-                    Start,
+                    0,
                     LocalSiloHealthCheckKind.GarbageCollectionPause,
                     LocalSiloHealthCheckCategory.Local,
                     Source: null,
@@ -105,7 +107,7 @@ namespace NonSilo.Tests.Membership
                     Complaint: "gc pause",
                     Duration: TimeSpan.FromSeconds(1)),
                 new(
-                    Start,
+                    0,
                     LocalSiloHealthCheckKind.RuntimeStall,
                     LocalSiloHealthCheckCategory.Local,
                     Source: null,
@@ -113,7 +115,7 @@ namespace NonSilo.Tests.Membership
                     Complaint: "runtime stall",
                     Duration: TimeSpan.FromSeconds(2)),
                 new(
-                    Start,
+                    0,
                     LocalSiloHealthCheckKind.ComponentHealthCheckStall,
                     LocalSiloHealthCheckCategory.Local,
                     Source: null,
@@ -203,5 +205,6 @@ namespace NonSilo.Tests.Membership
         {
             public void Dispose() => ServiceProvider.Dispose();
         }
+
     }
 }

--- a/test/Orleans.Core.Tests/Membership/MembershipSystemTargetTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipSystemTargetTests.cs
@@ -31,6 +31,7 @@ namespace NonSilo.Tests.Membership
             await rig.PingEntered.Task;
 
             Assert.False(responseTask.IsCompleted);
+            Assert.Empty(rig.LocalHealthMonitor.ReceivedCalls());
             rig.TimeProvider.Advance(elapsed);
             rig.PingRelease.SetResult();
 
@@ -41,7 +42,8 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(elapsed, response.ProbeResponseTime);
             Assert.Null(response.FailureMessage);
             rig.LocalHealthMonitor.Received(1).GetLocalHealthStatus(
-                probeTimeout,
+                Start,
+                Start + elapsed,
                 LocalSiloHealthCheckCategory.Local);
             rig.GrainFactory.Received(1).GetSystemTarget<IMembershipService>(
                 Constants.MembershipServiceType,
@@ -64,6 +66,7 @@ namespace NonSilo.Tests.Membership
                 var responseTask = rig.Target.ProbeIndirectly(targetSilo, probeTimeout, ProbeNumber);
                 await rig.PingEntered.Task;
 
+                Assert.Empty(rig.LocalHealthMonitor.ReceivedCalls());
                 rig.TimeProvider.Advance(probeTimeout - TimeSpan.FromTicks(1));
                 Assert.False(responseTask.IsCompleted);
 
@@ -75,7 +78,8 @@ namespace NonSilo.Tests.Membership
                 Assert.Equal(probeTimeout, response.ProbeResponseTime);
                 Assert.Contains(nameof(TimeoutException), response.FailureMessage, StringComparison.Ordinal);
                 rig.LocalHealthMonitor.Received(1).GetLocalHealthStatus(
-                    probeTimeout,
+                    Start,
+                    Start + probeTimeout,
                     LocalSiloHealthCheckCategory.Local);
                 rig.GrainFactory.Received(1).GetSystemTarget<IMembershipService>(
                     Constants.MembershipServiceType,
@@ -122,7 +126,7 @@ namespace NonSilo.Tests.Membership
         {
             var timeProvider = new FakeTimeProvider(Start);
             var localHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
-            localHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(healthStatus);
+            localHealthMonitor.GetLocalHealthStatus(default, default, default).ReturnsForAnyArgs(healthStatus);
             var services = new ServiceCollection();
             services.AddSingleton(localHealthMonitor);
             services.AddMetrics();

--- a/test/Orleans.Core.Tests/Membership/ProbeRequestMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ProbeRequestMonitorTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Time.Testing;
+using Orleans.Runtime.Messaging;
+using TestExtensions;
+using Xunit;
+
+namespace NonSilo.Tests.Membership
+{
+    [TestCategory("BVT"), TestCategory("Membership")]
+    public class ProbeRequestMonitorTests
+    {
+        [Fact]
+        public void ElapsedSinceLastProbeRequest_UsesInjectedTimeAndResetsOnReceipt()
+        {
+            var start = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+            var timeProvider = new FakeTimeProvider(start);
+            var monitor = new ProbeRequestMonitor(timeProvider);
+
+            Assert.Null(monitor.ElapsedSinceLastProbeRequest);
+
+            monitor.OnReceivedProbeRequest();
+            Assert.Equal(TimeSpan.Zero, monitor.ElapsedSinceLastProbeRequest);
+
+            timeProvider.Advance(TimeSpan.FromSeconds(17));
+            Assert.Equal(TimeSpan.FromSeconds(17), monitor.ElapsedSinceLastProbeRequest);
+
+            monitor.OnReceivedProbeRequest();
+            Assert.Equal(TimeSpan.Zero, monitor.ElapsedSinceLastProbeRequest);
+
+            timeProvider.Advance(TimeSpan.FromMilliseconds(250));
+            Assert.Equal(TimeSpan.FromMilliseconds(250), monitor.ElapsedSinceLastProbeRequest);
+            Assert.Equal(start.AddSeconds(17).AddMilliseconds(250), timeProvider.GetUtcNow());
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
@@ -369,7 +369,7 @@ namespace NonSilo.Tests.Membership
             optionsMonitor.CurrentValue.Returns(options);
             var localHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
             localHealthMonitor
-                .GetLocalHealthStatus(default, default, default)
+                .GetLocalHealthStatus(default, default)
                 .ReturnsForAnyArgs(new LocalSiloHealthStatus(localHealthScore, []));
             var prober = Substitute.For<IRemoteSiloProber>();
             var probeEntered = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -408,13 +408,12 @@ namespace NonSilo.Tests.Membership
                 if (extendProbeTimeout)
                 {
                     localHealthMonitor.Received(1).GetLocalHealthStatus(
-                        timeProvider.GetUtcNow() - options.ProbeTimeout,
-                        timeProvider.GetUtcNow(),
+                        options.ProbeTimeout,
                         LocalSiloHealthCheckCategory.Local);
                 }
                 else
                 {
-                    localHealthMonitor.DidNotReceiveWithAnyArgs().GetLocalHealthStatus(default, default, default);
+                    localHealthMonitor.DidNotReceiveWithAnyArgs().GetLocalHealthStatus(default, default);
                 }
 
                 await prober.Received(1).Probe(_targetSilo, 1, cancellationToken);

--- a/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
@@ -67,7 +67,7 @@ namespace NonSilo.Tests.Membership
                 });
 
             _localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
-            _localSiloHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
+            _localSiloHealthMonitor.GetLocalHealthStatus(default, default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
 
             _prober = Substitute.For<IRemoteSiloProber>();
 
@@ -369,8 +369,8 @@ namespace NonSilo.Tests.Membership
             optionsMonitor.CurrentValue.Returns(options);
             var localHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
             localHealthMonitor
-                .GetLocalHealthStatus(options.ProbeTimeout, LocalSiloHealthCheckCategory.Local)
-                .Returns(new LocalSiloHealthStatus(localHealthScore, []));
+                .GetLocalHealthStatus(default, default, default)
+                .ReturnsForAnyArgs(new LocalSiloHealthStatus(localHealthScore, []));
             var prober = Substitute.For<IRemoteSiloProber>();
             var probeEntered = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
             var pendingProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -408,12 +408,13 @@ namespace NonSilo.Tests.Membership
                 if (extendProbeTimeout)
                 {
                     localHealthMonitor.Received(1).GetLocalHealthStatus(
-                        options.ProbeTimeout,
+                        timeProvider.GetUtcNow() - options.ProbeTimeout,
+                        timeProvider.GetUtcNow(),
                         LocalSiloHealthCheckCategory.Local);
                 }
                 else
                 {
-                    localHealthMonitor.DidNotReceiveWithAnyArgs().GetLocalHealthStatus(default, default);
+                    localHealthMonitor.DidNotReceiveWithAnyArgs().GetLocalHealthStatus(default, default, default);
                 }
 
                 await prober.Received(1).Probe(_targetSilo, 1, cancellationToken);

--- a/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
@@ -67,7 +67,7 @@ namespace NonSilo.Tests.Membership
                 });
 
             _localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
-            _localSiloHealthMonitor.GetLocalHealthDegradationScore(default).ReturnsForAnyArgs(0);
+            _localSiloHealthMonitor.GetLocalHealthStatus(default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
 
             _prober = Substitute.For<IRemoteSiloProber>();
 
@@ -347,6 +347,147 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(_targetSilo, _monitor.TargetSiloAddress);
 
             await Shutdown();
+        }
+
+        [Theory]
+        [InlineData(true, 2, 3)]
+        [InlineData(false, 8, 1)]
+        public async Task SiloHealthMonitor_DirectProbeTimeoutUsesConfiguredLocalHealthDilation(
+            bool extendProbeTimeout,
+            int localHealthScore,
+            int expectedTimeoutFactor)
+        {
+            var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(
+                new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+            var options = new ClusterMembershipOptions
+            {
+                ProbeTimeout = TimeSpan.FromSeconds(5),
+                ExtendProbeTimeoutDuringDegradation = extendProbeTimeout,
+                EnableIndirectProbes = false,
+            };
+            var optionsMonitor = Substitute.For<IOptionsMonitor<ClusterMembershipOptions>>();
+            optionsMonitor.CurrentValue.Returns(options);
+            var localHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
+            localHealthMonitor
+                .GetLocalHealthStatus(options.ProbeTimeout, LocalSiloHealthCheckCategory.Local)
+                .Returns(new LocalSiloHealthStatus(localHealthScore, []));
+            var prober = Substitute.For<IRemoteSiloProber>();
+            var probeEntered = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pendingProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            prober.Probe(default!, default, default).ReturnsForAnyArgs(call =>
+            {
+                probeEntered.TrySetResult(call.ArgAt<CancellationToken>(2));
+                return pendingProbe.Task;
+            });
+            var probeResult = new TaskCompletionSource<ProbeResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var timer = new DilationProbeTimer();
+            var timerFactory = new DelegateAsyncTimerFactory((_, _) => timer);
+            var monitor = new SiloHealthMonitor(
+                _targetSilo,
+                (_, result) =>
+                {
+                    probeResult.TrySetResult(result);
+                    return Task.CompletedTask;
+                },
+                optionsMonitor,
+                _loggerFactory,
+                prober,
+                timerFactory,
+                localHealthMonitor,
+                _membershipService,
+                _localSiloDetails,
+                timeProvider);
+
+            try
+            {
+                monitor.Start();
+                var firstTick = await timer.Ticks.ReadAsync();
+                firstTick.SetResult(true);
+                var cancellationToken = await probeEntered.Task;
+
+                if (extendProbeTimeout)
+                {
+                    localHealthMonitor.Received(1).GetLocalHealthStatus(
+                        options.ProbeTimeout,
+                        LocalSiloHealthCheckCategory.Local);
+                }
+                else
+                {
+                    localHealthMonitor.DidNotReceiveWithAnyArgs().GetLocalHealthStatus(default, default);
+                }
+
+                await prober.Received(1).Probe(_targetSilo, 1, cancellationToken);
+
+                var dilatedTimeout = options.ProbeTimeout.Multiply(expectedTimeoutFactor);
+                timeProvider.Advance(dilatedTimeout - TimeSpan.FromTicks(1));
+                Assert.False(cancellationToken.IsCancellationRequested);
+                Assert.False(probeResult.Task.IsCompleted);
+
+                timeProvider.Advance(TimeSpan.FromTicks(1));
+                Assert.True(cancellationToken.IsCancellationRequested);
+
+                var result = await probeResult.Task;
+                Assert.Equal(ProbeResultStatus.Failed, result.Status);
+                Assert.Equal(1, result.FailedProbeCount);
+                Assert.True(result.IsDirectProbe);
+                Assert.Equal(0, result.IntermediaryHealthDegradationScore);
+            }
+            finally
+            {
+                await monitor.StopAsync(CancellationToken.None);
+            }
+        }
+
+        private sealed class DilationProbeTimer : IAsyncTimer
+        {
+            private readonly object _lock = new();
+            private readonly Channel<TaskCompletionSource<bool>> _ticks = Channel.CreateUnbounded<TaskCompletionSource<bool>>();
+            private bool _disposed;
+
+            public ChannelReader<TaskCompletionSource<bool>> Ticks => _ticks.Reader;
+
+            public Task<bool> NextTick(TimeSpan? overrideDelay = null)
+            {
+                lock (_lock)
+                {
+                    if (_disposed)
+                    {
+                        return Task.FromResult(false);
+                    }
+
+                    var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    if (!_ticks.Writer.TryWrite(completion))
+                    {
+                        throw new InvalidOperationException("Unable to publish the next timer tick.");
+                    }
+
+                    return completion.Task;
+                }
+            }
+
+            public bool CheckHealth(DateTime lastCheckTime, out string reason)
+            {
+                reason = string.Empty;
+                return true;
+            }
+
+            public void Dispose()
+            {
+                lock (_lock)
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    _disposed = true;
+                    _ticks.Writer.TryComplete();
+                    while (_ticks.Reader.TryRead(out var completion))
+                    {
+                        completion.TrySetResult(false);
+                    }
+                }
+            }
         }
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);

--- a/test/Orleans.Runtime.Tests/Diagnostics/WatchdogTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/WatchdogTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class WatchdogTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact, TestCategory("BVT")]
+    public void CheckRuntimeHealth_RecordsGarbageCollectionPauseEvent()
+    {
+        using var fixture = new WatchdogFixture();
+        fixture.SetWatchdogTimestamp("_platformWatchdogTimestamp");
+        fixture.SetWatchdogTimestamp("_componentWatchdogTimestamp");
+        fixture.SetField("_cumulativeGCPauseDuration", GC.GetTotalPauseDuration() - TimeSpan.FromTicks(1));
+
+        fixture.CheckRuntimeHealth();
+
+        var healthEvent = Assert.Single(fixture.Events);
+        Assert.Equal(LocalSiloHealthCheckKind.GarbageCollectionPause, healthEvent.Kind);
+        Assert.Equal(0, healthEvent.Score);
+        Assert.Contains("garbage collection", healthEvent.Complaint, StringComparison.OrdinalIgnoreCase);
+        Assert.True(healthEvent.Duration > TimeSpan.Zero);
+        Assert.Null(healthEvent.Source);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CheckRuntimeHealth_RecordsRuntimeStallEvent()
+    {
+        using var fixture = new WatchdogFixture();
+        var stallDuration = TimeSpan.FromSeconds(2) + TimeSpan.FromTicks(1);
+        fixture.SetWatchdogTimestamp("_platformWatchdogTimestamp");
+        fixture.TimeProvider.Advance(stallDuration);
+        fixture.SetWatchdogTimestamp("_componentWatchdogTimestamp");
+        fixture.SetField("_cumulativeGCPauseDuration", GC.GetTotalPauseDuration());
+
+        fixture.CheckRuntimeHealth();
+
+        var healthEvent = Assert.Single(
+            fixture.Events,
+            item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall);
+        Assert.Equal(1, healthEvent.Score);
+        Assert.Equal(stallDuration, healthEvent.Duration);
+        Assert.Contains(".NET Runtime Platform stalled", healthEvent.Complaint, StringComparison.Ordinal);
+        Assert.Null(healthEvent.Source);
+        Assert.DoesNotContain(
+            fixture.Events,
+            item => item.Kind == LocalSiloHealthCheckKind.ComponentHealthCheckStall);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CheckRuntimeHealth_DoesNotRecordRuntimeStallAtThreshold()
+    {
+        using var fixture = new WatchdogFixture();
+        fixture.SetWatchdogTimestamp("_platformWatchdogTimestamp");
+        fixture.TimeProvider.Advance(TimeSpan.FromSeconds(2));
+        fixture.SetWatchdogTimestamp("_componentWatchdogTimestamp");
+        fixture.SetField("_cumulativeGCPauseDuration", GC.GetTotalPauseDuration());
+
+        fixture.CheckRuntimeHealth();
+
+        Assert.DoesNotContain(fixture.Events, item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CheckRuntimeHealth_RecordsComponentHealthCheckStallEvent()
+    {
+        var componentPeriod = TimeSpan.FromSeconds(5);
+        using var fixture = new WatchdogFixture(componentPeriod);
+        var stallDuration = componentPeriod.Multiply(2) + TimeSpan.FromTicks(1);
+        fixture.SetWatchdogTimestamp("_componentWatchdogTimestamp");
+        fixture.TimeProvider.Advance(stallDuration);
+        fixture.SetWatchdogTimestamp("_platformWatchdogTimestamp");
+        fixture.SetField("_cumulativeGCPauseDuration", GC.GetTotalPauseDuration());
+
+        fixture.CheckRuntimeHealth();
+
+        var healthEvent = Assert.Single(
+            fixture.Events,
+            item => item.Kind == LocalSiloHealthCheckKind.ComponentHealthCheckStall);
+        Assert.Equal(1, healthEvent.Score);
+        Assert.Equal(stallDuration, healthEvent.Duration);
+        Assert.Contains("Participant check thread", healthEvent.Complaint, StringComparison.Ordinal);
+        Assert.Null(healthEvent.Source);
+        Assert.DoesNotContain(
+            fixture.Events,
+            item => item.Kind == LocalSiloHealthCheckKind.RuntimeStall);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CheckRuntimeHealth_DoesNotRecordComponentHealthCheckStallAtThreshold()
+    {
+        var componentPeriod = TimeSpan.FromSeconds(5);
+        using var fixture = new WatchdogFixture(componentPeriod);
+        fixture.SetWatchdogTimestamp("_componentWatchdogTimestamp");
+        fixture.TimeProvider.Advance(componentPeriod.Multiply(2));
+        fixture.SetWatchdogTimestamp("_platformWatchdogTimestamp");
+        fixture.SetField("_cumulativeGCPauseDuration", GC.GetTotalPauseDuration());
+
+        fixture.CheckRuntimeHealth();
+
+        Assert.DoesNotContain(
+            fixture.Events,
+            item => item.Kind == LocalSiloHealthCheckKind.ComponentHealthCheckStall);
+    }
+
+    private sealed class WatchdogFixture : IDisposable
+    {
+        private readonly ServiceProvider _serviceProvider;
+        private readonly Watchdog _watchdog;
+        private readonly RecordingHealthEventRecorder _recorder = new();
+
+        public WatchdogFixture(TimeSpan? componentPeriod = null)
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            _serviceProvider = services.BuildServiceProvider();
+            TimeProvider = new FakeTimeProvider(Start);
+            var options = new ClusterMembershipOptions
+            {
+                LocalHealthDegradationMonitoringPeriod = componentPeriod ?? TimeSpan.FromSeconds(5),
+            };
+            _watchdog = new Watchdog(
+                Options.Create(options),
+                [],
+                NullLogger<Watchdog>.Instance,
+                new OrleansInstruments(_serviceProvider.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>()),
+                _recorder,
+                TimeProvider);
+        }
+
+        public FakeTimeProvider TimeProvider { get; }
+
+        public RecordedHealthEvent[] Events => _recorder.Events;
+
+        public void SetWatchdogTimestamp(string fieldName)
+            => SetField(fieldName, TimeProvider.GetTimestamp());
+
+        public void SetField<T>(string fieldName, T value)
+            => typeof(Watchdog)
+                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(_watchdog, value);
+
+        public void CheckRuntimeHealth()
+            => typeof(Watchdog)
+                .GetMethod("CheckRuntimeHealth", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(_watchdog, null);
+
+        public void Dispose()
+        {
+            _watchdog.Dispose();
+            _serviceProvider.Dispose();
+        }
+    }
+
+    private sealed class RecordingHealthEventRecorder : ILocalSiloHealthEventRecorder
+    {
+        private readonly ConcurrentQueue<RecordedHealthEvent> _events = new();
+
+        public RecordedHealthEvent[] Events => _events.ToArray();
+
+        public void RecordHealthEvent(
+            LocalSiloHealthCheckKind kind,
+            int score,
+            string? complaint,
+            TimeSpan? duration = null,
+            string? source = null)
+            => _events.Enqueue(new(kind, score, complaint, duration, source));
+    }
+
+    private readonly record struct RecordedHealthEvent(
+        LocalSiloHealthCheckKind Kind,
+        int Score,
+        string? Complaint,
+        TimeSpan? Duration,
+        string? Source);
+}


### PR DESCRIPTION
Local silo health checks currently run on demand, can overlap, and retain no history. This makes concurrent probe decisions repeat expensive checks and prevents callers from reasoning about recent host degradation.

This change records one minute of typed health events, serializes sampling to at most once per second, and aggregates the worst observation per check over a requested interval. Host-local and network-derived checks are classified separately so probe timeout dilation uses only recent local-host degradation.

Watchdog runtime, GC, component-check, and thread-pool stalls remain distinct events for query-time aggregation. Membership health components now use the keyed membership TimeProvider while preserving the connection-liveness checks already present on main.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10502)