### PR TITLE
docs: update stale NGINX external link

### DIFF
--- a/docs/site/src/data/external-link-allowlist.json
+++ b/docs/site/src/data/external-link-allowlist.json
@@ -13,6 +13,7 @@
     "https://www.nuget.org/packages/Microsoft.Orleans.Persistence.Firestore": "The new Firestore persistence package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
     "https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Firestore": "The new Firestore reminders package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
     "https://www.nuget.org/packages/Microsoft.Orleans.Streaming.Kinesis": "The new Kinesis streaming package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://en.wikipedia.org/wiki/Kalman_filter": "Wikipedia serves this public article to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403."
+    "https://en.wikipedia.org/wiki/Kalman_filter": "Wikipedia serves this public article to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
+    "https://www.f5.com/company/blog/nginx/nginx-power-of-two-choices-load-balancing-algorithm": "The F5 site serves this canonical NGINX article to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403."
   }
 }

--- a/docs/site/src/data/external-link-allowlist.json
+++ b/docs/site/src/data/external-link-allowlist.json
@@ -12,8 +12,6 @@
     "https://www.nuget.org/packages/Microsoft.Orleans.Journaling.Redis": "The new Redis journaling package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
     "https://www.nuget.org/packages/Microsoft.Orleans.Persistence.Firestore": "The new Firestore persistence package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
     "https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Firestore": "The new Firestore reminders package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.Streaming.Kinesis": "The new Kinesis streaming package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://en.wikipedia.org/wiki/Kalman_filter": "Wikipedia serves this public article to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
-    "https://www.nginx.com/blog/nginx-power-of-two-choices-load-balancing-algorithm/": "The NGINX/F5 site redirects browsers but rejects the bounded automated HEAD/GET probe with HTTP 403."
+    "https://www.nuget.org/packages/Microsoft.Orleans.Streaming.Kinesis": "The new Kinesis streaming package is documented but not yet published; remove this entry and its unpublished API-package entry after publication."
   }
 }

--- a/docs/site/src/data/external-link-allowlist.json
+++ b/docs/site/src/data/external-link-allowlist.json
@@ -12,6 +12,7 @@
     "https://www.nuget.org/packages/Microsoft.Orleans.Journaling.Redis": "The new Redis journaling package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
     "https://www.nuget.org/packages/Microsoft.Orleans.Persistence.Firestore": "The new Firestore persistence package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
     "https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Firestore": "The new Firestore reminders package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.Streaming.Kinesis": "The new Kinesis streaming package is documented but not yet published; remove this entry and its unpublished API-package entry after publication."
+    "https://www.nuget.org/packages/Microsoft.Orleans.Streaming.Kinesis": "The new Kinesis streaming package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
+    "https://en.wikipedia.org/wiki/Kalman_filter": "Wikipedia serves this public article to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403."
   }
 }

--- a/src/Orleans.Core.Abstractions/Placement/ActivationCountBasedPlacement.cs
+++ b/src/Orleans.Core.Abstractions/Placement/ActivationCountBasedPlacement.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime
     /// but this value is configurable via <c>Orleans.Runtime.ActivationCountBasedPlacementOptions</c>.
     /// <br/>
     /// This algorithm is based on the thesis The Power of Two Choices in Randomized Load Balancing by Michael David Mitzenmacher <see href="https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf"/>,
-    /// and is also used by NGINX's Random with Two Choices load-balancing method <see href="https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/"/>.
+    /// and is also used in NGINX for distributed load balancing, as described in the article NGINX and the "Power of Two Choices" Load-Balancing Algorithm <see href="https://www.f5.com/company/blog/nginx/nginx-power-of-two-choices-load-balancing-algorithm"/>.
     /// <br/>
     /// This placement strategy is configured by adding the <see cref="Orleans.Placement.ActivationCountBasedPlacementAttribute"/> attribute to a grain.
     /// </remarks>

--- a/src/Orleans.Core.Abstractions/Placement/ActivationCountBasedPlacement.cs
+++ b/src/Orleans.Core.Abstractions/Placement/ActivationCountBasedPlacement.cs
@@ -15,7 +15,7 @@ namespace Orleans.Runtime
     /// but this value is configurable via <c>Orleans.Runtime.ActivationCountBasedPlacementOptions</c>.
     /// <br/>
     /// This algorithm is based on the thesis The Power of Two Choices in Randomized Load Balancing by Michael David Mitzenmacher <see href="https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf"/>,
