### PR TITLE
feat(streaming): support compact JSON Azure Queue migration

### DIFF
--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
         /// <returns>The client builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
             string name,
             Action<ClusterClientAzureQueueJsonStreamConfigurator> configure)
@@ -56,7 +56,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
         /// <returns>The client builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
             string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 
@@ -25,8 +26,41 @@ namespace Orleans.Hosting
         public static IClientBuilder AddAzureQueueStreams(this IClientBuilder builder,
             string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
-            builder.AddAzureQueueStreams(name, b=>
-                 b.ConfigureAzureQueue(configureOptions));
+            builder.AddAzureQueueStreams(name, b => b.ConfigureAzureQueue(configureOptions));
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure cluster client to use Azure Queue persistent streams with JSON serialization.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The client builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
+        /// <returns>The client builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
+            string name,
+            Action<ClusterClientAzureQueueJsonStreamConfigurator> configure)
+        {
+            var configurator = new ClusterClientAzureQueueJsonStreamConfigurator(name, builder);
+            configure?.Invoke(configurator);
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure cluster client to use Azure Queue persistent streams with JSON serialization and default settings.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The client builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
+        /// <returns>The client builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
+            string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
+        {
+            builder.AddAzureQueueJsonStreams(name, b=> b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
     }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/ClientBuilderExtensions.cs
@@ -60,7 +60,7 @@ namespace Orleans.Hosting
         public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder,
             string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
-            builder.AddAzureQueueJsonStreams(name, b=> b.ConfigureAzureQueue(configureOptions));
+            builder.AddAzureQueueJsonStreams(name, b => b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
     }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
         /// <returns>The silo builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name,
             Action<SiloAzureQueueJsonStreamConfigurator> configure)
         {
@@ -55,7 +55,7 @@ namespace Orleans.Hosting
         /// <param name="name">The stream provider name.</param>
         /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
         /// <returns>The silo builder for method chaining.</returns>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
             builder.AddAzureQueueJsonStreams(name, b =>b.ConfigureAzureQueue(configureOptions));

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -15,8 +16,7 @@ namespace Orleans.Hosting
         public static ISiloBuilder AddAzureQueueStreams(this ISiloBuilder builder, string name,
             Action<SiloAzureQueueStreamConfigurator> configure)
         {
-            var configurator = new SiloAzureQueueStreamConfigurator(name,
-                configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate));
+            var configurator = new SiloAzureQueueStreamConfigurator(name, configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate));
             configure?.Invoke(configurator);
             return builder;
         }
@@ -26,8 +26,39 @@ namespace Orleans.Hosting
         /// </summary>
         public static ISiloBuilder AddAzureQueueStreams(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
-            builder.AddAzureQueueStreams(name, b =>
-                 b.ConfigureAzureQueue(configureOptions));
+            builder.AddAzureQueueStreams(name, b => b.ConfigureAzureQueue(configureOptions));
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure silo to use Azure Queue persistent streams with JSON serialization.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The silo builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configure">Configuration delegate for the JSON-enabled Azure Queue stream provider.</param>
+        /// <returns>The silo builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name,
+            Action<SiloAzureQueueJsonStreamConfigurator> configure)
+        {
+            var configurator = new SiloAzureQueueJsonStreamConfigurator(name, configureServicesDelegate => builder.ConfigureServices(configureServicesDelegate));
+            configure?.Invoke(configurator);
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure silo to use Azure Queue persistent streams with JSON serialization and default settings.
+        /// This feature is experimental and subject to change in future updates.
+        /// </summary>
+        /// <param name="builder">The silo builder.</param>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configureOptions">Configuration delegate for Azure Queue options.</param>
+        /// <returns>The silo builder for method chaining.</returns>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
+        {
+            builder.AddAzureQueueJsonStreams(name, b =>b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -58,7 +58,7 @@ namespace Orleans.Hosting
         [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name, Action<OptionsBuilder<AzureQueueOptions>> configureOptions)
         {
-            builder.AddAzureQueueJsonStreams(name, b =>b.ConfigureAzureQueue(configureOptions));
+            builder.AddAzureQueueJsonStreams(name, b => b.ConfigureAzureQueue(configureOptions));
             return builder;
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -104,8 +104,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="cacheSize">The cache size.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureCacheSize(this ISiloAzureQueueJsonStreamConfigurator configurator, int cacheSize = SimpleQueueCacheOptions.DEFAULT_CACHE_SIZE)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.Configure<SimpleQueueCacheOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
         }
@@ -115,8 +116,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonSerialization(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
         }
@@ -126,8 +128,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonAdapter(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
         }
@@ -137,7 +140,7 @@ namespace Orleans.Hosting
     /// Silo configurator for Azure Queue streams with JSON serialization support.
     /// This configurator automatically sets up the JSON data adapter and required dependencies.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public class SiloAzureQueueJsonStreamConfigurator : SiloPersistentStreamConfigurator, ISiloAzureQueueJsonStreamConfigurator
     {
         public SiloAzureQueueJsonStreamConfigurator(string name, Action<Action<IServiceCollection>> configureServicesDelegate)
@@ -171,7 +174,7 @@ namespace Orleans.Hosting
     /// Cluster client configurator interface for Azure Queue streams with JSON serialization.
     /// This feature is experimental and subject to change in future updates.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public interface IClusterClientAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, IClusterClientPersistentStreamConfigurator { }
 
     /// <summary>
@@ -184,8 +187,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonSerialization(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
         }
@@ -195,8 +199,9 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
-        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         public static void ConfigureJsonAdapter(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
         }
@@ -206,7 +211,7 @@ namespace Orleans.Hosting
     /// Cluster client configurator for Azure Queue streams with JSON serialization support.
     /// This configurator automatically sets up the JSON data adapter and required dependencies.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public class ClusterClientAzureQueueJsonStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueJsonStreamConfigurator
     {
         public ClusterClientAzureQueueJsonStreamConfigurator(string name, IClientBuilder builder)

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Configuration;
+using Orleans.Serialization;
 using Orleans.Streams;
+using Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
 
 namespace Orleans.Hosting
 {
@@ -80,6 +84,153 @@ namespace Orleans.Hosting
                 }
             }));
             this.ConfigureDelegate(services => services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueDataAdapterV2>());
+        }
+    }
+
+    /// <summary>
+    /// Silo configurator interface for Azure Queue streams with JSON serialization.
+    /// This feature is experimental and subject to change in future updates.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public interface ISiloAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, ISiloPersistentStreamConfigurator { }
+
+    /// <summary>
+    /// Extension methods for JSON-enabled silo Azure Queue stream configurator.
+    /// </summary>
+    public static class SiloAzureQueueJsonStreamConfiguratorExtensions
+    {
+        /// <summary>
+        /// Configures the cache size for the JSON-enabled Azure Queue stream provider.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="cacheSize">The cache size.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureCacheSize(this ISiloAzureQueueJsonStreamConfigurator configurator, int cacheSize = SimpleQueueCacheOptions.DEFAULT_CACHE_SIZE)
+        {
+            configurator.Configure<SimpleQueueCacheOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
+        }
+
+        /// <summary>
+        /// Configures JSON serializer options for the Azure Queue stream provider.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonSerialization(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
+        }
+
+        /// <summary>
+        /// Configures the JSON data adapter behavior options.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonAdapter(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
+        }
+    }
+
+    /// <summary>
+    /// Silo configurator for Azure Queue streams with JSON serialization support.
+    /// This configurator automatically sets up the JSON data adapter and required dependencies.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public class SiloAzureQueueJsonStreamConfigurator : SiloPersistentStreamConfigurator, ISiloAzureQueueJsonStreamConfigurator
+    {
+        public SiloAzureQueueJsonStreamConfigurator(string name, Action<Action<IServiceCollection>> configureServicesDelegate)
+            : base(name, configureServicesDelegate, AzureQueueAdapterFactory.Create)
+        {
+            this.ConfigureComponent(AzureQueueOptionsValidator.Create);
+            this.ConfigureComponent(SimpleQueueCacheOptionsValidator.Create);
+
+            // Configure default queue names
+            this.ConfigureAzureQueue(ob => ob.PostConfigure<IOptions<ClusterOptions>>((op, clusterOp) =>
+            {
+                if (op.QueueNames == null || op.QueueNames?.Count == 0)
+                {
+                    op.QueueNames =
+                        AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(clusterOp.Value.ServiceId,
+                            this.Name);
+                }
+            }));
+
+            // Configure JSON serialization dependencies and data adapter
+            this.ConfigureDelegate(services =>
+            {
+                services.TryAddSingleton<OrleansJsonSerializer>();
+                services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueJsonDataAdapter>();
+                services.TryAddSingleton<AzureQueueDataAdapterV2>(); // fallback adapter
+            });
+        }
+    }
+
+    /// <summary>
+    /// Cluster client configurator interface for Azure Queue streams with JSON serialization.
+    /// This feature is experimental and subject to change in future updates.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public interface IClusterClientAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, IClusterClientPersistentStreamConfigurator { }
+
+    /// <summary>
+    /// Extension methods for JSON-enabled cluster client Azure Queue stream configurator.
+    /// </summary>
+    public static class ClusterClientAzureQueueJsonStreamConfiguratorExtensions
+    {
+        /// <summary>
+        /// Configures JSON serializer options for the Azure Queue stream provider.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonSerialization(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
+        }
+
+        /// <summary>
+        /// Configures the JSON data adapter behavior options.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+        public static void ConfigureJsonAdapter(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
+        {
+            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
+        }
+    }
+
+    /// <summary>
+    /// Cluster client configurator for Azure Queue streams with JSON serialization support.
+    /// This configurator automatically sets up the JSON data adapter and required dependencies.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    public class ClusterClientAzureQueueJsonStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueJsonStreamConfigurator
+    {
+        public ClusterClientAzureQueueJsonStreamConfigurator(string name, IClientBuilder builder)
+            : base(name, builder, AzureQueueAdapterFactory.Create)
+        {
+            this.ConfigureComponent(AzureQueueOptionsValidator.Create);
+
+            // Configure default queue names
+            this.ConfigureAzureQueue(ob => ob.PostConfigure<IOptions<ClusterOptions>>((op, clusterOp) =>
+            {
+                if (op.QueueNames == null || op.QueueNames?.Count == 0)
+                {
+                    op.QueueNames =
+                        AzureQueueStreamProviderUtils.GenerateDefaultAzureQueueNames(clusterOp.Value.ServiceId, this.Name);
+                }
+            }));
+
+            // Configure JSON serialization dependencies and data adapter
+            this.ConfigureDelegate(services =>
+            {
+                services.TryAddSingleton<OrleansJsonSerializer>();
+                services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueJsonDataAdapter>();
+                services.TryAddSingleton<AzureQueueDataAdapterV2>(); // fallback adapter
+            });
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamBuilder.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Configuration;
@@ -91,7 +90,7 @@ namespace Orleans.Hosting
     /// Silo configurator interface for Azure Queue streams with JSON serialization.
     /// This feature is experimental and subject to change in future updates.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public interface ISiloAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, ISiloPersistentStreamConfigurator { }
 
     /// <summary>
@@ -104,9 +103,8 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="cacheSize">The cache size.</param>
-#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static void ConfigureCacheSize(this ISiloAzureQueueJsonStreamConfigurator configurator, int cacheSize = SimpleQueueCacheOptions.DEFAULT_CACHE_SIZE)
-#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
             configurator.Configure<SimpleQueueCacheOptions>(ob => ob.Configure(options => options.CacheSize = cacheSize));
         }
@@ -116,11 +114,10 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
-#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static void ConfigureJsonSerialization(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
-#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
-            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
+            configurator.Configure<OrleansJsonSerializerOptions>(options => options.Configure(configureJsonOptions));
         }
 
         /// <summary>
