### PR TITLE
docs: clarify client lifetime and reconnect guidance

### DIFF
--- a/docs/site/src/content/docs/host/client.md
+++ b/docs/site/src/content/docs/host/client.md
@@ -54,7 +54,15 @@ You can replace the default with <xref:Orleans.Hosting.ClientBuilderExtensions.U
 - Honor the supplied cancellation token.
 - Let startup fail when the cluster or configuration is persistently unavailable.
 
-After startup, Orleans refreshes gateways and reconnects as cluster membership changes. A transient failure can still surface from an individual grain call. The grain reference remains valid, but retry the operation only if the application can safely tolerate duplicate execution.
+### Client lifetime and registration
+
+For generic-host and ASP.NET Core applications, treat <xref:Orleans.IClusterClient> as a singleton for the lifetime of the application process. Register it once with <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> and resolve it from dependency injection instead of creating a second client per request, per controller, or in a static field.
+
+A web app or worker can safely share the same client across all requests and background services, because Orleans is designed for concurrent use from multiple threads. The client is thread-safe for reuse; protect only mutable application state that you share outside Orleans.
+
+Let the host own client startup and shutdown. The host starts the client during application startup and closes it during normal termination, so you should not dispose the dependency-injected singleton manually. If the cluster is unavailable during startup, the host fails fast rather than leaving the app in a partially started state.
+
+After startup, Orleans refreshes gateways and reconnects as cluster membership changes. If a gateway or silo becomes unavailable, the client tries to reconnect automatically and a transient failure can still surface from an individual grain call. The grain reference remains valid, but retry the operation only if the application can safely tolerate duplicate execution.
 
 ## Make calls to grains
 

--- a/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
@@ -11,7 +11,9 @@ An external client runs outside a silo process and reaches the cluster through s
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="external_client":::
 
-Client settings participate in the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve <xref:Orleans.IClusterClient> or <xref:Orleans.IGrainFactory> from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection); don't build a second client singleton manually.
+Client settings participate in the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve <xref:Orleans.IClusterClient> or <xref:Orleans.IGrainFactory> from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection); don't build a second client singleton manually or create a new client per request.
+
+For ASP.NET Core and other generic-host apps, keep a single client instance for the lifetime of the process. This is the same client you inject into controllers, background workers, hosted services, and other long-lived components. The host owns startup and shutdown; do not dispose the dependency-injected singleton or replace it with a static cache.
 
 ## Orleans clustering information
 

--- a/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
@@ -11,7 +11,7 @@ An external client runs outside a silo process and reaches the cluster through s
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="external_client":::
 
-Client settings participate in the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve <xref:Orleans.IClusterClient> or <xref:Orleans.IGrainFactory> from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection); don't build a second client singleton manually or create a new client per request.
+Client settings participate in the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). The host starts the Orleans client before later registered hosted services and stops it with the rest of the application. Resolve <xref:Orleans.IClusterClient> or <xref:Orleans.IGrainFactory> from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection); don't build a second client singleton manually or create a new client per request.
 
 For ASP.NET Core and other generic-host apps, keep a single client instance for the lifetime of the process. This is the same client you inject into controllers, background workers, hosted services, and other long-lived components. The host owns startup and shutdown; do not dispose the dependency-injected singleton or replace it with a static cache.
 


### PR DESCRIPTION
Fixes #3839

This update clarifies the recommended IClusterClient lifetime for generic-host and ASP.NET Core applications: register one client per application process, resolve it from dependency injection, and let the host own startup and shutdown instead of creating one per request or keeping a second static singleton.

It also documents the current reconnect behavior: Orleans refreshes gateway state and reconnects automatically as gateways or silos become unavailable, while transient grain-call failures can still surface and should only be retried when the operation is safe to repeat.

The guidance keeps the current Orleans hosting model explicit and avoids stale pre-3.x assumptions about client reuse and connectivity.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10581)