### PR TITLE
test(reminders): re-enable basic list operations

### DIFF
--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -110,7 +110,7 @@ namespace UnitTests.TimerTests
         /// <summary>
         /// Tests basic reminder list operations including creation and retrieval.
         /// </summary>
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/9555")]
+        [Fact]
         public async Task Rem_Grain_Basic_ListOps()
         {
             await Test_Reminders_Basic_ListOps();


### PR DESCRIPTION
## Problem

`Rem_Grain_Basic_ListOps` remained skipped after its timing race was resolved. The skip points to closed issue #9555, leaving the deterministic in-memory reminder list coverage disabled and the original issue open.

## Solution

Re-enable the existing test. PR #10317 scoped fake time to the reminder service, and PR #10400 replaced the test's wall-clock cadence assumption with a single fake-time orchestrator which waits for every reminder schedule and exact counter transition before advancing.

This restores coverage without duplicating reminder logic or relaxing timing assertions.

Fixes #8004
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10540)