### PR TITLE
refactor(runtime): centralize placement compatibility caching

### DIFF
--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -22,7 +21,7 @@ namespace Orleans.Runtime.Placement
     /// <summary>
     /// Central point for placement decisions.
     /// </summary>
-    internal partial class PlacementService : IPlacementContext, ISiloStatusListener, ILifecycleParticipant<ISiloLifecycle>, PlacementService.ITestAccessor
+    internal partial class PlacementService : IPlacementContext, ILifecycleParticipant<ISiloLifecycle>, PlacementService.ITestAccessor
     {
         private const int PlacementWorkerCount = 16;
         private readonly PlacementStrategyResolver _strategyResolver;
@@ -32,21 +31,15 @@ namespace Orleans.Runtime.Placement
         private readonly GrainVersionManifest _grainInterfaceVersions;
         private readonly CachedVersionSelectorManager _versionSelectorManager;
         private readonly ISiloStatusOracle _siloStatusOracle;
-        private readonly IClusterManifestProvider _clusterManifestProvider;
         private readonly bool _assumeHomogeneousSilosForTesting;
         private readonly PlacementWorker[] _workers;
         private readonly PlacementFilterStrategyResolver _filterStrategyResolver;
         private readonly PlacementFilterDirectorResolver _placementFilterDirectoryResolver;
-        private readonly ConcurrentDictionary<CompatibleSilosCacheKey, SiloAddress[]> _compatibleSilosCache = new();
         private readonly CancellationTokenSource _shutdownCts = new();
-        private long _placementCacheGeneration;
-        private Task? _manifestUpdatesTask;
 
         internal interface ITestAccessor
         {
             Task[] WorkerTasks { get; }
-
-            int CompatibleSilosCacheCount { get; }
 
             Task<SiloAddress> GetOrPlaceActivationAsync(Message message);
         }
@@ -62,7 +55,6 @@ namespace Orleans.Runtime.Placement
             GrainLocator grainLocator,
             GrainVersionManifest grainInterfaceVersions,
             CachedVersionSelectorManager versionSelectorManager,
-            IClusterManifestProvider clusterManifestProvider,
             PlacementDirectorResolver directorResolver,
             PlacementStrategyResolver strategyResolver,
             PlacementFilterStrategyResolver filterStrategyResolver,
@@ -78,10 +70,7 @@ namespace Orleans.Runtime.Placement
             _grainInterfaceVersions = grainInterfaceVersions;
             _versionSelectorManager = versionSelectorManager;
             _siloStatusOracle = siloStatusOracle;
-            _clusterManifestProvider = clusterManifestProvider;
             _assumeHomogeneousSilosForTesting = siloMessagingOptions.CurrentValue.AssumeHomogenousSilosForTesting;
-            _siloStatusOracle.SubscribeToSiloStatusEvents(this);
-            _versionSelectorManager.CacheInvalidated += InvalidatePlacementCaches;
             _workers = new PlacementWorker[PlacementWorkerCount];
             for (var i = 0; i < PlacementWorkerCount; i++)
             {
@@ -94,8 +83,6 @@ namespace Orleans.Runtime.Placement
         public SiloStatus LocalSiloStatus => _siloStatusOracle.CurrentStatus;
 
         Task[] ITestAccessor.WorkerTasks => _workers.Select(static worker => worker.CompletionTask).ToArray();
-
-        int ITestAccessor.CompatibleSilosCacheCount => _compatibleSilosCache.Count;
 
         Task<SiloAddress> ITestAccessor.GetOrPlaceActivationAsync(Message message)
         {
@@ -115,14 +102,8 @@ namespace Orleans.Runtime.Placement
             lifecycle.Subscribe(
                 nameof(PlacementService),
                 ServiceLifecycleStage.RuntimeInitialize + 1,
-                StartAsync,
+                _ => Task.CompletedTask,
                 StopAsync);
-        }
-
-        private Task StartAsync(CancellationToken cancellationToken)
-        {
-            _manifestUpdatesTask = Task.Run(ProcessClusterManifestUpdates);
-            return Task.CompletedTask;
         }
 
         private async Task StopAsync(CancellationToken cancellationToken)
@@ -147,20 +128,6 @@ namespace Orleans.Runtime.Placement
                 await completionTask.WaitAsync(cancellationToken).SuppressThrowing();
             }
 
-            if (_manifestUpdatesTask is Task manifestUpdatesTask)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    await manifestUpdatesTask.SuppressThrowing();
-                }
-                else
-                {
-                    await manifestUpdatesTask.WaitAsync(cancellationToken).SuppressThrowing();
-                }
-            }
-
-            _siloStatusOracle.UnSubscribeFromSiloStatusEvents(this);
-            _versionSelectorManager.CacheInvalidated -= InvalidatePlacementCaches;
         }
 
         /// <summary>
