### PR TITLE
test(reminders): synchronize exact-due recovery

### DIFF
--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -559,13 +559,15 @@ namespace UnitTests.TimerTests
             outage.Release();
             await activatedTask;
             await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
+            // Complete a reminder-service round trip so the recovery reconciliation turn cannot overlap time advancement.
+            Assert.NotNull(await grain.GetReminderObject(reminderName));
 
             var tickTask = observer.WaitForReminderTickAsync(grainId, cts.Token, reminderName);
-            await AdvanceUntilAsync(tickTask, cts.Token);
+            await AdvanceReminderTimeAsync(ReminderRefreshPeriod, cts.Token);
             var tick = await tickTask;
 
             Assert.Equal(firstTickTime, tick.Status.FirstTickTime);
-            Assert.InRange(tick.Status.CurrentTickTime, firstTickTime, firstTickTime + period - TimeSpan.FromTicks(1));
+            Assert.Equal(firstTickTime + ReminderRefreshPeriod, tick.Status.CurrentTickTime);
 
             await grain.StopReminder(reminderName);
         }


### PR DESCRIPTION
## Problem

The exact-due reminder storage recovery test kept advancing fake time while the recovery reconciliation turn was still completing. Under Windows/net10 Functional CI contention, delivery could therefore observe a timestamp several reminder periods later and fail its range assertion.

## Solution

Add a reminder-service round trip after the recovered schedule is armed, ensuring reconciliation has completed before advancing fake time. Advance once by the configured refresh period and assert the exact deterministic delivery timestamp instead of a broad period range.

Fixes #10548
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10563)