### PR TITLE
fix(runtime): preserve rebalancer state on shutdown

### DIFF
--- a/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerMonitor.cs
+++ b/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerMonitor.cs
@@ -61,6 +61,13 @@ internal sealed partial class ActivationRebalancerMonitor : SystemTarget, IActiv
            OnStart,
            _ => Task.CompletedTask);
 
+        // The rebalancer must migrate before the catalog deactivates ordinary grains during shutdown.
+        observer.Subscribe(
+           $"{nameof(ActivationRebalancerMonitor)}.Migration",
+           ServiceLifecycleStage.GrainDeactivation + 1,
+           _ => Task.CompletedTask,
+           MigrateRebalancerOnStop);
+
         observer.Subscribe(
            nameof(ActivationRepartitioner),
            ServiceLifecycleStage.ApplicationServices,
@@ -101,23 +108,25 @@ internal sealed partial class ActivationRebalancerMonitor : SystemTarget, IActiv
         });
     }
 
-    private async Task OnStop(CancellationToken cancellationToken)
+    private async Task MigrateRebalancerOnStop(CancellationToken cancellationToken)
     {
-        await this.RunOrQueueTask(() =>
+        await this.RunOrQueueTask(async () =>
         {
-            if (_latestReport is { } report && Silo.IsSameLogicalSilo(report.Host))
+            if (!cancellationToken.IsCancellationRequested &&
+                _activationDirectory.FindTarget(_rebalancerGrain.GetGrainId()) is { } activation)
             {
-                if (_activationDirectory.FindTarget(_rebalancerGrain.GetGrainId()) is { } activation)
-                {
-                    LogMigratingRebalancer(Silo);
-                    activation.Migrate(null, cancellationToken); // migrate it anywhere else
-                }
+                LogMigratingRebalancer(Silo);
+                activation.Migrate(null, cancellationToken); // migrate it anywhere else
+                await activation.Deactivated.WaitAsync(cancellationToken);
             }
-
-            _monitorTimer?.Dispose();
-            return Task.CompletedTask;
         });
     }
+
+    private Task OnStop(CancellationToken cancellationToken) => this.RunOrQueueTask(() =>
+    {
+        _monitorTimer?.Dispose();
+        return Task.CompletedTask;
+    });
 
     public Task ResumeRebalancing() => _rebalancerGrain.ResumeRebalancing();
     public Task SuspendRebalancing(TimeSpan? duration) => _rebalancerGrain.SuspendRebalancing(duration);

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/RebalancingTestBase.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/RebalancingTestBase.cs
@@ -40,9 +40,16 @@ public abstract class RebalancingTestBase<TFixture>
     protected void AddTestActivations(List<Task> tasks, SiloAddress silo, int count)
     {
         RequestContext.Set(IPlacementDirector.PlacementHintKey, silo);
-        for (var i = 0; i < count; i++)
+        try
         {
-            tasks.Add(GrainFactory.GetGrain<IRebalancingTestGrain>(Guid.NewGuid()).Ping());
+            for (var i = 0; i < count; i++)
+            {
+                tasks.Add(GrainFactory.GetGrain<IRebalancingTestGrain>(Guid.NewGuid()).Ping());
+            }
+        }
+        finally
+        {
+            RequestContext.Remove(IPlacementDirector.PlacementHintKey);
         }
     }
 

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
@@ -23,6 +23,8 @@ namespace UnitTests.ActivationRebalancingTests;
 public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHelper output)
     : RebalancingTestBase<SPFixture>(fixture, output), IClassFixture<SPFixture>
 {
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(30);
+
     private const string ErrorMessage =
         "The rebalancer was not found in any of the 4 silos. " +
         "Either you have added more silos and not updated this code, " +
@@ -32,12 +34,13 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
     public async Task Should_Migrate_And_Preserve_State_When_Hosting_Silo_Dies()
     {
         var tasks = new List<Task>();
+        using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
+        var rebalancer = Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0);
+        var targetHost = Cluster.Silos[1].SiloAddress;
 
         // Move the rebalancer to the first secondary silo, since we will stop it later and we cannot stop
         // the primary in this test setup.
-        RequestContext.Set(IPlacementDirector.PlacementHintKey, Cluster.Silos[1].SiloAddress);
-        await Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0).Cast<IGrainManagementExtension>().MigrateOnIdle();
-        RequestContext.Remove(IPlacementDirector.PlacementHintKey);
+        await MoveRebalancerToSilo(rebalancer, targetHost);
 
         AddTestActivations(tasks, Silo1, 300);
         AddTestActivations(tasks, Silo2, 30);
@@ -45,6 +48,8 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
         AddTestActivations(tasks, Silo4, 100);
 
         await Task.WhenAll(tasks);
