### PR TITLE
test(transactions): preserve graceful recovery drain budget

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryFailureObservation.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryFailureObservation.cs
@@ -7,6 +7,13 @@ namespace Orleans.Transactions.TestKit;
 
 internal static class TransactionRecoveryFailureObservation
 {
+    internal sealed record Timeouts(
+        TimeSpan ObservationWindow,
+        TimeSpan ProducerDrainTimeout)
+    {
+        public TimeSpan MaximumDuration => ObservationWindow + ProducerDrainTimeout;
+    }
+
     internal enum OutcomeKind
     {
         FailureObserved,
@@ -37,20 +44,33 @@ internal static class TransactionRecoveryFailureObservation
 
     public static bool IsPremature(long observedAt, long shutdownRequestedAt) => observedAt < shutdownRequestedAt;
 
+    internal static Timeouts GetTimeouts(
+        bool gracefulShutdown,
+        TimeSpan clientResponseTimeout,
+        TimeSpan schedulingMargin)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(clientResponseTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(schedulingMargin, TimeSpan.Zero);
+
+        var observationWindow = gracefulShutdown ? TimeSpan.Zero : clientResponseTimeout;
+        var maximumDuration = clientResponseTimeout + schedulingMargin;
+        return new(observationWindow, maximumDuration - observationWindow);
+    }
+
     internal static async Task<Outcome<TFailure, TProducerResult>> DetectAsync<TFailure, TProducerResult>(
         Task<TProducerResult> producer,
         Task<TFailure> firstFailure,
         CancellationTokenSource stopProducing,
-        TimeSpan responseWindow,
-        TimeSpan schedulingMargin)
+        TimeSpan observationWindow,
+        TimeSpan producerDrainTimeout)
         where TFailure : class
     {
-        ArgumentOutOfRangeException.ThrowIfLessThan(responseWindow, TimeSpan.Zero);
-        ArgumentOutOfRangeException.ThrowIfLessThan(schedulingMargin, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(observationWindow, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(producerDrainTimeout, TimeSpan.Zero);
 
         var startedAt = Stopwatch.GetTimestamp();
-        var responseDeadline = GetDeadline(startedAt, responseWindow);
-        var drainDeadline = GetDeadline(responseDeadline, schedulingMargin);
+        var responseDeadline = GetDeadline(startedAt, observationWindow);
+        var drainDeadline = GetDeadline(responseDeadline, producerDrainTimeout);
 
         await WaitUntilAsync(firstFailure, producer, responseDeadline);
         if (firstFailure.IsCompleted)

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
@@ -80,7 +80,10 @@ namespace Orleans.Transactions.TestKit
                 .GetRequiredService<IOptions<ClientMessagingOptions>>()
                 .Value
                 .ResponseTimeout;
-            this.failureDetectionTimeout = this.clientResponseTimeout + FailureDetectionSchedulingMargin;
+            this.failureDetectionTimeout = TransactionRecoveryFailureObservation.GetTimeouts(
+                gracefulShutdown: true,
+                this.clientResponseTimeout,
+                FailureDetectionSchedulingMargin).MaximumDuration;
             this.recoveryTimeout =
                 this.failureDetectionTimeout + TransactionalStateOptions.DefaultRemoteTransactionPingFrequency;
         }
@@ -345,18 +348,22 @@ namespace Orleans.Transactions.TestKit
 
             this.Log("Observing transaction activity after silo shutdown");
             var failureDetectionStartedAt = Stopwatch.GetTimestamp();
-            var failureObservationWindow = gracefulShutdown ? TimeSpan.Zero : this.clientResponseTimeout;
-            var failureObservationTimeout = failureObservationWindow + FailureDetectionSchedulingMargin;
+            var failureObservationTimeout = TransactionRecoveryFailureObservation.GetTimeouts(
+                gracefulShutdown,
+                this.clientResponseTimeout,
+                FailureDetectionSchedulingMargin);
             this.Log(
                 $"Recovery phase=failure-watchdog started. ObservationWindow="
-                + $"{failureObservationWindow}, clientResponseTimeout={this.clientResponseTimeout}, "
-                + $"schedulingMargin={FailureDetectionSchedulingMargin}, watchdog={failureObservationTimeout}.");
+                + $"{failureObservationTimeout.ObservationWindow}, clientResponseTimeout={this.clientResponseTimeout}, "
+                + $"producerDrainTimeout={failureObservationTimeout.ProducerDrainTimeout}, "
+                + $"schedulingMargin={FailureDetectionSchedulingMargin}, "
+                + $"watchdog={failureObservationTimeout.MaximumDuration}.");
             var failureDetection = await TransactionRecoveryFailureObservation.DetectAsync(
                 producer,
                 firstFailure.Task,
                 stopProducing,
-                failureObservationWindow,
-                FailureDetectionSchedulingMargin);
+                failureObservationTimeout.ObservationWindow,
+                failureObservationTimeout.ProducerDrainTimeout);
             this.Log(
                 $"Recovery phase=failure-watchdog completed, timestamp={DateTime.UtcNow:O}. "
                 + $"Outcome={failureDetection.Kind}, elapsed={failureDetection.Elapsed}, "
@@ -365,7 +372,7 @@ namespace Orleans.Transactions.TestKit
             if (failureDetection.Kind == TransactionRecoveryFailureObservation.OutcomeKind.AttemptTimedOut)
             {
                 throw new TimeoutException(
-                    $"The in-flight transaction attempt did not settle within the {failureObservationTimeout} "
+                    $"The in-flight transaction attempt did not settle within the {failureObservationTimeout.MaximumDuration} "
                     + $"failure-detection deadline after silo death. Shutdown elapsed={shutdownElapsed}, "
                     + $"failure detection elapsed={failureDetection.Elapsed}, drain elapsed={failureDetection.DrainElapsed}. "
                     + $"Performed {Volatile.Read(ref index)} transactions on each group.");
@@ -396,7 +403,7 @@ namespace Orleans.Transactions.TestKit
                 {
                     throw new TimeoutException(
                         $"A transaction failure was observed at index {interruption.Index}, but the in-flight batch did not "
-                        + $"settle within the {failureObservationTimeout} absolute deadline. No recovery probe was started "
+                        + $"settle within the {failureObservationTimeout.MaximumDuration} absolute deadline. No recovery probe was started "
                         + $"while that state-mutating attempt remained active. Drain elapsed={failureDetection.DrainElapsed}.");
                 }
 
@@ -409,10 +416,10 @@ namespace Orleans.Transactions.TestKit
                 }
 
                 if (interruption.ObservedAt >= failureDetectionStartedAt
-                    && Stopwatch.GetElapsedTime(failureDetectionStartedAt, interruption.ObservedAt) > failureObservationTimeout)
+                    && Stopwatch.GetElapsedTime(failureDetectionStartedAt, interruption.ObservedAt) > failureObservationTimeout.MaximumDuration)
                 {
                     throw new TimeoutException(
-                        $"No transaction failure was observed within the {failureObservationTimeout} watchdog after silo death. "
+                        $"No transaction failure was observed within the {failureObservationTimeout.MaximumDuration} watchdog after silo death. "
                         + $"The first later failure was at index {interruption.Index} after "
                         + $"{Stopwatch.GetElapsedTime(failureDetectionStartedAt, interruption.ObservedAt)}.");
                 }

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryFailureObservationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryFailureObservationTests.cs
@@ -11,6 +11,27 @@ namespace Orleans.Transactions.Tests;
 [TestCategory("BVT"), TestCategory("Transactions")]
 public class TransactionRecoveryFailureObservationTests
 {
+    [Theory]
+    [InlineData(true, 0, 45)]
+    [InlineData(false, 30, 15)]
+    public void GetTimeouts_PreservesAbsoluteWatchdogWhenAllocatingProducerDrain(
+        bool gracefulShutdown,
+        int expectedObservationWindowSeconds,
+        int expectedProducerDrainSeconds)
+    {
+        var clientResponseTimeout = TimeSpan.FromSeconds(30);
+        var schedulingMargin = TimeSpan.FromSeconds(15);
+
+        var timeouts = TransactionRecoveryFailureObservation.GetTimeouts(
+            gracefulShutdown,
+            clientResponseTimeout,
+            schedulingMargin);
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedObservationWindowSeconds), timeouts.ObservationWindow);
+        Assert.Equal(TimeSpan.FromSeconds(expectedProducerDrainSeconds), timeouts.ProducerDrainTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(45), timeouts.MaximumDuration);
+    }
+
     [Fact]
     public async Task DetectAsync_NonCancellableProducerTimesOutAndStopsProducing()
     {
@@ -59,8 +80,8 @@ public class TransactionRecoveryFailureObservationTests
             producer.Task,
             failure.Task,
             stopProducing,
-            responseWindow: TimeSpan.Zero,
-            schedulingMargin: TimeSpan.FromSeconds(1));
+            observationWindow: TimeSpan.Zero,
+            producerDrainTimeout: TimeSpan.FromSeconds(1));
 
         Assert.Equal(TransactionRecoveryFailureObservation.OutcomeKind.FailureObserved, outcome.Kind);
         Assert.Same(expectedFailure, outcome.Failure);
