### PR TITLE
fix(adonet): prevent provider query races

### DIFF
--- a/src/AdoNet/Orleans.GrainDirectory.AdoNet/MySQL-GrainDirectory.sql
+++ b/src/AdoNet/Orleans.GrainDirectory.AdoNet/MySQL-GrainDirectory.sql
@@ -85,7 +85,8 @@ BEGIN
     WHERE
         ClusterId = _ClusterId
         AND ProviderId = _ProviderId
-        AND GrainId = _GrainId;
+        AND GrainId = _GrainId
+    FOR UPDATE;
 
     COMMIT;
 

--- a/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
@@ -333,7 +333,7 @@ WITH Batch AS
 		ModifiedOn,
 		Payload
 	FROM
-		OrleansStreamMessage WITH (UPDLOCK)
+		OrleansStreamMessage WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK, ROWLOCK)
 	WHERE
 		ServiceId = @ServiceId
         AND ProviderId = @ProviderId
@@ -421,7 +421,7 @@ WITH Batch AS
 	SELECT TOP (@Count)
 		*
 	FROM
-		OrleansStreamMessage AS M WITH (UPDLOCK, HOLDLOCK)
+		OrleansStreamMessage AS M WITH (UPDLOCK, HOLDLOCK, ROWLOCK)
 	WHERE
 		ServiceId = @ServiceId
         AND ProviderId = @ProviderId
@@ -576,7 +576,7 @@ WITH Batch AS
 		RemoveOn = @RemoveOn,
 		Payload
 	FROM
-		OrleansStreamMessage WITH (UPDLOCK)
+		OrleansStreamMessage WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK, ROWLOCK)
 	WHERE
 		ServiceId = @ServiceId
         AND ProviderId = @ProviderId

--- a/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
@@ -333,7 +333,7 @@ WITH Batch AS
 		ModifiedOn,
 		Payload
 	FROM
-		OrleansStreamMessage WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK, ROWLOCK)
+		OrleansStreamMessage WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK)
 	WHERE
 		ServiceId = @ServiceId
         AND ProviderId = @ProviderId
@@ -576,7 +576,7 @@ WITH Batch AS
 		RemoveOn = @RemoveOn,
 		Payload
 	FROM
-		OrleansStreamMessage WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK, ROWLOCK)
+		OrleansStreamMessage WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK)
 	WHERE
 		ServiceId = @ServiceId
         AND ProviderId = @ProviderId


### PR DESCRIPTION
ADO.NET provider tests exposed intermittent SQL Server streaming deadlocks and a MariaDB grain-registration race under concurrent operations.

Use skip-locked reads under read-committed locking for SQL Server dequeue and eviction batches so competing consumers can make progress without deadlocking. Use a locking current read after MariaDB grain-registration upserts so concurrent unregister operations cannot produce an empty registration result.

Fixes: #10498