### PR TITLE
test(runtime): synchronize cancellation callback registration

### DIFF
--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -219,7 +219,7 @@ namespace UnitTests.GrainInterfaces
         Task<bool> CancellationTokenCallbackResolve(CancellationToken tc, Guid callId);
         Task<bool> CallOtherGrainCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
         Task<bool> CallOtherCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
-        Task GrainCancellationTokenCallbackThrow(GrainCancellationToken tc, Guid callId);
+        Task GrainCancellationTokenCallbackThrow(GrainCancellationToken tc, Guid callId, ILongRunningTaskObserver observer);
         Task CancellationTokenCallbackThrow(CancellationToken tc, Guid callId);
         Task<T> GetLastValue();
 

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -639,13 +639,14 @@ namespace UnitTests.Grains
         [MaybeNull]
         private T lastValue;
 
-        public async Task GrainCancellationTokenCallbackThrow(GrainCancellationToken ct, Guid callId)
+        public async Task GrainCancellationTokenCallbackThrow(GrainCancellationToken ct, Guid callId, ILongRunningTaskObserver observer)
         {
             ct.CancellationToken.Register(() =>
             {
                 _cancelledCalls.Writer.TryWrite((callId, null!));
                 throw new InvalidOperationException("From cancellation token callback");
             });
+            observer.OnCallStarted(callId);
 
             await Task.Delay(TimeSpan.FromSeconds(10), ct.CancellationToken);
         }

--- a/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
@@ -168,21 +168,23 @@ namespace UnitTests.CancellationTests
         public async Task CancellationTokenCallbacksThrow_ExceptionShouldBePropagated()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            var observer = new LongRunningTaskObserver();
+            var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
             using var cts = new GrainCancellationTokenSource();
-            var callId = Guid.NewGuid();
-            grain.GrainCancellationTokenCallbackThrow(cts.Token, callId).Ignore();
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
             try
             {
-                await cts.Cancel();
-            }
-            catch (AggregateException ex)
-            {
-                Assert.True(ex.InnerException is InvalidOperationException, "Exception thrown has wrong type");
-                return;
-            }
+                var callId = Guid.NewGuid();
+                var grainTask = grain.GrainCancellationTokenCallbackThrow(cts.Token, callId, observerReference);
+                await observer.WaitForCallToStart(callId);
 
-            Assert.Fail("No exception was thrown");
+                var exception = await Assert.ThrowsAsync<AggregateException>(() => cts.Cancel());
+                Assert.IsType<InvalidOperationException>(Assert.Single(exception.InnerExceptions));
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+            }
+            finally
+            {
+                fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+            }
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -332,6 +334,19 @@ namespace UnitTests.CancellationTests
             }
 
             Assert.Fail("Did not encounter the expected call id");
+        }
+
+        private sealed class LongRunningTaskObserver : ILongRunningTaskObserver
+        {
+            private readonly TaskCompletionSource<Guid> _startedCall = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public void OnCallStarted(Guid callId) => _startedCall.TrySetResult(callId);
+
+            public async Task WaitForCallToStart(Guid callId)
+            {
+                var startedCallId = await _startedCall.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                Assert.Equal(callId, startedCallId);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #10598.

The test used a 100 ms delay as a proxy for the remote grain registering its cancellation callback. Under load, cancellation could arrive first, so `Cancel()` correctly completed before any throwing callback existed and the ignored grain call faulted during late registration.

This change replaces the delay with an observer barrier emitted immediately after callback registration. The test now asserts the exact aggregated callback exception and observes the canceled grain call, preventing discarded faults while preserving the production cancellation contract.

cc @sergeybykov for cancellation/runtime review.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10609)