### PR TITLE
fix(streaming): release ADO.NET messages during queue handoff

### DIFF
--- a/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterReceiver.cs
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterReceiver.cs
@@ -43,7 +43,7 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
     private int _activeOperations;
     private TaskCompletionSource? _operationsCompleted;
 
-    internal AdoNetQueueAdapterReceiver(
+    public AdoNetQueueAdapterReceiver(
         string providerId,
         string queueId,
         AdoNetStreamOptions streamOptions,

--- a/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterReceiver.cs
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterReceiver.cs
@@ -1,11 +1,38 @@
 namespace Orleans.Streaming.AdoNet;
 
+internal interface IStreamMessageQueries
+{
+    Task<IList<AdoNetStreamMessage>> GetStreamMessagesAsync(
+        string serviceId,
+        string providerId,
+        string queueId,
+        int maxCount,
+        int maxAttempts,
+        int visibilityTimeout,
+        int removalTimeout,
+        int evictionInterval,
+        int evictionBatchSize);
+
+    Task<IList<AdoNetStreamConfirmationAck>> ConfirmStreamMessagesAsync(
+        string serviceId,
+        string providerId,
+        string queueId,
+        IList<AdoNetStreamConfirmation> messages);
+
+    Task<IList<AdoNetStreamConfirmationAck>> ReleaseStreamMessagesAsync(
+        string serviceId,
+        string providerId,
+        string queueId,
+        IList<AdoNetStreamConfirmation> messages);
+}
+
 /// <summary>
 /// Receives message batches from an individual queue of an ADO.NET provider.
 /// </summary>
-internal partial class AdoNetQueueAdapterReceiver(string providerId, string queueId, AdoNetStreamOptions streamOptions, ClusterOptions clusterOptions, SimpleQueueCacheOptions cacheOptions, RelationalOrleansQueries queries, Serializer<AdoNetBatchContainer> serializer, ILogger<AdoNetQueueAdapterReceiver> logger) : IQueueAdapterReceiver
+internal partial class AdoNetQueueAdapterReceiver(string providerId, string queueId, AdoNetStreamOptions streamOptions, ClusterOptions clusterOptions, SimpleQueueCacheOptions cacheOptions, IStreamMessageQueries queries, Serializer<AdoNetBatchContainer> serializer, ILogger<AdoNetQueueAdapterReceiver> logger) : IQueueAdapterReceiver
 {
     private readonly ILogger<AdoNetQueueAdapterReceiver> _logger = logger;
+    private readonly object _lock = new();
     private readonly Dictionary<long, PendingMessage> _pendingMessages = [];
 
     /// <summary>
@@ -13,10 +40,21 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
     /// </summary>
     private bool _shutdown;
 
-    /// <summary>
-    /// Helps shutdown wait for any outstanding storage operation.
-    /// </summary>
-    private Task? _outstandingTask;
+    private int _activeOperations;
+    private TaskCompletionSource? _operationsCompleted;
+
+    internal AdoNetQueueAdapterReceiver(
+        string providerId,
+        string queueId,
+        AdoNetStreamOptions streamOptions,
+        ClusterOptions clusterOptions,
+        SimpleQueueCacheOptions cacheOptions,
+        RelationalOrleansQueries queries,
+        Serializer<AdoNetBatchContainer> serializer,
+        ILogger<AdoNetQueueAdapterReceiver> logger)
+        : this(providerId, queueId, streamOptions, clusterOptions, cacheOptions, new RelationalStreamMessageQueries(queries), serializer, logger)
+    {
+    }
 
     /// <summary>
     /// This receiver does not require initialization.
@@ -28,58 +66,61 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
     /// </summary>
     public async Task Shutdown(TimeSpan timeout)
     {
-        // disable any further attempts to access storage
-        _shutdown = true;
+        Task? operationsCompleted;
+        lock (_lock)
+        {
+            _shutdown = true;
+            operationsCompleted = _operationsCompleted?.Task;
+        }
 
-        // wait for any outstanding storage operation to complete.
-        var outstandingTask = _outstandingTask;
-        if (outstandingTask is not null)
+        if (operationsCompleted is not null)
         {
             try
             {
-                await outstandingTask.WaitAsync(timeout);
+                await operationsCompleted.WaitAsync(timeout);
             }
             catch (Exception ex)
             {
                 LogShutdownFault(ex, clusterOptions.ServiceId, providerId, queueId);
+                return;
             }
         }
 
-        RemoveExpiredPendingMessages();
-        if (_outstandingTask is not null || _pendingMessages.Count == 0)
+        List<AdoNetStreamConfirmation> pending;
+        lock (_lock)
         {
-            return;
-        }
+            RemoveExpiredPendingMessages();
+            if (_pendingMessages.Count == 0)
+            {
+                return;
+            }
 
-        var pending = _pendingMessages
-            .Select(static item => new AdoNetStreamConfirmation(item.Key, item.Value.Dequeued))
-            .ToList();
+            pending = _pendingMessages
+                .Select(static item => new AdoNetStreamConfirmation(item.Key, item.Value.Dequeued))
+                .ToList();
+        }
 
         try
         {
-            var task = queries.ReleaseStreamMessagesAsync(clusterOptions.ServiceId, providerId, queueId, pending);
-            _outstandingTask = task;
-            var released = await task.WaitAsync(timeout);
-            foreach (var message in released)
+            var released = await queries.ReleaseStreamMessagesAsync(clusterOptions.ServiceId, providerId, queueId, pending).WaitAsync(timeout);
+            lock (_lock)
             {
-                _pendingMessages.Remove(message.MessageId);
+                foreach (var message in released)
+                {
+                    _pendingMessages.Remove(message.MessageId);
+                }
             }
         }
         catch (Exception ex)
         {
             LogReleaseFailed(ex, clusterOptions.ServiceId, providerId, queueId, pending);
         }
-        finally
-        {
-            _outstandingTask = null;
-        }
     }
 
     /// <inheritdoc />
     public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
     {
-        // if shutdown has been called then we refuse further requests gracefully
-        if (_shutdown)
+        if (!TryBeginOperation())
         {
             return [];
         }
@@ -89,8 +130,7 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
 
         try
         {
-            // grab a message batch from storage while pinning the task so shutdown can wait for it
-            var task = queries.GetStreamMessagesAsync(
+            var messages = await queries.GetStreamMessagesAsync(
                 clusterOptions.ServiceId,
                 providerId,
                 queueId,
@@ -101,13 +141,13 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
                 streamOptions.EvictionInterval.TotalSecondsCeiling(),
                 streamOptions.EvictionBatchSize);
 
-            _outstandingTask = task;
-
-            var messages = await task;
-            RemoveExpiredPendingMessages();
-            foreach (var message in messages)
+            lock (_lock)
             {
-                _pendingMessages[message.MessageId] = new(message.Dequeued, message.ExpiresOn);
+                RemoveExpiredPendingMessages();
+                foreach (var message in messages)
+                {
+                    _pendingMessages[message.MessageId] = new(message.Dequeued, message.ExpiresOn);
+                }
             }
 
             // convert the messages into standard batch containers
@@ -120,7 +160,7 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
         }
         finally
         {
-            _outstandingTask = null;
+            EndOperation();
         }
     }
 
@@ -133,39 +173,76 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
             return;
         }
 
+        if (!TryBeginOperation())
+        {
+            return;
+        }
+
         // get the identifiers for the messages to confirm
         var items = messages.Cast<AdoNetBatchContainer>().Select(x => new AdoNetStreamConfirmation(x.SequenceToken.SequenceNumber, x.Dequeued)).ToList();
 
         try
         {
-            // execute the confirmation while pinning the task so shutdown can wait for it
-            var task = queries.ConfirmStreamMessagesAsync(clusterOptions.ServiceId, providerId, queueId, items);
-            _outstandingTask = task;
-
             try
             {
-                var confirmed = await task;
+                var confirmed = await queries.ConfirmStreamMessagesAsync(clusterOptions.ServiceId, providerId, queueId, items);
                 var receipts = items.ToDictionary(static item => item.MessageId, static item => item.Dequeued);
-                foreach (var message in confirmed)
+                lock (_lock)
                 {
-                    if (receipts.TryGetValue(message.MessageId, out var receipt)
-                        && _pendingMessages.TryGetValue(message.MessageId, out var pending)
-                        && receipt == pending.Dequeued)
+                    foreach (var message in confirmed)
                     {
-                        _pendingMessages.Remove(message.MessageId);
+                        if (receipts.TryGetValue(message.MessageId, out var receipt)
+                            && _pendingMessages.TryGetValue(message.MessageId, out var pending)
+                            && receipt == pending.Dequeued)
+                        {
+                            _pendingMessages.Remove(message.MessageId);
+                        }
                     }
                 }
             }
             catch (Exception ex)
             {
-                LogConfirmationFailed(ex, clusterOptions.ClusterId, providerId, queueId, items);
+                LogConfirmationFailed(ex, clusterOptions.ServiceId, providerId, queueId, items);
                 throw;
             }
         }
         finally
         {
-            _outstandingTask = null;
+            EndOperation();
         }
+    }
+
+    private bool TryBeginOperation()
+    {
+        lock (_lock)
+        {
+            if (_shutdown)
+            {
+                return false;
+            }
+
+            if (_activeOperations++ == 0)
+            {
+                _operationsCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            return true;
+        }
+    }
+
+    private void EndOperation()
+    {
+        TaskCompletionSource? operationsCompleted = null;
+        lock (_lock)
+        {
+            if (--_activeOperations == 0)
+            {
+                operationsCompleted = _operationsCompleted;
+                _operationsCompleted = null;
+            }
+        }
+
+        operationsCompleted?.TrySetResult();
     }
 
     private void RemoveExpiredPendingMessages()
@@ -182,6 +259,35 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
     }
 
     private readonly record struct PendingMessage(int Dequeued, DateTime ExpiresOn);
+
+    private sealed class RelationalStreamMessageQueries(RelationalOrleansQueries queries) : IStreamMessageQueries
+    {
+        public Task<IList<AdoNetStreamMessage>> GetStreamMessagesAsync(
+            string serviceId,
+            string providerId,
+            string queueId,
+            int maxCount,
+            int maxAttempts,
+            int visibilityTimeout,
+            int removalTimeout,
+            int evictionInterval,
+            int evictionBatchSize) =>
+            queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize);
+
+        public Task<IList<AdoNetStreamConfirmationAck>> ConfirmStreamMessagesAsync(
+            string serviceId,
+            string providerId,
+            string queueId,
+            IList<AdoNetStreamConfirmation> messages) =>
+            queries.ConfirmStreamMessagesAsync(serviceId, providerId, queueId, messages);
+
+        public Task<IList<AdoNetStreamConfirmationAck>> ReleaseStreamMessagesAsync(
+            string serviceId,
+            string providerId,
+            string queueId,
+            IList<AdoNetStreamConfirmation> messages) =>
+            queries.ReleaseStreamMessagesAsync(serviceId, providerId, queueId, messages);
+    }
 
     #region Logging
 

