### PR TITLE
docs: document Orleans scale limits

### DIFF
--- a/docs/site/src/content/docs/deployment/capacity-planning.md
+++ b/docs/site/src/content/docs/deployment/capacity-planning.md
@@ -1,13 +1,29 @@
 ---
 title: Capacity planning and scaling
 description: Size and scale Orleans clusters using measured workload and saturation signals.
-ms.date: 08/02/2026
+ms.date: 08/12/2026
 ms.topic: concept-article
 ---
 
 # Capacity planning and scaling
 
 Orleans distributes activations and work, but application behavior determines capacity. Grain count alone isn't a sizing metric: grains can be idle, CPU-intensive, memory-intensive, hot, or blocked on dependencies.
+
+## Understand scale limits
+
+Orleans doesn't impose a configured numeric maximum on the number of grain identities, active grain activations, or silos in a cluster. This isn't a guarantee that any cluster size or throughput is practical. The supported operating envelope ends where the application can no longer meet its latency, throughput, availability, or recovery objectives.
+
+A possible grain identity consumes no activation or grain-directory entry until the grain is used. Therefore, millions of addressable identities can cost less than a much smaller set of simultaneously active, stateful, or frequently called grains. Measure active activations and their resource use instead of sizing from the number of keys which can exist.
+
+Adding silos doesn't make every workload scale linearly:
+
+- A single ordinary grain activation processes one turn at a time by default. Adding silos doesn't divide a hot grain's work.
+- Every silo participates in membership and maintains a cluster view. Every advertised silo endpoint must be reachable from every other silo.
+- Membership changes can move grain-directory ownership and other partitioned runtime responsibilities.
+- Inter-silo calls, serialization, gateways, clustering, storage, reminders, streams, and telemetry can reach their limits before silo CPU or memory.
+- Skewed keys, placement constraints, and shared dependencies can leave some silos saturated while others have capacity.
+
+These costs don't establish a universal maximum, but they make very large clusters and frequent membership changes distinct test scenarios. Don't extrapolate a thousand-silo design or a failure-recovery target from a small, steady cluster. For the relevant control-plane behavior, see [Topology, networking, and clustering](networking.md), [Cluster membership protocol](../implementation/cluster-management.md), and [Grain directory architecture](../implementation/grain-directory.md).
 
 ## Establish a workload model
 
@@ -23,6 +39,21 @@ Measure production-like mixes of:
 
 Load tests should include bursts, one-silo loss, rolling replacement, dependency slowdown, and recovery after backlog accumulation.
 
+## Measure activation throughput
+
+There is no portable activations-per-second or deactivations-per-second limit. A cold call can include directory lookup and registration, placement, object construction, persistent-state reads, and application activation callbacks. Deactivation can include application callbacks, cleanup, and directory updates. Provider latency, state size, application lifecycle code, contention, and the number and size of silos therefore change the result.
+
+Test these paths separately:
+
+- **Warm steady state:** The target activations already exist.
+- **Cold-start burst:** Many previously inactive grain identities receive their first call.
+- **Sustained churn:** Activations are collected and soon needed again.
+- **Recovery:** A restart or silo loss causes concurrent reactivation and state reads.
+
+Record activation and deactivation rate and latency by grain type together with directory, storage, CPU, allocation, garbage collection, and request-latency signals. If churn is the bottleneck, remove unnecessary work from <xref:Orleans.Grain.OnActivateAsync*>, batch dependency access, and tune [activation collection](../host/configuration-guide/activation-collection.md) for the affected grain types. Retaining activations trades memory for fewer cold starts.
+
+Don't model every storage page or scan item as a grain solely to parallelize a data operation. A grain per page can be appropriate when each page is an independently addressed consistency boundary, but a scan which immediately cold-activates many pages pays activation, messaging, and backend access for each page. Compare that design against coarser grains, bounded batches using the storage backend's range or batch APIs, or a dedicated indexing service. Bound fan-out in every design.
+
 ## Size silos
 
 Choose a repeatable CPU and memory size, then measure:
@@ -37,6 +68,18 @@ Choose a repeatable CPU and memory size, then measure:
 Leave headroom for activation redistribution and traffic after losing a host or failure domain. Avoid very large silos when their restart and reactivation blast radius is unacceptable. Avoid very small silos when per-process runtime, connection, and membership overhead dominates.
 
 CPU limits can throttle a process even when node CPU appears available. Memory limits can terminate a process without a managed out-of-memory exception. Set requests from observed steady-state use and set limits only with an understood platform policy and tested behavior.
