### PR TITLE
fix(streaming): preserve ADO.NET dequeue order

### DIFF
--- a/src/AdoNet/Orleans.Streaming.AdoNet/MySQL-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/MySQL-Streaming.sql
@@ -318,7 +318,9 @@ FROM
         ON M.ServiceId = B.ServiceId
         AND M.ProviderId = B.ProviderId
         AND M.QueueId = B.QueueId
-        AND M.MessageId = B.MessageId;
+        AND M.MessageId = B.MessageId
+ORDER BY
+    M.MessageId;
 
 DROP TEMPORARY TABLE _Batch;
 

--- a/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
+++ b/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
@@ -464,7 +464,7 @@ namespace Orleans.Tests.SqlUtils
                     EvictionInterval = evictionInterval,
                     EvictionBatchSize = evictionBatchSize
                 },
-                result => result.ToList());
+                result => result.OrderBy(static message => message.MessageId).ToList());
         }
 
         /// <summary>

--- a/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
+++ b/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
@@ -464,7 +464,12 @@ namespace Orleans.Tests.SqlUtils
                     EvictionInterval = evictionInterval,
                     EvictionBatchSize = evictionBatchSize
                 },
-                result => result.OrderBy(static message => message.MessageId).ToList());
+                result =>
+                {
+                    var messages = result.ToList();
+                    messages.Sort(static (left, right) => left.MessageId.CompareTo(right.MessageId));
+                    return messages;
+                });
         }
 
         /// <summary>

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -88,6 +88,29 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         return payload;
     }
 
+    private async Task<AdoNetStreamMessageAck[]> QueueMessagesAsync(
+        string serviceId,
+        string providerId,
+        string queueId,
+        byte[] payload,
+        int expiryTimeout,
+        int count)
+    {
+        using var semaphore = new SemaphoreSlim(concurrency);
+        return await Task.WhenAll(Enumerable.Range(0, count).Select(async _ =>
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                return await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }));
+    }
+
     public Task DisposeAsync() => Task.CompletedTask;
 
     protected async Task VerifyProviderResultsAreOrdered()
@@ -105,9 +128,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var queueId = RandomQueueId();
         var payload = new byte[] { 0xFF };
 
-        await Task.WhenAll(Enumerable
-            .Range(0, 100)
-            .Select(_ => _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, 100)));
+        await QueueMessagesAsync(serviceId, providerId, queueId, payload, 100, 100);
 
         await _storage.ExecuteAsync(
             "UPDATE OrleansQuery SET QueryText = @QueryText WHERE QueryKey = 'GetStreamMessagesKey'",
@@ -416,10 +437,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
 
         // arrange - enqueue messages concurrently
         var beforeQueueing = DateTime.UtcNow.AddSeconds(-1);
-        var acks = await Task.WhenAll(Enumerable
-            .Range(0, total)
-            .Select(i => _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout))
-            .ToList());
+        var acks = await QueueMessagesAsync(serviceId, providerId, queueId, payload, expiryTimeout, total);
         var afterQueueing = DateTime.UtcNow.AddSeconds(1);
 
         // act - dequeue all messages

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -31,6 +31,9 @@ public class MySqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
     {
         MySqlConnection.ClearAllPools();
     }
+
+    [SkippableFact]
+    public Task RelationalOrleansQueries_OrdersProviderResults() => VerifyProviderResultsAreOrdered();
 }
 
 /// <summary>
@@ -86,6 +89,41 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
+
+    protected async Task VerifyProviderResultsAreOrdered()
+    {
+        const string reverseQuery = """
+            SELECT ServiceId, ProviderId, QueueId, MessageId, Dequeued, VisibleOn, ExpiresOn, CreatedOn, ModifiedOn, Payload
+            FROM OrleansStreamMessage
+            WHERE ServiceId = @ServiceId AND ProviderId = @ProviderId AND QueueId = @QueueId
+            ORDER BY MessageId DESC
+            LIMIT @MaxCount
+            """;
+
+        var serviceId = RandomServiceId();
+        var providerId = RandomProviderId();
+        var queueId = RandomQueueId();
+        var payload = new byte[] { 0xFF };
+
+        await Task.WhenAll(Enumerable
+            .Range(0, 100)
+            .Select(_ => _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, 100)));
+
+        await _storage.ExecuteAsync(
+            "UPDATE OrleansQuery SET QueryText = @QueryText WHERE QueryKey = 'GetStreamMessagesKey'",
+            command =>
+            {
+                var parameter = command.CreateParameter();
+                parameter.ParameterName = "QueryText";
+                parameter.Value = reverseQuery;
+                command.Parameters.Add(parameter);
+            });
+
+        var queries = await RelationalOrleansQueries.CreateInstance(invariant, _storage.ConnectionString);
+        var messages = await queries.GetStreamMessagesAsync(serviceId, providerId, queueId, 100, 3, 10, 100, 10, 1000);
+
+        Assert.Equal(messages.OrderBy(message => message.MessageId), messages);
+    }
 
     /// <summary>
     /// Tests that a single message is queued.
@@ -366,17 +404,17 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var serviceId = RandomServiceId();
         var providerId = RandomProviderId();
         var queueId = RandomQueueId();
-        var payload = RandomPayload();
+        var payload = new byte[] { 0xFF };
         var expiryTimeout = 100;
-        var maxCount = 3;
+        var maxCount = 60;
         var maxAttempts = 3;
         var visibilityTimeout = 10;
         var removalTimeout = 100;
         var evictionInterval = 10;
         var evictionBatchSize = 1000;
-        var total = 5;
+        var total = 100;
 
-        // arrange - enqueue five messages
+        // arrange - enqueue messages concurrently
         var beforeQueueing = DateTime.UtcNow.AddSeconds(-1);
         var acks = await Task.WhenAll(Enumerable
             .Range(0, total)
@@ -384,7 +422,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
             .ToList());
         var afterQueueing = DateTime.UtcNow.AddSeconds(1);
 
-        // act - dequeue three batches of three messages
+        // act - dequeue all messages
         var beforeDequeuing = DateTime.UtcNow.AddSeconds(-1);
         var first = await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize);
         var second = await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize);
@@ -396,9 +434,11 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(total - maxCount, second.Count);
         Assert.Empty(third);
 
+        var messages = first.Concat(second).Concat(third).ToList();
+        Assert.Equal(messages.OrderBy(message => message.MessageId), messages);
+
         // assert - dequeued messages are consistent with acks
         var ackLookup = acks.ToDictionary(x => (x.ServiceId, x.ProviderId, x.QueueId, x.MessageId));
-        var messages = first.Concat(second).Concat(third).ToList();
         foreach (var message in messages)
         {
             Assert.True(ackLookup.TryGetValue((message.ServiceId, message.ProviderId, message.QueueId, message.MessageId), out var ack), "Ack not found");


### PR DESCRIPTION
Fixes #10522.
Fixes #10458.

The ADO.NET stream pulling agent uses the first message returned for each stream as the cache cursor. MySQL selects dequeue batches in `MessageId` order but returns the joined rows without an ordering guarantee. PostgreSQL has the same issue because `UPDATE ... RETURNING` does not preserve the CTE's selection order. In preserved CI failures, affected streams produced all ten items but consumption began at `sequential#2`, skipping the older first row which had been returned later in the result set.

This change orders the MySQL procedure result and normalizes all ADO.NET dequeue results by `MessageId`, protecting existing database schemas and every provider whose result ordering is not guaranteed. It also adds a deterministic regression which supplies reverse-ordered provider results and strengthens batch coverage with concurrent enqueues.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10536)