### PR TITLE
fix(test): initialize ADO.NET fixtures asynchronously

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/LivenessTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/LivenessTests.cs
@@ -17,6 +17,8 @@ namespace UnitTests.MembershipTests
     {
         public const string TestDatabaseName = "OrleansTest_SqlServer_Liveness";
         private const string AdoNetInvariantName = AdoNetInvariants.InvariantNameSqlServer;
+        private string _connectionString = null!;
+
         public LivenessTests_SqlServer(ITestOutputHelper output) : base(output)
         {
             EnsurePreconditionsMet();
@@ -24,10 +26,16 @@ namespace UnitTests.MembershipTests
 
         protected override void CheckPreconditionsOrThrow() => RelationalStorageForTesting.CheckPreconditionsOrThrow(AdoNetInvariantName);
 
+        public override async Task InitializeAsync()
+        {
+            var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+            _connectionString = relationalStorage.CurrentConnectionString;
+            await base.InitializeAsync();
+        }
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult();
-            builder.Properties["RelationalStorageConnectionString"] = relationalStorage.CurrentConnectionString;
+            builder.Properties["RelationalStorageConnectionString"] = _connectionString;
             builder.AddSiloBuilderConfigurator<SiloConfigurator>();
         }
 
@@ -90,6 +98,8 @@ namespace UnitTests.MembershipTests
     {
         public const string TestDatabaseName = "OrleansTest_Postgres_Liveness";
         private const string AdoNetInvariantName = AdoNetInvariants.InvariantNamePostgreSql;
+        private string _connectionString = null!;
+
         public LivenessTests_PostgreSql(ITestOutputHelper output) : base(output)
         {
             EnsurePreconditionsMet();
@@ -97,10 +107,16 @@ namespace UnitTests.MembershipTests
 
         protected override void CheckPreconditionsOrThrow() => RelationalStorageForTesting.CheckPreconditionsOrThrow(AdoNetInvariantName);
 
+        public override async Task InitializeAsync()
+        {
+            var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+            _connectionString = relationalStorage.CurrentConnectionString;
+            await base.InitializeAsync();
+        }
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).Result;
-            builder.Properties["RelationalStorageConnectionString"] = relationalStorage.CurrentConnectionString;
+            builder.Properties["RelationalStorageConnectionString"] = _connectionString;
             builder.AddSiloBuilderConfigurator<SiloConfigurator>();
         }
 
@@ -163,6 +179,8 @@ namespace UnitTests.MembershipTests
     {
         public const string TestDatabaseName = "OrleansTest_MySql_Liveness";
         private const string AdoNetInvariantName = AdoNetInvariants.InvariantNameMySql;
+        private string _connectionString = null!;
+
         public LivenessTests_MySql(ITestOutputHelper output) : base(output)
         {
             EnsurePreconditionsMet();
@@ -170,10 +188,16 @@ namespace UnitTests.MembershipTests
 
         protected override void CheckPreconditionsOrThrow() => RelationalStorageForTesting.CheckPreconditionsOrThrow(AdoNetInvariantName);
 
+        public override async Task InitializeAsync()
+        {
+            var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+            _connectionString = relationalStorage.CurrentConnectionString;
+            await base.InitializeAsync();
+        }
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
-            var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).Result;
-            builder.Properties["RelationalStorageConnectionString"] = relationalStorage.CurrentConnectionString;
+            builder.Properties["RelationalStorageConnectionString"] = _connectionString;
             builder.AddSiloBuilderConfigurator<SiloConfigurator>();
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql.cs
@@ -25,6 +25,8 @@ namespace Tester.AdoNet.Persistence
 
         public class Fixture : BaseTestClusterFixture
         {
+            private string _connectionString = null!;
+
             protected override void CheckPreconditionsOrThrow()
             {
                 if (string.IsNullOrEmpty(TestDefaultConfiguration.MySqlConnectionString))
@@ -33,13 +35,20 @@ namespace Tester.AdoNet.Persistence
                 }
             }
 
+            public override async Task InitializeAsync()
+            {
+                EnsurePreconditionsMet();
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                _connectionString = relationalStorage.CurrentConnectionString;
+                await base.InitializeAsync();
+            }
+
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName).Result;
                 builder.ConfigureHostConfiguration(configBuilder => configBuilder.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        {ConnectionStringKey, relationalStorage.CurrentConnectionString}
+                        {ConnectionStringKey, _connectionString}
                     }));
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql_DeleteStateOnClear.cs
@@ -26,6 +26,8 @@ namespace Tester.AdoNet.Persistence
 
         public class Fixture : BaseTestClusterFixture
         {
+            private string _connectionString = null!;
+
             protected override void CheckPreconditionsOrThrow()
             {
                 if (string.IsNullOrEmpty(TestDefaultConfiguration.MySqlConnectionString))
@@ -34,13 +36,20 @@ namespace Tester.AdoNet.Persistence
                 }
             }
 
