### PR TITLE
feat(membership): adapt probe timeouts

### DIFF
--- a/docs/site/src/content/docs/implementation/cluster-management.md
+++ b/docs/site/src/content/docs/implementation/cluster-management.md
@@ -1,7 +1,7 @@
 ---
 title: Cluster membership protocol
 description: Understand Orleans membership storage, failure detection, ordered views, and death-vote invariants.
-ms.date: 08/02/2026
+ms.date: 08/11/2026
 ms.topic: concept-article
 ---
 
@@ -41,6 +41,10 @@ The periodic `IAmAlive` value is not the peer heartbeat. It is a timestamp writt
 
 Active silos monitor peers selected from the membership view. `ClusterHealthMonitor` sends probes over silo-to-silo messaging, tracks consecutive failures, and can use indirect probes to distinguish a failed target from an unhealthy observer. A failed monitor writes a timestamped vote into the target's membership row.
 
+Each observer maintains a [Phi Accrual failure detector](https://paperhub.s3.amazonaws.com/f516fdfa940caa08c679d3946b273128.pdf) for each peer. The detector models successful direct-probe round-trip times and estimates the timeout at which the probability of a later response is sufficiently low. The timeout starts at <xref:Orleans.Configuration.ClusterMembershipOptions.InitialProbeTimeout?displayProperty=nameWithType> and adapts after enough observations. Failures are excluded because they only show that the response exceeded the current timeout, while indirect results are excluded because they measure a different observer's network path.
+
+Probe cadence remains fixed at <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeInterval?displayProperty=nameWithType>. Local-health and indirect-hop extensions are applied to the learned timeout before it is clamped between <xref:Orleans.Configuration.ClusterMembershipOptions.MinProbeTimeout?displayProperty=nameWithType> and <xref:Orleans.Configuration.ClusterMembershipOptions.MaxProbeTimeout?displayProperty=nameWithType>. Debugger-specific extensions are applied after the clamp so a paused process is not accused because of the configured production bound.
+
 ```mermaid
 sequenceDiagram
     participant A as Monitoring silo A
@@ -70,7 +74,10 @@ The defaults are defined by <xref:Orleans.Configuration.ClusterMembershipOptions
 | Option | Default | Protocol role |
 | --- | ---: | --- |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.NumProbedSilos?displayProperty=nameWithType> | 10 | Number of peers monitored by each silo |
-| <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeTimeout?displayProperty=nameWithType> | 5 seconds | Baseline direct probe timeout |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeInterval?displayProperty=nameWithType> | 5 seconds | Fixed interval between probes of a peer |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.InitialProbeTimeout?displayProperty=nameWithType> | 5 seconds | Timeout before the peer has supplied enough evidence |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.MinProbeTimeout?displayProperty=nameWithType> | Half the initial timeout (2.5 seconds by default) | Lower bound for an effective probe timeout |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.MaxProbeTimeout?displayProperty=nameWithType> | Twice the initial timeout (10 seconds by default) | Upper bound for an effective probe timeout |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.NumMissedProbesLimit?displayProperty=nameWithType> | 3 | Failed probes before a death vote |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.NumVotesForDeathDeclaration?displayProperty=nameWithType> | 2 | Fresh votes required to mark a member dead |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.DeathVoteExpirationTimeout?displayProperty=nameWithType> | 2 minutes | Lifetime of a death vote |

--- a/docs/site/src/content/docs/implementation/cluster-management.md
+++ b/docs/site/src/content/docs/implementation/cluster-management.md
@@ -41,9 +41,9 @@ The periodic `IAmAlive` value is not the peer heartbeat. It is a timestamp writt
 
 Active silos monitor peers selected from the membership view. `ClusterHealthMonitor` sends probes over silo-to-silo messaging, tracks consecutive failures, and can use indirect probes to distinguish a failed target from an unhealthy observer. A failed monitor writes a timestamped vote into the target's membership row.
 
-Each observer maintains a [Phi Accrual failure detector](https://paperhub.s3.amazonaws.com/f516fdfa940caa08c679d3946b273128.pdf) for each peer. The detector models successful direct-probe round-trip times and estimates the timeout at which the probability of a later response is sufficiently low. The timeout starts at <xref:Orleans.Configuration.ClusterMembershipOptions.InitialProbeTimeout?displayProperty=nameWithType> and adapts after enough observations. Failures are excluded because they only show that the response exceeded the current timeout, while indirect results are excluded because they measure a different observer's network path.
+Each observer maintains a [Phi Accrual failure detector](https://paperhub.s3.amazonaws.com/f516fdfa940caa08c679d3946b273128.pdf) for each peer. The detector models successful direct-probe round-trip times and estimates the timeout at which the probability of a later response is sufficiently low. The timeout starts at <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeTimeout?displayProperty=nameWithType> and adapts after enough observations. Failures are excluded because they only show that the response exceeded the current timeout, while indirect results are excluded because they measure a different observer's network path.
 
-Probe cadence remains fixed at <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeInterval?displayProperty=nameWithType>. Local-health and indirect-hop extensions are applied to the learned timeout before it is clamped between <xref:Orleans.Configuration.ClusterMembershipOptions.MinProbeTimeout?displayProperty=nameWithType> and <xref:Orleans.Configuration.ClusterMembershipOptions.MaxProbeTimeout?displayProperty=nameWithType>. Debugger-specific extensions are applied after the clamp so a paused process is not accused because of the configured production bound.
+The learned timeout also determines probe cadence. Each probe is scheduled relative to the previous probe's start, so a quick response waits for the remainder of the current timeout while a probe which consumes its timeout is followed immediately by the next attempt. Local-health and indirect-hop extensions are applied to the learned timeout before it is clamped between <xref:Orleans.Configuration.ClusterMembershipOptions.MinProbeTimeout?displayProperty=nameWithType> and <xref:Orleans.Configuration.ClusterMembershipOptions.MaxProbeTimeout?displayProperty=nameWithType>. Debugger-specific extensions are applied after the clamp so a paused process is not accused because of the configured production bound.
 
 ```mermaid
 sequenceDiagram
@@ -74,10 +74,9 @@ The defaults are defined by <xref:Orleans.Configuration.ClusterMembershipOptions
 | Option | Default | Protocol role |
 | --- | ---: | --- |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.NumProbedSilos?displayProperty=nameWithType> | 10 | Number of peers monitored by each silo |
-| <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeInterval?displayProperty=nameWithType> | 5 seconds | Fixed interval between probes of a peer |
-| <xref:Orleans.Configuration.ClusterMembershipOptions.InitialProbeTimeout?displayProperty=nameWithType> | 5 seconds | Timeout before the peer has supplied enough evidence |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeTimeout?displayProperty=nameWithType> | 5 seconds | Initial timeout and probe period before the peer has supplied enough evidence |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.MinProbeTimeout?displayProperty=nameWithType> | Half the initial timeout (2.5 seconds by default) | Lower bound for an effective probe timeout |
-| <xref:Orleans.Configuration.ClusterMembershipOptions.MaxProbeTimeout?displayProperty=nameWithType> | Twice the initial timeout (10 seconds by default) | Upper bound for an effective probe timeout |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.MaxProbeTimeout?displayProperty=nameWithType> | Four times the initial timeout (20 seconds by default) | Upper bound for an effective probe timeout |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.NumMissedProbesLimit?displayProperty=nameWithType> | 3 | Failed probes before a death vote |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.NumVotesForDeathDeclaration?displayProperty=nameWithType> | 2 | Fresh votes required to mark a member dead |
 | <xref:Orleans.Configuration.ClusterMembershipOptions.DeathVoteExpirationTimeout?displayProperty=nameWithType> | 2 minutes | Lifetime of a death vote |

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -7,6 +7,12 @@ namespace Orleans.Configuration
     /// </summary>
     public class ClusterMembershipOptions
     {
+        private static readonly TimeSpan DefaultProbeInterval = TimeSpan.FromSeconds(5);
+        private TimeSpan _probeInterval = DefaultProbeInterval;
+        private TimeSpan _initialProbeTimeout = DefaultProbeInterval;
+        private TimeSpan? _minProbeTimeout;
+        private TimeSpan? _maxProbeTimeout;
+
         /// <summary>
         /// Gets or sets the number of missed "I am alive" updates in the table from a silo that causes warning to be logged.
         /// </summary>
@@ -23,10 +29,68 @@ namespace Orleans.Configuration
         public bool LivenessEnabled { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets both the period between sending a liveness probe to any given host as well as the timeout for each probe.
+        /// Gets or sets both the period between sending a liveness probe to any given host and the initial timeout for each probe.
         /// </summary>
-        /// <value>Probes time out and a new probe is sent every 5 seconds by default.</value>
-        public TimeSpan ProbeTimeout { get; set; } = TimeSpan.FromSeconds(5);
+        /// <remarks>
+        /// Setting this property sets both <see cref="ProbeInterval"/> and <see cref="InitialProbeTimeout"/>.
+        /// The getter returns <see cref="InitialProbeTimeout"/>.
+        /// </remarks>
+        [Obsolete($"Use {nameof(ProbeInterval)} and {nameof(InitialProbeTimeout)} instead.")]
+        public TimeSpan ProbeTimeout
+        {
+            get => InitialProbeTimeout;
+            set
+            {
+                ProbeInterval = value;
+                InitialProbeTimeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the period between sending liveness probes to any given host.
+        /// </summary>
+        /// <value>A new probe is sent every 5 seconds by default.</value>
+        public TimeSpan ProbeInterval
+        {
+            get => _probeInterval;
+            set => _probeInterval = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the initial timeout for a liveness probe.
+        /// </summary>
+        /// <remarks>
+        /// The effective probe timeout is adjusted independently for each monitored silo based on observed direct-probe
+        /// response times.
+        /// </remarks>
+        /// <value>The initial probe timeout is 5 seconds by default.</value>
+        public TimeSpan InitialProbeTimeout
+        {
+            get => _initialProbeTimeout;
+            set => _initialProbeTimeout = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the minimum effective timeout for a liveness probe.
+        /// </summary>
+        /// <value>Half of <see cref="InitialProbeTimeout"/> by default.</value>
+        public TimeSpan MinProbeTimeout
+        {
+            get => _minProbeTimeout ?? TimeSpan.FromTicks(InitialProbeTimeout.Ticks / 2);
+            set => _minProbeTimeout = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum effective timeout for a liveness probe.
+        /// </summary>
+        /// <value>Twice <see cref="InitialProbeTimeout"/> by default.</value>
+        public TimeSpan MaxProbeTimeout
+        {
+            get => _maxProbeTimeout ?? (InitialProbeTimeout.Ticks <= TimeSpan.MaxValue.Ticks / 2
+                ? TimeSpan.FromTicks(InitialProbeTimeout.Ticks * 2)
+                : TimeSpan.MaxValue);
+            set => _maxProbeTimeout = value;
+        }
 
         /// <summary>
         /// Gets or sets the period between fetching updates from the membership table.
@@ -131,7 +195,7 @@ namespace Orleans.Configuration
         public TimeSpan LocalHealthDegradationMonitoringPeriod { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
-        /// Gets or sets a value indicating whether to extend the effective <see cref="ProbeTimeout"/> value based upon current local health degradation.
+        /// Gets or sets a value indicating whether to extend the effective probe timeout based upon current local health degradation.
         /// </summary>
         public bool ExtendProbeTimeoutDuringDegradation { get; set; } = true;
 

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -7,9 +7,6 @@ namespace Orleans.Configuration
     /// </summary>
     public class ClusterMembershipOptions
     {
-        private static readonly TimeSpan DefaultProbeInterval = TimeSpan.FromSeconds(5);
-        private TimeSpan _probeInterval = DefaultProbeInterval;
-        private TimeSpan _initialProbeTimeout = DefaultProbeInterval;
         private TimeSpan? _minProbeTimeout;
         private TimeSpan? _maxProbeTimeout;
 
@@ -29,65 +26,34 @@ namespace Orleans.Configuration
         public bool LivenessEnabled { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets both the period between sending a liveness probe to any given host and the initial timeout for each probe.
+        /// Gets or sets the initial timeout for liveness probes.
         /// </summary>
         /// <remarks>
-        /// Setting this property sets both <see cref="ProbeInterval"/> and <see cref="InitialProbeTimeout"/>.
-        /// The getter returns <see cref="InitialProbeTimeout"/>.
-        /// </remarks>
-        [Obsolete($"Use {nameof(ProbeInterval)} and {nameof(InitialProbeTimeout)} instead.")]
-        public TimeSpan ProbeTimeout
-        {
-            get => InitialProbeTimeout;
-            set
-            {
-                ProbeInterval = value;
-                InitialProbeTimeout = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the period between sending liveness probes to any given host.
-        /// </summary>
-        /// <value>A new probe is sent every 5 seconds by default.</value>
-        public TimeSpan ProbeInterval
-        {
-            get => _probeInterval;
-            set => _probeInterval = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the initial timeout for a liveness probe.
-        /// </summary>
-        /// <remarks>
-        /// The effective probe timeout is adjusted independently for each monitored silo based on observed direct-probe
-        /// response times.
+        /// The effective probe timeout and the period between probe starts are adjusted independently for each monitored silo
+        /// based on observed direct-probe response times and are bounded by <see cref="MinProbeTimeout"/> and
+        /// <see cref="MaxProbeTimeout"/>.
         /// </remarks>
         /// <value>The initial probe timeout is 5 seconds by default.</value>
-        public TimeSpan InitialProbeTimeout
-        {
-            get => _initialProbeTimeout;
-            set => _initialProbeTimeout = value;
-        }
+        public TimeSpan ProbeTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// Gets or sets the minimum effective timeout for a liveness probe.
         /// </summary>
-        /// <value>Half of <see cref="InitialProbeTimeout"/> by default.</value>
+        /// <value>Half of <see cref="ProbeTimeout"/> by default.</value>
         public TimeSpan MinProbeTimeout
         {
-            get => _minProbeTimeout ?? TimeSpan.FromTicks(InitialProbeTimeout.Ticks / 2);
+            get => _minProbeTimeout ?? TimeSpan.FromTicks(ProbeTimeout.Ticks / 2);
             set => _minProbeTimeout = value;
         }
 
         /// <summary>
         /// Gets or sets the maximum effective timeout for a liveness probe.
         /// </summary>
-        /// <value>Twice <see cref="InitialProbeTimeout"/> by default.</value>
+        /// <value>Four times <see cref="ProbeTimeout"/> by default.</value>
         public TimeSpan MaxProbeTimeout
         {
-            get => _maxProbeTimeout ?? (InitialProbeTimeout.Ticks <= TimeSpan.MaxValue.Ticks / 2
-                ? TimeSpan.FromTicks(InitialProbeTimeout.Ticks * 2)
+            get => _maxProbeTimeout ?? (ProbeTimeout.Ticks <= TimeSpan.MaxValue.Ticks / 4
+                ? TimeSpan.FromTicks(ProbeTimeout.Ticks * 4)
                 : TimeSpan.MaxValue);
             set => _maxProbeTimeout = value;
         }
@@ -209,7 +175,7 @@ namespace Orleans.Configuration
         /// </summary>
         /// <remarks>
         /// When enabled, if an active connection to a silo has recently received messages within the monitoring window
-        /// (<see cref="ProbeTimeout"/> × <see cref="NumMissedProbesLimit"/>), votes to suspect that silo will be suppressed
+        /// (<see cref="MaxProbeTimeout"/> × <see cref="NumMissedProbesLimit"/>), votes to suspect that silo will be suppressed
         /// since the connection activity demonstrates the silo is alive. This helps prevent false death declarations
         /// when probes fail due to local issues such as GC pauses or thread pool saturation.
         /// </remarks>

--- a/src/Orleans.Runtime/Configuration/ClusterMembershipOptionsExtensions.cs
+++ b/src/Orleans.Runtime/Configuration/ClusterMembershipOptionsExtensions.cs
@@ -5,14 +5,6 @@ namespace Orleans.Configuration;
 
 internal static class ClusterMembershipOptionsExtensions
 {
-    internal static TimeSpan GetMaxProbeCycleTime(this ClusterMembershipOptions options)
-    {
-        var cycleTime = options.ProbeInterval > options.MaxProbeTimeout
-            ? options.ProbeInterval
-            : options.MaxProbeTimeout;
-        return cycleTime;
-    }
-
     internal static TimeSpan GetFailureDetectionTimeout(this ClusterMembershipOptions options) =>
-        options.GetMaxProbeCycleTime().Multiply(options.NumMissedProbesLimit);
+        options.MaxProbeTimeout.Multiply(options.NumMissedProbesLimit);
 }

--- a/src/Orleans.Runtime/Configuration/ClusterMembershipOptionsExtensions.cs
+++ b/src/Orleans.Runtime/Configuration/ClusterMembershipOptionsExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using Orleans.Internal;
+
+namespace Orleans.Configuration;
+
+internal static class ClusterMembershipOptionsExtensions
+{
+    internal static TimeSpan GetMaxProbeCycleTime(this ClusterMembershipOptions options)
+    {
+        var cycleTime = options.ProbeInterval > options.MaxProbeTimeout
+            ? options.ProbeInterval
+            : options.MaxProbeTimeout;
+        return cycleTime;
+    }
+
+    internal static TimeSpan GetFailureDetectionTimeout(this ClusterMembershipOptions options) =>
+        options.GetMaxProbeCycleTime().Multiply(options.NumMissedProbesLimit);
+}

--- a/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
@@ -13,6 +13,7 @@ namespace Orleans.Runtime.Configuration
     /// </summary>
     internal class SiloClusteringValidator : IConfigurationValidator
     {
+        private const uint MaxSupportedTimeoutMilliseconds = 0xfffffffe;
         private readonly IServiceProvider serviceProvider;
 
         public SiloClusteringValidator(IServiceProvider serviceProvider)
@@ -49,6 +50,51 @@ namespace Orleans.Runtime.Configuration
             if (clusterMembershipOptions.MaxDefunctSiloEntries < 0)
             {
                 throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxDefunctSiloEntries)} ({clusterMembershipOptions.MaxDefunctSiloEntries}) must be greater than or equal to 0, or null.");
+            }
+
+            if (clusterMembershipOptions.ProbeInterval <= TimeSpan.Zero)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ProbeInterval)} ({clusterMembershipOptions.ProbeInterval}) must be greater than 0.");
+            }
+
+            if (clusterMembershipOptions.ProbeInterval.TotalMilliseconds > MaxSupportedTimeoutMilliseconds)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ProbeInterval)} ({clusterMembershipOptions.ProbeInterval}) must be less than or equal to {TimeSpan.FromMilliseconds(MaxSupportedTimeoutMilliseconds)}.");
+            }
+
+            if (clusterMembershipOptions.InitialProbeTimeout <= TimeSpan.Zero)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.InitialProbeTimeout)} ({clusterMembershipOptions.InitialProbeTimeout}) must be greater than 0.");
+            }
+
+            if (clusterMembershipOptions.MinProbeTimeout <= TimeSpan.Zero)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MinProbeTimeout)} ({clusterMembershipOptions.MinProbeTimeout}) must be greater than 0.");
+            }
+
+            if (clusterMembershipOptions.MaxProbeTimeout < clusterMembershipOptions.MinProbeTimeout)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxProbeTimeout)} ({clusterMembershipOptions.MaxProbeTimeout}) must be greater than or equal to {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MinProbeTimeout)} ({clusterMembershipOptions.MinProbeTimeout}).");
+            }
+
+            if (clusterMembershipOptions.MaxProbeTimeout.TotalMilliseconds > MaxSupportedTimeoutMilliseconds)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxProbeTimeout)} ({clusterMembershipOptions.MaxProbeTimeout}) must be less than or equal to {TimeSpan.FromMilliseconds(MaxSupportedTimeoutMilliseconds)}.");
+            }
+
+            if (clusterMembershipOptions.InitialProbeTimeout < clusterMembershipOptions.MinProbeTimeout
+                || clusterMembershipOptions.InitialProbeTimeout > clusterMembershipOptions.MaxProbeTimeout)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.InitialProbeTimeout)} ({clusterMembershipOptions.InitialProbeTimeout}) must be between {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MinProbeTimeout)} ({clusterMembershipOptions.MinProbeTimeout}) and {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxProbeTimeout)} ({clusterMembershipOptions.MaxProbeTimeout}).");
+            }
+
+            var maxProbeCycleTime = clusterMembershipOptions.ProbeInterval > clusterMembershipOptions.MaxProbeTimeout
+                ? clusterMembershipOptions.ProbeInterval
+                : clusterMembershipOptions.MaxProbeTimeout;
+            if (clusterMembershipOptions.NumMissedProbesLimit > 0
+                && maxProbeCycleTime.Ticks > TimeSpan.MaxValue.Ticks / clusterMembershipOptions.NumMissedProbesLimit)
+            {
+                throw new OrleansConfigurationException($"The maximum probe cycle time ({maxProbeCycleTime}) multiplied by {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.NumMissedProbesLimit)} ({clusterMembershipOptions.NumMissedProbesLimit}) must not exceed {TimeSpan.MaxValue}.");
             }
 
             if (clusterMembershipOptions.LivenessEnabled)

