### PR TITLE
fix(testing): align stream provider readiness with assignments

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
@@ -132,20 +132,10 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
             grainFactory.GetSystemTarget<IStreamingDiagnosticsProbe>(
                 StreamingDiagnosticsProbeConstants.SystemTargetType,
                 siloAddress)
-            .WaitForProviderReady(AdoNetStreamProviderName, expectedQueueCount: 1, StreamingDiagnosticTimeout))
+            .WaitForProviderReady(AdoNetStreamProviderName, StreamingDiagnosticTimeout))
             .ToArray();
 
-        foreach (var wait in waits)
-        {
-            _ = wait.ContinueWith(
-                static completed => _ = completed.Exception,
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
-        }
-
-        // ADO.NET uses one queue by default, so readiness on its owning silo is sufficient.
-        await await Task.WhenAny(waits);
+        await Task.WhenAll(waits);
     }
 
     //------------------------ One to One -----------------------------------------------------//

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/StreamReliabilityTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/StreamReliabilityTests.cs
@@ -1168,7 +1168,7 @@ namespace UnitTests.Streaming.Reliability
             }
 
             var waits = probes
-                .Select(probe => probe.WaitForProviderReady(_streamProviderName, expectedQueueCount: 1, StreamingDiagnosticTimeout))
+                .Select(probe => probe.WaitForProviderReady(_streamProviderName, StreamingDiagnosticTimeout))
                 .ToArray();
             await WaitForAllStreamingSignalsAsync(
                 when,

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/StreamingDiagnosticEventRecorderTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/StreamingDiagnosticEventRecorderTests.cs
@@ -19,6 +19,7 @@ public class StreamingDiagnosticEventRecorderTests
         var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
         var otherSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13001), 1);
         var queue = QueueId.GetQueueId("queue", 1, 1);
+        var otherQueue = QueueId.GetQueueId("other-queue", 2, 1);
         using var recorder = new StreamingDiagnosticEventRecorder(new TestLocalSiloDetails(localSilo));
 
         recorder.OnEvent(new StreamingEvents.PullingAgentStarted(
@@ -28,14 +29,119 @@ public class StreamingDiagnosticEventRecorderTests
             TimeSpan.Zero,
             TimeSpan.FromSeconds(1)));
         recorder.OnEvent(new StreamingEvents.QueueReceiverInitialized(providerName, localSilo, queue));
+        recorder.OnEvent(new StreamingEvents.PullingAgentManagerState(
+            providerName,
+            localSilo,
+            [queue],
+            runningAgents: 1));
         recorder.OnEvent(new StreamingEvents.BalancerChanged(
             providerName,
             otherSilo,
-            [queue],
             [],
+            [otherQueue],
             new TestQueueBalancer()));
 
