### PR TITLE
test(transactions): tolerate load-induced consistency timeouts

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/ConsistencyTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/ConsistencyTransactionTestRunner.cs
@@ -47,9 +47,16 @@ namespace Orleans.Transactions.TestKit
             }
 
             // then, analyze the history results
-            var tolerateGenericTimeouts = StorageErrorInjectionActive || (scale >= 3 && !avoidTimeouts);
+            var tolerateGenericTimeouts = ShouldTolerateGenericTimeouts(scale, StorageErrorInjectionActive);
             var tolerateUnknownExceptions = StorageAdaptorHasLimitedCommitSpace || StorageErrorInjectionActive;
             harness.CheckConsistency(tolerateGenericTimeouts, tolerateUnknownExceptions);
+        }
+
+        internal static bool ShouldTolerateGenericTimeouts(int scale, bool storageErrorInjectionActive)
+        {
+            // AvoidTimeouts limits recursive work before the response timeout, but cannot prevent
+            // the response timeout itself from expiring when the system is under load.
+            return storageErrorInjectionActive || scale >= 3;
         }
     }
 }

--- a/test/Transactions/Orleans.Transactions.Tests/ConsistencyTransactionTestRunnerTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConsistencyTransactionTestRunnerTests.cs
@@ -1,0 +1,23 @@
+using Orleans.Transactions.TestKit;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+public class ConsistencyTransactionTestRunnerTests
+{
+    [Theory]
+    [InlineData(2, false, false)]
+    [InlineData(3, false, true)]
+    [InlineData(2, true, true)]
+    public void GenericTimeoutToleranceMatchesWorkloadRisk(
+        int scale,
+        bool storageErrorInjectionActive,
+        bool expected)
+    {
+        var actual = ConsistencyTransactionTestRunner.ShouldTolerateGenericTimeouts(
+            scale,
+            storageErrorInjectionActive);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/ConsistencyTransactionTestRunnerTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConsistencyTransactionTestRunnerTests.cs
@@ -1,8 +1,13 @@
 using Orleans.Transactions.TestKit;
+using TestExtensions;
 using Xunit;
 
 namespace Orleans.Transactions.Tests;
 
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
 public class ConsistencyTransactionTestRunnerTests
 {
     [Theory]


### PR DESCRIPTION
## Problem

`RandomizedConsistency` treats `avoidTimeouts` as a guarantee that no generic Orleans response timeout can occur. The option only limits recursive work before the response-timeout deadline; an in-flight call can still exceed that deadline under the existing high-load test configurations. The harness then rejects the timeout even though it already treats the resulting history as incomplete.

## Solution

Tolerate generic response timeouts at the existing `scale >= 3` workload threshold regardless of `avoidTimeouts`, while continuing to run the serializability checks which remain valid with incomplete history. Add deterministic coverage for the timeout-tolerance policy, including the reported non-fault-injection workload.

## Rationale

This preserves strict timeout rejection for low-load runs, keeps fault-injection behavior unchanged, and avoids conflating best-effort recursive-work limiting with the outer Orleans response timeout.

Fixes #10509
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10524)