### PR TITLE
fix(runtime): synchronize version selector cache generations

### DIFF
--- a/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
+++ b/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Orleans.Metadata;
 using Orleans.Runtime.Versions.Compatibility;
 using Orleans.Runtime.Versions.Selector;
@@ -10,15 +10,34 @@ namespace Orleans.Runtime.Versions
 {
     internal class CachedVersionSelectorManager
     {
-        private readonly ConcurrentDictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry> suitableSilosCache;
+#if NET9_0_OR_GREATER
+        private readonly Lock cacheLock = new();
+#else
+        private readonly object cacheLock = new();
+#endif
+        private readonly Dictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry> suitableSilosCache;
         private readonly GrainVersionManifest grainInterfaceVersions;
+        private readonly IClusterMembershipService? clusterMembershipService;
+        private MajorMinorVersion observedManifestVersion;
+        private long cacheGeneration;
 
         public CachedVersionSelectorManager(GrainVersionManifest grainInterfaceVersions, VersionSelectorManager versionSelectorManager, CompatibilityDirectorManager compatibilityDirectorManager)
+            : this(grainInterfaceVersions, versionSelectorManager, compatibilityDirectorManager, clusterMembershipService: null)
+        {
+        }
+
+        public CachedVersionSelectorManager(
+            GrainVersionManifest grainInterfaceVersions,
+            VersionSelectorManager versionSelectorManager,
+            CompatibilityDirectorManager compatibilityDirectorManager,
+            IClusterMembershipService? clusterMembershipService)
         {
             this.grainInterfaceVersions = grainInterfaceVersions;
             this.VersionSelectorManager = versionSelectorManager;
             this.CompatibilityDirectorManager = compatibilityDirectorManager;
-            this.suitableSilosCache = new ConcurrentDictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry>();
+            this.clusterMembershipService = clusterMembershipService;
+            this.observedManifestVersion = grainInterfaceVersions.LatestVersion;
+            this.suitableSilosCache = new Dictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry>();
         }
 
         public VersionSelectorManager VersionSelectorManager { get; }
@@ -30,21 +49,71 @@ namespace Orleans.Runtime.Versions
         public CachedEntry GetSuitableSilos(GrainType grainType, GrainInterfaceType interfaceId, ushort requestedVersion)
         {
             var key = ValueTuple.Create(grainType, interfaceId, requestedVersion);
-            if (!suitableSilosCache.TryGetValue(key, out var entry) || entry.Version < this.grainInterfaceVersions.LatestVersion)
+            while (true)
             {
-                entry = suitableSilosCache[key] = GetSuitableSilosImpl(key);
-            }
+                CacheState state;
+                lock (this.cacheLock)
+                {
+                    state = ObserveCacheState();
+                    if (state.ManifestVersion.Major == state.MembershipVersion.Value
+                        && suitableSilosCache.TryGetValue(key, out var cachedEntry)
+                        && cachedEntry.Generation == state.Generation)
+                    {
+                        return cachedEntry;
+                    }
+                }
 
-            return entry;
+                var (resultVersion, entry) = GetSuitableSilosImpl(key, state.Generation);
+                lock (this.cacheLock)
+                {
+                    var current = ObserveCacheState();
+                    if (current.Generation == state.Generation
+                        && resultVersion == current.ManifestVersion
+                        && resultVersion.Major == current.MembershipVersion.Value)
+                    {
+                        return suitableSilosCache[key] = entry;
+                    }
+                }
+            }
+        }
+
+        public SiloAddress[] GetSupportedSilos(GrainType grainType)
+        {
+            while (true)
+            {
+                CacheState state;
+                lock (this.cacheLock)
+                {
+                    state = ObserveCacheState();
+                }
+
+                var (resultVersion, result) = this.grainInterfaceVersions.GetSupportedSilos(grainType);
+                lock (this.cacheLock)
+                {
+                    var current = ObserveCacheState();
+                    if (current.Generation == state.Generation
+                        && resultVersion == current.ManifestVersion
+                        && resultVersion.Major == current.MembershipVersion.Value)
+                    {
+                        return result;
+                    }
+                }
+            }
         }
 
         public void ResetCache()
         {
-            this.suitableSilosCache.Clear();
+            lock (this.cacheLock)
+            {
+                ++this.cacheGeneration;
+            }
+
             CacheInvalidated?.Invoke();
         }
 
-        private CachedEntry GetSuitableSilosImpl((GrainType Type, GrainInterfaceType Interface, ushort Version) key)
+        private (MajorMinorVersion Version, CachedEntry Entry) GetSuitableSilosImpl(
+            (GrainType Type, GrainInterfaceType Interface, ushort Version) key,
+            long generation)
         {
             var grainType = key.Type;
             var interfaceType = key.Interface;
@@ -60,17 +129,38 @@ namespace Orleans.Runtime.Versions
 
             (_, var result) = this.grainInterfaceVersions.GetSupportedSilos(grainType, interfaceType, versions);
 
-            return new CachedEntry
-            {
-                Version = version,
-                SuitableSilos = result.SelectMany(sv => sv.Value).Distinct().OrderBy(addr => addr).ToArray(),
-                SuitableSilosByVersion = result,
-            };
+            return (
+                version,
+                new CachedEntry
+                {
+                    Generation = generation,
+                    SuitableSilos = result.SelectMany(sv => sv.Value).Distinct().OrderBy(addr => addr).ToArray(),
+                    SuitableSilosByVersion = result,
+                });
         }
+
+        private CacheState ObserveCacheState()
+        {
+            var manifestVersion = this.grainInterfaceVersions.LatestVersion;
+            var membershipVersion = this.clusterMembershipService?.CurrentSnapshot.Version
+                ?? new MembershipVersion(manifestVersion.Major);
+            if (manifestVersion != this.observedManifestVersion)
+            {
+                this.observedManifestVersion = manifestVersion;
+                ++this.cacheGeneration;
+            }
+
+            return new CacheState(this.cacheGeneration, membershipVersion, manifestVersion);
+        }
+
+        private readonly record struct CacheState(
+            long Generation,
+            MembershipVersion MembershipVersion,
+            MajorMinorVersion ManifestVersion);
 
         internal struct CachedEntry
         {
-            public MajorMinorVersion Version { get; set; }
+            public long Generation { get; set; }
 
             public SiloAddress[] SuitableSilos { get; set; }
 

--- a/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
+++ b/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
@@ -49,6 +49,7 @@ namespace Orleans.Runtime.Versions
         public CachedEntry GetSuitableSilos(GrainType grainType, GrainInterfaceType interfaceId, ushort requestedVersion)
         {
             var key = ValueTuple.Create(grainType, interfaceId, requestedVersion);
+            var spinner = new SpinWait();
             while (true)
             {
                 CacheState state;
@@ -74,11 +75,14 @@ namespace Orleans.Runtime.Versions
                         return suitableSilosCache[key] = entry;
                     }
                 }
+
+                spinner.SpinOnce();
             }
         }
 
         public SiloAddress[] GetSupportedSilos(GrainType grainType)
         {
+            var spinner = new SpinWait();
             while (true)
             {
                 CacheState state;
@@ -98,6 +102,8 @@ namespace Orleans.Runtime.Versions
                         return result;
                     }
                 }
