### PR TITLE
fix(docs): redirect legacy Orleans tutorials

### DIFF
--- a/docs/site/src/data/redirects.json
+++ b/docs/site/src/data/redirects.json
@@ -1,4 +1,6 @@
 {
+  "/orleans/Tutorials/Minimal-Orleans-Application.html": "/orleans/docs/tutorials-and-samples/hello-world/",
+  "/orleans/Tutorials/Running-in-a-Stand-alone-Silo.html": "/orleans/docs/quickstarts/build-your-first-orleans-app/",
   "/orleans/docs/tutorials-and-samples/tutorial-1/": "/orleans/docs/quickstarts/build-your-first-orleans-app/",
   "/orleans/docs/tutorials_and_samples/tutorial_1.html": "/orleans/docs/quickstarts/build-your-first-orleans-app/",
   "/orleans/docs/tutorials-and-samples/multi-project-orleans-application/": "/orleans/docs/quickstarts/build-your-first-orleans-app/",

--- a/docs/site/tests/redirects.test.mjs
+++ b/docs/site/tests/redirects.test.mjs
@@ -2,6 +2,19 @@ import { readFile } from 'node:fs/promises';
 import { describe, expect, test } from 'vitest';
 
 describe('legacy redirects', () => {
+  test('routes the original onboarding tutorials to their modern successors', async () => {
+    const redirects = JSON.parse(
+      await readFile(new URL('../src/data/redirects.json', import.meta.url), 'utf8'),
+    );
+
+    expect(
+      redirects['/orleans/Tutorials/Minimal-Orleans-Application.html'],
+    ).toBe('/orleans/docs/tutorials-and-samples/hello-world/');
+    expect(
+      redirects['/orleans/Tutorials/Running-in-a-Stand-alone-Silo.html'],
+    ).toBe('/orleans/docs/quickstarts/build-your-first-orleans-app/');
+  });
+
   test('routes the Azure Web Apps legacy page to the restored App Service guide', async () => {
     const redirects = JSON.parse(
       await readFile(new URL('../src/data/redirects.json', import.meta.url), 'utf8'),


### PR DESCRIPTION
## Problem

The two tutorial URLs named in #2617 still return 404 even though their content has modern, maintained successors.

## Solution

Add exact compatibility redirects from the historical minimal-application and stand-alone-silo URLs to the current Hello World quickstart and first-app tutorial. Add regression coverage for both mappings.

## Rationale

Preserving the original URLs closes the remaining onboarding gap without duplicating or reviving obsolete Orleans 1.x content. The successor tutorials use current packages and compiling .NET 10 snippets.

Fixes #2617
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10619)