### PR TITLE
docs: document Orleans metrics monitoring guidance

### DIFF
--- a/docs/site/src/content/docs/deployment/health-and-observability.md
+++ b/docs/site/src/content/docs/deployment/health-and-observability.md
@@ -1,7 +1,7 @@
 ---
 title: Health and observability
 description: Design Orleans startup, readiness, liveness, dependency health, telemetry, and alerts.
-ms.date: 08/02/2026
+ms.date: 08/15/2026
 ms.topic: concept-article
 ---
 
@@ -64,7 +64,7 @@ Apply timeouts and concurrency limits at every remote boundary. Use circuit brea
 
 ## Telemetry
 
-Orleans uses `Microsoft.Extensions.Logging`, `System.Diagnostics.Metrics`, and distributed tracing. Configure a central exporter and see [Orleans observability](../host/monitoring/index.md) for the runtime instruments.
+Orleans uses `Microsoft.Extensions.Logging`, `System.Diagnostics.Metrics`, and distributed tracing. Configure a central exporter, see [Orleans observability](../host/monitoring/index.md) for signal configuration, and use [Monitor Orleans metrics](../host/monitoring/metrics.md) to interpret runtime instruments.
 
 At minimum, correlate these dimensions:
 

--- a/docs/site/src/content/docs/host/monitoring/index.md
+++ b/docs/site/src/content/docs/host/monitoring/index.md
@@ -78,6 +78,7 @@ The example's 10% head-sampling ratio is a starting point, not a universal produ
 
 ## Next steps
 
+- [Monitor Orleans metrics](metrics.md)
 - [Interpret Orleans signals](signals.md)
 - [Troubleshoot Orleans incidents](troubleshooting.md)
 - [Secure and operate the Orleans Dashboard](../../dashboard/index.md)