+            public override async Task InitializeAsync()
+            {
+                EnsurePreconditionsMet();
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                _connectionString = relationalStorage.CurrentConnectionString;
+                await base.InitializeAsync();
+            }
+
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName).Result;
                 builder.ConfigureHostConfiguration(configBuilder => configBuilder.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        {ConnectionStringKey, relationalStorage.CurrentConnectionString}
+                        {ConnectionStringKey, _connectionString}
                     }));
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres.cs
@@ -25,6 +25,8 @@ namespace Tester.AdoNet.Persistence
 
         public class Fixture : BaseTestClusterFixture
         {
+            private string _connectionString = null!;
+
             protected override void CheckPreconditionsOrThrow()
             {
                 if (string.IsNullOrEmpty(TestDefaultConfiguration.PostgresConnectionString))
@@ -33,13 +35,20 @@ namespace Tester.AdoNet.Persistence
                 }
             }
 
+            public override async Task InitializeAsync()
+            {
+                EnsurePreconditionsMet();
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                _connectionString = relationalStorage.CurrentConnectionString;
+                await base.InitializeAsync();
+            }
+
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName).Result;
                 builder.ConfigureHostConfiguration(configBuilder => configBuilder.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        {ConnectionStringKey, relationalStorage.CurrentConnectionString}
+                        {ConnectionStringKey, _connectionString}
                     }));
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres_DeleteStateOnClear.cs
@@ -26,6 +26,8 @@ namespace Tester.AdoNet.Persistence
 
         public class Fixture : BaseTestClusterFixture
         {
+            private string _connectionString = null!;
+
             protected override void CheckPreconditionsOrThrow()
             {
                 if (string.IsNullOrEmpty(TestDefaultConfiguration.PostgresConnectionString))
@@ -34,13 +36,20 @@ namespace Tester.AdoNet.Persistence
                 }
             }
 
+            public override async Task InitializeAsync()
+            {
+                EnsurePreconditionsMet();
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                _connectionString = relationalStorage.CurrentConnectionString;
+                await base.InitializeAsync();
+            }
+
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName).Result;
                 builder.ConfigureHostConfiguration(configBuilder => configBuilder.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        {ConnectionStringKey, relationalStorage.CurrentConnectionString}
+                        {ConnectionStringKey, _connectionString}
                     }));
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer.cs
@@ -24,6 +24,8 @@ namespace Tester.AdoNet.Persistence
         public static string ConnectionStringKey = "AdoNetConnectionString";
         public class Fixture : BaseTestClusterFixture
         {
+            private string _connectionString = null!;
+
             protected override void CheckPreconditionsOrThrow()
             {
                 if (string.IsNullOrEmpty(TestDefaultConfiguration.MsSqlConnectionString))
@@ -32,13 +34,20 @@ namespace Tester.AdoNet.Persistence
                 }
             }
 