--- a/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterReceiver.cs
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterReceiver.cs
@@ -6,6 +6,7 @@ namespace Orleans.Streaming.AdoNet;
 internal partial class AdoNetQueueAdapterReceiver(string providerId, string queueId, AdoNetStreamOptions streamOptions, ClusterOptions clusterOptions, SimpleQueueCacheOptions cacheOptions, RelationalOrleansQueries queries, Serializer<AdoNetBatchContainer> serializer, ILogger<AdoNetQueueAdapterReceiver> logger) : IQueueAdapterReceiver
 {
     private readonly ILogger<AdoNetQueueAdapterReceiver> _logger = logger;
+    private readonly Dictionary<long, PendingMessage> _pendingMessages = [];
 
     /// <summary>
     /// Flags that no further work should be attempted.
@@ -43,6 +44,35 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
                 LogShutdownFault(ex, clusterOptions.ServiceId, providerId, queueId);
             }
         }
+
+        RemoveExpiredPendingMessages();
+        if (_outstandingTask is not null || _pendingMessages.Count == 0)
+        {
+            return;
+        }
+
+        var pending = _pendingMessages
+            .Select(static item => new AdoNetStreamConfirmation(item.Key, item.Value.Dequeued))
+            .ToList();
+
+        try
+        {
+            var task = queries.ReleaseStreamMessagesAsync(clusterOptions.ServiceId, providerId, queueId, pending);
+            _outstandingTask = task;
+            var released = await task.WaitAsync(timeout);
+            foreach (var message in released)
+            {
+                _pendingMessages.Remove(message.MessageId);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogReleaseFailed(ex, clusterOptions.ServiceId, providerId, queueId, pending);
+        }
+        finally
+        {
+            _outstandingTask = null;
+        }
     }
 
     /// <inheritdoc />
@@ -74,6 +104,11 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
             _outstandingTask = task;
 
             var messages = await task;
+            RemoveExpiredPendingMessages();
+            foreach (var message in messages)
+            {
+                _pendingMessages[message.MessageId] = new(message.Dequeued, message.ExpiresOn);
+            }
 
             // convert the messages into standard batch containers
             return messages.Select(x => AdoNetBatchContainer.FromMessage(serializer, x)).Cast<IBatchContainer>().ToList();
@@ -109,7 +144,17 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
 
             try
             {
-                await task;
+                var confirmed = await task;
+                var receipts = items.ToDictionary(static item => item.MessageId, static item => item.Dequeued);
+                foreach (var message in confirmed)
+                {
+                    if (receipts.TryGetValue(message.MessageId, out var receipt)
+                        && _pendingMessages.TryGetValue(message.MessageId, out var pending)
+                        && receipt == pending.Dequeued)
+                    {
+                        _pendingMessages.Remove(message.MessageId);
+                    }
+                }
             }
             catch (Exception ex)
             {
@@ -123,6 +168,21 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
         }
     }
 
+    private void RemoveExpiredPendingMessages()
+    {
+        var now = DateTime.UtcNow;
+        var expired = _pendingMessages
+            .Where(message => message.Value.ExpiresOn <= now)
+            .Select(static message => message.Key)
+            .ToList();
+        foreach (var messageId in expired)
+        {
+            _pendingMessages.Remove(messageId);
+        }
+    }
+
+    private readonly record struct PendingMessage(int Dequeued, DateTime ExpiresOn);
+
     #region Logging
 
     [LoggerMessage(1, LogLevel.Error, "Failed to get messages from ({ServiceId}, {ProviderId}, {QueueId})")]
@@ -133,6 +193,9 @@ internal partial class AdoNetQueueAdapterReceiver(string providerId, string queu
 
     [LoggerMessage(3, LogLevel.Warning, "Handled fault while shutting down receiver for ({ServiceId}, {ProviderId}, {QueueId})")]
     private partial void LogShutdownFault(Exception exception, string serviceId, string providerId, string queueId);
+
+    [LoggerMessage(4, LogLevel.Warning, "Failed to release messages while shutting down receiver for ({ServiceId}, {ProviderId}, {QueueId}, {@Items})")]
+    private partial void LogReleaseFailed(Exception exception, string serviceId, string providerId, string queueId, List<AdoNetStreamConfirmation> items);
 
     #endregion Logging
 }

