### PR TITLE
fix(docs): avoid parallel snippet build races

### DIFF
--- a/docs/site/src/content/docs/validate-snippets.ps1
+++ b/docs/site/src/content/docs/validate-snippets.ps1
@@ -12,7 +12,7 @@
     documentation examples remain buildable and executable test examples pass.
 
 .PARAMETER Parallel
-    Run validations in parallel (default: false for clearer output)
+    Run validations in dependency-safe parallel batches (default: false for clearer output)
 
 .PARAMETER PolicyOnly
     Validate target frameworks and Orleans package versions without building.
@@ -32,7 +32,8 @@
 .EXAMPLE
     .\validate-snippets.ps1 -Parallel
     
-    Validates all snippet projects in parallel for faster validation.
+    Validates independent snippet projects in parallel while serializing projects whose
+    transitive project-reference closures overlap.
 
 .NOTES
     Exit codes:
@@ -113,7 +114,8 @@ function Get-EvaluatedProject {
         "-getProperty:OrleansDocumentationVersionException",
         "-getItem:PackageReference",
         "-getItem:PackageVersion",
-        "-getItem:Compile"
+        "-getItem:Compile",
+        "-getItem:ProjectReference"
     )
     if ($ForNet10) {
         $arguments += "-property:TargetFramework=net10.0"
@@ -132,6 +134,7 @@ function Get-EvaluatedProject {
 
 $pathComparer = $(if ($IsWindows) { [StringComparer]::OrdinalIgnoreCase } else { [StringComparer]::Ordinal })
 $compiledSources = [Collections.Generic.HashSet[string]]::new($pathComparer)
+$projectReferences = [Collections.Generic.Dictionary[string, string[]]]::new($pathComparer)
 $policyIssues = @()
 
 function Test-ContainedPath {
@@ -210,6 +213,10 @@ foreach ($project in $snippetProjects) {
             continue
         }
     }
+
+    $projectReferences[$project] = @($evaluation.Items.ProjectReference |
+        Where-Object { $_.FullPath } |
+        ForEach-Object { [IO.Path]::GetFullPath([string]$_.FullPath) })
 
     $exceptionReason = ([string]$evaluation.Properties.OrleansDocumentationVersionException).Trim()
     $isMigrationProject = $relativePath -split '[\\/]' -contains 'migration'
@@ -447,26 +454,136 @@ function Invoke-ProjectValidation {
     }
 }
 
-if ($Parallel) {
-    Write-Host "Running validations in parallel..." -ForegroundColor Cyan
-    $results = $snippetProjects | ForEach-Object -Parallel {
-        $ProjectPath = $_
-        $validationRoot = $using:validationRoot
-        $relativePath = [IO.Path]::GetRelativePath($validationRoot, $ProjectPath)
-        [xml] $projectXml = Get-Content -LiteralPath $ProjectPath -Raw
-        $isTestProject = $projectXml.Project.PropertyGroup.IsTestProject -contains "true"
-        $command = if ($isTestProject) { "test" } else { "build" }
-        
-        $output = & dotnet $command $ProjectPath --framework net10.0 --nologo -v q 2>&1
-        $exitCode = $LASTEXITCODE
-        
-        @{
-            Project = $relativePath
-            Action = $command
-            Success = ($exitCode -eq 0)
-            Output = $output -join "`n"
+function Get-EvaluatedProjectReferences {
+    param([string]$ProjectPath)
+
+    $arguments = @(
+        "msbuild",
+        $ProjectPath,
+        "-nologo",
+        "-getItem:ProjectReference",
+        "-property:TargetFramework=net10.0"
+    )
+    $output = @(& dotnet @arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "MSBuild project-reference evaluation failed with exit code $LASTEXITCODE.`n$($output -join "`n")"
+    }
+
+    try {
+        $evaluation = ($output -join "`n") | ConvertFrom-Json
+    }
+    catch {
+        throw "MSBuild returned invalid project-reference evaluation JSON.`n$($output -join "`n")"
+    }
+
+    return @($evaluation.Items.ProjectReference |
+        Where-Object { $_.FullPath } |
+        ForEach-Object { [IO.Path]::GetFullPath([string]$_.FullPath) })
+}
+
+function Get-ProjectReferenceClosure {
+    param([string]$ProjectPath)
+
+    $closure = [Collections.Generic.HashSet[string]]::new($pathComparer)
+    $pending = [Collections.Generic.Queue[string]]::new()
+    $pending.Enqueue([IO.Path]::GetFullPath($ProjectPath))
+
+    while ($pending.Count -gt 0) {
+        $current = $pending.Dequeue()
+        if (-not $closure.Add($current)) {
+            continue
         }
-    } -ThrottleLimit 4
+
+        if (-not $projectReferences.ContainsKey($current)) {
+            if (Test-Path -LiteralPath $current -PathType Leaf) {
+                $projectReferences[$current] = @(Get-EvaluatedProjectReferences -ProjectPath $current)
+            } else {
+                $projectReferences[$current] = @()
+            }
+        }
+
+        foreach ($reference in $projectReferences[$current]) {
+            $pending.Enqueue($reference)
+        }
+    }
+
+    return @($closure)
+}
+
+function Get-ParallelValidationBatches {
+    param([string[]]$ProjectPaths)
+
+    $batches = [Collections.Generic.List[object]]::new()
+    foreach ($project in $ProjectPaths) {
+        $closure = @(Get-ProjectReferenceClosure -ProjectPath $project)
+        $selectedBatch = $null
+
+        foreach ($batch in $batches) {
+            $overlaps = $false
+            foreach ($path in $closure) {
+                if ($batch.Closure.Contains($path)) {
+                    $overlaps = $true
+                    break
+                }
+            }
+
+            if (-not $overlaps) {
+                $selectedBatch = $batch
+                break
+            }
+        }
+
+        if (-not $selectedBatch) {
+            $selectedBatch = [pscustomobject]@{
+                Projects = [Collections.Generic.List[string]]::new()
+                Closure = [Collections.Generic.HashSet[string]]::new($pathComparer)
+            }
+            [void]$batches.Add($selectedBatch)
+        }
+
+        [void]$selectedBatch.Projects.Add($project)
+        foreach ($path in $closure) {
+            [void]$selectedBatch.Closure.Add($path)
+        }
+    }
+
+    return $batches
+}
+
+if ($Parallel) {
+    try {
+        $parallelBatches = @(Get-ParallelValidationBatches -ProjectPaths $snippetProjects)
+    }
+    catch {
+        Write-Host "Could not build the project-reference graph required for parallel validation." -ForegroundColor Red
+        Write-Host $_.Exception.Message -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Running validations in $($parallelBatches.Count) dependency-safe parallel batch(es)..." -ForegroundColor Cyan
+    for ($batchIndex = 0; $batchIndex -lt $parallelBatches.Count; $batchIndex++) {
+        $batch = $parallelBatches[$batchIndex]
+        Write-Host "  Batch $($batchIndex + 1): $($batch.Projects.Count) project(s)" -ForegroundColor Gray
+        $batchResults = $batch.Projects | ForEach-Object -Parallel {
+            $ProjectPath = $_
+            $validationRoot = $using:validationRoot
+            $relativePath = [IO.Path]::GetRelativePath($validationRoot, $ProjectPath)
+            [xml] $projectXml = Get-Content -LiteralPath $ProjectPath -Raw
+            $isTestProject = $projectXml.Project.PropertyGroup.IsTestProject -contains "true"
+            $command = if ($isTestProject) { "test" } else { "build" }
+
+            $output = & dotnet $command $ProjectPath --framework net10.0 --nologo -v q 2>&1
+            $exitCode = $LASTEXITCODE
+
+            @{
+                Project = $relativePath
+                Action = $command
+                Success = ($exitCode -eq 0)
+                Output = $output -join "`n"
+            }
+        } -ThrottleLimit 4
+        $results += @($batchResults)
+    }
 } else {
     foreach ($project in $snippetProjects) {
         $result = Invoke-ProjectValidation -ProjectPath $project -IsTestProject (Test-IsTestProject -ProjectPath $project)

--- a/docs/site/tests/snippet-policy.test.mjs
+++ b/docs/site/tests/snippet-policy.test.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { copyFile, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, copyFile, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -138,6 +138,160 @@ describe('snippet project policy', { timeout: 30_000 }, () => {
     );
 
     expect(await runPolicy(root)).toMatchObject({ exitCode: 0 });
+  });
+
+  test('parallel validation separates related Aspire projects while keeping independent projects concurrent', async () => {
+    const root = await temporaryDirectory();
+    const toolDirectory = path.join(root, 'tools');
+    const aspireDirectory = path.join(root, 'snippets', 'aspire');
+    const dependencyDirectory = path.join(root, 'dependencies');
+    const independentDirectory = path.join(root, 'snippets', 'independent');
+    await mkdir(toolDirectory);
+    await mkdir(dependencyDirectory);
+    await mkdir(independentDirectory, { recursive: true });
+    await writeFile(
+      path.join(root, 'Directory.Build.props'),
+      '<Project><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>',
+    );
+
+    for (const projectName of ['Silo', 'Client']) {
+      const projectDirectory = path.join(aspireDirectory, projectName);
+      await mkdir(projectDirectory, { recursive: true });
+      await writeFile(
+        path.join(projectDirectory, `${projectName}.csproj`),
+        [
+          '<Project Sdk="Microsoft.NET.Sdk">',
+          `  <ItemGroup><ProjectReference Include="../../../dependencies/${projectName}Defaults/${projectName}Defaults.csproj" /></ItemGroup>`,
+          '</Project>',
+        ].join('\n'),
+      );
+    }
+
+    for (const projectName of ['ServiceDefaults', 'SiloDefaults', 'ClientDefaults']) {
+      await mkdir(path.join(dependencyDirectory, projectName));
+    }
+    await writeFile(
+      path.join(dependencyDirectory, 'ServiceDefaults', 'ServiceDefaults.csproj'),
+      '<Project Sdk="Microsoft.NET.Sdk" />',
+    );
+    await writeFile(
+      path.join(dependencyDirectory, 'SiloDefaults', 'SiloDefaults.csproj'),
+      [
+        '<Project Sdk="Microsoft.NET.Sdk">',
+        '  <ItemGroup><ProjectReference Include="../ServiceDefaults/ServiceDefaults.csproj" /></ItemGroup>',
+        '</Project>',
+      ].join('\n'),
+    );
+    await writeFile(
+      path.join(dependencyDirectory, 'ClientDefaults', 'ClientDefaults.csproj'),
+      [
+        '<Project Sdk="Microsoft.NET.Sdk">',
+        '  <PropertyGroup><TargetFrameworks>net8.0;net10.0</TargetFrameworks></PropertyGroup>',
+        '  <ItemGroup Condition="\'$(TargetFramework)\' == \'net10.0\'">',
+        '    <ProjectReference Include="../ServiceDefaults/ServiceDefaults.csproj" />',
+        '  </ItemGroup>',
+        '</Project>',
+      ].join('\n'),
+    );
+
+    for (const projectName of ['IndependentA', 'IndependentB']) {
+      await writeFile(
+        path.join(independentDirectory, `${projectName}.csproj`),
+        '<Project Sdk="Microsoft.NET.Sdk" />',
+      );
+    }
+
+    const fakeDotnet = path.join(toolDirectory, 'fake-dotnet.ps1');
+    await writeFile(
+      fakeDotnet,
+      [
+        'param([Parameter(ValueFromRemainingArguments = $true)][string[]]$CommandArguments)',
+        '$projectName = [IO.Path]::GetFileNameWithoutExtension($CommandArguments[1])',
+        'if ($projectName -in @("Silo", "Client")) {',
+        '    try {',
+        '        $lock = [IO.File]::Open($env:SHARED_BUILD_LOCK, "OpenOrCreate", "ReadWrite", "None")',
+        '    } catch {',
+        '        Write-Error "Related projects attempted to build their shared output concurrently."',
+        '        exit 1',
+        '    }',
+        '    try { Start-Sleep -Milliseconds 750 } finally { $lock.Dispose() }',
+        '} elseif ($projectName -in @("IndependentA", "IndependentB")) {',
+        '    $marker = Join-Path $env:BUILD_SYNC_DIRECTORY "$projectName.ready"',
+        '    [IO.File]::WriteAllText($marker, "")',
+        '    $partnerName = if ($projectName -eq "IndependentA") { "IndependentB" } else { "IndependentA" }',
+        '    $partner = Join-Path $env:BUILD_SYNC_DIRECTORY "$partnerName.ready"',
+        '    $deadline = [DateTime]::UtcNow.AddSeconds(5)',
+        '    while (-not (Test-Path -LiteralPath $partner) -and [DateTime]::UtcNow -lt $deadline) {',
+        '        Start-Sleep -Milliseconds 50',
+        '    }',
+        '    if (-not (Test-Path -LiteralPath $partner)) {',
+        '        Write-Error "Independent projects were not validated concurrently."',
+        '        exit 1',
+        '    }',
+        '}',
+        'exit 0',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      path.join(toolDirectory, 'dotnet.cmd'),
+      [
+        '@echo off',
+        'if "%~1"=="msbuild" (',
+        '  "%REAL_DOTNET%" %*',
+        ') else (',
+        '  pwsh -NoProfile -File "%~dp0fake-dotnet.ps1" %*',
+        ')',
+        '',
+      ].join('\r\n'),
+    );
+    const unixDotnet = path.join(toolDirectory, 'dotnet');
+    await writeFile(
+      unixDotnet,
+      [
+        '#!/bin/sh',
+        'if [ "$1" = "msbuild" ]; then',
+        '  exec "$REAL_DOTNET" "$@"',
+        'fi',
+        'exec pwsh -NoProfile -File "$(dirname "$0")/fake-dotnet.ps1" "$@"',
+        '',
+      ].join('\n'),
+    );
+    await chmod(unixDotnet, 0o755);
+
+    const locator = process.platform === 'win32'
+      ? await execFileAsync('where.exe', ['dotnet'])
+      : await execFileAsync('which', ['dotnet']);
+    const realDotnet = locator.stdout.trim().split(/\r?\n/u)[0];
+    const pathVariable = Object.keys(process.env).find((name) => name.toLowerCase() === 'path') ?? 'PATH';
+    const environment = {
+      ...process.env,
+      [pathVariable]: `${toolDirectory}${path.delimiter}${process.env[pathVariable] ?? ''}`,
+      REAL_DOTNET: realDotnet,
+      SHARED_BUILD_LOCK: path.join(root, 'shared-build.lock'),
+      BUILD_SYNC_DIRECTORY: root,
+      DOTNET_NOLOGO: 'true',
+    };
+
+    let result;
+    try {
+      const execution = await execFileAsync(
+        'pwsh',
+        [validator, '-Parallel', '-RootPath', root, '-SiteRootPath', root],
+        { env: environment },
+      );
+      result = { exitCode: 0, output: `${execution.stdout}${execution.stderr}` };
+    } catch (error) {
+      result = {
+        exitCode: error.code,
+        output: `${error.stdout ?? ''}${error.stderr ?? ''}`,
+      };
+    }
+
+    expect(result, result.output).toMatchObject({ exitCode: 0 });
+    expect(result.output).toContain('Succeeded: 4');
+    expect(result.output).toContain('Failed:    0');
+    expect(result.output).toContain('dependency-safe parallel batch(es)');
   });
 
   test('evaluates central PackageVersion metadata', async () => {


### PR DESCRIPTION
## Problem

The documented snippet validator `-Parallel` mode can build roots with overlapping project-reference closures at the same time, causing concurrent writes to shared outputs and intermittent file-lock failures.

## Solution

Evaluate the transitive `ProjectReference` graph and partition validations into dependency-safe batches. Projects within a batch have disjoint closures and still run concurrently, while related roots are serialized across batches.

Add a regression with Aspire-shaped roots which converge through external, conditioned project references. The fixture fails if related roots overlap and also fails if independent roots stop running concurrently.

Fixes #10602
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10631)