--- a/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
@@ -52,19 +52,14 @@ namespace Orleans.Runtime.Configuration
                 throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxDefunctSiloEntries)} ({clusterMembershipOptions.MaxDefunctSiloEntries}) must be greater than or equal to 0, or null.");
             }
 
-            if (clusterMembershipOptions.ProbeInterval <= TimeSpan.Zero)
+            if (clusterMembershipOptions.ProbeTimeout <= TimeSpan.Zero)
             {
-                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ProbeInterval)} ({clusterMembershipOptions.ProbeInterval}) must be greater than 0.");
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ProbeTimeout)} ({clusterMembershipOptions.ProbeTimeout}) must be greater than 0.");
             }
 
-            if (clusterMembershipOptions.ProbeInterval.TotalMilliseconds > MaxSupportedTimeoutMilliseconds)
+            if (clusterMembershipOptions.ProbeTimeout.TotalMilliseconds > MaxSupportedTimeoutMilliseconds)
             {
-                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ProbeInterval)} ({clusterMembershipOptions.ProbeInterval}) must be less than or equal to {TimeSpan.FromMilliseconds(MaxSupportedTimeoutMilliseconds)}.");
-            }
-
-            if (clusterMembershipOptions.InitialProbeTimeout <= TimeSpan.Zero)
-            {
-                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.InitialProbeTimeout)} ({clusterMembershipOptions.InitialProbeTimeout}) must be greater than 0.");
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ProbeTimeout)} ({clusterMembershipOptions.ProbeTimeout}) must be less than or equal to {TimeSpan.FromMilliseconds(MaxSupportedTimeoutMilliseconds)}.");
             }
 
             if (clusterMembershipOptions.MinProbeTimeout <= TimeSpan.Zero)