--- a/src/AdoNet/Orleans.Streaming.AdoNet/MySQL-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/MySQL-Streaming.sql
@@ -375,8 +375,8 @@ WHILE LOCATE(_Delimiter1, _Items) > 0 DO
 
     SET _Value = SUBSTRING_INDEX(_Items, _Delimiter1, 1);
     SET _MessageId = CAST(SUBSTRING_INDEX(_Value, _Delimiter2, 1) AS UNSIGNED);
-    SET _Dequeued = CAST(SUBSTRING_INDEX(_Value, _Delimiter2, -1) AS UNSIGNED);
-    
+    SET _Dequeued = CAST(SUBSTRING_INDEX(_Value, _Delimiter2, -1) AS SIGNED);
+
     INSERT INTO _ItemsTable
     (
         ServiceId,
@@ -414,7 +414,7 @@ FROM
         AND M.ProviderId = I.ProviderId
         AND M.QueueId = I.QueueId
         AND M.MessageId = I.MessageId
-        AND M.Dequeued = I.Dequeued
+        AND M.Dequeued = ABS(I.Dequeued)
 ORDER BY
     M.ServiceId,
     M.ProviderId,
@@ -422,14 +422,27 @@ ORDER BY
 	M.MessageId
 FOR UPDATE;
 
-/* delete the elected batch */
-DELETE M
-FROM OrleansStreamMessage AS M
-INNER JOIN _Batch AS B
-    ON M.ServiceId = B.ServiceId
-    AND M.ProviderId = B.ProviderId
-    AND M.QueueId = B.QueueId
-    AND M.MessageId = B.MessageId;
+IF EXISTS (SELECT 1 FROM _ItemsTable WHERE Dequeued < 0) THEN
+    /* negative dequeue receipts release messages for immediate redelivery */
+    UPDATE OrleansStreamMessage AS M
+    INNER JOIN _Batch AS B
+        ON M.ServiceId = B.ServiceId
+        AND M.ProviderId = B.ProviderId
+        AND M.QueueId = B.QueueId
+        AND M.MessageId = B.MessageId
+    SET
+        M.VisibleOn = UTC_TIMESTAMP(6),
+        M.ModifiedOn = UTC_TIMESTAMP(6);
+ELSE
+    /* delete the elected batch */
+    DELETE M
+    FROM OrleansStreamMessage AS M
+    INNER JOIN _Batch AS B
+        ON M.ServiceId = B.ServiceId
+        AND M.ProviderId = B.ProviderId
+        AND M.QueueId = B.QueueId
+        AND M.MessageId = B.MessageId;
+END IF;
 
 /* return the ack */
 SELECT

--- a/src/AdoNet/Orleans.Streaming.AdoNet/PostgreSQL-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/PostgreSQL-Streaming.sql
@@ -316,6 +316,7 @@ AS $$
 #VARIABLE_CONFLICT USE_COLUMN
 DECLARE
 	_Count INT;
+    _Now TIMESTAMP(6) WITHOUT TIME ZONE := CURRENT_TIMESTAMP AT TIME ZONE 'UTC';
 BEGIN
 
 CREATE TEMP TABLE _ItemsTable
@@ -334,6 +335,48 @@ SELECT
 	CAST(split_part(Value, ':', 2) AS INT) AS Dequeued
 FROM
 	UNNEST(string_to_array(_Items, '|')) AS Value;
+
+/* negative dequeue receipts release messages for immediate redelivery */
+IF EXISTS (SELECT 1 FROM _ItemsTable WHERE Dequeued < 0) THEN
+    RETURN QUERY
+    WITH Batch AS
+    (
+        SELECT
+            M.*
+        FROM
+            OrleansStreamMessage AS M
+            INNER JOIN _ItemsTable AS I
+                ON I.MessageId = M.MessageId
+                AND -I.Dequeued = M.Dequeued
+        WHERE
+            ServiceId = _ServiceId
+            AND ProviderId = _ProviderId
+            AND QueueId = _QueueId
+        ORDER BY
+            ServiceId,
+            ProviderId,
+            QueueId,
+            MessageId
+        FOR UPDATE
+    )
+    UPDATE OrleansStreamMessage AS M
+    SET
+        VisibleOn = _Now,
+        ModifiedOn = _Now
+    FROM
+        Batch AS B
+    WHERE
+        M.ServiceId = B.ServiceId
+        AND M.ProviderId = B.ProviderId
+        AND M.QueueId = B.QueueId
+        AND M.MessageId = B.MessageId
+    RETURNING
+        M.ServiceId,
+        M.ProviderId,
+        M.QueueId,
+        M.MessageId;
+    RETURN;
+END IF;
 
 RETURN QUERY
 WITH Batch AS

--- a/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/SQLServer-Streaming.sql
@@ -415,6 +415,47 @@ FROM
 /* count the number of messages to delete so we can use order by in the next query */
 DECLARE @Count INT = (SELECT COUNT(*) FROM @ItemsTable);
 
+/* negative dequeue receipts release messages for immediate redelivery */
+IF EXISTS (SELECT 1 FROM @ItemsTable WHERE Dequeued < 0)
+BEGIN
+    DECLARE @Now DATETIME2(7) = SYSUTCDATETIME();
+
+    WITH Batch AS
+    (
+        SELECT TOP (@Count)
+            M.*
+        FROM
+            OrleansStreamMessage AS M WITH (UPDLOCK, READPAST, READCOMMITTEDLOCK, ROWLOCK)
+        WHERE
+            ServiceId = @ServiceId
+            AND ProviderId = @ProviderId
+            AND QueueId = @QueueId
+            AND EXISTS
+            (
+                SELECT *
+                FROM @ItemsTable AS I
+                WHERE I.MessageId = M.MessageId
+                AND -I.Dequeued = M.Dequeued
+            )
+        ORDER BY
+            ServiceId,
+            ProviderId,
+            QueueId,
+            MessageId
+    )
+    UPDATE Batch
+    SET
+        VisibleOn = @Now,
+        ModifiedOn = @Now
+    OUTPUT
+        Inserted.ServiceId,
+        Inserted.ProviderId,
+        Inserted.QueueId,
+        Inserted.MessageId;
+
+    RETURN;
+END;
+
 /* delete messages in the exact same order as the clustered index to avoid deadlocks with other queries */
 /* skip messages being changed concurrently since their dequeue receipt may no longer match */
 WITH Batch AS

--- a/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
+++ b/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
@@ -495,10 +495,46 @@ namespace Orleans.Tests.SqlUtils
                 return Task.FromResult<IList<AdoNetStreamConfirmationAck>>([]);
             }
 
