### PR TITLE
fix(durablejobs): preserve shard execution failures

### DIFF
--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -70,6 +71,7 @@ internal sealed partial class ShardExecutor
         EnsureSlowStartRampUpStarted();
 
         var tasks = new ConcurrentDictionary<string, Task>();
+        var taskFailures = new ConcurrentQueue<ExceptionDispatchInfo>();
         var processingStarted = false;
         var processingStartTimestamp = 0L;
         var canceled = false;
@@ -98,7 +100,7 @@ internal sealed partial class ShardExecutor
                 await _jobConcurrencyLimiter.WaitAsync(cancellationToken);
 
                 // Start processing the job. ExecuteJobAsync will release the semaphore when done and remove itself from the tasks dictionary
-                tasks[jobContext.Job.Id] = ExecuteJobAsync(jobContext, shard, tasks, cancellationToken);
+                tasks[jobContext.Job.Id] = ExecuteJobAsync(jobContext, shard, tasks, taskFailures, cancellationToken);
             }
 
             LogCompletedProcessingShard(_logger, shard.Id);
@@ -120,6 +122,20 @@ internal sealed partial class ShardExecutor
             try
             {
                 await Task.WhenAll(tasks.Values);
+                if (taskFailures.TryDequeue(out var failure))
+                {
+                    failure.Throw();
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                if (!canceled)
+                {
+                    canceled = true;
+                    LogShardCancelled(_logger, shard.Id);
+                }
+
+                throw;
             }
             catch
             {
@@ -217,6 +233,7 @@ internal sealed partial class ShardExecutor
         IJobRunContext jobContext,
         IJobShard shard,
         ConcurrentDictionary<string, Task>? runningTasks,
+        ConcurrentQueue<ExceptionDispatchInfo> taskFailures,
         CancellationToken cancellationToken)
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
@@ -289,10 +306,15 @@ internal sealed partial class ShardExecutor
                 }
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {
             activity?.SetTag(ActivityTagKeys.DurableJobStatus, "canceled");
-            throw;
+            taskFailures.Enqueue(ExceptionDispatchInfo.Capture(exception));
+        }
+        catch (Exception exception)
+        {
+            DurableJobsDiagnostics.SetError(activity, exception);
+            taskFailures.Enqueue(ExceptionDispatchInfo.Capture(exception));
         }
         finally
         {

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -395,7 +395,7 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenRetryPersistenceFails_ReleasesConcurrencyAndContinuesProcessing()
+    public async Task RunShardAsync_WhenRetryPersistenceFails_PropagatesAfterReleasingConcurrencyAndContinuingProcessing()
     {
         var options = CreateOptions(
             maxConcurrentJobs: 1,
@@ -403,24 +403,38 @@ public class ShardExecutorTests
         );
         var overloadDetector = CreateOverloadDetector(isOverloaded: false);
         var jobs = CreateJobs(2);
-        var shard = CreateJobShard(jobs);
+        var firstJobRegistered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shard = CreateJobShard(jobs, firstJobRegistered: firstJobRegistered);
         var grainFactory = CreateGrainFactory();
         var completedJobs = new List<string>();
         var failedJobs = new List<string>();
         var jobExecutionCount = 0;
         ConfigureGrainFactoryWithSelectiveFailures(grainFactory, completedJobs, failedJobs, ref jobExecutionCount);
+        var retryPersistenceStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failRetryPersistence = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expectedException = new InvalidOperationException("Simulated retry persistence failure");
 
         shard.RetryJobLaterAsync(
             Arg.Any<IJobRunContext>(),
             Arg.Any<DateTimeOffset>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new InvalidOperationException("Simulated retry persistence failure")));
+            .Returns(async _ =>
+            {
+                retryPersistenceStarted.SetResult();
+                await failRetryPersistence.Task;
+            });
 
         var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await executor.RunShardAsync(shard, cts.Token);
+        var runTask = executor.RunShardAsync(shard, cts.Token);
 
+        await Task.WhenAll(firstJobRegistered.Task, retryPersistenceStarted.Task).WaitAsync(cts.Token);
+        failRetryPersistence.SetException(expectedException);
+
+        var actualException = await Assert.ThrowsAsync<InvalidOperationException>(() => runTask);
+
+        Assert.Same(expectedException, actualException);
         Assert.Single(failedJobs);
         Assert.Single(completedJobs);
         await shard.Received(1).RetryJobLaterAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
@@ -626,14 +640,15 @@ public class ShardExecutorTests
     private static IJobShard CreateJobShard(
         List<DurableJob> jobs, 
         DateTimeOffset? startTime = null,
-        DateTimeOffset? endTime = null)
+        DateTimeOffset? endTime = null,
+        TaskCompletionSource? firstJobRegistered = null)
     {
         var shard = Substitute.For<IJobShard>();
         shard.Id.Returns("shard-1");
         shard.StartTime.Returns(startTime ?? DateTimeOffset.UtcNow.AddMinutes(-10));
         shard.EndTime.Returns(endTime ?? DateTimeOffset.UtcNow.AddMinutes(10));
 
-        shard.ConsumeDurableJobsAsync().Returns(callInfo => CreateJobContexts(jobs));
+        shard.ConsumeDurableJobsAsync().Returns(callInfo => CreateJobContexts(jobs, firstJobRegistered));
 
         shard.RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
@@ -657,15 +672,24 @@ public class ShardExecutorTests
         return shard;
     }
 
