### PR TITLE
fix(directory): wait for active membership during startup

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -76,7 +76,8 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
                 {
                     await foreach (var update in ClusterMembershipService.MembershipUpdates.WithCancellation(_shutdownCts.Token))
                     {
-                        PublishMembershipUpdate(update);
+                        var view = new DirectoryMembershipSnapshot(update, _grainFactory, _partitionsPerSilo, _getRingBoundaries);
+                        _viewUpdates.Publish(view);
                     }
                 }
                 catch (Exception exception)
@@ -92,12 +93,6 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
         {
             _viewUpdates.Dispose();
         }
-    }
-
-    internal void PublishMembershipUpdate(ClusterMembershipSnapshot update)
-    {
-        var view = new DirectoryMembershipSnapshot(update, _grainFactory, _partitionsPerSilo, _getRingBoundaries);
-        _viewUpdates.Publish(view);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -76,8 +76,7 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
                 {
                     await foreach (var update in ClusterMembershipService.MembershipUpdates.WithCancellation(_shutdownCts.Token))
                     {
-                        var view = new DirectoryMembershipSnapshot(update, _grainFactory, _partitionsPerSilo, _getRingBoundaries);
-                        _viewUpdates.Publish(view);
+                        PublishMembershipUpdate(update);
                     }
                 }
                 catch (Exception exception)
@@ -93,6 +92,12 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
         {
             _viewUpdates.Dispose();
         }
+    }
+
+    internal void PublishMembershipUpdate(ClusterMembershipSnapshot update)
+    {
+        var view = new DirectoryMembershipSnapshot(update, _grainFactory, _partitionsPerSilo, _getRingBoundaries);
+        _viewUpdates.Publish(view);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -241,17 +241,15 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         {
             cancellationToken.ThrowIfCancellationRequested();
             var initialRecoveryMembershipVersion = _recoveryMembershipVersion;
-            var resolvedView = await GetViewWithOwnerAsync(grainId, view, initialRecoveryMembershipVersion, cancellationToken);
-            if (resolvedView is null)
+            var resolved = await GetViewWithOwnerAsync(grainId, view, initialRecoveryMembershipVersion, cancellationToken);
+            if (resolved is not { } ownerView)
             {
                 return default;
             }
 
-            view = resolvedView;
-            if (!view.TryGetOwner(grainId, out var owner, out var partitionReference))
-            {
-                throw new InvalidOperationException($"Directory membership view {view.Version} does not have an owner for grain '{grainId}'.");
-            }
+            view = ownerView.View;
+            var owner = ownerView.Owner;
+            var partitionReference = ownerView.PartitionReference;
 
 #if false
             if (logger.IsEnabled(LogLevel.Trace))
@@ -318,14 +316,20 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         }
     }
 
