### PR TITLE
docs: clarify observer vs stream guidance

### DIFF
--- a/docs/site/src/content/docs/grains/observers.md
+++ b/docs/site/src/content/docs/grains/observers.md
@@ -13,9 +13,9 @@ Use observers for a small set of known, live callbacks. They are intentionally t
 
 ## When to choose observers versus streams
 
-Use a grain observer when the callback target is a specific connected client object or grain and the application only needs a live notification while that connection remains active. Observers carry very little infrastructure: a local object reference is registered, and the grain notifies that reference directly.
+Use a grain observer when the callback target is a specific connected client object or grain and the application only needs a live notification while that connection remains active. Observers carry very little infrastructure: a callback target is registered, and the grain notifies that target directly.
 
-Use an Orleans stream when the application needs multicast delivery, dynamic subscriptions, playback, provider-defined durability, or recovery after a client or grain restarts. A stream can outlive a single activation or connection, while an observer registration is tied to the callback object and must be re-established after reconnect.
+Use an Orleans stream when the application needs multicast delivery, dynamic subscriptions, playback, provider-defined durability, or recovery after a client or grain restarts. A stream can outlive a single activation or connection, while an observer registration is tied to the callback target and must be re-established after reconnect.
 
 The tradeoff is mostly about lifetime and delivery guarantees:
 

--- a/docs/site/src/content/docs/grains/observers.md
+++ b/docs/site/src/content/docs/grains/observers.md
@@ -9,7 +9,20 @@ ms.topic: concept-article
 
 Observers let grains call an object hosted by an Orleans client or another grain. They are useful for live, best-effort notifications while the receiver is connected.
 
-Observers aren't durable subscriptions. A client can disconnect without notice, and a recreated observer has a different identity. Use [Orleans streams](../streaming/index.md) or another durable messaging mechanism when subscriptions or delivery must survive failures.
+Use observers for a small set of known, live callbacks. They are intentionally transient and are not a general replacement for a durable event bus. A client can disconnect without notice, and a recreated observer has a different identity. Use [Orleans streams](../streaming/index.md) or another durable messaging mechanism when subscriptions or delivery must survive failures or fan out to many independent consumers.
+
+## When to choose observers versus streams
+
+Use a grain observer when the callback target is a specific connected client object or grain and the application only needs a live notification while that connection remains active. Observers carry very little infrastructure: a local object reference is registered, and the grain notifies that reference directly.
+
+Use an Orleans stream when the application needs multicast delivery, dynamic subscriptions, playback, provider-defined durability, or recovery after a client or grain restarts. A stream can outlive a single activation or connection, while an observer registration is tied to the callback object and must be re-established after reconnect.
+
+The tradeoff is mostly about lifetime and delivery guarantees:
+
+- Observers are low-overhead, direct callbacks. They are best for ephemeral status or UI updates, but they are not durable, replayable, or automatically recovered after disconnects.
+- Streams are more operationally expensive because they depend on a configured provider, subscription records, and provider-specific delivery semantics. In return, they support independent subscribers, retained events, and more flexible failure recovery.
+
+See [Choose an Orleans messaging abstraction](../streaming/streams-why.md) and [Orleans streaming APIs](../streaming/streams-programming-apis.md) for the broader decision guidance.
 
 ## Define an observer
 

--- a/docs/site/src/content/docs/grains/observers.md
+++ b/docs/site/src/content/docs/grains/observers.md
@@ -17,10 +17,10 @@ Use a grain observer when the callback target is a specific connected client obj
 
 Use an Orleans stream when the application needs multicast delivery, dynamic subscriptions, playback, provider-defined durability, or recovery after a client or grain restarts. A stream can outlive a single activation or connection, while an observer registration is tied to the callback target and must be re-established after reconnect.
 
-The tradeoff is mostly about lifetime and delivery guarantees:
+The tradeoff is mostly about lifetime and delivery semantics:
 
 - Observers are low-overhead, direct callbacks. They are best for ephemeral status or UI updates, but they are not durable, replayable, or automatically recovered after disconnects.
-- Streams are more operationally expensive because they depend on a configured provider, subscription records, and provider-specific delivery semantics. In return, they support independent subscribers, retained events, and more flexible failure recovery.
+- Streams add operational cost through their configured provider and provider-specific delivery semantics. Explicit subscriptions can also require durable subscription records. In return, streams support independent subscribers, retained events, and more flexible failure recovery.
 
 See [Choose an Orleans messaging abstraction](../streaming/streams-why.md) and [Orleans streaming APIs](../streaming/streams-programming-apis.md) for the broader decision guidance.
 

