### PR TITLE
test: synchronize cancellation callback registration

### DIFF
--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -219,7 +219,7 @@ namespace UnitTests.GrainInterfaces
         Task<bool> CancellationTokenCallbackResolve(CancellationToken tc, Guid callId);
         Task<bool> CallOtherGrainCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
         Task<bool> CallOtherCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
-        Task GrainCancellationTokenCallbackThrow(GrainCancellationToken tc, Guid callId);
+        Task GrainCancellationTokenCallbackThrow(GrainCancellationToken tc, Guid callId, ILongRunningTaskObserver observer);
         Task CancellationTokenCallbackThrow(CancellationToken tc, Guid callId);
         Task<T> GetLastValue();
 

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -639,13 +639,14 @@ namespace UnitTests.Grains
         [MaybeNull]
         private T lastValue;
 
-        public async Task GrainCancellationTokenCallbackThrow(GrainCancellationToken ct, Guid callId)
+        public async Task GrainCancellationTokenCallbackThrow(GrainCancellationToken ct, Guid callId, ILongRunningTaskObserver observer)
         {
             ct.CancellationToken.Register(() =>
             {
                 _cancelledCalls.Writer.TryWrite((callId, null!));
                 throw new InvalidOperationException("From cancellation token callback");
             });
+            observer.OnCallStarted(callId);
 
             await Task.Delay(TimeSpan.FromSeconds(10), ct.CancellationToken);
         }

--- a/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Placement;
 using Orleans.TestingHost;
@@ -168,21 +169,23 @@ namespace UnitTests.CancellationTests
         public async Task CancellationTokenCallbacksThrow_ExceptionShouldBePropagated()
         {
             var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
-            using var cts = new GrainCancellationTokenSource();
-            var callId = Guid.NewGuid();
-            grain.GrainCancellationTokenCallbackThrow(cts.Token, callId).Ignore();
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            var observer = new LongRunningTaskObserver();
+            var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
             try
             {
-                await cts.Cancel();
-            }
-            catch (AggregateException ex)
-            {
-                Assert.True(ex.InnerException is InvalidOperationException, "Exception thrown has wrong type");
-                return;
-            }
+                using var cts = new GrainCancellationTokenSource();
+                var callId = Guid.NewGuid();
+                var grainTask = grain.GrainCancellationTokenCallbackThrow(cts.Token, callId, observerReference);
+                await observer.WaitForCallToStart(callId);
 
-            Assert.Fail("No exception was thrown");
+                var exception = await Assert.ThrowsAsync<AggregateException>(() => cts.Cancel());
+                Assert.IsType<InvalidOperationException>(exception.InnerException);
+                await Assert.ThrowsAsync<TaskCanceledException>(() => grainTask);
+            }
+            finally
+            {
+                fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+            }
         }
 
         [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -332,6 +335,18 @@ namespace UnitTests.CancellationTests
             }
 
             Assert.Fail("Did not encounter the expected call id");
+        }
+
+        private sealed class LongRunningTaskObserver : ILongRunningTaskObserver
+        {
+            private readonly ConcurrentDictionary<Guid, TaskCompletionSource> _startedCalls = new();
+
+            public void OnCallStarted(Guid callId) => GetCallStarted(callId).TrySetResult();
+
+            public Task WaitForCallToStart(Guid callId) => GetCallStarted(callId).Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            private TaskCompletionSource GetCallStarted(Guid callId) =>
+                _startedCalls.GetOrAdd(callId, static _ => new(TaskCreationOptions.RunContinuationsAsynchronously));
         }
     }
 }


### PR DESCRIPTION
## Problem

`CancellationTokenCallbacksThrow_ExceptionShouldBePropagated` used a fixed 100 ms delay before cancellation. Under load, cancellation could reach the grain before its callback was registered, so `Cancel()` completed successfully while the ignored grain call later faulted.

## Solution

- Notify a client observer immediately after the grain registers the callback.
- Wait for that explicit barrier before cancelling the token.
- Observe the cancelled grain call and clean up the observer reference.

## Rationale

`GrainCancellationTokenSource.Cancel()` propagates exceptions from callbacks which are registered when cancellation executes. Synchronizing registration tests that contract directly without depending on scheduler timing.

Fixes #10598
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10635)