### PR TITLE
fix(docs): isolate parallel snippet build outputs

### DIFF
--- a/docs/site/src/content/docs/validate-snippets.ps1
+++ b/docs/site/src/content/docs/validate-snippets.ps1
@@ -12,7 +12,7 @@
     documentation examples remain buildable and executable test examples pass.
 
 .PARAMETER Parallel
-    Run validations in parallel (default: false for clearer output)
+    Run validations in parallel with isolated build outputs (default: false for clearer output)
 
 .PARAMETER PolicyOnly
     Validate target frameworks and Orleans package versions without building.
@@ -449,24 +449,43 @@ function Invoke-ProjectValidation {
 
 if ($Parallel) {
     Write-Host "Running validations in parallel..." -ForegroundColor Cyan
-    $results = $snippetProjects | ForEach-Object -Parallel {
-        $ProjectPath = $_
-        $validationRoot = $using:validationRoot
-        $relativePath = [IO.Path]::GetRelativePath($validationRoot, $ProjectPath)
-        [xml] $projectXml = Get-Content -LiteralPath $ProjectPath -Raw
-        $isTestProject = $projectXml.Project.PropertyGroup.IsTestProject -contains "true"
-        $command = if ($isTestProject) { "test" } else { "build" }
-        
-        $output = & dotnet $command $ProjectPath --framework net10.0 --nologo -v q 2>&1
-        $exitCode = $LASTEXITCODE
-        
-        @{
-            Project = $relativePath
-            Action = $command
-            Success = ($exitCode -eq 0)
-            Output = $output -join "`n"
+    $artifactsRoot = Join-Path ([IO.Path]::GetTempPath()) "orleans-snippet-validation-$([Guid]::NewGuid().ToString("N"))"
+    New-Item -ItemType Directory -Path $artifactsRoot -ErrorAction Stop | Out-Null
+    try {
+        $validationTasks = for ($index = 0; $index -lt $snippetProjects.Count; $index++) {
+            @{
+                ProjectPath = $snippetProjects[$index]
+                ArtifactsPath = Join-Path $artifactsRoot $index.ToString("D3")
+            }
         }
-    } -ThrottleLimit 4
+        $results = $validationTasks | ForEach-Object -Parallel {
+            $ProjectPath = $_.ProjectPath
+            $ArtifactsPath = $_.ArtifactsPath
+            $validationRoot = $using:validationRoot
+            $relativePath = [IO.Path]::GetRelativePath($validationRoot, $ProjectPath)
+            [xml] $projectXml = Get-Content -LiteralPath $ProjectPath -Raw
+            $isTestProject = $projectXml.Project.PropertyGroup.IsTestProject -contains "true"
+            $command = if ($isTestProject) { "test" } else { "build" }
+
+            $output = & dotnet $command $ProjectPath --framework net10.0 --nologo -v q --artifacts-path $ArtifactsPath 2>&1
+            $exitCode = $LASTEXITCODE
+
+            @{
+                Project = $relativePath
+                Action = $command
+                Success = ($exitCode -eq 0)
+                Output = $output -join "`n"
+            }
+        } -ThrottleLimit 4
+    }
+    finally {
+        try {
+            Remove-Item -LiteralPath $artifactsRoot -Recurse -Force -ErrorAction Stop
+        }
+        catch {
+            Write-Warning "Could not remove temporary snippet artifacts '$artifactsRoot': $($_.Exception.Message)"
+        }
+    }
 } else {
     foreach ($project in $snippetProjects) {
         $result = Invoke-ProjectValidation -ProjectPath $project -IsTestProject (Test-IsTestProject -ProjectPath $project)

--- a/docs/site/tests/snippet-policy.test.mjs
+++ b/docs/site/tests/snippet-policy.test.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { copyFile, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { copyFile, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -19,8 +19,18 @@ async function temporaryDirectory() {
   return directory;
 }
 
-async function runPolicy(root, siteRoot, projectPolicyPath) {
-  const commandArguments = [validator, '-PolicyOnly', '-RootPath', root];
+async function runValidator(
+  root,
+  { policyOnly = false, parallel = false, siteRoot, projectPolicyPath } = {},
+) {
+  const commandArguments = [validator];
+  if (policyOnly) {
+    commandArguments.push('-PolicyOnly');
+  }
+  if (parallel) {
+    commandArguments.push('-Parallel');
+  }
+  commandArguments.push('-RootPath', root);
   if (siteRoot) {
     commandArguments.push('-SiteRootPath', siteRoot);
   }
@@ -42,6 +52,10 @@ async function runPolicy(root, siteRoot, projectPolicyPath) {
   }
 }
 
+async function runPolicy(root, siteRoot, projectPolicyPath) {
+  return runValidator(root, { policyOnly: true, siteRoot, projectPolicyPath });
+}
+
 async function writeValidatedProject(root, projectBody) {
   await writeFile(
     path.join(root, 'Directory.Build.props'),
@@ -61,6 +75,52 @@ afterEach(async () => {
 });
 
 describe('snippet project policy', { timeout: 30_000 }, () => {
+  test('isolates outputs for parallel builds with shared project references', async () => {
+    const root = await temporaryDirectory();
+    const firstProject = path.join(root, 'snippets', 'first');
+    const secondProject = path.join(root, 'snippets', 'second');
+    const sharedProject = path.join(root, 'shared');
+    await Promise.all([
+      mkdir(firstProject, { recursive: true }),
+      mkdir(secondProject, { recursive: true }),
+      mkdir(sharedProject, { recursive: true }),
+    ]);
+    await writeFile(
+      path.join(root, 'Directory.Build.props'),
+      '<Project><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>',
+    );
+    await writeFile(
+      path.join(sharedProject, 'Shared.csproj'),
+      '<Project Sdk="Microsoft.NET.Sdk" />',
+    );
+
+    const projectBody = (marker) => [
+      '<Project Sdk="Microsoft.NET.Sdk">',
+      '  <ItemGroup>',
+      '    <ProjectReference Include="..\\..\\shared\\Shared.csproj" />',
+      '  </ItemGroup>',
+      '  <Target Name="RecordArtifactsPath" AfterTargets="Build">',
+      '    <Error Condition="\'$(ArtifactsPath)\' == \'\'" Text="Parallel validation must set ArtifactsPath." />',
+      `    <WriteLinesToFile File="$(MSBuildProjectDirectory)/${marker}" Lines="$(ArtifactsPath)" Overwrite="true" />`,
+      '  </Target>',
+      '</Project>',
+    ].join('\n');
+    await Promise.all([
+      writeFile(path.join(firstProject, 'First.csproj'), projectBody('artifacts-path.txt')),
+      writeFile(path.join(secondProject, 'Second.csproj'), projectBody('artifacts-path.txt')),
+    ]);
+
+    const result = await runValidator(root, { parallel: true });
+    expect(result).toMatchObject({ exitCode: 0 });
+    const [firstArtifactsPath, secondArtifactsPath] = await Promise.all([
+      readFile(path.join(firstProject, 'artifacts-path.txt'), 'utf8'),
+      readFile(path.join(secondProject, 'artifacts-path.txt'), 'utf8'),
+    ]);
+    expect(firstArtifactsPath.trim()).not.toBe('');
+    expect(secondArtifactsPath.trim()).not.toBe('');
+    expect(firstArtifactsPath.trim()).not.toBe(secondArtifactsPath.trim());
+  }, 120_000);
+
   test('executes the rendered Markdown resolver without npm packages installed', async () => {
     const root = await temporaryDirectory();
     const toolRoot = path.join(root, 'tool');


### PR DESCRIPTION
Fixes #10602.

Parallel documentation snippet validation launches independent `dotnet` builds for each top-level project. Related projects can therefore rebuild shared project references into the same output directories and race on generated files.

Give each parallel build or test invocation a unique temporary `--artifacts-path` and clean it up after validation. This preserves four-way parallelism and full project-reference validation while eliminating shared output writes. Add regression coverage proving related parallel builds receive distinct artifact roots.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10611)