+
+                spinner.SpinOnce();
             }
         }
 
@@ -106,6 +112,7 @@ namespace Orleans.Runtime.Versions
             lock (this.cacheLock)
             {
                 ++this.cacheGeneration;
+                this.suitableSilosCache.Clear();
             }
 
             CacheInvalidated?.Invoke();

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -227,6 +227,46 @@ public class ClusterManifestProviderTests
             selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos.OrderBy(static silo => silo));
     }
 
+    [Fact]
+    public async Task CachedVersionSelectorManager_RetriesUntilMembershipAndManifestVersionsConverge()
+    {
+        var localSilo = CreateSiloAddress(11111, 1);
+        var remoteSilo = CreateSiloAddress(11112, 1);
+        var clusterManifestProvider = new TestClusterManifestProvider(CreateClusterManifest(1, 0, localSilo));
+        using var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            2,
+            (localSilo, SiloStatus.Active),
+            (remoteSilo, SiloStatus.Active)));
+        var selectorManager = CreateCachedVersionSelectorManager(
+            new GrainVersionManifest(clusterManifestProvider),
+            membership);
+
+        var suitableSilosRead = membership.ObserveNextSnapshotRead();
+        var suitableSilosTask = Task.Run(
+            () => selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1));
+        await suitableSilosRead.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(suitableSilosTask.IsCompleted);
+
+        clusterManifestProvider.Current = CreateClusterManifest(2, 0, remoteSilo);
+
+        var suitableSilos = await suitableSilosTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(new[] { remoteSilo }, suitableSilos.SuitableSilos);
+
+        membership.Update(CreateMembershipSnapshot(
+            3,
+            (localSilo, SiloStatus.Active),
+            (remoteSilo, SiloStatus.Active)));
+        var supportedSilosRead = membership.ObserveNextSnapshotRead();
+        var supportedSilosTask = Task.Run(() => selectorManager.GetSupportedSilos(TestGrainType));
+        await supportedSilosRead.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(supportedSilosTask.IsCompleted);
+
+        clusterManifestProvider.Current = CreateClusterManifest(3, 0, localSilo, remoteSilo);
+
+        var supportedSilos = await supportedSilosTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(new[] { localSilo, remoteSilo }, supportedSilos.OrderBy(static silo => silo));
+    }
+
     private static ClusterManifestProvider CreateClusterManifestProvider(
         SiloAddress localSilo,
         TestClusterMembershipService membership,
@@ -438,20 +478,36 @@ public class ClusterManifestProviderTests
     private sealed class TestClusterMembershipService : IClusterMembershipService, IDisposable
     {
         private readonly AsyncEnumerable<ClusterMembershipSnapshot> _updates;
+        private ClusterMembershipSnapshot _currentSnapshot = ClusterMembershipSnapshot.Default;
+        private TaskCompletionSource? _nextSnapshotRead;
 
         public TestClusterMembershipService(ClusterMembershipSnapshot initialSnapshot)
         {
             _updates = new AsyncEnumerable<ClusterMembershipSnapshot>(
                 initialValue: initialSnapshot,
                 updateValidator: (previous, proposed) => proposed.Version > previous.Version,
-                onPublished: update => CurrentSnapshot = update);
+                onPublished: update => Volatile.Write(ref _currentSnapshot, update));
         }
 
-        public ClusterMembershipSnapshot CurrentSnapshot { get; private set; } = ClusterMembershipSnapshot.Default;
+        public ClusterMembershipSnapshot CurrentSnapshot
+        {
+            get
+            {
+                Volatile.Read(ref _nextSnapshotRead)?.TrySetResult();
+                return Volatile.Read(ref _currentSnapshot);
+            }
+        }
 
         public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => _updates;
 
         public void Update(ClusterMembershipSnapshot snapshot) => _updates.Publish(snapshot);
+
+        public Task ObserveNextSnapshotRead()
+        {
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Interlocked.Exchange(ref _nextSnapshotRead, completion);
+            return completion.Task;
+        }
 
         public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) => default;
 

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -180,18 +180,51 @@ public class ClusterManifestProviderTests
         var localSilo = CreateSiloAddress(11111, 1);
         var remoteSilo = CreateSiloAddress(11112, 1);
         var clusterManifestProvider = new TestClusterManifestProvider(CreateClusterManifest(1, 0, localSilo, remoteSilo));
