### PR TITLE
fix(reminders): reconcile stale-owner registrations

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -217,7 +217,12 @@ namespace Orleans.Runtime.ReminderService
             if (newEtag != null)
             {
                 entry.ETag = newEtag;
-                ReconcileLocalReminder(entry, _timeProvider.GetUtcNow().UtcDateTime);
+                // A request can arrive on a stale owner. Persist it here, but let the current owner load it.
+                if (RingRange.InRange(grainId))
+                {
+                    ReconcileLocalReminder(entry, _timeProvider.GetUtcNow().UtcDateTime);
+                }
+
                 LogDebugRegisterReminder(entry, localTableSequence);
 
                 if (logger.IsEnabled(LogLevel.Trace)) PrintReminders();

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -211,6 +211,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         using (var recorder = new ReminderEventRecorder(ReminderEvents.AllEvents))
         {
             await grain.StartReminder(DR);
+            await SynchronizeReminderSchedulesAsync(cts.Token, (grain, DR));
             await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), firstTickCount + 1, cts.Token);
 
             Assert.Contains(recorder.Events, evt => evt is ReminderEvents.Registered registered && registered.GrainId == grainId && registered.ReminderName == DR);
@@ -423,18 +424,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
         for (var i = 0; i < tickCount; i++)
         {
-            await Task.WhenAll(reminders.Select(async reminder =>
-            {
-                await observer.WaitForActiveReminderCountAsync(
-                    reminder.Grain,
-                    1,
-                    cancellationToken,
-                    reminder.ReminderName);
-                await observer.WaitForLocalReminderScheduleAsync(
-                    reminder.Grain,
-                    reminder.ReminderName,
-                    cancellationToken);
-            }));
+            await SynchronizeReminderSchedulesAsync(cancellationToken, reminders);
 
             var counterWaitTasks = new List<Task>(reminders.Length);
             var previousTickCounts = new int[reminders.Length];
@@ -475,11 +465,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             await AdvanceReminderTimeAsync(period, cancellationToken);
             await Task.WhenAll(Task.WhenAll(counterWaitTasks), Task.WhenAll(tickTasks));
 
-            await Task.WhenAll(reminders.Select(reminder =>
-                observer.WaitForLocalReminderScheduleAsync(
-                    reminder.Grain,
-                    reminder.ReminderName,
-                    cancellationToken)));
+            await SynchronizeReminderSchedulesAsync(cancellationToken, reminders);
             for (var reminderIndex = 0; reminderIndex < reminders.Length; reminderIndex++)
             {
                 var reminder = reminders[reminderIndex];
@@ -600,7 +586,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
             var nextTickTarget = observer.GetTickCount(grainId, reminderName) + 1;
             var waitTask = observer.WaitForTickCountAsync(grainId, nextTickTarget, cancellationToken, reminderName);
-            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cancellationToken);
+            await SynchronizeReminderSchedulesAsync(cancellationToken, (grain, reminderName));
             var reminderPeriod = await GetReminderPeriodAsync(grain, reminderName);
             await AdvanceReminderTimeAsync(reminderPeriod, cancellationToken);
             await waitTask;
@@ -763,9 +749,45 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
     private async Task RefreshReminderServicesAsync(CancellationToken cancellationToken)
     {
-        var refreshTasks = HostedCluster.Silos.Select(silo =>
+        var refreshTasks = HostedCluster.GetActiveSilos().Select(silo =>
             silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyRefresh());
         await Task.WhenAll(refreshTasks).WaitAsync(cancellationToken);
+    }
+
+    private async Task SynchronizeReminderSchedulesAsync(
+        CancellationToken cancellationToken,
+        params (IAddressable Grain, string ReminderName)[] reminders)
+    {
+        await RefreshReminderServicesAsync(cancellationToken);
+        try
+        {
+            await Task.WhenAll(reminders.Select(async reminder =>
+            {
+                await observer.WaitForActiveReminderCountAsync(
+                    reminder.Grain,
+                    1,
+                    cancellationToken,
+                    reminder.ReminderName);
+                await observer.WaitForLocalReminderScheduleAsync(
+                    reminder.Grain,
+                    reminder.ReminderName,
+                    cancellationToken);
+            }));
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            var states = reminders.Select(reminder =>
+            {
+                var grainId = reminder.Grain.GetGrainId();
+                return $"{grainId}/{reminder.ReminderName}: " +
+                    $"owners={observer.GetActiveReminderCount(grainId, reminder.ReminderName)}, " +
+                    $"silos=[{string.Join(", ", observer.GetActiveReminderSilos(grainId, reminder.ReminderName).Select(static silo => silo.ToString()))}], " +
+                    $"ticks={observer.GetTickCount(grainId, reminder.ReminderName)}";
+            });
+            throw new InvalidOperationException(
+                $"Timed out synchronizing reminder schedules at {ReminderUtcNow:O}: {string.Join("; ", states)}",
+                exception);
+        }
     }
 
     private async Task<bool> HandleError(Exception ex, long i)


### PR DESCRIPTION
## Problem

Reminder registration requests can arrive on a silo which no longer owns the reminder's ring range. The service persisted the registration and also created a local schedule on that stale owner. The real owner only discovered the row during a later refresh, producing transient duplicate owners or leaving deterministic fake-time tests waiting for an owner transition which could not occur until time advanced.

This explains the recurring Azure suite pattern: missing local schedule-update diagnostics, tick-readiness waits timing out, and duplicate owner assertions after topology changes.

## Solution

Only reconcile a newly persisted registration into the local schedule when the receiving reminder service currently owns the grain's ring range. Non-owner registrations remain durable and are loaded by the current owner during reconciliation.

Make the deterministic reminder tests explicitly refresh active reminder services before waiting for owner schedules or advancing fake time. Timeout diagnostics now include reminder identity, owner silos, tick count, and fake time.

## Rationale

The runtime change restores the existing ownership invariant instead of masking the race with longer timeouts. The test barrier drives the same storage reconciliation used in production, removing the circular dependency between periodic refresh and fake-time advancement.

Fixes #10499
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10612)