@@ -82,15 +77,13 @@ namespace Orleans.Runtime.Configuration
                 throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxProbeTimeout)} ({clusterMembershipOptions.MaxProbeTimeout}) must be less than or equal to {TimeSpan.FromMilliseconds(MaxSupportedTimeoutMilliseconds)}.");
             }
 
-            if (clusterMembershipOptions.InitialProbeTimeout < clusterMembershipOptions.MinProbeTimeout
-                || clusterMembershipOptions.InitialProbeTimeout > clusterMembershipOptions.MaxProbeTimeout)
+            if (clusterMembershipOptions.ProbeTimeout < clusterMembershipOptions.MinProbeTimeout
+                || clusterMembershipOptions.ProbeTimeout > clusterMembershipOptions.MaxProbeTimeout)
             {
-                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.InitialProbeTimeout)} ({clusterMembershipOptions.InitialProbeTimeout}) must be between {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MinProbeTimeout)} ({clusterMembershipOptions.MinProbeTimeout}) and {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxProbeTimeout)} ({clusterMembershipOptions.MaxProbeTimeout}).");
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.ProbeTimeout)} ({clusterMembershipOptions.ProbeTimeout}) must be between {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MinProbeTimeout)} ({clusterMembershipOptions.MinProbeTimeout}) and {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxProbeTimeout)} ({clusterMembershipOptions.MaxProbeTimeout}).");
             }
 
-            var maxProbeCycleTime = clusterMembershipOptions.ProbeInterval > clusterMembershipOptions.MaxProbeTimeout
-                ? clusterMembershipOptions.ProbeInterval
-                : clusterMembershipOptions.MaxProbeTimeout;
+            var maxProbeCycleTime = clusterMembershipOptions.MaxProbeTimeout;
             var failureDetectionTimeoutTicks = 0L;
             if (clusterMembershipOptions.NumMissedProbesLimit > 0
                 && maxProbeCycleTime.Ticks > TimeSpan.MaxValue.Ticks / clusterMembershipOptions.NumMissedProbesLimit)

--- a/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
@@ -91,10 +91,22 @@ namespace Orleans.Runtime.Configuration
             var maxProbeCycleTime = clusterMembershipOptions.ProbeInterval > clusterMembershipOptions.MaxProbeTimeout
                 ? clusterMembershipOptions.ProbeInterval
                 : clusterMembershipOptions.MaxProbeTimeout;
+            var failureDetectionTimeoutTicks = 0L;
             if (clusterMembershipOptions.NumMissedProbesLimit > 0
                 && maxProbeCycleTime.Ticks > TimeSpan.MaxValue.Ticks / clusterMembershipOptions.NumMissedProbesLimit)
             {
                 throw new OrleansConfigurationException($"The maximum probe cycle time ({maxProbeCycleTime}) multiplied by {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.NumMissedProbesLimit)} ({clusterMembershipOptions.NumMissedProbesLimit}) must not exceed {TimeSpan.MaxValue}.");
+            }
+            else if (clusterMembershipOptions.NumMissedProbesLimit > 0)
+            {
+                failureDetectionTimeoutTicks = maxProbeCycleTime.Ticks * clusterMembershipOptions.NumMissedProbesLimit;
+            }
+
+            var tableRefreshTimeoutTicks = clusterMembershipOptions.TableRefreshTimeout.Ticks;
+            if (tableRefreshTimeoutTicks > 0
+                && tableRefreshTimeoutTicks > (TimeSpan.MaxValue.Ticks - failureDetectionTimeoutTicks) / 2)
+            {
+                throw new OrleansConfigurationException($"The failure detection timeout plus twice {nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.TableRefreshTimeout)} ({clusterMembershipOptions.TableRefreshTimeout}) must not exceed {TimeSpan.MaxValue}.");
             }
 
             if (clusterMembershipOptions.LivenessEnabled)

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -140,7 +140,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         TimeSpan rangeLeaseDuration,
         ClusterMembershipOptions membershipOptions)
     {
-        var failureDetectionDuration = membershipOptions.ProbeTimeout * membershipOptions.NumMissedProbesLimit;
+        var failureDetectionDuration = membershipOptions.GetFailureDetectionTimeout();
         return rangeLeaseDuration > failureDetectionDuration
             ? rangeLeaseDuration - failureDetectionDuration
             : TimeSpan.Zero;

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -102,7 +102,7 @@ namespace Orleans.Runtime.MembershipService
                         if (!newMonitoredSilos.ContainsKey(pair.Key))
                         {
                             using var cancellation = new CancellationTokenSource(
-                                this.clusterMembershipOptions.CurrentValue.ProbeTimeout,
+                                this.clusterMembershipOptions.CurrentValue.MaxProbeTimeout,
                                 this.timeProvider);
                             await pair.Value.StopAsync(cancellation.Token);
                         }
@@ -359,7 +359,7 @@ namespace Orleans.Runtime.MembershipService
 
         /// <summary>
         /// Checks whether a connection to the specified silo has received a message within the monitoring window
-        /// (<see cref="ClusterMembershipOptions.ProbeTimeout"/> × <see cref="ClusterMembershipOptions.NumMissedProbesLimit"/>).
+        /// (the maximum probe cycle time multiplied by <see cref="ClusterMembershipOptions.NumMissedProbesLimit"/>).
         /// If so, the silo is demonstrably alive and the vote should be suppressed.
         /// </summary>
         private bool IsConnectionActiveWithinMonitoringWindow(SiloAddress targetSilo)
@@ -370,7 +370,7 @@ namespace Orleans.Runtime.MembershipService
                 return false;
             }
 
-            var monitoringWindow = options.ProbeTimeout.Multiply(options.NumMissedProbesLimit);
+            var monitoringWindow = options.GetFailureDetectionTimeout();
 
             if (this.connectionManager.GetElapsedSinceLastMessageReceived(targetSilo) is { } elapsed && elapsed <= monitoringWindow)
             {

--- a/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/LocalSiloHealthMonitor.cs
@@ -326,7 +326,7 @@ namespace Orleans.Runtime.MembershipService
                 }
 
                 // Only consider certain checks if the silo has been a member of a multi-silo cluster for a certain period.
-                var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
+                var recencyWindow = _clusterMembershipOptions.GetFailureDetectionTimeout();
                 if (_clusteredSinceTimestamp is { } clusteredSince
                     && _timeProvider.GetElapsedTime(clusteredSince, timestamp) > recencyWindow)
                 {

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -126,7 +126,7 @@ namespace Orleans.Runtime.MembershipService
 
             // Continue attempting to validate connectivity until some reasonable timeout.
             var maxAttemptTime = this.clusterMembershipOptions.MaxJoinAttemptTime;
-            var retryDelay = this.clusterMembershipOptions.ProbeInterval;
+            var retryDelay = this.clusterMembershipOptions.ProbeTimeout;
             var attemptNumber = 1;
             var now = this.getUtcDateTime();
             var attemptUntil = now + maxAttemptTime;
@@ -195,7 +195,7 @@ namespace Orleans.Runtime.MembershipService
 
                 LogInformationAboutToSendPings(members.Length, new EnumerableToStringLogValue<SiloAddress>(members));
 
-                var timeout = this.clusterMembershipOptions.InitialProbeTimeout;
+                var timeout = this.clusterMembershipOptions.ProbeTimeout;
                 foreach (var silo in members)
                 {
                     tasks.Add(ProbeSilo(this.siloProber, silo, timeout, this.log, cancellationToken));

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -126,7 +126,7 @@ namespace Orleans.Runtime.MembershipService
 
             // Continue attempting to validate connectivity until some reasonable timeout.
             var maxAttemptTime = this.clusterMembershipOptions.MaxJoinAttemptTime;
-            var retryDelay = this.clusterMembershipOptions.ProbeTimeout;
+            var retryDelay = this.clusterMembershipOptions.ProbeInterval;
             var attemptNumber = 1;
             var now = this.getUtcDateTime();
             var attemptUntil = now + maxAttemptTime;
@@ -195,7 +195,7 @@ namespace Orleans.Runtime.MembershipService
 
                 LogInformationAboutToSendPings(members.Length, new EnumerableToStringLogValue<SiloAddress>(members));
 
-                var timeout = this.clusterMembershipOptions.ProbeTimeout;
+                var timeout = this.clusterMembershipOptions.InitialProbeTimeout;
                 foreach (var silo in members)
                 {
                     tasks.Add(ProbeSilo(this.siloProber, silo, timeout, this.log, cancellationToken));

--- a/src/Orleans.Runtime/MembershipService/PhiAccrualFailureDetector.cs
+++ b/src/Orleans.Runtime/MembershipService/PhiAccrualFailureDetector.cs
@@ -1,0 +1,104 @@
+using System;
+
+namespace Orleans.Runtime.MembershipService;
+
+internal sealed class PhiAccrualFailureDetector
+{
+    private const double Threshold = 8;
+    private const int MaxSampleSize = 100;
+    private const int MinimumSampleCount = 4;
+    private static readonly double ThresholdStandardDeviations = CalculateThresholdStandardDeviations();
+
+    private readonly double[] _samples = new double[MaxSampleSize];
+    private readonly TimeSpan _initialTimeout;
+    private readonly double _minimumStandardDeviationMilliseconds;
+    private int _nextSampleIndex;
+    private int _sampleCount;
+    private double _sampleSum;
+    private double _squaredSampleSum;
+
+    public PhiAccrualFailureDetector(TimeSpan initialTimeout)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(initialTimeout, TimeSpan.Zero);
+
+        _initialTimeout = initialTimeout;
+        _minimumStandardDeviationMilliseconds = initialTimeout.TotalMilliseconds / (2 * ThresholdStandardDeviations);
+    }
+
+    public int SampleCount => _sampleCount;
+
+    public void RecordResponseTime(TimeSpan responseTime)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(responseTime, TimeSpan.Zero);
+
+        var sample = responseTime.TotalMilliseconds;
+        if (_sampleCount == MaxSampleSize)
+        {
+            var replacedSample = _samples[_nextSampleIndex];
+            _sampleSum -= replacedSample;
+            _squaredSampleSum -= replacedSample * replacedSample;
+        }
+        else
+        {
+            _sampleCount++;
+        }
+
+        _samples[_nextSampleIndex] = sample;
+        _nextSampleIndex = (_nextSampleIndex + 1) % MaxSampleSize;
+        _sampleSum += sample;
+        _squaredSampleSum += sample * sample;
+    }
+
+    public TimeSpan GetTimeout() =>
+        _sampleCount < MinimumSampleCount
+            ? _initialTimeout
+            : TimeSpan.FromMilliseconds(Math.Min(GetEstimatedTimeoutMilliseconds(), TimeSpan.MaxValue.TotalMilliseconds));
+
+    public TimeSpan GetTimeout(TimeSpan minimumTimeout, TimeSpan maximumTimeout, int extensionFactor)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(minimumTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumTimeout, minimumTimeout);
+        ArgumentOutOfRangeException.ThrowIfLessThan(extensionFactor, 1);
+
+        var timeoutTicks = GetTimeout().Ticks * (double)extensionFactor;
+        return TimeSpan.FromTicks((long)Math.Clamp(timeoutTicks, minimumTimeout.Ticks, maximumTimeout.Ticks));
+    }
+
+    internal static double CalculatePhi(double elapsedMilliseconds, double meanMilliseconds, double standardDeviationMilliseconds)
+    {
+        // Logistic approximation of the normal CDF used by Akka's Phi Accrual implementation.
+        var y = (elapsedMilliseconds - meanMilliseconds) / standardDeviationMilliseconds;
+        var e = Math.Exp(-y * (1.5976 + (0.070566 * y * y)));
+        return elapsedMilliseconds > meanMilliseconds
+            ? -Math.Log10(e / (1 + e))
+            : -Math.Log10(1 - (1 / (1 + e)));
+    }
+
+    private double GetEstimatedTimeoutMilliseconds()
+    {
+        var mean = _sampleSum / _sampleCount;
+        var variance = Math.Max(0, (_squaredSampleSum / _sampleCount) - (mean * mean));
+        var standardDeviation = Math.Max(Math.Sqrt(variance), _minimumStandardDeviationMilliseconds);
+        return mean + (ThresholdStandardDeviations * standardDeviation);
+    }
+
+    private static double CalculateThresholdStandardDeviations()
+    {
+        var lower = 0d;
+        var upper = 10d;
+        for (var i = 0; i < 64; i++)
+        {
+            var midpoint = (lower + upper) / 2;
+            if (CalculatePhi(midpoint, 0, 1) < Threshold)
+            {
+                lower = midpoint;
+            }
+            else
+            {
+                upper = midpoint;
+            }
+        }
+
+        return upper;
+    }
+}