--- a/docs/site/src/content/docs/streaming/index.md
+++ b/docs/site/src/content/docs/streaming/index.md
@@ -13,7 +13,7 @@ Orleans streams are typed, logical, multicast channels. Producers and consumers 
 
 The stream is a virtual address. Its transport, retention, retry behavior, ordering, and ability to replay are supplied by the configured [stream provider](stream-providers.md). A stream handle alone doesn't make data durable.
 
-Use streams when events should fan out to independently managed consumers, when subscriptions should outlive a grain activation, or when an external queue or event log should feed grains. For request/response calls, transient client callbacks, or low-overhead best-effort fan-out, another Orleans messaging abstraction can be a better fit. Start with [Choose an Orleans messaging abstraction](streams-why.md).
+Use streams when events should fan out to independently managed consumers, when subscriptions should outlive a grain activation, or when an external queue or event log should feed grains. For request/response calls, specific connected-client callbacks, or low-overhead best-effort fan-out, another Orleans messaging abstraction can be a better fit. See [grain observers](../grains/observers.md) for direct client callbacks and [Choose an Orleans messaging abstraction](streams-why.md) for the full decision model.
 
 ## Programming model
 

--- a/docs/site/src/content/docs/streaming/streams-why.md
+++ b/docs/site/src/content/docs/streaming/streams-why.md
@@ -25,7 +25,7 @@ Use **response streaming** when one call produces many results: the grain method
 
 ## Prefer observers for client callbacks
 
-Use a grain observer when a connected Orleans client wants transient callbacks and can re-register after reconnecting. See [Orleans observers](../grains/observers.md) for the supported lifecycle and registration model. Observers are not categorically redundant: they are a low-overhead direct-callback API for a small set of live client objects, while streams are the appropriate abstraction for multicast event flow and provider-managed delivery guarantees.
+Use a grain observer when a connected Orleans client wants transient callbacks and can re-register after reconnecting. See [Orleans observers](../grains/observers.md) for the supported lifecycle and registration model. Observers are not categorically redundant: they are a low-overhead direct-callback API for a small set of live client objects, while streams are the appropriate abstraction for multicast event flow and provider-specific delivery semantics.
 
 Choose streams instead when a producer needs to fan out to many independent subscribers, when delivery must survive client disconnects or grain reactivation, or when a provider offers replay, retention, or durable subscription state. Observer references are not durable subscriptions and are not a replacement for retained events or server-side pub/sub.
 

--- a/docs/site/src/content/docs/streaming/streams-why.md
+++ b/docs/site/src/content/docs/streaming/streams-why.md
@@ -25,7 +25,9 @@ Use **response streaming** when one call produces many results: the grain method
 
 ## Prefer observers for client callbacks
 
-Use a grain observer when a connected Orleans client wants transient callbacks and can re-register after reconnecting. Observer references aren't durable subscriptions. They aren't a replacement for retained events or server-side pub/sub.
+Use a grain observer when a connected Orleans client wants transient callbacks and can re-register after reconnecting. See [Orleans observers](../grains/observers.md) for the supported lifecycle and registration model. Observers are not categorically redundant: they are a low-overhead direct-callback API for a small set of live client objects, while streams are the appropriate abstraction for multicast event flow and provider-managed delivery guarantees.
+
+Choose streams instead when a producer needs to fan out to many independent subscribers, when delivery must survive client disconnects or grain reactivation, or when a provider offers replay, retention, or durable subscription state. Observer references are not durable subscriptions and are not a replacement for retained events or server-side pub/sub.
 
 ## Prefer streams for multicast event flow
 


### PR DESCRIPTION
Fixes #5132

This change clarifies when Orleans grain observers are the right fit versus when Orleans streams should be used. The docs now explain the lifetime, reliability, and resource tradeoffs directly, rather than treating observers as categorically redundant.

The observer page links to the streaming guidance, and the stream selection docs link back to the observer guidance so readers can move between the abstractions without confusion. This keeps the guidance aligned with the runtime behavior: observers are transient callback registrations, while streams are multicast event flows whose delivery semantics come from the configured provider.