### PR TITLE
docs: document explicit grain deactivation and idle collection

### DIFF
--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -70,7 +70,7 @@ To explicitly request deactivation of a grain from outside it, cast its referenc
 
 This is a request, not a wait-for-deactivation call. The method returns immediately after scheduling deactivation for the current activation of that grain identity; queued calls are forwarded to a new or existing activation. If there is no current activation, the next call can reactivate the grain.
 
-For tests which use <xref:Orleans.TestingHost.TestCluster> or <xref:Orleans.TestingHost.InProcessTestCluster>, use <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> or <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*> instead. These helpers request deactivation through the same mechanism and wait for actual deactivation to finish.
+For tests that need a deterministic shutdown check, use <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> or <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*>. These helpers are convenience wrappers around the external management request: they trigger the same deactivation request and then wait until the current activation has actually finished deactivating. That wait makes them useful in tests that need to assert the activation is fully gone before continuing.
 
 The <xref:Orleans.Grain.DeactivateOnIdle*> method is also available inside grain code when the grain itself decides that its current activation should end:
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -64,18 +64,18 @@ For example, assume a 10-minute collection age and ignore scan latency:
 
 ## How to deactivate a specific grain identity
 
-For internal or test code that needs to target a specific grain identity from outside the grain, cast the reference to <xref:Orleans.Core.Internal.IGrainManagementExtension> and call <xref:Orleans.Core.Internal.IGrainManagementExtension.DeactivateOnIdle*>:
+Code that needs to target a specific grain identity from outside the grain can cast the reference to the public <xref:Orleans.Core.Internal.IGrainManagementExtension> extension and call <xref:Orleans.Core.Internal.IGrainManagementExtension.DeactivateOnIdle*>:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="deactivate_grain_externally":::
 
 This is a request, not a wait-for-deactivation call. The method returns immediately after requesting deactivation for that grain identity; queued calls are forwarded to a new or existing activation. If there is no current activation, a later call can reactivate the grain.
 
-The test-host helpers are convenience APIs for test assertions:
+The test-host helpers are convenience APIs for tests:
 
-- <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> sends the external management-extension request and then waits for the server to finish deactivating the current activation.
+- <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> uses the public management extension and then waits for the server to finish deactivating the current activation.
 - <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*> directly deactivates the current grain context and waits for that deactivation to complete.
 
-These helpers are useful because they make deactivation deterministic in tests, but they are not a separate public runtime feature.
+These helpers are valuable because they make deactivation deterministic in tests, but they are not a different runtime capability.
 
 The <xref:Orleans.Grain.DeactivateOnIdle*> method is also available inside grain code when the grain itself decides that its current activation should end:
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -29,13 +29,11 @@ Prefer type-specific changes over a cluster-wide increase. Longer ages trade mem
 
 ### Expedite activation collection
 
-Call <xref:Orleans.Grain.DeactivateOnIdle*> when the current activation should deactivate after its current turn:
+Call <xref:Orleans.Grain.DeactivateOnIdle*> when the current activation should request deactivation after its current turn:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="deactivate_on_idle":::
 
-This API applies to the current activation only. You can't call it from outside the grain to deactivate an arbitrary grain ID.
-
-Queued calls are forwarded to a new or existing activation.
+This instance method is only called from inside the grain implementation. It requests deactivation; it does not wait for the activation to stop. Queued calls are forwarded to a new or existing activation.
 
 ### Delay activation collection
 
@@ -70,9 +68,9 @@ To explicitly request deactivation of a grain from outside it, cast its referenc
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="deactivate_grain_externally":::
 
-The management extension targets the current activation for that grain identity and requests deactivation once the current turn and queued work complete. The same grain reference is still valid: a later call can activate the grain again on any compatible silo.
+This is a request, not a wait-for-deactivation call. The method returns immediately after scheduling deactivation for the current activation of that grain identity; queued calls are forwarded to a new or existing activation. If there is no current activation, the next call can reactivate the grain.
 
-For tests which use <xref:Orleans.TestingHost.TestCluster> or <xref:Orleans.TestingHost.InProcessTestCluster>, use <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> or <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*> instead. These helpers request deactivation through the same mechanism and wait for it to complete.
+For tests which use <xref:Orleans.TestingHost.TestCluster> or <xref:Orleans.TestingHost.InProcessTestCluster>, use <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> or <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*> instead. These helpers request deactivation through the same mechanism and wait for actual deactivation to finish.
 
 The <xref:Orleans.Grain.DeactivateOnIdle*> method is also available inside grain code when the grain itself decides that its current activation should end:
 
@@ -84,7 +82,7 @@ Use explicit deactivation only when there is a domain or operational reason to e
 
 An activation is idle when it hasn't processed inbound work during the configured idle window. Inbound grain calls, reminders, and stream events reset idleness. Outbound calls and arbitrary local work don't. Timer callbacks reset idleness only when the timer is created with <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive>.
 
