### PR TITLE
fix(runtime)!: configure grain context before construction

### DIFF
--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -49,7 +49,7 @@ internal partial class ActivationDataActivatorProvider(
         return true;
     }
 
-    private partial class ActivationDataActivator : IGrainContextActivatorWithConfiguration
+    private partial class ActivationDataActivator : IGrainContextActivator
     {
         private readonly IOptions<SchedulingOptions> _schedulingOptions;
         private readonly IGrainActivator _grainActivator;
@@ -75,8 +75,6 @@ internal partial class ActivationDataActivatorProvider(
                 schedulerInstruments);
             _startActivation = state => ((ActivationData)state!).Start(_grainActivator);
         }
-
-        public IGrainContext CreateContext(GrainAddress activationAddress) => CreateContext(activationAddress, []);
 
         public IGrainContext CreateContext(GrainAddress activationAddress, IConfigureGrainContext[] configureActions)
         {
@@ -105,5 +103,14 @@ internal partial class ActivationDataActivatorProvider(
 
 internal class StatelessWorkerActivator(StatelessWorkerGrainTypeSharedContext sharedContext, IGrainContextActivator innerActivator) : IGrainContextActivator
 {
-    public IGrainContext CreateContext(GrainAddress address) => new StatelessWorkerGrainContext(address, sharedContext, innerActivator);
+    public IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions)
+    {
+        var result = new StatelessWorkerGrainContext(address, sharedContext, innerActivator);
+        foreach (var configure in configureActions)
+        {
+            configure.Configure(result);
+        }
+
+        return result;
+    }
 }

--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -104,13 +104,5 @@ internal partial class ActivationDataActivatorProvider(
 internal class StatelessWorkerActivator(StatelessWorkerGrainTypeSharedContext sharedContext, IGrainContextActivator innerActivator) : IGrainContextActivator
 {
     public IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions)
-    {
-        var result = new StatelessWorkerGrainContext(address, sharedContext, innerActivator);
-        foreach (var configure in configureActions)
-        {
-            configure.Configure(result);
-        }
-
-        return result;
-    }
+        => new StatelessWorkerGrainContext(address, sharedContext, innerActivator, configureActions);
 }

--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -49,7 +49,7 @@ internal partial class ActivationDataActivatorProvider(
         return true;
     }
 
-    private partial class ActivationDataActivator : IGrainContextActivator
+    private partial class ActivationDataActivator : IGrainContextActivatorWithConfiguration
     {
         private readonly IOptions<SchedulingOptions> _schedulingOptions;
         private readonly IGrainActivator _grainActivator;
@@ -76,13 +76,20 @@ internal partial class ActivationDataActivatorProvider(
             _startActivation = state => ((ActivationData)state!).Start(_grainActivator);
         }
 
-        public IGrainContext CreateContext(GrainAddress activationAddress)
+        public IGrainContext CreateContext(GrainAddress activationAddress) => CreateContext(activationAddress, []);
+
+        public IGrainContext CreateContext(GrainAddress activationAddress, IConfigureGrainContext[] configureActions)
         {
             var context = new ActivationData(
                 activationAddress,
                 _createWorkItemGroup,
                 _serviceProvider,
                 _sharedComponents);
+
+            foreach (var configure in configureActions)
+            {
+                configure.Configure(context);
+            }
 
             using var ecSuppressor = ExecutionContext.SuppressFlow();
             _ = Task.Factory.StartNew(

--- a/src/Orleans.Runtime/Activation/IGrainContextActivator.cs
+++ b/src/Orleans.Runtime/Activation/IGrainContextActivator.cs
@@ -64,18 +64,7 @@ namespace Orleans.Runtime
                 activator = this.CreateActivator(grainId.Type);
             }
 
-            if (activator.Activator is IGrainContextActivatorWithConfiguration configurableActivator)
-            {
-                return configurableActivator.CreateContext(address, activator.ConfigureActions);
-            }
-
-            var result = activator.Activator.CreateContext(address);
-            foreach (var configure in activator.ConfigureActions)
-            {
-                configure.Configure(result);
-            }
-
-            return result;
+            return activator.Activator.CreateContext(address, activator.ConfigureActions);
         }
 
         private (IGrainContextActivator, IConfigureGrainContext[]) CreateActivator(GrainType grainType)
@@ -140,13 +129,9 @@ namespace Orleans.Runtime
         /// Creates a grain context for the given grain address.
         /// </summary>
         /// <param name="address">The grain address.</param>
+        /// <param name="configureActions">The actions which must be used to configure the context before grain construction begins.</param>
         /// <returns>The newly created grain context.</returns>
-        public IGrainContext CreateContext(GrainAddress address);
-    }
-
-    internal interface IGrainContextActivatorWithConfiguration : IGrainContextActivator
-    {
-        IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions);
+        public IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions);
     }
 
     /// <summary>

