### PR TITLE
fix(persistence): use a stable hash to pick the memory storage grain

### DIFF
--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -130,7 +130,7 @@ namespace Orleans.Storage
 
         private IMemoryStorageGrain GetStorageGrain(string id)
         {
-            var idx = (uint)id.GetHashCode() % (uint)storageGrains.Length;
+            var idx = StableHash.ComputeHash(id) % (uint)storageGrains.Length;
             return storageGrains[idx].Value;
         }
 


### PR DESCRIPTION
MemoryGrainStorage.GetStorageGrain(id) uses string.GetHashCode() to determine the storage grain. However, in the environment I verified (.NET 10), string.GetHashCode() uses a random seed per process:

ulong seed = Marvin.DefaultSeed;

Marvin.DefaultSeed is generated once per process using RandomNumberGenerator
As a result, the same ID can produce different hash values across processes, causing the same ID to be mapped to different shards (storageGrains[idx]).
To ensure consistent shard selection, the implementation was changed to use Orleans' stable hash function instead of string.GetHashCode().
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10617)