### PR TITLE
docs(reminders): clarify reminder timing constraints

### DIFF
--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -65,7 +65,7 @@ The current Orleans runtime validates reminder timing when the reminder is regis
 - `period` must be greater than `TimeSpan.Zero`.
 - `period` cannot be negative, zero, or <xref:System.Threading.Timeout.InfiniteTimeSpan>.
 - The runtime also enforces a configured lower bound through <xref:Orleans.Hosting.ReminderOptions.MinimumReminderPeriod?displayProperty=nameWithType> (default: one minute).
-- There is no special reminder-specific "maximum" beyond the ordinary `DateTime` scheduling range. Values are limited by the runtime's scheduling range, and the scheduler clamps overflow to <xref:System.DateTime.MaxValue> when needed.
+- `dueTime` is also bounded by the remaining <xref:System.DateTime> range from the time of registration. A value which would place the first tick after <xref:System.DateTime.MaxValue> is rejected rather than clamped. Later occurrences are scheduled from the persisted start time and period.
 
 There is no special `period` value that means "fire once and never again." To model a one-shot reminder, create a valid reminder with a positive `period`, then unregister it in the first callback or after the first tick. `TimeSpan.Zero` and negative values are rejected by the runtime rather than treated as a one-shot schedule.
 

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -57,14 +57,13 @@ Reminders are intended for periods measured in minutes, hours, or days, not high
 
 ### Reminder timing constraints
 
-The current Orleans runtime validates reminder timing when the reminder is registered:
+Reminder timing is subject to the following constraints:
 
-- <xref:System.TimeSpan> values are validated before they are stored.
 - `dueTime` must be greater than or equal to `TimeSpan.Zero`; a zero `dueTime` means the first tick is scheduled immediately.
 - `dueTime` cannot be negative or <xref:System.Threading.Timeout.InfiniteTimeSpan>.
 - `period` must be greater than `TimeSpan.Zero`.
 - `period` cannot be negative, zero, or <xref:System.Threading.Timeout.InfiniteTimeSpan>.
-- The runtime also enforces a configured lower bound through <xref:Orleans.Hosting.ReminderOptions.MinimumReminderPeriod?displayProperty=nameWithType> (default: one minute).
+- The runtime rejects `period` values below the lower bound configured by <xref:Orleans.Hosting.ReminderOptions.MinimumReminderPeriod?displayProperty=nameWithType> (default: one minute).
 - `dueTime` is also bounded by the remaining <xref:System.DateTime> range from the time of registration. A value which would place the first tick after <xref:System.DateTime.MaxValue> is rejected rather than clamped. Later occurrences are scheduled from the persisted start time and period.
 
 There is no special `period` value that means "fire once and never again." To model a one-shot reminder, create a valid reminder with a positive `period`, then unregister it in the first callback or after the first tick. `TimeSpan.Zero` and negative values are rejected by the runtime rather than treated as a one-shot schedule.

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -1,7 +1,7 @@
 ---
 title: Grain timers and reminders
 description: Schedule activation-scoped and durable periodic work in Orleans.
-ms.date: 08/07/2026
+ms.date: 08/13/2026
 ms.topic: concept-article
 ---
 
@@ -54,6 +54,20 @@ Store the reminder name, not the <xref:Orleans.Runtime.IGrainReminder> handle, a
 Reminder definitions are durable, but individual tick messages aren't. If the cluster is unavailable at a scheduled time, that occurrence can be missed. The next scheduled tick still occurs. Reminder delivery follows normal grain request scheduling and can activate an inactive grain.
 
 Reminders are intended for periods measured in minutes, hours, or days, not high-frequency scheduling. A common pattern is for a reminder to wake a grain and create a finer-grained local timer.
+
+### Reminder timing constraints
+
+The current Orleans runtime validates reminder timing when the reminder is registered:
+
+- <xref:System.TimeSpan> values are validated before they are stored.
+- `dueTime` must be greater than or equal to `TimeSpan.Zero`; a zero `dueTime` means the first tick is scheduled immediately.
+- `dueTime` cannot be negative or <xref:System.Threading.Timeout.InfiniteTimeSpan>.
+- `period` must be greater than `TimeSpan.Zero`.
+- `period` cannot be negative, zero, or <xref:System.Threading.Timeout.InfiniteTimeSpan>.
+- The runtime also enforces a configured lower bound through <xref:Orleans.Hosting.ReminderOptions.MinimumReminderPeriod?displayProperty=nameWithType> (default: one minute).
+- There is no special reminder-specific "maximum" beyond the ordinary `DateTime` scheduling range. Values are limited by the runtime's scheduling range, and the scheduler clamps overflow to <xref:System.DateTime.MaxValue> when needed.
+
+There is no special `period` value that means "fire once and never again." To model a one-shot reminder, create a valid reminder with a positive `period`, then unregister it in the first callback or after the first tick. `TimeSpan.Zero` and negative values are rejected by the runtime rather than treated as a one-shot schedule.
 
 ## Configure reminder storage
 

