### PR TITLE
docs: add Orleans scenarios and use cases guide

### DIFF
--- a/docs/site/src/content/docs/overview.md
+++ b/docs/site/src/content/docs/overview.md
@@ -77,7 +77,7 @@ For more information, see [Transactions](grains/transactions.md).
 
 ## When to use Orleans
 
-Orleans is a strong fit when an application has many independently addressable entities, benefits from per-entity isolation, and needs to distribute work across processes or machines. Common examples include games, device management, collaboration, financial workflows, shopping, and online services.
+Orleans is a strong fit when an application has many independently addressable entities, benefits from per-entity isolation, and needs to distribute work across processes or machines. Common examples include AI agent sessions, games, device management, collaboration, financial workflows, shopping, and online services.
 
 Orleans can run in a single process during development and scale to a cluster without changing grain interfaces. Production deployments still require deliberate choices for clustering, storage, retries, observability, capacity, and deployment.
 

--- a/docs/site/src/content/docs/overview.md
+++ b/docs/site/src/content/docs/overview.md
@@ -81,6 +81,8 @@ Orleans is a strong fit when an application has many independently addressable e
 
 Orleans can run in a single process during development and scale to a cluster without changing grain interfaces. Production deployments still require deliberate choices for clustering, storage, retries, observability, capacity, and deployment.
 
+For a decision guide with concrete examples and counterexamples, see [Orleans scenarios and use cases](scenarios.md).
+
 ## Next step
 
 > [!div class="nextstepaction"]

--- a/docs/site/src/content/docs/overview.md
+++ b/docs/site/src/content/docs/overview.md
@@ -77,7 +77,7 @@ For more information, see [Transactions](grains/transactions.md).
 
 ## When to use Orleans
 
-Orleans is a strong fit when an application has many independently addressable entities, benefits from per-entity isolation, and needs to distribute work across processes or machines. Common examples include AI agent sessions, games, device management, collaboration, financial workflows, shopping, and online services.
+Orleans is a strong fit when an application has many independently addressable entities, benefits from per-entity isolation, and needs to distribute work across processes or machines. Common examples include AI agent sessions, fraud protection and risk, IoT and digital twins, monitoring and resource orchestration, online games, collaboration, commerce, and financial services.
 
 Orleans can run in a single process during development and scale to a cluster without changing grain interfaces. Production deployments still require deliberate choices for clustering, storage, retries, observability, capacity, and deployment.
 

--- a/docs/site/src/content/docs/scenarios.md
+++ b/docs/site/src/content/docs/scenarios.md
@@ -7,23 +7,23 @@ ms.topic: conceptual
 
 # Orleans scenarios and use cases
 
-Orleans is most useful when an application has many independently addressable entities whose state and work can be partitioned by identity. A grain can own the behavior and state for one entity while Orleans handles activation, placement, routing, and turn-based execution.
+Orleans supports applications with many independently addressable entities whose state and work partition by identity. A grain owns the behavior and state for one entity, and the runtime manages its activation, placement, routing, and turn-based execution.
 
-The domain name alone doesn't determine whether Orleans is a good fit. A game, device platform, or financial service can contain workloads which suit grains and workloads which are better handled by databases, queues, stream processors, or compute services.
+Choose grains according to identity, state ownership, concurrency, and call patterns. Combine them with databases, queues, stream processors, and compute services according to each workload.
 
 ## Signals that Orleans is a strong fit
 
 Consider Orleans when several of these statements describe the application:
 
 - Domain entities have stable identities, such as a player, device, account, order, room, tenant, or session.
-- Each entity owns state or coordinates work over time instead of serving one stateless request.
+- Each entity owns state or coordinates work over time.
 - Requests for one entity benefit from serialized, turn-based execution.
 - The workload contains many entities and can distribute traffic across their keys.
 - Entities need timers, reminders, streams, persistence, or calls to other entities.
