### PR TITLE
fix(streaming): serialize SQL Server queue commits

### DIFF
--- a/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
@@ -174,41 +174,99 @@ BEGIN
 SET NOCOUNT ON;
 SET XACT_ABORT ON;
 
-DECLARE @MessageId BIGINT = NEXT VALUE FOR OrleansStreamMessageSequence;
-DECLARE @Now DATETIME2(7) = SYSUTCDATETIME();
-DECLARE @ExpiresOn DATETIME2(7) = DATEADD(SECOND, @ExpiryTimeout, @Now);
-
-INSERT INTO OrleansStreamMessage
+/*
+MessageIds must become visible in allocation order within each queue. Otherwise,
+concurrent transactions can expose a later MessageId while an earlier insert is
+still uncommitted, violating the stream cache's monotonic sequence invariant.
+*/
+DECLARE @LockResource NVARCHAR(255) = CONCAT
 (
-	ServiceId,
-    ProviderId,
-	QueueId,
-	MessageId,
-	Dequeued,
-	VisibleOn,
-	ExpiresOn,
-	CreatedOn,
-	ModifiedOn,
-	Payload
-)
-OUTPUT
-    Inserted.ServiceId,
-    Inserted.ProviderId,
-    Inserted.QueueId,
-    Inserted.MessageId
-VALUES
-(
-	@ServiceId,
-    @ProviderId,
-	@QueueId,
-	@MessageId,
-	0,
-	@Now,
-	@ExpiresOn,
-	@Now,
-	@Now,
-	@Payload
+    N'OrleansStreamMessage:',
+    CONVERT
+    (
+        VARCHAR(64),
+        HASHBYTES
+        (
+            'SHA2_256',
+            CONCAT
+            (
+                DATALENGTH(@ServiceId), N':', @ServiceId,
+                DATALENGTH(@ProviderId), N':', @ProviderId,
+                DATALENGTH(@QueueId), N':', @QueueId
+            )
+        ),
+        2
+    )
 );
+DECLARE @LockResult INT;
+DECLARE @StartedTransaction BIT = 0;
+
+BEGIN TRY
+    IF @@TRANCOUNT = 0
+    BEGIN
+        BEGIN TRANSACTION;
+        SET @StartedTransaction = 1;
+    END;
+
+    EXECUTE @LockResult = sys.sp_getapplock
+        @Resource = @LockResource,
+        @LockMode = 'Exclusive',
+        @LockOwner = 'Transaction';
+
+    IF @LockResult < 0
+    BEGIN
+        THROW 51000, 'Failed to acquire the stream message queue lock.', 1;
+    END;
+
+    DECLARE @MessageId BIGINT = NEXT VALUE FOR OrleansStreamMessageSequence;
+    DECLARE @Now DATETIME2(7) = SYSUTCDATETIME();
+    DECLARE @ExpiresOn DATETIME2(7) = DATEADD(SECOND, @ExpiryTimeout, @Now);
+
+    INSERT INTO OrleansStreamMessage
+    (
+        ServiceId,
+        ProviderId,
+        QueueId,
+        MessageId,
+        Dequeued,
+        VisibleOn,
+        ExpiresOn,
+        CreatedOn,
+        ModifiedOn,
+        Payload
+    )
+    OUTPUT
+        Inserted.ServiceId,
+        Inserted.ProviderId,
+        Inserted.QueueId,
+        Inserted.MessageId
+    VALUES
+    (
+        @ServiceId,
+        @ProviderId,
+        @QueueId,
+        @MessageId,
+        0,
+        @Now,
+        @ExpiresOn,
+        @Now,
+        @Now,
+        @Payload
+    );
+
+    IF @StartedTransaction = 1
+    BEGIN
+        COMMIT TRANSACTION;
+    END;
+END TRY
+BEGIN CATCH
+    IF @StartedTransaction = 1 AND XACT_STATE() <> 0
+    BEGIN
+        ROLLBACK TRANSACTION;
+    END;
+
+    THROW;
+END CATCH;
 
 END
 GO

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Data;
+using Microsoft.Data.SqlClient;
 using MySql.Data.MySqlClient;
 using Npgsql;
 using Orleans.Configuration;
