### PR TITLE
docs: document multi-host container networking

### DIFF
--- a/docs/site/src/content/docs/deployment/containers.md
+++ b/docs/site/src/content/docs/deployment/containers.md
@@ -1,0 +1,109 @@
+---
+title: Run Orleans in containers across multiple hosts
+description: Configure routable Orleans endpoints for multi-host container deployments.
+ms.date: 08/15/2026
+ms.topic: how-to
+ms.custom: devops
+---
+
+# Run Orleans in containers across multiple hosts
+
+An Orleans cluster can span container hosts only when every silo has a unique endpoint that all other silos can reach directly. External Orleans clients need the same reachability to every advertised gateway endpoint. Container discovery, a shared membership table, and published host ports don't create those network paths by themselves.
+
+Use a private routed network, container overlay, or per-workload network interface whenever possible. Don't expose the Orleans silo or gateway ports to the public internet.
+
+## Choose an endpoint model
+
+Each silo has separate listening and advertised endpoints:
+
+| Setting | Meaning | Typical container value |
+| --- | --- | --- |
+| <xref:Orleans.Configuration.EndpointOptions.SiloListeningEndpoint> | Address and port opened inside the container for silo traffic | `0.0.0.0:11111` |
+| <xref:Orleans.Configuration.EndpointOptions.GatewayListeningEndpoint> | Address and port opened inside the container for client traffic | `0.0.0.0:30000` |
+| <xref:Orleans.Configuration.EndpointOptions.AdvertisedIPAddress> | Per-silo address that peers and clients dial | A routable private container, task, pod, or host address |
+| <xref:Orleans.Configuration.EndpointOptions.SiloPort> | Silo port stored in membership | The directly routed or published silo port |
+| <xref:Orleans.Configuration.EndpointOptions.GatewayPort> | Gateway port returned to clients | The directly routed or published gateway port |
+
+Binding to `0.0.0.0` or `::` only opens local interfaces. A wildcard address can't be advertised, and Orleans doesn't infer a host's published port from a container bind.
+
+Prefer one of these models:
+
+- **Direct per-container addressing:** Give every container a private address routable from all silo and client networks. Advertise that address and use the same ports inside and outside the container.
+- **Per-silo host-port mapping:** Advertise the host's private address and a unique published silo and gateway port pair. Bind to the corresponding target ports inside the container.
+
+Don't advertise a shared load balancer, ingress virtual IP, or service name which can route a connection to a different replica. Orleans membership identifies a specific silo, not an interchangeable backend pool.
+
+## Configure listening and advertised endpoints
+
+Pass the advertised address and published ports to each replica from the deployment platform. The following example uses fixed container target ports and independently supplied advertised values:
+
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="container_endpoint_usings":::
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="configure_container_endpoints":::
+
+For example, a container can listen on `0.0.0.0:11111` and `0.0.0.0:30000` while advertising the private host mappings `10.0.8.24:21111` and `10.0.8.24:23000`. Every other silo must be able to connect to `10.0.8.24:21111`, and every external Orleans client must be able to connect to `10.0.8.24:23000`.
+
+If the address or published ports are dynamically allocated, discover them before starting Orleans and keep them stable for the lifetime of that silo membership entry. A replacement instance can use a different endpoint, but it must join with a new silo generation.
+
+## Provide private bidirectional connectivity
+
+Validate the complete network matrix:
+
+1. From every silo network, connect to every advertised silo endpoint.
+1. From every client network, connect to every advertised gateway endpoint.
+1. When using host-port translation, test the published endpoint from the owning host or container as well as from remote hosts. Some network address translation implementations don't support the required hairpin path.
+1. Repeat the tests after scale-out, scale-in, host replacement, and rolling deployment.
+
+Firewall rules, security groups, network policies, and service-mesh policy must allow long-lived TCP connections in both directions between silos. Clients only need gateway access, not silo-port access. Restrict both ports to trusted workloads and use [Orleans Transport Layer Security](../host/transport-layer-security.md) when the network isn't a trusted boundary.
+
+## Understand discovery versus connectivity
+
+A clustering provider such as DynamoDB, Azure Table Storage, ADO.NET, Redis, Consul, or ZooKeeper coordinates membership and gateway discovery. It records the endpoints that participants advertise; it doesn't proxy Orleans traffic, create routes, or verify that those endpoints are reachable.
+
+Therefore, all silos can successfully read and write the same membership table while the cluster still fails to communicate. Likewise, a client can discover active gateways and then time out because its network can't reach one or more advertised gateway endpoints.
+
+HTTP ingress and application service discovery are separate. A frontend load balancer can route HTTP requests to an application, but Orleans silo and gateway connections must still reach the specific member selected from cluster membership.
+
+## Account for container platform behavior
+
+- A host-local bridge address is normally meaningful only on that host. Don't advertise it across hosts unless the platform explicitly routes that address range between hosts.
+- A published port is usable only if the host address is routable, the mapping is unique to one silo, and the mapping works from every required source network.
+- Multiple silos on one host need distinct advertised silo and gateway ports when they share the host address.
+- A dynamic or shared load-balancer mapping which can select any replica doesn't preserve silo identity and isn't suitable as an advertised endpoint.
+
+For Docker Engine, a user-defined [overlay network](https://docs.docker.com/engine/network/drivers/overlay/) can provide cross-host container connectivity; standalone containers still require the participating hosts to be in Swarm mode. With a host bridge and published ports, explicitly advertise the host's private address and each container's unique published ports.
+
+On Amazon ECS, [`awsvpc` task networking](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html) assigns each task its own network interface and private address, which matches the direct-address model. Other network modes require explicit validation of host-port uniqueness, routing, and security-group rules. A DynamoDB membership table can discover silos on AWS, but it doesn't compensate for unreachable task or host endpoints.
+
+For orchestrated and managed platforms, also review [Platform requirements](platform-guides.md), [Host Orleans on Kubernetes](kubernetes.md), and [Host Orleans on Azure Container Apps](deploy-to-azure-container-apps.md).
+
+## Diagnose forwarding loops and timeouts
+
+Start with the exact endpoints, not only the membership-provider health:
+
+1. Record each process's effective advertised silo endpoint, advertised gateway endpoint, and listening endpoints.
+1. Inspect the membership records and confirm that every active row contains a unique, expected, routable silo endpoint.
+1. From each silo container, test TCP connectivity to every active advertised silo endpoint. From the client network, test every advertised gateway endpoint.
+1. Compare container target ports, host or platform mappings, firewall rules, and the advertised ports.
+1. Correlate failures with instance replacement and remove stale membership only after confirming that the old silo can't still be running in a partition.
+
+Use the platform's TCP test tool. For example:
+
+```bash
+nc -vz 10.0.8.24 21111
+```
+
+```powershell
+Test-NetConnection 10.0.8.24 -Port 21111
+```
+
+Common indicators include:
+
+| Symptom | Likely endpoint problem |
+| --- | --- |
+| Membership is healthy, but calls expire at the request timeout | Discovery succeeded, but the advertised transport endpoint is blocked or unroutable. |
+| Logs or membership show `127.0.0.1`, a host-local bridge address, or the container target port | The silo advertised its bind-side address or port instead of the peer-reachable mapping. |
+| Multiple active silos advertise the same address and port | A shared load balancer or non-unique host mapping can't select the intended silo. |
+| Repeated forwarding, connection attempts, or timeout messages target an endpoint which should represent the local or destination silo | The advertised identity doesn't match a reachable endpoint for that silo. Messages can be retried or forwarded without reaching the intended process. |
+| A TCP connection succeeds but traffic reaches another replica | A proxy, ingress, or load balancer is distributing Orleans transport connections across replicas. |
+
+Correct the endpoint mapping first. Increasing response timeouts or changing the clustering provider won't make an unreachable advertised endpoint routable. For broader incident triage, see [Troubleshoot deployments](troubleshooting-deployments.md).

--- a/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
+++ b/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
@@ -1,7 +1,7 @@
 ---
 title: Host Orleans on Azure Container Apps
 description: Design, secure, deploy, and validate an Orleans cluster on Azure Container Apps.
-ms.date: 08/06/2026
+ms.date: 08/15/2026
 ms.topic: concept-article
 ---
 
@@ -44,8 +44,8 @@ Place clients in the same environment or in a connected private network that can
 
 Pass the environment's `properties.staticIp` and the app's unique exposed ports to every silo. Bind the listening endpoints to the container target ports:
 
-:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="container_apps_endpoint_usings":::
-:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="configure_container_apps_endpoints":::
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="container_endpoint_usings":::
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="configure_container_endpoints":::
 
 A **listening endpoint** is where the process binds inside its container. An **advertised endpoint** is what Orleans writes to membership for peers and clients. Binding to `0.0.0.0` doesn't discover an address to advertise. If ingress maps different exposed and target ports, configure <xref:Orleans.Configuration.EndpointOptions> directly so that:
 
@@ -54,7 +54,7 @@ A **listening endpoint** is where the process binds inside its container. An **a
 
 Container Apps provides `CONTAINER_APP_REPLICA_NAME` to identify a replica and `CONTAINER_APP_HOSTNAME` to identify a revision host. Neither value is a supported per-replica network address. Don't advertise an app or revision host name from multiple silo replicas: a peer can be routed to a different replica than the membership entry identifies.
 
-See [Networking in Azure Container Apps](https://learn.microsoft.com/azure/container-apps/networking), [Configure ingress](https://learn.microsoft.com/azure/container-apps/ingress-how-to), and [Topology, networking, and clustering](networking.md) for the underlying network requirements.
+See [Networking in Azure Container Apps](https://learn.microsoft.com/azure/container-apps/networking), [Configure ingress](https://learn.microsoft.com/azure/container-apps/ingress-how-to), [Run Orleans in containers across multiple hosts](containers.md), and [Topology, networking, and clustering](networking.md) for the underlying network requirements.
 
 ## Configure clustering and durable state
 

--- a/docs/site/src/content/docs/deployment/index.md
+++ b/docs/site/src/content/docs/deployment/index.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy and operate Orleans
 description: Plan, deploy, and operate an Orleans application in production.
-ms.date: 08/02/2026
+ms.date: 08/15/2026
 ms.topic: overview
 ---
 
@@ -26,6 +26,7 @@ Use these articles together:
 
 ## Choose a platform
 
+- [Containers across multiple hosts](containers.md)
 - [Kubernetes](kubernetes.md)
 - [Service Fabric](service-fabric.md)
 - [Azure App Service on Windows](deploy-to-azure-app-service.md)

--- a/docs/site/src/content/docs/deployment/networking.md
+++ b/docs/site/src/content/docs/deployment/networking.md
@@ -1,7 +1,7 @@
 ---
 title: Topology, networking, and clustering
 description: Configure Orleans endpoints, network paths, and cluster discovery for production.
-ms.date: 08/02/2026
+ms.date: 08/15/2026
 ms.topic: concept-article
 ---
 
@@ -39,6 +39,8 @@ For a platform that maps private addresses or ports:
 - Confirm every peer can connect to the advertised values. A successful local bind isn't sufficient.
 
 Never advertise loopback, a host name that peers resolve differently, a load balancer virtual IP for the silo endpoint, or an ephemeral address that the clustering provider can retain after the instance is gone.
+
+For host-port mapping, overlay networks, container bridge limitations, and endpoint diagnostics, see [Run Orleans in containers across multiple hosts](containers.md).
 
 ## Cluster identity
 

--- a/docs/site/src/content/docs/deployment/platform-guides.md
+++ b/docs/site/src/content/docs/deployment/platform-guides.md
@@ -1,7 +1,7 @@
 ---
 title: Platform requirements
 description: Evaluate whether a hosting platform can run an Orleans production cluster safely.
-ms.date: 08/02/2026
+ms.date: 08/15/2026
 ms.topic: concept-article
 ---
 
@@ -28,6 +28,7 @@ An HTTP-only platform isn't sufficient unless Orleans silos can also establish d
 
 ## Platform guidance
 
+- [Multi-host container deployments](containers.md) require either direct per-container private addresses or unique, peer-reachable host-port mappings for every silo.
 - [Kubernetes](kubernetes.md) provides direct pod networking. Explicit endpoint configuration is recommended; the Orleans hosting package is optional and limited to simple one-`Deployment`-per-cluster topologies.
 - [Service Fabric](service-fabric.md) uses an application-authored stateless Reliable Service integration with runtime-allocated endpoints and an external Orleans clustering provider.
 - Azure App Service requires validation of private per-instance address and port mapping on [Windows](deploy-to-azure-app-service.md) and [Linux](deploy-to-azure-app-service-linux.md).

--- a/docs/site/src/content/docs/deployment/troubleshooting-deployments.md
+++ b/docs/site/src/content/docs/deployment/troubleshooting-deployments.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshoot deployments
 description: Triage Orleans deployment and production incidents.
-ms.date: 08/02/2026
+ms.date: 08/15/2026
 ms.topic: troubleshooting
 ms.custom: devops
 ---
@@ -44,6 +44,8 @@ Compare every silo's:
 - Orleans package and application versions.
 
 From each silo network, test TCP connectivity to every advertised silo endpoint. A process can listen successfully while advertising an address no peer can reach.
+
+Periodic request timeouts, repeated forwarding, or connection attempts to loopback, a host-local container address, or a shared virtual IP indicate an advertised endpoint problem. Compare the membership endpoint with the container bind, published host port, and actual destination reached by that mapping. See [Run Orleans in containers across multiple hosts](containers.md) for a diagnostic matrix.
 
 ## Clients can't connect
 

--- a/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Server configuration
 description: Configure Orleans silos, providers, and network endpoints.
-ms.date: 08/02/2026
+ms.date: 08/15/2026
 ms.topic: how-to
 ---
 
@@ -55,6 +55,8 @@ For containers, NAT, or port forwarding, configure advertised and listening endp
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="advertised_and_listening_endpoints":::
 
 This silo listens on ports `40000` and `50000` but publishes `172.16.0.42:11111` and `172.16.0.42:30000`. Ensure membership data never contains an address that peers can't route to.
+
+For private networking, host-port mappings, and cross-host container diagnostics, see [Run Orleans in containers across multiple hosts](../../deployment/containers.md).
 
 ## Configure providers and options
 

--- a/docs/site/src/content/docs/snippets/compiled/Deployment/DeploymentSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Deployment/DeploymentSnippets.cs
@@ -27,19 +27,19 @@ siloBuilder.ConfigureEndpoints(
     }
 }
 
-namespace Documentation.Deployment.ContainerApps.Endpoints
+namespace Documentation.Deployment.ContainerEndpoints
 {
-    // <container_apps_endpoint_usings>
+    // <container_endpoint_usings>
 using System.Net;
 using Orleans.Configuration;
 
-    // </container_apps_endpoint_usings>
+    // </container_endpoint_usings>
 
-    internal static class ContainerAppsEndpointSnippets
+    internal static class ContainerEndpointSnippets
     {
         internal static void Configure(WebApplicationBuilder builder)
         {
-            // <configure_container_apps_endpoints>
+            // <configure_container_endpoints>
 var advertisedAddress = IPAddress.Parse(
     builder.Configuration["ORLEANS_ADVERTISED_IP"]
         ?? throw new InvalidOperationException("ORLEANS_ADVERTISED_IP isn't configured."));
@@ -61,7 +61,7 @@ builder.Host.UseOrleans(siloBuilder =>
         options.GatewayListeningEndpoint = new IPEndPoint(IPAddress.Any, 30_000);
     });
 });
-            // </configure_container_apps_endpoints>
+            // </configure_container_endpoints>
         }
     }
 }

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -233,6 +233,8 @@ items:
         href: deployment/production-readiness.md
       - name: Topology, networking, and clustering
         href: deployment/networking.md
