### PR TITLE
test(azure): bound table retry budget

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/AzureClientOptionsTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureClientOptionsTests.cs
@@ -18,6 +18,15 @@ public class AzureClientOptionsTests
     }
 
     [Fact]
+    public void TestTableServiceClient_HasBoundedRetryBudget()
+    {
+        var options = AzureStorageOperationOptionsExtensions.GetTableClientOptions();
+
+        Assert.Equal(2, options.Retry.MaxRetries);
+        Assert.Equal(TimeSpan.FromSeconds(5), options.Retry.NetworkTimeout);
+    }
+
+    [Fact]
     public void BlobStorageServiceClient_RejectsNull()
     {
         var options = new AzureBlobStorageOptions();

--- a/test/Extensions/Orleans.Azure.Tests/AzureClientOptionsTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureClientOptionsTests.cs
@@ -18,7 +18,7 @@ public class AzureClientOptionsTests
     }
 
     [Fact]
-    public void TestTableServiceClient_HasBoundedRetryBudget()
+    public void TestTableClientOptions_HasBoundedRetryBudget()
     {
         var options = AzureStorageOperationOptionsExtensions.GetTableClientOptions();
 

--- a/test/Extensions/Orleans.Azure.Tests/AzureStorageOperationOptionsExtensions.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureStorageOperationOptionsExtensions.cs
@@ -8,6 +8,10 @@ namespace Tester.AzureUtils
 {
     public static class AzureStorageOperationOptionsExtensions
     {
+        // Keep a stalled emulator request within Orleans' 30-second response timeout.
+        private const int TableStorageMaxRetries = 2;
+        private static readonly TimeSpan TableStorageNetworkTimeout = TimeSpan.FromSeconds(5);
+
         public static DefaultAzureCredential Credential = new DefaultAzureCredential();
 
         public static Orleans.Clustering.AzureStorage.AzureStorageOperationOptions ConfigureTestDefaults(this Orleans.Clustering.AzureStorage.AzureStorageOperationOptions options)
@@ -19,9 +23,18 @@ namespace Tester.AzureUtils
 
         public static TableServiceClient GetTableServiceClient()
         {
+            var clientOptions = GetTableClientOptions();
             return TestDefaultConfiguration.UseAadAuthentication
-                ? new(TestDefaultConfiguration.TableEndpoint, TestDefaultConfiguration.TokenCredential)
-                : new(TestDefaultConfiguration.DataConnectionString);
+                ? new(TestDefaultConfiguration.TableEndpoint, TestDefaultConfiguration.TokenCredential, clientOptions)
+                : new(TestDefaultConfiguration.DataConnectionString, clientOptions);
+        }
+
+        internal static TableClientOptions GetTableClientOptions()
+        {
+            var options = new TableClientOptions();
+            options.Retry.MaxRetries = TableStorageMaxRetries;
+            options.Retry.NetworkTimeout = TableStorageNetworkTimeout;
+            return options;
         }
 
         public static Orleans.GrainDirectory.AzureStorage.AzureStorageOperationOptions ConfigureTestDefaults(this Orleans.GrainDirectory.AzureStorage.AzureStorageOperationOptions options)

--- a/test/Extensions/Orleans.Azure.Tests/AzureStorageOperationOptionsExtensions.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureStorageOperationOptionsExtensions.cs
@@ -8,7 +8,7 @@ namespace Tester.AzureUtils
 {
     public static class AzureStorageOperationOptionsExtensions
     {
-        // Keep a stalled emulator request within Orleans' 30-second response timeout.
+        // Keep stalled table storage requests within Orleans' 30-second response timeout.
         private const int TableStorageMaxRetries = 2;
         private static readonly TimeSpan TableStorageNetworkTimeout = TimeSpan.FromSeconds(5);
 


### PR DESCRIPTION
## Problem

In the failing Azure Storage job, both reminder services spent 5m10s in their initial `ReadTableEntriesAndEtags` turn. Every affected grain activation then blocked behind that turn in `IReminderService.GetReminders`, producing six unrelated-looking 30-second request timeouts.

The Azure test fixture supplies a prebuilt `TableServiceClient`, so it bypasses Orleans' configured storage retry policy and inherits the Azure SDK's 100-second per-attempt network timeout. PR #10531 addresses a separate exact-due fake-time boundary and does not cover this provider stall.

## Solution

Configure test `TableServiceClient` instances with a 5-second network timeout and two retries, keeping a complete retry sequence below Orleans' 30-second response timeout. Add a credential-free regression assertion for that retry budget. Production client defaults are unchanged.

Fixes #10499
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10534)