@@ -200,12 +167,14 @@ namespace Orleans.Runtime.Placement
             var grainType = target.GrainIdentity.Type;
             // For test only: if we have silos that are not yet in the Cluster TypeMap, we assume that they are compatible
             // with the current silo
-            var compatibleSilos = _assumeHomogeneousSilosForTesting
-                ? _siloStatusOracle.GetActiveSilos()
-                : GetUnfilteredCompatibleSilos(grainType, target.InterfaceType, target.InterfaceVersion);
-
-            if (!_assumeHomogeneousSilosForTesting)
+            SiloAddress[] compatibleSilos;
+            if (_assumeHomogeneousSilosForTesting)
             {
+                compatibleSilos = _siloStatusOracle.GetActiveSilos();
+            }
+            else
+            {
+                compatibleSilos = GetCompatibleSilos(grainType, target.InterfaceType, target.InterfaceVersion);
                 ThrowIfStopping();
                 var filters = _filterStrategyResolver.GetPlacementFilterStrategies(grainType);
                 if (filters.Length > 0)
@@ -252,41 +221,14 @@ namespace Orleans.Runtime.Placement
             return compatibleSilos;
         }
 
-        private SiloAddress[] GetUnfilteredCompatibleSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort interfaceVersion)
+        private SiloAddress[] GetCompatibleSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort interfaceVersion)
         {
             if (interfaceVersion == 0)
             {
-                interfaceType = default;
+                return _versionSelectorManager.GetSupportedSilos(grainType);
             }
 
-            while (true)
-            {
-                var generation = Volatile.Read(ref _placementCacheGeneration);
-                var key = new CompatibleSilosCacheKey(grainType, interfaceType, interfaceVersion, generation);
-                var result = _compatibleSilosCache.GetOrAdd(
-                    key,
-                    static (key, placementService) => placementService.ComputeUnfilteredCompatibleSilos(
-                        key.GrainType,
-                        key.InterfaceType,
-                        key.InterfaceVersion),
-                    this);
-
-                if (generation == Volatile.Read(ref _placementCacheGeneration))
-                {
-                    return result;
-                }
-
-                _compatibleSilosCache.TryRemove(key, out _);
-            }
-        }
-
-        private SiloAddress[] ComputeUnfilteredCompatibleSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort interfaceVersion)
-        {
-            var silos = interfaceVersion > 0
-                ? _versionSelectorManager.GetSuitableSilos(grainType, interfaceType, interfaceVersion).SuitableSilos
-                : _grainInterfaceVersions.GetSupportedSilos(grainType).Result;
-
-            return silos;
+            return _versionSelectorManager.GetSuitableSilos(grainType, interfaceType, interfaceVersion).SuitableSilos;
         }
 
         public IReadOnlyDictionary<ushort, SiloAddress[]> GetCompatibleSilosWithVersions(PlacementTarget target)
@@ -298,38 +240,9 @@ namespace Orleans.Runtime.Placement
 
             ThrowIfStopping();
             var grainType = target.GrainIdentity.Type;
-            var silos = _versionSelectorManager
+            return _versionSelectorManager
                 .GetSuitableSilos(grainType, target.InterfaceType, target.InterfaceVersion)
                 .SuitableSilosByVersion;
