### PR TITLE
perf(streaming): avoid copying memory stream payloads

### DIFF
--- a/src/Orleans.Streaming/MemoryStreams/MemoryMessageBody.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryMessageBody.cs
@@ -56,7 +56,7 @@ namespace Orleans.Providers
         public MemoryMessageBody Deserialize(ArraySegment<byte> bodyBytes)
         {
             // Serialize only accepts a non-null MemoryMessageBody.
-            return serializer.Deserialize(bodyBytes.ToArray())!;
+            return serializer.Deserialize(bodyBytes)!;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The default memory-stream deserializer materializes every serialized payload with `ArraySegment<byte>.ToArray()` before deserializing it. This adds an allocation and an O(payload-size) copy for every batch read.

Pass the existing `ArraySegment<byte>` directly to Orleans' serializer instead. Its segment overload deserializes from the underlying span, preserving offsets and lengths while avoiding the payload clone.