-`DeactivateOnIdle` requests deactivation after the current turn and currently queued work complete. A later call to the same grain identity can reactivate it on any compatible silo.
+`DeactivateOnIdle` requests deactivation after the current turn; queued calls are forwarded to a new or existing activation. A later call to the same grain identity can reactivate it on any compatible silo.
 
 ### Cautions
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -33,6 +33,8 @@ Call <xref:Orleans.Grain.DeactivateOnIdle*> when the current activation should d
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="deactivate_on_idle":::
 
+This API applies to the current activation only. You can't call it from outside the grain to deactivate an arbitrary grain ID.
+
 Queued calls are forwarded to a new or existing activation.
 
 ### Delay activation collection
@@ -61,6 +63,26 @@ For example, assume a 10-minute collection age and ignore scan latency:
 | Call `DelayDeactivation` with 5 minutes at minute 0, then receive an ordinary grain call at minute 7. | No earlier than minute 17, after the new 10-minute idle period. |
 
 <xref:Orleans.Grain.DeactivateOnIdle*> takes priority over a delay. Delaying deactivation is an optimization, not a durability or placement guarantee. It doesn't pin an activation to a silo, and failures, shutdown, migration, explicit deactivation, and memory pressure can still remove the activation.
+
+## How to deactivate a specific grain identity
+
+Orleans intentionally doesn't expose a "deactivate by grain ID" management API. To explicitly deactivate one logical grain, expose an application method on that grain and call <xref:Orleans.Grain.DeactivateOnIdle*> from inside the grain.
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="explicit_deactivate_grain":::
+
+Use this pattern only when the grain has a domain reason to end its current activation (for example, after completing a one-off workflow or releasing costly in-memory resources). Don't use it for ordinary lifecycle management; idle collection is the default and preferred behavior.
+
+### What "idle" means for collection
+
+An activation is idle when it hasn't processed inbound work during the configured idle window. Inbound grain calls, reminders, and stream events reset idleness. Outbound calls and arbitrary local work don't. Timer callbacks reset idleness only when the timer is created with <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive>.
+
+`DeactivateOnIdle` requests deactivation after the current turn and currently queued work complete. A later call to the same grain identity can reactivate it on any compatible silo.
+
+### Cautions
+
+- Treat deactivation as best effort cleanup. It can be skipped by abrupt process termination and some failure paths.
+- Persist important state as part of normal operations, not only in <xref:Orleans.Grain.OnDeactivateAsync*>.
+- Don't use explicit deactivation as a substitute for memory-pressure tuning. Use collection settings and scaling based on measurements.
 
 ### Keep alive
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -66,11 +66,19 @@ For example, assume a 10-minute collection age and ignore scan latency:
 
 ## How to deactivate a specific grain identity
 
-Orleans intentionally doesn't expose a "deactivate by grain ID" management API. To explicitly deactivate one logical grain, expose an application method on that grain and call <xref:Orleans.Grain.DeactivateOnIdle*> from inside the grain.
+To explicitly request deactivation of a grain from outside it, cast its reference to <xref:Orleans.Core.Internal.IGrainManagementExtension> and call <xref:Orleans.Core.Internal.IGrainManagementExtension.DeactivateOnIdle*>:
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="deactivate_grain_externally":::
+
+The management extension targets the current activation for that grain identity and requests deactivation once the current turn and queued work complete. The same grain reference is still valid: a later call can activate the grain again on any compatible silo.
+
+For tests which use <xref:Orleans.TestingHost.TestCluster> or <xref:Orleans.TestingHost.InProcessTestCluster>, use <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> or <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*> instead. These helpers request deactivation through the same mechanism and wait for it to complete.
+
+The <xref:Orleans.Grain.DeactivateOnIdle*> method is also available inside grain code when the grain itself decides that its current activation should end:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="explicit_deactivate_grain":::
 
-Use this pattern only when the grain has a domain reason to end its current activation (for example, after completing a one-off workflow or releasing costly in-memory resources). Don't use it for ordinary lifecycle management; idle collection is the default and preferred behavior.
+Use explicit deactivation only when there is a domain or operational reason to end an activation (for example, after completing a one-off workflow or releasing costly in-memory resources). Don't use it for ordinary lifecycle management; idle collection is the default and preferred behavior.
 
 ### What "idle" means for collection
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -62,7 +62,7 @@ For example, assume a 10-minute collection age and ignore scan latency:
 
 <xref:Orleans.Grain.DeactivateOnIdle*> takes priority over a delay. Delaying deactivation is an optimization, not a durability or placement guarantee. It doesn't pin an activation to a silo, and failures, shutdown, migration, explicit deactivation, and memory pressure can still remove the activation.
 
-## How to deactivate a specific grain identity
+### How to deactivate a specific grain identity
 
 Code that needs to target a specific grain identity from outside the grain can cast the reference to the public <xref:Orleans.Core.Internal.IGrainManagementExtension> extension and call <xref:Orleans.Core.Internal.IGrainManagementExtension.DeactivateOnIdle*>:
 
@@ -87,7 +87,7 @@ Use explicit deactivation only when there is a domain or operational reason to e
 
 An activation is idle when it hasn't processed inbound work during the configured idle window. Inbound grain calls, reminders, and stream events reset idleness. Outbound calls and arbitrary local work don't. Timer callbacks reset idleness only when the timer is created with <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive>.
 