--- a/src/Orleans.Runtime/MembershipService/ProbingSiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ProbingSiloHealthMonitor.cs
@@ -51,7 +51,7 @@ internal sealed partial class ProbingSiloHealthMonitor : IProbeHealthMonitor
         }
 
         var sinceLastProbeRequest = _probeRequestMonitor.ElapsedSinceLastProbeRequest;
-        var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
+        var recencyWindow = _clusterMembershipOptions.GetFailureDetectionTimeout();
 
         if (!sinceLastProbeRequest.HasValue)
         {
@@ -96,7 +96,7 @@ internal sealed partial class ProbingSiloHealthMonitor : IProbeHealthMonitor
             return 0;
         }
 
-        var recencyWindow = _clusterMembershipOptions.ProbeTimeout.Multiply(_clusterMembershipOptions.NumMissedProbesLimit);
+        var recencyWindow = _clusterMembershipOptions.GetFailureDetectionTimeout();
 
         if (!elapsedSinceLastResponse.HasValue)
         {

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -85,7 +85,7 @@ namespace Orleans.Runtime.MembershipService
             _timeProvider = timeProvider;
             _log = loggerFactory.CreateLogger<SiloHealthMonitor>();
             _pingTimer = asyncTimerFactory.Create(
-                _clusterMembershipOptions.CurrentValue.ProbeInterval,
+                _clusterMembershipOptions.CurrentValue.ProbeTimeout,
                 nameof(SiloHealthMonitor),
                 timeProvider);
             _onProbeResult = onProbeResult;
@@ -111,7 +111,7 @@ namespace Orleans.Runtime.MembershipService
 
         int ITestAccessor.MissedProbes => _failedProbes;
         int ITestAccessor.ProbeTimeoutSampleCount => _failureDetector?.SampleCount ?? 0;
-        TimeSpan ITestAccessor.CurrentProbeTimeout => _failureDetector?.GetTimeout() ?? _clusterMembershipOptions.CurrentValue.InitialProbeTimeout;
+        TimeSpan ITestAccessor.CurrentProbeTimeout => _failureDetector?.GetTimeout() ?? _clusterMembershipOptions.CurrentValue.ProbeTimeout;
 
         /// <summary>
         /// Start the monitor.
@@ -176,12 +176,15 @@ namespace Orleans.Runtime.MembershipService
             MembershipTableSnapshot? activeMembersSnapshot = default;
             SiloAddress[]? otherNodes = default;
             var options = _clusterMembershipOptions.CurrentValue;
-            var failureDetector = _failureDetector = new PhiAccrualFailureDetector(options.InitialProbeTimeout);
-            TimeSpan? overrideDelay = RandomTimeSpan.Next(options.ProbeInterval);
-            while (await _pingTimer.NextTick(overrideDelay))
+            var failureDetector = _failureDetector = new PhiAccrualFailureDetector(options.ProbeTimeout);
+            var previousProbePeriod = options.ProbeTimeout;
+            TimeSpan? nextProbeDelay = RandomTimeSpan.Next(previousProbePeriod);
+            while (await _pingTimer.NextTick(nextProbeDelay))
             {
                 ProbeResult probeResult;
-                overrideDelay = default;
+                var isDirectProbe = true;
+                var localDegradationScore = 0;
+                long? probeStartTimestamp = null;
                 var now = _timeProvider.GetUtcNow().UtcDateTime;
 
                 try
@@ -200,9 +203,10 @@ namespace Orleans.Runtime.MembershipService
                             .ToArray();
                     }
 
-                    var isDirectProbe = !options.EnableIndirectProbes || _failedProbes < options.NumMissedProbesLimit - 1 || otherNodes.Length == 0;
-                    var localDegradationScore = GetLocalDegradationScore();
+                    isDirectProbe = !options.EnableIndirectProbes || _failedProbes < options.NumMissedProbesLimit - 1 || otherNodes.Length == 0;
+                    localDegradationScore = GetLocalDegradationScore(previousProbePeriod);
                     var timeout = CalculateProbeTimeout(failureDetector, options, localDegradationScore, isDirectProbe, Debugger.IsAttached);
+                    probeStartTimestamp = _timeProvider.GetTimestamp();
                     using var cancellation = new CancellationTokenSource(timeout, _timeProvider);
 
                     if (isDirectProbe)
@@ -227,7 +231,6 @@ namespace Orleans.Runtime.MembershipService
                         {
                             LogInformationRecusingUnhealthyIntermediary(_log, intermediary);
                             otherNodes = [.. otherNodes.Where(node => !node.Equals(intermediary))];
-                            overrideDelay = TimeSpan.FromMilliseconds(250);
                         }
                     }
 
@@ -240,9 +243,21 @@ namespace Orleans.Runtime.MembershipService
                 {
                     LogErrorExceptionMonitoringSilo(_log, exception, TargetSiloAddress);
                 }
+                finally
+                {
+                    previousProbePeriod = CalculateProbeTimeout(
+                        failureDetector,
+                        options,
+                        localDegradationScore,
+                        isDirectProbe,
+                        Debugger.IsAttached);
+                    nextProbeDelay = probeStartTimestamp is { } timestamp
+                        ? CalculateNextProbeDelay(previousProbePeriod, _timeProvider.GetElapsedTime(timestamp))
+                        : previousProbePeriod;
+                }
             }
 
-            int GetLocalDegradationScore()
+            int GetLocalDegradationScore(TimeSpan period)
             {
                 if (!options.ExtendProbeTimeoutDuringDegradation)
                 {
@@ -252,7 +267,7 @@ namespace Orleans.Runtime.MembershipService
                 // This query must happen before the probe because its result determines the probe timeout.
                 // Outcome-reporting health checks, such as an intermediary's health score, run after probing.
                 return _localSiloHealthMonitor.GetLocalHealthStatus(
-                    options.ProbeInterval,
+                    period,
                     LocalSiloHealthCheckCategory.Local).Score;
             }
         }
@@ -279,6 +294,17 @@ namespace Orleans.Runtime.MembershipService
             }
 
             return timeout;
+        }
+
+        internal static TimeSpan CalculateNextProbeDelay(TimeSpan probePeriod, TimeSpan elapsed)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(probePeriod, TimeSpan.Zero);
+            if (elapsed < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(elapsed), elapsed, "Elapsed time must not be negative.");
+            }
+
+            return elapsed < probePeriod ? probePeriod - elapsed : TimeSpan.Zero;
         }
 
         internal static TimeSpan CalculateIndirectProbeTargetTimeout(TimeSpan timeout, int localDegradationScore)

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -201,7 +201,8 @@ namespace Orleans.Runtime.MembershipService
                     }
 
                     var isDirectProbe = !options.EnableIndirectProbes || _failedProbes < options.NumMissedProbesLimit - 1 || otherNodes.Length == 0;
-                    var timeout = GetTimeout(isDirectProbe);
+                    var localDegradationScore = GetLocalDegradationScore();
+                    var timeout = CalculateProbeTimeout(failureDetector, options, localDegradationScore, isDirectProbe, Debugger.IsAttached);
                     using var cancellation = new CancellationTokenSource(timeout, _timeProvider);
 
                     if (isDirectProbe)
@@ -217,7 +218,8 @@ namespace Orleans.Runtime.MembershipService
                         // Select a timeout which will allow the intermediary node to attempt to probe the target node and still respond to this node
                         // if the remote node does not respond in time.
                         // Attempt to account for local health degradation by extending the timeout period.
-                        probeResult = await this.ProbeIndirectly(intermediary, timeout, cancellation.Token).ConfigureAwait(false);
+                        var directProbeTimeout = CalculateIndirectProbeTargetTimeout(timeout, localDegradationScore);
+                        probeResult = await this.ProbeIndirectly(intermediary, directProbeTimeout, cancellation.Token).ConfigureAwait(false);
 
                         // If the intermediary is not entirely healthy, remove it from consideration and continue to probe.
                         // Note that all recused silos will be included in the consideration set the next time cluster membership changes.
@@ -240,19 +242,18 @@ namespace Orleans.Runtime.MembershipService
                 }
             }
 
