### PR TITLE
test(adonet): stabilize SQL Server database resets

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
@@ -126,6 +126,7 @@ namespace UnitTests.General
             }
 
             Console.WriteLine("Dropping and recreating database '{0}' with ConnectionString '{1}'", testDatabaseName, testStorage.CurrentConnectionString);
+            testStorage.PrepareForDatabaseReset();
 
             if (await testStorage.ExistsDatabaseAsync(testDatabaseName))
             {
@@ -136,6 +137,7 @@ namespace UnitTests.General
 
             //The old storage instance has the previous connection string, time have a new handle with a new connection string...
             testStorage = testStorage.CopyInstance(testDatabaseName);
+            await testStorage.WaitForDatabaseReadyAsync();
 
             Console.WriteLine("Creating database tables...");
 
@@ -178,6 +180,12 @@ namespace UnitTests.General
                 throw new SkipException("ConnectionString not provided.");
             }
         }
+
+        protected virtual void PrepareForDatabaseReset()
+        {
+        }
+
+        protected virtual Task WaitForDatabaseReadyAsync() => Task.CompletedTask;
 
         /// <summary>
         /// Executes the given script in a test context.

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
@@ -126,7 +126,7 @@ namespace UnitTests.General
             }
 
             Console.WriteLine("Dropping and recreating database '{0}' with ConnectionString '{1}'", testDatabaseName, testStorage.CurrentConnectionString);
-            testStorage.PrepareForDatabaseReset();
+            testStorage.PrepareForDatabaseReset(testDatabaseName);
 
             if (await testStorage.ExistsDatabaseAsync(testDatabaseName))
             {
@@ -181,7 +181,7 @@ namespace UnitTests.General
             }
         }
 
-        protected virtual void PrepareForDatabaseReset()
+        protected virtual void PrepareForDatabaseReset(string databaseName)
         {
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -13,6 +13,42 @@ namespace UnitTests.General
         {
         }
 
+        protected override void PrepareForDatabaseReset() => SqlConnection.ClearAllPools();
+
+        protected override async Task WaitForDatabaseReadyAsync()
+        {
+            const int maxAttempts = 3;
+            var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
+            {
+                Pooling = false,
+                ConnectTimeout = 5
+            };
+
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    await using var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
+                    await connection.OpenAsync();
+                    await using var command = connection.CreateCommand();
+                    command.CommandText = "SELECT 1";
+                    command.CommandTimeout = 5;
+                    _ = await command.ExecuteScalarAsync();
+                    return;
+                }
+                catch (SqlException exception) when (exception.Number == 18456 && exception.State == 1 && attempt < maxAttempts)
+                {
+                    Console.WriteLine(
+                        "SQL Server database '{0}' was not ready after recreation (attempt {1}/{2}): {3}",
+                        connectionStringBuilder.InitialCatalog,
+                        attempt,
+                        maxAttempts,
+                        exception.Message);
+                    await Task.Delay(TimeSpan.FromMilliseconds(250));
+                }
+            }
+        }
+
         public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }
 
         public override string CreateStreamTestTable { get { return "CREATE TABLE StreamingTest(Id INT NOT NULL, StreamData VARBINARY(MAX) NOT NULL);"; } }

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
@@ -13,7 +14,20 @@ namespace UnitTests.General
         {
         }
 
-        protected override void PrepareForDatabaseReset() => SqlConnection.ClearAllPools();
+        protected override void PrepareForDatabaseReset(string databaseName)
+        {
+            using var administrativeConnection = new SqlConnection(CurrentConnectionString);
+            SqlConnection.ClearPool(administrativeConnection);
+
+            var builder = new DbConnectionStringBuilder
+            {
+                ConnectionString = CurrentConnectionString
+            };
+            builder["Database"] = databaseName;
+
+            using var databaseConnection = new SqlConnection(builder.ConnectionString);
+            SqlConnection.ClearPool(databaseConnection);
+        }
 
         protected override async Task WaitForDatabaseReadyAsync()
         {

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -38,12 +38,6 @@ namespace UnitTests.General
                 }
                 catch (SqlException exception) when (exception.Number == 18456 && exception.State == 1 && attempt < maxAttempts)
                 {
-                    Console.WriteLine(
-                        "SQL Server database '{0}' was not ready after recreation (attempt {1}/{2}): {3}",
-                        connectionStringBuilder.InitialCatalog,
-                        attempt,
-                        maxAttempts,
-                        exception.Message);
                     await Task.Delay(TimeSpan.FromMilliseconds(250));
                 }
             }

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.Data.SqlClient;
+using Orleans.Tests.SqlUtils;
+using TestExtensions;
+
+namespace UnitTests.General;
+
+[TestCategory("SqlServer")]
+[TestSuite("Functional")]
+[TestProvider("SqlServer")]
+public class SqlServerStorageForTestingTests
+{
+    private const string TestDatabaseName = "OrleansSqlServerSetupTest";
+
+    [SkippableFact]
+    public async Task RecreatesDatabaseWithPooledConnections()
+    {
+        for (var iteration = 0; iteration < 3; iteration++)
+        {
+            var storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName);
+
+            await using var connection = new SqlConnection(storage.CurrentConnectionString);
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+
+            Assert.Equal(1, await command.ExecuteScalarAsync());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10474.

SQL Server 2025 can briefly reject new logins with error 18456/state 1 while the test harness resets a database using `SINGLE_USER`. Existing pooled connections extend that transition, and SqlClient pool blocking can fan one transient rejection out across subsequent fixture initializations.

Clear SqlClient pools before destructive SQL Server test database resets, then require an authenticated query against the recreated target database before schema setup continues. The readiness probe bypasses pooling and retries only the observed state-1 infrastructure transition; unrelated authentication failures still surface immediately. A focused regression repeatedly recreates the database while returning authenticated connections to the pool.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10589)