--- a/docs/site/src/content/docs/host/monitoring/metrics-catalog.md
+++ b/docs/site/src/content/docs/host/monitoring/metrics-catalog.md
@@ -1,0 +1,270 @@
+---
+title: Orleans metrics catalog
+description: Complete reference for metrics emitted by the Microsoft.Orleans meter.
+ms.date: 08/18/2026
+ms.topic: reference
+---
+
+# Orleans metrics catalog
+
+This catalog lists every instrument created for the `Microsoft.Orleans` meter in the current source tree. Core runtime instruments are available when their component runs. Streaming, transactions, durable jobs, journaling, and provider-specific instruments appear only when those features are configured. Discover the instruments emitted by the deployed Orleans version because releases and configured packages can differ.
+
+The **Unit** column gives the natural unit recorded by Orleans. "Implicit" means the instrument doesn't set unit metadata. `TimeSpan` ticks are 100 nanoseconds. The **Attributes** column lists attributes added by Orleans; resource attributes such as `service.instance.id` also identify each time series.
+
+Instrument types use these abbreviations:
+
+- **C**: <xref:System.Diagnostics.Metrics.Counter`1>
+- **OC**: <xref:System.Diagnostics.Metrics.ObservableCounter`1>
+- **UDC**: <xref:System.Diagnostics.Metrics.UpDownCounter`1>
+- **OG**: <xref:System.Diagnostics.Metrics.ObservableGauge`1>
+- **H**: <xref:System.Diagnostics.Metrics.Histogram`1>
+
+Some instruments retain historical types or unit strings. The descriptions below state the runtime behavior so queries can preserve those semantics.
+
+## Application requests and clients
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-app-requests-canceled` | C | Requests, implicit | `grain_type` | Outbound grain requests canceled by their caller. |
+| `orleans-app-requests-latency-bucket` | OC | Milliseconds, implicit | `duration` | Completed outbound request callbacks in one latency band. Bands are mutually exclusive, range from `1ms` through `15000ms`, and include an overflow band. |
+| `orleans-app-requests-latency-count` | OC | Requests, implicit | - | Total completed outbound request callbacks represented by the latency bands. |
+| `orleans-app-requests-latency-sum` | OC | Milliseconds, implicit | - | Sum of caller-observed elapsed time for completed outbound request callbacks. |
+| `orleans-app-requests-timedout` | C | Requests, implicit | `grain_type` | Outbound grain requests which exceeded the configured response timeout. |
+| `orleans-client-connected-gateways` | OG | Gateways, implicit | - | Gateway connections currently held by an Orleans client. |
+
+Request latency covers the interval until the caller's callback completes, including terminal timeout, cancellation, target-silo failure, and host-shutdown paths.
+
+## Networking, gateways, and messaging
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-gateway-connected-clients` | UDC | Clients, implicit | - | Client identities currently tracked by a silo gateway, including disconnected clients retained during the configured drop timeout. |
+| `orleans-gateway-load-shedding` | C | Messages, implicit | - | Client requests rejected because the gateway overload detector reported saturation. |
+| `orleans-gateway-received` | C | Messages, implicit | - | Messages received by a silo through a client gateway connection. |
+| `orleans-gateway-sent` | C | Messages, implicit | - | Gateway message-send events, including messages written to client connections. |
+| `orleans-messaging-expired` | C | Messages, implicit | `Phase` | Messages which expired during `Send`, `Receive`, `Dispatch`, `Invoke`, or `Respond`. |
+| `orleans-messaging-pings-received` | C | Pings, implicit | `Destination` | Membership probe messages received from the identified silo address. |
+| `orleans-messaging-pings-reply-missed` | C | Replies, implicit | `Destination` | Direct or indirect membership probes which didn't receive a successful reply from the identified silo address. |
+| `orleans-messaging-pings-reply-received` | C | Replies, implicit | `Destination` | Successful direct or indirect membership probe replies from the identified silo address. |
+| `orleans-messaging-pings-sent` | C | Pings, implicit | `Destination` | Membership probe messages sent to the identified silo address. |
+| `orleans-messaging-processing-activation-data` | OG | Requests, implicit | - | Requests currently queued or executing across all grain activations on the silo. |
+| `orleans-messaging-processing-dispatcher-forwarded` | OC | Messages, implicit | - | Messages forwarded by the dispatcher. |
+| `orleans-messaging-processing-dispatcher-processed` | OC | Messages, implicit | `Direction`, `Status` | Messages processed by the dispatcher, split by message direction and `Ok` or `Error` result. |
+| `orleans-messaging-processing-dispatcher-received` | OC | Messages, implicit | `Context`, `Direction` | Messages received by the dispatcher, split by message direction and whether a grain runtime context was present. |
+| `orleans-messaging-processing-ima-enqueued` | OC | Messages, implicit | `Context` | Messages enqueued to an incoming-message-agent target: `ToNull`, `ToSystemTarget`, or `ToGrain`. |
+| `orleans-messaging-processing-ima-received` | OC | Messages, implicit | - | Messages received by the incoming message agent. |
+| `orleans-messaging-received-header-size` | OC | `bytes` | - | Cumulative serialized header bytes received by the process. |
+| `orleans-messaging-received-messages-size` | H | `bytes` | `ConnectionDirection`, `MessageDirection`, optional `silo` | Distribution of total received message sizes. |
+| `orleans-messaging-rejected` | C | Messages, implicit | `Direction` | Messages rejected by the runtime. |
+| `orleans-messaging-rerouted` | C | Messages, implicit | `Direction` | Messages rerouted after their original route couldn't be used. |
+| `orleans-messaging-sent-dropped` | C | Messages, implicit | `Direction` | Outbound messages dropped before successful transmission. |
+| `orleans-messaging-sent-failed` | C | Messages, implicit | `Direction` | Outbound messages whose send attempt failed. |
+| `orleans-messaging-sent-header-size` | OC | `bytes` | - | Cumulative serialized header bytes sent by the process. |
+| `orleans-messaging-sent-local` | OC | Messages, implicit | - | Messages delivered locally without a network send. |
+| `orleans-messaging-sent-messages-size` | H | `bytes` | `ConnectionDirection`, `MessageDirection`, optional `silo` | Distribution of total sent message sizes. |
+| `orleans-networking-sockets-closed` | C | Sockets, implicit | `Direction` | Network connections closed, split by connection direction. |
+| `orleans-networking-sockets-opened` | C | Sockets, implicit | `Direction` | Network connections opened, split by connection direction. |
+
+`Destination` and `silo` contain silo addresses and incarnations. They are useful during incident diagnosis and can create new time series during restarts.
+
+## Scheduling, activations, and grains
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-catalog-activation-collections` | C | Scans, implicit | - | Activation-collection scans performed by the silo. |
+| `orleans-catalog-activation-concurrent-registration-attempts` | C | Attempts, implicit | - | Activation registrations which encountered an activation already registered elsewhere. |
+| `orleans-catalog-activation-created` | C | Activations, implicit | - | Activation objects created on the silo. |
+| `orleans-catalog-activation-destroyed` | C | Activations, implicit | - | Activations removed from the silo catalog. |
+| `orleans-catalog-activation-failed-to-activate` | C | Activations, implicit | - | Activations whose lifecycle initialization failed or was canceled. |
+| `orleans-catalog-activation-latency` | H | `ms` | `status`, `directory` | Activation duration, split by outcome and whether the grain uses the directory. Status values include `success`, `canceled`, `directory_error`, `duplicate`, and `error`. |
+| `orleans-catalog-activation-non-existent` | C | Messages, implicit | - | Messages which targeted an activation that wasn't present in the local catalog. |
+| `orleans-catalog-activation-shutdown` | C | Activations, implicit | `via` | Activation shutdowns split by `collection`, `deactivateOnIdle`, `deactivateStuckActivation`, or `migration`. |
+| `orleans-catalog-activation-working-set` | OG | Activations, implicit | - | Activations currently in the silo's active working set. |
+| `orleans-catalog-activations` | OG | Activations, implicit | - | Activations currently registered in the silo catalog. |
+| `orleans-catalog-deactivation-latency` | H | `ms` | `via` | Deactivation duration, split by the shutdown path. |
+| `orleans-grains` | UDC | Grains, implicit | `type` | Current grain instances by grain type. |
+| `orleans-scheduler-long-running-turns` | C | Turns, implicit | - | Grain micro-turns whose synchronous execution exceeded <xref:Orleans.Configuration.SchedulingOptions.TurnWarningLengthThreshold>. |
+| `orleans-system-targets` | UDC | System targets, implicit | `type` | Current Orleans system-target instances by type. |
+
+## Grain directory and consistent rings
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-consistent-ring-range-percentage-average` | OG | Percent, implicit | - | Equal-share percentage of the consistent-hash ring for one silo (`100 / ring size`). |
+| `orleans-consistent-ring-range-percentage-local` | OG | Percent, implicit | - | Percentage of the consistent-hash ring currently owned by this silo. |
+| `orleans-consistent-ring-size` | OG | Silos, implicit | - | Members in the consistent-hash ring. |
+| `orleans-directory-cache-size` | OG | Entries, implicit | - | Total entries across registered local grain-directory caches. |
+| `orleans-directory-lookups-cache-issued` | C | Lookups, implicit | - | Grain-location lookups attempted against the local directory cache. |
+| `orleans-directory-lookups-cache-successes` | C | Lookups, implicit | - | Local directory-cache lookups which returned a usable entry. |
+| `orleans-directory-lookups-full-issued` | C | Lookups, implicit | - | Full grain-directory lookups initiated by this silo. |
+| `orleans-directory-lookups-local-directory-issued` | C | Lookups, implicit | - | Lookups issued directly against the local directory partition. |
+| `orleans-directory-lookups-local-directory-successes` | C | Lookups, implicit | - | Direct local-partition lookups which returned a grain address. |
+| `orleans-directory-lookups-local-issued` | C | Lookups, implicit | - | Grain-location lookups issued through the local grain locator. |
+| `orleans-directory-lookups-local-successes` | C | Lookups, implicit | - | Local grain-locator lookups which returned a grain address. |
+| `orleans-directory-lookups-remote-received` | C | Lookups, implicit | - | Forwarded directory lookup requests received from another silo. |
+| `orleans-directory-lookups-remote-sent` | C | Lookups, implicit | - | Directory lookup requests forwarded to another silo. |
+| `orleans-directory-partition-size` | OG | Entries, implicit | - | Grain registrations in this silo's local directory partition. |
+| `orleans-directory-range-lock-held-duration` | H | Milliseconds, implicit | - | Distribution of time directory range locks were held. |
+| `orleans-directory-recovery-count` | C | Recoveries, implicit | - | Directory range recoveries completed after membership changes. |
+| `orleans-directory-recovery-duration` | H | Milliseconds, implicit | - | Distribution of completed directory range-recovery durations. |
+| `orleans-directory-registration-duration` | H | `ms` | `locator`, `status` | Grain registration duration by locator implementation and `success`, `canceled`, or `error` outcome. |
+| `orleans-directory-registrations` | C | Registrations, implicit | `locator`, `status` | Completed grain registration attempts by locator implementation and outcome. |
+| `orleans-directory-registrations-single-act-issued` | C | Registrations, implicit | - | Single-activation registration requests initiated on this silo. |
+| `orleans-directory-registrations-single-act-local` | C | Registrations, implicit | - | Single-activation registrations handled by the local directory owner. |
+| `orleans-directory-registrations-single-act-remote-received` | C | Registrations, implicit | - | Forwarded single-activation registration requests received from another silo. |
+| `orleans-directory-registrations-single-act-remote-sent` | C | Registrations, implicit | - | Single-activation registration requests forwarded to another silo. |
+| `orleans-directory-ring-local-portion-average-percentage` | OG | Percent, implicit | - | Equal-share percentage of the local grain-directory ring (`100 / ring size`). |
+| `orleans-directory-ring-local-portion-distance` | OG | Hash-ring distance, implicit | - | Raw hash-ring distance from this silo to its successor. |
+| `orleans-directory-ring-local-portion-percentage` | OG | Percent, implicit | - | Percentage of the local grain-directory ring assigned to this silo. |
+| `orleans-directory-ring-size` | OG | Silos, implicit | - | Members in the local grain-directory ring. |
+| `orleans-directory-snapshot-transfer-count` | C | Transfers, implicit | - | Directory range snapshots successfully received from the previous partition owner. |
+| `orleans-directory-snapshot-transfer-duration` | H | Milliseconds, implicit | - | Distribution of successful directory snapshot-transfer durations. |
+| `orleans-directory-unregistrations-issued` | C | Unregistrations, implicit | - | Single grain-unregistration requests initiated on this silo. |
+| `orleans-directory-unregistrations-local` | C | Unregistrations, implicit | - | Single grain-unregistration requests handled by the local directory owner. |
+| `orleans-directory-unregistrations-many-issued` | C | Requests, implicit | - | Batch grain-unregistration requests initiated on this silo. |
+| `orleans-directory-unregistrations-many-remote-received` | C | Requests, implicit | - | Forwarded batch unregistration requests received from another silo. |
+| `orleans-directory-unregistrations-many-remote-sent` | C | Requests, implicit | - | Batch unregistration requests forwarded to another silo. |
+| `orleans-directory-unregistrations-remote-received` | C | Unregistrations, implicit | - | Forwarded single unregistration requests received from another silo. |
+| `orleans-directory-unregistrations-remote-sent` | C | Unregistrations, implicit | - | Single unregistration requests forwarded to another silo. |
+| `orleans-directory-validations-cache-received` | C | Requests, implicit | - | Batch directory-cache validation requests received from another silo. |
+
+## Reminders, storage, runtime resources, and watchdog
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-reminders-active` | OG | Reminders, implicit | - | Upper bound on reminders tracked locally, including temporary tombstones. |
+| `orleans-reminders-tardiness` | H | `seconds` | - | Delay between a reminder's scheduled tick time and the time delivery begins. |
+| `orleans-reminders-ticks-delivered` | C | Ticks, implicit | - | Reminder ticks successfully delivered to `IRemindable.ReceiveReminder`. |
+| `orleans-runtime-available-memory` | OG | `MB` | - | GC-reported available memory budget, divided by 1,024 squared. |
+| `orleans-runtime-total-physical-memory` | OG | `MB` | - | <xref:System.GCMemoryInfo.TotalAvailableMemoryBytes>, divided by 1,024 squared. The historical name can represent a process or container memory limit instead of host physical RAM. |
+| `orleans-storage-clear-errors` | C | Errors, implicit | `provider_type_name`, `state_name`, `state_type` | Grain-state clear operations which threw an exception. |
+| `orleans-storage-clear-latency` | H | `ms` | `provider_type_name`, `state_name`, `state_type` | Latency of successfully completed grain-state clear operations. |
+| `orleans-storage-read-errors` | C | Errors, implicit | `provider_type_name`, `state_name`, `state_type` | Grain-state read operations which threw an exception. |
+| `orleans-storage-read-latency` | H | `ms` | `provider_type_name`, `state_name`, `state_type` | Latency of successfully completed grain-state reads. |
+| `orleans-storage-write-errors` | C | Errors, implicit | `provider_type_name`, `state_name`, `state_type` | Grain-state write operations which threw an exception. |
+| `orleans-storage-write-latency` | H | `ms` | `provider_type_name`, `state_name`, `state_type` | Latency of successfully completed grain-state writes. |
+| `orleans-watchdog-health-checks` | C | Checks, implicit | - | Runtime watchdog health checks performed. |
+| `orleans-watchdog-health-checks-failed` | C | Checks, implicit | - | Runtime watchdog health checks which reported failure. |
+
+## Streaming
+
+Pub/sub instruments use `provider` and `grain_type`. Persistent-stream read instruments use `provider` and `queue`; sent instruments use `provider` and `grain_type`. Default receiver and cache monitors use `QueueId`, and default block-pool monitors use `BlockPoolId`. Custom monitor implementations can choose different dimensions.
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-streams-block-pool-allocated-memory` | OC | `bytes` | Default: `BlockPoolId` | Cumulative bytes allocated from the stream buffer pool. |
+| `orleans-streams-block-pool-available-memory` | OC | `bytes` | Default: `BlockPoolId` | Current available bytes reported by the stream buffer pool. This point-in-time value is implemented as an observable counter. |
+| `orleans-streams-block-pool-claimed-memory` | OC | `bytes` | Default: `BlockPoolId` | Current claimed bytes reported by the stream buffer pool. This point-in-time value is implemented as an observable counter. |
+| `orleans-streams-block-pool-released-memory` | OC | `bytes` | Default: `BlockPoolId` | Cumulative bytes released to the stream buffer pool. |
+| `orleans-streams-block-pool-total-memory` | OC | `bytes` | Default: `BlockPoolId` | Current total bytes reported by the stream buffer pool. This point-in-time value is implemented as an observable counter. |
+| `orleans-streams-persistent-stream-messages-read` | C | Batch containers, implicit | `provider`, `queue` | Batch containers read from persistent-stream receiver queues. One container can hold multiple stream events. |
+| `orleans-streams-persistent-stream-messages-sent` | C | Batch containers, implicit | `provider`, `grain_type` | Batch containers selected for consumer delivery. The counter increments before delivery, so it isn't a successful-delivery count. |
+| `orleans-streams-persistent-stream-pubsub-cache-size` | OG | Entries, implicit | `name` | Pub/sub cache entries held by a persistent-stream pulling agent. |
+| `orleans-streams-persistent-stream-pulling-agents` | OG | Agents, implicit | `name` | Pulling agents currently owned by a persistent-stream provider on this silo. |
+| `orleans-streams-pubsub-consumers` | C, signed deltas | Consumers, implicit | `provider`, `grain_type` | Signed cumulative consumer-registration deltas recorded by this process, using positive additions and negative removals. The series isn't initialized from persisted pub/sub state and isn't a point-in-time count. |
+| `orleans-streams-pubsub-consumers-added` | C | Attempts, implicit | `provider`, `grain_type` | Pub/sub consumer registration attempts. |
+| `orleans-streams-pubsub-consumers-removed` | C | Attempts, implicit | `provider`, `grain_type` | Pub/sub consumer unregistration attempts. |
+| `orleans-streams-pubsub-producers` | C, signed deltas | Producers, implicit | `provider`, `grain_type` | Signed cumulative producer-registration deltas recorded by this process, using positive additions and negative removals. The series isn't initialized from persisted pub/sub state and isn't a point-in-time count. |
+| `orleans-streams-pubsub-producers-added` | C | Attempts, implicit | `provider`, `grain_type` | Pub/sub producer registration attempts. |
+| `orleans-streams-pubsub-producers-removed` | C | Attempts, implicit | `provider`, `grain_type` | Pub/sub producer unregistration attempts. |
+| `orleans-streams-queue-cache-length` | OC | `messages` | Default: `QueueId` | Current number of messages in a queue cache. This point-in-time value is implemented as an observable counter. |
+| `orleans-streams-queue-cache-memory-allocated` | OC | Bytes, implicit | Default: `QueueId` | Cumulative bytes allocated by a queue cache. |
+| `orleans-streams-queue-cache-memory-released` | OC | Bytes, implicit | Default: `QueueId` | Cumulative bytes released by a queue cache. |
+| `orleans-streams-queue-cache-messages-added` | OC | Messages, implicit | Default: `QueueId` | Cumulative messages added to a queue cache. |
+| `orleans-streams-queue-cache-messages-purged` | OC | Messages, implicit | Default: `QueueId` | Cumulative messages purged from a queue cache. |
+| `orleans-streams-queue-cache-oldest-age` | OG | `TimeSpan` ticks, implicit | Default: `QueueId` | Age of the oldest dequeued message still represented by the cache monitor. |
+| `orleans-streams-queue-cache-oldest-to-newest-duration` | OG | `TimeSpan` ticks, implicit | Default: `QueueId` | Enqueue-time span from the oldest to newest messages represented by the cache monitor. |
+| `orleans-streams-queue-cache-pressure` | OG | Ratio, implicit | Default: `QueueId`, `PressureMonitorType` | Current pressure value reported by each cache pressure monitor. |
+| `orleans-streams-queue-cache-pressure-contribution-count` | OG | Contributions, implicit | Default: `QueueId`, `PressureMonitorType` | Pressure-contribution count reported by each cache pressure monitor. |
+| `orleans-streams-queue-cache-size` | OC | `bytes` | Default: `QueueId` | Current queue-cache size. This point-in-time value is implemented as an observable counter. |
+| `orleans-streams-queue-cache-under-pressure` | OG | Boolean (`0` or `1`), implicit | Default: `QueueId`, `PressureMonitorType` | Whether each cache pressure monitor currently reports pressure. |
+| `orleans-streams-queue-initialization-duration` | C | `TimeSpan` ticks, implicit | Default: `QueueId` | Cumulative duration of queue receiver initialization calls. |
+| `orleans-streams-queue-initialization-exceptions` | C | Exceptions, implicit | Default: `QueueId` | Queue receiver initialization calls which supplied an exception. |
+| `orleans-streams-queue-initialization-failures` | C | Failures, implicit | Default: `QueueId` | Queue receiver initialization calls reported as unsuccessful. |
+| `orleans-streams-queue-messages-received` | OC | Messages, implicit | Default: `QueueId` | Cumulative messages received from a stream queue. |
+| `orleans-streams-queue-newest-message-enqueue-age` | OG | `TimeSpan` ticks, implicit | Default: `QueueId` | Age of the newest message returned by the latest queue read. |
+| `orleans-streams-queue-oldest-message-enqueue-age` | OG | `TimeSpan` ticks, implicit | Default: `QueueId` | Age of the oldest message returned by the latest queue read. |
+| `orleans-streams-queue-read-duration` | C | `TimeSpan` ticks, implicit | Default: `QueueId` | Cumulative duration of queue receiver read calls. |
+| `orleans-streams-queue-read-exceptions` | C | Exceptions, implicit | Default: `QueueId` | Queue receiver read calls which supplied an exception. |
+| `orleans-streams-queue-read-failures` | C | Failures, implicit | Default: `QueueId` | Queue receiver read calls reported as unsuccessful. |
+| `orleans-streams-queue-shutdown-duration` | C | `TimeSpan` ticks, implicit | Default: `QueueId` | Cumulative duration of queue receiver shutdown calls. |
+| `orleans-streams-queue-shutdown-exceptions` | C | Exceptions, implicit | Default: `QueueId` | Queue receiver shutdown calls which supplied an exception. |
+| `orleans-streams-queue-shutdown-failures` | C | Failures, implicit | Default: `QueueId` | Queue receiver shutdown calls reported as unsuccessful. |
+
+Failure and exception counters can both increment for one operation. Duration counters aggregate total elapsed ticks; divide their increase by the matching operation count when calculating a windowed mean.
+
+## Transactions
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-transactions-failed` | OC | Transactions, implicit | - | Transactions which completed unsuccessfully. |
+| `orleans-transactions-started` | OC | Transactions, implicit | - | Transactions started by the local transaction agent. |
+| `orleans-transactions-successful` | OC | Transactions, implicit | - | Transactions which completed successfully. |
+| `orleans-transactions-throttled` | OC | Transactions, implicit | - | Transaction attempts rejected by transaction-agent throttling. |
+
+## Durable jobs
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-durablejobs-cancel-job-call-duration` | H | `ms` | `status` | Duration of cancel-job API calls, split by `ok`, `not_found`, `canceled`, or `error`. |
+| `orleans-durablejobs-cancel-job-calls` | C | Calls, implicit | `status` | Completed cancel-job API calls by outcome. |
+| `orleans-durablejobs-handler-execution-duration` | H | `ms` | `status` | Duration of completed handler executions, split by `completed`, `canceled`, or `failed`. |
+| `orleans-durablejobs-handler-executions` | C | Executions, implicit | `status` | Handler executions which reached a terminal outcome. |
+| `orleans-durablejobs-handler-executions-started` | C | Executions, implicit | - | Durable-job handler executions started. |
+| `orleans-durablejobs-job-attempt-duration` | H | `ms` | `status` | Duration of job attempts ending as `completed`, `failed`, or `retried`. |
+| `orleans-durablejobs-job-attempts-started` | C | Attempts, implicit | - | Durable-job attempts started. |
+| `orleans-durablejobs-job-dispatch-lag` | H | `ms` | - | Delay between a job's due time and the start of its attempt. |
+| `orleans-durablejobs-job-schedule-duration` | H | `ms` | - | Time required to persist and schedule a job. |
+| `orleans-durablejobs-jobs-canceled` | C | Jobs, implicit | - | Durable jobs canceled. |
+| `orleans-durablejobs-jobs-completed` | C | Jobs, implicit | - | Durable jobs completed successfully. |
+| `orleans-durablejobs-jobs-failed` | C | Jobs, implicit | - | Durable-job attempts recorded as failed. |
+| `orleans-durablejobs-jobs-retried` | C | Jobs, implicit | - | Durable-job attempts scheduled for retry. |
+| `orleans-durablejobs-jobs-scheduled` | C | Jobs, implicit | - | Durable jobs successfully scheduled. |
+| `orleans-durablejobs-ownership-check-duration` | H | `ms` | - | Duration of shard-ownership checks. |
+| `orleans-durablejobs-schedule-job-call-duration` | H | `ms` | `status` | Duration of schedule-job API calls, split by `ok`, `canceled`, or `error`. |
+| `orleans-durablejobs-schedule-job-calls` | C | Calls, implicit | `status` | Completed schedule-job API calls by outcome. |
+| `orleans-durablejobs-shard-batch-bytes` | H | `bytes` | - | Serialized byte size of durable-job shard mutation batches. |
+| `orleans-durablejobs-shard-batch-mutations` | H | Mutations, implicit | - | Mutation count in durable-job shard batches. |
+| `orleans-durablejobs-shard-pending-depth` | H | Mutations, implicit | - | Pending mutation operations collected into each shard batch immediately before processing. |
+| `orleans-durablejobs-shard-processing-duration` | H | `ms` | `status` | Shard processing duration, split by `completed`, `canceled`, or `error`. |
+| `orleans-durablejobs-shards-processed` | C | Shards, implicit | `status` | Shard processing passes completed by outcome. |
+| `orleans-durablejobs-storage-batch-size` | H | Mutations, implicit | `status` | Applied shard mutations included in each state-write attempt, split by outcome. |
+| `orleans-durablejobs-storage-batches` | C | Batches, implicit | `status` | Durable-job storage batches written, canceled, or failed. |
+| `orleans-durablejobs-stripe-distribution` | C | Assignments, implicit | `stripe` | Job assignments by durable-job stripe number. |
+
+## Journaling
+
+Core journaling instruments use `operation` and `status` where applicable. Operation values include `append`, `snapshot`, `replace`, `read`, `delete`, and `recovery`; status is `ok` or `error`.
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-journaling-compaction-triggers` | C | Triggers, implicit | `reason` | Journal compactions requested because of `user_snapshot`, `storage_requested`, or `migration`. |
+| `orleans-journaling-gather-duration` | H | `ms` | `operation` | Time spent gathering journal state for a storage operation. |
+| `orleans-journaling-recoveries` | C | Recoveries, implicit | `operation`, `status` | Journal recovery attempts by outcome. |
+| `orleans-journaling-recovery-duration` | H | `ms` | `operation`, `status` | Journal recovery duration by outcome. |
+| `orleans-journaling-state-delete-duration` | H | `ms` | `operation`, `status` | Duration of journaled-state delete requests. |
+| `orleans-journaling-state-delete-requests` | C | Requests, implicit | `operation`, `status` | Journaled-state delete requests by outcome. |
+| `orleans-journaling-state-scan-count` | H | States, implicit | `operation` | Journal states scanned while gathering work for an operation. |
+| `orleans-journaling-state-write-duration` | H | `ms` | `operation`, `status` | Duration of journaled-state write requests. |
+| `orleans-journaling-state-write-requests` | C | Requests, implicit | `operation`, `status` | Journaled-state write requests by operation and outcome. |
+| `orleans-journaling-storage-bytes` | C | `bytes` | `operation` | Cumulative bytes successfully processed by journal storage operations. |
+| `orleans-journaling-storage-operation-bytes` | H | `bytes` | `operation`, `status` | Distribution of successful journal storage operation sizes. |
+| `orleans-journaling-storage-operation-duration` | H | `ms` | `operation`, `status` | Journal storage operation duration by operation and outcome. |
+| `orleans-journaling-storage-operation-queue-duration` | H | `ms` | `operation`, `status` | Time journal storage operations spent queued before execution. |
+| `orleans-journaling-storage-operations` | C | Operations, implicit | `operation`, `status` | Journal storage operations by operation and outcome. |
+| `orleans-journaling-write-coalesced-callers` | H | Callers, implicit | `operation` | Number of callers combined into each coalesced journal write. |
+
+Azure journaling storage instruments use operations `create`, `get_metadata`, `update_metadata`, `append`, `delete`, `read`, and `replace`.
+
+| Instrument | Type | Unit | Attributes | Description |
+|---|---|---|---|---|
+| `orleans-journaling-azure-blob-operation-bytes` | C | `bytes` | `operation` | Cumulative bytes successfully processed by Azure Blob journal storage operations. |
+| `orleans-journaling-azure-blob-operation-duration` | H | `ms` | `operation`, `status` | Azure Blob journal storage operation duration by operation and outcome. |
+| `orleans-journaling-azure-blob-operations` | C | Operations, implicit | `operation`, `status` | Azure Blob journal storage operations by operation and `ok` or `error` status. |
+| `orleans-journaling-azure-table-operation-bytes` | C | `bytes` | `operation` | Cumulative bytes successfully processed by Azure Table journal storage operations. |
+| `orleans-journaling-azure-table-operation-duration` | H | `ms` | `operation`, `status` | Azure Table journal storage operation duration by operation and outcome. |
+| `orleans-journaling-azure-table-operations` | C | Operations, implicit | `operation`, `status` | Azure Table journal storage operations by operation and `ok` or `error` status. |
+
+## Use the catalog
+
+Use [Monitor Orleans metrics](metrics.md) to select health indicators, aggregate each instrument according to its type, control cardinality, and build alerts. Use [Troubleshoot Orleans incidents](troubleshooting.md) to correlate metrics with logs, traces, deployment changes, and dependency health.

