### PR TITLE
test(runtime): await manifest before shutdown migration

### DIFF
--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -33,6 +33,7 @@ public sealed class GrainDirectoryShutdownMigrationTests
         await using var cluster = builder.Build();
         await cluster.DeployAsync();
         await cluster.WaitForLivenessToStabilizeAsync();
+        await cluster.WaitForClusterManifestToStabilizeAsync();
         await WaitForDirectoryMembershipAsync(cluster);
 
         var survivingSilo = cluster.Silos[0];


### PR DESCRIPTION
## Problem

The shutdown migration test could stop the hosting silo after membership and directory convergence but before cluster manifests converged. PreferLocal placement then had no deterministic knowledge that the surviving silo supported the grain, so migration could fall back to a fresh activation with default state.

## Solution

Wait for the cluster manifest to stabilize before creating and shutting down the test grains. This uses the existing TestingHost readiness barrier and preserves the test's intended directory-handoff coverage.

Fixes #10523
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10528)