+
+        await rebalancerEvents.WaitForCycleCountAsync(targetHost, 3, WaitTimeout);
 
         var stats = await MgmtGrain.GetDetailedGrainStatistics();
 
@@ -60,95 +65,90 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
            $"Silo3: {initialSilo3Activations}\n" +
            $"Silo4: {initialSilo4Activations}\n");
 
-        var silo1Activations = initialSilo1Activations;
-        var silo2Activations = initialSilo2Activations;
-        var silo3Activations = initialSilo3Activations;
-        var silo4Activations = initialSilo4Activations;
+        (var rebalancerHost, var rebalancerHostNum) = await FindRebalancerHost(Silo1);
+        var reportBeforeStop = await rebalancer.GetReport();
 
-        var rebalancerHostNum = 0;
-        var index = 0;
+        OutputHelper.WriteLine($"Now stopping Silo{rebalancerHostNum}, which is the host of the rebalancer\n");
 
-        while (index < 6)
-        {
-            if (index == 3)
-            {
-                (var rebalancerHost, rebalancerHostNum) = await FindRebalancerHost(Silo1);
+        Assert.Equal(targetHost, rebalancerHost);
+        Assert.NotEqual(rebalancerHost, Cluster.Silos[0].SiloAddress);
 
-                OutputHelper.WriteLine($"Cycle {index}: Now stopping Silo{rebalancerHostNum}, which is the host of the rebalancer\n");
+        await Cluster.StopSiloAsync(Cluster.Silos.First(x => x.SiloAddress.Equals(rebalancerHost)));
 
-                Assert.NotEqual(rebalancerHost, Cluster.Silos[0].SiloAddress);
-                await Cluster.StopSiloAsync(Cluster.Silos.First(x => x.SiloAddress.Equals(rebalancerHost)));
-            }
+        var reportAfterStop = await rebalancer.GetReport();
+        var newHost = reportAfterStop.Host;
+        Assert.NotEqual(rebalancerHost, newHost);
+        Assert.Equal(reportBeforeStop.ClusterImbalance, reportAfterStop.ClusterImbalance);
+        Assert.Equal(reportBeforeStop.Status, reportAfterStop.Status);
+        Assert.Equal(
+            reportBeforeStop.Statistics
+                .Single(statistic => statistic.SiloAddress.Equals(newHost))
+                .AcquiredActivations,
+            reportAfterStop.Statistics
+                .Single(statistic => statistic.SiloAddress.Equals(newHost))
+                .AcquiredActivations);
+        Assert.Equal(
+            reportBeforeStop.Statistics
+                .Where(statistic => !statistic.SiloAddress.Equals(rebalancerHost))
+                .OrderBy(statistic => statistic.SiloAddress.ToString(), StringComparer.Ordinal)
+                .Select(statistic => (
+                    statistic.TimeStamp,
+                    statistic.SiloAddress,
+                    statistic.DispersedActivations,
+                    statistic.AcquiredActivations)),
+            reportAfterStop.Statistics
+                .Where(statistic => !statistic.SiloAddress.Equals(rebalancerHost))
+                .OrderBy(statistic => statistic.SiloAddress.ToString(), StringComparer.Ordinal)
+                .Select(statistic => (
+                    statistic.TimeStamp,
+                    statistic.SiloAddress,
+                    statistic.DispersedActivations,
+                    statistic.AcquiredActivations)));
 
-            await Task.Delay(SPFixture.SessionCyclePeriod);
-            stats = await MgmtGrain.GetDetailedGrainStatistics();
+        rebalancerEvents.Clear();
+        await rebalancerEvents.WaitForCycleCountAsync(newHost, 3, WaitTimeout);
 
-            silo1Activations = GetActivationCount(stats, Silo1);
-            silo2Activations = GetActivationCount(stats, Silo2);
-            silo3Activations = GetActivationCount(stats, Silo3);
-            silo4Activations = GetActivationCount(stats, Silo4);
+        stats = await MgmtGrain.GetDetailedGrainStatistics();
+        Assert.DoesNotContain(stats, statistic => statistic.SiloAddress.Equals(rebalancerHost));
 
-            index++;
-        }
-
-        if (rebalancerHostNum == 1)
-        {
-            Assert.True(silo2Activations > initialSilo2Activations,
-                $"Did not expect Silo2 to have less activations than what it started with: " +
-                $"[{initialSilo2Activations} -> {silo2Activations}]");
-
-            Assert.True(silo3Activations < initialSilo3Activations,
-                $"Did not expect Silo3 to have more activations than what it started with: " +
-                $"[{initialSilo3Activations} -> {silo3Activations}]");
-        }
-        else if (rebalancerHostNum == 2)
-        {
-            Assert.True(silo3Activations < initialSilo3Activations,
-                $"Did not expect Silo3 to have more activations than what it started with: " +
-                $"[{initialSilo3Activations} -> {silo3Activations}]");
-
-            Assert.True(silo4Activations > initialSilo4Activations,
-                $"Did not expect Silo4 to have less activations than what it started with: " +
-                $"[{initialSilo4Activations} -> {silo4Activations}]");
-        }
-        else if (rebalancerHostNum == 3)
-        {
-            Assert.True(silo1Activations < initialSilo1Activations,
-                $"Did not expect Silo1 to have more activations than what it started with: " +
-                $"[{initialSilo1Activations} -> {silo1Activations}]");
-
-            Assert.True(silo2Activations > initialSilo2Activations,
-                $"Did not expect Silo2 to have less activations than what it started with: " +
-                $"[{initialSilo2Activations} -> {silo2Activations}]");
-        }
-        else if (rebalancerHostNum == 4)
-        {
-            Assert.True(silo1Activations < initialSilo1Activations,
-                $"Did not expect Silo1 to have more activations than what it started with: " +
-                $"[{initialSilo1Activations} -> {silo1Activations}]");
-
-            Assert.True(silo2Activations > initialSilo2Activations,
-                $"Did not expect Silo2 to have less activations than what it started with: " +
-                $"[{initialSilo2Activations} -> {silo2Activations}]");
-        }
+        var silo1Activations = GetActivationCount(stats, Silo1);
+        var silo2Activations = GetActivationCount(stats, Silo2);
+        var silo3Activations = GetActivationCount(stats, Silo3);
+        var silo4Activations = GetActivationCount(stats, Silo4);
 
         OutputHelper.WriteLine(
-            $"Post-rebalancing activations ({index} cycles):\n" +
+            $"Post-rebalancing activations:\n" +
             $"Silo1: {(rebalancerHostNum == 1 ? "DEAD" : silo1Activations)}\n" +
             $"Silo2: {(rebalancerHostNum == 2 ? "DEAD" : silo2Activations)}\n" +
             $"Silo3: {(rebalancerHostNum == 3 ? "DEAD" : silo3Activations)}\n" +
             $"Silo4: {(rebalancerHostNum == 4 ? "DEAD" : silo4Activations)}\n");
 
