### PR TITLE
docs(streaming): explain Event Hubs slow-consumer pressure

### DIFF
--- a/docs/site/src/content/docs/streaming/snippets/streaming/EventHubCachePressure.cs
+++ b/docs/site/src/content/docs/streaming/snippets/streaming/EventHubCachePressure.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
+
+namespace Orleans.Docs.Snippets.Streaming;
+
+public static class EventHubCachePressure
+{
+    public static void FavorSlowConsumers(
+        ISiloEventHubStreamConfigurator configurator)
+    {
+        // <event_hub_slow_consumer_pressure>
+        configurator.ConfigureCachePressuring(builder => builder.Configure(options =>
+        {
+            options.AveragingCachePressureMonitorFlowControlThreshold = null;
+            options.SlowConsumingMonitorFlowControlThreshold = 0.7;
+            options.SlowConsumingMonitorPressureWindowSize =
+                TimeSpan.FromSeconds(10);
+        }));
+        // </event_hub_slow_consumer_pressure>
+    }
+}

--- a/docs/site/src/content/docs/streaming/snippets/streaming/EventHubCachePressure.cs
+++ b/docs/site/src/content/docs/streaming/snippets/streaming/EventHubCachePressure.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Orleans.Hosting;
 
 namespace Orleans.Docs.Snippets.Streaming;

--- a/docs/site/src/content/docs/streaming/snippets/streaming/streaming.csproj
+++ b/docs/site/src/content/docs/streaming/snippets/streaming/streaming.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
     <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.2" />
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Streaming.EventHubs" Version="10.2.2" />
     <PackageReference Include="Microsoft.Orleans.Streaming.AzureStorage" Version="10.2.2" />
     <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.2.2" />
     <PackageReference Include="Azure.Identity" Version="1.18.0" />

--- a/docs/site/src/content/docs/streaming/streaming-operations.md
+++ b/docs/site/src/content/docs/streaming/streaming-operations.md
@@ -1,7 +1,7 @@
 ---
 title: Operate and tune Orleans streams
 description: Apply backpressure, tune persistent providers, and observe Orleans streaming health.
-ms.date: 08/02/2026
+ms.date: 08/17/2026
 ms.topic: concept-article
 ---
 
@@ -21,6 +21,20 @@ Keep consumer turns bounded:
 - Scale by choosing enough provider queues or partitions and by distributing stream keys. One hot stream targeting one stateful grain remains limited by that grain's processing rate.
 
 Backpressure on the consumer side doesn't imply producer completion. `OnNextAsync` on the producer reports provider acceptance, not that downstream consumers caught up.
+
+### Protect a slow Event Hubs consumer
+
+The Event Hubs provider maintains an independent cache cursor for each subscription, so a fast subscription can continue while another subscription falls behind. All cursors for an Event Hubs partition share the same silo-side cache, however. By default, the provider averages the pressure reported by those cursors. This policy favors aggregate throughput, but faster subscriptions can outweigh a small number of lagging subscriptions.
+
+<xref:Orleans.Configuration.StreamCacheEvictionOptions.DataMinTimeInCache> and <xref:Orleans.Configuration.StreamCacheEvictionOptions.DataMaxAgeInCache> control time-based cache eviction; they don't guarantee that every subscription remains within the cache. If eviction advances past a lagging cursor, delivery reports `Item not found in cache`.
+
+When every subscription must be protected from time-based eviction, replace the default averaging monitor with the slow-consuming monitor:
+
+:::code source="snippets/streaming/EventHubCachePressure.cs" id="event_hub_slow_consumer_pressure":::
+
+In this example, any subscription which falls more than 70% behind the newest cached position stops new Event Hubs reads for at least 10 seconds. Tune both values from measured lag and processing time. The slow-consuming policy intentionally limits partition ingestion to protect the slowest subscription: cache misses are less likely, but end-to-end lag for every subscription can increase and backlog can move into Event Hubs. Ensure that Event Hubs retention can absorb that backlog and that sustained ingress doesn't exceed the slowest required subscription's capacity.
+
+First reduce blocking work, CPU saturation, and hot-grain bottlenecks. If workloads need independent throughput or retention policies, isolate them using separate Orleans stream providers and Event Hubs consumer groups instead of coupling them through one partition cache.
 
 ## Tune the pulling pipeline
 