-            // this builds a string in the form "1:2|3:4|5:6" where the first number is the message id and the second is the dequeue counter which acts as a receipt
-            // while we have more efficient ways of passing this data per RDMS, we use a string here to ensure call compatibility across ADONET providers
-            // it is the responsibility of the RDMS implementation to parse this string and apply it correctly
-            var items = messages.Aggregate(new StringBuilder(), (b, m) => b.Append(b.Length > 0 ? "|" : "").Append(m.MessageId).Append(':').Append(m.Dequeued), b => b.ToString());
+            return ReadAsync<AdoNetStreamConfirmationAck, IList<AdoNetStreamConfirmationAck>>(
+                dbStoredQueries.ConfirmStreamMessagesKey,
+                record => new AdoNetStreamConfirmationAck(
+                    (string)record[nameof(AdoNetStreamConfirmationAck.ServiceId)],
+                    (string)record[nameof(AdoNetStreamConfirmationAck.ProviderId)],
+                    (string)record[nameof(AdoNetStreamConfirmationAck.QueueId)],
+                    (long)record[nameof(AdoNetStreamConfirmationAck.MessageId)]),
+                command => new DbStoredQueries.Columns(command)
+                {
+                    ServiceId = serviceId,
+                    ProviderId = providerId,
+                    QueueId = queueId,
+                    Items = FormatStreamConfirmations(messages, release: false)
+                },
+                result => result.ToList());
+        }
+
+        /// <summary>
+        /// Makes unconfirmed stream messages immediately available for redelivery.
+        /// </summary>
+        /// <param name="serviceId">The service identifier.</param>
+        /// <param name="providerId">The provider identifier.</param>
+        /// <param name="queueId">The queue identifier.</param>
+        /// <param name="messages">The messages to release.</param>
+        /// <returns>A list of released messages.</returns>
+        /// <remarks>
+        /// The dequeue counter acts as a receipt so that a stale receiver cannot release a message
+        /// which has already been dequeued by a new receiver.
+        /// </remarks>
+        internal Task<IList<AdoNetStreamConfirmationAck>> ReleaseStreamMessagesAsync(string serviceId, string providerId, string queueId, IList<AdoNetStreamConfirmation> messages)
+        {
+            ArgumentNullException.ThrowIfNull(serviceId);
+            ArgumentNullException.ThrowIfNull(providerId);
+            ArgumentNullException.ThrowIfNull(queueId);
+            ArgumentNullException.ThrowIfNull(messages);
+
+            if (messages.Count == 0)
+            {
+                return Task.FromResult<IList<AdoNetStreamConfirmationAck>>([]);
+            }
 
             return ReadAsync<AdoNetStreamConfirmationAck, IList<AdoNetStreamConfirmationAck>>(
                 dbStoredQueries.ConfirmStreamMessagesKey,
@@ -512,10 +548,21 @@ namespace Orleans.Tests.SqlUtils
                     ServiceId = serviceId,
                     ProviderId = providerId,
                     QueueId = queueId,
-                    Items = items
+                    Items = FormatStreamConfirmations(messages, release: true)
                 },
                 result => result.ToList());
         }
+
+        // Builds a provider-neutral receipt list in the form "1:2|3:4|5:6".
+        private static string FormatStreamConfirmations(IList<AdoNetStreamConfirmation> messages, bool release) =>
+            messages.Aggregate(
+                new StringBuilder(),
+                (builder, message) => builder
+                    .Append(builder.Length > 0 ? "|" : "")
+                    .Append(message.MessageId)
+                    .Append(':')
+                    .Append(release ? -message.Dequeued : message.Dequeued),
+                static builder => builder.ToString());
 
         /// <summary>
         /// Applies delivery failure logic to a stream message, such as making the message visible again or moving it to dead letters.

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -329,11 +329,6 @@ namespace Orleans.Streams
                 data.LastProcessedToken = startToken;
                 data.PendingStartToken = null;
                 data.IsRegistered = true;
-                if (streamDataCollection.AllConsumers().All(static consumer => consumer.IsRegistered))
-                {
-                    streamDataCollection.ReleaseRegistrationPin();
-                }
-
                 StreamingEvents.EmitSubscriptionAttached(streamProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, Silo);
                 if (data.State == StreamConsumerDataState.Inactive)
                     RunConsumerCursor(data).Ignore(); // Start delivering events if not actively doing so
@@ -365,7 +360,16 @@ namespace Orleans.Streams
                     if (requestedToken != null)
                     {
                         consumerData.SafeDisposeCursor(logger);
-                        consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, requestedToken);
+                        try
+                        {
+                            consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, requestedToken);
+                        }
+                        catch (QueueCacheMissException) when (cacheToken is not null)
+                        {
+                            // A cold stream's triggering batch is the receiver's first available
+                            // message, so resume there if the consumer's prior token was evicted.
+                            consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, cacheToken);
+                        }
                     }
                     else
                     {
@@ -426,10 +430,7 @@ namespace Orleans.Streams
             }
 
             if (streamData.Count == 0)
-            {
-                streamData.DisposeAll(logger);
                 pubSubCache.Remove(streamId);
-            }
         }
 
         private Task RunQueuePump(QueueId queueId, CancellationToken cancellationToken)
@@ -562,14 +563,6 @@ namespace Orleans.Streams
 
             if (queueCache is not null && queueCache.IsUnderPressure())
             {
-                foreach (var stream in pubSubCache.Values)
-                {
-                    if (stream.Count == 0 && stream.RegistrationTask is null)
-                    {
-                        stream.ReleaseRegistrationPin();
-                    }
-                }
-
                 // Under back pressure. Exit the loop. Will attempt again in the next timer callback.
                 LogInfoStreamCacheUnderPressure();
                 return false;
@@ -611,18 +604,6 @@ namespace Orleans.Streams
                 if (pubSubCache.TryGetValue(streamId, out var streamData))
                 {
                     streamData.RefreshActivity(now);
-                    if (streamData.Count == 0 || streamData.AllConsumers().Any(static consumer => !consumer.IsRegistered))
-                    {
-                        if (streamData.PendingStartToken is null || startToken.Older(streamData.PendingStartToken))
-                        {
-                            streamData.PendingStartToken = startToken;
-                        }
-                    }
-                    else
-                    {
-                        streamData.PendingStartToken = null;
-                    }
-
                     StartInactiveCursors(streamData, startToken);
                 }
                 else
@@ -724,16 +705,13 @@ namespace Orleans.Streams
                 return;
             }
 
-            var streamData = new StreamConsumerCollection(now)
-            {
-                PendingStartToken = firstToken
-            };
+            var streamData = new StreamConsumerCollection(now);
 
             // Create a fake cursor to point into a cache.
             // That way we will not purge the event from the cache, until we talk to pub sub.
             // This will help ensure the "casual consistency" between pre-existing subscripton (of a potentially new already subscribed consumer)
             // and later production.
-            streamData.RegistrationPin = queueCache?.GetCacheCursor(streamId, firstToken);
+            var pinCursor = queueCache?.GetCacheCursor(streamId, firstToken);
             streamData.RegistrationTask = RegisterStreamAsync();
             pubSubCache.Add(streamId, streamData);
 
@@ -783,11 +761,7 @@ namespace Orleans.Streams
                 finally
                 {
                     streamData.RegistrationTask = null;
-
-                    if (streamData.Count > 0 && streamData.AllConsumers().All(static consumer => consumer.IsRegistered))
-                    {
-                        streamData.ReleaseRegistrationPin();
-                    }
+                    pinCursor?.Dispose();
                 }
             }
 
