### PR TITLE
test(azure): wait for reminder service startup

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -23,10 +23,17 @@ namespace Tester.AzureUtils.TimerTests
     [TestCategory("Reminders"), TestCategory("AzureStorage")]
     public class ReminderTests_AzureTable : ReminderTestsBase, IClassFixture<ReminderTests_AzureTable.Fixture>
     {
+        private readonly Fixture _fixture;
+
         public class Fixture : BaseInProcessAzureTestClusterFixture
         {
+            private static readonly TimeSpan ReminderServiceStartupTimeout = TimeSpan.FromMinutes(5);
             private ReminderTestClock? _reminderClock;
+            private readonly ReminderDiagnosticObserver _startupObserver = ReminderDiagnosticObserver.Create();
+            private IReadOnlyList<SiloAddress>? _startedReminderServices;
             internal ReminderTestClock ReminderClock => _reminderClock ?? throw new InvalidOperationException($"{nameof(ReminderTestClock)} has not been configured.");
+            internal IReadOnlyList<SiloAddress> StartedReminderServices => _startedReminderServices
+                ?? throw new InvalidOperationException("Reminder services have not completed startup.");
 
             protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
             {
@@ -40,6 +47,32 @@ namespace Tester.AzureUtils.TimerTests
                 });
             }
 
+            public override async Task InitializeAsync()
+            {
+                await base.InitializeAsync();
+
+                var silos = HostedCluster.Silos.ToArray();
+                using var cancellation = new CancellationTokenSource(ReminderServiceStartupTimeout);
+                var startedTasks = silos
+                    .Select(silo => _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress))
+                    .ToArray();
+
+                try
+                {
+                    _startedReminderServices = (await Task.WhenAll(startedTasks))
+                        .Select(started => started.SiloAddress!)
+                        .ToArray();
+                }
+                catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+                {
+                    var missing = silos
+                        .Where((_, index) => !startedTasks[index].IsCompletedSuccessfully)
+                        .Select(silo => silo.SiloAddress);
+                    throw new TimeoutException(
+                        $"Azure reminder services did not start within {ReminderServiceStartupTimeout}. Missing silos: {string.Join(", ", missing)}.");
+                }
+            }
+
             public override async Task DisposeAsync()
             {
                 try
@@ -49,16 +82,26 @@ namespace Tester.AzureUtils.TimerTests
                 finally
                 {
                     _reminderClock?.Dispose();
+                    _startupObserver.Dispose();
                 }
             }
         }
 
         public ReminderTests_AzureTable(Fixture fixture) : base(fixture.ReminderClock, fixture.HostedCluster)
         {
+            _fixture = fixture;
             fixture.EnsurePreconditionsMet();
         }
 
         // Basic tests
+
+        [SkippableFact, TestCategory("Functional")]
+        public void Fixture_WaitsForReminderServicesToStart()
+        {
+            Assert.All(
+                HostedCluster.Silos,
+                silo => Assert.Contains(silo.SiloAddress, _fixture.StartedReminderServices));
+        }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_Basic_StopByRef()

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -30,8 +30,11 @@ namespace Tester.AzureUtils.TimerTests
             private static readonly TimeSpan ReminderServiceStartupTimeout = TimeSpan.FromMinutes(5);
             private ReminderTestClock? _reminderClock;
             private readonly ReminderDiagnosticObserver _startupObserver = ReminderDiagnosticObserver.Create();
+            private IReadOnlyList<SiloAddress>? _initialSilos;
             private IReadOnlyList<SiloAddress>? _startedReminderServices;
             internal ReminderTestClock ReminderClock => _reminderClock ?? throw new InvalidOperationException($"{nameof(ReminderTestClock)} has not been configured.");
+            internal IReadOnlyList<SiloAddress> InitialSilos => _initialSilos
+                ?? throw new InvalidOperationException("The initial silos have not been captured.");
             internal IReadOnlyList<SiloAddress> StartedReminderServices => _startedReminderServices
                 ?? throw new InvalidOperationException("Reminder services have not completed startup.");
 
@@ -52,6 +55,7 @@ namespace Tester.AzureUtils.TimerTests
                 await base.InitializeAsync();
 
                 var silos = HostedCluster.Silos.ToArray();
+                _initialSilos = silos.Select(silo => silo.SiloAddress).ToArray();
                 using var cancellation = new CancellationTokenSource(ReminderServiceStartupTimeout);
                 var startedTasks = silos
                     .Select(silo => _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress))
@@ -98,9 +102,7 @@ namespace Tester.AzureUtils.TimerTests
         [SkippableFact, TestCategory("Functional")]
         public void Fixture_WaitsForReminderServicesToStart()
         {
-            Assert.All(
-                HostedCluster.Silos,
-                silo => Assert.Contains(silo.SiloAddress, _fixture.StartedReminderServices));
+            Assert.Equal(_fixture.InitialSilos, _fixture.StartedReminderServices);
         }
 
         [SkippableFact, TestCategory("Functional")]


### PR DESCRIPTION
## Problem

The Azure reminder fixture allows tests to begin as soon as the silos report started, but `LocalReminderService` performs its initial reminder-table refresh in the background. Under storage or runner stalls, that refresh can retain the non-reentrant service turn for minutes, causing otherwise unrelated reminder tests and cleanup activations to time out behind it. Bounding the Azure SDK network retry budget in #10534 did not close this readiness gap.

## Solution

Subscribe to reminder lifecycle diagnostics before cluster deployment and hold fixture initialization until every initial silo emits `ReminderServiceStarted`. A five-minute startup deadline reports the exact missing silos instead of surfacing several unrelated 30-second grain-call failures.

## Rationale

This uses the runtime's explicit readiness transition as the phase barrier, so tests begin only when reminder registrations and table reads can be serviced. Normal request timeouts and production retry behavior remain unchanged.

Fixes #10499
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10571)