+
+## Find the operating envelope
+
+Use the production runtime version, host shape, network, providers, serialization settings, and representative state. A useful capacity test proceeds as follows:
+
+1. Define latency percentiles, completed throughput, error and timeout rates, and recovery objectives.
+1. At a fixed cluster size, increase offered load until one objective fails or a resource saturates.
+1. Repeat with larger cluster sizes and compare completed work, not only submitted work.
+1. Repeat cold-start, hot-key, burst, scale-out, scale-in, rolling-upgrade, dependency-throttling, and silo-loss scenarios.
+1. Select an operating point below the first sustained bottleneck and reserve headroom for the required failure domain.
+
+Correlate client-visible results with per-silo CPU, scheduler delay, memory, garbage collection, network, activation distribution, request queues, rejected work, and provider latency or throttling. A balanced cluster average can hide one saturated silo or storage partition. Use the [observability signals](../host/monitoring/signals.md) emitted by the deployed Orleans version.
 
 ## Scale out and in
 
@@ -62,6 +105,18 @@ Unlimited queues convert overload into high latency and memory pressure. Apply:
 - Per-tenant or per-key limits where one workload can starve others.
 
 Retries consume capacity. Include retry traffic in the load model and use exponential backoff with jitter, a retry budget, and an end-to-end deadline.
+
+## Choose a tenant topology
+
+The choice between a shared cluster and a cluster per tenant is primarily an isolation and operations decision, not a grain-count limit:
+
+| Topology | Benefits | Costs and risks |
+|---|---|---|
+| Shared cluster | Pools spare capacity and reduces the number of deployments and runtime dependencies. | Tenants share failure, deployment, provider, and capacity domains. Orleans doesn't automatically enforce tenant quotas or prevent noisy neighbors. |
+| Cluster per tenant | Separates capacity, failures, deployments, credentials, and provider namespaces. | Adds baseline resource cost and operational work for upgrades, monitoring, recovery, and fleet-wide changes. |
+| Sharded tenant pools | Limits blast radius and fleet size while retaining some capacity pooling. | Requires tenant placement, shard-capacity management, and a tenant-migration strategy. |
+
+In a shared cluster, partition hot work by tenant and key, apply per-tenant admission and concurrency limits, and test the most skewed tenant behavior. Use separate clusters when security, data residency, independent upgrades, or fault and resource isolation require a hard boundary. A hybrid of multiple tenant pools is often preferable to assuming either one unbounded cluster or one deployment per small tenant.
 
 ## Revisit the model
 

--- a/docs/site/src/content/docs/resources/frequently-asked-questions.md
+++ b/docs/site/src/content/docs/resources/frequently-asked-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Frequently asked questions
 description: Answers to common questions about Orleans.
-ms.date: 08/08/2026
+ms.date: 08/12/2026
 ms.topic: faq
 ---
 
@@ -34,6 +34,12 @@ Orleans is a set of .NET libraries used to build an application. An application 
 ### Where can Orleans run?
 
 Orleans runs wherever its supported .NET targets run, including Linux and Windows hosts, containers, Kubernetes, Azure services, AWS, other clouds, on-premises environments, and developer machines.
+
+### How many grains or silos can a cluster contain?
+
+Orleans doesn't impose a configured numeric maximum on grain identities, activations, or silos. The practical limit depends on the workload, active grain footprint, hot keys, lifecycle cost, network topology, providers, failure-recovery objectives, and host resources. Adding silos doesn't guarantee linear scaling because cluster coordination and shared dependencies also have costs.
+
+Use production-like capacity tests to find a safe operating envelope rather than relying on a universal grain, silo, or activation-rate number. See [Capacity planning and scaling](../deployment/capacity-planning.md).
 
 ### Is Orleans tied to Azure?
 


### PR DESCRIPTION
## Problem

Orleans does not publish a universal grain, silo, or activation-rate limit, leaving operators without guidance on the practical constraints behind large deployments.

## Solution

Expand the capacity-planning guidance to explain workload-dependent limits, non-linear cluster costs, activation churn, a production-like capacity-testing method, and shared-versus-isolated tenant topology tradeoffs. Add a concise FAQ entry that points readers to the stable capacity-planning page.

## Rationale

The guidance avoids unsupported numeric promises and instead identifies the runtime, application, infrastructure, and dependency signals which determine a safe operating envelope.

Fixes #7873
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10553)