### PR TITLE
test(durable-jobs): avoid response timeout in concurrent scheduling

### DIFF
--- a/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobTestsRunner.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.DurableJobs;
+using Orleans.TestingHost.Utils;
 using Xunit;
 using UnitTests.GrainInterfaces;
 
@@ -217,8 +218,38 @@ public class DurableJobTestsRunner
         Assert.Equal(jobCount, jobs.Length);
         Assert.Equal(jobCount, jobs.Select(j => j.Id).Distinct().Count());
 
-        var waitTasks = jobs.Select(j => grain.WaitForJobToRun(j.Id));
-        await Task.WhenAll(waitTasks).WaitAsync(cancellationToken);
+        // Avoid holding grain calls open until the client response timeout while the provider is under load.
+        var pendingJobs = jobs.ToDictionary(job => job.Id);
+        await TestingUtils.WaitUntilAsync(
+            async (lastTry, token) =>
+            {
+                foreach (var job in pendingJobs.Values.ToArray())
+                {
+                    if (await grain.HasJobRan(job.Id).WaitAsync(token))
+                    {
+                        pendingJobs.Remove(job.Id);
+                    }
+                }
+
+                if (pendingJobs.Count == 0)
+                {
+                    return true;
+                }
+
+                if (lastTry)
+                {
+                    var pendingJobDetails = string.Join(
+                        ", ",
+                        pendingJobs.Values
+                            .OrderBy(job => job.Name)
+                            .Select(job => $"{job.Name} ({job.Id})"));
+                    Assert.Fail($"The following durable jobs did not run within the expected time: {pendingJobDetails}");
+                }
+
+                return false;
+            },
+            timeout: TimeSpan.FromMinutes(2),
+            cancellationToken: cancellationToken);
 
         foreach (var job in jobs)
         {

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobTestsRunner.cs
@@ -223,9 +223,13 @@ public class DurableJobTestsRunner
         await TestingUtils.WaitUntilAsync(
             async (lastTry, token) =>
             {
-                foreach (var job in pendingJobs.Values.ToArray())
+                var jobResults = await Task.WhenAll(
+                    pendingJobs.Values.Select(
+                        async job => (Job: job, HasRun: await grain.HasJobRan(job.Id).WaitAsync(token))));
+
+                foreach (var (job, hasRun) in jobResults)
                 {
-                    if (await grain.HasJobRan(job.Id).WaitAsync(token))
+                    if (hasRun)
                     {
                         pendingJobs.Remove(job.Id);
                     }


### PR DESCRIPTION
Fixes #10616

`ConcurrentScheduling` opened 20 long-running grain calls and each call was still limited by the default 30-second response timeout, despite the test having a two-minute cancellation budget. Under Azure provider load, that transport timeout could fail the test before it established whether the jobs were making progress.

Await the explicit per-job execution state instead. The test now removes completed job IDs from a pending set within its intended two-minute budget and reports the names and IDs of any jobs which genuinely remain pending, distinguishing slow provider progress from a liveness failure.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10632)