### PR TITLE
test(streaming): isolate memory batching fixture

### DIFF
--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamBatchingTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamBatchingTests.cs
@@ -25,7 +25,7 @@ namespace UnitTests.StreamingTests
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
                 // This fixture tests batching, not rebalancing. Keep one owner for the destructive in-memory queue.
-                builder.Options.InitialSilosCount = partitionCount;
+                builder.Options.InitialSilosCount = 1;
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
                 builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
             }

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamBatchingTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamBatchingTests.cs
@@ -24,6 +24,8 @@ namespace UnitTests.StreamingTests
 
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
+                // This fixture tests batching, not rebalancing. Keep one owner for the destructive in-memory queue.
+                builder.Options.InitialSilosCount = partitionCount;
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
                 builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
             }


### PR DESCRIPTION
Fixes #10538.

The one-partition memory-stream batching fixture started two silos. During cluster startup, both consistent-ring balancers temporarily owned the same queue, and the failing CI run published while the primary pulling agent was still shutting down. Since the in-memory queue dequeues destructively, the retiring agent could remove messages before the surviving owner delivered them.

Run this batching-only fixture with one silo so the queue has a single owner from startup. This preserves multi-silo and rebalance coverage in the dedicated streaming tests and avoids overlapping with the broader provider-readiness work tracked by #10452.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10542)