+      - name: Run containers across multiple hosts
+        href: deployment/containers.md
       - name: Platform requirements
         href: deployment/platform-guides.md
       - name: Host on Kubernetes

--- a/docs/site/src/data/external-link-allowlist.json
+++ b/docs/site/src/data/external-link-allowlist.json
@@ -1,6 +1,7 @@
 {
   "description": "Exact external URLs which cannot be probed reliably. Every entry requires a narrow reason.",
   "urls": {
+    "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html": "AWS serves this public ECS task-networking page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html": "AWS serves this public SQS visibility-timeout page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues-at-least-once-delivery.html": "AWS serves this public SQS delivery-semantics page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html": "AWS serves this public SQS overview page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",


### PR DESCRIPTION
## Problem
Orleans documentation explains endpoint configuration in general, but it did not provide an end-to-end guide for container clusters spanning multiple hosts. This left the distinction between bind-side and advertised endpoints, provider discovery, and actual transport reachability unclear, especially with NAT, published ports, and shared ingress.

## Solution
Add a dedicated multi-host container deployment guide covering private routing, unique silo and gateway endpoints, NAT and port-mapping constraints, membership versus transport connectivity, current Docker overlay and Amazon ECS networking models, and practical diagnostics for forwarding loops and request timeouts. Reuse the compiled endpoint snippet and cross-link the guide from deployment, server configuration, troubleshooting, Kubernetes-adjacent, and Azure Container Apps guidance.

## Rationale
Orleans membership identifies a specific silo but does not proxy traffic to it. Making the network contract explicit helps operators choose a compatible platform topology and diagnose cases where discovery succeeds while peers or clients cannot reach the endpoints recorded in membership.

Fixes #3551
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10607)