+            public override async Task InitializeAsync()
+            {
+                EnsurePreconditionsMet();
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                _connectionString = relationalStorage.CurrentConnectionString;
+                await base.InitializeAsync();
+            }
+
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName).Result;
                 builder.ConfigureHostConfiguration(configBuilder => configBuilder.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        {ConnectionStringKey, relationalStorage.CurrentConnectionString}
+                        {ConnectionStringKey, _connectionString}
                     }));
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer_DeleteStateOnClear.cs
@@ -26,6 +26,8 @@ namespace Tester.AdoNet.Persistence
 
         public class Fixture : BaseTestClusterFixture
         {
+            private string _connectionString = null!;
+
             protected override void CheckPreconditionsOrThrow()
             {
                 if (string.IsNullOrEmpty(TestDefaultConfiguration.MsSqlConnectionString))
@@ -34,13 +36,20 @@ namespace Tester.AdoNet.Persistence
                 }
             }
 
+            public override async Task InitializeAsync()
+            {
+                EnsurePreconditionsMet();
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                _connectionString = relationalStorage.CurrentConnectionString;
+                await base.InitializeAsync();
+            }
+
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
-                var relationalStorage = RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName).Result;
                 builder.ConfigureHostConfiguration(configBuilder => configBuilder.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        {ConnectionStringKey, relationalStorage.CurrentConnectionString}
+                        {ConnectionStringKey, _connectionString}
                     }));
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageFixture.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageFixture.cs
@@ -11,10 +11,11 @@ using Orleans.Serialization.Serializers;
 using Orleans.Storage;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
+using Xunit;
 
 namespace Tester.AdoNet.Persistence
 {
-    public sealed class SqlitePersistenceGrainStorageFixture : TestEnvironmentFixture
+    public sealed class SqlitePersistenceGrainStorageFixture : TestEnvironmentFixture, IAsyncLifetime
     {
         public const string AdoInvariant = AdoNetInvariants.InvariantNameSqlLite;
 
@@ -28,8 +29,6 @@ namespace Tester.AdoNet.Persistence
             }.ToString();
 
             this.DatabaseStorage = RelationalStorage.CreateInstance(AdoInvariant, this.ConnectionString);
-            this.InitializeSchemaAsync().GetAwaiter().GetResult();
-            this.Storage = this.CreateGrainStorageAsync().GetAwaiter().GetResult();
         }
 
         public string DatabaseFilePath { get; }
@@ -38,7 +37,15 @@ namespace Tester.AdoNet.Persistence
 
         public IRelationalStorage DatabaseStorage { get; }
 