@@ -927,10 +901,20 @@ namespace Orleans.Streams
                             {
                                 consumerData.LastProcessedToken = newToken.Token;
                                 consumerData.LastToken = newToken;
-                                IQueueCacheCursor newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, newToken.Token); // queueCache must be non-null here: consumerData.Cursor was only ever populated via queueCache.GetCacheCursor.
-                                // The handshake token points to an already processed event, we need to advance the cursor to
-                                // the next event.
-                                newCursor.MoveNext();
+                                IQueueCacheCursor newCursor;
+                                try
+                                {
+                                    newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, newToken.Token); // queueCache must be non-null here: consumerData.Cursor was only ever populated via queueCache.GetCacheCursor.
+                                    // The handshake token points to an already processed event, so advance past it.
+                                    newCursor.MoveNext();
+                                }
+                                catch (QueueCacheMissException)
+                                {
+                                    // The current batch is the receiver's first available message.
+                                    // Keep it pending when the consumer resumes from an evicted token.
+                                    newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, batch.SequenceToken);
+                                }
+
                                 consumerData.SafeDisposeCursor(logger);
                                 consumerData.Cursor = newCursor;
                             }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -515,6 +515,7 @@ namespace Orleans.Streams
                 return false;
             }
 
+            // Pause all queue reads so a cold stream's first batch stays pinned until registration completes.
             if (pubSubCache.Values.Any(static stream => stream.RegistrationTask is { IsCompleted: false }))
             {
                 return false;

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -329,6 +329,11 @@ namespace Orleans.Streams
                 data.LastProcessedToken = startToken;
                 data.PendingStartToken = null;
                 data.IsRegistered = true;
+                if (streamDataCollection.AllConsumers().All(static consumer => consumer.IsRegistered))
+                {
+                    streamDataCollection.ReleaseRegistrationPin();
+                }
+
                 StreamingEvents.EmitSubscriptionAttached(streamProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, Silo);
                 if (data.State == StreamConsumerDataState.Inactive)
                     RunConsumerCursor(data).Ignore(); // Start delivering events if not actively doing so
@@ -421,7 +426,10 @@ namespace Orleans.Streams
             }
 
             if (streamData.Count == 0)
+            {
+                streamData.DisposeAll(logger);
                 pubSubCache.Remove(streamId);
+            }
         }
 
         private Task RunQueuePump(QueueId queueId, CancellationToken cancellationToken)
@@ -507,6 +515,11 @@ namespace Orleans.Streams
                 return false;
             }
 
+            if (pubSubCache.Values.Any(static stream => stream.RegistrationTask is { IsCompleted: false }))
+            {
+                return false;
+            }
+
             var now = _timeProvider.GetUtcNow().UtcDateTime;
             TagList? tags = null;
 
@@ -548,6 +561,14 @@ namespace Orleans.Streams
 
             if (queueCache is not null && queueCache.IsUnderPressure())
             {
+                foreach (var stream in pubSubCache.Values)
+                {
+                    if (stream.Count == 0 && stream.RegistrationTask is null)
+                    {
+                        stream.ReleaseRegistrationPin();
+                    }
+                }
+
                 // Under back pressure. Exit the loop. Will attempt again in the next timer callback.
                 LogInfoStreamCacheUnderPressure();
                 return false;
@@ -589,6 +610,18 @@ namespace Orleans.Streams
                 if (pubSubCache.TryGetValue(streamId, out var streamData))
                 {
                     streamData.RefreshActivity(now);
+                    if (streamData.Count == 0 || streamData.AllConsumers().Any(static consumer => !consumer.IsRegistered))
+                    {
+                        if (streamData.PendingStartToken is null || startToken.Older(streamData.PendingStartToken))
+                        {
+                            streamData.PendingStartToken = startToken;
+                        }
+                    }
+                    else
+                    {
+                        streamData.PendingStartToken = null;
+                    }
+
                     StartInactiveCursors(streamData, startToken);
                 }
                 else
@@ -690,13 +723,16 @@ namespace Orleans.Streams
                 return;
             }
 
-            var streamData = new StreamConsumerCollection(now);
+            var streamData = new StreamConsumerCollection(now)
+            {
+                PendingStartToken = firstToken
+            };
 
             // Create a fake cursor to point into a cache.
             // That way we will not purge the event from the cache, until we talk to pub sub.
             // This will help ensure the "casual consistency" between pre-existing subscripton (of a potentially new already subscribed consumer)
             // and later production.
-            var pinCursor = queueCache?.GetCacheCursor(streamId, firstToken);
+            streamData.RegistrationPin = queueCache?.GetCacheCursor(streamId, firstToken);
             streamData.RegistrationTask = RegisterStreamAsync();
             pubSubCache.Add(streamId, streamData);
 
@@ -747,9 +783,10 @@ namespace Orleans.Streams
                 {
                     streamData.RegistrationTask = null;
 
-                    // Disposed after all initial subscriber handshakes complete so the first
-                    // batch stays pinned until each subscriber has its own cache cursor.
-                    pinCursor?.Dispose();
+                    if (streamData.Count > 0 && streamData.AllConsumers().All(static consumer => consumer.IsRegistered))
+                    {
+                        streamData.ReleaseRegistrationPin();
+                    }
                 }
             }
 

--- a/src/Orleans.Streaming/PersistentStreams/StreamConsumerCollection.cs
+++ b/src/Orleans.Streaming/PersistentStreams/StreamConsumerCollection.cs
@@ -23,14 +23,6 @@ namespace Orleans.Streams
         [NonSerialized]
         public Task? RegistrationTask;
 