-        (_, rebalancerHostNum) = await FindRebalancerHost(rebalancerHostNum switch
-        {
-            1 => Silo2,
-            2 => Silo3,
-            3 => Silo4,
-            4 => Silo1,
-            _ => throw new InvalidOperationException(ErrorMessage)
-        });
+        (var finalHost, rebalancerHostNum) = await FindRebalancerHost(newHost);
 
+        Assert.Equal(newHost, finalHost);
         OutputHelper.WriteLine($"The rebalancer is hosted by Silo{rebalancerHostNum} now");
+    }
+
+    private async Task MoveRebalancerToSilo(
+        IActivationRebalancerWorker rebalancer,
+        SiloAddress targetHost)
+    {
+        if ((await rebalancer.GetReport()).Host.Equals(targetHost))
+        {
+            return;
+        }
+
+        RequestContext.Set(IPlacementDirector.PlacementHintKey, targetHost);
+        try
+        {
+            await rebalancer.Cast<IGrainManagementExtension>().MigrateOnIdle();
+        }
+        finally
+        {
+            RequestContext.Remove(IPlacementDirector.PlacementHintKey);
+        }
+
+        Assert.Equal(targetHost, (await rebalancer.GetReport()).Host);
     }
 
     private async Task<(SiloAddress, int)> FindRebalancerHost(SiloAddress target)

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
@@ -49,6 +49,7 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
 
         await Task.WhenAll(tasks);
 
+        rebalancerEvents.Clear();
         await rebalancerEvents.WaitForCycleCountAsync(targetHost, 3, WaitTimeout);
 
         var stats = await MgmtGrain.GetDetailedGrainStatistics();


### PR DESCRIPTION
## Problem

During graceful silo shutdown, the activation rebalancer monitor requested migration of its worker but did not wait for the asynchronous migration to finish. Ordinary grain deactivation could therefore overtake the handoff, causing the worker to reactivate without its serialized state and leaving tests dependent on stale monitor reports and timing.

## Solution

Move the rebalancer handoff to a lifecycle stage immediately before ordinary grain deactivation and await the worker's deactivation/migration completion. Update the regression test to synchronize initial placement and rebalancing cycles explicitly, verify the dead host is no longer used, and compare the preserved report state after migration. Placement hints are now cleared after test activation creation so they cannot leak into later calls.

## Rationale

The migration manager and grain directory are still available at this stage, while the catalog has not yet begun bulk deactivation. Awaiting the handoff makes graceful shutdown ordering deterministic and preserves the worker's migration state instead of relying on retries or longer delays.

Fixes #10570
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10573)