### PR TITLE
test(runtime): stabilize interleaving cancellation

### DIFF
--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -448,33 +448,30 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
     public async Task InterleavingGrainTaskCancellation(int delay)
     {
         var grain = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+        using var cts = new CancellationTokenSource();
+        var callId = Guid.NewGuid();
+        if (delay == 0)
+        {
+            var grainTask = grain.LongWaitInterleaving(cts.Token, TimeSpan.FromSeconds(10), callId);
+            cts.CancelAfter(delay);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+            return;
+        }
+
         var observer = new LongRunningTaskObserver();
         var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
         try
         {
-            using var cts = new CancellationTokenSource();
-            var callId = Guid.NewGuid();
-            var grainTask = delay > 0
-                ? grain.LongWaitInterleavingWithStartNotification(
-                    TimeSpan.FromSeconds(10),
-                    callId,
-                    observerReference,
-                    cts.Token)
-                : grain.LongWaitInterleaving(
-                    cts.Token,
-                    TimeSpan.FromSeconds(10),
-                    callId);
-            if (delay > 0)
-            {
-                await observer.WaitForCallToStart(callId);
-            }
+            var grainTask = grain.LongWaitInterleavingWithStartNotification(
+                TimeSpan.FromSeconds(10),
+                callId,
+                observerReference,
+                cts.Token);
+            await observer.WaitForCallToStart(callId);
 
             cts.CancelAfter(delay);
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
-            if (delay > 0)
-            {
-                await WaitForCallCancellation(grain, callId);
-            }
+            await WaitForCallCancellation(grain, callId);
         }
         finally
         {

--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -448,14 +448,37 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
     public async Task InterleavingGrainTaskCancellation(int delay)
     {
         var grain = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource();
-        var callId = Guid.NewGuid();
-        var grainTask = grain.LongWaitInterleaving(cts.Token, TimeSpan.FromSeconds(10), callId);
-        cts.CancelAfter(delay);
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
-        if (delay > 0)
+        var observer = new LongRunningTaskObserver();
+        var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
+        try
         {
-            await WaitForCallCancellation(grain, callId);
+            using var cts = new CancellationTokenSource();
+            var callId = Guid.NewGuid();
+            var grainTask = delay > 0
+                ? grain.LongWaitInterleavingWithStartNotification(
+                    TimeSpan.FromSeconds(10),
+                    callId,
+                    observerReference,
+                    cts.Token)
+                : grain.LongWaitInterleaving(
+                    cts.Token,
+                    TimeSpan.FromSeconds(10),
+                    callId);
+            if (delay > 0)
+            {
+                await observer.WaitForCallToStart(callId);
+            }
+
+            cts.CancelAfter(delay);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+            if (delay > 0)
+            {
+                await WaitForCallCancellation(grain, callId);
+            }
+        }
+        finally
+        {
+            fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
         }
     }
 


### PR DESCRIPTION
Fixes #10615.

The delayed interleaving cancellation cases could cancel before the grain method began executing. When that happened, the grain never recorded cancellation evidence and the acknowledgement stream eventually threw its own timeout-driven OperationCanceledException.

Use the existing grain-start observer barrier before scheduling delayed cancellation, matching the synchronization pattern used by neighboring cancellation tests. The zero-delay path remains unchanged so immediate cancellation coverage is preserved.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10633)