--- a/src/Orleans.Reminders/GrainReminderExtensions.cs
+++ b/src/Orleans.Reminders/GrainReminderExtensions.cs
@@ -21,9 +21,12 @@ public static class GrainReminderExtensions
     /// </summary>
     /// <param name="grain">The grain instance.</param>
     /// <param name="reminderName">Name of this reminder</param>
-    /// <param name="dueTime">Due time for this reminder</param>
-    /// <param name="period">Frequency period for this reminder</param>
+    /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
+    /// <param name="period">Frequency period for this reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> values are rejected. The minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
     /// <returns>Promise for Reminder handle.</returns>
+    /// <remarks>
+    /// There is no special one-shot reminder value for <paramref name="period"/>. Register a valid positive period and then unregister the reminder when the first callback fires.
+    /// </remarks>
     public static Task<IGrainReminder> RegisterOrUpdateReminder(this Grain grain, string reminderName, TimeSpan dueTime, TimeSpan period)
         => RegisterOrUpdateReminder(grain is IRemindable, grain?.GrainContext, reminderName, dueTime, period);
 
@@ -36,9 +39,12 @@ public static class GrainReminderExtensions
     /// </summary>
     /// <param name="grain">The grain instance.</param>
     /// <param name="reminderName">Name of this reminder</param>
-    /// <param name="dueTime">Due time for this reminder</param>
-    /// <param name="period">Frequency period for this reminder</param>
+    /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
+    /// <param name="period">Frequency period for this reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> values are rejected. The minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
     /// <returns>Promise for Reminder handle.</returns>
+    /// <remarks>
+    /// There is no special one-shot reminder value for <paramref name="period"/>. Register a valid positive period and then unregister the reminder when the first callback fires.
+    /// </remarks>
     public static Task<IGrainReminder> RegisterOrUpdateReminder(this IGrainBase grain, string reminderName, TimeSpan dueTime, TimeSpan period)
         => RegisterOrUpdateReminder(grain is IRemindable, grain?.GrainContext, reminderName, dueTime, period);
 

--- a/src/Orleans.Reminders/GrainReminderExtensions.cs
+++ b/src/Orleans.Reminders/GrainReminderExtensions.cs
@@ -22,7 +22,7 @@ public static class GrainReminderExtensions
     /// <param name="grain">The grain instance.</param>
     /// <param name="reminderName">Name of this reminder</param>
     /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative, infinite, or values which exceed the remaining <see cref="DateTime"/> range are rejected.</param>
-    /// <param name="period">Frequency period for this reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> values are rejected. The minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
+    /// <param name="period">Frequency period for this reminder. The value must be at least <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>; smaller values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
     /// <returns>Promise for Reminder handle.</returns>
     /// <remarks>
     /// There is no special one-shot reminder value for <paramref name="period"/>. Register a valid positive period and then unregister the reminder when the first callback fires.
@@ -40,7 +40,7 @@ public static class GrainReminderExtensions
     /// <param name="grain">The grain instance.</param>
     /// <param name="reminderName">Name of this reminder</param>
     /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative, infinite, or values which exceed the remaining <see cref="DateTime"/> range are rejected.</param>
-    /// <param name="period">Frequency period for this reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> values are rejected. The minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
+    /// <param name="period">Frequency period for this reminder. The value must be at least <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>; smaller values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
     /// <returns>Promise for Reminder handle.</returns>
     /// <remarks>
     /// There is no special one-shot reminder value for <paramref name="period"/>. Register a valid positive period and then unregister the reminder when the first callback fires.

--- a/src/Orleans.Reminders/GrainReminderExtensions.cs
+++ b/src/Orleans.Reminders/GrainReminderExtensions.cs
@@ -21,7 +21,7 @@ public static class GrainReminderExtensions
     /// </summary>
     /// <param name="grain">The grain instance.</param>
     /// <param name="reminderName">Name of this reminder</param>
-    /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
+    /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative, infinite, or values which exceed the remaining <see cref="DateTime"/> range are rejected.</param>
     /// <param name="period">Frequency period for this reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> values are rejected. The minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
     /// <returns>Promise for Reminder handle.</returns>
     /// <remarks>