+        using var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active),
+            (remoteSilo, SiloStatus.Active)));
         var manifest = new GrainVersionManifest(clusterManifestProvider);
-        var selectorManager = CreateCachedVersionSelectorManager(manifest);
+        var selectorManager = CreateCachedVersionSelectorManager(manifest, membership);
 
         var initial = selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1);
         SiloAddress[] initialSilos = initial.SuitableSilos;
         Assert.Equal(new[] { localSilo, remoteSilo }, initialSilos.OrderBy(static silo => silo));
+        Assert.Equal(new[] { localSilo, remoteSilo }, selectorManager.GetSupportedSilos(TestGrainType).OrderBy(static silo => silo));
 
-        clusterManifestProvider.Current = CreateClusterManifest(2, 0, localSilo);
+        membership.Update(CreateMembershipSnapshot(
+            2,
+            (localSilo, SiloStatus.ShuttingDown),
+            (remoteSilo, SiloStatus.Active)));
+        clusterManifestProvider.Current = CreateClusterManifest(2, 0, remoteSilo);
 
         var updated = selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1);
         SiloAddress[] updatedSilos = updated.SuitableSilos;
-        Assert.Equal(new[] { localSilo }, updatedSilos);
+        Assert.Equal(new[] { remoteSilo }, updatedSilos);
+        Assert.Equal(new[] { remoteSilo }, selectorManager.GetSupportedSilos(TestGrainType));
+    }
+
+    [Fact]
+    public void CachedVersionSelectorManager_RefreshesSuitableSilosWhenManifestMinorVersionChanges()
+    {
+        var localSilo = CreateSiloAddress(11111, 1);
+        var remoteSilo = CreateSiloAddress(11112, 1);
+        var clusterManifestProvider = new TestClusterManifestProvider(CreateClusterManifest(1, 0, localSilo));
+        using var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active),
+            (remoteSilo, SiloStatus.Active)));
+        var selectorManager = CreateCachedVersionSelectorManager(
+            new GrainVersionManifest(clusterManifestProvider),
+            membership);
+
+        Assert.Equal(new[] { localSilo }, selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos);
+
+        clusterManifestProvider.Current = CreateClusterManifest(1, 1, localSilo, remoteSilo);
+
+        Assert.Equal(
+            new[] { localSilo, remoteSilo },
+            selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos.OrderBy(static silo => silo));
     }
 
     private static ClusterManifestProvider CreateClusterManifestProvider(
@@ -229,7 +262,9 @@ public class ClusterManifestProviderTests
         return grainFactory;
     }
 