-
-            return silos;
-        }
-
-        void ISiloStatusListener.SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status) => InvalidatePlacementCaches();
-
-        private async Task ProcessClusterManifestUpdates()
-        {
-            try
-            {
-                await foreach (var _ in _clusterManifestProvider.Updates.WithCancellation(_shutdownCts.Token))
-                {
-                    InvalidatePlacementCaches();
-                }
-            }
-            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
-            {
-                // Ignore during shutdown.
-            }
-            catch (Exception exception)
-            {
-                LogErrorProcessingClusterManifestUpdates(exception);
-            }
-        }
-
-        private void InvalidatePlacementCaches()
-        {
-            Interlocked.Increment(ref _placementCacheGeneration);
-            _compatibleSilosCache.Clear();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -713,12 +626,6 @@ namespace Orleans.Runtime.Placement
         private partial void LogTraceAddressMessageSelectTarget(Message message);
 
         [LoggerMessage(
-            Level = LogLevel.Error,
-            Message = "Error processing cluster manifest updates."
-        )]
-        private partial void LogErrorProcessingClusterManifestUpdates(Exception exception);
-
-        [LoggerMessage(
             Level = LogLevel.Debug,
             Message = "Invalidating {Count} cached entries for message {Message}"
         )]
@@ -730,10 +637,5 @@ namespace Orleans.Runtime.Placement
         )]
         private static partial void LogWarnInPlacementWorker(ILogger logger, Exception exception);
 
-        private readonly record struct CompatibleSilosCacheKey(
-            GrainType GrainType,
-            GrainInterfaceType InterfaceType,
-            ushort InterfaceVersion,
-            long CacheGeneration);
     }
 }

--- a/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
+++ b/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
@@ -17,20 +17,15 @@ namespace Orleans.Runtime.Versions
 #endif
         private readonly Dictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry> suitableSilosCache;
         private readonly GrainVersionManifest grainInterfaceVersions;
-        private readonly IClusterMembershipService? clusterMembershipService;
+        private readonly IClusterMembershipService clusterMembershipService;
         private MajorMinorVersion observedManifestVersion;
         private long cacheGeneration;
