### PR TITLE
test(durable-jobs): synchronize receiver completion

### DIFF
--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -79,20 +79,20 @@ public class DurableJobReceiverExtensionTests
         handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(executionTask.Task);
 
-        var extension = CreateExtension(handler);
+        var extension = CreateExtension(handler, TimeSpan.FromMinutes(1));
         var firstNotification = CreateJobContext("run-1", jobId: "job-1", dequeueCount: 1);
         var secondNotification = CreateJobContext("run-2", jobId: "job-1", dequeueCount: 1);
 
-        var first = await extension.HandleDurableJobAsync(firstNotification, CancellationToken.None);
+        var first = extension.HandleDurableJobAsync(firstNotification, CancellationToken.None);
         var second = await extension.HandleDurableJobAsync(secondNotification, CancellationToken.None);
 
-        Assert.True(first.IsPending);
+        Assert.False(first.IsCompleted);
         Assert.True(second.IsPending);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
         executionTask.SetResult(true);
 
-        var completed = await WaitForTerminalResult(extension, firstNotification);
+        var completed = await first.AsTask().WaitAsync(TimeSpan.FromMinutes(1));
         Assert.Equal(DurableJobRunStatus.Completed, completed.Status);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
@@ -140,21 +140,5 @@ public class DurableJobReceiverExtensionTests
         });
 
         return context;
-    }
-
-    private static async Task<DurableJobRunResult> WaitForTerminalResult(DurableJobReceiverExtension extension, IJobRunContext context)
-    {
-        for (var i = 0; i < 10; i++)
-        {
-            var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
-            if (!result.IsPending)
-            {
-                return result;
-            }
-
-            await Task.Yield();
-        }
-
-        throw new TimeoutException("Durable job receiver did not observe terminal job status.");
     }
 }


### PR DESCRIPTION
## Problem

The receiver deduplication test polled for completion with ten `Task.Yield` calls. Under macOS CI thread-pool pressure, the receiver's asynchronous completion continuation could remain queued beyond those yields, producing a false timeout even though the handler task had completed.

## Solution

Keep the initial long-poll request in flight and use it as the explicit terminal-state barrier. The test still verifies that a notification with a different run ID for the same job attempt remains pending and does not start a second execution, then awaits the original request after completing the handler. This removes scheduler-dependent polling while preserving the deduplication assertions.

Fixes #10583
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10585)