-    private static CachedVersionSelectorManager CreateCachedVersionSelectorManager(GrainVersionManifest manifest)
+    private static CachedVersionSelectorManager CreateCachedVersionSelectorManager(
+        GrainVersionManifest manifest,
+        IClusterMembershipService membership)
     {
         var services = new ServiceCollection();
         services.AddOptions<GrainVersioningOptions>();
@@ -243,7 +278,8 @@ public class ClusterManifestProviderTests
         return new CachedVersionSelectorManager(
             manifest,
             new VersionSelectorManager(serviceProvider, options),
-            new CompatibilityDirectorManager(serviceProvider, options));
+            new CompatibilityDirectorManager(serviceProvider, options),
+            membership);
     }
 
     private static ClusterManifest CreateClusterManifest(long major, long minor, params SiloAddress[] silos)


### PR DESCRIPTION
Cached version selector results can otherwise be computed and retained across different cluster manifest and membership generations, allowing stale silo selections during topology changes.

This change synchronizes selector reads with both membership and manifest versions using a unified cache generation, refreshes results when either generation changes, and adds a membership-aligned `GetSupportedSilos` path.

The existing `CacheInvalidated` event is intentionally retained and raised after the generation advances because the current `PlacementService` still subscribes to it. The follow-up placement integration will remove that compatibility event.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10597)