### PR TITLE
test: stabilize multi-grain cancellation

### DIFF
--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -135,10 +135,8 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
                 Assert.ThrowsAnyAsync<OperationCanceledException>(() => task)));
             if (delay > 0)
             {
-                for (var i = 0; i < grains.Count; i++)
-                {
-                    await WaitForCallCancellation(grains[i], callIds[i]);
-                }
+                await Task.WhenAll(grains.Select((grain, index) =>
+                    WaitForCallCancellation(grain, callIds[index])));
             }
         }
         finally

--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -107,20 +107,43 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
     public async Task MultipleGrainsTaskCancellation(int delay)
     {
         using var cts = new CancellationTokenSource();
-        var callId = Guid.NewGuid();
         var grains = Enumerable.Range(0, 5).Select(_ => fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid())).ToList();
-        var grainTasks = grains.Select(grain =>
-            Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                grain.LongWaitInterleaving(cts.Token, TimeSpan.FromSeconds(10), callId)))
-            .ToList();
-        cts.CancelAfter(delay);
-        await Task.WhenAll(grainTasks);
-        if (delay > 0)
+        var callIds = grains.Select(_ => Guid.NewGuid()).ToArray();
+        var observer = new LongRunningTaskObserver();
+        var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
+        try
         {
-            foreach (var grain in grains)
+            var grainTasks = grains.Select((grain, index) =>
+                delay > 0
+                    ? grain.LongWaitInterleavingWithStartNotification(
+                        TimeSpan.FromSeconds(10),
+                        callIds[index],
+                        observerReference,
+                        cts.Token)
+                    : grain.LongWaitInterleaving(
+                        cts.Token,
+                        TimeSpan.FromSeconds(10),
+                        callIds[index]))
+                .ToArray();
+            if (delay > 0)
             {
-                await WaitForCallCancellation(grain, callId);
+                await Task.WhenAll(callIds.Select(observer.WaitForCallToStart));
             }
+
+            cts.CancelAfter(delay);
+            await Task.WhenAll(grainTasks.Select(task =>
+                Assert.ThrowsAnyAsync<OperationCanceledException>(() => task)));
+            if (delay > 0)
+            {
+                for (var i = 0; i < grains.Count; i++)
+                {
+                    await WaitForCallCancellation(grains[i], callIds[i]);
+                }
+            }
+        }
+        finally
+        {
+            fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
         }
     }
 


### PR DESCRIPTION
`MultipleGrainsTaskCancellation` can complete caller-side cancellation before one or more delayed requests begin executing. The test then waits for grain-side cancellation evidence which can never exist, producing the five-minute timeout seen on macOS.

Use the start-notification barrier added by #10461 for each delayed grain call before cancelling the shared token. Assigning each grain a distinct evidence ID lets the test prove that all five calls started and observed cancellation, while the zero-delay cases retain pre-start cancellation coverage.

Fixes #10439
Fixes #10440
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10525)