-    private async ValueTask<DirectoryMembershipSnapshot?> GetViewWithOwnerAsync(
+    private async ValueTask<(DirectoryMembershipSnapshot View, SiloAddress Owner, IGrainDirectoryPartition PartitionReference)?> GetViewWithOwnerAsync(
         GrainId grainId,
         DirectoryMembershipSnapshot view,
         long minimumVersion,
         CancellationToken cancellationToken)
     {
-        while (view.Version.Value < minimumVersion || !view.TryGetOwner(grainId, out _, out _))
+        while (true)
         {
+            if (view.Version.Value >= minimumVersion
+                && view.TryGetOwner(grainId, out var owner, out var partitionReference))
+            {
+                return (view, owner, partitionReference);
+            }
+
             // Cluster membership advances before the directory's asynchronous view. If the latest cluster view
             // still has an active member, this empty directory view is stale; otherwise it is terminal, as on shutdown.
             if (view.Members.Length == 0
@@ -338,8 +342,6 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
             var targetVersion = Math.Max(view.Version.Value + 1, minimumVersion);
             view = await _membershipService.RefreshViewAsync(new(targetVersion), cancellationToken);
         }
-
-        return view;
     }
 
     private static bool HasActiveMembers(ClusterMembershipSnapshot snapshot)
@@ -634,12 +636,12 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
 
     async Task<SiloAddress?> ITestHooks.WaitForPrimaryForGrain(GrainId grainId, CancellationToken cancellationToken)
     {
-        var view = await GetViewWithOwnerAsync(
+        var result = await GetViewWithOwnerAsync(
             grainId,
             _membershipService.CurrentView,
             _recoveryMembershipVersion,
             cancellationToken);
-        return view is not null && view.TryGetOwner(grainId, out var owner, out _) ? owner : null;
+        return result?.Owner;
     }
 
     async Task<GrainAddress?> ITestHooks.GetLocalRecord(GrainId grainId)

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -241,20 +241,16 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         {
             cancellationToken.ThrowIfCancellationRequested();
             var initialRecoveryMembershipVersion = _recoveryMembershipVersion;
-            if (view.Version.Value < initialRecoveryMembershipVersion || !view.TryGetOwner(grainId, out var owner, out var partitionReference))
+            var resolvedView = await GetViewWithOwnerAsync(grainId, view, initialRecoveryMembershipVersion, cancellationToken);
+            if (resolvedView is null)
             {
-                // If there are no members and this view is current, bail out with the default return value.
-                // Otherwise, wait for the directory to observe the newer cluster membership view.
-                if (view.Members.Length == 0
-                    && view.Version.Value > 0
-                    && LatestClusterMembershipSnapshot.Version <= view.Version)
-                {
-                    return default;
-                }
+                return default;
+            }
 
-                var targetVersion = Math.Max(view.Version.Value + 1, initialRecoveryMembershipVersion);
-                view = await _membershipService.RefreshViewAsync(new(targetVersion), cancellationToken);
-                continue;
+            view = resolvedView;
+            if (!view.TryGetOwner(grainId, out var owner, out var partitionReference))
+            {
+                throw new InvalidOperationException($"Directory membership view {view.Version} does not have an owner for grain '{grainId}'.");
             }
 
 #if false
@@ -320,6 +316,43 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
 
             return result;
         }
+    }
+
+    private async ValueTask<DirectoryMembershipSnapshot?> GetViewWithOwnerAsync(
+        GrainId grainId,
+        DirectoryMembershipSnapshot view,
+        long minimumVersion,
+        CancellationToken cancellationToken)
+    {
+        while (view.Version.Value < minimumVersion || !view.TryGetOwner(grainId, out _, out _))
+        {
+            // Cluster membership advances before the directory's asynchronous view. If the latest cluster view
+            // still has an active member, this empty directory view is stale; otherwise it is terminal, as on shutdown.
+            if (view.Members.Length == 0
+                && view.Version.Value > 0
+                && !HasActiveMembers(LatestClusterMembershipSnapshot))
+            {
+                return null;
+            }
+
+            var targetVersion = Math.Max(view.Version.Value + 1, minimumVersion);
+            view = await _membershipService.RefreshViewAsync(new(targetVersion), cancellationToken);
+        }
+
+        return view;
+    }
+
+    private static bool HasActiveMembers(ClusterMembershipSnapshot snapshot)
+    {
+        foreach (var member in snapshot.Members.Values)
+        {
+            if (member.Status == SiloStatus.Active)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal static bool CanInvokeClusterMember(ClusterMembershipSnapshot snapshot, SiloAddress siloAddress)
@@ -599,6 +632,16 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         return owner;
     }
 
+    async Task<SiloAddress?> ITestHooks.WaitForPrimaryForGrain(GrainId grainId, CancellationToken cancellationToken)
+    {
+        var view = await GetViewWithOwnerAsync(
+            grainId,
+            _membershipService.CurrentView,
+            _recoveryMembershipVersion,
+            cancellationToken);
+        return view is not null && view.TryGetOwner(grainId, out var owner, out _) ? owner : null;
+    }
+
     async Task<GrainAddress?> ITestHooks.GetLocalRecord(GrainId grainId)
     {
         var view = _membershipService.CurrentView;
@@ -617,6 +660,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     internal interface ITestHooks
     {
         SiloAddress? GetPrimaryForGrain(GrainId grainId);
+        Task<SiloAddress?> WaitForPrimaryForGrain(GrainId grainId, CancellationToken cancellationToken);
         Task<GrainAddress?> GetLocalRecord(GrainId grainId);
     }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Immutable;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.GrainDirectory;
 using Orleans.Runtime.GrainDirectory;
@@ -22,4 +23,77 @@ public sealed class DefaultGrainDirectoryTests(DefaultClusterFixture fixture, IT
 
     protected override IGrainDirectory CreateGrainDirectory() =>
         Primary.SiloHost.Services.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
+}
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("GrainDirectory")]
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class DistributedGrainDirectoryMembershipTests
+{
+    [Fact]
+    public async Task OwnerResolutionWaitsForActiveDirectoryMembership()
+    {
+        var builder = new InProcessTestClusterBuilder(1);
+#pragma warning disable ORLEANSEXP003
+        builder.Options.UseDistributedGrainDirectory = true;
+#pragma warning restore ORLEANSEXP003
+        var cluster = builder.Build();
+
+        try
+        {
+            await cluster.DeployAsync();
+            var silo = cluster.Silos[0];
+            var membership = silo.ServiceProvider.GetRequiredService<DirectoryMembershipService>();
+            var directory = silo.ServiceProvider.GetRequiredService<DistributedGrainDirectory>();
+            var testHooks = (DistributedGrainDirectory.ITestHooks)directory;
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            var activeView = membership.CurrentView;
+            if (activeView.Members.Length == 0)
+            {
+                await foreach (var view in membership.ViewUpdates.WithCancellation(timeout.Token))
+                {
+                    if (view.Members.Length > 0)
+                    {
+                        activeView = view;
+                        break;
+                    }
+                }
+            }
+
+            var siloAddress = silo.SiloAddress;
+            var activeMember = activeView.ClusterMembershipSnapshot.Members[siloAddress];
+            var joiningVersion = activeView.Version;
+            membership.PublishMembershipUpdate(CreateSnapshot(siloAddress, activeMember.Name, SiloStatus.Joining, joiningVersion));
+            Assert.Empty(membership.CurrentView.Members);
+
+            var grainId = GrainId.Create("directory-readiness", "registration");
+            var primaryTask = testHooks.WaitForPrimaryForGrain(grainId, timeout.Token);
+            Assert.False(primaryTask.IsCompleted);
+
+            membership.PublishMembershipUpdate(CreateSnapshot(
+                siloAddress,
+                activeMember.Name,
+                SiloStatus.Active,
+                new MembershipVersion(joiningVersion.Value + 1)));
+
+            Assert.Equal(siloAddress, await primaryTask);
+        }
+        finally
+        {
+            await cluster.DisposeAsync();
+        }
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(
+        SiloAddress siloAddress,
+        string siloName,
+        SiloStatus status,
+        MembershipVersion version) =>
+        new(
+            ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(
+                siloAddress,
+                new ClusterMember(siloAddress, status, siloName)),
+            version);
 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
@@ -1,6 +1,11 @@
 #nullable enable
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Runtime.GrainDirectory;
 using Orleans.TestingHost;
@@ -38,6 +43,16 @@ public sealed class DistributedGrainDirectoryMembershipTests
 #pragma warning disable ORLEANSEXP003
         builder.Options.UseDistributedGrainDirectory = true;
 #pragma warning restore ORLEANSEXP003
+        builder.ConfigureSilo((_, siloBuilder) => siloBuilder.ConfigureServices(services =>
+        {
+            services.AddSingleton<ControlledMembershipService>();
+            services.Replace(ServiceDescriptor.Singleton(static sp => new DirectoryMembershipService(
+                sp.GetRequiredService<ControlledMembershipService>(),
+                sp.GetRequiredService<IInternalGrainFactory>(),
+                sp.GetRequiredService<ILogger<DirectoryMembershipService>>(),
+                sp.GetRequiredService<IOptions<GrainDirectoryOptions>>().Value.PartitionsPerSilo,
+                DirectoryMembershipSnapshot.DefaultGetRingBoundaries)));
+        }));
         var cluster = builder.Build();
 
         try
@@ -47,36 +62,18 @@ public sealed class DistributedGrainDirectoryMembershipTests
             var membership = silo.ServiceProvider.GetRequiredService<DirectoryMembershipService>();
             var directory = silo.ServiceProvider.GetRequiredService<DistributedGrainDirectory>();
             var testHooks = (DistributedGrainDirectory.ITestHooks)directory;
+            var controlledMembership = silo.ServiceProvider.GetRequiredService<ControlledMembershipService>();
             using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-            var activeView = membership.CurrentView;
-            if (activeView.Members.Length == 0)
-            {
-                await foreach (var view in membership.ViewUpdates.WithCancellation(timeout.Token))
-                {
-                    if (view.Members.Length > 0)
-                    {
-                        activeView = view;
-                        break;
-                    }
-                }
-            }
-
+            await controlledMembership.ActiveUpdateBlocked.WaitAsync(timeout.Token);
             var siloAddress = silo.SiloAddress;
-            var activeMember = activeView.ClusterMembershipSnapshot.Members[siloAddress];
-            var joiningVersion = new MembershipVersion(membership.CurrentView.Version.Value + 1);
-            membership.PublishMembershipUpdate(CreateSnapshot(siloAddress, activeMember.Name, SiloStatus.Joining, joiningVersion));
             Assert.Empty(membership.CurrentView.Members);
 
             var grainId = GrainId.Create("directory-readiness", "registration");
             var primaryTask = testHooks.WaitForPrimaryForGrain(grainId, timeout.Token);
             Assert.False(primaryTask.IsCompleted);
 
-            membership.PublishMembershipUpdate(CreateSnapshot(
-                siloAddress,
-                activeMember.Name,
-                SiloStatus.Active,
-                new MembershipVersion(membership.CurrentView.Version.Value + 1)));
+            controlledMembership.ReleaseActiveUpdate();
 
             Assert.Equal(siloAddress, await primaryTask);
         }
@@ -86,14 +83,49 @@ public sealed class DistributedGrainDirectoryMembershipTests
         }
     }
 
-    private static ClusterMembershipSnapshot CreateSnapshot(
-        SiloAddress siloAddress,
-        string siloName,
-        SiloStatus status,
-        MembershipVersion version) =>
-        new(
-            ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(
-                siloAddress,
-                new ClusterMember(siloAddress, status, siloName)),
-            version);
+    private sealed class ControlledMembershipService(IClusterMembershipService inner) : IClusterMembershipService
+    {
+        private readonly TaskCompletionSource _activeUpdateBlocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseActiveUpdate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _hasBlockedActiveUpdate;
+
+        public ClusterMembershipSnapshot CurrentSnapshot => inner.CurrentSnapshot;
+
+        public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => GetMembershipUpdates();
+
+        public Task ActiveUpdateBlocked => _activeUpdateBlocked.Task;
+
+        public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) =>
+            inner.Refresh(minimumVersion, cancellationToken);
+
+        public Task<bool> TryKill(SiloAddress siloAddress) => inner.TryKill(siloAddress);
+
+        public void ReleaseActiveUpdate() => _releaseActiveUpdate.TrySetResult();
+
+        private async IAsyncEnumerable<ClusterMembershipSnapshot> GetMembershipUpdates(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await foreach (var update in inner.MembershipUpdates.WithCancellation(cancellationToken))
+            {
+                if (update.Members.Values.Any(static member => member.Status == SiloStatus.Active)
+                    && Interlocked.CompareExchange(ref _hasBlockedActiveUpdate, 1, 0) == 0)
+                {
+                    var joiningVersion = new MembershipVersion(update.Version.Value - 1);
+                    if (joiningVersion <= MembershipVersion.MinValue)
+                    {
+                        throw new InvalidOperationException($"Expected an Active membership version greater than one, encountered {update.Version}.");
+                    }
+
+                    var joiningMembers = update.Members.ToImmutableDictionary(
+                        static member => member.Key,
+                        static member => new ClusterMember(member.Key, SiloStatus.Joining, member.Value.Name));
+                    yield return new ClusterMembershipSnapshot(joiningMembers, joiningVersion);
+                    _activeUpdateBlocked.TrySetResult();
+                    await _releaseActiveUpdate.Task.WaitAsync(cancellationToken);
+                }
+
+                yield return update;
+            }
+        }
+    }
 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
@@ -64,7 +64,7 @@ public sealed class DistributedGrainDirectoryMembershipTests
 
             var siloAddress = silo.SiloAddress;
             var activeMember = activeView.ClusterMembershipSnapshot.Members[siloAddress];
-            var joiningVersion = activeView.Version;
+            var joiningVersion = new MembershipVersion(membership.CurrentView.Version.Value + 1);
             membership.PublishMembershipUpdate(CreateSnapshot(siloAddress, activeMember.Name, SiloStatus.Joining, joiningVersion));
             Assert.Empty(membership.CurrentView.Members);
 
@@ -76,7 +76,7 @@ public sealed class DistributedGrainDirectoryMembershipTests
                 siloAddress,
                 activeMember.Name,
                 SiloStatus.Active,
-                new MembershipVersion(joiningVersion.Value + 1)));
+                new MembershipVersion(membership.CurrentView.Version.Value + 1)));
 
             Assert.Equal(siloAddress, await primaryTask);
         }


### PR DESCRIPTION
Fixes #10600

## Problem

Startup tasks run after cluster membership reports the silo as active, but the distributed grain directory can briefly lag on a joining-only view with no active directory owners. That transient view was treated as terminal, returning a null registration result and invalidating the new activation.

## Solution

Wait for the directory view to catch up when the latest cluster membership still contains an active member. Preserve the existing terminal behavior when the cluster truly has no active members, including shutdown. Add a deterministic regression which holds directory membership on a joining-only view and verifies owner resolution resumes after the active view is published.

## Rationale

This restores the readiness invariant at the directory operation boundary instead of masking the failure with startup-task retries or delays, while retaining prompt shutdown behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10613)