-        // Retains the first cached token until subscriptions discovered after producer registration
-        // have attached their cursors.
-        [NonSerialized]
-        public StreamSequenceToken? PendingStartToken;
-
-        [NonSerialized]
-        public IQueueCacheCursor? RegistrationPin;
-
         public StreamConsumerCollection(DateTime now)
         {
             queueData = new Dictionary<GuidId, StreamConsumerData>();
@@ -39,10 +31,7 @@ namespace Orleans.Streams
 
         public StreamConsumerData AddConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string? filterData, DateTime now)
         {
-            var consumerData = new StreamConsumerData(subscriptionId, streamId, streamConsumer, filterData)
-            {
-                PendingStartToken = PendingStartToken
-            };
+            var consumerData = new StreamConsumerData(subscriptionId, streamId, streamConsumer, filterData);
             queueData.Add(subscriptionId, consumerData);
             lastActivityTime = now;
             return consumerData;
@@ -73,21 +62,12 @@ namespace Orleans.Streams
 
         public void DisposeAll(ILogger logger)
         {
-            ReleaseRegistrationPin();
             foreach (StreamConsumerData consumer in queueData.Values)
             {
                 consumer.SafeDisposeCursor(logger);
             }
             queueData.Clear();
         }
-
-        public void ReleaseRegistrationPin()
-        {
-            RegistrationPin?.Dispose();
-            RegistrationPin = null;
-            PendingStartToken = null;
-        }
-
 
         public int Count
         {

--- a/src/Orleans.Streaming/PersistentStreams/StreamConsumerCollection.cs
+++ b/src/Orleans.Streaming/PersistentStreams/StreamConsumerCollection.cs
@@ -23,6 +23,14 @@ namespace Orleans.Streams
         [NonSerialized]
         public Task? RegistrationTask;
 
+        // Retains the first cached token until subscriptions discovered after producer registration
+        // have attached their cursors.
+        [NonSerialized]
+        public StreamSequenceToken? PendingStartToken;
+
+        [NonSerialized]
+        public IQueueCacheCursor? RegistrationPin;
+
         public StreamConsumerCollection(DateTime now)
         {
             queueData = new Dictionary<GuidId, StreamConsumerData>();
@@ -31,7 +39,10 @@ namespace Orleans.Streams
 
         public StreamConsumerData AddConsumer(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string? filterData, DateTime now)
         {
-            var consumerData = new StreamConsumerData(subscriptionId, streamId, streamConsumer, filterData);
+            var consumerData = new StreamConsumerData(subscriptionId, streamId, streamConsumer, filterData)
+            {
+                PendingStartToken = PendingStartToken
+            };
             queueData.Add(subscriptionId, consumerData);
             lastActivityTime = now;
             return consumerData;
@@ -62,11 +73,19 @@ namespace Orleans.Streams
 
         public void DisposeAll(ILogger logger)
         {
+            ReleaseRegistrationPin();
             foreach (StreamConsumerData consumer in queueData.Values)
             {
                 consumer.SafeDisposeCursor(logger);
             }
             queueData.Clear();
+        }
+
+        public void ReleaseRegistrationPin()
+        {
+            RegistrationPin?.Dispose();
+            RegistrationPin = null;
+            PendingStartToken = null;
         }
 
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
@@ -3,6 +3,7 @@ using MySql.Data.MySqlClient;
 using Orleans.Configuration;
 using Orleans.Streaming.AdoNet;
 using Orleans.Tests.SqlUtils;
+using System.Runtime.CompilerServices;
 using TestExtensions;
 using UnitTests.General;
 using static System.String;
@@ -20,6 +21,10 @@ namespace Tester.AdoNet.Streaming;
 [TestArea("Streaming")]
 public class AdoNetQueueAdapterReceiverLifecycleTests(TestEnvironmentFixture fixture)
 {
+    [Fact]
+    public void AdoNetQueueAdapterReceiver_CanBeCreatedByAdapterFactory() =>
+        RuntimeHelpers.RunClassConstructor(typeof(AdoNetQueueAdapter).TypeHandle);
+
     [Fact]
     public async Task AdoNetQueueAdapterReceiver_Shutdown_WaitsForDequeueBookkeepingBeforeRelease()
     {

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
@@ -148,6 +148,44 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
     }
 
     /// <summary>
+    /// Tests that shutting down a receiver immediately releases its unconfirmed messages.
+    /// </summary>
+    [SkippableFact]
+    public async Task AdoNetQueueAdapterReceiver_Shutdown_ReleasesUnconfirmedMessages()
+    {
+        var serviceId = $"Service-{Guid.NewGuid()}";
+        var providerId = $"Provider-{Guid.NewGuid()}";
+        var queueId = $"Queue-{Guid.NewGuid()}";
+        var clusterOptions = new ClusterOptions { ServiceId = serviceId };
+        var streamOptions = new AdoNetStreamOptions
+        {
+            Invariant = invariant,
+            ConnectionString = _storage.ConnectionString,
+            VisibilityTimeout = TimeSpan.FromMinutes(5),
+            EvictionBatchSize = 0
+        };
+        var cacheOptions = new SimpleQueueCacheOptions();
+        var serializer = _fixture.Serializer.GetSerializer<AdoNetBatchContainer>();
+        var logger = NullLogger<AdoNetQueueAdapterReceiver>.Instance;
+        var streamId = StreamId.Create("MyNamespace", "MyKey");
+        var payload = serializer.SerializeToArray(new AdoNetBatchContainer(streamId, [new TestModel(1)], null!));
+        var ack = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, 100);
+
+        var receiver = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, _queries, serializer, logger);
+        var first = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await receiver.GetQueueMessagesAsync(1)));
+        Assert.Equal(1, first.Dequeued);
+
+        await receiver.Shutdown(TimeSpan.FromSeconds(10));
+
+        var replacement = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, _queries, serializer, logger);
+        var redelivered = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await replacement.GetQueueMessagesAsync(1)));
+        Assert.Equal(ack.MessageId, redelivered.SequenceToken.SequenceNumber);
+        Assert.Equal(2, redelivered.Dequeued);
+        await replacement.MessagesDeliveredAsync([redelivered]);
+        await replacement.Shutdown(TimeSpan.FromSeconds(10));
+    }
+
+    /// <summary>
     /// Tests that <see cref="AdoNetQueueAdapterReceiver.Shutdown(TimeSpan)"/> waits for the outstanding task.
     /// </summary>
     /// <returns></returns>

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
@@ -11,6 +11,103 @@ using RelationalOrleansQueries = Orleans.Streaming.AdoNet.Storage.RelationalOrle
 namespace Tester.AdoNet.Streaming;
 
 /// <summary>
+/// Provider-independent lifecycle tests for <see cref="AdoNetQueueAdapterReceiver"/>.
+/// </summary>
+[Collection(TestEnvironmentFixture.DefaultCollection)]
+[TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
+[TestProvider("None")]
+[TestSuite("BVT")]
+[TestArea("Streaming")]
+public class AdoNetQueueAdapterReceiverLifecycleTests(TestEnvironmentFixture fixture)
+{
+    [Fact]
+    public async Task AdoNetQueueAdapterReceiver_Shutdown_WaitsForDequeueBookkeepingBeforeRelease()
+    {
+        var serviceId = $"Service-{Guid.NewGuid()}";
+        var providerId = $"Provider-{Guid.NewGuid()}";
+        var queueId = $"Queue-{Guid.NewGuid()}";
+        var clusterOptions = new ClusterOptions { ServiceId = serviceId };
+        var streamOptions = new AdoNetStreamOptions
+        {
+            VisibilityTimeout = TimeSpan.FromMinutes(5),
+            EvictionBatchSize = 0
+        };
+        var cacheOptions = new SimpleQueueCacheOptions();
+        var serializer = fixture.Serializer.GetSerializer<AdoNetBatchContainer>();
+        var logger = NullLogger<AdoNetQueueAdapterReceiver>.Instance;
+        var payload = serializer.SerializeToArray(new AdoNetBatchContainer(StreamId.Create("MyNamespace", "MyKey"), [new TestModel(1)], null!));
+        var now = DateTime.UtcNow;
+        var message = new AdoNetStreamMessage(serviceId, providerId, queueId, 42, 1, now.AddMinutes(5), now.AddHours(1), now, now, payload);
+        var dequeueStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueDequeue = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var queries = new BlockingStreamMessageQueries(message, dequeueStarted, continueDequeue);
+
+        var receiver = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, queries, serializer, logger);
+        var getTask = receiver.GetQueueMessagesAsync(1);
+        await dequeueStarted.Task;
+
+        var shutdownTask = receiver.Shutdown(TimeSpan.FromSeconds(10));
+        Assert.False(shutdownTask.IsCompleted);
+
+        continueDequeue.SetResult();
+        var dequeued = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await getTask));
+        await shutdownTask;
+
+        Assert.Equal(message.MessageId, dequeued.SequenceToken.SequenceNumber);
+        var released = Assert.Single(queries.Released);
+        Assert.Equal(message.MessageId, released.MessageId);
+        Assert.Equal(message.Dequeued, released.Dequeued);
+    }
+
+    [GenerateSerializer]
+    [Alias("Tester.AdoNet.Streaming.AdoNetQueueAdapterReceiverLifecycleTests.TestModel")]
+    public record TestModel(
+        [property: Id(0)] int Value);
+
+    private sealed class BlockingStreamMessageQueries(
+        AdoNetStreamMessage message,
+        TaskCompletionSource dequeueStarted,
+        TaskCompletionSource continueDequeue) : IStreamMessageQueries
+    {
+        public IList<AdoNetStreamConfirmation> Released { get; private set; } = [];
+
+        public async Task<IList<AdoNetStreamMessage>> GetStreamMessagesAsync(
+            string serviceId,
+            string providerId,
+            string queueId,
+            int maxCount,
+            int maxAttempts,
+            int visibilityTimeout,
+            int removalTimeout,
+            int evictionInterval,
+            int evictionBatchSize)
+        {
+            dequeueStarted.SetResult();
+            await continueDequeue.Task;
+            return [message];
+        }
+
+        public Task<IList<AdoNetStreamConfirmationAck>> ConfirmStreamMessagesAsync(
+            string serviceId,
+            string providerId,
+            string queueId,
+            IList<AdoNetStreamConfirmation> messages) =>
+            throw new NotSupportedException();
+
+        public Task<IList<AdoNetStreamConfirmationAck>> ReleaseStreamMessagesAsync(
+            string serviceId,
+            string providerId,
+            string queueId,
+            IList<AdoNetStreamConfirmation> messages)
+        {
+            Released = messages.ToList();
+            return Task.FromResult<IList<AdoNetStreamConfirmationAck>>(
+                [new(serviceId, providerId, queueId, message.MessageId)]);
+        }
+    }
+}
+
+/// <summary>
 /// Tests for <see cref="AdoNetQueueAdapterReceiverTests"/> against SQL Server.
 /// </summary>
 [TestCategory("SqlServer"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
@@ -188,41 +285,40 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
     /// <summary>
     /// Tests that <see cref="AdoNetQueueAdapterReceiver.Shutdown(TimeSpan)"/> waits for the outstanding task.
     /// </summary>
-    /// <returns></returns>
     [SkippableFact]
     public async Task AdoNetQueueAdapterReceiver_Shutdown_WaitsForOutstandingTask()
     {
-        // arrange - receiver
-        var serviceId = "MyServiceId";
-        var clusterOptions = new ClusterOptions
-        {
-            ServiceId = serviceId
-        };
-        var providerId = "MyProviderId";
-        var queueId = "MyQueueId";
+        var serviceId = $"Service-{Guid.NewGuid()}";
+        var providerId = $"Provider-{Guid.NewGuid()}";
+        var queueId = $"Queue-{Guid.NewGuid()}";
+        var clusterOptions = new ClusterOptions { ServiceId = serviceId };
         var streamOptions = new AdoNetStreamOptions
         {
             Invariant = invariant,
-            ConnectionString = _storage.ConnectionString
+            ConnectionString = _storage.ConnectionString,
+            VisibilityTimeout = TimeSpan.FromMinutes(5),
+            EvictionBatchSize = 0
         };
         var cacheOptions = new SimpleQueueCacheOptions();
         var serializer = _fixture.Serializer.GetSerializer<AdoNetBatchContainer>();
         var logger = NullLogger<AdoNetQueueAdapterReceiver>.Instance;
         var receiver = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, _queries, serializer, logger);
-        await receiver.Initialize(TimeSpan.FromSeconds(10));
-
-        // arrange - enqueue a message
         var payload = serializer.SerializeToArray(new AdoNetBatchContainer(StreamId.Create("MyNamespace", "MyKey"), [new TestModel(1)], null!));
-        await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, 100);
+        var ack = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, 100);
 
