### PR TITLE
fix(rebalancing): honor latest suspension duration

### DIFF
--- a/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerWorker.cs
+++ b/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerWorker.cs
@@ -566,6 +566,6 @@ internal sealed partial class ActivationRebalancerWorker(
             suspendUntil = long.MaxValue;
         }
 
-        _suspendedUntilTs = Math.Max(_suspendedUntilTs, suspendUntil);
+        _suspendedUntilTs = suspendUntil;
     }
 }

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -111,6 +111,35 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
         Assert.Equal(host, report.Host);
     }
 
+    [Fact]
+    public async Task Explicit_Suspension_Should_Reflect_The_Latest_Requested_Duration()
+    {
+        var serviceProvider = Cluster.GetSiloServiceProvider();
+        var rebalancer = serviceProvider.GetRequiredService<IActivationRebalancer>();
+
+        await rebalancer.ResumeRebalancing();
+
+        var longerDuration = TimeSpan.FromSeconds(10);
+        var shorterDuration = TimeSpan.FromSeconds(2);
+
+        await rebalancer.SuspendRebalancing(longerDuration);
+        var afterLongerCall = await rebalancer.GetRebalancingReport();
+
+        await rebalancer.SuspendRebalancing(shorterDuration);
+        var afterShorterCall = await rebalancer.GetRebalancingReport();
+
+        Assert.Equal(RebalancerStatus.Suspended, afterShorterCall.Status);
+        Assert.True(afterShorterCall.SuspensionDuration.HasValue);
+        Assert.Equal(afterLongerCall.Host, afterShorterCall.Host);
+        Assert.InRange(afterShorterCall.SuspensionDuration.Value, TimeSpan.FromTicks(1), shorterDuration);
+
+        await rebalancer.SuspendRebalancing(longerDuration);
+        var afterLongerRequest = await rebalancer.GetRebalancingReport();
+
+        Assert.True(afterLongerRequest.SuspensionDuration.HasValue);
+        Assert.InRange(afterLongerRequest.SuspensionDuration.Value, shorterDuration, longerDuration);
+    }
+
     private static string Format(RebalancingReport report) =>
         $"Host={report.Host}, Status={report.Status}, SuspensionDuration={report.SuspensionDuration?.ToString() ?? "<null>"}";
 

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -137,7 +137,7 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
         var afterLongerRequest = await rebalancer.GetRebalancingReport();
 
         Assert.True(afterLongerRequest.SuspensionDuration.HasValue);
-        Assert.InRange(afterLongerRequest.SuspensionDuration.Value, shorterDuration, longerDuration);
+        Assert.InRange(afterLongerRequest.SuspensionDuration.Value, shorterDuration + TimeSpan.FromTicks(1), longerDuration);
     }
 
     private static string Format(RebalancingReport report) =>


### PR DESCRIPTION
Explicit suspension requests previously retained the later of the existing and requested deadlines. A shorter follow-up request could therefore report a duration greater than the caller requested.

Set the suspension deadline from the latest explicit request and add regression coverage for shortening and extending a suspension.

Fixes #10478
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10614)