--- a/docs/site/src/content/docs/streaming/streaming-operations.md
+++ b/docs/site/src/content/docs/streaming/streaming-operations.md
@@ -24,17 +24,17 @@ Backpressure on the consumer side doesn't imply producer completion. `OnNextAsyn
 
 ### Protect a slow Event Hubs consumer
 
-The Event Hubs provider maintains an independent cache cursor for each subscription, so a fast subscription can continue while another subscription falls behind. All cursors for an Event Hubs partition share the same silo-side cache, however. By default, the provider averages the pressure reported by those cursors. This policy favors aggregate throughput, but faster subscriptions can outweigh a small number of lagging subscriptions.
+The Event Hubs provider maintains an independent cache cursor for each subscription, so a fast subscription can continue while another subscription falls behind. All cursors for an Event Hubs partition share the same silo-side cache, however. By default, the provider uses a weighted average of the pressure contributions from those cursors: contributions at or above the flow-control threshold receive three times the weight of lower-pressure contributions. Repeated contributions from faster subscriptions can still outweigh a small number of lagging subscriptions.
 
 <xref:Orleans.Configuration.StreamCacheEvictionOptions.DataMinTimeInCache> and <xref:Orleans.Configuration.StreamCacheEvictionOptions.DataMaxAgeInCache> control time-based cache eviction; they don't guarantee that every subscription remains within the cache. If eviction advances past a lagging cursor, delivery reports `Item not found in cache`.
 
-When every subscription must be protected from time-based eviction, replace the default averaging monitor with the slow-consuming monitor:
+The slow-consuming monitor lets a single observed lagging cursor apply cache pressure instead of averaging that pressure with faster cursors:
 
 :::code source="snippets/streaming/EventHubCachePressure.cs" id="event_hub_slow_consumer_pressure":::
 
-In this example, any subscription which falls more than 70% behind the newest cached position stops new Event Hubs reads for at least 10 seconds. Tune both values from measured lag and processing time. The slow-consuming policy intentionally limits partition ingestion to protect the slowest subscription: cache misses are less likely, but end-to-end lag for every subscription can increase and backlog can move into Event Hubs. Ensure that Event Hubs retention can absorb that backlog and that sustained ingress doesn't exceed the slowest required subscription's capacity.
+The monitor starts calculating cursor pressure after the partition cache spans at least 10,000 Event Hubs sequence numbers. In this example, when Orleans reads the next cached item for a subscription whose cursor is more than 70% of the cache span behind the newest cached position, the provider stops new Event Hubs reads for at least 10 seconds. Tune both values from measured lag and processing time. The slow-consuming policy intentionally limits partition ingestion to protect the slowest observed subscription: cache misses are less likely, but end-to-end lag for every subscription can increase and backlog can move into Event Hubs. Ensure that Event Hubs retention can absorb that backlog and that sustained ingress doesn't exceed the slowest required subscription's capacity.
 
-First reduce blocking work, CPU saturation, and hot-grain bottlenecks. If workloads need independent throughput or retention policies, isolate them using separate Orleans stream providers and Event Hubs consumer groups instead of coupling them through one partition cache.
+Pressure is sampled as Orleans advances subscriptions through cached items, so keep consumer turns bounded to keep detection current. First reduce CPU saturation and hot-grain bottlenecks. If workloads need independent throughput or retention policies, isolate them using separate Orleans stream providers and Event Hubs consumer groups instead of coupling them through one partition cache.
 
 ## Tune the pulling pipeline
 


### PR DESCRIPTION
## Problem

The Event Hubs provider gives each stream subscription an independent cursor over a shared per-partition silo cache. Its default cache-pressure policy averages cursor lag, so fast subscriptions can outweigh a small number of slower subscriptions until time-based eviction advances past a lagging cursor and delivery reports `Item not found in cache`. The operations guide named Event Hubs cache-pressure settings but did not explain this behavior or the policy tradeoff.

## Solution

- Explain the independent-cursor and shared-cache behavior, including why cache eviction durations do not guarantee retention for every subscription.
- Add a compiling snippet which disables the default averaging monitor and enables slow-consumer protection.
- Document the throughput, lag, Event Hubs retention, capacity, and workload-isolation tradeoffs of protecting the slowest subscription.

## Rationale

This gives operators a source-verified way to choose between aggregate throughput and slow-consumer protection instead of treating cache retention values as a fairness guarantee. It also makes clear that throttling moves backlog rather than creating processing capacity.

Fixes #5301
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10628)