### PR TITLE
fix(adonet): avoid SQL stream confirmation deadlocks

### DIFF
--- a/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
@@ -416,12 +416,13 @@ FROM
 DECLARE @Count INT = (SELECT COUNT(*) FROM @ItemsTable);
 
 /* delete messages in the exact same order as the clustered index to avoid deadlocks with other queries */
+/* skip messages being changed concurrently since their dequeue receipt may no longer match */
 WITH Batch AS
 (
 	SELECT TOP (@Count)
 		*
 	FROM
-		OrleansStreamMessage AS M WITH (UPDLOCK, HOLDLOCK, ROWLOCK)
+		OrleansStreamMessage AS M WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK, ROWLOCK)
 	WHERE
 		ServiceId = @ServiceId
         AND ProviderId = @ProviderId


### PR DESCRIPTION
## Problem

SQL Server stream confirmations took serializable key-range locks. Under concurrent enqueue, dequeue, and confirmation load, those range locks conflicted with inserts and could select `QueueStreamMessage` as a deadlock victim.

## Solution

Use ordered, skip-locked row updates for confirmations, matching the dequeue and eviction strategy. Locked rows are skipped because a concurrent operation can change their dequeue receipt, making the pending confirmation stale.

This removes the insert-range conflict without retrying or suppressing database errors, while retaining receipt-based confirmation semantics.



Fixes #10520
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10527)