-
-        public CachedVersionSelectorManager(GrainVersionManifest grainInterfaceVersions, VersionSelectorManager versionSelectorManager, CompatibilityDirectorManager compatibilityDirectorManager)
-            : this(grainInterfaceVersions, versionSelectorManager, compatibilityDirectorManager, clusterMembershipService: null)
-        {
-        }
 
         public CachedVersionSelectorManager(
             GrainVersionManifest grainInterfaceVersions,
             VersionSelectorManager versionSelectorManager,
             CompatibilityDirectorManager compatibilityDirectorManager,
-            IClusterMembershipService? clusterMembershipService)
+            IClusterMembershipService clusterMembershipService)
         {
             this.grainInterfaceVersions = grainInterfaceVersions;
             this.VersionSelectorManager = versionSelectorManager;
@@ -43,8 +38,6 @@ namespace Orleans.Runtime.Versions
         public VersionSelectorManager VersionSelectorManager { get; }
 
         public CompatibilityDirectorManager CompatibilityDirectorManager { get; }
-
-        public event Action? CacheInvalidated;
 
         public CachedEntry GetSuitableSilos(GrainType grainType, GrainInterfaceType interfaceId, ushort requestedVersion)
         {
@@ -114,8 +107,6 @@ namespace Orleans.Runtime.Versions
                 ++this.cacheGeneration;
                 this.suitableSilosCache.Clear();
             }
-
-            CacheInvalidated?.Invoke();
         }
 
         private (MajorMinorVersion Version, CachedEntry Entry) GetSuitableSilosImpl(
@@ -148,9 +139,8 @@ namespace Orleans.Runtime.Versions
 
         private CacheState ObserveCacheState()
         {
+            var membershipVersion = this.clusterMembershipService.CurrentSnapshot.Version;
             var manifestVersion = this.grainInterfaceVersions.LatestVersion;
-            var membershipVersion = this.clusterMembershipService?.CurrentSnapshot.Version
-                ?? new MembershipVersion(manifestVersion.Major);
             if (manifestVersion != this.observedManifestVersion)
             {
                 this.observedManifestVersion = manifestVersion;

--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -18,6 +18,10 @@ using Orleans.Runtime.Diagnostics;
 using Orleans.Runtime.Placement;
 using Orleans.Runtime.Placement.Filtering;
 using Orleans.Runtime.Versions;
+using Orleans.Runtime.Versions.Compatibility;
+using Orleans.Runtime.Versions.Selector;
+using Orleans.Versions.Compatibility;
+using Orleans.Versions.Selector;
 using Orleans.TestingHost.Diagnostics;
 using TestExtensions;
 using Xunit;
@@ -146,7 +150,44 @@ namespace UnitTests.Runtime
             var second = fixture.Target.GetCompatibleSilos(secondTarget);
 
             Assert.Same(first, second);
-            Assert.Equal(1, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
+
+            await StopAsync(fixture.Target);
+        }
+
+        [Fact]
+        public async Task GetCompatibleSilos_LocalSiloShuttingDown_ExcludesLocalSiloFromCachedManifest()
+        {
+            var silos = CreateSilos(2);
+            var fixture = new PlacementServiceFixture(
+                activeSilos: silos,
+                manifestSilos: [silos[1]],
+                localSiloStatus: SiloStatus.ShuttingDown);
+
+            var result = fixture.Target.GetCompatibleSilos(CreatePlacementTarget());
+
+            Assert.Equal(new[] { silos[1] }, result);
+
+            await StopAsync(fixture.Target);
+        }
+
+        [Fact]
+        public async Task GetCompatibleSilosWithVersions_LocalSiloShuttingDown_ExcludesLocalSiloFromCachedManifest()
+        {
+            var silos = CreateSilos(2);
+            var fixture = new PlacementServiceFixture(
+                activeSilos: silos,
+                manifestSilos: [silos[1]],
+                localSiloStatus: SiloStatus.ShuttingDown,
+                interfaceVersion: 1);
+            var target = new PlacementTarget(
+                GrainId.Create(TestGrainType, "grain-1"),
+                new Dictionary<string, object>(),
+                TestInterfaceType,
+                1);
+
+            var result = fixture.Target.GetCompatibleSilosWithVersions(target);
+
+            Assert.Equal(new[] { silos[1] }, result[1]);
 
             await StopAsync(fixture.Target);
         }
@@ -161,30 +202,11 @@ namespace UnitTests.Runtime
             var first = fixture.Target.GetCompatibleSilos(placementTarget);
 
             fixture.ClusterManifestProvider.SetCurrent(CreateClusterManifest(new[] { silos[1] }, version: new MajorMinorVersion(1, 0)));
-            fixture.NotifyMembershipChanged(silos[1]);
+            fixture.SetActiveSilos(silos[1]);
             var second = fixture.Target.GetCompatibleSilos(placementTarget);
 
             Assert.NotSame(first, second);
             Assert.Equal(new[] { silos[1] }, second);
-
-            await StopAsync(fixture.Target);
-        }
-
-        [Fact]
-        public async Task GetCompatibleSilos_VersionSelectorCacheReset_InvalidatesCachedResult()
-        {
-            var silos = CreateSilos(2);
-            var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: silos);
-            var placementTarget = CreatePlacementTarget();
-
-            fixture.Target.GetCompatibleSilos(placementTarget);
-            Assert.Equal(1, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
-
-            fixture.VersionSelectorManager.ResetCache();
-
-            Assert.Equal(0, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
-            fixture.Target.GetCompatibleSilos(placementTarget);
-            Assert.Equal(1, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
 
             await StopAsync(fixture.Target);
         }
@@ -196,20 +218,18 @@ namespace UnitTests.Runtime
             var manifestProvider = new TestClusterManifestProvider(CreateClusterManifest(new[] { silos[0] }));
             var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: new[] { silos[0] }, manifestProvider: manifestProvider);
             var placementTarget = CreatePlacementTarget();
-            var lifecycle = await StartAsync(fixture.Target);
-
             var first = fixture.Target.GetCompatibleSilos(placementTarget);
             Assert.Equal(new[] { silos[0] }, first);
 
             manifestProvider.Publish(CreateClusterManifest(new[] { silos[1] }, version: new MajorMinorVersion(1, 0)));
+            fixture.SetActiveSilos(silos[1]);
 
-            await Until(() => fixture.Target.GetCompatibleSilos(placementTarget).SequenceEqual(new[] { silos[1] }));
             var second = fixture.Target.GetCompatibleSilos(placementTarget);
 
             Assert.NotSame(first, second);
             Assert.Equal(new[] { silos[1] }, second);
 
-            await lifecycle.OnStop();
+            await StopAsync(fixture.Target);
         }
 
         [Fact]
@@ -262,7 +282,6 @@ namespace UnitTests.Runtime
                 grainLocator: null!,
                 grainInterfaceVersions: grainVersionManifest,
                 versionSelectorManager,
-                clusterManifestProvider,
                 directorResolver: null!,
                 strategyResolver: null!,
                 filterStrategyResolver,
@@ -280,14 +299,28 @@ namespace UnitTests.Runtime
             return result;
         }
 
-        private static ClusterManifest CreateClusterManifest(SiloAddress[] silos, bool useFilter = false, MajorMinorVersion? version = null)
+        private static ClusterMembershipSnapshot CreateMembershipSnapshot(
+            long version,
+            IReadOnlyDictionary<SiloAddress, SiloStatus> statuses)
         {
-            var manifest = CreateGrainManifest(useFilter);
+            var members = statuses.ToImmutableDictionary(
+                static entry => entry.Key,
+                static entry => new ClusterMember(entry.Key, entry.Value, entry.Key.ToString()));
+            return new ClusterMembershipSnapshot(members, new MembershipVersion(version));
+        }
+
+        private static ClusterManifest CreateClusterManifest(
+            SiloAddress[] silos,
+            bool useFilter = false,
+            MajorMinorVersion? version = null,
+            ushort interfaceVersion = 0)
+        {
+            var manifest = CreateGrainManifest(useFilter, interfaceVersion);
             var manifests = silos.ToImmutableDictionary(silo => silo, _ => manifest);
             return new ClusterManifest(version ?? MajorMinorVersion.Zero, manifests);
         }
 
-        private static GrainManifest CreateGrainManifest(bool useFilter)
+        private static GrainManifest CreateGrainManifest(bool useFilter, ushort interfaceVersion = 0)
         {
             var grainProperties = ImmutableDictionary.Create<string, string>(StringComparer.Ordinal);
             if (useFilter)
@@ -306,8 +339,28 @@ namespace UnitTests.Runtime
                         TestInterfaceType,
                         new GrainInterfaceProperties(
                             ImmutableDictionary.Create<string, string>(StringComparer.Ordinal)
-                                .Add(WellKnownGrainInterfaceProperties.Version, "0")))
+                           .Add(WellKnownGrainInterfaceProperties.Version, interfaceVersion.ToString())))
                 }));
