### PR TITLE
fix(runtime): refresh stale empty directory views

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -26,7 +26,7 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
 
     public IAsyncEnumerable<DirectoryMembershipSnapshot> ViewUpdates => _viewUpdates;
 
-    public ClusterMembershipService ClusterMembershipService { get; }
+    public IClusterMembershipService ClusterMembershipService { get; }
 
     public async ValueTask<DirectoryMembershipSnapshot> RefreshViewAsync(MembershipVersion version, CancellationToken cancellationToken)
     {
@@ -46,7 +46,7 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
     }
 
     public DirectoryMembershipService(
-        ClusterMembershipService clusterMembershipService,
+        IClusterMembershipService clusterMembershipService,
         IInternalGrainFactory grainFactory,
         ILogger<DirectoryMembershipService> logger,
         int partitionsPerSilo,

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -243,8 +243,11 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
             var initialRecoveryMembershipVersion = _recoveryMembershipVersion;
             if (view.Version.Value < initialRecoveryMembershipVersion || !view.TryGetOwner(grainId, out var owner, out var partitionReference))
             {
-                // If there are no members, bail out with the default return value.
-                if (view.Members.Length == 0 && view.Version.Value > 0)
+                // If there are no members and this view is current, bail out with the default return value.
+                // Otherwise, wait for the directory to observe the newer cluster membership view.
+                if (view.Members.Length == 0
+                    && view.Version.Value > 0
+                    && LatestClusterMembershipSnapshot.Version <= view.Version)
                 {
                     return default;
                 }

--- a/test/Orleans.Runtime.Tests/StartupTaskTests.cs
+++ b/test/Orleans.Runtime.Tests/StartupTaskTests.cs
@@ -56,7 +56,7 @@ namespace DefaultCluster.Tests
                     hostBuilder.ConfigureServices(services =>
                     {
                         services.AddSingleton<DelayedDirectoryMembershipService>();
-                        services.Replace(ServiceDescriptor.Singleton(sp => new DirectoryMembershipService(
+                        services.Replace(ServiceDescriptor.Singleton(static sp => new DirectoryMembershipService(
                             sp.GetRequiredService<DelayedDirectoryMembershipService>(),
                             sp.GetRequiredService<IInternalGrainFactory>(),
                             sp.GetRequiredService<ILogger<DirectoryMembershipService>>(),
@@ -139,7 +139,7 @@ namespace DefaultCluster.Tests
                             Volatile.Write(ref this.staleDirectoryVersion, staleVersion);
                             Volatile.Write(ref this.activeDirectoryVersion, update.Version.Value);
                             yield return new ClusterMembershipSnapshot(joiningMembers, new(staleVersion));
-                            await this.releaseActiveUpdate.Task.WaitAsync(cancellationToken);
+                            await this.releaseActiveUpdate.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
                         }
 
                         yield return update;

--- a/test/Orleans.Runtime.Tests/StartupTaskTests.cs
+++ b/test/Orleans.Runtime.Tests/StartupTaskTests.cs
@@ -1,5 +1,13 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
 using Orleans.TestingHost;
 
 using TestExtensions;
@@ -24,10 +32,37 @@ namespace DefaultCluster.Tests
                 builder.AddSiloBuilderConfigurator<StartupTaskSiloConfigurator>();
             }
 
+            public bool ActiveDirectoryUpdateDelayed => GetPrimaryMembership().ActiveUpdateDelayed;
+
+            public int DirectoryRefreshCount => GetPrimaryMembership().RefreshCount;
+
+            public MembershipVersion StaleDirectoryVersion => GetPrimaryMembership().StaleDirectoryVersion;
+
+            public MembershipVersion ActiveDirectoryVersion => GetPrimaryMembership().ActiveDirectoryVersion;
+
+            public MembershipVersion FirstRefreshMinimumVersion => GetPrimaryMembership().FirstRefreshMinimumVersion;
+
+            private DelayedDirectoryMembershipService GetPrimaryMembership()
+            {
+                var primary = HostedCluster.Primary as InProcessSiloHandle
+                    ?? throw new InvalidOperationException("Expected an in-process primary silo.");
+                return primary.SiloHost.Services.GetRequiredService<DelayedDirectoryMembershipService>();
+            }
+
             private class StartupTaskSiloConfigurator : ISiloConfigurator
             {
                 public void Configure(ISiloBuilder hostBuilder)
                 {
+                    hostBuilder.ConfigureServices(services =>
+                    {
+                        services.AddSingleton<DelayedDirectoryMembershipService>();
+                        services.Replace(ServiceDescriptor.Singleton(sp => new DirectoryMembershipService(
+                            sp.GetRequiredService<DelayedDirectoryMembershipService>(),
+                            sp.GetRequiredService<IInternalGrainFactory>(),
+                            sp.GetRequiredService<ILogger<DirectoryMembershipService>>(),
+                            sp.GetRequiredService<IOptions<GrainDirectoryOptions>>().Value.PartitionsPerSilo,
+                            DirectoryMembershipSnapshot.DefaultGetRingBoundaries)));
+                    });
                     hostBuilder.AddStartupTask<CallGrainStartupTask>();
                     hostBuilder.AddStartupTask(
                         async (services, cancellation) =>
@@ -36,6 +71,79 @@ namespace DefaultCluster.Tests
                             var grain = grainFactory.GetGrain<ISimpleGrain>(1);
                             await grain.SetA(888);
                         });
+                }
+            }
+
+            private sealed class DelayedDirectoryMembershipService : IClusterMembershipService
+            {
+                private readonly IClusterMembershipService inner;
+                private readonly TaskCompletionSource releaseActiveUpdate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                private int activeUpdateDelayed;
+                private int refreshCount;
+                private long staleDirectoryVersion;
+                private long activeDirectoryVersion;
+                private long firstRefreshMinimumVersion;
+
+                public DelayedDirectoryMembershipService(IClusterMembershipService inner)
+                {
+                    this.inner = inner;
+                }
+
+                public ClusterMembershipSnapshot CurrentSnapshot => this.inner.CurrentSnapshot;
+
+                public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => this.GetMembershipUpdates();
+
+                public bool ActiveUpdateDelayed => Volatile.Read(ref this.activeUpdateDelayed) != 0;
+
+                public int RefreshCount => Volatile.Read(ref this.refreshCount);
+
+                public MembershipVersion StaleDirectoryVersion => new(Volatile.Read(ref this.staleDirectoryVersion));
+
+                public MembershipVersion ActiveDirectoryVersion => new(Volatile.Read(ref this.activeDirectoryVersion));
+
+                public MembershipVersion FirstRefreshMinimumVersion => new(Volatile.Read(ref this.firstRefreshMinimumVersion));
+
+                public async ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default)
+                {
+                    var staleVersion = Volatile.Read(ref this.staleDirectoryVersion);
+                    if (Volatile.Read(ref this.activeUpdateDelayed) != 0 && minimumVersion.Value > staleVersion)
+                    {
+                        Interlocked.Increment(ref this.refreshCount);
+                        Interlocked.CompareExchange(ref this.firstRefreshMinimumVersion, minimumVersion.Value, 0);
+                        this.releaseActiveUpdate.TrySetResult();
+                    }
+
+                    await this.inner.Refresh(minimumVersion, cancellationToken);
+                }
+
+                public Task<bool> TryKill(SiloAddress siloAddress) => this.inner.TryKill(siloAddress);
+
+                private async IAsyncEnumerable<ClusterMembershipSnapshot> GetMembershipUpdates(
+                    [EnumeratorCancellation] CancellationToken cancellationToken = default)
+                {
+                    await foreach (var update in this.inner.MembershipUpdates.WithCancellation(cancellationToken))
+                    {
+                        if (update.Members.Values.Any(static member => member.Status == SiloStatus.Active)
+                            && Interlocked.CompareExchange(ref this.activeUpdateDelayed, 1, 0) == 0)
+                        {
+                            var staleVersion = update.Version.Value - 1;
+                            if (staleVersion <= 0)
+                            {
+                                throw new InvalidOperationException($"Expected an Active membership version greater than one, encountered {update.Version}.");
+                            }
+
+                            // Keep the directory on a stale Joining view until it explicitly refreshes to the Active view.
+                            var joiningMembers = update.Members.ToImmutableDictionary(
+                                static member => member.Key,
+                                static member => new ClusterMember(member.Key, SiloStatus.Joining, member.Value.Name));
+                            Volatile.Write(ref this.staleDirectoryVersion, staleVersion);
+                            Volatile.Write(ref this.activeDirectoryVersion, update.Version.Value);
+                            yield return new ClusterMembershipSnapshot(joiningMembers, new(staleVersion));
+                            await this.releaseActiveUpdate.Task.WaitAsync(cancellationToken);
+                        }
+
+                        yield return update;
+                    }
                 }
             }
         }
@@ -76,6 +184,12 @@ namespace DefaultCluster.Tests
             grain = this.fixture.GrainFactory.GetGrain<ISimpleGrain>(2);
             value = await grain.GetA();
             Assert.Equal(777, value);
+
+            Assert.True(this.fixture.ActiveDirectoryUpdateDelayed);
+            Assert.True(this.fixture.DirectoryRefreshCount > 0);
+            Assert.True(this.fixture.StaleDirectoryVersion > MembershipVersion.MinValue);
+            Assert.True(this.fixture.ActiveDirectoryVersion > this.fixture.StaleDirectoryVersion);
+            Assert.Equal(this.fixture.ActiveDirectoryVersion, this.fixture.FirstRefreshMinimumVersion);
         }
     }
 }


### PR DESCRIPTION
Fixes #10600

During silo startup, the distributed grain directory could still hold an empty Joining view after cluster membership had advanced to Active. That stale view was treated as authoritative, so activation registration returned no address and Active-stage startup task grain calls were rejected after forwarding.

Refresh the directory when cluster membership is newer than an empty directory view, while preserving the immediate empty result when the view is current. Add deterministic coverage which holds the directory on a positive-version Joining view until it requests the newer Active view, preserving the supported Active-stage startup task contract without retry-based masking.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10625)