--- a/docs/site/src/content/docs/host/monitoring/metrics.md
+++ b/docs/site/src/content/docs/host/monitoring/metrics.md
@@ -1,0 +1,138 @@
+---
+title: Monitor Orleans metrics
+description: Interpret current Orleans client and silo metrics, instrument types, units, dimensions, and health indicators.
+ms.date: 08/15/2026
+ms.topic: concept-article
+---
+
+# Monitor Orleans metrics
+
+Orleans emits metrics from a <xref:System.Diagnostics.Metrics.Meter> named `Microsoft.Orleans`. The instrument names and semantics on this page describe the current runtime implementation. Discover the instruments emitted by the deployed Orleans version because releases and provider packages can differ.
+
+```dotnetcli
+dotnet-counters monitor -n <ProcessName> --counters Microsoft.Orleans
+```
+
+The names below are .NET instrument names. An exporter can normalize them for its backend, for example by replacing hyphens with underscores. To inspect definitions under active development, see [InstrumentNames.cs](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Diagnostics/Metrics/InstrumentNames.cs) and the adjacent instrument implementations.
+
+## Interpret instrument types
+
+The instrument type determines which query is meaningful. Don't alert on every displayed "current" value without checking the instrument type and exporter temporality.
+
+| Instrument type | Orleans use | Interpret it as |
+|---|---|---|
+| Counter or observable counter | Completed events, failures, bytes, and preaggregated request-latency data | A monotonically increasing total for one process lifetime. Query the increase or rate over a window. Account for resets when a process restarts. |
+| Up/down counter | Connected clients and grain instances | A running total which can increase or decrease. Query the latest aggregated value, not its rate, when the question is "how many exist now?" |
+| Observable gauge | Connected gateways, activations, working-set members, and available memory | A point-in-time observation. Aggregate intentionally: a minimum often finds an unhealthy instance, while a sum gives a cluster total for counts. |
+| Histogram | Storage, activation, deactivation, message-size, and reminder-tardiness distributions | A distribution of observations. Use count for volume and buckets or percentiles for tail behavior. Configure backend bucket boundaries which cover expected values. |
+
+OpenTelemetry can transport sums using cumulative or delta temporality. "Current" and "Delta" fields shown by older telemetry exporters were views over a counter, not separate Orleans instruments. Current OpenTelemetry guidance similarly distinguishes monotonic sums, gauges, and histograms and allows [temporality conversion and reaggregation](https://opentelemetry.io/docs/specs/otel/metrics/data-model/).
+
+Units in the tables are the metadata emitted by Orleans. Some established instruments use historical strings such as `ms`, `seconds`, `bytes`, and `MB`, while current [OpenTelemetry metric semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/) generally recommend UCUM units such as `s` and `By`. Preserve the emitted unit in storage and convert explicitly in queries instead of inferring a unit from the metric name.
+
+## Client signals
+
+Start with the caller's view of availability and latency. A healthy silo cannot compensate for a client which has no route to the cluster.
+
+Caller-side request instruments are emitted by standalone clients and by silos when they issue grain calls.
+
+| Instrument | Type and unit | Meaning and interpretation |
+|---|---|---|
+| `orleans-client-connected-gateways` | Observable gauge, count | Number of gateway connections held by this client. Alert when it remains zero beyond the expected reconnect window. A reduction which remains above zero indicates less path redundancy and should be correlated with gateway and network signals. |
+| `orleans-app-requests-latency-count` | Observable counter, count | Completed outbound request callbacks observed by the caller. Use its increase as the request volume denominator. |
+| `orleans-app-requests-latency-sum` | Observable counter, milliseconds, without unit metadata | Cumulative caller-observed elapsed time. Divide the increase in `sum` by the increase in `count` for a windowed mean, but use the bucket series for tail behavior. |
+| `orleans-app-requests-latency-bucket` | Observable counter, milliseconds encoded by the `duration` attribute | Preaggregated latency bands with boundaries from `1ms` through `15000ms`, plus an overflow band. Each series counts observations in its own band, rather than cumulative observations less than or equal to the boundary. Compute a distribution from increases in all bands over the same window. |
+| `orleans-app-requests-timedout` | Counter, count; `grain_type` | Requests which exceeded the configured response timeout. Alert on a volume-gated ratio against completed requests, not one timeout or the lifetime total. |
+| `orleans-app-requests-canceled` | Counter, count; `grain_type` | Requests canceled by their caller. Separate expected cancellation from service failure using application context and traces. |
+
+Caller-observed request latency includes time until the callback completes, so it can include transport, queueing, grain execution, storage, and response delivery. It also records terminal paths such as timeout, cancellation, target-silo failure, and host shutdown. Use traces and the [incident runbooks](troubleshooting.md) to locate the delay.
+
+## Silo signals
+
+### Admission, messaging, and membership
+
+| Instrument | Type and unit | Meaning and interpretation |
+|---|---|---|
+| `orleans-gateway-connected-clients` | Up/down counter, count | Current client connections on this gateway after aggregation. Sudden loss across gateways can indicate a rollout or network break; sustained skew can indicate uneven routing. |
+| `orleans-gateway-load-shedding` | Counter, count | Requests rejected because the gateway's overload detector reported saturation. Any sustained nonzero rate indicates user-visible admission pressure. |
+| `orleans-messaging-rejected` | Counter, count; `Direction` | Rejected messages. Correlate the rate with load shedding, request timeouts, CPU, memory, and dependency latency. |
+| `orleans-messaging-sent-failed` | Counter, count; `Direction` | Messages which couldn't be sent. Correlate by instance and direction with socket churn and remote-silo logs. |
+| `orleans-messaging-sent-dropped` | Counter, count; `Direction` | Messages intentionally dropped by the runtime. A sustained increase requires log and trace investigation. |
+| `orleans-messaging-expired` | Counter, count; `Phase` | Messages which expired during `Send`, `Receive`, `Dispatch`, `Invoke`, or `Respond`. The phase narrows whether delay occurred before or during execution. |
+| `orleans-messaging-pings-reply-missed` | Counter, count; `Destination` | Failed direct or indirect membership probes. Alert on a sustained increase or missed-reply ratio and correlate with membership transitions. Isolated misses can occur during pauses, restarts, or transient packet loss. |
+| `orleans-networking-sockets-opened` / `orleans-networking-sockets-closed` | Counters, count; `Direction` | Connection churn. Compare their rates and correlate with send failures. Their difference is only meaningful within one process lifetime. |
+
+Message-size instruments `orleans-messaging-sent-messages-size` and `orleans-messaging-received-messages-size` are histograms in `bytes`. Use them for payload growth and bandwidth diagnosis, not primary availability alerts. They include `ConnectionDirection`, `MessageDirection`, and sometimes a remote `silo` attribute.
+
+### Scheduling and activations
+
+| Instrument | Type and unit | Meaning and interpretation |
+|---|---|---|
+| `orleans-scheduler-long-running-turns` | Counter, count | Grain micro-turns whose synchronous execution exceeded <xref:Orleans.Configuration.SchedulingOptions.TurnWarningLengthThreshold>. The default is one second. The lifetime total naturally only increases; alert on its rate and correlate with latency, CPU, thread-pool, traces, and warning logs. |
+| `orleans-catalog-activations` | Observable gauge, count | Activations currently registered on this silo. Trend it against memory and traffic. A high value isn't intrinsically unhealthy; unexpected growth, imbalance, or churn is the useful signal. |
+| `orleans-catalog-activation-working-set` | Observable gauge, count | Activations in the local active working set. Compare it with total activations to understand the active portion of the catalog. |
+| `orleans-grains` | Up/down counter, count; `type` | Current grain instances by grain type after aggregation. Use it to identify placement imbalance or a grain type driving activation growth. |
+| `orleans-catalog-activation-created` / `orleans-catalog-activation-destroyed` | Counters, count | Activation lifecycle throughput. High rates in both directions indicate churn even when the current activation gauge is flat. |
+| `orleans-catalog-activation-latency` | Histogram, `ms`; `status`, `directory` | Activation duration and outcome. Break down non-success statuses (`canceled`, `directory_error`, `duplicate`, or `error`) and correlate tail latency with directory and storage health. |
+| `orleans-catalog-activation-failed-to-activate` | Counter, count | Activation attempts which failed to construct or initialize an activation. A sustained increase is an application availability signal. |
+
+A long-running turn means Orleans observed one scheduled work item executing synchronously beyond the configured warning threshold. It doesn't by itself prove a deadlock. Common causes include synchronous blocking, lock contention, CPU-heavy work, or blocking I/O. See [Grain turns appear stuck](troubleshooting.md#grain-turns-appear-stuck).
+
+### Storage
+
+| Instrument | Type and unit | Meaning and interpretation |
+|---|---|---|
+| `orleans-storage-read-latency` | Histogram, `ms` | Successfully completed grain-state read latency. |
+| `orleans-storage-write-latency` | Histogram, `ms` | Successfully completed grain-state write latency. |
+| `orleans-storage-clear-latency` | Histogram, `ms` | Successfully completed grain-state clear latency. |
+| `orleans-storage-read-errors` | Counter, count | Read failures. |
+| `orleans-storage-write-errors` | Counter, count | Write failures. |
+| `orleans-storage-clear-errors` | Counter, count | Clear failures. |
+
+All storage instruments use `provider_type_name`, `state_name`, and `state_type`. The histogram count is successful-operation volume. For a windowed error ratio, divide the error-counter increase by the sum of the matching histogram-count increase and error-counter increase. Percentiles identify tail latency which an average hides. Compare Orleans latency with the provider's own throttling, capacity, and service metrics.
+
+### Runtime resources and watchdog
+
+| Instrument | Type and unit | Meaning and interpretation |
+|---|---|---|
+| `orleans-runtime-available-memory` | Observable gauge, `MB` | GC-reported available memory budget. Values are calculated using 1,024² bytes per reported MB. Alert on the ratio to the total budget and correlate with working set, GC heap, allocation rate, and container limits. |
+| `orleans-runtime-total-physical-memory` | Observable gauge, `MB` | Despite the historical name, the implementation reports <xref:System.GC.GetGCMemoryInfo*> <xref:System.GCMemoryInfo.TotalAvailableMemoryBytes>, which can reflect a configured or container memory limit rather than host physical RAM. |
+| `orleans-watchdog-health-checks` | Counter, count | Runtime watchdog checks performed. |
+| `orleans-watchdog-health-checks-failed` | Counter, count | Failed runtime watchdog checks. Alert on failures while confirming that checks continue to run. |
+
+Collect the [built-in `System.Runtime` metrics](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-runtime) alongside Orleans. At minimum, monitor process CPU time, working set, allocation rate, GC heap size and fragmentation by generation, GC pause time, thread-pool queue length and thread count, lock contention, exception count, and socket counts. A rising Orleans latency signal becomes actionable when correlated with the constrained runtime resource.
+
+## Dimensions and cardinality
+
+Metric identity includes resource attributes and instrument attributes. Set stable resource attributes such as `service.name`, `service.version`, `service.instance.id`, and `deployment.environment.name`. Add cluster, region, and deployment-ring identity only when values are bounded and permitted by the telemetry data policy.
+
+Useful Orleans dimensions are bounded operational categories:
+
+- `grain_type` or `type` for deployed grain types.
+- `Direction`, `ConnectionDirection`, `MessageDirection`, and `Phase`.
+- `status`, `directory`, and `via` for lifecycle outcomes.
+- `provider_type_name`, `state_name`, and `state_type` for configured storage.
+
+Use caution with `Destination` and `silo`. Their values include silo addresses and incarnations, so rolling restarts and unstable membership create new series. Retain them for short-lived diagnosis or use an OpenTelemetry view or Collector processor to remove them from long-term aggregates. Don't add grain keys, request or trace IDs, user or tenant IDs, exception messages, or other unbounded values as metric attributes.
+
+Analyze each important signal both per instance and across the cluster:
+
+- **Minimum per instance** finds a disconnected client or a silo low on available memory.
+- **Maximum per instance** finds a hot silo, slow provider path, or placement imbalance.
+- **Cluster sum or rate** measures total demand, errors, and capacity.
+- **Deployment-version comparison** identifies regressions during rollout.
+
+## Build alerts from symptoms
+
+Prefer ratios, rates, and sustained windows over lifetime totals:
+
+- Page when connected gateways remain zero, request timeout/error ratios violate the service objective, or gateway load shedding is sustained.
+- Page when missed probes coincide with lost membership or reduced redundancy, not for one missed reply.
+- Page when storage error ratios or tail latency cause activation or request failures.
+- Page when available-memory headroom is nearly exhausted or GC pauses coincide with stalled progress.
+- Create a capacity alert before activation growth, CPU, queueing, or long-running turns reach the load-shedding point.
+- Route isolated failures, per-grain-type imbalance, and gradual resource trends to dashboards or tickets unless user impact is present.
+
+Gate latency and error-ratio alerts on enough request volume to avoid noisy percentages. Establish thresholds from normal deployment and load-test baselines instead of copying universal numeric values.
+
+For investigation sequences, see [Troubleshoot Orleans incidents](troubleshooting.md). For startup, readiness, liveness, and dependency health, see [Health and observability](../../deployment/health-and-observability.md).

--- a/docs/site/src/content/docs/host/monitoring/metrics.md
+++ b/docs/site/src/content/docs/host/monitoring/metrics.md
@@ -13,7 +13,7 @@ Orleans emits metrics from a <xref:System.Diagnostics.Metrics.Meter> named `Micr
 dotnet-counters monitor -n <ProcessName> --counters Microsoft.Orleans
 ```
 
-The names below are .NET instrument names. An exporter can normalize them for its backend, for example by replacing hyphens with underscores. To inspect definitions under active development, see [InstrumentNames.cs](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Diagnostics/Metrics/InstrumentNames.cs) and the adjacent instrument implementations.
+The names below are .NET instrument names. An exporter can normalize them for its backend, for example by replacing hyphens with underscores. See the [complete Orleans metrics catalog](metrics-catalog.md) for every current instrument and its source-derived description. To inspect definitions under active development, see [InstrumentNames.cs](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Diagnostics/Metrics/InstrumentNames.cs) and the adjacent instrument implementations.
 
 ## Interpret instrument types
 

--- a/docs/site/src/content/docs/host/monitoring/metrics.md
+++ b/docs/site/src/content/docs/host/monitoring/metrics.md
@@ -28,7 +28,7 @@ The instrument type determines which query is meaningful. Don't alert on every d
 
 OpenTelemetry can transport sums using cumulative or delta temporality. "Current" and "Delta" fields shown by older telemetry exporters were views over a counter, not separate Orleans instruments. Current OpenTelemetry guidance similarly distinguishes monotonic sums, gauges, and histograms and allows [temporality conversion and reaggregation](https://opentelemetry.io/docs/specs/otel/metrics/data-model/).
 
-Units in the tables are the metadata emitted by Orleans. Some established instruments use historical strings such as `ms`, `seconds`, `bytes`, and `MB`, while current [OpenTelemetry metric semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/) generally recommend UCUM units such as `s` and `By`. Preserve the emitted unit in storage and convert explicitly in queries instead of inferring a unit from the metric name.
+Units in the tables describe each instrument's natural unit. Orleans doesn't set unit metadata on every instrument, so `count` can be the natural unit even when exporters receive no unit string. Where unit metadata is emitted, some established instruments use historical strings such as `ms`, `seconds`, `bytes`, and `MB`, while current [OpenTelemetry metric semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/) generally recommend UCUM units such as `s` and `By`. Preserve emitted units in storage and convert explicitly in queries instead of inferring a unit from the metric name.
 
 ## Client signals
 
@@ -96,7 +96,7 @@ All storage instruments use `provider_type_name`, `state_name`, and `state_type`
 | Instrument | Type and unit | Meaning and interpretation |
 |---|---|---|
 | `orleans-runtime-available-memory` | Observable gauge, `MB` | GC-reported available memory budget. Values are calculated using 1,024² bytes per reported MB. Alert on the ratio to the total budget and correlate with working set, GC heap, allocation rate, and container limits. |
-| `orleans-runtime-total-physical-memory` | Observable gauge, `MB` | Despite the historical name, the implementation reports <xref:System.GC.GetGCMemoryInfo*> <xref:System.GCMemoryInfo.TotalAvailableMemoryBytes>, which can reflect a configured or container memory limit rather than host physical RAM. |
+| `orleans-runtime-total-physical-memory` | Observable gauge, `MB` | Despite the historical name, the implementation reports <xref:System.GC.GetGCMemoryInfo> <xref:System.GCMemoryInfo.TotalAvailableMemoryBytes>, which can reflect a configured or container memory limit rather than host physical RAM. |
 | `orleans-watchdog-health-checks` | Counter, count | Runtime watchdog checks performed. |
 | `orleans-watchdog-health-checks-failed` | Counter, count | Failed runtime watchdog checks. Alert on failures while confirming that checks continue to run. |
 

--- a/docs/site/src/content/docs/host/monitoring/signals.md
+++ b/docs/site/src/content/docs/host/monitoring/signals.md
@@ -1,7 +1,7 @@
 ---
 title: Interpret Orleans observability signals
 description: Use Orleans logs, metrics, traces, correlation, and alerts without relying on stale catalogs.
-ms.date: 08/02/2026
+ms.date: 08/15/2026
 ms.topic: concept-article
 ---
 
@@ -23,27 +23,13 @@ Record application correlation fields in structured properties or an approved ac
 
 ## Metrics
 
-Subscribe to the `Microsoft.Orleans` meter. Discover the exact instrument set emitted by your deployed version instead of copying a static list. For installation and command details, see the [`dotnet-counters` diagnostic tool](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters):
+Subscribe to the `Microsoft.Orleans` meter. Discover the exact instrument set emitted by your deployed version. For installation and command details, see the [`dotnet-counters` diagnostic tool](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters):
 
 ```dotnetcli
 dotnet-counters monitor -n <ProcessName> --counters Microsoft.Orleans
 ```
 
-To inspect instruments under active development, see [InstrumentNames.cs on the `main` branch](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Diagnostics/Metrics/InstrumentNames.cs). Discover the emitted instruments from the deployed process because provider packages and released versions can differ from that branch.
-
-Useful starting signals include:
-
-| Concern | Signals to correlate |
-|---|---|
-| Requests | `orleans-app-requests-latency` histogram components (`-bucket`/`-count`/`-sum`), timed-out/canceled requests, application error rate |
-| Connectivity | open/closed sockets, failed/dropped sends, connected gateways, ping replies missed |
-| Overload | rejected messages, gateway load shedding, activation working set, host CPU and thread-pool metrics |
-| Stuck turns | `orleans-scheduler-long-running-turns`, request latency, process CPU, traces |
-| Storage | storage latency and error instruments, provider logs, backend health |
-| Memory | Orleans available/physical memory, .NET GC heap, allocation rate, working set, container limit |
-| Membership | membership warnings, ping failures, active-silo view, membership-store health |
-
-Counter values usually need a rate or increase over a time window. Histograms need percentiles and request volume. Compare each silo with the cluster aggregate: one outlier suggests a host or partition problem, while a cluster-wide shift suggests a shared dependency or traffic change.
+See [Monitor Orleans metrics](metrics.md) for the current client and silo signals, instrument types, units, dimensions, and health interpretation. Counter values usually need a rate or increase over a time window, gauges need a deliberately chosen point-in-time aggregation, and histograms need percentiles plus request volume. Compare each silo with the cluster aggregate: one outlier suggests a host or partition problem, while a cluster-wide shift suggests a shared dependency or traffic change.
 
 ### Cardinality
 

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -233,6 +233,8 @@ items:
             href: host/monitoring/signals.md
           - name: Metrics
             href: host/monitoring/metrics.md
+          - name: Metrics catalog
+            href: host/monitoring/metrics-catalog.md
           - name: Troubleshooting workflow
             href: host/monitoring/troubleshooting.md
           - name: Silo error codes

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -231,6 +231,8 @@ items:
             displayName: zipkin,jaeger,OpenTelemetry,opentelemetry,meter,counter,activity source,observability,monitoring,logging,metrics,telemetry,distributed tracing
           - name: Signals and alerting
             href: host/monitoring/signals.md
+          - name: Metrics
+            href: host/monitoring/metrics.md
           - name: Troubleshooting workflow
             href: host/monitoring/troubleshooting.md
           - name: Silo error codes


### PR DESCRIPTION
## Problem

Issue #3065 references telemetry names and exporter conventions from 2017, while Orleans now emits `System.Diagnostics.Metrics` instruments through the `Microsoft.Orleans` meter. Operators need current, source-verified guidance for choosing and interpreting client and silo health signals without treating removed counters as current.

## Solution

- add a dedicated metrics operations page covering current client, gateway, messaging, membership, scheduling, activation, storage, memory, and watchdog instruments
- add a complete catalog of all 184 current `Microsoft.Orleans` instruments, including streaming, transactions, durable jobs, journaling, and provider-specific metrics, with type, unit, attributes, and source-derived descriptions
- document emitted units, counter/up-down-counter/gauge/histogram semantics, exporter temporality, process resets, and the preaggregated request-latency bucket/count/sum representation
- explain useful dimensions, per-instance versus cluster aggregation, cardinality risks, and symptom-based alerting
- cross-link the existing observability, signal interpretation, deployment health, and troubleshooting guidance without duplicating the symptom catalog in #10554

## Rationale

The guidance is derived from the current instrument definitions and call sites and directs readers to discover the exact set emitted by their deployed version. This gives operators durable interpretation rules while keeping version-specific instrument details accurate and avoiding the obsolete 2017 counter catalog.

Fixes #3065
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10605)