### PR TITLE
fix(dashboard): add ESLint flat configuration

### DIFF
--- a/src/Dashboard/Orleans.Dashboard.App/eslint.config.js
+++ b/src/Dashboard/Orleans.Dashboard.App/eslint.config.js
@@ -1,0 +1,52 @@
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
+
+const recommendedTypeScript = [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+];
+
+export default defineConfig([
+  globalIgnores(["dist"]),
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    extends: recommendedTypeScript,
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-this-alias": "warn",
+      "@typescript-eslint/no-unsafe-function-type": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  {
+    files: ["vite.config.ts"],
+    extends: recommendedTypeScript,
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+  },
+]);

--- a/src/Dashboard/Orleans.Dashboard.App/package-lock.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package-lock.json
@@ -377,8 +377,8 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
-      "integrity": "sha1-iRG9crLDZApUNgngQAuMTS5+fLY=",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -478,8 +478,8 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha1-iY10E8Kbq89rr+Vvyt3thYrack4=",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -491,8 +491,8 @@
     },
     "node_modules/@eslint/js": {
       "version": "9.39.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha1-by+8/3VQDSKdU14KlJrhNHLIR4c=",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1430,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-      "integrity": "sha1-duhqpaJFn79bvXqDnA3AzOHVYiQ=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1459,8 +1459,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1469,8 +1469,8 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-      "integrity": "sha1-iOOGXs9zsBGBNOfLgx2oepYaV6E=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1494,8 +1494,8 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-      "integrity": "sha1-go94iJXfUtnrK1Q0RaOloT41q04=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1516,8 +1516,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-      "integrity": "sha1-T//Mbr0N+f55g8AlaWdWfqb1rGM=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1534,8 +1534,8 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-      "integrity": "sha1-OokGbFB6owVB3BdoBGhbS0ROHlI=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1551,8 +1551,8 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-      "integrity": "sha1-sjFTA+ynL62a+nvk9Y8FPI8qBHk=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1576,8 +1576,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha1-PKyrlNO1ZMHUjFbrN7ifiabUhHk=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1590,8 +1590,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-      "integrity": "sha1-GjjDqX3Gxmm2bVhdf5DrxPuzKlA=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1618,8 +1618,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1628,8 +1628,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "5.0.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1641,8 +1641,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1657,8 +1657,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1670,8 +1670,8 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-      "integrity": "sha1-4nfWdCcEPNyiWA7pGqYpIeRomWk=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1694,8 +1694,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-      "integrity": "sha1-TElOlHRfsnJKTzejEAkeVrZE0Yo=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1712,8 +1712,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2759,8 +2759,8 @@
     },
     "node_modules/eslint/node_modules/@eslint/js": {
       "version": "9.39.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha1-DdWcOp9A4/GIKXXDIUcJaSQ+AWQ=",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3015,8 +3015,8 @@
     },
     "node_modules/globals": {
       "version": "16.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha1-zPFZSkN7l2U7K+E+1Nj1yfhQysE=",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4210,8 +4210,8 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4265,8 +4265,8 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.66.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
-      "integrity": "sha1-CAm20lyKCSRpC6MNwfBWBwk8Efs=",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Dashboard/Orleans.Dashboard.App/package-lock.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.5",
         "@rollup/plugin-commonjs": "^29.0.0",
         "@types/humanize-duration": "^3.27.4",
         "@types/react": "^18.3.26",
@@ -29,7 +30,9 @@
         "eslint": "^9.18.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "globals": "^16.5.0",
         "typescript": "~5.7.3",
+        "typescript-eslint": "^8.66.0",
         "vite": "^8.0.16",
         "vite-plugin-commonjs": "^0.10.4"
       }
@@ -373,10 +376,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.10.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha1-iRG9crLDZApUNgngQAuMTS5+fLY=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -472,11 +476,25 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha1-iY10E8Kbq89rr+Vvyt3thYrack4=",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha1-by+8/3VQDSKdU14KlJrhNHLIR4c=",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1409,6 +1427,301 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha1-duhqpaJFn79bvXqDnA3AzOHVYiQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.66.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha1-iOOGXs9zsBGBNOfLgx2oepYaV6E=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha1-go94iJXfUtnrK1Q0RaOloT41q04=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha1-T//Mbr0N+f55g8AlaWdWfqb1rGM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha1-OokGbFB6owVB3BdoBGhbS0ROHlI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha1-sjFTA+ynL62a+nvk9Y8FPI8qBHk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha1-PKyrlNO1ZMHUjFbrN7ifiabUhHk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha1-GjjDqX3Gxmm2bVhdf5DrxPuzKlA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha1-/ZVrvgt3JB6fFaxdzLHGOAYJaO8=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha1-4nfWdCcEPNyiWA7pGqYpIeRomWk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha1-TElOlHRfsnJKTzejEAkeVrZE0Yo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@upsetjs/venn.js": {
       "version": "2.0.0",