@@ -111,8 +132,8 @@ public class TransactionRecoveryFailureObservationTests
             producer,
             failure.Task,
             stopProducing,
-            responseWindow: TimeSpan.Zero,
-            schedulingMargin: TimeSpan.FromSeconds(1));
+            observationWindow: TimeSpan.Zero,
+            producerDrainTimeout: TimeSpan.FromSeconds(1));
 
         Assert.Equal(TransactionRecoveryFailureObservation.OutcomeKind.StoppedWithoutFailure, outcome.Kind);
         Assert.Null(outcome.Failure);


### PR DESCRIPTION
## Problem

#10514 correctly stops transaction production immediately after a graceful silo shutdown, but its absolute producer-drain watchdog consequently retained only the 15-second scheduling margin. The active batch contains non-cancellable grain calls whose configured response lifetime is 30 seconds, so a valid in-flight batch can outlive that reduced drain budget.

## Solution

Model failure observation and producer drain as explicit allocations within the existing 45-second absolute watchdog. Ungraceful shutdown keeps its 30-second observation window plus 15-second drain margin; graceful shutdown reallocates the skipped observation window to drain, giving active calls the full 45 seconds without increasing the overall watchdog.

Add deterministic coverage for both shutdown-mode allocations and report the individual phase budgets in diagnostics.

Fixes #10529
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10537)