-    private static async IAsyncEnumerable<IJobRunContext> CreateJobContexts(List<DurableJob> jobs)
+    private static async IAsyncEnumerable<IJobRunContext> CreateJobContexts(
+        List<DurableJob> jobs,
+        TaskCompletionSource? firstJobRegistered = null)
     {
-        foreach (var job in jobs)
+        for (var i = 0; i < jobs.Count; i++)
         {
+            var job = jobs[i];
             var context = Substitute.For<IJobRunContext>();
             context.Job.Returns(job);
             context.RunId.Returns(Guid.NewGuid().ToString());
             context.DequeueCount.Returns(1);
             yield return context;
+
+            // The iterator resumes only after RunShardAsync has registered the yielded job task.
+            if (i == 0)
+            {
+                firstJobRegistered?.SetResult();
+            }
         }
         
         await Task.CompletedTask;

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -420,7 +420,7 @@ public class ShardExecutorTests
             Arg.Any<CancellationToken>())
             .Returns(async _ =>
             {
-                retryPersistenceStarted.SetResult();
+                retryPersistenceStarted.TrySetResult();
                 await failRetryPersistence.Task;
             });
 
@@ -430,7 +430,7 @@ public class ShardExecutorTests
         var runTask = executor.RunShardAsync(shard, cts.Token);
 
         await Task.WhenAll(firstJobRegistered.Task, retryPersistenceStarted.Task).WaitAsync(cts.Token);
-        failRetryPersistence.SetException(expectedException);
+        Assert.True(failRetryPersistence.TrySetException(expectedException));
 
         var actualException = await Assert.ThrowsAsync<InvalidOperationException>(() => runTask);
 
@@ -688,7 +688,7 @@ public class ShardExecutorTests
             // The iterator resumes only after RunShardAsync has registered the yielded job task.
             if (i == 0)
             {
-                firstJobRegistered?.SetResult();
+                firstJobRegistered?.TrySetResult();
             }
         }
         


### PR DESCRIPTION
## Problem

`ShardExecutor` tracked active job tasks in a dictionary while each task removed itself during cleanup. A fast retry-persistence failure could race that task's dictionary assignment, so the shard-level `Task.WhenAll` observed the exception only for one ordering and silently lost it for the other.

## Solution

Capture per-job infrastructure failures independently from the active-task map, continue draining available shard work, and rethrow the original exception at the shard boundary while preserving cancellation classification. Replace the immediate-fault test setup with explicit phase barriers which inject the failure only after the first job task is registered, then verify that the next job completes before the original failure propagates.

Fixes #10546
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10547)