### PR TITLE
fix(docs): use native Orleans API links

### DIFF
--- a/docs/site/scripts/lib/docfx.mjs
+++ b/docs/site/scripts/lib/docfx.mjs
@@ -1050,6 +1050,9 @@ function xrefUrl(uid, uidMap) {
       return uidMap.get(candidate);
     }
   }
+  if (withoutMethodArity.startsWith('Orleans.')) {
+    return 'https://dotnet.github.io/orleans/docs/api/csharp/';
+  }
   const slug = withoutMethodArity.replace(/`(\d+)/g, '-$1').toLowerCase();
   return `https://learn.microsoft.com/dotnet/api/${encodeURI(slug)}`;
 }

--- a/docs/site/scripts/lib/source-quality.mjs
+++ b/docs/site/scripts/lib/source-quality.mjs
@@ -813,10 +813,7 @@ async function validateReferenceInventories(repositoryRoot, sourceRoot, packageE
   const optionsPage = await readFile(optionsPath, 'utf8');
   if (
     !optionsPage.includes('This page is a curated starting point, not an exhaustive property catalog.') ||
-    !(
-      optionsPage.includes('<xref:Orleans.Configuration>') ||
-      optionsPage.includes('https://learn.microsoft.com/dotnet/api/orleans.configuration')
-    )
+    !optionsPage.includes('<xref:Orleans.Configuration>')
   ) {
     issues.push(
       diagnostic(

--- a/docs/site/src/content/docs/index.yml
+++ b/docs/site/src/content/docs/index.yml
@@ -231,7 +231,7 @@ additionalContent:
 
           - title: ".NET Orleans streams API reference"
             summary: API reference documentation for .NET Orleans.Streams
-            url: https://dotnet.github.io/orleans/docs/api/csharp/
+            url: https://dotnet.github.io/orleans/docs/api/csharp/microsoft.orleans.streaming/
 
           - title: ".NET Orleans providers API reference"
             summary: API reference documentation for .NET Orleans.Providers

--- a/docs/site/src/content/docs/index.yml
+++ b/docs/site/src/content/docs/index.yml
@@ -223,35 +223,35 @@ additionalContent:
 
           - title: ".NET Orleans core API reference"
             summary: API reference documentation for .NET Orleans.Core
-            url: https://learn.microsoft.com/dotnet/api/orleans.core
+            url: https://dotnet.github.io/orleans/docs/api/csharp/microsoft.orleans.core/
 
           - title: ".NET Orleans runtime API reference"
             summary: API reference documentation for .NET Orleans.Runtime
-            url: https://learn.microsoft.com/dotnet/api/orleans.runtime
+            url: https://dotnet.github.io/orleans/docs/api/csharp/microsoft.orleans.runtime/
 
           - title: ".NET Orleans streams API reference"
             summary: API reference documentation for .NET Orleans.Streams
-            url: https://learn.microsoft.com/dotnet/api/orleans.streams
+            url: https://dotnet.github.io/orleans/docs/api/csharp/
 
           - title: ".NET Orleans providers API reference"
             summary: API reference documentation for .NET Orleans.Providers
-            url: https://learn.microsoft.com/dotnet/api/orleans.providers
+            url: https://dotnet.github.io/orleans/docs/api/csharp/
 
           - title: ".NET Orleans storage API reference"
             summary: API reference documentation for .NET Orleans.Storage
-            url: https://learn.microsoft.com/dotnet/api/orleans.storage
+            url: https://dotnet.github.io/orleans/docs/api/csharp/
 
           - title: ".NET Orleans Azure Storage API reference"
             summary: API reference documentation for .NET Orleans.Clustering.AzureStorage
-            url: https://learn.microsoft.com/dotnet/api/orleans.clustering.azurestorage
+            url: https://dotnet.github.io/orleans/docs/api/csharp/microsoft.orleans.clustering.azurestorage/
 
           - title: ".NET Orleans services API reference"
             summary: API reference documentation for .NET Orleans.Services
-            url: https://learn.microsoft.com/dotnet/api/orleans.services
+            url: https://dotnet.github.io/orleans/docs/api/csharp/
 
           - title: ".NET Orleans transactions API reference"
             summary: API reference documentation for .NET Orleans.Transactions
-            url: https://learn.microsoft.com/dotnet/api/orleans.transactions
+            url: https://dotnet.github.io/orleans/docs/api/csharp/microsoft.orleans.transactions/
 
 
     # footer (optional)

--- a/docs/site/src/content/docs/resources/links.md
+++ b/docs/site/src/content/docs/resources/links.md
@@ -12,7 +12,7 @@ ms.topic: reference
 - [Orleans documentation](https://learn.microsoft.com/dotnet/orleans/)
 - [Orleans repository](https://github.com/dotnet/orleans)
 - [Maintained Orleans samples](https://github.com/dotnet/orleans/tree/main/samples)
-- [.NET API reference for Orleans](https://learn.microsoft.com/dotnet/api/)
+- [.NET API reference for Orleans](https://dotnet.github.io/orleans/docs/api/csharp/)
 - [Orleans NuGet packages](https://www.nuget.org/profiles/Orleans)
 - [Release notes](https://github.com/dotnet/orleans/releases)
 - [Migration guide](../migration-guide.md)

--- a/docs/site/tests/docfx.test.mjs
+++ b/docs/site/tests/docfx.test.mjs
@@ -146,17 +146,17 @@ describe('DocFX conversion', () => {
     expect(converted).toContain('<div class="image-lightbox" data-image-lightbox>');
     expect(converted).toContain('![An image](image.png)');
     expect(converted).toContain(
-      '[ObserverManager&lt;IChat>](https://learn.microsoft.com/dotnet/api/orleans.utilities.observermanager-1)',
+      '[ObserverManager&lt;IChat>](https://dotnet.github.io/orleans/docs/api/csharp/)',
     );
     expect(converted).toContain(
-      '[Notify](https://learn.microsoft.com/dotnet/api/orleans.utilities.observermanager-2.notify) method on [ObserverManager&lt;IChat>](https://learn.microsoft.com/dotnet/api/orleans.utilities.observermanager-1)',
+      '[Notify](https://dotnet.github.io/orleans/docs/api/csharp/) method on [ObserverManager&lt;IChat>](https://dotnet.github.io/orleans/docs/api/csharp/)',
     );
     expect(converted).toContain('[grain references](/orleans/docs/next/)');
     expect(converted).toContain(
-      '[`[assembly: GenerateSerializer(Type)]`](https://learn.microsoft.com/dotnet/api/orleans.codegeneration.generateserializerattribute)',
+      '[`[assembly: GenerateSerializer(Type)]`](https://dotnet.github.io/orleans/docs/api/csharp/)',
     );
     expect(converted).toContain(
-      '[IGrain](https://learn.microsoft.com/dotnet/api/orleans.igrain)',
+      '[IGrain](https://dotnet.github.io/orleans/docs/api/csharp/)',
     );
     expect(converted).toContain('[Overview](/orleans/docs/overview/)');
     expect(converted).toContain('slug: docs/guide');
@@ -958,7 +958,7 @@ describe('DocFX conversion', () => {
       sourcePath,
     });
 
-    expect(converted).toContain('(https://learn.microsoft.com/dotnet/api/orleans.igrain)');
+    expect(converted).toContain('(https://dotnet.github.io/orleans/docs/api/csharp/)');
   });
 
   test('scans unmatched link labels in linear time', async () => {


### PR DESCRIPTION
Fixes #10557.

Orleans API links generated from xrefs could fall back to Microsoft Learn when a symbol was not present in the generated UID map. Unpublished package APIs therefore produced hard 404 failures during documentation validation.

Route unresolved Orleans xrefs to the native Orleans API reference, update the remaining authored Orleans API links to dotnet.github.io/orleans, and tighten source policy so the old Learn destination is no longer accepted. Framework API xrefs continue to use Microsoft Learn.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10564)