### PR TITLE
fix(security): remediate repository alerts

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -11,7 +11,7 @@
         "@astrojs/markdown-remark": "7.2.1",
         "@astrojs/starlight": "0.41.3",
         "astro": "7.1.3",
-        "mermaid": "11.16.0",
+        "mermaid": "11.16.1",
         "pagefind": "1.5.2",
         "remark-directive": "4.0.0",
         "sharp": "0.35.3",
@@ -6320,9 +6320,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha1-3JRryEvenQk7oUlA1J3x2ffYwy8=",
+      "version": "11.16.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha1-V64jQvbEW5ZxE7BMklhDC90Ffug=",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
@@ -7132,9 +7132,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
+      "version": "3.3.17",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
       "funding": [
         {
           "type": "github",
@@ -7434,9 +7434,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha1-R6d5vYMXM/9iDmCNIzsZXuHn1mw=",
+      "version": "8.5.25",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha1-UBKlmOqqiX8hu+hVO+PLe9K9eMs=",
       "funding": [
         {
           "type": "opencollective",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -22,7 +22,7 @@
     "@astrojs/markdown-remark": "7.2.1",
     "@astrojs/starlight": "0.41.3",
     "astro": "7.1.3",
-    "mermaid": "11.16.0",
+    "mermaid": "11.16.1",
     "pagefind": "1.5.2",
     "remark-directive": "4.0.0",
     "sharp": "0.35.3",

--- a/playground/ActivationRepartitioning/ActivationRepartitioning.Frontend/wwwroot/index.html
+++ b/playground/ActivationRepartitioning/ActivationRepartitioning.Frontend/wwwroot/index.html
@@ -7,7 +7,11 @@
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/site.css" rel="stylesheet" />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js"
+      integrity="sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw=="
+      crossorigin="anonymous"
+    ></script>
     <style>
       body,
       html {

--- a/src/Dashboard/Orleans.Dashboard.App/package-lock.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package-lock.json
@@ -1469,10 +1469,11 @@
       "license": "MIT"
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1544,9 +1545,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2839,9 +2840,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "dev": true,
       "funding": [
         {
@@ -3379,9 +3380,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
       "dev": true,
       "funding": [
         {

--- a/src/Dashboard/Orleans.Dashboard.App/package-lock.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package-lock.json
@@ -1470,8 +1470,8 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1546,8 +1546,8 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2841,8 +2841,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3381,8 +3381,8 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.17",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {

--- a/src/Dashboard/Orleans.Dashboard.App/src/lib/routie.ts
+++ b/src/Dashboard/Orleans.Dashboard.App/src/lib/routie.ts
@@ -95,6 +95,7 @@ const pathToRegexp = function(
   if (path instanceof Array) path = '(' + path.join('|') + ')';
   path = (path as string)
     .concat(strict ? '' : '/?')
+    .replace(/\\/g, '\\\\')
     .replace(/\/\(/g, '(?:/')
     .replace(/\+/g, '__plus__')
     .replace(/(\/)?(\.)?:(\w+)(?:(\(.*?\)))?(\?)?/g, function(


### PR DESCRIPTION
GitHub security scanning identified vulnerable frontend dependencies and two code-scanning findings in the documentation, dashboard, and activation-repartitioning playground.

This updates the affected npm dependency resolutions, adds Subresource Integrity and anonymous CORS enforcement to the externally hosted D3 script, and escapes backslashes before constructing dashboard route regular expressions. The refreshed lockfiles also clear newly detected transitive npm advisories in the dashboard dependency graph.

The separately reported OpenVSX credential is not present in this repository checkout. It must be revoked or rotated and removed from the wiki history outside this PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10516)