--- a/src/Orleans.Runtime/Activation/IGrainContextActivator.cs
+++ b/src/Orleans.Runtime/Activation/IGrainContextActivator.cs
@@ -64,6 +64,11 @@ namespace Orleans.Runtime
                 activator = this.CreateActivator(grainId.Type);
             }
 
+            if (activator.Activator is IGrainContextActivatorWithConfiguration configurableActivator)
+            {
+                return configurableActivator.CreateContext(address, activator.ConfigureActions);
+            }
+
             var result = activator.Activator.CreateContext(address);
             foreach (var configure in activator.ConfigureActions)
             {
@@ -137,6 +142,11 @@ namespace Orleans.Runtime
         /// <param name="address">The grain address.</param>
         /// <returns>The newly created grain context.</returns>
         public IGrainContext CreateContext(GrainAddress address);
+    }
+
+    internal interface IGrainContextActivatorWithConfiguration : IGrainContextActivator
+    {
+        IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions);
     }
 
     /// <summary>

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -43,11 +43,17 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     public StatelessWorkerGrainContext(
         GrainAddress address,
         StatelessWorkerGrainTypeSharedContext sharedContext,
-        IGrainContextActivator innerActivator)
+        IGrainContextActivator innerActivator,
+        IConfigureGrainContext[] configureActions)
     {
         Address = address;
         _shared = sharedContext;
         _innerActivator = innerActivator;
+
+        foreach (var configure in configureActions)
+        {
+            configure.Configure(this);
+        }
 
         if (_shared.RemoveIdleWorkers)
         {

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -320,7 +320,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     {
         Debug.Assert(!_terminated, "CreateWorker must not be called on a terminated stateless worker context.");
         var address = GrainAddress.GetAddress(Address.SiloAddress, Address.GrainId, ActivationId.NewId());
-        var newWorker = (ActivationData)_innerActivator.CreateContext(address);
+        var newWorker = (ActivationData)_innerActivator.CreateContext(address, []);
 
         // Observe the create/destroy lifecycle of the activation
         newWorker.SetComponent<IActivationLifecycleObserver>(this);

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -749,7 +749,7 @@ namespace Orleans.Runtime
 
     public partial interface IGrainContextActivator
     {
-        IGrainContext CreateContext(GrainAddress address);
+        IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions);
     }
 
     public partial interface IGrainContextActivatorProvider

--- a/test/Orleans.Core.Tests/Runtime/GrainContextActivatorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/GrainContextActivatorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using NSubstitute;
 using Orleans.Metadata;
 using Orleans.Runtime;
@@ -27,7 +28,7 @@ public class GrainContextActivatorTests
 
     private sealed class TestGrainContextActivatorProvider(IGrainContextActivator activator) : IGrainContextActivatorProvider
     {
-        public bool TryGet(GrainType grainType, out IGrainContextActivator result)
+        public bool TryGet(GrainType grainType, [NotNullWhen(true)] out IGrainContextActivator? result)
         {
             result = activator;
             return true;
@@ -36,7 +37,10 @@ public class GrainContextActivatorTests
 
     private sealed class TestConfigureGrainContextProvider(List<string> events) : IConfigureGrainContextProvider
     {
-        public bool TryGetConfigurator(GrainType grainType, GrainProperties properties, out IConfigureGrainContext configurator)
+        public bool TryGetConfigurator(
+            GrainType grainType,
+            GrainProperties properties,
+            [NotNullWhen(true)] out IConfigureGrainContext? configurator)
         {
             configurator = new TestConfigureGrainContext(events);
             return true;

--- a/test/Orleans.Core.Tests/Runtime/GrainContextActivatorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/GrainContextActivatorTests.cs
@@ -48,14 +48,8 @@ public class GrainContextActivatorTests
         public void Configure(IGrainContext context) => events.Add("configure");
     }
 
-    private sealed class TestGrainContextActivator(IGrainContext context, List<string> events) : IGrainContextActivatorWithConfiguration
+    private sealed class TestGrainContextActivator(IGrainContext context, List<string> events) : IGrainContextActivator
     {
-        public IGrainContext CreateContext(GrainAddress address)
-        {
-            events.Add("activate");
-            return context;
-        }
-
         public IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions)
         {
             foreach (var configure in configureActions)

--- a/test/Orleans.Core.Tests/Runtime/GrainContextActivatorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/GrainContextActivatorTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using NSubstitute;
+using Orleans.Metadata;
+using Orleans.Runtime;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Runtime;
+
+public class GrainContextActivatorTests
+{
+    [Fact, TestCategory("BVT")]
+    public void CreateInstance_ConfiguresContextBeforeStartingActivation()
+    {
+        var events = new List<string>();
+        var context = Substitute.For<IGrainContext>();
+        var contextActivator = new TestGrainContextActivator(context, events);
+        var activator = new GrainContextActivator(
+            [new TestGrainContextActivatorProvider(contextActivator)],
+            [new TestConfigureGrainContextProvider(events)],
+            new GrainPropertiesResolver(Substitute.For<IClusterManifestProvider>()));
+        var address = new GrainAddress { GrainId = GrainId.Create("test", "grain") };
+
+        Assert.Same(context, activator.CreateInstance(address));
+        Assert.Equal(["configure", "activate"], events);
+    }
+
+    private sealed class TestGrainContextActivatorProvider(IGrainContextActivator activator) : IGrainContextActivatorProvider
+    {
+        public bool TryGet(GrainType grainType, out IGrainContextActivator result)
+        {
+            result = activator;
+            return true;
+        }
+    }
+
+    private sealed class TestConfigureGrainContextProvider(List<string> events) : IConfigureGrainContextProvider
+    {
+        public bool TryGetConfigurator(GrainType grainType, GrainProperties properties, out IConfigureGrainContext configurator)
+        {
+            configurator = new TestConfigureGrainContext(events);
+            return true;
+        }
+    }
+
+    private sealed class TestConfigureGrainContext(List<string> events) : IConfigureGrainContext
+    {
+        public void Configure(IGrainContext context) => events.Add("configure");
+    }
+
+    private sealed class TestGrainContextActivator(IGrainContext context, List<string> events) : IGrainContextActivatorWithConfiguration
+    {
+        public IGrainContext CreateContext(GrainAddress address)
+        {
+            events.Add("activate");
+            return context;
+        }
+
+        public IGrainContext CreateContext(GrainAddress address, IConfigureGrainContext[] configureActions)
+        {
+            foreach (var configure in configureActions)
+            {
+                configure.Configure(context);
+            }
+
+            events.Add("activate");
+            return context;
+        }
+    }
+}

--- a/test/Orleans.Runtime.Tests/GrainActivatorTests.cs
+++ b/test/Orleans.Runtime.Tests/GrainActivatorTests.cs
@@ -135,7 +135,7 @@ namespace UnitTests.General
             {
                 // Selectively register this activator only for ExplicitlyRegisteredSimpleDIGrain types
                 // Other grain types will continue using the default DI-based activator
-                if (_grainClassMap.TryGetGrainClass(grainType, out var grainClass) && grainClass.IsAssignableFrom(typeof(ExplicitlyRegisteredSimpleDIGrain)))
+                if (_grainClassMap.TryGetGrainClass(grainType, out var grainClass) && grainClass == typeof(ExplicitlyRegisteredSimpleDIGrain))
                 {
                     shared.SetComponent<IGrainActivator>(this);
                 }
@@ -168,7 +168,7 @@ namespace UnitTests.General
                 [NotNullWhen(true)] out IConfigureGrainContext? configurator)
             {
                 if (grainClassMap.TryGetGrainClass(grainType, out var grainClass)
-                    && grainClass.IsAssignableFrom(typeof(ExplicitlyRegisteredSimpleDIGrain)))
+                    && grainClass == typeof(ExplicitlyRegisteredSimpleDIGrain))
                 {
                     configurator = ActivationOrderingState.Instance;
                     return true;
@@ -182,14 +182,15 @@ namespace UnitTests.General
         private sealed class ActivationOrderingState : IConfigureGrainContext
         {
             private int _armed;
+            private int _wasConfiguredAtConstruction;
 
             public static ActivationOrderingState Instance { get; } = new();
 
-            public bool WasConfiguredAtConstruction { get; private set; }
+            public bool WasConfiguredAtConstruction => Volatile.Read(ref _wasConfiguredAtConstruction) != 0;
 
             public void Arm()
             {
-                WasConfiguredAtConstruction = false;
+                Volatile.Write(ref _wasConfiguredAtConstruction, 0);
                 Volatile.Write(ref _armed, 1);
             }
 
@@ -210,7 +211,9 @@ namespace UnitTests.General
                     return;
                 }
 
-                WasConfiguredAtConstruction = context.GetComponent<ConfiguredContextMarker>() is not null;
+                Volatile.Write(
+                    ref _wasConfiguredAtConstruction,
+                    context.GetComponent<ConfiguredContextMarker>() is not null ? 1 : 0);
             }
         }
 

--- a/test/Orleans.Runtime.Tests/GrainActivatorTests.cs
+++ b/test/Orleans.Runtime.Tests/GrainActivatorTests.cs
@@ -1,12 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Metadata;
 using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
 using Xunit;
-using Orleans.Metadata;
 
 namespace UnitTests.General
 {
@@ -48,6 +49,7 @@ namespace UnitTests.General
                         // Register our custom grain activator as a grain type component configurator
                         // This allows it to selectively apply to specific grain types
                         services.AddSingleton<IConfigureGrainTypeComponents, HardcodedGrainActivator>();
+                        services.AddSingleton<IConfigureGrainContextProvider, ActivationOrderingConfiguratorProvider>();
                     });
                 }
             }
@@ -96,6 +98,20 @@ namespace UnitTests.General
             Assert.Equal(initialReleasedInstances + 1, finalReleasedInstances);
         }
 
+        [Fact, TestCategory("BVT")]
+        public async Task GrainContextIsConfiguredBeforeGrainConstruction()
+        {
+            var state = ActivationOrderingState.Instance;
+            state.Arm();
+            var grain = this.fixture.GrainFactory.GetGrain<ISimpleDIGrain>(
+                GetRandomGrainId(),
+                grainClassNamePrefix: "UnitTests.Grains.ExplicitlyRegistered");
+
+            await grain.GetStringValue();
+
+            Assert.True(state.WasConfiguredAtConstruction);
+        }
+
         /// <summary>
         /// Custom grain activator that bypasses dependency injection entirely.
         /// Implements both IGrainActivator (for creation/disposal) and IConfigureGrainTypeComponents
@@ -127,6 +143,8 @@ namespace UnitTests.General
 
             public object CreateInstance(IGrainContext context)
             {
+                ActivationOrderingState.Instance.ObserveConstruction(context);
+
                 // Custom instantiation logic - creates grain with hardcoded dependencies
                 // In real scenarios, this could get objects from a pool, perform complex
                 // initialization, or integrate with external systems
@@ -140,6 +158,65 @@ namespace UnitTests.General
                 ++_released;
                 return default;
             }
+        }
+
+        private sealed class ActivationOrderingConfiguratorProvider(GrainClassMap grainClassMap) : IConfigureGrainContextProvider
+        {
+            public bool TryGetConfigurator(
+                GrainType grainType,
+                GrainProperties properties,
+                [NotNullWhen(true)] out IConfigureGrainContext? configurator)
+            {
+                if (grainClassMap.TryGetGrainClass(grainType, out var grainClass)
+                    && grainClass.IsAssignableFrom(typeof(ExplicitlyRegisteredSimpleDIGrain)))
+                {
+                    configurator = ActivationOrderingState.Instance;
+                    return true;
+                }
+
+                configurator = null;
+                return false;
+            }
+        }
+
+        private sealed class ActivationOrderingState : IConfigureGrainContext
+        {
+            private int _armed;
+
+            public static ActivationOrderingState Instance { get; } = new();
+
+            public bool WasConfiguredAtConstruction { get; private set; }
+
+            public void Arm()
+            {
+                WasConfiguredAtConstruction = false;
+                Volatile.Write(ref _armed, 1);
+            }
+
+            public void Configure(IGrainContext context)
+            {
+                if (Volatile.Read(ref _armed) == 0)
+                {
+                    return;
+                }
+
+                context.SetComponent(ConfiguredContextMarker.Instance);
+            }
+
+            public void ObserveConstruction(IGrainContext context)
+            {
+                if (Interlocked.Exchange(ref _armed, 0) == 0)
+                {
+                    return;
+                }
+
+                WasConfiguredAtConstruction = context.GetComponent<ConfiguredContextMarker>() is not null;
+            }
+        }
+
+        private sealed class ConfiguredContextMarker
+        {
+            public static ConfiguredContextMarker Instance { get; } = new();
         }
     }
 }


### PR DESCRIPTION
Fixes #10556

## Problem

The built-in activation context creator scheduled grain construction before `IConfigureGrainContext` actions ran. The activation scheduler could therefore construct a grain against an incompletely configured context.

## Solution

Change `IGrainContextActivator.CreateContext` to receive the resolved `IConfigureGrainContext` actions. Activators must apply those actions before grain construction begins. The built-in activator now configures the context before enqueueing its existing activation task, deterministically closing the race while retaining asynchronous activation startup.

Stateless workers preserve their existing behavior: configurators apply to the outer stateless-worker context, while inner worker activations receive an empty configuration set.

## Breaking change

`IGrainContextActivator.CreateContext(GrainAddress)` is replaced by `CreateContext(GrainAddress, IConfigureGrainContext[])`. Custom implementations must accept and apply the supplied configurators before constructing the grain.

## Tests

Adds a deterministic configure-before-activate ordering regression and an in-process test proving configured context state is visible during grain construction. Focused stateless-worker coverage also passes on .NET 8 and .NET 10.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10565)