### PR TITLE
test: stabilize grain directory lease placement

### DIFF
--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -40,7 +40,7 @@ public class GrainDirectoryLeaseTests
     {
         var (cluster, timeProvider) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync();
+        await DeployAndWaitForClusterManifestAsync(cluster);
 
         try
         {
@@ -88,7 +88,7 @@ public class GrainDirectoryLeaseTests
     {
         var (cluster, timeProvider) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync();
+        await DeployAndWaitForClusterManifestAsync(cluster);
 
         try
         {
@@ -145,7 +145,7 @@ public class GrainDirectoryLeaseTests
     {
         var (cluster, _) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync();
+        await DeployAndWaitForClusterManifestAsync(cluster);
 
         try
         {
@@ -261,7 +261,7 @@ public class GrainDirectoryLeaseTests
     {
         var (cluster, _) = CreateCluster(TimeSpan.Zero);
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync();
+        await DeployAndWaitForClusterManifestAsync(cluster);
 
         try
         {
@@ -296,7 +296,7 @@ public class GrainDirectoryLeaseTests
     {
         var (cluster, _) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync();
+        await DeployAndWaitForClusterManifestAsync(cluster);
 
         try
         {
@@ -330,7 +330,7 @@ public class GrainDirectoryLeaseTests
     {
         var (cluster, timeProvider) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync();
+        await DeployAndWaitForClusterManifestAsync(cluster);
 
         try
         {
@@ -407,6 +407,12 @@ public class GrainDirectoryLeaseTests
         });
 
         return (builder.Build(), timeProvider);
+    }
+
+    private static async Task DeployAndWaitForClusterManifestAsync(InProcessTestCluster cluster)
+    {
+        await cluster.DeployAsync();
+        await cluster.WaitForClusterManifestToStabilizeAsync();
     }
 
     private static async Task DisposeClusterAsync(InProcessTestCluster cluster)


### PR DESCRIPTION
Fixes #10518.

The reported failure occurred before silo shutdown: the preferred victim silo was not always present in the placement compatibility set when the test issued its first grain call. Since placement hints are advisory, Orleans fell back to random placement and the setup assertion observed the other silo.

Wait for cluster manifests to stabilize before placement-sensitive lease tests create activations. This uses the existing TestingHost readiness barrier and applies it consistently to the lease scenarios which require a specific victim silo.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10526)