@@ -17,6 +19,8 @@ namespace Tester.AdoNet.Streaming;
 [TestSuite("Functional")]
 public class SqlServerRelationalOrleansQueriesTests() : RelationalOrleansQueriesTests(AdoNetInvariants.InvariantNameSqlServer, 90)
 {
+    [SkippableFact]
+    public Task RelationalOrleansQueries_SerializesQueueMessageCommits() => VerifySqlServerQueueMessageCommitsAreSerialized();
 }
 
 /// <summary>
@@ -144,6 +148,67 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var messages = await queries.GetStreamMessagesAsync(serviceId, providerId, queueId, 100, 3, 10, 100, 10, 1000);
 
         Assert.Equal(messages.OrderBy(message => message.MessageId), messages);
+    }
+
+    protected async Task VerifySqlServerQueueMessageCommitsAreSerialized()
+    {
+        var serviceId = RandomServiceId();
+        var providerId = RandomProviderId();
+        var queueId = RandomQueueId();
+        var payload = new byte[] { 0xFF };
+        const int expiryTimeout = 100;
+
+        await using var firstConnection = new SqlConnection(_storage.ConnectionString);
+        await firstConnection.OpenAsync();
+        await using var firstTransaction = (SqlTransaction)await firstConnection.BeginTransactionAsync();
+        await using var firstCommand = CreateQueueCommand(firstConnection, firstTransaction, serviceId, providerId, queueId, payload, expiryTimeout);
+        var firstMessageId = await ReadMessageId(firstCommand);
+
+        await using (var secondConnection = new SqlConnection(_storage.ConnectionString))
+        {
+            await secondConnection.OpenAsync();
+            await using var secondCommand = CreateQueueCommand(secondConnection, transaction: null, serviceId, providerId, queueId, payload, expiryTimeout);
+            secondCommand.CommandType = CommandType.Text;
+            secondCommand.CommandText = "SET LOCK_TIMEOUT 0; EXECUTE QueueStreamMessage @ServiceId, @ProviderId, @QueueId, @Payload, @ExpiryTimeout;";
+
+            var exception = await Assert.ThrowsAsync<SqlException>(() => secondCommand.ExecuteReaderAsync());
+            Assert.Equal(51000, exception.Number);
+        }
+
+        await firstTransaction.CommitAsync();
+
+        var secondAck = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout);
+        var messages = await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, 2, 3, 10, 100, 10, 1000);
+
+        Assert.Equal([firstMessageId, secondAck.MessageId], messages.Select(message => message.MessageId));
+    }
+
+    private static SqlCommand CreateQueueCommand(
+        SqlConnection connection,
+        SqlTransaction? transaction,
+        string serviceId,
+        string providerId,
+        string queueId,
+        byte[] payload,
+        int expiryTimeout)
+    {
+        var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandType = CommandType.StoredProcedure;
+        command.CommandText = "QueueStreamMessage";
+        command.Parameters.AddWithValue("ServiceId", serviceId);
+        command.Parameters.AddWithValue("ProviderId", providerId);
+        command.Parameters.AddWithValue("QueueId", queueId);
+        command.Parameters.AddWithValue("Payload", payload);
+        command.Parameters.AddWithValue("ExpiryTimeout", expiryTimeout);
+        return command;
+    }
+
+    private static async Task<long> ReadMessageId(SqlCommand command)
+    {
+        await using var reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        return reader.GetInt64(reader.GetOrdinal(nameof(AdoNetStreamMessage.MessageId)));
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #10568.

Concurrent SQL Server stream enqueues allocate their message IDs before their transactions commit. A later ID can therefore become visible first, allowing the pulling-agent cache to advance before an older row appears and violating its monotonic sequence-token invariant.

This change serializes message ID allocation and insertion commits per logical SQL Server queue using a transaction-owned application lock. Independent queues remain concurrent, while each queue now exposes IDs in allocation order. A focused regression holds one enqueue transaction open, verifies a competing enqueue cannot allocate an ID, then confirms dequeue order after the first commit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10572)