-            TimeSpan GetTimeout(bool isDirectProbe)
+            int GetLocalDegradationScore()
             {
-                var localDegradationScore = 0;
-                if (options.ExtendProbeTimeoutDuringDegradation)
+                if (!options.ExtendProbeTimeoutDuringDegradation)
                 {
-                    // This query must happen before the probe because its result determines the probe timeout.
-                    // Outcome-reporting health checks, such as an intermediary's health score, run after probing.
-                    localDegradationScore = _localSiloHealthMonitor.GetLocalHealthStatus(
-                        options.ProbeInterval,
-                        LocalSiloHealthCheckCategory.Local).Score;
+                    return 0;
                 }
 
-                return CalculateProbeTimeout(failureDetector, options, localDegradationScore, isDirectProbe, Debugger.IsAttached);
+                // This query must happen before the probe because its result determines the probe timeout.
+                // Outcome-reporting health checks, such as an intermediary's health score, run after probing.
+                return _localSiloHealthMonitor.GetLocalHealthStatus(
+                    options.ProbeInterval,
+                    LocalSiloHealthCheckCategory.Local).Score;
             }
         }
 
@@ -278,6 +279,16 @@ namespace Orleans.Runtime.MembershipService
             }
 
             return timeout;
+        }
+
+        internal static TimeSpan CalculateIndirectProbeTargetTimeout(TimeSpan timeout, int localDegradationScore)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+            ArgumentOutOfRangeException.ThrowIfNegative(localDegradationScore);
+
+            var extensionFactor = 1 + localDegradationScore;
+            var responseAllowanceTicks = Math.Max(1, timeout.Ticks / (extensionFactor + 1));
+            return TimeSpan.FromTicks(timeout.Ticks - responseAllowanceTicks);
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -20,6 +20,7 @@ namespace Orleans.Runtime.MembershipService
     /// </summary>
     internal partial class SiloHealthMonitor : ITestAccessor, IHealthCheckable, IDisposable, IAsyncDisposable
     {
+        private static readonly TimeSpan MaxSupportedTimerTimeout = TimeSpan.FromMilliseconds(0xfffffffe);
         private readonly ILogger _log;
         private readonly IOptionsMonitor<ClusterMembershipOptions> _clusterMembershipOptions;
         private readonly IRemoteSiloProber _prober;
@@ -37,6 +38,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly IAsyncTimer _pingTimer;
         private long? _lastSuccessfulResponseTimestamp;
         private readonly Func<SiloHealthMonitor, ProbeResult, Task> _onProbeResult;
+        private PhiAccrualFailureDetector? _failureDetector;
         private Task? _runTask;
 
         /// <summary>
@@ -83,7 +85,7 @@ namespace Orleans.Runtime.MembershipService
             _timeProvider = timeProvider;
             _log = loggerFactory.CreateLogger<SiloHealthMonitor>();
             _pingTimer = asyncTimerFactory.Create(
-                _clusterMembershipOptions.CurrentValue.ProbeTimeout,
+                _clusterMembershipOptions.CurrentValue.ProbeInterval,
                 nameof(SiloHealthMonitor),
                 timeProvider);
             _onProbeResult = onProbeResult;
@@ -93,6 +95,8 @@ namespace Orleans.Runtime.MembershipService
         internal interface ITestAccessor
         {
             int MissedProbes { get; }
+            int ProbeTimeoutSampleCount { get; }
+            TimeSpan CurrentProbeTimeout { get; }
         }
 
         /// <summary>
@@ -106,6 +110,8 @@ namespace Orleans.Runtime.MembershipService
         public bool IsCanceled => _stoppingCancellation.IsCancellationRequested;
 
         int ITestAccessor.MissedProbes => _failedProbes;
+        int ITestAccessor.ProbeTimeoutSampleCount => _failureDetector?.SampleCount ?? 0;
+        TimeSpan ITestAccessor.CurrentProbeTimeout => _failureDetector?.GetTimeout() ?? _clusterMembershipOptions.CurrentValue.InitialProbeTimeout;
 
         /// <summary>
         /// Start the monitor.
@@ -170,7 +176,8 @@ namespace Orleans.Runtime.MembershipService
             MembershipTableSnapshot? activeMembersSnapshot = default;
             SiloAddress[]? otherNodes = default;
             var options = _clusterMembershipOptions.CurrentValue;
-            TimeSpan? overrideDelay = RandomTimeSpan.Next(options.ProbeTimeout);
+            var failureDetector = _failureDetector = new PhiAccrualFailureDetector(options.InitialProbeTimeout);
+            TimeSpan? overrideDelay = RandomTimeSpan.Next(options.ProbeInterval);
             while (await _pingTimer.NextTick(overrideDelay))
             {
                 ProbeResult probeResult;
@@ -235,33 +242,42 @@ namespace Orleans.Runtime.MembershipService
 
             TimeSpan GetTimeout(bool isDirectProbe)
             {
-                var additionalTimeout = 0;
-
+                var localDegradationScore = 0;
                 if (options.ExtendProbeTimeoutDuringDegradation)
                 {
                     // This query must happen before the probe because its result determines the probe timeout.
                     // Outcome-reporting health checks, such as an intermediary's health score, run after probing.
-                    var localHealth = _localSiloHealthMonitor.GetLocalHealthStatus(
-                        options.ProbeTimeout,
-                        LocalSiloHealthCheckCategory.Local);
-                    additionalTimeout += localHealth.Score;
+                    localDegradationScore = _localSiloHealthMonitor.GetLocalHealthStatus(
+                        options.ProbeInterval,
+                        LocalSiloHealthCheckCategory.Local).Score;
                 }
 
-                if (!isDirectProbe)
-                {
-                    // Indirect probes need extra time to account for the additional hop.
-                    additionalTimeout += 1;
-                }
-
-                // When the debugger is attached, extend probe times so that silos are not terminated
-                // due to debugging pauses.
-                if (Debugger.IsAttached)
-                {
-                    additionalTimeout += 25;
-                }
-
-                return options.ProbeTimeout.Multiply(1 + additionalTimeout);
+                return CalculateProbeTimeout(failureDetector, options, localDegradationScore, isDirectProbe, Debugger.IsAttached);
             }
+        }
+
+        internal static TimeSpan CalculateProbeTimeout(
+            PhiAccrualFailureDetector failureDetector,
+            ClusterMembershipOptions options,
+            int localDegradationScore,
+            bool isDirectProbe,
+            bool isDebuggerAttached)
+        {
+            var extensionFactor = 1 + localDegradationScore;
+            if (!isDirectProbe)
+            {
+                extensionFactor++;
+            }
+
+            var timeout = failureDetector.GetTimeout(options.MinProbeTimeout, options.MaxProbeTimeout, extensionFactor);
+            if (isDebuggerAttached)
+            {
+                var debuggerExtensionTicks = failureDetector.GetTimeout().Ticks * 25d;
+                var extendedTimeoutTicks = Math.Min(MaxSupportedTimerTimeout.Ticks, timeout.Ticks + debuggerExtensionTicks);
+                timeout = TimeSpan.FromTicks((long)extendedTimeoutTicks);
+            }
+
+            return timeout;
         }
 
         /// <summary>
@@ -303,6 +319,7 @@ namespace Orleans.Runtime.MembershipService
                 _failedProbes = 0;
                 _lastSuccessfulResponseTimestamp = _timeProvider.GetTimestamp();
                 LastRoundTripTime = roundTripTime;
+                _failureDetector!.RecordResponseTime(roundTripTime);
                 probeResult = ProbeResult.CreateDirect(0, ProbeResultStatus.Succeeded);
             }
             else

--- a/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadaCache.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloMetadata/SiloMetadaCache.cs
@@ -28,7 +28,7 @@ internal partial class SiloMetadataCache(
         Task OnStart(CancellationToken _)
         {
             // This gives time for the cluster to be voted Dead and for membership updates to propagate that out
-            negativeCachePeriod = clusterMembershipOptions.Value.ProbeTimeout * clusterMembershipOptions.Value.NumMissedProbesLimit
+            negativeCachePeriod = clusterMembershipOptions.Value.GetFailureDetectionTimeout()
                                   + (2 * clusterMembershipOptions.Value.TableRefreshTimeout);
             task = Task.Run(() => this.ProcessMembershipUpdates(_cts.Token));
             return Task.CompletedTask;
@@ -144,4 +144,3 @@ internal partial class SiloMetadataCache(
         Message = "Stopping membership update processor")]
     private static partial void LogDebugStoppingMembershipProcessor(ILogger logger);
 }
