### PR TITLE
docs: improve contributor onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,45 @@
 
 Some notes and guidelines for developers who want to contribute to Orleans.
 
+## Getting started
+
+### Prerequisites
+
+Install [Git](https://git-scm.com/downloads) and the [.NET SDK](https://dotnet.microsoft.com/download/dotnet). The repository's `global.json` selects the SDK used by the build.
+
+### Clone and build
+
+Clone the repository and build the solution from its root directory:
+
+```console
+git clone https://github.com/dotnet/orleans.git
+cd orleans
+dotnet build Orleans.slnx -bl
+```
+
+The `Orleans.slnx` solution includes the source projects under `src` and the test projects under `test`. On Windows, `Build.cmd` additionally restores, builds, and packs the solution, placing packages in `Artifacts\<Configuration>`.
+
+### Run tests
+
+Run the full test suite for the current .NET target with:
+
+```console
+dotnet test Orleans.slnx --framework net10.0 -- -parallel none -noshadow
+```
+
+For a faster feedback loop, run a category or a single test. For example:
+
+```console
+dotnet test Orleans.slnx --framework net10.0 --filter "Category=BVT" -- -parallel none -noshadow
+dotnet test test\Orleans.Core.Tests\Orleans.Core.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~MyTestClass.MyTestMethod" -- -parallel none -noshadow
+```
+
+### Work on an application with local source
+
+For an application which needs to exercise an unreleased change, reference the relevant project under `src` instead of the published NuGet package. For example, reference `src\Orleans.Core\Orleans.Core.csproj` from the application project and build the application together with the Orleans solution. This lets the debugger step into the local Orleans source.
+
+Most changes should start in a project under `src` and have focused tests in the corresponding project under `test`. The repository also contains documentation under `docs` and examples under `samples`.
+
 ## Contributing to this project
 
 Here are some pointers for anyone looking for mini-features and work items that would make a positive contribution to Orleans.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ cd orleans
 dotnet build Orleans.slnx -bl
 ```
 
-The `Orleans.slnx` solution includes the source projects under `src` and the test projects under `test`. On Windows, `Build.cmd` additionally restores, builds, and packs the solution, placing packages in `Artifacts\<Configuration>`.
+The `Orleans.slnx` solution includes the source projects under `src` and the test projects under `test`. On Windows, `Build.cmd` additionally restores, builds, and packs the solution, placing packages in `Artifacts/<Configuration>`.
 
 ### Run tests
 
@@ -32,12 +32,12 @@ For a faster feedback loop, run a category or a single test. For example:
 
 ```console
 dotnet test Orleans.slnx --framework net10.0 --filter "Category=BVT" -- -parallel none -noshadow
-dotnet test test\Orleans.Core.Tests\Orleans.Core.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~MyTestClass.MyTestMethod" -- -parallel none -noshadow
+dotnet test test/Orleans.Core.Tests/Orleans.Core.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~MyTestClass.MyTestMethod" -- -parallel none -noshadow
 ```
 
 ### Work on an application with local source
 
-For an application which needs to exercise an unreleased change, reference the relevant project under `src` instead of the published NuGet package. For example, reference `src\Orleans.Core\Orleans.Core.csproj` from the application project and build the application together with the Orleans solution. This lets the debugger step into the local Orleans source.
+For an application which needs to exercise an unreleased change, reference the relevant project under `src` instead of the published NuGet package. For example, reference `src/Orleans.Core/Orleans.Core.csproj` from the application project and build the application together with the Orleans solution. This lets the debugger step into the local Orleans source.
 
 Most changes should start in a project under `src` and have focused tests in the corresponding project under `test`. The repository also contains documentation under `docs` and examples under `samples`.
 

--- a/README.md
+++ b/README.md
@@ -165,10 +165,9 @@ Please see the [Orleans Hello World quickstart](https://dotnet.github.io/orleans
 
 ### Building
 
-On Windows, run the `build.cmd` script to build the NuGet packages locally, then reference the required NuGet packages from `/Artifacts/Release/*`.
-You can run `Test.cmd` to run all BVT tests, and `TestAll.cmd` to also run Functional tests.
+For contributor prerequisites, building, testing, and using local source projects, see the [contributing guide](CONTRIBUTING.md).
 
-On Linux and macOS, run `dotnet build` to build Orleans.
+To build the solution directly, run `dotnet build Orleans.slnx -bl`. On Windows, `Build.cmd` also packs the solution and places packages in `Artifacts\<Configuration>`.
 
 ## Official builds
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Please see the [Orleans Hello World quickstart](https://dotnet.github.io/orleans
 
 For contributor prerequisites, building, testing, and using local source projects, see the [contributing guide](CONTRIBUTING.md).
 
-To build the solution directly, run `dotnet build Orleans.slnx -bl`. On Windows, `Build.cmd` also packs the solution and places packages in `Artifacts\<Configuration>`.
+To build the solution directly, run `dotnet build Orleans.slnx -bl`. On Windows, `Build.cmd` also packs the solution and places packages in `Artifacts/<Configuration>`.
 
 ## Official builds
 


### PR DESCRIPTION
Contributors currently have no concise path from cloning Orleans to building, testing, and debugging local source. The existing README build section also points to stale test-script guidance.

This adds a focused getting-started section to CONTRIBUTING.md covering prerequisites, the current solution and test commands, repository layout, and project references for debugging unreleased source changes. README.md now points contributors to that canonical guide and uses the current solution build command.

Fixes #3971

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10592)