### PR TITLE
docs(adonet): clarify production database configuration

### DIFF
--- a/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
@@ -67,4 +67,16 @@ Not every capability supports every database. The presence of a script in the pr
 4. Review and apply scripts under the provider's `Migrations` directory when upgrading from an older schema.
 5. Validate with a staging cluster using the same driver and database engine version.
 
+## Production database layout
+
+The supplied scripts are a starting schema, not a universal production
+database layout. They create unqualified table names in the database user's
+default schema, and the ADO.NET providers do not expose schema or filegroup
+configuration. A production deployment may choose a dedicated schema,
+filegroups, partitioning, or other database-specific storage features, but
+those choices must be implemented in the database deployment and kept
+consistent with the queries stored in `OrleansQuery`. Preserve the table names,
+columns, parameters, and result shapes expected by the provider, and validate
+the customized scripts and queries with a staging cluster before rollout.
+
 See [Configure ADO.NET providers](configuring-ado-dot-net-providers.md) for host configuration.

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
@@ -31,6 +31,15 @@ See [ADO.NET database configuration](adonet-configuration.md) for schema script 
 
 Apply schema changes as a controlled deployment step. Don't grant silos schema-owner permissions solely so they can create tables at runtime.
 
+The scripts create tables and the `OrleansQuery` table using the database user's
+default schema, and the provider queries refer to those objects by unqualified
+name. Orleans does not provide an option to select a schema or filegroup. If
+your production database requires a dedicated schema, filegroups, partitioning,
+or another storage layout, adapt the scripts as part of your database
+deployment and keep the resulting table names, columns, parameters, and query
+result shapes compatible with Orleans. Apply and test those changes outside the
+application startup path.
+
 ## Configure SQL Server
 
 Use `Microsoft.Data.SqlClient` for SQL Server:


### PR DESCRIPTION
The ADO.NET configuration guidance did not explain how the shipped scripts relate to production schema and storage-layout decisions.

This documents the current script locations and runtime constraints: scripts use the database user's default schema, providers expose no schema or filegroup setting, and production customizations must preserve the Orleans query contract and be deployed outside application startup. It also cross-links the configuration and schema-reference pages without changing existing URLs.

Fixes #3865
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10593)