-

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -413,7 +413,10 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         if (didKill)
         {
             // in case of hard kill (kill and not Stop), we should give silos time to detect failures first.
-            stabilizationTime = TestingUtils.Multiply(clusterMembershipOptions.ProbeTimeout, clusterMembershipOptions.NumMissedProbesLimit);
+            var maxProbeCycleTime = clusterMembershipOptions.ProbeInterval > clusterMembershipOptions.MaxProbeTimeout
+                ? clusterMembershipOptions.ProbeInterval
+                : clusterMembershipOptions.MaxProbeTimeout;
+            stabilizationTime = TestingUtils.Multiply(maxProbeCycleTime, clusterMembershipOptions.NumMissedProbesLimit);
         }
         if (clusterMembershipOptions.UseLivenessGossip)
         {

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -413,10 +413,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         if (didKill)
         {
             // in case of hard kill (kill and not Stop), we should give silos time to detect failures first.
-            var maxProbeCycleTime = clusterMembershipOptions.ProbeInterval > clusterMembershipOptions.MaxProbeTimeout
-                ? clusterMembershipOptions.ProbeInterval
-                : clusterMembershipOptions.MaxProbeTimeout;
-            stabilizationTime = TestingUtils.Multiply(maxProbeCycleTime, clusterMembershipOptions.NumMissedProbesLimit);
+            stabilizationTime = TestingUtils.Multiply(clusterMembershipOptions.MaxProbeTimeout, clusterMembershipOptions.NumMissedProbesLimit);
         }
         if (clusterMembershipOptions.UseLivenessGossip)
         {

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -485,10 +485,7 @@ namespace Orleans.TestingHost
             if (didKill)
             {
                 // in case of hard kill (kill and not Stop), we should give silos time to detect failures first.
-                var maxProbeCycleTime = clusterMembershipOptions.ProbeInterval > clusterMembershipOptions.MaxProbeTimeout
-                    ? clusterMembershipOptions.ProbeInterval
-                    : clusterMembershipOptions.MaxProbeTimeout;
-                stabilizationTime = TestingUtils.Multiply(maxProbeCycleTime, clusterMembershipOptions.NumMissedProbesLimit);
+                stabilizationTime = TestingUtils.Multiply(clusterMembershipOptions.MaxProbeTimeout, clusterMembershipOptions.NumMissedProbesLimit);
             }
             if (clusterMembershipOptions.UseLivenessGossip)
             {

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -485,7 +485,10 @@ namespace Orleans.TestingHost
             if (didKill)
             {
                 // in case of hard kill (kill and not Stop), we should give silos time to detect failures first.
-                stabilizationTime = TestingUtils.Multiply(clusterMembershipOptions.ProbeTimeout, clusterMembershipOptions.NumMissedProbesLimit);
+                var maxProbeCycleTime = clusterMembershipOptions.ProbeInterval > clusterMembershipOptions.MaxProbeTimeout
+                    ? clusterMembershipOptions.ProbeInterval
+                    : clusterMembershipOptions.MaxProbeTimeout;
+                stabilizationTime = TestingUtils.Multiply(maxProbeCycleTime, clusterMembershipOptions.NumMissedProbesLimit);
             }
             if (clusterMembershipOptions.UseLivenessGossip)
             {

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -453,6 +453,8 @@ namespace Orleans.Configuration
 
         public System.TimeSpan IAmAliveTablePublishTimeout { get { throw null; } set { } }
 
+        public System.TimeSpan InitialProbeTimeout { get { throw null; } set { } }
+
         public bool LivenessEnabled { get { throw null; } set { } }
 
         public System.TimeSpan LocalHealthDegradationMonitoringPeriod { get { throw null; } set { } }
@@ -461,6 +463,10 @@ namespace Orleans.Configuration
 
         public System.TimeSpan MaxJoinAttemptTime { get { throw null; } set { } }
 
+        public System.TimeSpan MaxProbeTimeout { get { throw null; } set { } }
+
+        public System.TimeSpan MinProbeTimeout { get { throw null; } set { } }
+
         public int NumMissedProbesLimit { get { throw null; } set { } }
 
         public int NumMissedTableIAmAliveLimit { get { throw null; } set { } }
@@ -468,6 +474,8 @@ namespace Orleans.Configuration
         public int NumProbedSilos { get { throw null; } set { } }
 
         public int NumVotesForDeathDeclaration { get { throw null; } set { } }
+
+        public System.TimeSpan ProbeInterval { get { throw null; } set { } }
 
         public System.TimeSpan ProbeTimeout { get { throw null; } set { } }
 

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -453,8 +453,6 @@ namespace Orleans.Configuration
 
         public System.TimeSpan IAmAliveTablePublishTimeout { get { throw null; } set { } }
 
-        public System.TimeSpan InitialProbeTimeout { get { throw null; } set { } }
-
         public bool LivenessEnabled { get { throw null; } set { } }
 
         public System.TimeSpan LocalHealthDegradationMonitoringPeriod { get { throw null; } set { } }
@@ -474,8 +472,6 @@ namespace Orleans.Configuration
         public int NumProbedSilos { get { throw null; } set { } }
 
         public int NumVotesForDeathDeclaration { get { throw null; } set { } }
-
-        public System.TimeSpan ProbeInterval { get { throw null; } set { } }
 
         public System.TimeSpan ProbeTimeout { get { throw null; } set { } }
 

--- a/test/Orleans.Core.Tests/Membership/ClusterMembershipOptionsTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterMembershipOptionsTests.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Orleans.Configuration;
+using Xunit;
+
+namespace NonSilo.Tests.Membership;
+
+[TestCategory("BVT"), TestCategory("Membership")]
+public class ClusterMembershipOptionsTests
+{
+    [Fact]
+    public void ProbeTimeoutDefaultsTrackInitialTimeout()
+    {
+        var options = new ClusterMembershipOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(5), options.ProbeInterval);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.InitialProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(2.5), options.MinProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(10), options.MaxProbeTimeout);
+
+        options.InitialProbeTimeout = TimeSpan.FromSeconds(8);
+
+        Assert.Equal(TimeSpan.FromSeconds(4), options.MinProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(16), options.MaxProbeTimeout);
+    }
+
+    [Fact]
+    public void ExplicitProbeTimeoutBoundsDoNotTrackInitialTimeout()
+    {
+        var options = new ClusterMembershipOptions
+        {
+            MinProbeTimeout = TimeSpan.FromSeconds(2),
+            MaxProbeTimeout = TimeSpan.FromSeconds(12),
+        };
+
+        options.InitialProbeTimeout = TimeSpan.FromSeconds(8);
+
+        Assert.Equal(TimeSpan.FromSeconds(2), options.MinProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(12), options.MaxProbeTimeout);
+    }
+
+    [Fact]
+    public void ObsoleteProbeTimeoutSetsIntervalAndInitialTimeout()
+    {
+        var options = new ClusterMembershipOptions();
+        var property = typeof(ClusterMembershipOptions).GetProperty("ProbeTimeout");
+
+        property!.SetValue(options, TimeSpan.FromSeconds(7));
+
+        Assert.Equal(TimeSpan.FromSeconds(7), options.ProbeInterval);
+        Assert.Equal(TimeSpan.FromSeconds(7), options.InitialProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(7), property.GetValue(options));
+        Assert.False(property.GetCustomAttribute<ObsoleteAttribute>()!.IsError);
+    }
+
+    [Fact]
+    public void NewProbeOptionsOverrideLegacyConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ProbeTimeout"] = "00:00:05",
+                ["ProbeInterval"] = "00:00:01",
+                ["InitialProbeTimeout"] = "00:00:02",
+            })
+            .Build();
+
+        var options = configuration.Get<ClusterMembershipOptions>();
+
+        Assert.Equal(TimeSpan.FromSeconds(1), options!.ProbeInterval);
+        Assert.Equal(TimeSpan.FromSeconds(2), options.InitialProbeTimeout);
+    }
+}

--- a/test/Orleans.Core.Tests/Membership/ClusterMembershipOptionsTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterMembershipOptionsTests.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using Microsoft.Extensions.Configuration;
 using Orleans.Configuration;
 using Xunit;
 
@@ -9,19 +7,18 @@ namespace NonSilo.Tests.Membership;
 public class ClusterMembershipOptionsTests
 {
     [Fact]
-    public void ProbeTimeoutDefaultsTrackInitialTimeout()
+    public void ProbeTimeoutBoundsTrackInitialTimeout()
     {
         var options = new ClusterMembershipOptions();
 
-        Assert.Equal(TimeSpan.FromSeconds(5), options.ProbeInterval);
-        Assert.Equal(TimeSpan.FromSeconds(5), options.InitialProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.ProbeTimeout);
         Assert.Equal(TimeSpan.FromSeconds(2.5), options.MinProbeTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(10), options.MaxProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(20), options.MaxProbeTimeout);
 
-        options.InitialProbeTimeout = TimeSpan.FromSeconds(8);
+        options.ProbeTimeout = TimeSpan.FromSeconds(8);
 
         Assert.Equal(TimeSpan.FromSeconds(4), options.MinProbeTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(16), options.MaxProbeTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(32), options.MaxProbeTimeout);
     }
 
     [Fact]
@@ -33,41 +30,18 @@ public class ClusterMembershipOptionsTests
             MaxProbeTimeout = TimeSpan.FromSeconds(12),
         };
 
-        options.InitialProbeTimeout = TimeSpan.FromSeconds(8);
+        options.ProbeTimeout = TimeSpan.FromSeconds(8);
 
         Assert.Equal(TimeSpan.FromSeconds(2), options.MinProbeTimeout);
         Assert.Equal(TimeSpan.FromSeconds(12), options.MaxProbeTimeout);
     }
 
     [Fact]
-    public void ObsoleteProbeTimeoutSetsIntervalAndInitialTimeout()
+    public void ProbeTimeoutIsNotObsolete()
     {
-        var options = new ClusterMembershipOptions();
         var property = typeof(ClusterMembershipOptions).GetProperty("ProbeTimeout");
 
-        property!.SetValue(options, TimeSpan.FromSeconds(7));
-
-        Assert.Equal(TimeSpan.FromSeconds(7), options.ProbeInterval);
-        Assert.Equal(TimeSpan.FromSeconds(7), options.InitialProbeTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(7), property.GetValue(options));
-        Assert.False(property.GetCustomAttribute<ObsoleteAttribute>()!.IsError);
-    }
-
-    [Fact]
-    public void NewProbeOptionsOverrideLegacyConfiguration()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["ProbeTimeout"] = "00:00:05",
-                ["ProbeInterval"] = "00:00:01",
-                ["InitialProbeTimeout"] = "00:00:02",
-            })
-            .Build();
-
-        var options = configuration.Get<ClusterMembershipOptions>();
-
-        Assert.Equal(TimeSpan.FromSeconds(1), options!.ProbeInterval);
-        Assert.Equal(TimeSpan.FromSeconds(2), options.InitialProbeTimeout);
+        Assert.NotNull(property);
+        Assert.Empty(property.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: true));
     }
 }

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -312,8 +312,7 @@ namespace NonSilo.Tests.Membership
         {
             this.clusterMembershipOptions.Value.NumMissedProbesLimit = 1;
             this.clusterMembershipOptions.Value.NumVotesForDeathDeclaration = 1;
-            this.clusterMembershipOptions.Value.ProbeInterval = TimeSpan.FromMilliseconds(20);
-            this.clusterMembershipOptions.Value.InitialProbeTimeout = TimeSpan.FromMilliseconds(20);
+            this.clusterMembershipOptions.Value.ProbeTimeout = TimeSpan.FromMilliseconds(20);
             this.remoteSiloProber.Probe(default!, default).ReturnsForAnyArgs(Task.FromException(new Exception("no")));
 
             var staleSilo = Silo("127.0.0.200:100@100");

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -312,7 +312,8 @@ namespace NonSilo.Tests.Membership
         {
             this.clusterMembershipOptions.Value.NumMissedProbesLimit = 1;
             this.clusterMembershipOptions.Value.NumVotesForDeathDeclaration = 1;
-            this.clusterMembershipOptions.Value.ProbeTimeout = TimeSpan.FromMilliseconds(20);
+            this.clusterMembershipOptions.Value.ProbeInterval = TimeSpan.FromMilliseconds(20);
+            this.clusterMembershipOptions.Value.InitialProbeTimeout = TimeSpan.FromMilliseconds(20);
             this.remoteSiloProber.Probe(default!, default).ReturnsForAnyArgs(Task.FromException(new Exception("no")));
 
             var staleSilo = Silo("127.0.0.200:100@100");

--- a/test/Orleans.Core.Tests/Membership/PhiAccrualFailureDetectorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/PhiAccrualFailureDetectorTests.cs
@@ -1,0 +1,109 @@
+using Orleans.Configuration;
+using Orleans.Runtime.MembershipService;
+using Xunit;
+
+namespace NonSilo.Tests.Membership;
+
+[TestCategory("BVT"), TestCategory("Membership")]
+public class PhiAccrualFailureDetectorTests
+{
+    [Fact]
+    public void UsesInitialTimeoutUntilEnoughEvidenceIsAvailable()
+    {
+        var detector = new PhiAccrualFailureDetector(TimeSpan.FromSeconds(5));
+
+        for (var i = 0; i < 3; i++)
+        {
+            detector.RecordResponseTime(TimeSpan.Zero);
+        }
+
+        Assert.Equal(TimeSpan.FromSeconds(5), detector.GetTimeout());
+    }
+
+    [Fact]
+    public void StableFastResponsesLowerTimeout()
+    {
+        var detector = new PhiAccrualFailureDetector(TimeSpan.FromSeconds(5));
+
+        for (var i = 0; i < 4; i++)
+        {
+            detector.RecordResponseTime(TimeSpan.Zero);
+        }
+
+        Assert.Equal(TimeSpan.FromSeconds(2.5), detector.GetTimeout());
+    }
+
+    [Fact]
+    public void StableSlowResponsesRaiseTimeout()
+    {
+        var detector = new PhiAccrualFailureDetector(TimeSpan.FromSeconds(5));
+
+        for (var i = 0; i < 4; i++)
+        {
+            detector.RecordResponseTime(TimeSpan.FromSeconds(4));
+        }
+
+        Assert.Equal(TimeSpan.FromSeconds(6.5), detector.GetTimeout());
+    }
+
+    [Fact]
+    public void EffectiveTimeoutIsClampedAfterExtensions()
+    {
+        var detector = new PhiAccrualFailureDetector(TimeSpan.FromSeconds(5));
+
+        for (var i = 0; i < 4; i++)
+        {
+            detector.RecordResponseTime(TimeSpan.FromSeconds(4));
+        }
+
+        var timeout = detector.GetTimeout(TimeSpan.FromSeconds(2.5), TimeSpan.FromSeconds(10), extensionFactor: 2);
+
+        Assert.Equal(TimeSpan.FromSeconds(10), timeout);
+    }
+
+    [Fact]
+    public void HistoryIsBounded()
+    {
+        var detector = new PhiAccrualFailureDetector(TimeSpan.FromSeconds(5));
+        for (var i = 0; i < 100; i++)
+        {
+            detector.RecordResponseTime(TimeSpan.Zero);
+        }
+
+        for (var i = 0; i < 100; i++)
+        {
+            detector.RecordResponseTime(TimeSpan.FromSeconds(4));
+        }
+
+        Assert.Equal(100, detector.SampleCount);
+        Assert.Equal(TimeSpan.FromSeconds(6.5), detector.GetTimeout());
+    }
+
+    [Theory]
+    [InlineData(0, true, false, 5)]
+    [InlineData(1, true, false, 10)]
+    [InlineData(0, false, false, 10)]
+    [InlineData(0, true, true, 130)]
+    public void MonitorExtensionsAndClampAreAppliedInOrder(
+        int localDegradationScore,
+        bool isDirectProbe,
+        bool isDebuggerAttached,
+        double expectedSeconds)
+    {
+        var detector = new PhiAccrualFailureDetector(TimeSpan.FromSeconds(5));
+        var options = new ClusterMembershipOptions
+        {
+            MinProbeTimeout = TimeSpan.FromSeconds(2.5),
+            MaxProbeTimeout = TimeSpan.FromSeconds(10),
+        };
+
+        var timeout = SiloHealthMonitor.CalculateProbeTimeout(
+            detector,
+            options,
+            localDegradationScore,
+            isDirectProbe,
+            isDebuggerAttached);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), timeout);
+    }
+}