-        public AdoNetGrainStorage Storage { get; }
+        public AdoNetGrainStorage Storage { get; private set; } = null!;
+
+        public async Task InitializeAsync()
+        {
+            await this.InitializeSchemaAsync();
+            this.Storage = await this.CreateGrainStorageAsync();
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         public async Task InitializeSchemaAsync()
         {

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
@@ -24,13 +24,14 @@ namespace Tester.AdoNet.Reminders
     [TestProvider("SqlServer")]
     [TestArea("Reminders")]
     [TestCategory("Reminders"), TestCategory("AdoNet"), TestCategory("SqlServer")]
-    public class ReminderTests_AdoNet_SqlServer : ReminderTestsBase, IClassFixture<ReminderTests_AdoNet_SqlServer.Fixture>
+    public class ReminderTests_AdoNet_SqlServer : ReminderTestsBase, IClassFixture<ReminderTests_AdoNet_SqlServer.Fixture>, IAsyncLifetime
     {
         private const string TestDatabaseName = "OrleansTest_SqlServer_Reminders";
         private static readonly string AdoInvariant = AdoNetInvariants.InvariantNameSqlServer;
 
         public class Fixture : BaseInProcessTestClusterFixture
         {
+            private string _connectionString = null!;
             private ReminderTestClock? _reminderClock;
             internal ReminderTestClock ReminderClock => _reminderClock ?? throw new InvalidOperationException($"{nameof(ReminderTestClock)} has not been configured.");
 
@@ -39,16 +40,22 @@ namespace Tester.AdoNet.Reminders
                 RelationalStorageForTesting.CheckPreconditionsOrThrow(AdoInvariant);
             }
 
+            public override async Task InitializeAsync()
+            {
+                EnsurePreconditionsMet();
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                _connectionString = relationalStorage.CurrentConnectionString;
+                await base.InitializeAsync();
+            }
+
             protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
             {
-                string connectionString = RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName)
-                    .Result.CurrentConnectionString;
                 _reminderClock = builder.AddReminderTestClock();
                 builder.ConfigureSilo((_, siloBuilder) =>
                 {
                     siloBuilder.UseAdoNetReminderService(options =>
                     {
-                        options.ConnectionString = connectionString;
+                        options.ConnectionString = _connectionString;
                         options.Invariant = AdoInvariant;
                     });
                 });
@@ -69,11 +76,17 @@ namespace Tester.AdoNet.Reminders
 
         public ReminderTests_AdoNet_SqlServer(Fixture fixture) : base(fixture.ReminderClock, fixture.HostedCluster)
         {
+        }
+
+        public async Task InitializeAsync()
+        {
             // ReminderTable.Clear() cannot be called from a non-Orleans thread,
             // so we must proxy the call through a grain.
             var controlProxy = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout).Wait();
+            await controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout);
         }
+
+        Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
         
         // Basic tests
 

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.ExceptionServices;
 using MySql.Data.MySqlClient;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
@@ -22,35 +21,21 @@ namespace UnitTests.StorageTests.AdoNet
 
         private readonly RelationalStorageForTesting _storage;
 
-        public class Fixture
+        public class Fixture : IAsyncLifetime
         {
-            private readonly ExceptionDispatchInfo? preconditionsException;
+            public RelationalStorageForTesting Storage { get; private set; } = null!;
 
-            public void EnsurePreconditionsMet()
+            public async Task InitializeAsync()
             {
-                this.preconditionsException?.Throw();
+                Storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
             }
 
-            public Fixture()
-            {
-                try
-                {
-                    Storage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    this.preconditionsException = ExceptionDispatchInfo.Capture(ex);
-                    return;
-                }
-            }
-
-            public RelationalStorageForTesting? Storage { get; private set; }
+            public Task DisposeAsync() => Task.CompletedTask;
         }
 
         public MySqlRelationalStoreTests(Fixture fixture) : base(AdoNetInvariantName)
         {
-            fixture.EnsurePreconditionsMet();
-            _storage = fixture.Storage!;
+            _storage = fixture.Storage;
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
@@ -18,26 +18,21 @@ namespace UnitTests.StorageTests.AdoNet
 
         private readonly RelationalStorageForTesting _storage;
 
-        public class Fixture
+        public class Fixture : IAsyncLifetime
         {
-            public Fixture()
+            public RelationalStorageForTesting Storage { get; private set; } = null!;
+
+            public async Task InitializeAsync()
             {
-                try
-                {
-                    Storage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Failed to initialize {AdoNetInvariantName} for testing: {ex}");
-                }
+                Storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
             }
 
-            public RelationalStorageForTesting? Storage { get; private set; }
+            public Task DisposeAsync() => Task.CompletedTask;
         }
 
         public PostgreSqlRelationalStoreTests(Fixture fixture) : base(AdoNetInvariantName)
         {
-            _storage = fixture.Storage!;
+            _storage = fixture.Storage;
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -59,7 +54,7 @@ namespace UnitTests.StorageTests.AdoNet
         [SkippableFact, TestCategory("Functional")]
         public async Task NativeDataSource_PostgreSql_Test()
         {
-            Skip.If(_storage is null || string.IsNullOrWhiteSpace(_storage.CurrentConnectionString), "Connection string not provided.");
+            Skip.If(string.IsNullOrWhiteSpace(_storage.CurrentConnectionString), "Connection string not provided.");
             await using var dataSource = Npgsql.NpgsqlDataSource.Create(_storage.CurrentConnectionString);
             var storage = RelationalStorage.CreateInstance(AdoNetInvariantName, dataSource);
 

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/CommonFixture.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/CommonFixture.cs
@@ -98,7 +98,7 @@ namespace UnitTests.StorageTests.Relational
                         {
                             // Each storage mode has its own class fixture, so it must not recreate a database used by the other mode.
                             var storageName = deleteStateOnClear ? "OrleansStorageTestsDeleteOnClear" : "OrleansStorageTests";
-                            Storage = Invariants.EnsureStorageForTesting(connectionString, storageName);
+                            Storage = await Invariants.EnsureStorageForTestingAsync(connectionString, storageName);
 
                             var options = new AdoNetGrainStorageOptions()
                             {

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/MySqlStorageDeleteOnClearTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/MySqlStorageDeleteOnClearTests.cs
@@ -17,7 +17,6 @@ namespace UnitTests.StorageTests.Relational
 
         public MySqlStorageDeleteOnClearTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture, deleteStateOnClear: true)
         {
-            Skip.If(PersistenceStorageTests == null, "Persistence storage not available for MySql.");
         }
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/MySqlStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/MySqlStorageTests.cs
@@ -25,8 +25,6 @@ namespace UnitTests.StorageTests.Relational
 
         public MySqlStorageTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture)
         {
-            //XUnit.NET will automatically call this constructor before every test method run.
-            Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for MySql.");
         }
 
         [SkippableFact]

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/PostgreSqlStorageDeleteOnClearTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/PostgreSqlStorageDeleteOnClearTests.cs
@@ -17,7 +17,6 @@ namespace UnitTests.StorageTests.Relational
 
         public PostgreSqlStorageDeleteOnClearTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture, deleteStateOnClear: true)
         {
-            Skip.If(PersistenceStorageTests == null, "Persistence storage not available for PostgreSql.");
         }
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/PostgreSqlStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/PostgreSqlStorageTests.cs
@@ -23,8 +23,6 @@ namespace UnitTests.StorageTests.Relational
         
         public PostgreSqlStorageTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture)
         {
-            //XUnit.NET will automatically call this constructor before every test method run.
-            Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for PostgreSql.");
         }
 
         [SkippableFact]

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageTests.cs
@@ -3,6 +3,7 @@ using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Storage;
 using UnitTests.StorageTests.Relational.TestDataSets;
+using Xunit;
 
 
 namespace UnitTests.StorageTests.Relational
@@ -12,14 +13,17 @@ namespace UnitTests.StorageTests.Relational
     /// is collected here, but concrete implementations can provide and implement storage specific
     /// actions.
     /// </summary>
-    public abstract class RelationalStorageTests
+    public abstract class RelationalStorageTests : IAsyncLifetime
     {
+        private readonly string _adoNetInvariant;
+        private readonly bool _deleteStateOnClear;
+
         private IStorageHasherPicker ConstantHasher { get; } = new StorageHasherPicker(new[] { new ConstantHasher() });
 
         /// <summary>
         /// The tests and assertions common across all back-ends are here.
         /// </summary>
-        internal CommonStorageTests PersistenceStorageTests { get; } = null!;
+        internal CommonStorageTests PersistenceStorageTests { get; private set; } = null!;
 
         /// <summary>
         /// The tests and assertions common across all back-ends are here.
@@ -35,12 +39,18 @@ namespace UnitTests.StorageTests.Relational
         public RelationalStorageTests(string adoNetInvariant, CommonFixture fixture, bool deleteStateOnClear = false)
         {
             Fixture = fixture;
-            var persistenceStorage = fixture.GetStorageProvider(adoNetInvariant, deleteStateOnClear).GetAwaiter().GetResult();
-            if(persistenceStorage != null)
-            {
-                PersistenceStorageTests = new CommonStorageTests(persistenceStorage);
-            }
+            _adoNetInvariant = adoNetInvariant;
+            _deleteStateOnClear = deleteStateOnClear;
         }
+
+        public async Task InitializeAsync()
+        {
+            var persistenceStorage = await Fixture.GetStorageProvider(_adoNetInvariant, _deleteStateOnClear);
+            Skip.If(persistenceStorage is null, $"Persistence storage not available for {_adoNetInvariant}.");
+            PersistenceStorageTests = new CommonStorageTests(persistenceStorage);
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         internal Task Relational_WriteReadWriteRead100StatesInParallel()
         {

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/SqlServerStorageDeleteOnClearTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/SqlServerStorageDeleteOnClearTests.cs
@@ -17,7 +17,6 @@ namespace UnitTests.StorageTests.Relational
 
         public SqlServerStorageDeleteOnClearTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture, deleteStateOnClear: true)
         {
-            Skip.If(PersistenceStorageTests == null, "Persistence storage not available for SqlServer.");
         }
 
         [SkippableTheory, ClassData(typeof(StorageDataSetPlain<long>))]

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/SqlServerStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/SqlServerStorageTests.cs
@@ -25,8 +25,6 @@ namespace UnitTests.StorageTests.Relational
 
         public SqlServerStorageTests(CommonFixture commonFixture) : base(AdoNetInvariant, commonFixture)
         {
-            //XUnit.NET will automatically call this constructor before every test method run.
-            Skip.If(PersistenceStorageTests == null, $"Persistence storage not available for SqlServer.");
         }
 
         [SkippableFact]

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/TestEnvironmentInvariant.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/TestEnvironmentInvariant.cs
@@ -93,13 +93,15 @@ namespace UnitTests.StorageTests.Relational
         /// <param name="connection">The connection with which to ensure the storage is functional.</param>
         /// <param name="storageName">Storage name. This is optional.</param>
         /// <returns></returns>
-        public RelationalStorageForTesting? EnsureStorageForTesting(StorageConnection connection, string? storageName = null)
+        public async Task<RelationalStorageForTesting?> EnsureStorageForTestingAsync(StorageConnection connection, string? storageName = null)
         {
-
             if (AdoNetInvariants.Invariants.Contains(connection.StorageInvariant))
             {
                 const string RelationalStorageTestDb = "OrleansStorageTests";
-                return RelationalStorageForTesting.SetupInstance(connection.StorageInvariant, storageName ?? RelationalStorageTestDb, connection.ConnectionString).GetAwaiter().GetResult();
+                return await RelationalStorageForTesting.SetupInstance(
+                    connection.StorageInvariant,
+                    storageName ?? RelationalStorageTestDb,
+                    connection.ConnectionString);
             }
 
             return null;

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
@@ -28,6 +28,7 @@ namespace UnitTests.StorageTests.AdoNet
 
             internal Fixture(Func<RelationalStorageForTesting> storageFactory)
             {
+                ArgumentNullException.ThrowIfNull(storageFactory);
                 Storage = storageFactory();
             }
 
@@ -84,6 +85,15 @@ namespace UnitTests.StorageTests.AdoNet
                 () => new SqlServerRelationalStoreTests.Fixture(() => throw expectedException));
 
             Assert.Same(expectedException, exception);
+        }
+
+        [Fact]
+        public void NullStorageFactoryIsRejected()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new SqlServerRelationalStoreTests.Fixture(null!));
+
+            Assert.Equal("storageFactory", exception.ParamName);
         }
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
@@ -19,20 +19,29 @@ namespace UnitTests.StorageTests.AdoNet
         private const string AdoNetInvariantName = AdoNetInvariants.InvariantNameSqlServer;
         private readonly RelationalStorageForTesting _storage;
 
-        public class Fixture
+        public class Fixture : IAsyncLifetime
         {
+            private readonly Func<Task<RelationalStorageForTesting>> _storageFactory;
+
             public Fixture() : this(
-                () => RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult())
+                () => RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName))
             {
             }
 