-        // act - start getting messages from the receiver
-        var getTask = receiver.GetQueueMessagesAsync(10);
-
-        // act - shutdown the receiver
+        var getTask = receiver.GetQueueMessagesAsync(1);
         await receiver.Shutdown(TimeSpan.FromSeconds(10));
 
-        // assert - the outstanding task completes before the shutdown task
         Assert.True(getTask.IsCompleted);
+        var first = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await getTask));
+        Assert.Equal(1, first.Dequeued);
+
+        var replacement = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, _queries, serializer, logger);
+        var redelivered = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await replacement.GetQueueMessagesAsync(1)));
+        Assert.Equal(ack.MessageId, redelivered.SequenceToken.SequenceNumber);
+        Assert.Equal(2, redelivered.Dequeued);
+        await replacement.MessagesDeliveredAsync([redelivered]);
+        await replacement.Shutdown(TimeSpan.FromSeconds(10));
     }
 
     public Task DisposeAsync() => Task.CompletedTask;

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -620,6 +620,43 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
     }
 
     /// <summary>
+    /// Tests that a message can be released for immediate redelivery using its dequeue receipt.
+    /// </summary>
+    [SkippableFact]
+    public async Task RelationalOrleansQueries_ReleasesMessageUsingDequeueReceipt()
+    {
+        var serviceId = $"Service-{Guid.NewGuid()}";
+        var providerId = $"Provider-{Guid.NewGuid()}";
+        var queueId = $"Queue-{Guid.NewGuid()}";
+        var payload = RandomPayload();
+        var expiryTimeout = 100;
+        var maxCount = 1;
+        var maxAttempts = 5;
+        var visibilityTimeout = 100;
+        var removalTimeout = 100;
+        var evictionInterval = 100;
+        var evictionBatchSize = 0;
+
+        var ack = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout);
+        var first = Assert.Single(await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize));
+        var firstReceipt = new AdoNetStreamConfirmation(first.MessageId, first.Dequeued);
+
+        var released = Assert.Single(await _queries.ReleaseStreamMessagesAsync(serviceId, providerId, queueId, [firstReceipt]));
+        Assert.Equal(ack.MessageId, released.MessageId);
+
+        var second = Assert.Single(await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize));
+        Assert.Equal(first.Dequeued + 1, second.Dequeued);
+
+        Assert.Empty(await _queries.ReleaseStreamMessagesAsync(serviceId, providerId, queueId, [firstReceipt]));
+        Assert.Empty(await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize));
+
+        var secondReceipt = new AdoNetStreamConfirmation(second.MessageId, second.Dequeued);
+        Assert.Single(await _queries.ReleaseStreamMessagesAsync(serviceId, providerId, queueId, [secondReceipt]));
+        var third = Assert.Single(await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize));
+        await _queries.ConfirmStreamMessagesAsync(serviceId, providerId, queueId, [new AdoNetStreamConfirmation(third.MessageId, third.Dequeued)]);
+    }
+
+    /// <summary>
     /// Tests that a single message is not dequeued again after expiry
     /// </summary>
     [SkippableFact]

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -60,10 +60,15 @@ namespace UnitTests.StreamingTests
 
             Assert.True(await readTask, "ReadFromQueue should return true indicating data was read");
 
+            Assert.False(await testAccessor.ReadFromQueue(queueId, receiver, 1));
+            await receiver.Received(1).GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
             // Completing registration should resolve the tracked task and clear it.
             registration.SetResult(new HashSet<PubSubSubscriptionState>());
             await registrationTask;
+            Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 1));
             Assert.Null(streamData.RegistrationTask);
+            await receiver.Received(2).GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
         }
 
         [TestSuite("BVT")]