-        await recorder.WaitForProviderReady(providerName, expectedQueueCount: 1, TimeSpan.FromSeconds(1));
+        await recorder.WaitForProviderReady(providerName, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public async Task ProviderReadinessRequiresManagerState()
+    {
+        const string providerName = "provider";
+        var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+        var queue = QueueId.GetQueueId("queue", 1, 1);
+        using var recorder = new StreamingDiagnosticEventRecorder(new TestLocalSiloDetails(localSilo));
+
+        recorder.OnEvent(new StreamingEvents.PullingAgentStarted(
+            providerName,
+            localSilo,
+            queue,
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1)));
+        recorder.OnEvent(new StreamingEvents.QueueReceiverInitialized(providerName, localSilo, queue));
+
+        var readiness = recorder.WaitForProviderReady(providerName, TimeSpan.FromSeconds(1));
+        Assert.False(readiness.IsCompleted);
+
+        recorder.OnEvent(new StreamingEvents.PullingAgentManagerState(
+            providerName,
+            localSilo,
+            [queue],
+            runningAgents: 1));
+        await readiness;
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public async Task ProviderReadinessAcceptsNoAssignedQueues()
+    {
+        const string providerName = "provider";
+        var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+        using var recorder = new StreamingDiagnosticEventRecorder(new TestLocalSiloDetails(localSilo));
+
+        recorder.OnEvent(new StreamingEvents.PullingAgentManagerState(
+            providerName,
+            localSilo,
+            [],
+            runningAgents: 0));
+
+        await recorder.WaitForProviderReady(providerName, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public async Task ProviderReadinessWaitsForAssignedQueueReceiverInitialization()
+    {
+        const string providerName = "provider";
+        var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+        var queue = QueueId.GetQueueId("queue", 1, 1);
+        using var recorder = new StreamingDiagnosticEventRecorder(new TestLocalSiloDetails(localSilo));
+
+        recorder.OnEvent(new StreamingEvents.PullingAgentManagerState(
+            providerName,
+            localSilo,
+            [queue],
+            runningAgents: 1));
+
+        var readiness = recorder.WaitForProviderReady(providerName, TimeSpan.FromSeconds(1));
+        Assert.False(readiness.IsCompleted);
+
+        recorder.OnEvent(new StreamingEvents.QueueReceiverInitialized(providerName, localSilo, queue));
+        await readiness;
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public async Task ProviderReadinessDoesNotReuseInitializationFromPreviousAssignment()
+    {
+        const string providerName = "provider";
+        var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+        var queue = QueueId.GetQueueId("queue", 1, 1);
+        using var recorder = new StreamingDiagnosticEventRecorder(new TestLocalSiloDetails(localSilo));
+
+        recorder.OnEvent(new StreamingEvents.PullingAgentManagerState(
+            providerName,
+            localSilo,
+            [queue],
+            runningAgents: 1));
+        recorder.OnEvent(new StreamingEvents.QueueReceiverInitialized(providerName, localSilo, queue));
+        await recorder.WaitForProviderReady(providerName, TimeSpan.FromSeconds(1));
+
+        recorder.OnEvent(new StreamingEvents.PullingAgentStopped(providerName, localSilo, queue));
+        recorder.OnEvent(new StreamingEvents.QueueReceiverInitialized(providerName, localSilo, queue));
+        recorder.OnEvent(new StreamingEvents.PullingAgentManagerState(
+            providerName,
+            localSilo,
+            [],
+            runningAgents: 0));
+        recorder.OnEvent(new StreamingEvents.PullingAgentManagerState(
+            providerName,
+            localSilo,
+            [queue],
+            runningAgents: 1));
+
+        var readiness = recorder.WaitForProviderReady(providerName, TimeSpan.FromSeconds(1));
+        Assert.False(readiness.IsCompleted);
+
+        recorder.OnEvent(new StreamingEvents.QueueReceiverInitialized(providerName, localSilo, queue));
+        await readiness;
     }
 
     private sealed class TestLocalSiloDetails(SiloAddress siloAddress) : ILocalSiloDetails

--- a/test/Grains/TestGrainInterfaces/IStreamingDiagnosticsProbe.cs
+++ b/test/Grains/TestGrainInterfaces/IStreamingDiagnosticsProbe.cs
@@ -11,7 +11,7 @@ public static class StreamingDiagnosticsProbeConstants
 public interface IStreamingDiagnosticsProbe : ISystemTarget
 {
     Task<SiloAddress> GetLocation();
-    Task WaitForProviderReady(string providerName, int expectedQueueCount, TimeSpan timeout);
+    Task WaitForProviderReady(string providerName, TimeSpan timeout);
     Task WaitForProducerRegistered(string providerName, StreamId streamId, TimeSpan timeout);
     Task WaitForPullingAgentStreamRegistered(string providerName, StreamId streamId, TimeSpan timeout);
     Task WaitForSubscriptionRegistered(string providerName, StreamId streamId, Guid subscriptionId, TimeSpan timeout);

--- a/test/Grains/TestInternalGrains/StreamingDiagnosticsProbeSystemTarget.cs
+++ b/test/Grains/TestInternalGrains/StreamingDiagnosticsProbeSystemTarget.cs
@@ -27,8 +27,8 @@ internal sealed class StreamingDiagnosticsProbeSystemTarget : SystemTarget, IStr
     public Task<SiloAddress> GetLocation()
         => Task.FromResult(Silo);
 
-    public Task WaitForProviderReady(string providerName, int expectedQueueCount, TimeSpan timeout)
-        => _recorder.WaitForProviderReady(providerName, expectedQueueCount, timeout);
+    public Task WaitForProviderReady(string providerName, TimeSpan timeout)
+        => _recorder.WaitForProviderReady(providerName, timeout);
 
     public Task WaitForProducerRegistered(string providerName, StreamId streamId, TimeSpan timeout)
         => _recorder.WaitForProducerRegistered(providerName, streamId, timeout);
@@ -63,6 +63,7 @@ public sealed class StreamingDiagnosticEventRecorder(
     private readonly object _lock = new();
     private readonly Dictionary<string, HashSet<QueueId>> _startedQueues = new(StringComparer.Ordinal);
     private readonly Dictionary<string, HashSet<QueueId>> _initializedQueues = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _observedManagerStates = new(StringComparer.Ordinal);
     private readonly HashSet<StreamKey> _producerRegistrations = [];
     private readonly HashSet<StreamKey> _pullingAgentStreamRegistrations = [];
     private readonly HashSet<SubscriptionKey> _subscriptionRegistrations = [];
@@ -85,11 +86,11 @@ public sealed class StreamingDiagnosticEventRecorder(
         return Task.CompletedTask;
     }
 
-    public Task WaitForProviderReady(string providerName, int expectedQueueCount, TimeSpan timeout)
+    public Task WaitForProviderReady(string providerName, TimeSpan timeout)
         => WaitUntil(
-            () => QueueCount(_startedQueues, providerName) >= expectedQueueCount
-                && QueueCount(_initializedQueues, providerName) >= expectedQueueCount,
-            $"provider '{providerName}' to have {expectedQueueCount} started and initialized queue(s)",
+            () => _observedManagerStates.Contains(providerName)
+                && AllStartedQueuesAreInitialized(providerName),
+            $"provider '{providerName}' to report its pulling-agent manager state and initialize all assigned queues",
             timeout);
 
     public Task WaitForProducerRegistered(string providerName, StreamId streamId, TimeSpan timeout)
@@ -194,7 +195,14 @@ public sealed class StreamingDiagnosticEventRecorder(
             {
                 case StreamingEvents.BalancerChanged e:
                     SetQueues(_startedQueues, e.StreamProvider, e.CurrentQueues);
+                    RetainQueues(_initializedQueues, e.StreamProvider, e.CurrentQueues);
                     AddRecent($"BalancerChanged provider={e.StreamProvider} silo={e.SiloAddress} currentQueues={e.CurrentQueues.Length}");
+                    break;
+                case StreamingEvents.PullingAgentManagerState e:
+                    SetQueues(_startedQueues, e.StreamProvider, e.CurrentQueues);
+                    RetainQueues(_initializedQueues, e.StreamProvider, e.CurrentQueues);
+                    _observedManagerStates.Add(e.StreamProvider);
+                    AddRecent($"PullingAgentManagerState provider={e.StreamProvider} silo={e.SiloAddress} currentQueues={e.CurrentQueues.Length} runningAgents={e.RunningAgents}");
                     break;
                 case StreamingEvents.PullingAgentStarted e:
                     AddQueue(_startedQueues, e.StreamProvider, e.QueueId);
@@ -270,6 +278,7 @@ public sealed class StreamingDiagnosticEventRecorder(
         var recent = string.Join(" | ", _recentEvents);
         return $"StartedQueues=[{started}] "
             + $"InitializedQueues=[{initialized}] "
+            + $"ObservedManagerStates=[{string.Join(", ", _observedManagerStates)}] "
             + $"ProducerRegistrations=[{FormatCollection(_producerRegistrations)}] "
             + $"PullingAgentStreamRegistrations=[{FormatCollection(_pullingAgentStreamRegistrations)}] "
             + $"SubscriptionRegistrations=[{FormatCollection(_subscriptionRegistrations)}] "
@@ -289,9 +298,16 @@ public sealed class StreamingDiagnosticEventRecorder(
         _recentEvents.Enqueue(message);
     }
 
-    private static int QueueCount(Dictionary<string, HashSet<QueueId>> queuesByProvider, string providerName)
+    private bool AllStartedQueuesAreInitialized(string providerName)
     {
-        return queuesByProvider.TryGetValue(providerName, out var queues) ? queues.Count : 0;
+        if (!_startedQueues.TryGetValue(providerName, out var startedQueues))
+        {
+            return false;
+        }
+
+        return _initializedQueues.TryGetValue(providerName, out var initializedQueues)
+            ? startedQueues.IsSubsetOf(initializedQueues)
+            : startedQueues.Count == 0;
     }
 
     private static void AddQueue(Dictionary<string, HashSet<QueueId>> queuesByProvider, string providerName, QueueId queueId)
@@ -315,6 +331,14 @@ public sealed class StreamingDiagnosticEventRecorder(
     private static void SetQueues(Dictionary<string, HashSet<QueueId>> queuesByProvider, string providerName, IEnumerable<QueueId> queues)
     {
         queuesByProvider[providerName] = [.. queues];
+    }
+
+    private static void RetainQueues(Dictionary<string, HashSet<QueueId>> queuesByProvider, string providerName, IEnumerable<QueueId> queues)
+    {
+        if (queuesByProvider.TryGetValue(providerName, out var currentQueues))
+        {
+            currentQueues.IntersectWith(queues);
+        }
     }
 
     private static string FormatCollection<T>(IReadOnlyCollection<T> values)


### PR DESCRIPTION
Fixes #10452.

`AQ_StreamRel_SiloJoins` treated every active silo as unready unless it owned at least one queue. The failure artifacts show a valid three-silo distribution of 0/4/4 queues, so the zero-queue silo waited until timeout despite having no receiver work to initialize.

Use each silo's pulling-agent manager state as the authoritative assignment snapshot and consider the provider ready once every currently assigned queue receiver has initialized. Reconcile initialization markers when assignments change so a late completion from a stopped receiver cannot satisfy a future reassignment, and keep silo-local event isolation from #10463.

Update the ADO.NET readiness barrier to await all silos under the corrected zero-queue semantics. Add deterministic coverage for zero assignments, required manager-state observation, assigned receiver initialization, foreign-silo isolation, and stale initialization across reassignment.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10543)