--- a/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
@@ -169,7 +169,7 @@ namespace NonSilo.Tests.Membership
             Assert.InRange(
                 testAccessor.CurrentProbeTimeout,
                 _clusterMembershipOptions.MinProbeTimeout,
-                _clusterMembershipOptions.InitialProbeTimeout);
+                _clusterMembershipOptions.ProbeTimeout);
 
             await Shutdown();
         }
@@ -204,7 +204,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task SiloHealthMonitor_FailedProbe_Timeout()
         {
-            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
 
             _prober.Probe(default!, default, default).ReturnsForAnyArgs(info => Task.Delay(TimeSpan.FromSeconds(30)));
             _prober.ProbeIndirectly(default!, default!, default, default).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
@@ -227,7 +227,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task SiloHealthMonitor_FailedProbe_Exception()
         {
-            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
 
             _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(new Exception("nope"));
             _prober.ProbeIndirectly(default!, default!, default, default).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
@@ -255,7 +255,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task SiloHealthMonitor_Indirect_FailedProbe()
         {
-            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
             _clusterMembershipOptions.EnableIndirectProbes = true;
 
             _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(info => new Exception("nonono!"));
@@ -367,7 +367,7 @@ namespace NonSilo.Tests.Membership
         public async Task SiloHealthMonitor_IndirectProbe_SkipsStaleSilo()
         {
             _clusterMembershipOptions.EnableIndirectProbes = true;
-            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
 
             // Make direct probes fail.
             _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(new Exception("Direct probe failing."));
@@ -416,8 +416,7 @@ namespace NonSilo.Tests.Membership
                 new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
             var options = new ClusterMembershipOptions
             {
-                ProbeInterval = TimeSpan.FromSeconds(5),
-                InitialProbeTimeout = TimeSpan.FromSeconds(5),
+                ProbeTimeout = TimeSpan.FromSeconds(5),
                 MaxProbeTimeout = TimeSpan.FromSeconds(45),
                 ExtendProbeTimeoutDuringDegradation = extendProbeTimeout,
                 EnableIndirectProbes = false,
@@ -459,13 +458,13 @@ namespace NonSilo.Tests.Membership
             {
                 monitor.Start();
                 var firstTick = await timer.Ticks.ReadAsync();
-                firstTick.SetResult(true);
+                firstTick.Completion.SetResult(true);
                 var cancellationToken = await probeEntered.Task;
 
                 if (extendProbeTimeout)
                 {
                     localHealthMonitor.Received(1).GetLocalHealthStatus(
-                        options.ProbeInterval,
+                        options.ProbeTimeout,
                         LocalSiloHealthCheckCategory.Local);
                 }
                 else
@@ -475,7 +474,7 @@ namespace NonSilo.Tests.Membership
 
                 await prober.Received(1).Probe(_targetSilo, 1, cancellationToken);
 
-                var dilatedTimeout = options.InitialProbeTimeout.Multiply(expectedTimeoutFactor);
+                var dilatedTimeout = options.ProbeTimeout.Multiply(expectedTimeoutFactor);
                 timeProvider.Advance(dilatedTimeout - TimeSpan.FromTicks(1));
                 Assert.False(cancellationToken.IsCancellationRequested);
                 Assert.False(probeResult.Task.IsCompleted);
@@ -488,6 +487,10 @@ namespace NonSilo.Tests.Membership
                 Assert.Equal(1, result.FailedProbeCount);
                 Assert.True(result.IsDirectProbe);
                 Assert.Equal(0, result.IntermediaryHealthDegradationScore);
+
+                var nextTick = await timer.Ticks.ReadAsync();
+                Assert.Equal(TimeSpan.Zero, nextTick.DelayOverride);
+                nextTick.Completion.SetResult(false);
             }
             finally
             {
@@ -495,13 +498,29 @@ namespace NonSilo.Tests.Membership
             }
         }
 
+        [Theory]
+        [InlineData(5, 1, 4)]
+        [InlineData(5, 5, 0)]
+        [InlineData(5, 6, 0)]
+        public void CalculateNextProbeDelay_MeasuresFromPreviousProbeStart(
+            int probePeriodSeconds,
+            int elapsedSeconds,
+            int expectedDelaySeconds)
+        {
+            var delay = CalculateNextProbeDelay(
+                TimeSpan.FromSeconds(probePeriodSeconds),
+                TimeSpan.FromSeconds(elapsedSeconds));
+
+            Assert.Equal(TimeSpan.FromSeconds(expectedDelaySeconds), delay);
+        }
+
         private sealed class DilationProbeTimer : IAsyncTimer
         {
             private readonly object _lock = new();
-            private readonly Channel<TaskCompletionSource<bool>> _ticks = Channel.CreateUnbounded<TaskCompletionSource<bool>>();
+            private readonly Channel<ProbeTimerTick> _ticks = Channel.CreateUnbounded<ProbeTimerTick>();
             private bool _disposed;
 
-            public ChannelReader<TaskCompletionSource<bool>> Ticks => _ticks.Reader;
+            public ChannelReader<ProbeTimerTick> Ticks => _ticks.Reader;
 
             public Task<bool> NextTick(TimeSpan? overrideDelay = null)
             {
@@ -513,7 +532,7 @@ namespace NonSilo.Tests.Membership
                     }
 
                     var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    if (!_ticks.Writer.TryWrite(completion))
+                    if (!_ticks.Writer.TryWrite(new(overrideDelay, completion)))
                     {
                         throw new InvalidOperationException("Unable to publish the next timer tick.");
                     }
@@ -539,13 +558,15 @@ namespace NonSilo.Tests.Membership
 
                     _disposed = true;
                     _ticks.Writer.TryComplete();
-                    while (_ticks.Reader.TryRead(out var completion))
+                    while (_ticks.Reader.TryRead(out var tick))
                     {
-                        completion.TrySetResult(false);
+                        tick.Completion.TrySetResult(false);
                     }
                 }
             }
         }
+
+        private readonly record struct ProbeTimerTick(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion);
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 

--- a/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
@@ -314,6 +314,7 @@ namespace NonSilo.Tests.Membership
             var args = probeCall.GetArguments();
             var intermediary = Assert.IsType<SiloAddress>(args[0]);
             Assert.Equal(otherSilo, intermediary);
+            Assert.Equal(TimeSpan.FromSeconds(2), Assert.IsType<TimeSpan>(args[2]));
 
             // Ensure that negative results from unhealthy intermediaries are not considered.
             _prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(new IndirectProbeResponse

--- a/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
@@ -150,9 +150,61 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public async Task SiloHealthMonitor_SuccessfulDirectProbesAdaptTimeout()
+        {
+            _prober.Probe(default!, default).ReturnsForAnyArgs(Task.CompletedTask);
+            _monitor.Start();
+
+            for (var i = 0; i < 4; i++)
+            {
+                var timerCall = await _timerCalls.Reader.ReadAsync();
+                timerCall.Completion.TrySetResult(true);
+                var probeResult = await _probeResults.Reader.ReadAsync();
+                Assert.Equal(ProbeResultStatus.Succeeded, probeResult.Status);
+                Assert.True(probeResult.IsDirectProbe);
+            }
+
+            var testAccessor = (ITestAccessor)_monitor;
+            Assert.Equal(4, testAccessor.ProbeTimeoutSampleCount);
+            Assert.InRange(
+                testAccessor.CurrentProbeTimeout,
+                _clusterMembershipOptions.MinProbeTimeout,
+                _clusterMembershipOptions.InitialProbeTimeout);
+
+            await Shutdown();
+        }
+
+        [Fact]
+        public async Task SiloHealthMonitor_SuccessfulIndirectProbeDoesNotAdaptTimeout()
+        {
+            _clusterMembershipOptions.NumMissedProbesLimit = 1;
+            var intermediary = Silo("127.0.0.1:1234@1234");
+            await _membershipTable.InsertRow(
+                Entry(intermediary, SiloStatus.Active, DateTime.UtcNow),
+                _membershipTable.Version.Next());
+            await _membershipService.Refresh();
+            _prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            {
+                Succeeded = true,
+                ProbeResponseTime = TimeSpan.FromMilliseconds(1),
+            });
+
+            _monitor.Start();
+            var timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall.Completion.TrySetResult(true);
+            var probeResult = await _probeResults.Reader.ReadAsync();
+
+            Assert.Equal(ProbeResultStatus.Succeeded, probeResult.Status);
+            Assert.False(probeResult.IsDirectProbe);
+            Assert.Equal(0, ((ITestAccessor)_monitor).ProbeTimeoutSampleCount);
+
+            await Shutdown();
+        }
+
+        [Fact]
         public async Task SiloHealthMonitor_FailedProbe_Timeout()
         {
-            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
 
             _prober.Probe(default!, default, default).ReturnsForAnyArgs(info => Task.Delay(TimeSpan.FromSeconds(30)));
             _prober.ProbeIndirectly(default!, default!, default, default).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
@@ -167,6 +219,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(1, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
             Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+            Assert.Equal(0, ((ITestAccessor)_monitor).ProbeTimeoutSampleCount);
 
             await Shutdown();
         }
@@ -174,7 +227,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task SiloHealthMonitor_FailedProbe_Exception()
         {
-            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
 
             _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(new Exception("nope"));
             _prober.ProbeIndirectly(default!, default!, default, default).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
@@ -194,6 +247,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(1, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
             Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
+            Assert.Equal(0, ((ITestAccessor)_monitor).ProbeTimeoutSampleCount);
 
             await Shutdown();
         }
@@ -201,7 +255,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task SiloHealthMonitor_Indirect_FailedProbe()
         {
-            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
             _clusterMembershipOptions.EnableIndirectProbes = true;
 
             _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(info => new Exception("nonono!"));
@@ -312,7 +366,7 @@ namespace NonSilo.Tests.Membership
         public async Task SiloHealthMonitor_IndirectProbe_SkipsStaleSilo()
         {
             _clusterMembershipOptions.EnableIndirectProbes = true;
-            _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
+            _clusterMembershipOptions.InitialProbeTimeout = TimeSpan.FromSeconds(2);
 
             // Make direct probes fail.
             _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(new Exception("Direct probe failing."));
@@ -361,7 +415,9 @@ namespace NonSilo.Tests.Membership
                 new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
             var options = new ClusterMembershipOptions
             {
-                ProbeTimeout = TimeSpan.FromSeconds(5),
+                ProbeInterval = TimeSpan.FromSeconds(5),
+                InitialProbeTimeout = TimeSpan.FromSeconds(5),
+                MaxProbeTimeout = TimeSpan.FromSeconds(45),
                 ExtendProbeTimeoutDuringDegradation = extendProbeTimeout,
                 EnableIndirectProbes = false,
             };
@@ -408,7 +464,7 @@ namespace NonSilo.Tests.Membership
                 if (extendProbeTimeout)
                 {
                     localHealthMonitor.Received(1).GetLocalHealthStatus(
-                        options.ProbeTimeout,
+                        options.ProbeInterval,
                         LocalSiloHealthCheckCategory.Local);
                 }
                 else
@@ -418,7 +474,7 @@ namespace NonSilo.Tests.Membership
 
                 await prober.Received(1).Probe(_targetSilo, 1, cancellationToken);
 
-                var dilatedTimeout = options.ProbeTimeout.Multiply(expectedTimeoutFactor);
+                var dilatedTimeout = options.InitialProbeTimeout.Multiply(expectedTimeoutFactor);
                 timeProvider.Advance(dilatedTimeout - TimeSpan.FromTicks(1));
                 Assert.False(cancellationToken.IsCancellationRequested);
                 Assert.False(probeResult.Task.IsCompleted);

--- a/test/Orleans.Core.Tests/SiloBuilderTests.cs
+++ b/test/Orleans.Core.Tests/SiloBuilderTests.cs
@@ -212,6 +212,21 @@ namespace NonSilo.Tests
                         });
                 }).RunConsoleAsync();
             });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options =>
