### PR TITLE
test(durable-jobs): align retry wait timeout

### DIFF
--- a/test/Grains/TestGrainInterfaces/IRetryTestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IRetryTestGrain.cs
@@ -13,6 +13,7 @@ public interface IRetryTestGrain : IGrainWithStringKey
     Task<bool> HasJobSucceeded(string jobId);
 
     [AlwaysInterleave]
+    [ResponseTimeout("00:02:00")]
     Task WaitForJobToSucceed(string jobId);
 
     Task<int> GetJobExecutionAttemptCount(string jobId);

--- a/test/Orleans.DefaultCluster.Tests/InMemoryDurableJobsTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/InMemoryDurableJobsTests.cs
@@ -1,12 +1,11 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
-using Orleans.Configuration;
-using Orleans.Hosting;
-using Orleans.TestingHost;
+using Orleans.Serialization.Invocation;
 using Tester.DurableJobs;
 using TestExtensions;
+using UnitTests.GrainInterfaces;
 using Xunit;
 
 namespace DefaultCluster.Tests;
@@ -118,42 +117,20 @@ public class InMemoryDurableJobsTests : HostedTestClusterEnsureDefaultStarted
 [TestSuite("BVT")]
 [TestProvider("None")]
 [TestArea("Runtime")]
-public class InMemoryDurableJobsResponseTimeoutTests : TestClusterPerTest
+public class DurableJobsResponseTimeoutTests
 {
-    private static readonly TimeSpan ClientResponseTimeout = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(6);
-
-    protected override void ConfigureTestCluster(TestClusterBuilder builder)
-    {
-        builder.AddSiloBuilderConfigurator<SiloConfigurator>();
-        builder.AddClientBuilderConfigurator<ClientConfigurator>();
-    }
-
     [Fact, TestCategory("BVT"), TestCategory("DurableJobs")]
-    public async Task JobRetryWaitOverridesClientResponseTimeout()
+    public void JobRetryWaitOverridesClientResponseTimeout()
     {
-        var runner = new DurableJobTestsRunner(GrainFactory);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await runner.JobRetry(cts.Token);
-    }
+        var request = typeof(IRetryTestGrain).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract
+                && !type.ContainsGenericParameters
+                && typeof(IInvokable).IsAssignableFrom(type))
+            .Select(type => (IInvokable)Activator.CreateInstance(type)!)
+            .Single(request => request.GetInterfaceType() == typeof(IRetryTestGrain)
+                && request.GetMethodName() == nameof(IRetryTestGrain.WaitForJobToSucceed));
 
-    private sealed class SiloConfigurator : ISiloConfigurator
-    {
-        public void Configure(ISiloBuilder hostBuilder)
-        {
-            hostBuilder
-                .UseInMemoryReminderService()
-                .UseInMemoryDurableJobs()
-                .Configure<DurableJobsOptions>(options => options.ShouldRetry = (_, _) => DateTimeOffset.UtcNow + RetryDelay)
-                .AddMemoryGrainStorageAsDefault();
-        }
-    }
-
-    private sealed class ClientConfigurator : IClientBuilderConfigurator
-    {
-        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
-        {
-            clientBuilder.Configure<ClientMessagingOptions>(options => options.ResponseTimeout = ClientResponseTimeout);
-        }
+        Assert.Equal(TimeSpan.FromMinutes(2), request.GetDefaultResponseTimeout());
     }
 }

--- a/test/Orleans.DefaultCluster.Tests/InMemoryDurableJobsTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/InMemoryDurableJobsTests.cs
@@ -120,6 +120,9 @@ public class InMemoryDurableJobsTests : HostedTestClusterEnsureDefaultStarted
 [TestArea("Runtime")]
 public class InMemoryDurableJobsResponseTimeoutTests : TestClusterPerTest
 {
+    private static readonly TimeSpan ClientResponseTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(6);
+
     protected override void ConfigureTestCluster(TestClusterBuilder builder)
     {
         builder.AddSiloBuilderConfigurator<SiloConfigurator>();
@@ -141,6 +144,7 @@ public class InMemoryDurableJobsResponseTimeoutTests : TestClusterPerTest
             hostBuilder
                 .UseInMemoryReminderService()
                 .UseInMemoryDurableJobs()
+                .Configure<DurableJobsOptions>(options => options.ShouldRetry = (_, _) => DateTimeOffset.UtcNow + RetryDelay)
                 .AddMemoryGrainStorageAsDefault();
         }
     }
@@ -149,7 +153,7 @@ public class InMemoryDurableJobsResponseTimeoutTests : TestClusterPerTest
     {
         public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
         {
-            clientBuilder.Configure<ClientMessagingOptions>(options => options.ResponseTimeout = TimeSpan.FromSeconds(1));
+            clientBuilder.Configure<ClientMessagingOptions>(options => options.ResponseTimeout = ClientResponseTimeout);
         }
     }
 }

--- a/test/Orleans.DefaultCluster.Tests/InMemoryDurableJobsTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/InMemoryDurableJobsTests.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.TestingHost;
 using Tester.DurableJobs;
 using TestExtensions;
 using Xunit;
@@ -108,5 +112,44 @@ public class InMemoryDurableJobsTests : HostedTestClusterEnsureDefaultStarted
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         await _runner.JobRetry(cts.Token);
+    }
+}
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+public class InMemoryDurableJobsResponseTimeoutTests : TestClusterPerTest
+{
+    protected override void ConfigureTestCluster(TestClusterBuilder builder)
+    {
+        builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        builder.AddClientBuilderConfigurator<ClientConfigurator>();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("DurableJobs")]
+    public async Task JobRetryWaitOverridesClientResponseTimeout()
+    {
+        var runner = new DurableJobTestsRunner(GrainFactory);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await runner.JobRetry(cts.Token);
+    }
+
+    private sealed class SiloConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder
+                .UseInMemoryReminderService()
+                .UseInMemoryDurableJobs()
+                .AddMemoryGrainStorageAsDefault();
+        }
+    }
+
+    private sealed class ClientConfigurator : IClientBuilderConfigurator
+    {
+        public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+        {
+            clientBuilder.Configure<ClientMessagingOptions>(options => options.ResponseTimeout = TimeSpan.FromSeconds(1));
+        }
     }
 }


### PR DESCRIPTION
## Problem

The Azure Storage durable-jobs retry test waits for terminal success through a long-running grain call. That call inherited Orleans' 30-second default response timeout even though the provider test intentionally allows two minutes, so CI load could time out a healthy retry lifecycle before completion.

## Solution

Give the event-driven retry wait method a two-minute response-timeout contract matching the test budget. Add a fast contract test which verifies that the generated invocation carries the two-minute timeout, without starting a cluster or introducing wall-clock delays.

This avoids raising messaging timeouts globally and keeps ordinary grain calls governed by the existing default.

Fixes #10576