@@ -104,6 +109,46 @@ namespace UnitTests.StreamingTests
             }
 
             Assert.True(streamData.StreamRegistered);
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task ReadFromQueue_PreservesColdStreamStartTokenForLateSubscriber()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var firstToken = new EventSequenceTokenV2(1);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>(
+                [
+                    new GeneratedBatchContainer(streamId, 1, firstToken),
+                ]));
+
+            var agent = CreateAgent(pubSub, queueId);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+
+            Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 1));
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            Assert.Equal(firstToken, streamData.PendingStartToken);
+
+            var consumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                qualifiedStreamId,
+                new RecordingConsumer(),
+                filterData: null,
+                now: DateTime.UtcNow);
+
+            Assert.Equal(firstToken, consumerData.PendingStartToken);
         }
 
         [TestSuite("BVT")]

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -115,46 +115,6 @@ namespace UnitTests.StreamingTests
         [TestProvider("None")]
         [TestArea("Streaming")]
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task ReadFromQueue_PreservesColdStreamStartTokenForLateSubscriber()
-        {
-            var pubSub = Substitute.For<IStreamPubSub>();
-            pubSub.RegisterProducer(default, default)
-                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
-
-            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
-            var streamId = StreamId.Create("namespace", Guid.NewGuid());
-            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
-            var firstToken = new EventSequenceTokenV2(1);
-            var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult<IList<IBatchContainer>>(
-                [
-                    new GeneratedBatchContainer(streamId, 1, firstToken),
-                ]));
-
-            var agent = CreateAgent(pubSub, queueId);
-            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
-            await InitializeAgent(agent);
-
-            Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 1));
-
-            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
-            Assert.Equal(firstToken, streamData.PendingStartToken);
-
-            var consumerData = streamData.AddConsumer(
-                GuidId.GetGuidId(Guid.NewGuid()),
-                qualifiedStreamId,
-                new RecordingConsumer(),
-                filterData: null,
-                now: DateTime.UtcNow);
-
-            Assert.Equal(firstToken, consumerData.PendingStartToken);
-        }
-
-        [TestSuite("BVT")]
-        [TestProvider("None")]
-        [TestArea("Streaming")]
-        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task ReadFromQueue_DoesNotStartQueueReadAfterShutdownStarts()
         {
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
@@ -178,13 +178,25 @@ public sealed class StreamingDiagnosticObserver : IDisposable
     /// </remarks>
     public async Task WaitForItemDeliveryCountAsync(StreamId streamId, int expectedCount, string? streamProvider, CancellationToken cancellationToken)
     {
-        await _events
-            .OfType<StreamingEvents.ItemDelivered>()
-            .Where(e => MatchesStream(e.StreamId, e.StreamProvider, streamId, streamProvider))
-            .Take(expectedCount)
-            .LastOrDefaultAsync()
-            .ToTask(cancellationToken)
-            .ConfigureAwait(false);
+        var actualCount = 0;
+        try
+        {
+            await _events
+                .OfType<StreamingEvents.ItemDelivered>()
+                .Where(e => MatchesStream(e.StreamId, e.StreamProvider, streamId, streamProvider))
+                .Do(_ => actualCount++)
+                .Take(expectedCount)
+                .LastOrDefaultAsync()
+                .ToTask(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(
+                $"Canceled while waiting for {expectedCount} item deliveries on stream {streamId} from provider '{streamProvider ?? "<any>"}'; observed {actualCount}.",
+                exception,
+                cancellationToken);
+        }
     }
 
     /// <summary>
@@ -192,13 +204,25 @@ public sealed class StreamingDiagnosticObserver : IDisposable
     /// </summary>
     public async Task WaitForItemDeliveryCountAsync(StreamId streamId, Guid subscriptionId, int expectedCount, string? streamProvider, CancellationToken cancellationToken)
     {
-        await _events
-            .OfType<StreamingEvents.ItemDelivered>()
-            .Where(e => MatchesSubscription(e.StreamId, e.SubscriptionId, e.StreamProvider, streamId, subscriptionId, streamProvider))
-            .Take(expectedCount)
-            .LastOrDefaultAsync()
-            .ToTask(cancellationToken)
-            .ConfigureAwait(false);
+        var actualCount = 0;
+        try
+        {
+            await _events
+                .OfType<StreamingEvents.ItemDelivered>()
+                .Where(e => MatchesSubscription(e.StreamId, e.SubscriptionId, e.StreamProvider, streamId, subscriptionId, streamProvider))
+                .Do(_ => actualCount++)
+                .Take(expectedCount)
+                .LastOrDefaultAsync()
+                .ToTask(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(
+                $"Canceled while waiting for {expectedCount} item deliveries on stream {streamId}, subscription {subscriptionId}, from provider '{streamProvider ?? "<any>"}'; observed {actualCount}.",
+                exception,
+                cancellationToken);
+        }
     }
 
     /// <summary>

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
@@ -184,7 +184,7 @@ public sealed class StreamingDiagnosticObserver : IDisposable
             await _events
                 .OfType<StreamingEvents.ItemDelivered>()
                 .Where(e => MatchesStream(e.StreamId, e.StreamProvider, streamId, streamProvider))
-                .Do(_ => actualCount++)
+                .Do(_ => Interlocked.Increment(ref actualCount))
                 .Take(expectedCount)
                 .LastOrDefaultAsync()
                 .ToTask(cancellationToken)
@@ -193,7 +193,7 @@ public sealed class StreamingDiagnosticObserver : IDisposable
         catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {
             throw new OperationCanceledException(
-                $"Canceled while waiting for {expectedCount} item deliveries on stream {streamId} from provider '{streamProvider ?? "<any>"}'; observed {actualCount}.",
+                $"Canceled while waiting for {expectedCount} item deliveries on stream {streamId} from provider '{streamProvider ?? "<any>"}'; observed {Volatile.Read(ref actualCount)}.",
                 exception,
                 cancellationToken);
         }
@@ -210,7 +210,7 @@ public sealed class StreamingDiagnosticObserver : IDisposable
             await _events
                 .OfType<StreamingEvents.ItemDelivered>()
                 .Where(e => MatchesSubscription(e.StreamId, e.SubscriptionId, e.StreamProvider, streamId, subscriptionId, streamProvider))
-                .Do(_ => actualCount++)
+                .Do(_ => Interlocked.Increment(ref actualCount))
                 .Take(expectedCount)
                 .LastOrDefaultAsync()
                 .ToTask(cancellationToken)
@@ -219,7 +219,7 @@ public sealed class StreamingDiagnosticObserver : IDisposable
         catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {
             throw new OperationCanceledException(
-                $"Canceled while waiting for {expectedCount} item deliveries on stream {streamId}, subscription {subscriptionId}, from provider '{streamProvider ?? "<any>"}'; observed {actualCount}.",
+                $"Canceled while waiting for {expectedCount} item deliveries on stream {streamId}, subscription {subscriptionId}, from provider '{streamProvider ?? "<any>"}'; observed {Volatile.Read(ref actualCount)}.",
                 exception,
                 cancellationToken);
         }


### PR DESCRIPTION
Fixes #10458.

ADO.NET stream rows dequeued by a pulling agent remain invisible until the visibility timeout if that agent relinquishes queue ownership before confirming them. A successor can therefore register a cold stream from a later row and miss the stream's first item within the test timeout. Sorting dequeue results in #10536 fixed within-poll ordering, but it could not recover rows still hidden by the previous owner.

This change tracks each receiver's unconfirmed dequeue receipts and releases those rows during shutdown so the successor can redeliver them immediately. Release operations match both message ID and dequeue receipt, preventing a stale receiver from changing a row already claimed by a new owner. The existing confirmation query contract carries the release marker, preserving startup compatibility with older database schemas.

The pulling agent now also prevents a later queue read from overtaking in-flight cold-stream registration and keeps the first cached batch pinned until subscriber cursors attach. This closes the related race where producer registration and subscriber notification cross, causing the cursor to begin at item 2 even though item 1 was successfully enqueued. Pins are disposed when subscriptions attach, streams are removed, or cache pressure requires progress.

The follow-up repair restores the concrete `RelationalOrleansQueries` receiver constructor expected by `ActivatorUtilities`, while retaining the injectable query abstraction used by deterministic lifecycle tests.

Cross-provider regressions cover immediate release and stale-receipt safety for SQL Server, PostgreSQL, and MySQL. Streaming timeout failures report the stream, provider, expected item count, and observed item count.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10574)