-`DeactivateOnIdle` requests deactivation after the current turn; queued calls are forwarded to a new or existing activation. A later call to the same grain identity can reactivate it on any compatible silo.
+`DeactivateOnIdle` requests deactivation when the current turn ends; queued calls are forwarded to a new or existing activation. A later call to the same grain identity can reactivate it on any compatible silo.
 
 ### Cautions
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -64,13 +64,18 @@ For example, assume a 10-minute collection age and ignore scan latency:
 
 ## How to deactivate a specific grain identity
 
-To explicitly request deactivation of a grain from outside it, cast its reference to <xref:Orleans.Core.Internal.IGrainManagementExtension> and call <xref:Orleans.Core.Internal.IGrainManagementExtension.DeactivateOnIdle*>:
+For internal or test code that needs to target a specific grain identity from outside the grain, cast the reference to <xref:Orleans.Core.Internal.IGrainManagementExtension> and call <xref:Orleans.Core.Internal.IGrainManagementExtension.DeactivateOnIdle*>:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="deactivate_grain_externally":::
 
-This is a request, not a wait-for-deactivation call. The method returns immediately after scheduling deactivation for the current activation of that grain identity; queued calls are forwarded to a new or existing activation. If there is no current activation, the next call can reactivate the grain.
+This is a request, not a wait-for-deactivation call. The method returns immediately after requesting deactivation for that grain identity; queued calls are forwarded to a new or existing activation. If there is no current activation, a later call can reactivate the grain.
 
-For tests that need a deterministic shutdown check, use <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> or <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*>. These helpers are convenience wrappers around the external management request: they trigger the same deactivation request and then wait until the current activation has actually finished deactivating. That wait makes them useful in tests that need to assert the activation is fully gone before continuing.
+The test-host helpers are convenience APIs for test assertions:
+
+- <xref:Orleans.TestingHost.TestCluster.DeactivateAsync*> sends the external management-extension request and then waits for the server to finish deactivating the current activation.
+- <xref:Orleans.TestingHost.InProcessTestCluster.DeactivateAsync*> directly deactivates the current grain context and waits for that deactivation to complete.
+
+These helpers are useful because they make deactivation deterministic in tests, but they are not a separate public runtime feature.
 
 The <xref:Orleans.Grain.DeactivateOnIdle*> method is also available inside grain code when the grain itself decides that its current activation should end:
 

--- a/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
@@ -526,7 +526,7 @@ public interface IUserSessionGrain : IGrainWithStringKey
 // <deactivate_grain_externally>
 public static class GrainDeactivation
 {
-    public static ValueTask DeactivateAsync(
+    public static ValueTask RequestDeactivationAsync(
         IUserSessionGrain grain)
     {
         return grain.Cast<IGrainManagementExtension>().DeactivateOnIdle();

--- a/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
+using Orleans.Core.Internal;
 using Orleans.GrainDirectory;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -521,6 +522,17 @@ public interface IUserSessionGrain : IGrainWithStringKey
 {
     Task ExpireAsync();
 }
+
+// <deactivate_grain_externally>
+public static class GrainDeactivation
+{
+    public static ValueTask DeactivateAsync(
+        IUserSessionGrain grain)
+    {
+        return grain.Cast<IGrainManagementExtension>().DeactivateOnIdle();
+    }
+}
+// </deactivate_grain_externally>
 
 // <grain_directory_attribute>
 [GrainDirectory("durable-directory")]

--- a/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
@@ -517,6 +517,11 @@ public interface IShoppingCartGrain : IGrainWithStringKey
 {
 }
 
+public interface IUserSessionGrain : IGrainWithStringKey
+{
+    Task ExpireAsync();
+}
+
 // <grain_directory_attribute>
 [GrainDirectory("durable-directory")]
 public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
@@ -566,6 +571,18 @@ public sealed class ReferenceDataGrain : Grain
 {
 }
 // </keep_alive_grain>
+
+// <explicit_deactivate_grain>
+public sealed class UserSessionGrain : Grain, IUserSessionGrain
+{
+    public Task ExpireAsync()
+    {
+        // Ends this activation after the current turn completes.
+        this.DeactivateOnIdle();
+        return Task.CompletedTask;
+    }
+}
+// </explicit_deactivate_grain>
 
 // <validate_dependencies_task>
 public sealed class ValidateDependenciesTask : IStartupTask


### PR DESCRIPTION
## Problem
Issue #8579 asks how to explicitly deactivate or request deactivation for a grain identity and what Orleans means by idle activation collection.

## Solution
Updated the activation collection documentation to add a cookbook-style section for explicit grain deactivation. It now covers:

- the instance-level `DeactivateOnIdle` pattern inside a grain,
- the public `IGrainManagementExtension` request path for targeting a specific grain identity from outside the grain, and
- the distinction between requesting deactivation and waiting for actual deactivation to complete in test-host helpers.

It also clarifies what counts as “idle” activity for collection and adds cautions around best-effort deactivation and state persistence.

## Rationale
This keeps the guidance aligned with the current Orleans runtime behavior and makes the operational caveats explicit for callers and tests.

Fixes #8579