-    /// and is also used in NGINX for distributed load balancing, as described in the article NGINX and the "Power of Two Choices" Load-Balancing Algorithm <see href="https://www.nginx.com/blog/nginx-power-of-two-choices-load-balancing-algorithm/"/>.
+    /// and is also used by NGINX's Random with Two Choices load-balancing method <see href="https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/"/>.
     /// <br/>
     /// This placement strategy is configured by adding the <see cref="Orleans.Placement.ActivationCountBasedPlacementAttribute"/> attribute to a grain.
     /// </remarks>

--- a/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
@@ -33,7 +33,8 @@ public readonly struct EnvironmentStatistics
     /// The system CPU usage.
     /// <br/>
     /// Applies Kalman filtering to smooth out short-term fluctuations.
-    /// See <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>.
+    /// See <see href="https://en.wikipedia.org/wiki/Kalman_filter"/>;
+    /// <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>
     /// </summary>
     /// <remarks>Ranges from 0.0-100.0.</remarks>
     [Id(0)]
@@ -43,7 +44,8 @@ public readonly struct EnvironmentStatistics
     /// The amount of managed memory currently consumed by the process.
     /// <br/>
     /// Applies Kalman filtering to smooth out short-term fluctuations.
-    /// See <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>.
+    /// See <see href="https://en.wikipedia.org/wiki/Kalman_filter"/>;
+    /// <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>
     /// </summary>
     /// <remarks>
     /// Includes fragmented memory, which is the unused memory between objects on the managed heaps.
@@ -55,7 +57,8 @@ public readonly struct EnvironmentStatistics
     /// The amount of memory currently available for allocations to the process.
     /// <br/>
     /// Applies Kalman filtering to smooth out short-term fluctuations.
-    /// See <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>.
+    /// See <see href="https://en.wikipedia.org/wiki/Kalman_filter"/>;
+    /// <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>
     /// </summary>
     /// <remarks>
     /// Includes the currently available memory of the process and the system.

--- a/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
@@ -33,8 +33,7 @@ public readonly struct EnvironmentStatistics
     /// The system CPU usage.
     /// <br/>
     /// Applies Kalman filtering to smooth out short-term fluctuations.
-    /// See <see href="https://en.wikipedia.org/wiki/Kalman_filter"/>;
-    /// <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>
+    /// See <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>.
     /// </summary>
     /// <remarks>Ranges from 0.0-100.0.</remarks>
     [Id(0)]
@@ -44,8 +43,7 @@ public readonly struct EnvironmentStatistics
     /// The amount of managed memory currently consumed by the process.
     /// <br/>
     /// Applies Kalman filtering to smooth out short-term fluctuations.
-    /// See <see href="https://en.wikipedia.org/wiki/Kalman_filter"/>;
-    /// <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>
+    /// See <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>.
     /// </summary>
     /// <remarks>
     /// Includes fragmented memory, which is the unused memory between objects on the managed heaps.
@@ -57,8 +55,7 @@ public readonly struct EnvironmentStatistics
     /// The amount of memory currently available for allocations to the process.
     /// <br/>
     /// Applies Kalman filtering to smooth out short-term fluctuations.
-    /// See <see href="https://en.wikipedia.org/wiki/Kalman_filter"/>;
-    /// <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>
+    /// See <see href="https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/"/>.
     /// </summary>
     /// <remarks>
     /// Includes the currently available memory of the process and the system.


### PR DESCRIPTION
## Problem
The external-link allowlist referenced a retired NGINX URL. The corresponding source API comment is absent from the checked-in documentation corpus but restored when CI generates API documentation, so removing the allowlist entry alone causes the generated-site link audit to probe the old URL and fail.

The Kalman filter Wikipedia URL reported in #10575 is also generated from source API comments and remains correct, so it is not stale.

## Solution
Update the source API comment to the canonical F5-hosted NGINX article and replace the old exact-URL allowlist entry with a reasoned entry for that canonical URL. Preserve the valid Kalman filter reference and its existing allowlist entry.

API data generation completed for all 63 packages, all 217 documentation tests pass, and full documentation validation passes with 578 external URLs probed. The Microsoft Learn 404s previously reported in #10558 did not reproduce against current main; this PR does not close or claim to fix #10558.

Fixes #10575