@@ -2444,6 +2757,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.39.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-9.39.1.tgz",
+      "integrity": "sha1-DdWcOp9A4/GIKXXDIUcJaSQ+AWQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -2688,10 +3014,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "16.5.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha1-zPFZSkN7l2U7K+E+1Nj1yfhQysE=",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3881,6 +4208,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -3921,6 +4261,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.66.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha1-CAm20lyKCSRpC6MNwfBWBwk8Efs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/src/Dashboard/Orleans.Dashboard.App/package.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.5",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@types/humanize-duration": "^3.27.4",
     "@types/react": "^18.3.26",
@@ -31,7 +32,9 @@
     "eslint": "^9.18.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "globals": "^16.5.0",
     "typescript": "~5.7.3",
+    "typescript-eslint": "^8.66.0",
     "vite": "^8.0.16",
     "vite-plugin-commonjs": "^0.10.4"
   },

--- a/src/Dashboard/Orleans.Dashboard.App/src/components/multi-series-chart-widget.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/components/multi-series-chart-widget.tsx
@@ -51,7 +51,7 @@ export default class MultiSeriesChartWidget extends React.Component<MultiSeriesC
     }
 
     const data = {
-      labels: this.props.series[0].map(function(x) {
+      labels: this.props.series[0].map(function() {
         return '';
       }),
       datasets: this.props.series.map((data, index) => {

--- a/src/Dashboard/Orleans.Dashboard.App/src/components/time-series-chart.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/components/time-series-chart.tsx
@@ -102,7 +102,7 @@ export default class TimeSeriesChart extends React.Component<TimeSeriesChartProp
             if (new Date(timepoint).getSeconds() % 30 == 0) {
               return new Date(timepoint).toLocaleTimeString();
             }
-          } catch (e) {
+          } catch {
             // not a valid date string
           }
         }

--- a/src/Dashboard/Orleans.Dashboard.App/src/index.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/index.tsx
@@ -64,11 +64,6 @@ interface MenuItem {
   isSeparated?: boolean;
 }
 
-interface GrainStatItem {
-  grain?: string;
-  grainType?: string;
-}
-
 const target = document.getElementById('content');
 
 // Restore theme preference.
@@ -93,7 +88,9 @@ let routeIndex = 0;
 function scroll() {
   try {
     document.getElementsByClassName('wrapper')[0].scrollTo(0, 0);
-  } catch (e) { }
+  } catch {
+    // Older browsers may not support scrolling the wrapper element.
+  }
 }
 
 let errorTimer: NodeJS.Timeout | null;
@@ -149,7 +146,7 @@ function getVersion() {
     );
   };
 
-  const loadData = function (cb?: any) {
+  const loadData = function () {
     http.get('version', function (err, data) {
       version = data.version;
       renderVersion();
@@ -192,7 +189,7 @@ function renderPage(jsx: JSX.Element, path: string) {
   let clusterStats: any = {};
   let grainMethodStats: any = [];
   let loadDataIsPending = false;
-  const loadData = function (cb?: any) {
+  const loadData = function () {
     if (!loadDataIsPending) {
       loadDataIsPending = true;
       http.get('ClusterStats', function (err, data) {
@@ -279,7 +276,7 @@ function renderPage(jsx: JSX.Element, path: string) {
 
   let siloData: any[] = [];
   let siloStats: any[] = [];
-  const loadData = function (cb?: any) {
+  const loadData = function () {
     http.get(`HistoricalStats/${host}`, (err, data) => {
       siloData = data;
       render();
@@ -371,7 +368,7 @@ function renderPage(jsx: JSX.Element, path: string) {
 
   let grainStats: any = {};
   let loadDataIsPending = false;
-  const loadData = function (cb?: any) {
+  const loadData = function () {
     if (!loadDataIsPending) {
       http.get('GrainStats/' + grainType, function (err, data) {
         grainStats = data;
@@ -406,7 +403,7 @@ function renderPage(jsx: JSX.Element, path: string) {
 
   let grainTypes: any = {};
   let loadDataIsPending = false;
-  const loadData = function (cb?: any) {
+  const loadData = function () {
     if (!loadDataIsPending) {
       http.get(`GrainTypes${getFilter(settings)}`, function (err, data) {
         grainTypes = data;
@@ -450,12 +447,8 @@ function renderPage(jsx: JSX.Element, path: string) {
     );
   };
 
-  const rerouteToLastPage = function (lastPage: number) {
-    return (document.location.hash = `/reminders/${lastPage}`);
-  };
-
   let loadDataIsPending = false;
-  const loadData = function (cb?: any) {
+  const loadData = function () {
     if (!loadDataIsPending) {
       loadDataIsPending = true;
       http.get(`Reminders/${pageNum}`, function (err, data) {
@@ -471,7 +464,7 @@ function renderPage(jsx: JSX.Element, path: string) {
 });
 
 (routie as any)('/trace', function () {
-  const thisRouteIndex = ++routeIndex;
+  ++routeIndex;
   events.clearAll();
   scroll();
   const xhr = http.stream('Trace');
@@ -516,7 +509,7 @@ function renderPage(jsx: JSX.Element, path: string) {
       ...settings
     };
 
-    if (newSettings.hasOwnProperty('dashboardGrainsHidden')) {
+    if (Object.prototype.hasOwnProperty.call(newSettings, 'dashboardGrainsHidden')) {
       storage.put(
         'dashboardGrains',
         newSettings.dashboardGrainsHidden ? 'hidden' : 'visible'
@@ -524,7 +517,7 @@ function renderPage(jsx: JSX.Element, path: string) {
       settings.dashboardGrainsHidden = newSettings.dashboardGrainsHidden!;
     }
 
-    if (newSettings.hasOwnProperty('systemGrainsHidden')) {
+    if (Object.prototype.hasOwnProperty.call(newSettings, 'systemGrainsHidden')) {
       storage.put(
         'systemGrains',
         newSettings.systemGrainsHidden ? 'hidden' : 'visible'

--- a/src/Dashboard/Orleans.Dashboard.App/src/lib/http.ts
+++ b/src/Dashboard/Orleans.Dashboard.App/src/lib/http.ts
@@ -1,5 +1,3 @@
-import events from 'eventthing';
-
 type HttpCallback = (error: string | null, result?: any) => void;
 
 function makeRequest(method: string, uri: string, body: string | null, cb: HttpCallback): Promise<any> {

--- a/src/Dashboard/Orleans.Dashboard.App/src/lib/routie.ts
+++ b/src/Dashboard/Orleans.Dashboard.App/src/lib/routie.ts
@@ -119,7 +119,7 @@ const pathToRegexp = function(
         (optional || '')
       );
     })
-    .replace(/([\/.])/g, '\\$1')
+    .replace(/([/.])/g, '\\$1')
     .replace(/__plus__/g, '(.+)')
     .replace(/\*/g, '(.*)');
   return new RegExp('^' + path + '$', sensitive ? '' : 'i');

--- a/src/Dashboard/Orleans.Dashboard.App/src/lib/storage.ts
+++ b/src/Dashboard/Orleans.Dashboard.App/src/lib/storage.ts
@@ -10,7 +10,7 @@ try {
   if (typeof localStorage !== 'undefined') {
     store = localStorage;
   }
-} catch (e) {
+} catch {
   // noop
 }
 

--- a/src/Dashboard/Orleans.Dashboard.App/src/silos/silo.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/silos/silo.tsx
@@ -183,8 +183,6 @@ export default class Silo extends React.Component<SiloProps> {
 
     let cpuGauge: React.ReactNode;
     let memGauge: React.ReactNode;
-    let metadata: React.ReactNode;
-
     if (this.hasSeries(x => (x.cpuUsage || 0) > 0)) {
       cpuGauge = (
         <div>


### PR DESCRIPTION
Fixes #10515.

The Dashboard uses ESLint 9 but had no flat configuration, so its advertised lint command exited before inspecting source files.

Add an ESLint 9 flat config for the Dashboard TypeScript, React, and Vite sources, including the recommended JavaScript, TypeScript, hooks, and refresh rules. Existing legacy typing findings remain visible as warnings while actionable errors are corrected, allowing the command to lint all intended files successfully without hiding the inherited backlog.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10567)