+                        {
+                            options.InitialProbeTimeout = TimeSpan.FromTicks(4_611_686_018);
+                            options.MaxProbeTimeout = options.InitialProbeTimeout;
+                            options.NumMissedProbesLimit = 2_000_000_000;
+                        });
+                }).RunConsoleAsync();
+            });
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/SiloBuilderTests.cs
+++ b/test/Orleans.Core.Tests/SiloBuilderTests.cs
@@ -153,6 +153,65 @@ namespace NonSilo.Tests
                         .Configure<ClusterMembershipOptions>(options => options.MaxDefunctSiloEntries = -1);
                 }).RunConsoleAsync();
             });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options => options.ProbeInterval = TimeSpan.Zero);
+                }).RunConsoleAsync();
+            });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options => options.MinProbeTimeout = TimeSpan.FromSeconds(6));
+                }).RunConsoleAsync();
+            });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options =>
+                        {
+                            options.MinProbeTimeout = TimeSpan.FromSeconds(1);
+                            options.MaxProbeTimeout = TimeSpan.FromSeconds(4);
+                        });
+                }).RunConsoleAsync();
+            });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options => options.MaxProbeTimeout = TimeSpan.FromDays(50));
+                }).RunConsoleAsync();
+            });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options =>
+                        {
+                            options.InitialProbeTimeout = TimeSpan.FromDays(1);
+                            options.MaxProbeTimeout = TimeSpan.FromDays(49);
+                            options.NumMissedProbesLimit = int.MaxValue;
+                        });
+                }).RunConsoleAsync();
+            });
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/SiloBuilderTests.cs
+++ b/test/Orleans.Core.Tests/SiloBuilderTests.cs
@@ -160,7 +160,7 @@ namespace NonSilo.Tests
                 {
                     siloBuilder
                         .UseLocalhostClustering()
-                        .Configure<ClusterMembershipOptions>(options => options.ProbeInterval = TimeSpan.Zero);
+                        .Configure<ClusterMembershipOptions>(options => options.ProbeTimeout = TimeSpan.Zero);
                 }).RunConsoleAsync();
             });
 
@@ -206,7 +206,7 @@ namespace NonSilo.Tests
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options =>
                         {
-                            options.InitialProbeTimeout = TimeSpan.FromDays(1);
+                            options.ProbeTimeout = TimeSpan.FromDays(1);
                             options.MaxProbeTimeout = TimeSpan.FromDays(49);
                             options.NumMissedProbesLimit = int.MaxValue;
                         });
@@ -221,8 +221,8 @@ namespace NonSilo.Tests
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options =>
                         {
-                            options.InitialProbeTimeout = TimeSpan.FromTicks(4_611_686_018);
-                            options.MaxProbeTimeout = options.InitialProbeTimeout;
+                            options.ProbeTimeout = TimeSpan.FromTicks(4_611_686_018);
+                            options.MaxProbeTimeout = options.ProbeTimeout;
                             options.NumMissedProbesLimit = 2_000_000_000;
                         });
                 }).RunConsoleAsync();

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -181,7 +181,7 @@ public class GrainDirectoryLeaseTests
         Assert.Equal(TimeSpan.FromSeconds(30), new GrainDirectoryOptions().RangeLeaseDuration);
 
     [Fact]
-    public void DefaultRangeLeaseDuration_LeavesFifteenSecondsAfterFailureDetection()
+    public void DefaultRangeLeaseDuration_IsConsumedByWorstCaseFailureDetection()
     {
         var membershipOptions = new ClusterMembershipOptions();
 
@@ -189,7 +189,7 @@ public class GrainDirectoryLeaseTests
             new GrainDirectoryOptions().RangeLeaseDuration,
             membershipOptions);
 
-        Assert.Equal(TimeSpan.FromSeconds(15), duration);
+        Assert.Equal(TimeSpan.Zero, duration);
     }
 
     [Fact]
@@ -400,7 +400,9 @@ public class GrainDirectoryLeaseTests
             siloBuilder.Services.AddKeyedSingleton(TimeProviderNames.Membership, TimeProvider.System);
             siloBuilder.Services.Configure<ClusterMembershipOptions>(options =>
             {
-                options.ProbeTimeout = TimeSpan.FromSeconds(1);
+                options.ProbeInterval = TimeSpan.FromSeconds(1);
+                options.InitialProbeTimeout = TimeSpan.FromSeconds(1);
+                options.MaxProbeTimeout = TimeSpan.FromSeconds(1);
                 options.NumMissedProbesLimit = 1;
             });
             siloBuilder.Services.PostConfigure<GrainDirectoryOptions>(o => o.RangeLeaseDuration = rangeLeaseDuration ?? RangeLeaseDuration);

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -400,8 +400,7 @@ public class GrainDirectoryLeaseTests
             siloBuilder.Services.AddKeyedSingleton(TimeProviderNames.Membership, TimeProvider.System);
             siloBuilder.Services.Configure<ClusterMembershipOptions>(options =>
             {
-                options.ProbeInterval = TimeSpan.FromSeconds(1);
-                options.InitialProbeTimeout = TimeSpan.FromSeconds(1);
+                options.ProbeTimeout = TimeSpan.FromSeconds(1);
                 options.MaxProbeTimeout = TimeSpan.FromSeconds(1);
                 options.NumMissedProbesLimit = 1;
             });

--- a/test/Orleans.Runtime.Internal.Tests/MembershipTests/ClientIdPartitionDataRebuildTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/MembershipTests/ClientIdPartitionDataRebuildTests.cs
@@ -144,8 +144,7 @@ namespace UnitTests.MembershipTests
                 hostBuilder.Configure<ClusterMembershipOptions>(options =>
                 {
                     options.NumMissedProbesLimit = 1;
-                    options.ProbeInterval = TimeSpan.FromMilliseconds(500);
-                    options.InitialProbeTimeout = TimeSpan.FromMilliseconds(500);
+                    options.ProbeTimeout = TimeSpan.FromMilliseconds(500);
                     options.MaxProbeTimeout = TimeSpan.FromMilliseconds(500);
                     options.NumVotesForDeathDeclaration = 1;
                 });

--- a/test/Orleans.Runtime.Internal.Tests/MembershipTests/ClientIdPartitionDataRebuildTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/MembershipTests/ClientIdPartitionDataRebuildTests.cs
@@ -144,7 +144,9 @@ namespace UnitTests.MembershipTests
                 hostBuilder.Configure<ClusterMembershipOptions>(options =>
                 {
                     options.NumMissedProbesLimit = 1;
-                    options.ProbeTimeout = TimeSpan.FromMilliseconds(500);
+                    options.ProbeInterval = TimeSpan.FromMilliseconds(500);
+                    options.InitialProbeTimeout = TimeSpan.FromMilliseconds(500);
+                    options.MaxProbeTimeout = TimeSpan.FromMilliseconds(500);
                     options.NumVotesForDeathDeclaration = 1;
                 });
 


### PR DESCRIPTION
## Problem

Membership probing uses the same fixed timeout and cadence for every peer despite differing network conditions. This can delay failure detection for responsive peers while giving slower peers too little tolerance.

## Solution

- retain `ProbeTimeout` as the initial per-peer timeout
- add configurable minimum and maximum bounds, defaulting to half and four times `ProbeTimeout`
- learn a timeout independently for each peer from successful direct-probe RTTs using a bounded Phi Accrual model
- adapt probe cadence to the latest effective timeout, measuring the delay from the previous probe attempt start so quick probes wait the remainder and timed-out probes retry immediately
- preserve indirect-probe, local-health, debugger, connection-liveness, and conservative failure-budget behavior
- document the protocol and validate option/API compatibility

## Rationale

Peer-local evidence allows responsive links to fail faster while giving consistently slower links more tolerance. Failed and indirect probes are excluded because they are censored measurements or represent a different network path. Tying cadence to the learned timeout lets shorter estimates improve detection latency without allowing probes from a monitor to overlap.