@@ -39,7 +39,7 @@ public static class GrainReminderExtensions
     /// </summary>
     /// <param name="grain">The grain instance.</param>
     /// <param name="reminderName">Name of this reminder</param>
-    /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
+    /// <param name="dueTime">Due time for this reminder. A value of <see cref="TimeSpan.Zero"/> schedules the first tick immediately; negative, infinite, or values which exceed the remaining <see cref="DateTime"/> range are rejected.</param>
     /// <param name="period">Frequency period for this reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> values are rejected. The minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
     /// <returns>Promise for Reminder handle.</returns>
     /// <remarks>

--- a/src/Orleans.Reminders/Timers/IReminderRegistry.cs
+++ b/src/Orleans.Reminders/Timers/IReminderRegistry.cs
@@ -17,7 +17,7 @@ namespace Orleans.Timers
         /// <param name="callingGrainId">The ID of the the currently executing grain</param>
         /// <param name="reminderName">The reminder name.</param>
         /// <param name="dueTime">The amount of time to delay before initially invoking the reminder. A value of <see cref="TimeSpan.Zero"/> means the first tick is scheduled immediately; negative, infinite, or values which exceed the remaining <see cref="DateTime"/> range are rejected.</param>
-        /// <param name="period">The time interval between invocations of the reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; values of zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected. The effective minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
+        /// <param name="period">The time interval between invocations of the reminder. The value must be at least <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>; smaller values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
         /// <returns>The reminder.</returns>
         /// <remarks>
         /// There is no special one-shot reminder value for <paramref name="period"/>. To schedule a single callback, register a valid positive period and unregister the reminder after the first callback fires.

--- a/src/Orleans.Reminders/Timers/IReminderRegistry.cs
+++ b/src/Orleans.Reminders/Timers/IReminderRegistry.cs
@@ -16,7 +16,7 @@ namespace Orleans.Timers
         /// </summary>
         /// <param name="callingGrainId">The ID of the the currently executing grain</param>
         /// <param name="reminderName">The reminder name.</param>
-        /// <param name="dueTime">The amount of time to delay before initially invoking the reminder. A value of <see cref="TimeSpan.Zero"/> means the first tick is scheduled immediately; negative values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
+        /// <param name="dueTime">The amount of time to delay before initially invoking the reminder. A value of <see cref="TimeSpan.Zero"/> means the first tick is scheduled immediately; negative, infinite, or values which exceed the remaining <see cref="DateTime"/> range are rejected.</param>
         /// <param name="period">The time interval between invocations of the reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; values of zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected. The effective minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
         /// <returns>The reminder.</returns>
         /// <remarks>

--- a/src/Orleans.Reminders/Timers/IReminderRegistry.cs
+++ b/src/Orleans.Reminders/Timers/IReminderRegistry.cs
@@ -16,9 +16,12 @@ namespace Orleans.Timers
         /// </summary>
         /// <param name="callingGrainId">The ID of the the currently executing grain</param>
         /// <param name="reminderName">The reminder name.</param>
-        /// <param name="dueTime">The amount of time to delay before initially invoking the reminder.</param>
-        /// <param name="period">The time interval between invocations of the reminder.</param>
+        /// <param name="dueTime">The amount of time to delay before initially invoking the reminder. A value of <see cref="TimeSpan.Zero"/> means the first tick is scheduled immediately; negative values and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected.</param>
+        /// <param name="period">The time interval between invocations of the reminder. The value must be greater than <see cref="TimeSpan.Zero"/>; values of zero, negative, and <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> are rejected. The effective minimum is also constrained by <see cref="Orleans.Hosting.ReminderOptions.MinimumReminderPeriod"/>.</param>
         /// <returns>The reminder.</returns>
+        /// <remarks>
+        /// There is no special one-shot reminder value for <paramref name="period"/>. To schedule a single callback, register a valid positive period and unregister the reminder after the first callback fires.
+        /// </remarks>
         Task<IGrainReminder> RegisterOrUpdateReminder(GrainId callingGrainId, string reminderName, TimeSpan dueTime, TimeSpan period);
 
         /// <summary>


### PR DESCRIPTION
Fixes #5052

The reminder docs did not reflect the runtime's actual validation rules. dueTime accepts zero to schedule immediately but rejects negative and infinite values, and period must be positive and not infinite. There is no special one-shot reminder period value; the correct pattern is to register a valid positive period and unregister the reminder after the first callback fires.

This change updates the grain reminder docs and API comments to describe the current behavior, including the configured minimum reminder period and the one-shot unregister pattern.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10580)