### PR TITLE
test(durable-jobs): synchronize fake-time polling

### DIFF
--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -325,7 +325,7 @@ public class ShardExecutorTests
         var runTask = executor.RunShardAsync(shard, CancellationToken.None);
 
         await firstCall.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromSeconds(5));
+        await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromMinutes(1));
         Assert.False(secondCall.Task.IsCompleted);
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -296,7 +296,7 @@ public class ShardExecutorTests
     [Fact]
     public async Task RunShardAsync_WhenJobReturnsPollAfter_UsesTimeProvider()
     {
-        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var timeProvider = new TimerTrackingFakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
         var options = CreateOptions(maxConcurrentJobs: 10);
         var overloadDetector = CreateOverloadDetector(isOverloaded: false);
         var jobs = CreateJobs(1, timeProvider.GetUtcNow().AddSeconds(-1));
@@ -325,6 +325,7 @@ public class ShardExecutorTests
         var runTask = executor.RunShardAsync(shard, CancellationToken.None);
 
         await firstCall.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.False(secondCall.Task.IsCompleted);
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
## Problem

The fake-time polling test signals its first callback before ShardExecutor registers the poll delay timer. Advancing time at that point can strand the subsequently scheduled delay and time out the test.

## Solution

Reuse the test's timer-tracking fake time provider and wait for timer registration before advancing the clock. This preserves the existing assertions and avoids arbitrary sleeps.

Fixes #10549
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10562)