@@ -128,11 +125,10 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
-#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static void ConfigureJsonAdapter(this ISiloAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
-#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
-            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
+            configurator.Configure<AzureQueueJsonDataAdapterOptions>(options => options.Configure(configureAdapterOptions));
         }
     }
 
@@ -143,6 +139,11 @@ namespace Orleans.Hosting
     [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public class SiloAzureQueueJsonStreamConfigurator : SiloPersistentStreamConfigurator, ISiloAzureQueueJsonStreamConfigurator
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SiloAzureQueueJsonStreamConfigurator"/> class.
+        /// </summary>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="configureServicesDelegate">The delegate used to configure services.</param>
         public SiloAzureQueueJsonStreamConfigurator(string name, Action<Action<IServiceCollection>> configureServicesDelegate)
             : base(name, configureServicesDelegate, AzureQueueAdapterFactory.Create)
         {
@@ -160,13 +161,9 @@ namespace Orleans.Hosting
                 }
             }));
 
-            // Configure JSON serialization dependencies and data adapter
-            this.ConfigureDelegate(services =>
-            {
-                services.TryAddSingleton<OrleansJsonSerializer>();
-                services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueJsonDataAdapter>();
-                services.TryAddSingleton<AzureQueueDataAdapterV2>(); // fallback adapter
-            });
+            this.Configure<OrleansJsonSerializerOptions>(options => { });
+            this.Configure<AzureQueueJsonDataAdapterOptions>(options => { });
+            this.ConfigureQueueDataAdapter(AzureQueueJsonDataAdapter.Create);
         }
     }
 
@@ -187,11 +184,10 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureJsonOptions">Action to configure JSON serializer options.</param>
-#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static void ConfigureJsonSerialization(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<OrleansJsonSerializerOptions> configureJsonOptions)
-#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
-            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureJsonOptions));
+            configurator.Configure<OrleansJsonSerializerOptions>(options => options.Configure(configureJsonOptions));
         }
 
         /// <summary>
@@ -199,11 +195,10 @@ namespace Orleans.Hosting
         /// </summary>
         /// <param name="configurator">The configurator.</param>
         /// <param name="configureAdapterOptions">Action to configure JSON data adapter options.</param>
-#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
         public static void ConfigureJsonAdapter(this IClusterClientAzureQueueJsonStreamConfigurator configurator, Action<AzureQueueJsonDataAdapterOptions> configureAdapterOptions)
-#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         {
-            configurator.ConfigureDelegate(services => services.Configure(configurator.Name, configureAdapterOptions));
+            configurator.Configure<AzureQueueJsonDataAdapterOptions>(options => options.Configure(configureAdapterOptions));
         }
     }
 
@@ -214,6 +209,11 @@ namespace Orleans.Hosting
     [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public class ClusterClientAzureQueueJsonStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueJsonStreamConfigurator
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusterClientAzureQueueJsonStreamConfigurator"/> class.
+        /// </summary>
+        /// <param name="name">The stream provider name.</param>
+        /// <param name="builder">The client builder.</param>
         public ClusterClientAzureQueueJsonStreamConfigurator(string name, IClientBuilder builder)
             : base(name, builder, AzureQueueAdapterFactory.Create)
         {
@@ -229,13 +229,9 @@ namespace Orleans.Hosting
                 }
             }));
 
-            // Configure JSON serialization dependencies and data adapter
-            this.ConfigureDelegate(services =>
-            {
-                services.TryAddSingleton<OrleansJsonSerializer>();
-                services.TryAddSingleton<IQueueDataAdapter<string, IBatchContainer>, AzureQueueJsonDataAdapter>();
-                services.TryAddSingleton<AzureQueueDataAdapterV2>(); // fallback adapter
-            });
+            this.Configure<OrleansJsonSerializerOptions>(options => { });
+            this.Configure<AzureQueueJsonDataAdapterOptions>(options => { });
+            this.ConfigureQueueDataAdapter(AzureQueueJsonDataAdapter.Create);
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -1,14 +1,15 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -233,35 +234,38 @@ namespace Orleans.Providers.Streams.AzureQueue
                 typeof(Dictionary<string, object>));
             using var eventsDocument = JsonDocument.Parse(serializedEvents);
             using var requestContextDocument = JsonDocument.Parse(serializedRequestContext);
-            using var textWriter = new StringWriter(CultureInfo.InvariantCulture);
-            using var jsonWriter = new JsonTextWriter(textWriter) { Formatting = Formatting.None };
+            var bufferWriter = new ArrayBufferWriter<byte>();
+            using var jsonWriter = new Utf8JsonWriter(bufferWriter);
             jsonWriter.WriteStartObject();
-            jsonWriter.WritePropertyName("version");
-            jsonWriter.WriteValue(CompactEnvelopeVersion);
-            jsonWriter.WritePropertyName("stream");
-            jsonWriter.WriteStartObject();
-            jsonWriter.WritePropertyName("namespace");
-            jsonWriter.WriteValue(streamNamespace);
-            jsonWriter.WritePropertyName("key");
-            jsonWriter.WriteValue(streamKey.ToString("D", CultureInfo.InvariantCulture));
+            jsonWriter.WriteNumber("version", CompactEnvelopeVersion);
+            jsonWriter.WriteStartObject("stream");
+            if (streamNamespace is null)
+            {
+                jsonWriter.WriteNull("namespace");
+            }
+            else
+            {
+                jsonWriter.WriteString("namespace", streamNamespace);
+            }
+
+            jsonWriter.WriteString("key", streamKey.ToString("D", CultureInfo.InvariantCulture));
             jsonWriter.WriteEndObject();
             jsonWriter.WritePropertyName("events");
             WriteCollectionValues(jsonWriter, eventsDocument.RootElement);
-            jsonWriter.WritePropertyName("requestContext");
-            jsonWriter.WriteStartObject();
+            jsonWriter.WriteStartObject("requestContext");
             foreach (var property in requestContextDocument.RootElement.EnumerateObject())
             {
                 if (property.Name is not "$id" and not "$type")
                 {
                     jsonWriter.WritePropertyName(property.Name);
-                    jsonWriter.WriteRawValue(property.Value.GetRawText());
+                    property.Value.WriteTo(jsonWriter);
                 }
             }
 
             jsonWriter.WriteEndObject();
             jsonWriter.WriteEndObject();
             jsonWriter.Flush();
-            return textWriter.ToString();
+            return Encoding.UTF8.GetString(bufferWriter.WrittenSpan);
         }
 
         private bool TryDeserializeCompactJson(string cloudMsg, out AzureQueueBatchContainerV2 batch)
@@ -309,7 +313,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             return true;
         }
 
-        private static void WriteCollectionValues(JsonTextWriter writer, JsonElement serializedCollection)
+        private static void WriteCollectionValues(Utf8JsonWriter writer, JsonElement serializedCollection)
         {
             var values = serializedCollection.ValueKind switch
             {
@@ -322,7 +326,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             writer.WriteStartArray();
             foreach (var item in values.EnumerateArray())
             {
-                writer.WriteRawValue(item.GetRawText());
+                item.WriteTo(writer);
             }
 
             writer.WriteEndArray();

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -106,13 +107,11 @@ namespace Orleans.Providers.Streams.AzureQueue
     /// This adapter is experimental and subject to change in future updates.
     /// </summary>
     [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
-    [SerializationCallbacks(typeof(OnDeserializedCallbacks))]
-    public class AzureQueueJsonDataAdapter : IQueueDataAdapter<string, IBatchContainer>, IOnDeserialized
+    public class AzureQueueJsonDataAdapter : IQueueDataAdapter<string, IBatchContainer>
     {
         private readonly AzureQueueJsonDataAdapterOptions _options;
         private readonly ILogger<AzureQueueJsonDataAdapter> _logger;
-
-        private OrleansJsonSerializer _jsonSerializer;
+        private readonly OrleansJsonSerializer _jsonSerializer;
         private readonly IQueueDataAdapter<string, IBatchContainer> _fallbackAdapter;
 
         /// <summary>
@@ -137,28 +136,27 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <summary>
         /// Creates a cloud queue message from stream event data.
         /// </summary>
-        public string ToQueueMessage<T>(StreamId streamId, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
+        public string ToQueueMessage<T>(StreamId streamId, IEnumerable<T> events, StreamSequenceToken? token, Dictionary<string, object>? requestContext)
         {
-            var azureQueueBatchMessage = new AzureQueueBatchContainerV2(streamId, events.Cast<object>().ToList(), requestContext);
+            var eventList = events.ToList();
+            var azureQueueBatchMessage = new AzureQueueBatchContainerV2(streamId, eventList.Cast<object>().ToList(), requestContext);
 
             try
             {
                 return _options.PreferJson
                     ? _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2))
-                    : _fallbackAdapter.ToQueueMessage(streamId, events, token, requestContext);
+                    : _fallbackAdapter.ToQueueMessage(streamId, eventList, token, requestContext);
             }
-            catch (Exception ex) when (this._options.EnableFallback)
+            catch (Exception ex) when (_options.EnableFallback)
             {
                 if (_options.PreferJson)
                 {
                     _logger.LogDebug(ex, "JSON serialization failed for stream {StreamId}, falling back to binary serialization", streamId);
-                    return _fallbackAdapter.ToQueueMessage(streamId, events, token, requestContext);
+                    return _fallbackAdapter.ToQueueMessage(streamId, eventList, token, requestContext);
                 }
-                else
-                {
-                    _logger.LogDebug(ex, "Binary serialization failed for stream {StreamId}, falling back to JSON serialization", streamId);
-                    return _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2));
-                }
+
+                _logger.LogDebug(ex, "Binary serialization failed for stream {StreamId}, falling back to JSON serialization", streamId);
+                return _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2));
             }
         }
 
@@ -173,14 +171,10 @@ namespace Orleans.Providers.Streams.AzureQueue
             {
                 if (_options.PreferJson)
                 {
-                    var azureQueueBatch = (AzureQueueBatchContainerV2)_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg);
-                    azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
-                    return azureQueueBatch;
+                    return DeserializeJson(cloudMsg, sequenceId);
                 }
-                else
-                {
-                    return _fallbackAdapter.FromQueueMessage(cloudMsg, sequenceId);
-                }
+
+                return _fallbackAdapter.FromQueueMessage(cloudMsg, sequenceId);
             }
             catch (Exception ex) when (_options.EnableFallback)
             {
@@ -189,19 +183,31 @@ namespace Orleans.Providers.Streams.AzureQueue
                     _logger.LogDebug(ex, "Failed to deserialize cloud message using JSON, falling back to binary deserialization");
                     return _fallbackAdapter.FromQueueMessage(cloudMsg, sequenceId);
                 }
-                else
-                {
-                    _logger.LogDebug(ex, "Binary deserialization failed for cloudMsg {cloudMsg}, falling back to JSON deserialization", cloudMsg);
-                    var azureQueueBatch = (AzureQueueBatchContainerV2)_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg);
-                    azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
-                    return azureQueueBatch;
-                }
+
+                _logger.LogDebug(ex, "Binary deserialization failed, falling back to JSON deserialization");
+                return DeserializeJson(cloudMsg, sequenceId);
             }
         }
 