+        }
+
+        private static CachedVersionSelectorManager CreateCachedVersionSelectorManager(
+            GrainVersionManifest manifest,
+            IClusterMembershipService membership)
+        {
+            var services = new ServiceCollection();
+            services.AddOptions<GrainVersioningOptions>();
+            services.AddKeyedSingleton<VersionSelectorStrategy, AllCompatibleVersions>(nameof(AllCompatibleVersions));
+            services.AddKeyedSingleton<CompatibilityStrategy, BackwardCompatible>(nameof(BackwardCompatible));
+            services.AddKeyedSingleton<IVersionSelector, AllCompatibleVersionsSelector>(typeof(AllCompatibleVersions));
+            services.AddKeyedSingleton<ICompatibilityDirector, BackwardCompatilityDirector>(typeof(BackwardCompatible));
+            var serviceProvider = services.BuildServiceProvider();
+            var options = serviceProvider.GetRequiredService<IOptions<GrainVersioningOptions>>();
+
+            return new CachedVersionSelectorManager(
+                manifest,
+                new VersionSelectorManager(serviceProvider, options),
+                new CompatibilityDirectorManager(serviceProvider, options),
+                membership);
         }
 
         private static ServiceProvider CreateServiceProvider(TestPlacementFilterDirector? filterDirector = null)
