### PR TITLE
fix(directory): preserve newer recovery registrations

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -801,7 +801,8 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
     {
         // During a rolling upgrade, LocalGrainDirectory does not participate in DistributedGrainDirectory's
         // recovery-registration barrier and can report an activation superseded in a newer membership view.
-        // Preserve the newest registration: conflicting registrations within one membership version remain invalid.
+        // This is the only expected case where recovery returns different registrations for one grain. Preserve
+        // the newest view while retaining recovery's existing last-response tie-breaking within the same view.
         if (!directory.TryGetValue(recovered.GrainId, out var existing)
             || recovered.MembershipVersion >= existing.MembershipVersion)
         {

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -799,7 +799,9 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     internal static void RecoverEntry(Dictionary<GrainId, GrainAddress> directory, GrainAddress recovered)
     {
-        // Concurrent recovery responses can include an activation which was superseded in a newer membership view.
+        // During a rolling upgrade, LocalGrainDirectory does not participate in DistributedGrainDirectory's
+        // recovery-registration barrier and can report an activation superseded in a newer membership view.
+        // Preserve the newest registration: conflicting registrations within one membership version remain invalid.
         if (!directory.TryGetValue(recovered.GrainId, out var existing)
             || recovered.MembershipVersion >= existing.MembershipVersion)
         {

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -788,13 +788,23 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             {
                 DebugAssertOwnership(current, entry.GrainId);
                 LogTraceRecoveredEntry(_logger, entry, current.Version);
-                _directory[entry.GrainId] = entry;
+                RecoverEntry(_directory, entry);
             }
         }
 
         _directoryInstruments.RangeRecoveryCount.Add(1);
         _directoryInstruments.RangeRecoveryDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
         LogDebugCompletedRecoveringActivations(_logger, addedRange, current.Version, stopwatch.Elapsed);
+    }
+
+    internal static void RecoverEntry(Dictionary<GrainId, GrainAddress> directory, GrainAddress recovered)
+    {
+        // Concurrent recovery responses can include an activation which was superseded in a newer membership view.
+        if (!directory.TryGetValue(recovered.GrainId, out var existing)
+            || recovered.MembershipVersion > existing.MembershipVersion)
+        {
+            directory[recovered.GrainId] = recovered;
+        }
     }
 
     private async IAsyncEnumerable<List<GrainAddress>> GetRegisteredActivations(DirectoryMembershipSnapshot current, RingRange range, bool isValidation)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -801,7 +801,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
     {
         // Concurrent recovery responses can include an activation which was superseded in a newer membership view.
         if (!directory.TryGetValue(recovered.GrainId, out var existing)
-            || recovered.MembershipVersion > existing.MembershipVersion)
+            || recovered.MembershipVersion >= existing.MembershipVersion)
         {
             directory[recovered.GrainId] = recovered;
         }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
@@ -200,8 +200,8 @@ public sealed class GrainDirectoryPartitionTests
         GrainDirectoryPartition.RecoverEntry(newThenOld, newRegistration);
         GrainDirectoryPartition.RecoverEntry(newThenOld, oldRegistration);
 
-        Assert.Same(newRegistration, oldThenNew[grainId]);
-        Assert.Same(newRegistration, newThenOld[grainId]);
+        Assert.Equal(newRegistration, oldThenNew[grainId]);
+        Assert.Equal(newRegistration, newThenOld[grainId]);
     }
 
     private static void AssertRanges(RingRange previousOwnerRange, RingRange addedRange, params RingRange[] expected)

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
@@ -173,6 +173,37 @@ public sealed class GrainDirectoryPartitionTests
             addedRange: RingRange.Create(30, 40));
     }
 
+    [Fact]
+    public void RecoverEntry_PreservesNewestRegistrationRegardlessOfResponseOrder()
+    {
+        var grainId = GrainId.Create("recovery-test", "grain");
+        var oldRegistration = new GrainAddress
+        {
+            GrainId = grainId,
+            ActivationId = ActivationId.NewId(),
+            SiloAddress = TestSiloAddress,
+            MembershipVersion = new MembershipVersion(1),
+        };
+        var newRegistration = new GrainAddress
+        {
+            GrainId = grainId,
+            ActivationId = ActivationId.NewId(),
+            SiloAddress = ReplacementSiloAddress,
+            MembershipVersion = new MembershipVersion(2),
+        };
+
+        Dictionary<GrainId, GrainAddress> oldThenNew = [];
+        GrainDirectoryPartition.RecoverEntry(oldThenNew, oldRegistration);
+        GrainDirectoryPartition.RecoverEntry(oldThenNew, newRegistration);
+
+        Dictionary<GrainId, GrainAddress> newThenOld = [];
+        GrainDirectoryPartition.RecoverEntry(newThenOld, newRegistration);
+        GrainDirectoryPartition.RecoverEntry(newThenOld, oldRegistration);
+
+        Assert.Same(newRegistration, oldThenNew[grainId]);
+        Assert.Same(newRegistration, newThenOld[grainId]);
+    }
+
     private static void AssertRanges(RingRange previousOwnerRange, RingRange addedRange, params RingRange[] expected)
     {
         var actual = GrainDirectoryPartition.GetSnapshotTransferRanges(previousOwnerRange, addedRange).ToArray();


### PR DESCRIPTION
During partition recovery, activation responses from live silos were merged using last-writer-wins ordering. In a rolling upgrade, a response from an older LocalGrainDirectory activation could therefore overwrite a registration created in a newer distributed-directory membership view, leaving the recovered directory pointing at the superseded activation.

Prefer recovered registrations with the highest membership version so response order cannot regress directory state. Add deterministic coverage for both response orders.

Fixes #10519