### PR TITLE
fix(tests): synchronize failed transaction restore

### DIFF
--- a/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
@@ -275,9 +275,10 @@ public class TransactionQueueStorageWorkTests
 
         failFirstStore.TrySetResult(null);
         await firstRestoreStarted.Task;
+        var backgroundWork = queue.WaitForBackgroundWorkAsync();
         failFirstRestore.TrySetResult(null);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(queue.WaitForBackgroundWorkAsync);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => backgroundWork);
         Assert.Equal("restore failed", exception.Message);
         Assert.Same(replacementBatch, queue.CurrentStorageBatch);
         Assert.False(replacementCompleted.Task.IsCompleted);


### PR DESCRIPTION
Fixes #10620.

Capture the transaction storage worker's in-flight task before releasing the coordinated restore failure. This prevents the worker continuation from clearing the faulted task before the test observes it, while preserving the exact exception and replacement-batch assertions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10630)