-- Callers should address an entity without tracking which process currently hosts it.
+- Callers use a stable logical identity while the runtime resolves the entity's current host.
 - The application is already a distributed .NET service, or is expected to grow into one.
 
-These signals aren't guarantees of scalability. Grain boundaries, key distribution, call patterns, storage, and external dependencies still determine capacity and failure behavior. A single popular grain remains a single hot key unless the application partitions its work.
+Scalability comes from grain boundaries, key distribution, call patterns, storage, and external dependencies. Partition popular entities across multiple keys to distribute their work.
 
 ## Common scenarios
 
@@ -37,9 +37,9 @@ See the [Adventure game](tutorials-and-samples/adventure.md) explanation and the
 
 ### Devices and digital twins
 
-A grain per device can maintain last-known state, apply commands in order, manage configuration, and coordinate periodic or scheduled work. Grain identity avoids maintaining an application-level map from device IDs to servers, and persistence can restore explicitly written state after reactivation.
+A grain per device can maintain last-known state, apply commands in order, manage configuration, and coordinate periodic or scheduled work. Grain identity lets callers address devices directly while Orleans resolves their current hosts, and persistence restores explicitly written state after reactivation.
 
-Orleans can participate in a telemetry pipeline, but sending every raw measurement through a grain isn't automatically the best design. High-volume ingestion, long-term retention, and fleet-wide analytics often belong in a broker, time-series store, or stream-processing system. Grains can consume selected events and own the stateful behavior of each device.
+Grains can consume selected telemetry events and own the stateful behavior of each device. Brokers, time-series stores, and stream-processing systems provide high-volume ingestion, long-term retention, and fleet-wide analytics for the surrounding telemetry pipeline.
 
 The [GPS Tracker sample](https://github.com/dotnet/orleans/tree/main/samples/GPSTracker) models devices as grains and integrates Orleans with ASP.NET Core SignalR.
 
@@ -47,7 +47,7 @@ The [GPS Tracker sample](https://github.com/dotnet/orleans/tree/main/samples/GPS
 
 Shopping carts, orders, accounts, reservations, and similar entities often have clear ownership boundaries and rules which must hold for one key. A grain can keep those rules with the state they protect, persist changes deliberately, and use reminders or durable jobs for later work.
 
-Some operations span multiple entities. Orleans supports distributed ACID transactions for supported transactional state, but transactions add storage and contention considerations and aren't required for every workflow. Applications can also use idempotent commands, explicit coordination, and reconciliation according to their consistency requirements.
+Orleans supports distributed ACID transactions for operations spanning supported transactional state across multiple entities. Idempotent commands, explicit coordination, and reconciliation support workflows whose consistency model permits independent state transitions.
 
 See the [Shopping Cart sample](https://github.com/dotnet/orleans/tree/main/samples/ShoppingCart), the [Bank Account transactions sample](https://github.com/dotnet/orleans/tree/main/samples/BankAccount), and [Orleans transactions](grains/transactions.md).
 
@@ -61,30 +61,30 @@ The [Chat Room sample](https://github.com/dotnet/orleans/tree/main/samples/ChatR
 
 ### AI agents and conversational sessions
 
-An AI agent session is a natural grain identity. A session grain can own conversation state, model and tool configuration, pending work, and coordination with other agents or services. Orleans activates sessions on demand, removes idle activations, routes each request to the current activation, and processes turns one at a time by default. This simplifies lifecycle management and prevents simultaneous requests from racing to update the same session state.
+An AI agent session is a natural grain identity. A session grain can own conversation state, model and tool configuration, pending work, and coordination with other agents or services. Orleans activates sessions on demand, removes idle activations, routes each request to the current activation, and processes turns one at a time by default. This provides lifecycle management and serializes concurrent session updates.
 
-Model inference and tool calls are typically asynchronous external operations. A grain can await them without blocking a thread, use [response streaming](grains/response-streaming.md) to return generated tokens or progress to one caller, and use timers, reminders, or durable jobs to schedule later work. Response streams are live call results, not durable or replayable token logs; use an appropriate stream or storage system when consumers must reconnect and resume.
+Model inference and tool calls are typically asynchronous external operations. A grain can await them efficiently, use [response streaming](grains/response-streaming.md) to return generated tokens or progress during a live invocation, and use timers, reminders, or durable jobs to schedule later work. A stream provider with retention and replay capabilities, or durable storage, can retain output for reconnection and later consumption.
 
-Orleans provides recovery mechanics rather than automatic fault tolerance for the whole agent operation. After a silo failure, a later request can reactivate the session on a healthy silo, but only [persisted session state](grains/grain-persistence/index.md) is restored. Applications must still define durability points, make tool calls and retries idempotent where possible, and reconcile model or tool operations whose outcome is uncertain.
+After membership converges following a silo failure, a later request can reactivate the session on a healthy silo, and [grain persistence](grains/grain-persistence/index.md) restores state written to durable storage. Explicit durability points, idempotent tool calls, bounded retries, and reconciliation preserve application-level outcomes across failures.
 
 ### Per-entity orchestration
 
 Long-lived processes such as a bot conversation, user workflow, subscription, or scheduled campaign can map to grains when each instance has an identity and progresses independently. Grain state records progress, grain calls express coordination, and timers, reminders, or durable jobs trigger later work.
 
-Orleans isn't a general-purpose workflow product. If the primary requirements are visual process authoring, human approval queues, or a queryable audit history supplied by a workflow engine, use that system directly or integrate it with Orleans.
+Orleans expresses programmatic, per-entity orchestration in grain code. Workflow engines provide visual process authoring, human approval queues, and queryable audit histories, and can integrate with grains which own domain state.
 
-## When another approach may fit better
+## Choose the architecture by workload
 
-Another design is usually simpler when the workload primarily consists of:
+Match the primary workload to the architecture designed for its execution and state model:
 
-- **Stateless request processing or straightforward CRUD.** An ASP.NET Core service backed by a database may provide all the required coordination and durability.
-- **A few large CPU-bound or data-parallel jobs.** Grain turns should remain short and asynchronous. Use parallel compute, batch, or job-processing tools for substantial computation.
+- **Stateless request processing or straightforward CRUD.** An ASP.NET Core service backed by a database provides request handling, coordination, and durability.
+- **A few large CPU-bound or data-parallel jobs.** Parallel compute, batch, or job-processing tools distribute substantial computation. Grain turns remain short and asynchronous.
 - **Bulk analytics, ETL, or declarative stream processing.** Databases and data-flow engines are designed for scans, joins, windows, and shared transformations across large data sets.
-- **One globally coordinated resource or a permanently hot key.** Adding silos doesn't divide one grain's work. Partition the domain, accept the bottleneck, or choose a system designed for that access pattern.
-- **Shared-memory or hard real-time processing.** Grain calls are asynchronous and can cross a network. Orleans doesn't provide shared mutable memory, deterministic scheduling, or hard real-time latency.
-- **A work queue with competing consumers.** Orleans streams are multicast rather than a competing-consumer queue. Model ownership explicitly or use a queue designed for worker dispatch.
+- **One globally coordinated resource or a permanently hot key.** Domain partitioning distributes the work, while systems specialized for single-resource coordination manage a centralized access pattern.
+- **Shared-memory or hard real-time processing.** A local concurrent runtime provides shared-memory access, and a hard real-time platform provides deterministic scheduling and bounded latency.
+- **A work queue with competing consumers.** A competing-consumer queue assigns each item to one worker. Orleans streams deliver each item to every subscription on a logical stream.
 
-A system can use Orleans for one stateful subsystem without modeling every component as a grain. HTTP APIs, databases, caches, brokers, compute workers, and analytics systems commonly remain part of the architecture.
+Orleans commonly owns the stateful entity subsystem alongside HTTP APIs, databases, caches, brokers, compute workers, and analytics systems.
 
 ## Evaluate the model against the workload
 

--- a/docs/site/src/content/docs/scenarios.md
+++ b/docs/site/src/content/docs/scenarios.md
@@ -1,0 +1,92 @@
+---
+title: Orleans scenarios and use cases
+description: Decide whether the Orleans virtual actor model fits an application's workload.
+ms.date: 08/15/2026
+ms.topic: conceptual
+---
+
+# Orleans scenarios and use cases
+
+Orleans is most useful when an application has many independently addressable entities whose state and work can be partitioned by identity. A grain can own the behavior and state for one entity while Orleans handles activation, placement, routing, and turn-based execution.
+
+The domain name alone doesn't determine whether Orleans is a good fit. A game, device platform, or financial service can contain workloads which suit grains and workloads which are better handled by databases, queues, stream processors, or compute services.
+
+## Signals that Orleans is a strong fit
+
+Consider Orleans when several of these statements describe the application:
+
+- Domain entities have stable identities, such as a player, device, account, order, room, tenant, or session.
+- Each entity owns state or coordinates work over time instead of serving one stateless request.
+- Requests for one entity benefit from serialized, turn-based execution.
+- The workload contains many entities and can distribute traffic across their keys.
+- Entities need timers, reminders, streams, persistence, or calls to other entities.
+- Callers should address an entity without tracking which process currently hosts it.
+- The application is already a distributed .NET service, or is expected to grow into one.
+
+These signals aren't guarantees of scalability. Grain boundaries, key distribution, call patterns, storage, and external dependencies still determine capacity and failure behavior. A single popular grain remains a single hot key unless the application partitions its work.
+
+## Common scenarios
+
+### Multiplayer games and presence
+
+Players, game sessions, rooms, parties, and matches have natural identities and typically own mutable state. Grains can serialize operations for each entity, coordinate interactions through grain calls, and notify connected clients through observers or streams.
+
+Use Orleans for authoritative game and social state, matchmaking coordination, presence, and session lifecycle. Keep latency-critical simulation, rendering, and other CPU-intensive loops in an execution model designed for that work.
+
+See the [Adventure game](tutorials-and-samples/adventure.md) explanation and the maintained [Presence Service sample](https://github.com/dotnet/orleans/tree/main/samples/Presence).
+
+### Devices and digital twins
+
+A grain per device can maintain last-known state, apply commands in order, manage configuration, and coordinate periodic or scheduled work. Grain identity avoids maintaining an application-level map from device IDs to servers, and persistence can restore explicitly written state after reactivation.
+
+Orleans can participate in a telemetry pipeline, but sending every raw measurement through a grain isn't automatically the best design. High-volume ingestion, long-term retention, and fleet-wide analytics often belong in a broker, time-series store, or stream-processing system. Grains can consume selected events and own the stateful behavior of each device.
+
+The [GPS Tracker sample](https://github.com/dotnet/orleans/tree/main/samples/GPSTracker) models devices as grains and integrates Orleans with ASP.NET Core SignalR.
+
+### Commerce, accounts, and business processes
+
+Shopping carts, orders, accounts, reservations, and similar entities often have clear ownership boundaries and rules which must hold for one key. A grain can keep those rules with the state they protect, persist changes deliberately, and use reminders or durable jobs for later work.
+
+Some operations span multiple entities. Orleans supports distributed ACID transactions for supported transactional state, but transactions add storage and contention considerations and aren't required for every workflow. Applications can also use idempotent commands, explicit coordination, and reconciliation according to their consistency requirements.
+
+See the [Shopping Cart sample](https://github.com/dotnet/orleans/tree/main/samples/ShoppingCart), the [Bank Account transactions sample](https://github.com/dotnet/orleans/tree/main/samples/BankAccount), and [Orleans transactions](grains/transactions.md).
+
+### Collaboration, messaging, and live sessions
+
+Rooms, channels, documents, users, and sessions can be independently addressed and can retain behavior between client requests. Grain observers fit transient callbacks to connected clients, while Orleans streams fit multicast event flows and subscriptions whose guarantees depend on the selected provider.
+
+Use a dedicated broker or storage system when the primary requirement is durable message retention, competing consumers, large broadcast fan-out, or analytics over the full event history. Orleans can complement those systems by applying per-entity state and behavior to selected events.
+
+The [Chat Room sample](https://github.com/dotnet/orleans/tree/main/samples/ChatRoom) combines a grain per channel with Orleans streams.
+
+### Per-entity orchestration
+
+Long-lived processes such as a bot conversation, user workflow, subscription, or scheduled campaign can map to grains when each instance has an identity and progresses independently. Grain state records progress, grain calls express coordination, and timers, reminders, or durable jobs trigger later work.
+
+Orleans isn't a general-purpose workflow product. If the primary requirements are visual process authoring, human approval queues, or a queryable audit history supplied by a workflow engine, use that system directly or integrate it with Orleans.
+
+## When another approach may fit better
+
+Another design is usually simpler when the workload primarily consists of:
+
+- **Stateless request processing or straightforward CRUD.** An ASP.NET Core service backed by a database may provide all the required coordination and durability.
+- **A few large CPU-bound or data-parallel jobs.** Grain turns should remain short and asynchronous. Use parallel compute, batch, or job-processing tools for substantial computation.
+- **Bulk analytics, ETL, or declarative stream processing.** Databases and data-flow engines are designed for scans, joins, windows, and shared transformations across large data sets.
+- **One globally coordinated resource or a permanently hot key.** Adding silos doesn't divide one grain's work. Partition the domain, accept the bottleneck, or choose a system designed for that access pattern.
+- **Shared-memory or hard real-time processing.** Grain calls are asynchronous and can cross a network. Orleans doesn't provide shared mutable memory, deterministic scheduling, or hard real-time latency.
+- **A work queue with competing consumers.** Orleans streams are multicast rather than a competing-consumer queue. Model ownership explicitly or use a queue designed for worker dispatch.
+
+A system can use Orleans for one stateful subsystem without modeling every component as a grain. HTTP APIs, databases, caches, brokers, compute workers, and analytics systems commonly remain part of the architecture.
+
+## Evaluate the model against the workload
+
+Before committing to a design, identify candidate grain keys and test the busiest paths:
+
+1. Define which entity owns each invariant and operation.
+1. Estimate the number of active keys and the traffic distribution between them.
+1. Look for hot keys, global coordinators, chatty call chains, and large messages.
+1. Decide what state must survive failure and when writes must complete.
+1. Define retry, idempotency, timeout, and recovery behavior for each external operation.
+1. Load test a representative key distribution and the production provider types.
+
+For the programming model's benefits and tradeoffs, see [Why Orleans](benefits.md). For design and operational guidance, see [Orleans best practices](resources/best-practices.md) and the [production-readiness checklist](deployment/production-readiness.md).

--- a/docs/site/src/content/docs/scenarios.md
+++ b/docs/site/src/content/docs/scenarios.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans scenarios and use cases
 description: Decide whether the Orleans virtual actor model fits an application's workload.
-ms.date: 08/15/2026
+ms.date: 08/17/2026
 ms.topic: conceptual
 ---
 
@@ -58,6 +58,14 @@ Rooms, channels, documents, users, and sessions can be independently addressed a
 Use a dedicated broker or storage system when the primary requirement is durable message retention, competing consumers, large broadcast fan-out, or analytics over the full event history. Orleans can complement those systems by applying per-entity state and behavior to selected events.
 
 The [Chat Room sample](https://github.com/dotnet/orleans/tree/main/samples/ChatRoom) combines a grain per channel with Orleans streams.
+
+### AI agents and conversational sessions
+
+An AI agent session is a natural grain identity. A session grain can own conversation state, model and tool configuration, pending work, and coordination with other agents or services. Orleans activates sessions on demand, removes idle activations, routes each request to the current activation, and processes turns one at a time by default. This simplifies lifecycle management and prevents simultaneous requests from racing to update the same session state.
+
+Model inference and tool calls are typically asynchronous external operations. A grain can await them without blocking a thread, use [response streaming](grains/response-streaming.md) to return generated tokens or progress to one caller, and use timers, reminders, or durable jobs to schedule later work. Response streams are live call results, not durable or replayable token logs; use an appropriate stream or storage system when consumers must reconnect and resume.
+
+Orleans provides recovery mechanics rather than automatic fault tolerance for the whole agent operation. After a silo failure, a later request can reactivate the session on a healthy silo, but only [persisted session state](grains/grain-persistence/index.md) is restored. Applications must still define durability points, make tool calls and retries idempotent where possible, and reconcile model or tool operations whose outcome is uncertain.
 
 ### Per-entity orchestration
 

--- a/docs/site/src/content/docs/scenarios.md
+++ b/docs/site/src/content/docs/scenarios.md
@@ -27,45 +27,65 @@ Scalability comes from grain boundaries, key distribution, call patterns, storag
 
 ## Common scenarios
 
-### Multiplayer games and presence
-
-Players, game sessions, rooms, parties, and matches have natural identities and typically own mutable state. Grains can serialize operations for each entity, coordinate interactions through grain calls, and notify connected clients through observers or streams.
-
-Use Orleans for authoritative game and social state, matchmaking coordination, presence, and session lifecycle. Keep latency-critical simulation, rendering, and other CPU-intensive loops in an execution model designed for that work.
-
-See the [Adventure game](tutorials-and-samples/adventure.md) explanation and the maintained [Presence Service sample](https://github.com/dotnet/orleans/tree/main/samples/Presence).
-
-### Devices and digital twins
-
-A grain per device can maintain last-known state, apply commands in order, manage configuration, and coordinate periodic or scheduled work. Grain identity lets callers address devices directly while Orleans resolves their current hosts, and persistence restores explicitly written state after reactivation.
-
-Grains can consume selected telemetry events and own the stateful behavior of each device. Brokers, time-series stores, and stream-processing systems provide high-volume ingestion, long-term retention, and fleet-wide analytics for the surrounding telemetry pipeline.
-
-The [GPS Tracker sample](https://github.com/dotnet/orleans/tree/main/samples/GPSTracker) models devices as grains and integrates Orleans with ASP.NET Core SignalR.
-
-### Commerce, accounts, and business processes
-
-Shopping carts, orders, accounts, reservations, and similar entities often have clear ownership boundaries and rules which must hold for one key. A grain can keep those rules with the state they protect, persist changes deliberately, and use reminders or durable jobs for later work.
-
-Orleans supports distributed ACID transactions for operations spanning supported transactional state across multiple entities. Idempotent commands, explicit coordination, and reconciliation support workflows whose consistency model permits independent state transitions.
-
-See the [Shopping Cart sample](https://github.com/dotnet/orleans/tree/main/samples/ShoppingCart), the [Bank Account transactions sample](https://github.com/dotnet/orleans/tree/main/samples/BankAccount), and [Orleans transactions](grains/transactions.md).
-
-### Collaboration, messaging, and live sessions
-
-Rooms, channels, documents, users, and sessions can be independently addressed and can retain behavior between client requests. Grain observers fit transient callbacks to connected clients, while Orleans streams fit multicast event flows and subscriptions whose guarantees depend on the selected provider.
-
-Use a dedicated broker or storage system when the primary requirement is durable message retention, competing consumers, large broadcast fan-out, or analytics over the full event history. Orleans can complement those systems by applying per-entity state and behavior to selected events.
-
-The [Chat Room sample](https://github.com/dotnet/orleans/tree/main/samples/ChatRoom) combines a grain per channel with Orleans streams.
-
 ### AI agents and conversational sessions
 
 An AI agent session is a natural grain identity. A session grain can own conversation state, model and tool configuration, pending work, and coordination with other agents or services. Orleans activates sessions on demand, removes idle activations, routes each request to the current activation, and processes turns one at a time by default. This provides lifecycle management and serializes concurrent session updates.
 
-Model inference and tool calls are typically asynchronous external operations. A grain can await them efficiently, use [response streaming](grains/response-streaming.md) to return generated tokens or progress during a live invocation, and use timers, reminders, or durable jobs to schedule later work. A stream provider with retention and replay capabilities, or durable storage, can retain output for reconnection and later consumption.
+Model inference and tool calls are typically asynchronous external operations. A grain can await them efficiently, use [response streaming](grains/response-streaming.md) to return generated tokens or progress during one live invocation, and use timers, reminders, or durable jobs to schedule later work. A stream provider with retention and replay capabilities, or durable storage, can retain output for reconnection and later consumption.
 
 After membership converges following a silo failure, a later request can reactivate the session on a healthy silo, and [grain persistence](grains/grain-persistence/index.md) restores state written to durable storage. Explicit durability points, idempotent tool calls, bounded retries, and reconciliation preserve application-level outcomes across failures.
+
+### Fraud protection, risk, and low-latency decisioning
+
+Fraud protection, financial services, actuarial systems, and regulated online gaming often make decisions from rapidly changing state. A grain can maintain low-latency *soft state*: reconstructible in-memory working data derived from durable records, event streams, market feeds, or model outputs. Turn-based execution keeps each entity's updates and decisions ordered.
+
+Account, payment instrument, merchant, policy, portfolio, market, and gaming-event grains can track recent activity, risk signals, limits, exposure, and current odds. Grain calls coordinate decisions across related entities, while streams distribute changing inputs and outputs. Durable stores and event logs retain the authoritative history used to rebuild working state and support audit.
+
+The same pattern supports real-time pricing, auctions, inventory allocation, recommendations, and other decisions which combine an entity's current context with incoming events. Parallel compute and data platforms can produce models or large analytical results which grains apply during online decisioning.
+
+The [Stocks sample](https://github.com/dotnet/orleans/tree/main/samples/Stocks) demonstrates per-symbol temporary caching and periodic updates. The [Bank Account transactions sample](https://github.com/dotnet/orleans/tree/main/samples/BankAccount) demonstrates coordinated state changes across accounts.
+
+### Internet of Things and digital twins
+
+Internet of Things (IoT) devices, vehicles, sensors, industrial assets, robots, buildings, and edge gateways have stable identities and evolving state. A grain per asset can maintain last-known state, apply commands in order, manage configuration, evaluate local rules, and coordinate periodic or scheduled work. Grain identity lets callers address each asset directly while Orleans resolves its current host, and persistence restores explicitly written state after reactivation.
+
+Grains can consume selected telemetry events and own the stateful behavior of each asset. Brokers, time-series stores, and stream-processing systems provide high-volume ingestion, long-term retention, fleet-wide analytics, and model training for the surrounding telemetry pipeline.
+
+The [GPS Tracker sample](https://github.com/dotnet/orleans/tree/main/samples/GPSTracker) models IoT devices as grains and integrates Orleans with ASP.NET Core SignalR.
+
+### Monitoring, resource governance, and job orchestration
+
+Servers, services, containers, clusters, tenants, quotas, jobs, and hardware resources map naturally to grains. A resource grain can combine heartbeats, health signals, desired configuration, capacity, reservations, and remediation state. Timers detect stale health reports, reminders trigger recurring checks, and durable jobs schedule one-time follow-up actions.
+
+Job grains can own submission state, dependencies, retries, progress, and completion. Resource grains can own hardware availability and allocation. Partitioned scheduler grains match jobs to eligible resources, and external workers execute assigned work and report status through grain calls or streams. Stable grain identities let operators and automation address the same job or resource throughout its lifecycle.
+
+This model supports fleet health monitoring, automated remediation, quota enforcement, workload placement, batch and build farms, and orchestration across specialized hardware. [Heterogeneous silos](host/heterogeneous-silos.md) and [placement filtering](grains/grain-placement-filtering.md) also direct Orleans grain workloads to hosts with specific capabilities.
+
+### Multiplayer and online games
+
+Players, game sessions, rooms, parties, matches, tournaments, and leaderboards have natural identities and typically own mutable state. Grains can serialize operations for each entity, coordinate interactions through grain calls, and notify connected clients through observers or streams.
+
+Use Orleans for authoritative game and social state, matchmaking coordination, presence, progression, and session lifecycle. Real-time simulation, rendering, and other CPU-intensive loops can run in specialized compute services while grains coordinate durable and interactive state.
+
+See the [Adventure game](tutorials-and-samples/adventure.md) explanation and the maintained [Presence Service sample](https://github.com/dotnet/orleans/tree/main/samples/Presence).
+
+### Commerce, reservations, and customer services
+
+Shopping carts, orders, accounts, reservations, subscriptions, and customer profiles often have clear ownership boundaries and rules which must hold for one key. A grain can keep those rules with the state they protect, persist changes deliberately, and use reminders or durable jobs for later work.
+
+Per-user grains can maintain preferences, session context, entitlements, notification state, quotas, and recent interactions for responsive personalization. Recommendation and search services can provide ranked results which the grain combines with current user and business state.
+
+Orleans supports distributed ACID transactions for operations spanning supported transactional state across multiple entities. Idempotent commands, explicit coordination, and reconciliation support workflows whose consistency model permits independent state transitions.
+
+See the [Shopping Cart sample](https://github.com/dotnet/orleans/tree/main/samples/ShoppingCart) and [Orleans transactions](grains/transactions.md).
+
+### Collaboration, social applications, and live sessions
+
+Rooms, channels, documents, users, social profiles, and sessions can be independently addressed and can retain behavior between client requests. Grain observers fit transient callbacks to connected clients, while Orleans streams fit multicast event flows and subscriptions whose guarantees depend on the selected provider.
+
+Brokers and storage systems provide durable message retention, competing consumers, large broadcast fan-out, and analytics over full event histories. Grains apply per-entity state and behavior to selected events and coordinate live interactions.
+
+The [Chat Room sample](https://github.com/dotnet/orleans/tree/main/samples/ChatRoom) combines a grain per channel with Orleans streams. The [Chirper sample](https://github.com/dotnet/orleans/tree/main/samples/Chirper) models a social network with user grains, persistence, and observers.
 
 ### Per-entity orchestration
 

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -8,6 +8,8 @@ items:
         href: overview.md
       - name: Why Orleans?
         href: benefits.md
+      - name: Scenarios and use cases
+        href: scenarios.md
   - name: Get started
     items:
       - name: Hello World


### PR DESCRIPTION
## Problem
Readers need a focused guide for choosing architectures for application workloads which use the virtual actor model.

## Solution
Add a scenarios and use-cases page led by AI agent sessions and covering fraud protection, risk and low-latency soft-state decisioning, IoT and digital twins, monitoring and automated remediation, resource governance and hardware-aware job orchestration, multiplayer and online games, commerce and personalization, collaboration and social applications, and per-entity workflows. The page states the runtime behavior and outcomes each feature supplies, links to maintained examples and capability documentation, describes workload-specific architecture choices, and is linked from the overview and primary navigation.

## Rationale
A decision-oriented guide helps readers evaluate Orleans from workload characteristics. It connects runtime capabilities to concrete outcomes and shows how grains compose with specialized storage, messaging, compute, analytics, and workflow systems.

Fixes #2937