### PR TITLE
test(grain-directory): make shutdown migration deterministic

### DIFF
--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -178,7 +178,11 @@ public sealed class ShutdownMigrationGrain : Grain, IShutdownMigrationGrain, IGr
                 await ShutdownMigrationTestCoordinator.WaitForDirectoryHandoff(cancellationToken);
             }
 
-            this.MigrateOnIdle();
+            // A migration must not honor a hint targeting the shutting-down source silo.
+            GrainContext.Migrate(new()
+            {
+                [IPlacementDirector.PlacementHintKey] = GrainContext.Address.SiloAddress!
+            });
         }
 
         await base.OnDeactivateAsync(reason, cancellationToken);


### PR DESCRIPTION
## Problem

The shutdown migration regression depended on random fallback placement after the local silo entered ShuttingDown. If stale compatibility data still included the source silo, PreferLocalPlacement only selected it probabilistically, so the test could pass despite the state-loss defect or fail intermittently with reactivated default state.

The production synchronization fix is now covered by #10596, #10597, and #10599, but the integration test did not deterministically prove that the shutting-down source is excluded from migration candidates.

## Solution

Initiate shutdown migration with an explicit placement hint targeting the source silo. Correct placement rejects that hint because the source is no longer compatible and migrates to the surviving silo. A regression which re-admits the source honors the hint, skips migration, and deterministically reproduces the lost state (42 becoming 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10610)