### PR TITLE
docs(persistence): clarify default provider registration

### DIFF
--- a/docs/site/src/content/docs/grains/grain-persistence/index.md
+++ b/docs/site/src/content/docs/grains/grain-persistence/index.md
@@ -1,7 +1,7 @@
 ---
 title: Grain persistence
 description: Persist Orleans grain state using IPersistentState and storage providers.
-ms.date: 08/02/2026
+ms.date: 08/17/2026
 ms.topic: overview
 ---
 
@@ -54,6 +54,14 @@ Configure every provider name referenced by `[PersistentState]` on the silo:
 :::code language="csharp" source="./snippets/persistence/StorageConfiguration.cs" id="configure_managed_identity":::
 
 The state name distinguishes records owned by the same grain. The provider name selects a keyed <xref:Orleans.Storage.IGrainStorage> registration. Different records aren't required to share a provider or backing store.
+
+When `[PersistentState]` omits the storage name, Orleans resolves the default <xref:Orleans.Storage.IGrainStorage> registration instead. Configure that registration with the provider's `Add*GrainStorageAsDefault` extension. Calling `Add*GrainStorage` with another name only adds that named provider; it doesn't configure a default.
+
+Default and named registrations represent separate roles even when they use the same provider type and backing database. For example, grain-based stream pub/sub conventionally uses the named provider `PubSubStore`, independently of the default provider used by grain state. Register both roles when a silo needs both:
+
+:::code language="csharp" source="./snippets/persistence/StorageConfiguration.cs" id="configure_adonet_default_and_pubsub":::
+
+The two registrations can share configuration, but neither name is an alias for the other. For details about the streaming role, see [Configure PubSub storage](../../streaming/pubsub-storage).
 
 ## Consistency and atomicity
 

--- a/docs/site/src/content/docs/grains/grain-persistence/index.md
+++ b/docs/site/src/content/docs/grains/grain-persistence/index.md
@@ -55,7 +55,7 @@ Configure every provider name referenced by `[PersistentState]` on the silo:
 
 The state name distinguishes records owned by the same grain. The provider name selects a keyed <xref:Orleans.Storage.IGrainStorage> registration. Different records aren't required to share a provider or backing store.
 
-When `[PersistentState]` omits the storage name, Orleans resolves the default <xref:Orleans.Storage.IGrainStorage> registration instead. Configure that registration with the provider's `Add*GrainStorageAsDefault` extension, or pass <xref:Orleans.Runtime.ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME> (`"Default"`) to the corresponding `Add*GrainStorage` extension. Any other name only adds that named provider; it doesn't configure a default.
+When `[PersistentState]` omits the storage name, Orleans resolves the default <xref:Orleans.Storage.IGrainStorage> registration instead. Configure that registration with the provider's `Add*GrainStorageAsDefault` extension, or pass <xref:Orleans.Providers.ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME> (`"Default"`) to the corresponding `Add*GrainStorage` extension. Any other name only adds that named provider; it doesn't configure a default.
 
 Default and named registrations represent separate roles even when they use the same provider type and backing database. For example, grain-based stream pub/sub conventionally uses the named provider `PubSubStore`, independently of the default provider used by grain state. Register both roles when a silo needs both:
 

--- a/docs/site/src/content/docs/grains/grain-persistence/index.md
+++ b/docs/site/src/content/docs/grains/grain-persistence/index.md
@@ -55,13 +55,13 @@ Configure every provider name referenced by `[PersistentState]` on the silo:
 
 The state name distinguishes records owned by the same grain. The provider name selects a keyed <xref:Orleans.Storage.IGrainStorage> registration. Different records aren't required to share a provider or backing store.
 
-When `[PersistentState]` omits the storage name, Orleans resolves the default <xref:Orleans.Storage.IGrainStorage> registration instead. Configure that registration with the provider's `Add*GrainStorageAsDefault` extension. Calling `Add*GrainStorage` with another name only adds that named provider; it doesn't configure a default.
+When `[PersistentState]` omits the storage name, Orleans resolves the default <xref:Orleans.Storage.IGrainStorage> registration instead. Configure that registration with the provider's `Add*GrainStorageAsDefault` extension, or pass <xref:Orleans.Runtime.ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME> (`"Default"`) to the corresponding `Add*GrainStorage` extension. Any other name only adds that named provider; it doesn't configure a default.
 
 Default and named registrations represent separate roles even when they use the same provider type and backing database. For example, grain-based stream pub/sub conventionally uses the named provider `PubSubStore`, independently of the default provider used by grain state. Register both roles when a silo needs both:
 
 :::code language="csharp" source="./snippets/persistence/StorageConfiguration.cs" id="configure_adonet_default_and_pubsub":::
 
-The two registrations can share configuration, but neither name is an alias for the other. For details about the streaming role, see [Configure PubSub storage](../../streaming/pubsub-storage).
+The default and `PubSubStore` registrations can share configuration, but neither role aliases the other. For details about the streaming role, see [Configure PubSub storage](../../streaming/pubsub-storage).
 
 ## Consistency and atomicity
 

--- a/docs/site/src/content/docs/grains/grain-persistence/snippets/persistence/StorageConfiguration.cs
+++ b/docs/site/src/content/docs/grains/grain-persistence/snippets/persistence/StorageConfiguration.cs
@@ -206,6 +206,23 @@ public static class StorageConfiguration
         // </configure_cosmos_default>
     }
 
+    public static void ConfigureDefaultAndPubSubStorage(
+        ISiloBuilder siloBuilder,
+        string connectionString)
+    {
+        // <configure_adonet_default_and_pubsub>
+        Action<AdoNetGrainStorageOptions> configureStorage = options =>
+        {
+            options.Invariant = "Npgsql";
+            options.ConnectionString = connectionString;
+        };
+
+        siloBuilder
+            .AddAdoNetGrainStorageAsDefault(configureStorage)
+            .AddAdoNetGrainStorage("PubSubStore", configureStorage);
+        // </configure_adonet_default_and_pubsub>
+    }
+
     public static void ConfigureAdoNetSerializer()
     {
         // <configure_adonet_serializer>


### PR DESCRIPTION
## Problem

The grain persistence documentation showed named provider registration but did not explain how Orleans selects the default provider when `PersistentStateAttribute` omits a storage name. It also left the relationship between the grain default and special named registrations such as `PubSubStore` ambiguous.

## Solution

Document the current default-versus-named provider contract and add a compiled ADO.NET example which registers the same backend separately as the grain default and as `PubSubStore`.

## Rationale

Default and named storage providers are distinct DI registrations in the current runtime. Making that distinction explicit prevents users from assuming that an arbitrary named registration becomes the default, or that the default registration also satisfies a component-specific provider name.

Fixes #4556
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10629)