-        void IOnDeserialized.OnDeserialized(DeserializationContext context)
+        internal static AzureQueueJsonDataAdapter Create(IServiceProvider services, string name)
         {
-            _jsonSerializer = context.ServiceProvider.GetRequiredService<OrleansJsonSerializer>();
+            var jsonSerializer = new OrleansJsonSerializer(Options.Create(services.GetOptionsByName<OrleansJsonSerializerOptions>(name)));
+            var fallbackAdapter = ActivatorUtilities.CreateInstance<AzureQueueDataAdapterV2>(services);
+            var options = services.GetOptionsByName<AzureQueueJsonDataAdapterOptions>(name);
+            var logger = services.GetRequiredService<ILogger<AzureQueueJsonDataAdapter>>();
+
+            return new AzureQueueJsonDataAdapter(jsonSerializer, fallbackAdapter, options, logger);
+        }
+
+        private AzureQueueBatchContainerV2 DeserializeJson(string cloudMsg, long sequenceId)
+        {
+            if (_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg) is not AzureQueueBatchContainerV2 azureQueueBatch)
+            {
+                throw new InvalidDataException("The queue message did not contain an Azure Queue batch.");
+            }
+
+            azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
+            return azureQueueBatch;
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -225,10 +224,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         private string SerializeJson<T>(StreamId streamId, List<T> events, Dictionary<string, object>? requestContext)
         {
             var streamNamespace = streamId.GetNamespace();
-            if (!Guid.TryParseExact(streamId.GetKeyAsString(), "N", out var streamKey))
-            {
-                throw new InvalidDataException("The compact JSON envelope only supports GUID-keyed streams.");
-            }
+            var streamKey = streamId.GetKeyAsString();
 
             var serializedEvents = _jsonSerializer.Serialize(events.Cast<object>().ToList(), typeof(List<object>));
             var serializedRequestContext = _jsonSerializer.Serialize(
@@ -265,7 +261,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 jsonWriter.WriteString("namespace", streamNamespace);
             }
 
-            jsonWriter.WriteString("key", streamKey.ToString("D", CultureInfo.InvariantCulture));
+            jsonWriter.WriteString("key", streamKey);
             jsonWriter.WriteEndObject();
             jsonWriter.WritePropertyName("events");
             eventValues.WriteTo(jsonWriter);
@@ -304,11 +300,8 @@ namespace Orleans.Providers.Streams.AzureQueue
             var eventsElement = GetRequiredProperty(root, "events", JsonValueKind.Array);
             var requestContextElement = GetRequiredProperty(root, "requestContext", JsonValueKind.Object);
             var streamNamespace = namespaceElement.ValueKind == JsonValueKind.Null ? null : namespaceElement.GetString();
-            var streamKeyText = keyElement.GetString();
-            if (!Guid.TryParseExact(streamKeyText, "D", out var streamKey))
-            {
-                throw new InvalidDataException("The Azure Queue JSON envelope stream key is not a GUID in D format.");
-            }
+            var streamKey = keyElement.GetString()
+                ?? throw new InvalidDataException("The Azure Queue JSON envelope stream key is missing.");
 
             var events = _jsonSerializer.Deserialize(typeof(List<object>), eventsElement.GetRawText()) as List<object>
                 ?? throw new InvalidDataException("The Azure Queue JSON envelope events could not be deserialized.");

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -139,12 +139,11 @@ namespace Orleans.Providers.Streams.AzureQueue
         public string ToQueueMessage<T>(StreamId streamId, IEnumerable<T> events, StreamSequenceToken? token, Dictionary<string, object>? requestContext)
         {
             var eventList = events.ToList();
-            var azureQueueBatchMessage = new AzureQueueBatchContainerV2(streamId, eventList.Cast<object>().ToList(), requestContext);
 
             try
             {
                 return _options.PreferJson
-                    ? _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2))
+                    ? SerializeJson()
                     : _fallbackAdapter.ToQueueMessage(streamId, eventList, token, requestContext);
             }
             catch (Exception ex) when (_options.EnableFallback)
@@ -156,7 +155,13 @@ namespace Orleans.Providers.Streams.AzureQueue
                 }
 
                 _logger.LogDebug(ex, "Binary serialization failed for stream {StreamId}, falling back to JSON serialization", streamId);
-                return _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2));
+                return SerializeJson();
+            }
+
+            string SerializeJson()
+            {
+                var batchMessage = new AzureQueueBatchContainerV2(streamId, eventList.Cast<object>().ToList(), requestContext);
+                return _jsonSerializer.Serialize(batchMessage, typeof(AzureQueueBatchContainerV2));
             }
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Serialization;
+using Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.AzureQueue
@@ -94,6 +98,110 @@ namespace Orleans.Providers.Streams.AzureQueue
         void IOnDeserialized.OnDeserialized(DeserializationContext context)
         {
             this.serializer = context.ServiceProvider.GetRequiredService<Serializer<AzureQueueBatchContainerV2>>();
+        }
+    }
+
+    /// <summary>
+    /// Data adapter that uses OrleansJsonSerializer for serializing stream event data with fallback support.
+    /// This adapter is experimental and subject to change in future updates.
+    /// </summary>
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [SerializationCallbacks(typeof(OnDeserializedCallbacks))]
+    public class AzureQueueJsonDataAdapter : IQueueDataAdapter<string, IBatchContainer>, IOnDeserialized
+    {
+        private readonly AzureQueueJsonDataAdapterOptions _options;
+        private readonly ILogger<AzureQueueJsonDataAdapter> _logger;
+
+        private OrleansJsonSerializer _jsonSerializer;
+        private readonly IQueueDataAdapter<string, IBatchContainer> _fallbackAdapter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureQueueJsonDataAdapter"/> class.
+        /// </summary>
+        /// <param name="jsonSerializer">The JSON serializer.</param>
+        /// <param name="fallbackAdapter">The fallback data adapter (typically AzureQueueDataAdapterV2).</param>
+        /// <param name="options">The adapter options.</param>
+        /// <param name="logger">The logger.</param>
+        public AzureQueueJsonDataAdapter(
+            OrleansJsonSerializer jsonSerializer,
+            AzureQueueDataAdapterV2 fallbackAdapter,
+            AzureQueueJsonDataAdapterOptions options,
+            ILogger<AzureQueueJsonDataAdapter> logger)
+        {
+            _jsonSerializer = jsonSerializer;
+            _fallbackAdapter = fallbackAdapter;
+            _options = options;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Creates a cloud queue message from stream event data.
+        /// </summary>
+        public string ToQueueMessage<T>(StreamId streamId, IEnumerable<T> events, StreamSequenceToken token, Dictionary<string, object> requestContext)
+        {
+            var azureQueueBatchMessage = new AzureQueueBatchContainerV2(streamId, events.Cast<object>().ToList(), requestContext);
+
+            try
+            {
+                return _options.PreferJson
+                    ? _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2))
+                    : _fallbackAdapter.ToQueueMessage(streamId, events, token, requestContext);
+            }
+            catch (Exception ex) when (this._options.EnableFallback)
+            {
+                if (_options.PreferJson)
+                {
+                    _logger.LogDebug(ex, "JSON serialization failed for stream {StreamId}, falling back to binary serialization", streamId);
+                    return _fallbackAdapter.ToQueueMessage(streamId, events, token, requestContext);
+                }
+                else
+                {
+                    _logger.LogDebug(ex, "Binary serialization failed for stream {StreamId}, falling back to JSON serialization", streamId);
+                    return _jsonSerializer.Serialize(azureQueueBatchMessage, typeof(AzureQueueBatchContainerV2));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a batch container from a cloud queue message
+        /// </summary>
+        public IBatchContainer FromQueueMessage(string cloudMsg, long sequenceId)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(cloudMsg, nameof(cloudMsg));
+
+            try
+            {
+                if (_options.PreferJson)
+                {
+                    var azureQueueBatch = (AzureQueueBatchContainerV2)_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg);
+                    azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
+                    return azureQueueBatch;
+                }
+                else
+                {
+                    return _fallbackAdapter.FromQueueMessage(cloudMsg, sequenceId);
+                }
+            }
+            catch (Exception ex) when (_options.EnableFallback)
+            {
+                if (_options.PreferJson)
+                {
+                    _logger.LogDebug(ex, "Failed to deserialize cloud message using JSON, falling back to binary deserialization");
+                    return _fallbackAdapter.FromQueueMessage(cloudMsg, sequenceId);
+                }
+                else
+                {
+                    _logger.LogDebug(ex, "Binary deserialization failed for cloudMsg {cloudMsg}, falling back to JSON deserialization", cloudMsg);
+                    var azureQueueBatch = (AzureQueueBatchContainerV2)_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg);
+                    azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
+                    return azureQueueBatch;
+                }
+            }
+        }
+
+        void IOnDeserialized.OnDeserialized(DeserializationContext context)
+        {
+            _jsonSerializer = context.ServiceProvider.GetRequiredService<OrleansJsonSerializer>();
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Serialization;
@@ -109,6 +112,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     public class AzureQueueJsonDataAdapter : IQueueDataAdapter<string, IBatchContainer>
     {
+        private const int CompactEnvelopeVersion = 1;
         private readonly AzureQueueJsonDataAdapterOptions _options;
         private readonly ILogger<AzureQueueJsonDataAdapter> _logger;
         private readonly OrleansJsonSerializer _jsonSerializer;
@@ -143,7 +147,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             try
             {
                 return _options.PreferJson
-                    ? SerializeJson()
+                    ? SerializeJson(streamId, eventList, requestContext)
                     : _fallbackAdapter.ToQueueMessage(streamId, eventList, token, requestContext);
             }
             catch (Exception ex) when (_options.EnableFallback)
@@ -155,13 +159,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 }
 
                 _logger.LogDebug(ex, "Binary serialization failed for stream {StreamId}, falling back to JSON serialization", streamId);
-                return SerializeJson();
-            }
-
-            string SerializeJson()
-            {
-                var batchMessage = new AzureQueueBatchContainerV2(streamId, eventList.Cast<object>().ToList(), requestContext);
-                return _jsonSerializer.Serialize(batchMessage, typeof(AzureQueueBatchContainerV2));
+                return SerializeJson(streamId, eventList, requestContext);
             }
         }
 