-            internal Fixture(Func<RelationalStorageForTesting> storageFactory)
+            internal Fixture(Func<Task<RelationalStorageForTesting>> storageFactory)
             {
                 ArgumentNullException.ThrowIfNull(storageFactory);
-                Storage = storageFactory();
+                _storageFactory = storageFactory;
             }
 
-            public RelationalStorageForTesting Storage { get; }
+            public RelationalStorageForTesting Storage { get; private set; } = null!;
+
+            public async Task InitializeAsync()
+            {
+                Storage = await _storageFactory();
+            }
+
+            public Task DisposeAsync() => Task.CompletedTask;
         }
 
         public SqlServerRelationalStoreTests(Fixture fixture) : base(AdoNetInvariantName)
@@ -77,12 +86,12 @@ namespace UnitTests.StorageTests.AdoNet
     public class SqlServerRelationalStoreFixtureTests
     {
         [Fact]
-        public void InitializationFailureIsPropagated()
+        public async Task InitializationFailureIsPropagated()
         {
             var expectedException = new InvalidOperationException("Simulated SQL Server database initialization failure.");
+            var fixture = new SqlServerRelationalStoreTests.Fixture(() => throw expectedException);
 
-            var exception = Assert.Throws<InvalidOperationException>(
-                () => new SqlServerRelationalStoreTests.Fixture(() => throw expectedException));
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(fixture.InitializeAsync);
 
             Assert.Same(expectedException, exception);
         }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
@@ -21,24 +21,22 @@ namespace UnitTests.StorageTests.AdoNet
 
         public class Fixture
         {
-            public Fixture()
+            public Fixture() : this(
+                () => RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult())
             {
-                try
-                {
-                    Storage = RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName).GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Failed to initialize {AdoNetInvariantName} for testing: {ex}");
-                }
             }
 
-            public RelationalStorageForTesting? Storage { get; private set; }
+            internal Fixture(Func<RelationalStorageForTesting> storageFactory)
+            {
+                Storage = storageFactory();
+            }
+
+            public RelationalStorageForTesting Storage { get; }
         }
 
         public SqlServerRelationalStoreTests(Fixture fixture) : base(AdoNetInvariantName)
         {
-            _storage = fixture.Storage!;
+            _storage = fixture.Storage;
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -60,7 +58,7 @@ namespace UnitTests.StorageTests.AdoNet
         [SkippableFact, TestCategory("Functional")]
         public async Task DataSource_SqlServer_Test()
         {
-            Skip.If(_storage is null || string.IsNullOrWhiteSpace(_storage.CurrentConnectionString), "Connection string not provided.");
+            Skip.If(string.IsNullOrWhiteSpace(_storage.CurrentConnectionString), "Connection string not provided.");
             using var dataSource = new ProviderDbDataSource(
                 _storage.CurrentConnectionString,
                 () => new SqlConnection(_storage.CurrentConnectionString));
@@ -72,6 +70,20 @@ namespace UnitTests.StorageTests.AdoNet
                 (record, _, _) => Task.FromResult(record.GetInt32(0)));
 
             Assert.Equal([47], values);
+        }
+    }
+
+    public class SqlServerRelationalStoreFixtureTests
+    {
+        [Fact]
+        public void InitializationFailureIsPropagated()
+        {
+            var expectedException = new InvalidOperationException("Simulated SQL Server database initialization failure.");
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => new SqlServerRelationalStoreTests.Fixture(() => throw expectedException));
+
+            Assert.Same(expectedException, exception);
         }
     }
 }


### PR DESCRIPTION
Several ADO.NET test fixtures synchronously block on asynchronous database setup using `.Result`, `.Wait()`, or `GetAwaiter().GetResult()`. The SQL Server and PostgreSQL relational-store fixtures could also hide initialization failures and leave storage unavailable, producing misleading downstream failures.

Move database and cluster setup into xUnit `IAsyncLifetime` initialization (or existing asynchronous lifecycle overrides), including relational-store, persistence, liveness, reminder, and SQLite fixtures. Shared relational storage setup is now asynchronous end-to-end, and initialization failures propagate with their original diagnostics. A database-independent regression test verifies that the exact setup exception reaches the caller.

Closes #10544.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10560)