### PR TITLE
docs: fix grain service client registration

### DIFF
--- a/docs/site/src/content/docs/grains/grainservices.md
+++ b/docs/site/src/content/docs/grains/grainservices.md
@@ -38,7 +38,7 @@ Register both the service and its client:
 Inject the client into a normal grain:
 
 :::code language="csharp" source="../snippets/compiled/Grains/ServicesAndObserversSnippets.cs" id="use_index_grain_service":::
-Register and inject the same client interface. For example, registering `IIndexServiceClient` but requesting `IIndexService` in the grain constructor fails dependency resolution because those are distinct service types.
+Register and inject the same client interface. In this example, both registration and constructor injection use `IIndexServiceClient`. Registering `IIndexServiceClient` but requesting `IIndexService` in the grain constructor fails dependency resolution because those are distinct service types.
 
 The client can route to a remote silo; don't assume calls stay local.
 

--- a/docs/site/src/content/docs/grains/grainservices.md
+++ b/docs/site/src/content/docs/grains/grainservices.md
@@ -1,7 +1,7 @@
 ---
 title: Grain services
 description: Implement silo-resident partitioned services for Orleans grains.
-ms.date: 08/07/2026
+ms.date: 08/12/2026
 ms.topic: how-to
 ---
 
@@ -28,6 +28,8 @@ Define a client interface and proxy:
 :::code language="csharp" source="../snippets/compiled/Grains/ServicesAndObserversSnippets.cs" id="index_grain_service_client":::
 <xref:Orleans.Runtime.Services.GrainServiceClient`1.GetGrainService*> consistently maps the calling grain to a service partition. Other overloads support explicit silo or hash routing for advanced implementations.
 
+`IIndexService` is the runtime contract implemented by the silo-resident service. `IIndexServiceClient` is the grain-facing dependency-injection contract implemented by the proxy. Keep these roles separate: application grains call the client, and the client routes each call to an `IIndexService` instance.
+
 ## Register and consume the service
 
 Register both the service and its client:
@@ -36,6 +38,8 @@ Register both the service and its client:
 Inject the client into a normal grain:
 
 :::code language="csharp" source="../snippets/compiled/Grains/ServicesAndObserversSnippets.cs" id="use_index_grain_service":::
+Register and inject the same client interface. For example, registering `IIndexServiceClient` but requesting `IIndexService` in the grain constructor fails dependency resolution because those are distinct service types.
+
 The client can route to a remote silo; don't assume calls stay local.
 
 Grain service implementation APIs are provided by [Microsoft.Orleans.Runtime](https://www.nuget.org/packages/Microsoft.Orleans.Runtime), which silo applications receive through `Microsoft.Orleans.Server`.

--- a/docs/site/src/content/docs/snippets/compiled/Grains/ServicesAndObserversSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Grains/ServicesAndObserversSnippets.cs
@@ -57,9 +57,13 @@ public sealed class IndexServiceClient :
 
     public Task Add(string key)
     {
-        var grainReference = CurrentGrainReference
-            ?? throw new InvalidOperationException(
+        GrainReference? grainReference = CurrentGrainReference;
+        if (grainReference is null)
+        {
+            throw new InvalidOperationException(
                 "Grain service clients can only be called from a grain.");
+        }
+
         IIndexService service =
             GetGrainService(grainReference.GrainId);
 

--- a/docs/site/src/content/docs/snippets/compiled/Grains/ServicesAndObserversSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Grains/ServicesAndObserversSnippets.cs
@@ -57,9 +57,12 @@ public sealed class IndexServiceClient :
 
     public Task Add(string key)
     {
+        var grainReference = CurrentGrainReference
+            ?? throw new InvalidOperationException(
+                "Grain service clients can only be called from a grain.");
         IIndexService service =
-            GetGrainService(CurrentGrainReference.GrainId);
-
+            GetGrainService(grainReference.GrainId);
+  
         return service.Add(key);
     }
 }

--- a/docs/site/src/content/docs/snippets/compiled/Grains/ServicesAndObserversSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Grains/ServicesAndObserversSnippets.cs
@@ -62,7 +62,7 @@ public sealed class IndexServiceClient :
                 "Grain service clients can only be called from a grain.");
         IIndexService service =
             GetGrainService(grainReference.GrainId);
-  
+
         return service.Add(key);
     }
 }


### PR DESCRIPTION
## Summary

- clarify that grain service clients are registered and injected through the client interface
- replace inline fragments with a compiled, self-contained grain service example

## Rationale

The silo-resident service contract and its grain-facing DI client have distinct roles. Making that distinction explicit prevents grains from requesting an unregistered service interface while preserving the current Orleans routing pattern.

Fixes #7518
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10552)