@@ -206,6 +204,12 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         private AzureQueueBatchContainerV2 DeserializeJson(string cloudMsg, long sequenceId)
         {
+            if (TryDeserializeCompactJson(cloudMsg, out var compactBatch))
+            {
+                compactBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
+                return compactBatch;
+            }
+
             if (_jsonSerializer.Deserialize(typeof(AzureQueueBatchContainerV2), cloudMsg) is not AzureQueueBatchContainerV2 azureQueueBatch)
             {
                 throw new InvalidDataException("The queue message did not contain an Azure Queue batch.");
@@ -213,6 +217,125 @@ namespace Orleans.Providers.Streams.AzureQueue
 
             azureQueueBatch.RealSequenceToken = new EventSequenceTokenV2(sequenceId);
             return azureQueueBatch;
+        }
+
+        private string SerializeJson<T>(StreamId streamId, List<T> events, Dictionary<string, object>? requestContext)
+        {
+            var streamNamespace = streamId.GetNamespace();
+            if (!Guid.TryParseExact(streamId.GetKeyAsString(), "N", out var streamKey))
+            {
+                throw new InvalidDataException("The compact JSON envelope only supports GUID-keyed streams.");
+            }
+
+            var serializedEvents = _jsonSerializer.Serialize(events.Cast<object>().ToList(), typeof(List<object>));
+            var serializedRequestContext = _jsonSerializer.Serialize(
+                requestContext ?? new Dictionary<string, object>(),
+                typeof(Dictionary<string, object>));
+            using var eventsDocument = JsonDocument.Parse(serializedEvents);
+            using var requestContextDocument = JsonDocument.Parse(serializedRequestContext);
+            using var textWriter = new StringWriter(CultureInfo.InvariantCulture);
+            using var jsonWriter = new JsonTextWriter(textWriter) { Formatting = Formatting.None };
+            jsonWriter.WriteStartObject();
+            jsonWriter.WritePropertyName("version");
+            jsonWriter.WriteValue(CompactEnvelopeVersion);
+            jsonWriter.WritePropertyName("stream");
+            jsonWriter.WriteStartObject();
+            jsonWriter.WritePropertyName("namespace");
+            jsonWriter.WriteValue(streamNamespace);
+            jsonWriter.WritePropertyName("key");
+            jsonWriter.WriteValue(streamKey.ToString("D", CultureInfo.InvariantCulture));
+            jsonWriter.WriteEndObject();
+            jsonWriter.WritePropertyName("events");
+            WriteCollectionValues(jsonWriter, eventsDocument.RootElement);
+            jsonWriter.WritePropertyName("requestContext");
+            jsonWriter.WriteStartObject();
+            foreach (var property in requestContextDocument.RootElement.EnumerateObject())
+            {
+                if (property.Name is not "$id" and not "$type")
+                {
+                    jsonWriter.WritePropertyName(property.Name);
+                    jsonWriter.WriteRawValue(property.Value.GetRawText());
+                }
+            }
+
+            jsonWriter.WriteEndObject();
+            jsonWriter.WriteEndObject();
+            jsonWriter.Flush();
+            return textWriter.ToString();
+        }
+
+        private bool TryDeserializeCompactJson(string cloudMsg, out AzureQueueBatchContainerV2 batch)
+        {
+            using var document = JsonDocument.Parse(cloudMsg);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("version", out var versionElement))
+            {
+                batch = null!;
+                return false;
+            }
+
+            if (versionElement.ValueKind != JsonValueKind.Number
+                || !versionElement.TryGetInt32(out var version)
+                || version != CompactEnvelopeVersion)
+            {
+                throw new InvalidDataException($"Unsupported Azure Queue JSON envelope version: {versionElement.GetRawText()}.");
+            }
+
+            var streamElement = GetRequiredProperty(root, "stream", JsonValueKind.Object);
+            if (!streamElement.TryGetProperty("namespace", out var namespaceElement)
+                || namespaceElement.ValueKind is not JsonValueKind.String and not JsonValueKind.Null)
+            {
+                throw new InvalidDataException("The Azure Queue JSON envelope property 'namespace' must be a String or Null.");
+            }
+
+            var keyElement = GetRequiredProperty(streamElement, "key", JsonValueKind.String);
+            var eventsElement = GetRequiredProperty(root, "events", JsonValueKind.Array);
+            var requestContextElement = GetRequiredProperty(root, "requestContext", JsonValueKind.Object);
+            var streamNamespace = namespaceElement.ValueKind == JsonValueKind.Null ? null : namespaceElement.GetString();
+            var streamKeyText = keyElement.GetString();
+            if (!Guid.TryParseExact(streamKeyText, "D", out var streamKey))
+            {
+                throw new InvalidDataException("The Azure Queue JSON envelope stream key is not a GUID in D format.");
+            }
+
+            var events = _jsonSerializer.Deserialize(typeof(List<object>), eventsElement.GetRawText()) as List<object>
+                ?? throw new InvalidDataException("The Azure Queue JSON envelope events could not be deserialized.");
+            var requestContext = _jsonSerializer.Deserialize(
+                typeof(Dictionary<string, object>),
+                requestContextElement.GetRawText()) as Dictionary<string, object>
+                ?? throw new InvalidDataException("The Azure Queue JSON envelope request context could not be deserialized.");
+
+            batch = new AzureQueueBatchContainerV2(StreamId.Create(streamNamespace, streamKey), events, requestContext);
+            return true;
+        }
+
+        private static void WriteCollectionValues(JsonTextWriter writer, JsonElement serializedCollection)
+        {
+            var values = serializedCollection.ValueKind switch
+            {
+                JsonValueKind.Array => serializedCollection,
+                JsonValueKind.Object when serializedCollection.TryGetProperty("$values", out var result)
+                    && result.ValueKind == JsonValueKind.Array => result,
+                _ => throw new InvalidDataException("The serialized event collection is not a JSON array.")
+            };
+
+            writer.WriteStartArray();
+            foreach (var item in values.EnumerateArray())
+            {
+                writer.WriteRawValue(item.GetRawText());
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private static JsonElement GetRequiredProperty(JsonElement parent, string name, JsonValueKind valueKind)
+        {
+            if (!parent.TryGetProperty(name, out var result) || result.ValueKind != valueKind)
+            {
+                throw new InvalidDataException($"The Azure Queue JSON envelope property '{name}' must be a {valueKind}.");
+            }
+
+            return result;
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -6,7 +6,9 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -232,10 +234,25 @@ namespace Orleans.Providers.Streams.AzureQueue
             var serializedRequestContext = _jsonSerializer.Serialize(
                 requestContext ?? new Dictionary<string, object>(),
                 typeof(Dictionary<string, object>));
-            using var eventsDocument = JsonDocument.Parse(serializedEvents);
-            using var requestContextDocument = JsonDocument.Parse(serializedRequestContext);
+            var serializedEventNode = JsonNode.Parse(serializedEvents)
+                ?? throw new InvalidDataException("The serialized event collection is not valid JSON.");
+            var eventValues = serializedEventNode switch
+            {
+                JsonArray array => array,
+                JsonObject obj when obj["$values"] is JsonArray array => array,
+                _ => throw new InvalidDataException("The serialized event collection is not a JSON array.")
+            };
+            RemoveUnreferencedIds(eventValues);
+
+            var requestContextObject = JsonNode.Parse(serializedRequestContext) as JsonObject
+                ?? throw new InvalidDataException("The serialized request context is not a JSON object.");
+            requestContextObject.Remove("$type");
+            RemoveUnreferencedIds(requestContextObject);
+
             var bufferWriter = new ArrayBufferWriter<byte>();
-            using var jsonWriter = new Utf8JsonWriter(bufferWriter);
+            using var jsonWriter = new Utf8JsonWriter(
+                bufferWriter,
+                new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             jsonWriter.WriteStartObject();
             jsonWriter.WriteNumber("version", CompactEnvelopeVersion);
             jsonWriter.WriteStartObject("stream");
@@ -251,18 +268,9 @@ namespace Orleans.Providers.Streams.AzureQueue
             jsonWriter.WriteString("key", streamKey.ToString("D", CultureInfo.InvariantCulture));
             jsonWriter.WriteEndObject();
             jsonWriter.WritePropertyName("events");
-            WriteCollectionValues(jsonWriter, eventsDocument.RootElement);
-            jsonWriter.WriteStartObject("requestContext");
-            foreach (var property in requestContextDocument.RootElement.EnumerateObject())
-            {
-                if (property.Name is not "$id" and not "$type")
-                {
-                    jsonWriter.WritePropertyName(property.Name);
-                    property.Value.WriteTo(jsonWriter);
-                }
-            }
-
-            jsonWriter.WriteEndObject();
+            eventValues.WriteTo(jsonWriter);
+            jsonWriter.WritePropertyName("requestContext");
+            requestContextObject.WriteTo(jsonWriter);
             jsonWriter.WriteEndObject();
             jsonWriter.Flush();
             return Encoding.UTF8.GetString(bufferWriter.WrittenSpan);
@@ -313,23 +321,69 @@ namespace Orleans.Providers.Streams.AzureQueue
             return true;
         }
 
-        private static void WriteCollectionValues(Utf8JsonWriter writer, JsonElement serializedCollection)
+        private static void RemoveUnreferencedIds(JsonNode value)
         {
-            var values = serializedCollection.ValueKind switch
-            {
-                JsonValueKind.Array => serializedCollection,
-                JsonValueKind.Object when serializedCollection.TryGetProperty("$values", out var result)
-                    && result.ValueKind == JsonValueKind.Array => result,
-                _ => throw new InvalidDataException("The serialized event collection is not a JSON array.")
-            };
+            var referencedIds = new HashSet<string>(StringComparer.Ordinal);
+            CollectReferences(value);
+            RemoveIds(value);
 
-            writer.WriteStartArray();
-            foreach (var item in values.EnumerateArray())
+            void CollectReferences(JsonNode node)
             {
-                item.WriteTo(writer);
+                if (node is JsonObject obj)
+                {
+                    if (obj["$ref"]?.GetValue<string>() is { } reference)
+                    {
+                        referencedIds.Add(reference);
+                    }
+
+                    foreach (var property in obj)
+                    {
+                        if (property.Value is not null)
+                        {
+                            CollectReferences(property.Value);
+                        }
+                    }
+                }
+                else if (node is JsonArray array)
+                {
+                    foreach (var item in array)
+                    {
+                        if (item is not null)
+                        {
+                            CollectReferences(item);
+                        }
+                    }
+                }
             }
 
-            writer.WriteEndArray();
+            void RemoveIds(JsonNode node)
+            {
+                if (node is JsonObject obj)
+                {
+                    if (obj["$id"]?.GetValue<string>() is { } id && !referencedIds.Contains(id))
+                    {
+                        obj.Remove("$id");
+                    }
+
+                    foreach (var property in obj)
+                    {
+                        if (property.Value is not null)
+                        {
+                            RemoveIds(property.Value);
+                        }
+                    }
+                }
+                else if (node is JsonArray array)
+                {
+                    foreach (var item in array)
+                    {
+                        if (item is not null)
+                        {
+                            RemoveIds(item);
+                        }
+                    }
+                }
+            }
         }
 
         private static JsonElement GetRequiredProperty(JsonElement parent, string name, JsonValueKind valueKind)

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -105,7 +105,7 @@ namespace Orleans.Providers.Streams.AzureQueue
     /// Data adapter that uses OrleansJsonSerializer for serializing stream event data with fallback support.
     /// This adapter is experimental and subject to change in future updates.
     /// </summary>
-    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+    [Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
     [SerializationCallbacks(typeof(OnDeserializedCallbacks))]
     public class AzureQueueJsonDataAdapter : IQueueDataAdapter<string, IBatchContainer>, IOnDeserialized
     {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
@@ -10,7 +10,7 @@ namespace Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
 /// <summary>
 /// Configuration options for the Azure Queue JSON data adapter.
 /// </summary>
-[Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+[Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
 public class AzureQueueJsonDataAdapterOptions
 {
     /// <summary>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
+
+/// <summary>
+/// Configuration options for the Azure Queue JSON data adapter.
+/// </summary>
+[Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/todo")]
+public class AzureQueueJsonDataAdapterOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable fallback to binary serialization when JSON serialization fails.
+    /// Default is true.
+    /// </summary>
+    public bool EnableFallback { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to prefer JSON serialization/deserialization first, then fallback to binary.
+    /// When false, it will try binary serialization/deserialization first, then fallback to JSON.
+    /// </summary>
+    public bool PreferJson { get; set; } = false;
+}

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/Json/AzureQueueJsonDataAdapterOptions.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
 
@@ -23,5 +18,5 @@ public class AzureQueueJsonDataAdapterOptions
     /// Gets or sets a value indicating whether to prefer JSON serialization/deserialization first, then fallback to binary.
     /// When false, it will try binary serialization/deserialization first, then fallback to JSON.
     /// </summary>
-    public bool PreferJson { get; set; } = false;
+    public bool PreferJson { get; set; } = true;
 }

--- a/src/api/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.cs
@@ -137,9 +137,30 @@ namespace Orleans.Hosting
 
     public static partial class ClientBuilderExtensions
     {
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder, string name, System.Action<Microsoft.Extensions.Options.OptionsBuilder<Configuration.AzureQueueOptions>> configureOptions) { throw null; }
+
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static IClientBuilder AddAzureQueueJsonStreams(this IClientBuilder builder, string name, System.Action<ClusterClientAzureQueueJsonStreamConfigurator> configure) { throw null; }
+
         public static IClientBuilder AddAzureQueueStreams(this IClientBuilder builder, string name, System.Action<Microsoft.Extensions.Options.OptionsBuilder<Configuration.AzureQueueOptions>> configureOptions) { throw null; }
 
         public static IClientBuilder AddAzureQueueStreams(this IClientBuilder builder, string name, System.Action<ClusterClientAzureQueueStreamConfigurator> configure) { throw null; }
+    }
+
+    [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+    public partial class ClusterClientAzureQueueJsonStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueJsonStreamConfigurator, IAzureQueueStreamConfigurator, INamedServiceConfigurator, IClusterClientPersistentStreamConfigurator, IPersistentStreamConfigurator
+    {
+        public ClusterClientAzureQueueJsonStreamConfigurator(string name, IClientBuilder builder) : base(default!, default!, default!) { }
+    }
+
+    public static partial class ClusterClientAzureQueueJsonStreamConfiguratorExtensions
+    {
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static void ConfigureJsonAdapter(this IClusterClientAzureQueueJsonStreamConfigurator configurator, System.Action<Streaming.AzureStorage.Providers.Streams.AzureQueue.Json.AzureQueueJsonDataAdapterOptions> configureAdapterOptions) { }
+
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static void ConfigureJsonSerialization(this IClusterClientAzureQueueJsonStreamConfigurator configurator, System.Action<Serialization.OrleansJsonSerializerOptions> configureJsonOptions) { }
     }
 
     public partial class ClusterClientAzureQueueStreamConfigurator : ClusterClientPersistentStreamConfigurator, IClusterClientAzureQueueStreamConfigurator, IAzureQueueStreamConfigurator, INamedServiceConfigurator, IClusterClientPersistentStreamConfigurator, IPersistentStreamConfigurator
@@ -151,12 +172,40 @@ namespace Orleans.Hosting
     {
     }
 
+    [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+    public partial interface IClusterClientAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, INamedServiceConfigurator, IClusterClientPersistentStreamConfigurator, IPersistentStreamConfigurator
+    {
+    }
+
     public partial interface IClusterClientAzureQueueStreamConfigurator : IAzureQueueStreamConfigurator, INamedServiceConfigurator, IClusterClientPersistentStreamConfigurator, IPersistentStreamConfigurator
+    {
+    }
+
+    [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+    public partial interface ISiloAzureQueueJsonStreamConfigurator : IAzureQueueStreamConfigurator, INamedServiceConfigurator, ISiloPersistentStreamConfigurator, IPersistentStreamConfigurator
     {
     }
 
     public partial interface ISiloAzureQueueStreamConfigurator : IAzureQueueStreamConfigurator, INamedServiceConfigurator, ISiloPersistentStreamConfigurator, IPersistentStreamConfigurator
     {
+    }
+
+    [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+    public partial class SiloAzureQueueJsonStreamConfigurator : SiloPersistentStreamConfigurator, ISiloAzureQueueJsonStreamConfigurator, IAzureQueueStreamConfigurator, INamedServiceConfigurator, ISiloPersistentStreamConfigurator, IPersistentStreamConfigurator
+    {
+        public SiloAzureQueueJsonStreamConfigurator(string name, System.Action<System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection>> configureServicesDelegate) : base(default!, default!, default!) { }
+    }
+
+    public static partial class SiloAzureQueueJsonStreamConfiguratorExtensions
+    {
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static void ConfigureCacheSize(this ISiloAzureQueueJsonStreamConfigurator configurator, int cacheSize = 4096) { }
+
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static void ConfigureJsonAdapter(this ISiloAzureQueueJsonStreamConfigurator configurator, System.Action<Streaming.AzureStorage.Providers.Streams.AzureQueue.Json.AzureQueueJsonDataAdapterOptions> configureAdapterOptions) { }
+
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static void ConfigureJsonSerialization(this ISiloAzureQueueJsonStreamConfigurator configurator, System.Action<Serialization.OrleansJsonSerializerOptions> configureJsonOptions) { }
     }
 
     public partial class SiloAzureQueueStreamConfigurator : SiloPersistentStreamConfigurator, ISiloAzureQueueStreamConfigurator, IAzureQueueStreamConfigurator, INamedServiceConfigurator, ISiloPersistentStreamConfigurator, IPersistentStreamConfigurator
@@ -171,6 +220,12 @@ namespace Orleans.Hosting
 
     public static partial class SiloBuilderExtensions
     {
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name, System.Action<Microsoft.Extensions.Options.OptionsBuilder<Configuration.AzureQueueOptions>> configureOptions) { throw null; }
+
+        [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+        public static ISiloBuilder AddAzureQueueJsonStreams(this ISiloBuilder builder, string name, System.Action<SiloAzureQueueJsonStreamConfigurator> configure) { throw null; }
+
         public static ISiloBuilder AddAzureQueueStreams(this ISiloBuilder builder, string name, System.Action<Microsoft.Extensions.Options.OptionsBuilder<Configuration.AzureQueueOptions>> configureOptions) { throw null; }
 
         public static ISiloBuilder AddAzureQueueStreams(this ISiloBuilder builder, string name, System.Action<SiloAzureQueueStreamConfigurator> configure) { throw null; }
@@ -238,6 +293,16 @@ namespace Orleans.Providers.Streams.AzureQueue
         public Orleans.Streams.IBatchContainer FromQueueMessage(string cloudMsg, long sequenceId) { throw null; }
 
         void Serialization.IOnDeserialized.OnDeserialized(Serialization.DeserializationContext context) { }
+
+        public string ToQueueMessage<T>(Runtime.StreamId streamId, System.Collections.Generic.IEnumerable<T> events, Orleans.Streams.StreamSequenceToken? token, System.Collections.Generic.Dictionary<string, object>? requestContext) { throw null; }
+    }
+
+    [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+    public partial class AzureQueueJsonDataAdapter : Orleans.Streams.IQueueDataAdapter<string, Orleans.Streams.IBatchContainer>, Orleans.Streams.IQueueDataAdapter<string>
+    {
+        public AzureQueueJsonDataAdapter(Serialization.OrleansJsonSerializer jsonSerializer, AzureQueueDataAdapterV2 fallbackAdapter, Streaming.AzureStorage.Providers.Streams.AzureQueue.Json.AzureQueueJsonDataAdapterOptions options, Microsoft.Extensions.Logging.ILogger<AzureQueueJsonDataAdapter> logger) { }
+
+        public Orleans.Streams.IBatchContainer FromQueueMessage(string cloudMsg, long sequenceId) { throw null; }
 
         public string ToQueueMessage<T>(Runtime.StreamId streamId, System.Collections.Generic.IEnumerable<T> events, Orleans.Streams.StreamSequenceToken? token, System.Collections.Generic.Dictionary<string, object>? requestContext) { throw null; }
     }
@@ -364,5 +429,16 @@ namespace Orleans.Streaming.AzureStorage
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenOperationRetries { get { throw null; } set { } }
+    }
+}
+
+namespace Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("StreamingJsonSerializationExperimental", UrlFormat = "https://github.com/dotnet/orleans/pull/9618")]
+    public partial class AzureQueueJsonDataAdapterOptions
+    {
+        public bool EnableFallback { get { throw null; } set { } }
+
+        public bool PreferJson { get { throw null; } set { } }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Orleans.Azure.Tests.csproj
+++ b/test/Extensions/Orleans.Azure.Tests/Orleans.Azure.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
-    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Extensions/Orleans.Azure.Tests/Orleans.Azure.Tests.csproj
+++ b/test/Extensions/Orleans.Azure.Tests/Orleans.Azure.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -1,0 +1,259 @@
+#pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+using System.Buffers.Text;
+using System.Collections.Concurrent;
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streaming.AzureStorage.Providers.Streams.AzureQueue.Json;
+using Orleans.Streams;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tester.AzureUtils.Streaming
+{
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    [TestCategory("AzureStorage"), TestCategory("Streaming")]
+    public class AzureQueueJsonDataAdapterTests : AzureStorageBasicTests, IAsyncLifetime
+    {
+        private readonly ITestOutputHelper output;
+        private readonly TestEnvironmentFixture fixture;
+        private const int NumBatches = 20;
+        private const int NumMessagesPerBatch = 20;
+        public static readonly string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AQAdapterTests";
+        private readonly ILoggerFactory loggerFactory;
+        private static readonly List<string> azureQueueNames = AzureQueueUtilities.GenerateQueueNames($"AzureQueueAdapterTests-{Guid.NewGuid()}", 8);
+
+        public AzureQueueJsonDataAdapterTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
+        {
+            this.output = output;
+            this.fixture = fixture;
+            this.loggerFactory = this.fixture.Services.GetService<ILoggerFactory>();
+        }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
+        {
+            try
+            {
+                TestUtils.CheckForAzureStorage();
+                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(this.loggerFactory, azureQueueNames, new AzureQueueOptions().ConfigureTestDefaults());
+            }
+            catch (SkipException) { }
+        }
+
+        private AzureQueueJsonDataAdapter InitializeQueueJsonDataAdapter(bool enableFallback, bool preferJson)
+        {
+            var serializer = this.fixture.Services.GetService<Serializer>();
+            var azureQueueDataAdapterV2 = new AzureQueueDataAdapterV2(serializer);
+            var jsonOrleansSerializer = new OrleansJsonSerializer(Options.Create(new OrleansJsonSerializerOptions()));
+            var logger = Substitute.For<ILogger<AzureQueueJsonDataAdapter>>();
+
+            var jsonQueueDataAdapter = new AzureQueueJsonDataAdapter(
+                jsonOrleansSerializer,
+                fallbackAdapter: azureQueueDataAdapterV2,
+                new AzureQueueJsonDataAdapterOptions() { EnableFallback = enableFallback, PreferJson = preferJson },
+                logger);
+
+            return jsonQueueDataAdapter;
+        }
+
+        private AzureQueueDataAdapterV2 InitializeBinaryOnlyAdapter()
+        {
+            var serializer = this.fixture.Services.GetService<Serializer>();
+
+            var codec = serializer.SessionPool.CodecProvider.TryGetCodec<EventData>();
+            Assert.NotNull(codec);
+            this.output.WriteLine("Codec for EventData: {0}", codec);
+
+            return new AzureQueueDataAdapterV2(serializer);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void ToAndFromQueueMessage_SerializesAccordingToFormat()
+        {
+            var options = new AzureQueueOptions
+            {
+                MessageVisibilityTimeout = TimeSpan.FromSeconds(30),
+                QueueNames = azureQueueNames
+            };
+            options.ConfigureTestDefaults();
+            var queueCacheOptions = new SimpleQueueCacheOptions();
+            var queueDataAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+
+            var data = new EventData();
+            var token = new EventSequenceTokenV2();
+
+            var msg = queueDataAdapter.ToQueueMessage(
+                StreamId.Create("ns", Guid.NewGuid()),
+                [data],
+                token,
+                new Dictionary<string, object>());
+
+            this.output.WriteLine("Serialized message: {0}", msg);
+            Assert.True(IsValidJson(msg), "Message should be valid JSON");
+
+            var batchContainer = queueDataAdapter.FromQueueMessage(msg, token.SequenceNumber);
+            var deserializedMsg = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            Assert.NotNull(deserializedMsg);
+            Assert.Equal(data, deserializedMsg.Item1);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void BinaryOnlyAdapter_SerializesToBinaryFormat()
+        {
+            var binaryAdapter = InitializeBinaryOnlyAdapter();
+            var data = new EventData { Id = 123, Name = "BinaryTest" };
+            var token = new EventSequenceTokenV2();
+            var streamId = StreamId.Create("binary-ns", Guid.NewGuid());
+
+            var msg = binaryAdapter.ToQueueMessage(
+                streamId,
+                [data],
+                token,
+                new Dictionary<string, object> { { "source", "binary-test" } });
+
+            this.output.WriteLine("Binary serialized message: {0}", msg);
+            
+            // Should be base64 encoded binary data, not JSON
+            Assert.False(IsValidJson(msg), "Binary adapter should not produce JSON");
+            Assert.True(IsValidBase64String(msg), "Binary adapter should produce valid base64");
+
+            // Verify round-trip works
+            var batchContainer = binaryAdapter.FromQueueMessage(msg, token.SequenceNumber);
+            var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            
+            Assert.NotNull(deserializedEvent);
+            Assert.Equal(data, deserializedEvent.Item1);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void JsonAdapter_FallsBackToBinaryWhenDeserializingBinaryData()
+        {
+            // First create a binary message using the V2 adapter
+            var binaryAdapter = InitializeBinaryOnlyAdapter();
+            var data = new EventData { Id = 456, Name = "FallbackTest" };
+            var token = new EventSequenceTokenV2();
+            var streamId = StreamId.Create("fallback-ns", Guid.NewGuid());
+
+            var binaryMsg = binaryAdapter.ToQueueMessage(
+                streamId,
+                [data],
+                token,
+                new Dictionary<string, object> { { "format", "binary" } });
+
+            this.output.WriteLine("Original binary message: {0}", binaryMsg);
+            Assert.True(IsValidBase64String(binaryMsg), "Should be valid base64 binary data");
+
+            // Now try to deserialize it with JSON adapter
+            var jsonAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+            
+            var batchContainer = jsonAdapter.FromQueueMessage(binaryMsg, token.SequenceNumber);
+            var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            
+            Assert.NotNull(deserializedEvent);
+            Assert.Equal(data, deserializedEvent.Item1);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void BinaryPreferredAdapter_FallsBackToJsonWhenDeserializingJsonData()
+        {
+            // First create a JSON message using JSON-preferred adapter
+            var jsonFirstAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+            var data = new EventData { Id = 789, Name = "JsonToJsonTest" };
+            var token = new EventSequenceTokenV2();
+            var streamId = StreamId.Create("json-fallback-ns", Guid.NewGuid());
+
+            var jsonMsg = jsonFirstAdapter.ToQueueMessage(
+                streamId,
+                [data],
+                token,
+                new Dictionary<string, object> { { "format", "json" } });
+
+            this.output.WriteLine("Original JSON message: {0}", jsonMsg);
+            Assert.True(IsValidJson(jsonMsg), "Should be valid JSON data");
+
+            // Now try to deserialize it with binary-preferred adapter
+            var binaryPreferredAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: false);
+            
+            var batchContainer = binaryPreferredAdapter.FromQueueMessage(jsonMsg, token.SequenceNumber);
+            var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
+            
+            Assert.NotNull(deserializedEvent);
+            Assert.Equal(data, deserializedEvent.Item1);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public void JsonAdapter_WithoutFallback_FailsOnIncompatibleData()
+        {
+            // Create a binary message
+            var binaryAdapter = InitializeBinaryOnlyAdapter();
+            var data = new EventData { Id = 999, Name = "FailureTest" };
+            var token = new EventSequenceTokenV2();
+
+            var binaryMsg = binaryAdapter.ToQueueMessage(
+                StreamId.Create("failure-ns", Guid.NewGuid()),
+                [data],
+                token,
+                new Dictionary<string, object>());
+
+            // Try to deserialize with JSON adapter that has fallback disabled
+            var jsonAdapterNoFallback = InitializeQueueJsonDataAdapter(enableFallback: false, preferJson: true);
+            
+            Assert.ThrowsAny<Exception>(() => jsonAdapterNoFallback.FromQueueMessage(binaryMsg, token.SequenceNumber));
+        }
+
+        [GenerateSerializer]
+        public class EventData : IEquatable<EventData>
+        {
+            [Id(0)]
+            public int Id { get; set; }
+            
+            [Id(1)]
+            public string Name { get; set; }
+
+            public override bool Equals(object obj) => Equals(obj as EventData);
+            public bool Equals(EventData other) => other is not null && Id == other.Id && Name == other.Name;
+            public override int GetHashCode() => HashCode.Combine(Id, Name);
+
+            public static bool operator ==(EventData left, EventData right) => EqualityComparer<EventData>.Default.Equals(left, right);
+            public static bool operator !=(EventData left, EventData right) => !(left == right);
+        }
+
+        private static bool IsValidJson(string msg)
+        {
+            try
+            {
+                _ = JsonConvert.DeserializeObject(msg);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsValidBase64String(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+                return false;
+
+            // generated by copilot
+            return Base64.IsValid(s);
+        }
+    }
+}
+#pragma warning restore StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -45,7 +45,8 @@ namespace Tester.AzureUtils.Streaming
         {
             var serializer = this.fixture.Services.GetRequiredService<Serializer>();
             var azureQueueDataAdapterV2 = new AzureQueueDataAdapterV2(serializer);
-            var jsonOrleansSerializer = new OrleansJsonSerializer(Options.Create(new OrleansJsonSerializerOptions()));
+            var jsonOptions = this.fixture.Services.GetRequiredService<IOptions<OrleansJsonSerializerOptions>>();
+            var jsonOrleansSerializer = new OrleansJsonSerializer(jsonOptions);
 
             return new AzureQueueJsonDataAdapter(
                 jsonOrleansSerializer,
@@ -275,7 +276,7 @@ namespace Tester.AzureUtils.Streaming
 
         private static bool IsValidBase64String(string s)
         {
-            return !string.IsNullOrWhiteSpace(s) && Base64.IsValid(s);
+            return !string.IsNullOrWhiteSpace(s) && Base64.IsValid(s, out _);
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -1,14 +1,11 @@
 #pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Buffers.Text;
-using System.Collections.Concurrent;
-using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using NSubstitute;
-using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
@@ -23,54 +20,43 @@ namespace Tester.AzureUtils.Streaming
 {
     [Collection(TestEnvironmentFixture.DefaultCollection)]
     [TestCategory("AzureStorage"), TestCategory("Streaming")]
-    public class AzureQueueJsonDataAdapterTests : AzureStorageBasicTests, IAsyncLifetime
+    public class AzureQueueJsonDataAdapterTests
     {
+        private const string Orleans3JsonMessage =
+            "{\"$id\":\"1\",\"$type\":\"Orleans.Providers.Streams.AzureQueue.AzureQueueBatchContainerV2, Orleans.Streaming.AzureStorage\"," +
+            "\"events\":{\"$type\":\"System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib]], System.Private.CoreLib\"," +
+            "\"$values\":[\"test-event\"]},\"requestContext\":{\"$id\":\"2\"," +
+            "\"$type\":\"System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.Object, System.Private.CoreLib]], System.Private.CoreLib\"," +
+            "\"key\":\"value\"},\"StreamId\":{\"$id\":\"3\",\"$type\":\"Orleans.Runtime.StreamId, Orleans.Streaming\"," +
+            "\"fk\":{\"$type\":\"System.Byte[], System.Private.CoreLib\"," +
+            "\"$value\":\"dGVzdC1uYW1lc3BhY2UwMDExMjIzMzQ0NTU2Njc3ODg5OWFhYmJjY2RkZWVmZg==\"}," +
+            "\"ki\":14,\"fh\":1821817189}}";
+
         private readonly ITestOutputHelper output;
         private readonly TestEnvironmentFixture fixture;
-        private const int NumBatches = 20;
-        private const int NumMessagesPerBatch = 20;
-        public static readonly string AZURE_QUEUE_STREAM_PROVIDER_NAME = "AQAdapterTests";
-        private readonly ILoggerFactory loggerFactory;
-        private static readonly List<string> azureQueueNames = AzureQueueUtilities.GenerateQueueNames($"AzureQueueAdapterTests-{Guid.NewGuid()}", 8);
 
         public AzureQueueJsonDataAdapterTests(ITestOutputHelper output, TestEnvironmentFixture fixture)
         {
             this.output = output;
             this.fixture = fixture;
-            this.loggerFactory = this.fixture.Services.GetService<ILoggerFactory>();
         }
 
-        public Task InitializeAsync() => Task.CompletedTask;
-
-        public async Task DisposeAsync()
+        private AzureQueueJsonDataAdapter InitializeQueueJsonDataAdapter(AzureQueueJsonDataAdapterOptions? options = null)
         {
-            try
-            {
-                TestUtils.CheckForAzureStorage();
-                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(this.loggerFactory, azureQueueNames, new AzureQueueOptions().ConfigureTestDefaults());
-            }
-            catch (SkipException) { }
-        }
-
-        private AzureQueueJsonDataAdapter InitializeQueueJsonDataAdapter(bool enableFallback, bool preferJson)
-        {
-            var serializer = this.fixture.Services.GetService<Serializer>();
+            var serializer = this.fixture.Services.GetRequiredService<Serializer>();
             var azureQueueDataAdapterV2 = new AzureQueueDataAdapterV2(serializer);
             var jsonOrleansSerializer = new OrleansJsonSerializer(Options.Create(new OrleansJsonSerializerOptions()));
-            var logger = Substitute.For<ILogger<AzureQueueJsonDataAdapter>>();
 
-            var jsonQueueDataAdapter = new AzureQueueJsonDataAdapter(
+            return new AzureQueueJsonDataAdapter(
                 jsonOrleansSerializer,
                 fallbackAdapter: azureQueueDataAdapterV2,
-                new AzureQueueJsonDataAdapterOptions() { EnableFallback = enableFallback, PreferJson = preferJson },
-                logger);
-
-            return jsonQueueDataAdapter;
+                options ?? new AzureQueueJsonDataAdapterOptions(),
+                NullLogger<AzureQueueJsonDataAdapter>.Instance);
         }
 
         private AzureQueueDataAdapterV2 InitializeBinaryOnlyAdapter()
         {
-            var serializer = this.fixture.Services.GetService<Serializer>();
+            var serializer = this.fixture.Services.GetRequiredService<Serializer>();
 
             var codec = serializer.SessionPool.CodecProvider.TryGetCodec<EventData>();
             Assert.NotNull(codec);
@@ -79,17 +65,10 @@ namespace Tester.AzureUtils.Streaming
             return new AzureQueueDataAdapterV2(serializer);
         }
 
-        [SkippableFact, TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void ToAndFromQueueMessage_SerializesAccordingToFormat()
         {
-            var options = new AzureQueueOptions
-            {
-                MessageVisibilityTimeout = TimeSpan.FromSeconds(30),
-                QueueNames = azureQueueNames
-            };
-            options.ConfigureTestDefaults();
-            var queueCacheOptions = new SimpleQueueCacheOptions();
-            var queueDataAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+            var queueDataAdapter = InitializeQueueJsonDataAdapter();
 
             var data = new EventData();
             var token = new EventSequenceTokenV2();
@@ -109,7 +88,7 @@ namespace Tester.AzureUtils.Streaming
             Assert.Equal(data, deserializedMsg.Item1);
         }
 
-        [SkippableFact, TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void BinaryOnlyAdapter_SerializesToBinaryFormat()
         {
             var binaryAdapter = InitializeBinaryOnlyAdapter();
@@ -125,11 +104,9 @@ namespace Tester.AzureUtils.Streaming
 
             this.output.WriteLine("Binary serialized message: {0}", msg);
             
-            // Should be base64 encoded binary data, not JSON
             Assert.False(IsValidJson(msg), "Binary adapter should not produce JSON");
             Assert.True(IsValidBase64String(msg), "Binary adapter should produce valid base64");
 
-            // Verify round-trip works
             var batchContainer = binaryAdapter.FromQueueMessage(msg, token.SequenceNumber);
             var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
             
@@ -138,10 +115,9 @@ namespace Tester.AzureUtils.Streaming
             Assert.Equal(streamId, batchContainer.StreamId);
         }
 
-        [SkippableFact, TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void JsonAdapter_FallsBackToBinaryWhenDeserializingBinaryData()
         {
-            // First create a binary message using the V2 adapter
             var binaryAdapter = InitializeBinaryOnlyAdapter();
             var data = new EventData { Id = 456, Name = "FallbackTest" };
             var token = new EventSequenceTokenV2();
@@ -156,8 +132,7 @@ namespace Tester.AzureUtils.Streaming
             this.output.WriteLine("Original binary message: {0}", binaryMsg);
             Assert.True(IsValidBase64String(binaryMsg), "Should be valid base64 binary data");
 
-            // Now try to deserialize it with JSON adapter
-            var jsonAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
             
             var batchContainer = jsonAdapter.FromQueueMessage(binaryMsg, token.SequenceNumber);
             var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
@@ -167,11 +142,39 @@ namespace Tester.AzureUtils.Streaming
             Assert.Equal(streamId, batchContainer.StreamId);
         }
 
-        [SkippableFact, TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_DeserializesOrleans7BinaryMessage()
+        {
+            const string orleans727Message = "IMABIQADSQUPcGF5bG9hZODBASFAGWxlZ2FjeXN0cmVhbQENYTLyfF/g4A==";
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+
+            var batchContainer = jsonAdapter.FromQueueMessage(orleans727Message, sequenceId: 42);
+            var deserializedEvent = Assert.Single(batchContainer.GetEvents<string>());
+
+            Assert.Equal("payload", deserializedEvent.Item1);
+            Assert.Equal(new EventSequenceTokenV2(42), deserializedEvent.Item2);
+            Assert.Equal(StreamId.Create("legacy", "stream"), batchContainer.StreamId);
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_DeserializesOrleans3JsonMessage()
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+
+            var batchContainer = jsonAdapter.FromQueueMessage(Orleans3JsonMessage, sequenceId: 43);
+            var deserializedEvent = Assert.Single(batchContainer.GetEvents<string>());
+
+            Assert.Equal("test-event", deserializedEvent.Item1);
+            Assert.Equal(new EventSequenceTokenV2(43), deserializedEvent.Item2);
+            Assert.Equal(
+                StreamId.Create("test-namespace", Guid.Parse("00112233-4455-6677-8899-aabbccddeeff")),
+                batchContainer.StreamId);
+        }
+
+        [Fact, TestCategory("BVT")]
         public void BinaryPreferredAdapter_FallsBackToJsonWhenDeserializingJsonData()
         {
-            // First create a JSON message using JSON-preferred adapter
-            var jsonFirstAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: true);
+            var jsonFirstAdapter = InitializeQueueJsonDataAdapter();
             var data = new EventData { Id = 789, Name = "JsonToJsonTest" };
             var token = new EventSequenceTokenV2();
             var streamId = StreamId.Create("json-fallback-ns", Guid.NewGuid());
@@ -185,8 +188,7 @@ namespace Tester.AzureUtils.Streaming
             this.output.WriteLine("Original JSON message: {0}", jsonMsg);
             Assert.True(IsValidJson(jsonMsg), "Should be valid JSON data");
 
-            // Now try to deserialize it with binary-preferred adapter
-            var binaryPreferredAdapter = InitializeQueueJsonDataAdapter(enableFallback: true, preferJson: false);
+            var binaryPreferredAdapter = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { PreferJson = false });
             
             var batchContainer = binaryPreferredAdapter.FromQueueMessage(jsonMsg, token.SequenceNumber);
             var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
@@ -196,10 +198,9 @@ namespace Tester.AzureUtils.Streaming
             Assert.Equal(streamId, batchContainer.StreamId);
         }
 
-        [SkippableFact, TestCategory("Functional")]
+        [Fact, TestCategory("BVT")]
         public void JsonAdapter_WithoutFallback_FailsOnIncompatibleData()
         {
-            // Create a binary message
             var binaryAdapter = InitializeBinaryOnlyAdapter();
             var data = new EventData { Id = 999, Name = "FailureTest" };
             var token = new EventSequenceTokenV2();
@@ -210,27 +211,53 @@ namespace Tester.AzureUtils.Streaming
                 token,
                 new Dictionary<string, object>());
 
-            // Try to deserialize with JSON adapter that has fallback disabled
-            var jsonAdapterNoFallback = InitializeQueueJsonDataAdapter(enableFallback: false, preferJson: true);
+            var jsonAdapterNoFallback = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { EnableFallback = false });
             
             Assert.ThrowsAny<Exception>(() => jsonAdapterNoFallback.FromQueueMessage(binaryMsg, token.SequenceNumber));
         }
 
+        [Fact, TestCategory("BVT")]
+        public void Configurators_UseProviderSpecificAdapterOptions()
+        {
+            const string binaryProviderName = "binary-preferred";
+            const string jsonProviderName = "json-preferred";
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(this.fixture.Services.GetRequiredService<Serializer>());
+            services.AddSingleton(this.fixture.Services.GetRequiredService<IRuntimeClient>());
+
+            var binaryConfigurator = new SiloAzureQueueJsonStreamConfigurator(binaryProviderName, configure => configure(services));
+            binaryConfigurator.ConfigureJsonAdapter(options => options.PreferJson = false);
+            _ = new SiloAzureQueueJsonStreamConfigurator(jsonProviderName, configure => configure(services));
+
+            using var serviceProvider = services.BuildServiceProvider();
+            var binaryAdapter = serviceProvider.GetRequiredKeyedService<IQueueDataAdapter<string, IBatchContainer>>(binaryProviderName);
+            var jsonAdapter = serviceProvider.GetRequiredKeyedService<IQueueDataAdapter<string, IBatchContainer>>(jsonProviderName);
+            var streamId = StreamId.Create("options", Guid.NewGuid());
+            var events = new[] { new EventData { Id = 1, Name = "test" } };
+
+            var binaryMessage = binaryAdapter.ToQueueMessage(streamId, events, token: null, requestContext: null);
+            var jsonMessage = jsonAdapter.ToQueueMessage(streamId, events, token: null, requestContext: null);
+
+            Assert.False(IsValidJson(binaryMessage));
+            Assert.True(IsValidJson(jsonMessage));
+        }
+
         [GenerateSerializer]
-        public class EventData : IEquatable<EventData>
+        public sealed class EventData : IEquatable<EventData>
         {
             [Id(0)]
             public int Id { get; set; }
             
             [Id(1)]
-            public string Name { get; set; }
+            public string Name { get; set; } = string.Empty;
 
-            public override bool Equals(object obj) => Equals(obj as EventData);
-            public bool Equals(EventData other) => other is not null && Id == other.Id && Name == other.Name;
+            public override bool Equals(object? obj) => Equals(obj as EventData);
+            public bool Equals(EventData? other) => other is not null && Id == other.Id && Name == other.Name;
             public override int GetHashCode() => HashCode.Combine(Id, Name);
 
-            public static bool operator ==(EventData left, EventData right) => EqualityComparer<EventData>.Default.Equals(left, right);
-            public static bool operator !=(EventData left, EventData right) => !(left == right);
+            public static bool operator ==(EventData? left, EventData? right) => EqualityComparer<EventData>.Default.Equals(left, right);
+            public static bool operator !=(EventData? left, EventData? right) => !(left == right);
         }
 
         private static bool IsValidJson(string msg)
@@ -248,11 +275,7 @@ namespace Tester.AzureUtils.Streaming
 
         private static bool IsValidBase64String(string s)
         {
-            if (string.IsNullOrWhiteSpace(s))
-                return false;
-
-            // generated by copilot
-            return Base64.IsValid(s);
+            return !string.IsNullOrWhiteSpace(s) && Base64.IsValid(s);
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -103,13 +103,13 @@ namespace Tester.AzureUtils.Streaming
                 new Dictionary<string, object> { { "source", "binary-test" } });
 
             this.output.WriteLine("Binary serialized message: {0}", msg);
-            
+
             Assert.False(IsValidJson(msg), "Binary adapter should not produce JSON");
             Assert.True(IsValidBase64String(msg), "Binary adapter should produce valid base64");
 
             var batchContainer = binaryAdapter.FromQueueMessage(msg, token.SequenceNumber);
             var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
-            
+
             Assert.NotNull(deserializedEvent);
             Assert.Equal(data, deserializedEvent.Item1);
             Assert.Equal(streamId, batchContainer.StreamId);
@@ -133,10 +133,10 @@ namespace Tester.AzureUtils.Streaming
             Assert.True(IsValidBase64String(binaryMsg), "Should be valid base64 binary data");
 
             var jsonAdapter = InitializeQueueJsonDataAdapter();
-            
+
             var batchContainer = jsonAdapter.FromQueueMessage(binaryMsg, token.SequenceNumber);
             var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
-            
+
             Assert.NotNull(deserializedEvent);
             Assert.Equal(data, deserializedEvent.Item1);
             Assert.Equal(streamId, batchContainer.StreamId);
@@ -189,10 +189,10 @@ namespace Tester.AzureUtils.Streaming
             Assert.True(IsValidJson(jsonMsg), "Should be valid JSON data");
 
             var binaryPreferredAdapter = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { PreferJson = false });
-            
+
             var batchContainer = binaryPreferredAdapter.FromQueueMessage(jsonMsg, token.SequenceNumber);
             var deserializedEvent = batchContainer.GetEvents<EventData>().FirstOrDefault();
-            
+
             Assert.NotNull(deserializedEvent);
             Assert.Equal(data, deserializedEvent.Item1);
             Assert.Equal(streamId, batchContainer.StreamId);
@@ -212,7 +212,7 @@ namespace Tester.AzureUtils.Streaming
                 new Dictionary<string, object>());
 
             var jsonAdapterNoFallback = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { EnableFallback = false });
-            
+
             Assert.ThrowsAny<Exception>(() => jsonAdapterNoFallback.FromQueueMessage(binaryMsg, token.SequenceNumber));
         }
 
@@ -248,7 +248,7 @@ namespace Tester.AzureUtils.Streaming
         {
             [Id(0)]
             public int Id { get; set; }
-            
+
             [Id(1)]
             public string Name { get; set; } = string.Empty;
 

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -24,7 +24,7 @@ namespace Tester.AzureUtils.Streaming
     public class AzureQueueJsonDataAdapterTests
     {
         private const string CompactOrleans3JsonMessage =
-            "{\"version\":1,\"stream\":{\"namespace\":\"test-namespace\",\"key\":\"00112233-4455-6677-8899-aabbccddeeff\"}," +
+            "{\"version\":1,\"stream\":{\"namespace\":\"test-namespace\",\"key\":\"00112233445566778899aabbccddeeff\"}," +
             "\"events\":[\"test-event\"],\"requestContext\":{\"key\":\"value\"}}";
 
         private const string LegacyDirectContainerJsonMessage =
@@ -224,6 +224,20 @@ namespace Tester.AzureUtils.Streaming
             var batchContainer = jsonAdapter.FromQueueMessage(message, sequenceId: 45);
 
             Assert.Contains("\"namespace\":null", message);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [Theory, TestCategory("BVT")]
+        [InlineData("customer/\u03B2")]
+        [InlineData("00112233-4455-6677-8899-aabbccddeeff")]
+        public void JsonAdapter_RoundTripsUtf8StringStreamKey(string key)
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+            var streamId = StreamId.Create("string-key", key);
+
+            var message = jsonAdapter.ToQueueMessage(streamId, ["test-event"], token: null, requestContext: null);
+            var batchContainer = jsonAdapter.FromQueueMessage(message, sequenceId: 48);
+
             Assert.Equal(streamId, batchContainer.StreamId);
         }
 

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Orleans.Hosting;
 using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
@@ -22,7 +23,11 @@ namespace Tester.AzureUtils.Streaming
     [TestCategory("AzureStorage"), TestCategory("Streaming")]
     public class AzureQueueJsonDataAdapterTests
     {
-        private const string Orleans3JsonMessage =
+        private const string CompactOrleans3JsonMessage =
+            "{\"version\":1,\"stream\":{\"namespace\":\"test-namespace\",\"key\":\"00112233-4455-6677-8899-aabbccddeeff\"}," +
+            "\"events\":[\"test-event\"],\"requestContext\":{\"key\":\"value\"}}";
+
+        private const string LegacyDirectContainerJsonMessage =
             "{\"$id\":\"1\",\"$type\":\"Orleans.Providers.Streams.AzureQueue.AzureQueueBatchContainerV2, Orleans.Streaming.AzureStorage\"," +
             "\"events\":{\"$type\":\"System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib]], System.Private.CoreLib\"," +
             "\"$values\":[\"test-event\"]},\"requestContext\":{\"$id\":\"2\"," +
@@ -78,15 +83,34 @@ namespace Tester.AzureUtils.Streaming
                 StreamId.Create("ns", Guid.NewGuid()),
                 [data],
                 token,
-                new Dictionary<string, object>());
+                new Dictionary<string, object> { ["context"] = data });
 
             this.output.WriteLine("Serialized message: {0}", msg);
             Assert.True(IsValidJson(msg), "Message should be valid JSON");
+            var envelope = JObject.Parse(msg);
+            Assert.Equal(
+                ["version", "stream", "events", "requestContext"],
+                envelope.Properties().Select(property => property.Name));
+            Assert.NotNull(envelope["events"]![0]!["$type"]);
+            Assert.NotNull(envelope["requestContext"]!["context"]!["$type"]);
+            Assert.DoesNotContain("AzureQueueBatchContainerV2", msg);
+            Assert.DoesNotContain("System.Collections.Generic.List", msg);
+            Assert.DoesNotContain("System.Collections.Generic.Dictionary", msg);
+            Assert.DoesNotContain(nameof(StreamId), msg);
 
             var batchContainer = queueDataAdapter.FromQueueMessage(msg, token.SequenceNumber);
             var deserializedMsg = batchContainer.GetEvents<EventData>().FirstOrDefault();
             Assert.NotNull(deserializedMsg);
             Assert.Equal(data, deserializedMsg.Item1);
+            try
+            {
+                Assert.True(batchContainer.ImportRequestContext());
+                Assert.Equal(data, Assert.IsType<EventData>(RequestContext.Get("context")));
+            }
+            finally
+            {
+                RequestContext.Clear();
+            }
         }
 
         [Fact, TestCategory("BVT")]
@@ -158,15 +182,107 @@ namespace Tester.AzureUtils.Streaming
         }
 
         [Fact, TestCategory("BVT")]
-        public void JsonAdapter_DeserializesOrleans3JsonMessage()
+        public void JsonAdapter_DeserializesCompactOrleans3JsonMessage()
         {
             var jsonAdapter = InitializeQueueJsonDataAdapter();
 
-            var batchContainer = jsonAdapter.FromQueueMessage(Orleans3JsonMessage, sequenceId: 43);
+            var batchContainer = jsonAdapter.FromQueueMessage(CompactOrleans3JsonMessage, sequenceId: 43);
             var deserializedEvent = Assert.Single(batchContainer.GetEvents<string>());
 
             Assert.Equal("test-event", deserializedEvent.Item1);
             Assert.Equal(new EventSequenceTokenV2(43), deserializedEvent.Item2);
+            Assert.Equal(
+                StreamId.Create("test-namespace", Guid.Parse("00112233-4455-6677-8899-aabbccddeeff")),
+                batchContainer.StreamId);
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_ProducesCompactVersion1Message()
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+
+            var message = jsonAdapter.ToQueueMessage(
+                StreamId.Create("test-namespace", Guid.Parse("00112233-4455-6677-8899-aabbccddeeff")),
+                ["test-event"],
+                token: null,
+                new Dictionary<string, object> { ["key"] = "value" });
+
+            Assert.Equal(CompactOrleans3JsonMessage, message);
+            Assert.DoesNotContain("$type", message);
+            Assert.DoesNotContain("$id", message);
+            Assert.DoesNotContain("StreamId", message);
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_RoundTripsNamespaceLessGuidStream()
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+            var streamId = StreamId.Create(null, Guid.Parse("00112233-4455-6677-8899-aabbccddeeff"));
+
+            var message = jsonAdapter.ToQueueMessage(streamId, ["test-event"], token: null, requestContext: null);
+            var batchContainer = jsonAdapter.FromQueueMessage(message, sequenceId: 45);
+
+            Assert.Contains("\"namespace\":null", message);
+            Assert.Equal(streamId, batchContainer.StreamId);
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_RoundTripsSharedReferencesWithinCollections()
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+            var sharedEvent = new EventData { Id = 123, Name = "shared" };
+            var sharedContext = new EventData { Id = 456, Name = "context" };
+
+            var message = jsonAdapter.ToQueueMessage(
+                StreamId.Create("shared", Guid.NewGuid()),
+                [sharedEvent, sharedEvent],
+                token: null,
+                new Dictionary<string, object>
+                {
+                    ["first"] = sharedContext,
+                    ["second"] = sharedContext
+                });
+            var batchContainer = jsonAdapter.FromQueueMessage(message, sequenceId: 46);
+            var deserializedEvents = batchContainer.GetEvents<EventData>().Select(item => item.Item1).ToList();
+
+            Assert.Same(deserializedEvents[0], deserializedEvents[1]);
+            try
+            {
+                Assert.True(batchContainer.ImportRequestContext());
+                Assert.Same(RequestContext.Get("first"), RequestContext.Get("second"));
+            }
+            finally
+            {
+                RequestContext.Clear();
+            }
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_SerializesNullRequestContextAsEmptyObject()
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+
+            var message = jsonAdapter.ToQueueMessage(
+                StreamId.Create("context", Guid.NewGuid()),
+                ["test-event"],
+                token: null,
+                requestContext: null);
+            var batchContainer = jsonAdapter.FromQueueMessage(message, sequenceId: 47);
+
+            Assert.EndsWith("\"requestContext\":{}}", message);
+            Assert.True(batchContainer.ImportRequestContext());
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_DeserializesLegacyDirectContainerJsonMessage()
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter();
+
+            var batchContainer = jsonAdapter.FromQueueMessage(LegacyDirectContainerJsonMessage, sequenceId: 44);
+            var deserializedEvent = Assert.Single(batchContainer.GetEvents<string>());
+
+            Assert.Equal("test-event", deserializedEvent.Item1);
+            Assert.Equal(new EventSequenceTokenV2(44), deserializedEvent.Item2);
             Assert.Equal(
                 StreamId.Create("test-namespace", Guid.Parse("00112233-4455-6677-8899-aabbccddeeff")),
                 batchContainer.StreamId);

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -97,6 +97,7 @@ namespace Tester.AzureUtils.Streaming
             Assert.DoesNotContain("System.Collections.Generic.List", msg);
             Assert.DoesNotContain("System.Collections.Generic.Dictionary", msg);
             Assert.DoesNotContain(nameof(StreamId), msg);
+            Assert.DoesNotContain("\"$id\"", msg);
 
             var batchContainer = queueDataAdapter.FromQueueMessage(msg, token.SequenceNumber);
             var deserializedMsg = batchContainer.GetEvents<EventData>().FirstOrDefault();
@@ -242,6 +243,8 @@ namespace Tester.AzureUtils.Streaming
                     ["first"] = sharedContext,
                     ["second"] = sharedContext
                 });
+            Assert.Contains("\"$id\"", message);
+            Assert.Contains("\"$ref\"", message);
             var batchContainer = jsonAdapter.FromQueueMessage(message, sequenceId: 46);
             var deserializedEvents = batchContainer.GetEvents<EventData>().Select(item => item.Item1).ToList();
 


### PR DESCRIPTION
## Summary

Continues and supersedes #9618 from a maintainer-owned fork because the original same-repository branch does not permit maintainer edits.

This preserves @DeagleGross's original contributor commits and authorship while replaying them onto current `main`.

- adds the experimental Azure Queue JSON migration adapter
- uses a compact, explicit versioned envelope instead of serializing Orleans' internal batch container and `StreamId` representation
- writes the envelope with System.Text.Json and preserves the raw UTF-8 stream namespace and key
- serializes event and request-context collections through the configured secure Orleans JSON serializer, preserving polymorphism and shared references without enabling unrestricted type loading
- retains legacy direct-container JSON and Orleans binary fallback behavior
- corrects provider-keyed DI and named-options registration and updates the generated API surface

## Wire format

```json
{"version":1,"stream":{"namespace":"test-namespace","key":"00112233445566778899aabbccddeeff"},"events":["test-event"],"requestContext":{"key":"value"}}
```

## Compatibility

Orleans 3.x emits GUID stream keys in canonical `N` format. Orleans 7+ stores GUID keys using those same UTF-8 bytes, so the modern reader reconstructs the identity directly from the raw key without a key-type discriminator. This also allows arbitrary UTF-8 modern stream keys—including GUID-shaped strings—to round-trip without coercion. Orleans 3.x can consume only keys which are valid `N`-format GUIDs because its streaming API is GUID-based.

The exact golden payload emitted by the Orleans 3.x producer in #10508 is covered, along with Unicode and GUID-shaped string keys, shared references, null request contexts, null namespaces, legacy direct-container JSON, Orleans 7 binary messages, and JSON/binary fallback paths.

Application event types must be permitted by the configured JSON serializer.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10507)