### PR TITLE
fix(runtime): publish local shutdown membership state

### DIFF
--- a/src/Orleans.Runtime/Lifecycle/SiloLifecycleSubject.cs
+++ b/src/Orleans.Runtime/Lifecycle/SiloLifecycleSubject.cs
@@ -19,12 +19,16 @@ namespace Orleans.Runtime
         private readonly SiloAddress? _siloAddress;
         private int highestCompletedStage;
         private int lowestStoppedStage;
+        private int _isStarted;
+        private int _isStopping;
 
         /// <inheritdoc />
         public int HighestCompletedStage => this.highestCompletedStage;
 
         /// <inheritdoc />
         public int LowestStoppedStage => this.lowestStoppedStage;
+
+        internal bool IsStopping => Volatile.Read(ref _isStopping) != 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SiloLifecycleSubject"/> class.
@@ -51,12 +55,24 @@ namespace Orleans.Runtime
         /// <inheritdoc />
         public override Task OnStart(CancellationToken cancellationToken = default)
         {
+            Volatile.Write(ref _isStarted, 1);
             foreach (var stage in this.observers.GroupBy(o => o.Stage).OrderBy(s => s.Key))
             {
                 LogDebugLifecycleStagesReport(stage.Key, string.Join(", ", stage.Select(o => o.Name)));
             }
 
             return base.OnStart(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override Task OnStop(CancellationToken cancellationToken = default)
+        {
+            if (Volatile.Read(ref _isStarted) != 0)
+            {
+                Volatile.Write(ref _isStopping, 1);
+            }
+
+            return base.OnStop(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -36,7 +36,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly IMembershipTable membershipTableProvider;
         private readonly ILogger log;
-        private readonly ISiloLifecycle siloLifecycle;
+        private readonly SiloLifecycleSubject siloLifecycle;
         private readonly ClusterMembershipOptions clusterMembershipOptions;
         private readonly DateTime siloStartTime = DateTime.UtcNow;
         private readonly SiloAddress myAddress;
@@ -47,7 +47,8 @@ namespace Orleans.Runtime.MembershipService
         private readonly Task _suspectOrKillsListTask;
         private readonly Channel<SuspectOrKillRequest> _trySuspectOrKillChannel = Channel.CreateBounded<SuspectOrKillRequest>(new BoundedChannelOptions(100) { FullMode = BoundedChannelFullMode.DropOldest });
 
-        private MembershipTableSnapshot snapshot;
+        private MembershipState _state;
+        private int _fatalTerminationTriggered;
 
         public MembershipTableManager(
             ILocalSiloDetails localSiloDetails,
@@ -57,7 +58,7 @@ namespace Orleans.Runtime.MembershipService
             IMembershipGossiper gossiper,
             ILogger<MembershipTableManager> log,
             IAsyncTimerFactory timerFactory,
-            ISiloLifecycle siloLifecycle,
+            SiloLifecycleSubject siloLifecycle,
             [FromKeyedServices(TimeProviderNames.Membership)] TimeProvider timeProvider)
         {
             this.localSiloDetails = localSiloDetails;
@@ -68,14 +69,16 @@ namespace Orleans.Runtime.MembershipService
             this.myAddress = this.localSiloDetails.SiloAddress;
             this.log = log;
             this.siloLifecycle = siloLifecycle;
-            var initialEntries = ImmutableDictionary<SiloAddress, MembershipEntry>.Empty.SetItem(this.myAddress, this.CreateLocalSiloEntry(this.CurrentStatus));
-            this.snapshot = new MembershipTableSnapshot(
-                    MembershipVersion.MinValue,
-                    initialEntries);
+            var initialSnapshot = new MembershipTableSnapshot(
+                MembershipVersion.MinValue,
+                ImmutableDictionary<SiloAddress, MembershipEntry>.Empty.SetItem(
+                    this.myAddress,
+                    this.CreateLocalSiloEntry(SiloStatus.Created)));
+            _state = new MembershipState(initialSnapshot, SiloStatus.Created);
             this.updates = new AsyncEnumerable<MembershipTableSnapshot>(
-                initialValue: this.snapshot,
+                initialValue: initialSnapshot,
                 updateValidator: (previous, proposed) => proposed.IsSuccessorTo(previous),
-                onPublished: update => Interlocked.Exchange(ref this.snapshot, update));
+                onPublished: PublishSnapshot);
 
             this.membershipUpdateTimer = timerFactory.Create(
                 this.clusterMembershipOptions.TableRefreshTimeout,
@@ -87,14 +90,14 @@ namespace Orleans.Runtime.MembershipService
 
         internal Func<DateTime> GetDateTimeUtcNow { get; set; } = () => DateTime.UtcNow;
 
-        public MembershipTableSnapshot MembershipTableSnapshot => this.snapshot;
+        public MembershipTableSnapshot MembershipTableSnapshot => Volatile.Read(ref _state).Snapshot;
 
         public IAsyncEnumerable<MembershipTableSnapshot> MembershipTableUpdates => this.updates;
 
-        public SiloStatus CurrentStatus { get; private set; } = SiloStatus.Created;
+        public SiloStatus CurrentStatus => Volatile.Read(ref _state).LocalSiloStatus;
 
         // IMembershipManager explicit interface implementations
-        MembershipTableSnapshot IMembershipManager.CurrentSnapshot => this.snapshot;
+        MembershipTableSnapshot IMembershipManager.CurrentSnapshot => Volatile.Read(ref _state).Snapshot;
         IAsyncEnumerable<MembershipTableSnapshot> IMembershipManager.MembershipUpdates => this.updates;
         SiloStatus IMembershipManager.LocalSiloStatus => this.CurrentStatus;
         Task IMembershipManager.UpdateLocalStatus(SiloStatus status, CancellationToken cancellationToken) => this.UpdateStatus(status);
@@ -104,13 +107,13 @@ namespace Orleans.Runtime.MembershipService
         Task IMembershipManager.ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => this.RefreshFromSnapshot(snapshot);
         Task IMembershipManager.UpdateIAmAlive(CancellationToken cancellationToken) => this.UpdateIAmAlive();
 
-        private bool IsStopping => this.siloLifecycle.LowestStoppedStage <= ServiceLifecycleStage.Active;
+        private bool IsStopping => this.siloLifecycle.IsStopping;
 
         private Task? pendingRefresh;
 
         public async Task Refresh(MembershipVersion? targetVersion = null, CancellationToken cancellationToken = default)
         {
-            while (!targetVersion.HasValue || this.snapshot.Version < targetVersion.Value)
+            while (!targetVersion.HasValue || this.MembershipTableSnapshot.Version < targetVersion.Value)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -196,7 +199,7 @@ namespace Orleans.Runtime.MembershipService
                 }
 
                 // read the table and look for my node migration occurrences
-                DetectNodeMigration(this.snapshot, this.localSiloDetails.DnsHostName);
+                DetectNodeMigration(this.MembershipTableSnapshot, this.localSiloDetails.DnsHostName);
             }
             catch (Exception exception)
             {
@@ -340,7 +343,6 @@ namespace Orleans.Runtime.MembershipService
                     gossipTask.Ignore();
                     await Task.WhenAny(Task.Delay(TimeSpan.FromMilliseconds(500)), gossipTask);
 
-                    this.CurrentStatus = status;
                     return;
                 }
 
@@ -397,15 +399,14 @@ namespace Orleans.Runtime.MembershipService
 
             LogDebugTryUpdateMyStatusGlobalOnce(this.log, newStatus.Equals(SiloStatus.Active) ? "All" : " my entry from", table.ToString());
             LogMissedIAmAlives(table);
-            var (myEntry, myEtag) = this.GetOrCreateLocalSiloEntry(table, newStatus);
+            this.ProcessTableUpdate(table, nameof(TryUpdateMyStatusGlobalOnce));
 
-            if (myEntry.Status == SiloStatus.Dead && myEntry.Status != newStatus)
+            if (this.CurrentStatus == SiloStatus.Dead)
             {
-                LogWarningFoundMyselfDead1(this.log, myEntry.ToFullString());
-                this.KillMyselfLocally($"I should be Dead according to membership table (in TryUpdateMyStatusGlobalOnce): Entry = {(myEntry.ToFullString())}.");
                 return true;
             }
 
+            var (myEntry, myEtag) = this.GetOrCreateLocalSiloEntry(table, newStatus);
             var now = GetDateTimeUtcNow();
             if (newStatus == SiloStatus.Dead)
                 myEntry.AddSuspector(myAddress, now); // add the killer (myself) to the suspect list, for easier diagnostics later on.
@@ -426,7 +427,6 @@ namespace Orleans.Runtime.MembershipService
 
             if (ok)
             {
-                this.CurrentStatus = newStatus;
                 var entries = table.Members.ToDictionary(e => e.Item1.SiloAddress, e => e);
                 entries[myEntry.SiloAddress] = Tuple.Create(myEntry, myEtag!);
                 var updatedTable = new MembershipTableData(entries.Values.ToList(), next);
@@ -477,7 +477,7 @@ namespace Orleans.Runtime.MembershipService
                 this.LogMissedIAmAlives(table);
 
                 LogDebugProcessTableUpdateWithTable(this.log, caller, new(table));
-                MembershipEvents.EmitViewChanged(this.snapshot, this.myAddress);
+                MembershipEvents.EmitViewChanged(this.MembershipTableSnapshot, this.myAddress);
             }
         }
 
@@ -531,8 +531,8 @@ namespace Orleans.Runtime.MembershipService
 
         private void CheckIfLocalSiloIsDead(string caller)
         {
-            var current = this.snapshot;
-            if (this.CurrentStatus != SiloStatus.Dead
+            var current = this.MembershipTableSnapshot;
+            if (!this.IsStopping
                 && current.Entries.TryGetValue(this.myAddress, out var localSiloEntry)
                 && localSiloEntry.Status == SiloStatus.Dead)
             {
@@ -571,11 +571,6 @@ namespace Orleans.Runtime.MembershipService
 
                 if (siloAddress.Generation.Equals(myAddress.Generation))
                 {
-                    if (entry.Status == SiloStatus.Dead)
-                    {
-                        LogWarningFoundMyselfDead2(this.log, entry.ToFullString());
-                        KillMyselfLocally($"I should be Dead according to membership table (in CleanupTableEntries): entry = {(entry.ToFullString())}.");
-                    }
                     continue;
                 }
 
@@ -598,8 +593,16 @@ namespace Orleans.Runtime.MembershipService
                 {
                     // I am the older clone - Newer version of me should survive - I need to kill myself
                     LogWarningDetectedNewer(this.log, myAddress, siloAddress, entry.ToString());
-                    await this.UpdateStatus(SiloStatus.Dead);
-                    KillMyselfLocally($"Detected newer version of myself - I am the older clone so I will stop -- Current Me={myAddress} Newer Me={siloAddress}, Current entry={entry}");
+                    var reason = $"Detected newer version of myself - I am the older clone so I will stop -- Current Me={myAddress} Newer Me={siloAddress}, Current entry={entry}";
+                    try
+                    {
+                        await this.UpdateStatus(SiloStatus.Dead);
+                    }
+                    finally
+                    {
+                        this.KillMyselfLocally(reason);
+                    }
+
                     return true; // No point continuing!
                 }
             }
@@ -625,13 +628,27 @@ namespace Orleans.Runtime.MembershipService
 
         private void KillMyselfLocally(string reason)
         {
-            LogErrorKillMyselfLocally(this.log, reason);
-            this.CurrentStatus = SiloStatus.Dead;
-            if (!this.IsStopping)
+            if (this.IsStopping || Interlocked.Exchange(ref _fatalTerminationTriggered, 1) != 0)
             {
-                this.fatalErrorHandler.OnFatalException(this, $"I have been told I am dead, so this silo will stop! Reason: {reason}", null);
+                return;
             }
+
+            LogErrorKillMyselfLocally(this.log, reason);
+            this.fatalErrorHandler.OnFatalException(this, $"I have been told I am dead, so this silo will stop! Reason: {reason}", null);
         }
+
+        private void PublishSnapshot(MembershipTableSnapshot snapshot)
+        {
+            var previous = Volatile.Read(ref _state);
+            var localSiloStatus = snapshot.Entries.TryGetValue(this.myAddress, out var localEntry)
+                ? localEntry.Status
+                : previous.LocalSiloStatus;
+            Debug.Assert(localSiloStatus >= previous.LocalSiloStatus, "The local silo status cannot transition backwards.");
+
+            Interlocked.Exchange(ref _state, new MembershipState(snapshot, localSiloStatus));
+        }
+
+        private sealed record MembershipState(MembershipTableSnapshot Snapshot, SiloStatus LocalSiloStatus);
 
         private async Task GossipToOthers(SiloAddress updatedSilo, SiloStatus updatedStatus)
         {
@@ -794,9 +811,7 @@ namespace Orleans.Runtime.MembershipService
             var (localSiloEntry, _) = this.GetOrCreateLocalSiloEntry(table, this.CurrentStatus);
             if (localSiloEntry.Status == SiloStatus.Dead)
             {
-                var msg = string.Format("I should be Dead according to membership table (in TryKill): entry = {0}.", localSiloEntry.ToFullString());
-                LogWarningFoundMyselfDead3(this.log, msg);
-                KillMyselfLocally(msg);
+                this.ProcessTableUpdate(table, nameof(InnerTryKill));
                 return true;
             }
 
@@ -813,7 +828,7 @@ namespace Orleans.Runtime.MembershipService
             // Check if the table already knows that this silo is dead
             if (entry.Status == SiloStatus.Dead)
             {
-                this.ProcessTableUpdate(table, "TryKill");
+                this.ProcessTableUpdate(table, nameof(InnerTryKill));
                 return true;
             }
 
@@ -840,12 +855,9 @@ namespace Orleans.Runtime.MembershipService
                 return true;
             }
 
-            var (localSiloEntry, _) = this.GetOrCreateLocalSiloEntry(table, this.CurrentStatus);
-            if (localSiloEntry.Status == SiloStatus.Dead)
+            this.ProcessTableUpdate(table, nameof(InnerTryToSuspectOrKill));
+            if (this.CurrentStatus == SiloStatus.Dead)
             {
-                var localSiloEntryDetails = localSiloEntry.ToFullString();
-                LogWarningFoundMyselfDead3(this.log, $"I should be Dead according to membership table (in TryToSuspectOrKill): entry = {localSiloEntryDetails}.");
-                KillMyselfLocally($"I should be Dead according to membership table (in TryToSuspectOrKill): entry = {localSiloEntryDetails}.");
                 return true;
             }
 
@@ -911,7 +923,7 @@ namespace Orleans.Runtime.MembershipService
                 this.ProcessTableUpdate(table, "TrySuspectOrKill");
 
                 // Gossip using the local silo status, since this is just informational to propagate the suspicion vote.
-                GossipToOthers(localSiloEntry.SiloAddress, localSiloEntry.Status).Ignore();
+                GossipToOthers(this.myAddress, this.CurrentStatus).Ignore();
             }
 
             return ok;
@@ -1073,13 +1085,6 @@ namespace Orleans.Runtime.MembershipService
         private static partial void LogWarningMissedIAmAliveTableUpdate(ILogger logger, SiloAddress siloAddress, DateTime lastUpdateTime, DateTime currentTime, TimeSpan sinceUpdate, TimeSpan allowedIAmAliveMissPeriod);
 
         [LoggerMessage(
-            EventId = (int)ErrorCode.MembershipFoundMyselfDead2,
-            Level = LogLevel.Warning,
-            Message = "I should be Dead according to membership table (in CleanupTableEntries): entry = {Entry}."
-        )]
-        private static partial void LogWarningFoundMyselfDead2(ILogger logger, string entry);
-
-        [LoggerMessage(
             Level = LogLevel.Trace,
             Message = "Skipping my previous old Dead entry in membership table: {Entry}"
         )]
@@ -1169,13 +1174,6 @@ namespace Orleans.Runtime.MembershipService
         private static partial void LogDebugTryUpdateMyStatusGlobalOnce(ILogger logger, string selection, string table);
 
         [LoggerMessage(
-            EventId = (int)ErrorCode.MembershipFoundMyselfDead1,
-            Level = LogLevel.Warning,
-            Message = "I should be Dead according to membership table (in TryUpdateMyStatusGlobalOnce): Entry = {Entry}."
-        )]
-        private static partial void LogWarningFoundMyselfDead1(ILogger logger, string entry);
-
-        [LoggerMessage(
             Level = LogLevel.Debug,
             Message = "TryKill: Read Membership table {Table}"
         )]
@@ -1187,13 +1185,6 @@ namespace Orleans.Runtime.MembershipService
             Message = "Ignoring call to TryKill for silo {Silo} since the local silo is stopping"
         )]
         private static partial void LogInformationIgnoringCallToTryKill(ILogger logger, SiloAddress silo);
-
-        [LoggerMessage(
-            EventId = (int)ErrorCode.MembershipFoundMyselfDead3,
-            Level = LogLevel.Warning,
-            Message = "{Message}"
-        )]
-        private static partial void LogWarningFoundMyselfDead3(ILogger logger, string message);
 
         [LoggerMessage(
             EventId = (int)ErrorCode.MembershipFailedToReadSilo,

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -483,6 +483,57 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public async Task MembershipTableManager_DeadTransitionOutsideShutdown_Terminates()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+            await this.lifecycle.OnStart();
+            await manager.UpdateStatus(SiloStatus.Joining);
+
+            await manager.UpdateStatus(SiloStatus.Dead);
+
+            Assert.Equal(SiloStatus.Dead, manager.CurrentStatus);
+            this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task MembershipTableManager_DeadTransitionDuringLaterStopStage_DoesNotTerminate()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+            this.lifecycle.Subscribe(
+                "CustomLaterStage",
+                ServiceLifecycleStage.Active + 1,
+                _ => Task.CompletedTask,
+                _ => manager.UpdateStatus(SiloStatus.Dead));
+            await this.lifecycle.OnStart();
+            await manager.UpdateStatus(SiloStatus.Joining);
+
+            await this.lifecycle.OnStop();
+
+            Assert.Equal(SiloStatus.Dead, manager.CurrentStatus);
+            this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
+        }
+
+        [Fact]
+        public async Task MembershipTableManager_StopBeforeStart_DoesNotMarkLifecycleStopping()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+
+            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStart();
+            await manager.UpdateStatus(SiloStatus.Dead);
+
+            this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
         public async Task MembershipTableManager_MissingLocalEntry_OnlyNewerSnapshotAfterJoiningTerminates()
         {
             var now = DateTimeOffset.UtcNow;
@@ -531,7 +582,7 @@ namespace NonSilo.Tests.Membership
 
             await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(125)));
             await manager.UpdateStatus(SiloStatus.Joining);
-            Assert.Equal(SiloStatus.Joining, manager.CurrentStatus);
+            Assert.Equal(SiloStatus.Created, manager.CurrentStatus);
             Assert.DoesNotContain(this.localSilo, manager.MembershipTableSnapshot.Entries.Keys);
 
             await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(126)));


### PR DESCRIPTION
MembershipTableManager maintained local status separately from published membership snapshots, allowing local state to diverge and treating intentional shutdown transitions as fatal membership failures.

This change atomically publishes each membership snapshot together with the local silo status derived from it. It also records lifecycle stop entry so Dead transitions during an intentional shutdown do not invoke fatal termination, while preserving fatal handling for unexpected Dead transitions. When a newer incarnation is detected, the silo now persists its Dead status before self-termination.

Keeping snapshot and local status in one published state makes membership decisions consistent and gives shutdown paths a clear distinction from unexpected membership death.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10596)