@@ -362,33 +415,28 @@ namespace UnitTests.Runtime
             Assert.Equal(workerCount, stoppedEvents.Count);
         }
 
-        private static async Task Until(Func<bool> condition)
-        {
-            var maxTimeout = 10_000;
-            while (!condition() && (maxTimeout -= 10) > 0)
-            {
-                await Task.Delay(10);
-            }
-
-            Assert.True(maxTimeout > 0);
-        }
-
         private sealed class PlacementServiceFixture
         {
             private Dictionary<SiloAddress, SiloStatus> _siloStatuses = new();
+            private long _membershipVersion;
 
             public PlacementServiceFixture(
                 SiloAddress[]? activeSilos = null,
                 SiloAddress[]? manifestSilos = null,
                 TestClusterManifestProvider? manifestProvider = null,
-                bool useFilter = false)
+                bool useFilter = false,
+                SiloStatus localSiloStatus = SiloStatus.Active,
+                ushort interfaceVersion = 0)
             {
                 activeSilos ??= CreateSilos(1);
                 manifestSilos ??= activeSilos;
                 SetActiveSilos(activeSilos);
+                _siloStatuses[activeSilos[0]] = localSiloStatus;
 
-                ClusterManifestProvider = manifestProvider ?? new TestClusterManifestProvider(CreateClusterManifest(manifestSilos, useFilter));
-                VersionSelectorManager = new CachedVersionSelectorManager(new GrainVersionManifest(ClusterManifestProvider), null!, null!);
+                ClusterManifestProvider = manifestProvider ?? new TestClusterManifestProvider(CreateClusterManifest(manifestSilos, useFilter, interfaceVersion: interfaceVersion));
+                _membershipVersion = ClusterManifestProvider.Current.Version.Major;
+                ClusterMembershipService = new TestClusterMembershipService(CreateMembershipSnapshot(_membershipVersion, _siloStatuses));
+                VersionSelectorManager = CreateCachedVersionSelectorManager(new GrainVersionManifest(ClusterManifestProvider), ClusterMembershipService);
                 FilterDirector = useFilter ? new TestPlacementFilterDirector() : null;
                 ServiceProvider = CreateServiceProvider(FilterDirector);
 
@@ -399,11 +447,14 @@ namespace UnitTests.Runtime
                 localSiloDetails.SiloAddress.Returns(activeSilos[0]);
 
                 SiloStatusOracle = Substitute.For<ISiloStatusOracle>();
-                SiloStatusOracle.CurrentStatus.Returns(SiloStatus.Active);
-                SiloStatusOracle.GetActiveSilos().Returns(_ => _siloStatuses.Keys.ToArray());
-                SiloStatusOracle.SubscribeToSiloStatusEvents(Arg.Do<ISiloStatusListener>(listener => StatusListener = listener)).Returns(true);
-                SiloStatusOracle.UnSubscribeFromSiloStatusEvents(Arg.Any<ISiloStatusListener>()).Returns(true);
-
+                SiloStatusOracle.CurrentStatus.Returns(localSiloStatus);
+                SiloStatusOracle.GetActiveSilos().Returns(_ => _siloStatuses
+                    .Where(static entry => entry.Value == SiloStatus.Active)
+                    .Select(static entry => entry.Key)
+                    .ToArray());
+                SiloStatusOracle.GetApproximateSiloStatuses(onlyActive: true).Returns(_ => _siloStatuses
+                    .Where(static entry => entry.Value == SiloStatus.Active)
+                    .ToDictionary());
                 Target = CreateTarget(optionsMonitor, localSiloDetails, SiloStatusOracle, ClusterManifestProvider, ServiceProvider, VersionSelectorManager);
             }
 
@@ -413,22 +464,21 @@ namespace UnitTests.Runtime
 
             public TestClusterManifestProvider ClusterManifestProvider { get; }
 
+            public TestClusterMembershipService ClusterMembershipService { get; }
+
             public ServiceProvider ServiceProvider { get; }
 
             public CachedVersionSelectorManager VersionSelectorManager { get; }
 
             public TestPlacementFilterDirector? FilterDirector { get; }
 
-            private ISiloStatusListener StatusListener { get; set; } = null!;
-
             public void SetActiveSilos(params SiloAddress[] silos)
             {
                 _siloStatuses = silos.ToDictionary(silo => silo, _ => SiloStatus.Active);
-            }
-
-            public void NotifyMembershipChanged(SiloAddress silo)
-            {
-                StatusListener.SiloStatusChangeNotification(silo, SiloStatus.Active);
+                if (ClusterMembershipService is not null)
+                {
+                    ClusterMembershipService.Update(CreateMembershipSnapshot(++_membershipVersion, _siloStatuses));
+                }
             }
         }
 
@@ -465,6 +515,25 @@ namespace UnitTests.Runtime
                 {
                     yield return manifest;
                 }
+            }
+        }
+
+        public sealed class TestClusterMembershipService(ClusterMembershipSnapshot current) : IClusterMembershipService
+        {
+            public ClusterMembershipSnapshot CurrentSnapshot { get; private set; } = current;
+
+            public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => GetUpdates();
+
+            public void Update(ClusterMembershipSnapshot snapshot) => CurrentSnapshot = snapshot;
+
+            public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) => default;
+
+            public Task<bool> TryKill(SiloAddress siloAddress) => Task.FromResult(false);
+
+            private async IAsyncEnumerable<ClusterMembershipSnapshot> GetUpdates()
+            {
+                yield return CurrentSnapshot;
+                await Task.CompletedTask;
             }
         }
 

--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -17,6 +17,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Diagnostics;
 using Orleans.Runtime.Placement;
 using Orleans.Runtime.Placement.Filtering;
+using Orleans.Runtime.Utilities;
 using Orleans.Runtime.Versions;
 using Orleans.Runtime.Versions.Compatibility;
 using Orleans.Runtime.Versions.Selector;
@@ -518,23 +519,29 @@ namespace UnitTests.Runtime
             }
         }
 
-        public sealed class TestClusterMembershipService(ClusterMembershipSnapshot current) : IClusterMembershipService
+        public sealed class TestClusterMembershipService : IClusterMembershipService
         {
-            public ClusterMembershipSnapshot CurrentSnapshot { get; private set; } = current;
+            private readonly AsyncEnumerable<ClusterMembershipSnapshot> _updates;
+            private ClusterMembershipSnapshot _current;
 
-            public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => GetUpdates();
+            public TestClusterMembershipService(ClusterMembershipSnapshot current)
+            {
+                _current = current;
+                _updates = new AsyncEnumerable<ClusterMembershipSnapshot>(
+                    initialValue: current,
+                    updateValidator: (previous, proposed) => proposed.Version > previous.Version,
+                    onPublished: update => Volatile.Write(ref _current, update));
+            }
 
-            public void Update(ClusterMembershipSnapshot snapshot) => CurrentSnapshot = snapshot;
+            public ClusterMembershipSnapshot CurrentSnapshot => Volatile.Read(ref _current);
+
+            public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => _updates;
+
+            public void Update(ClusterMembershipSnapshot snapshot) => _updates.Publish(snapshot);
 
             public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) => default;
 
             public Task<bool> TryKill(SiloAddress siloAddress) => Task.FromResult(false);
-
-            private async IAsyncEnumerable<ClusterMembershipSnapshot> GetUpdates()
-            {
-                yield return CurrentSnapshot;
-                await Task.CompletedTask;
-            }
         }
 
         private sealed class TestPlacementFilterStrategy : PlacementFilterStrategy


### PR DESCRIPTION
PlacementService maintained a second compatibility cache and its own invalidation plumbing alongside CachedVersionSelectorManager. That duplication made placement compatibility state harder to reason about and risked the two caches observing membership and manifest publication at different points.

This change centralizes placement compatibility caching in CachedVersionSelectorManager. PlacementService now delegates compatible-silo lookups to the selector manager, while the selector preserves the retry yielding and cache-clearing behavior introduced by #10597 and removes the temporary CacheInvalidated event and legacy constructor shim.

This follows #10596 and #10597, consolidating ownership of compatibility cache state so placement decisions align with the published membership and grain manifest versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10599)