### PR TITLE
fix(tests): allow restart addressing cancellation

### DIFF
--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1397,7 +1397,10 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         return (entry.Message.Contains("IGrainDirectoryPartition.", StringComparison.Ordinal)
                 && entry.Message.Contains("not active on this silo", StringComparison.Ordinal))
             || (string.Equals(entry.ExceptionType, typeof(SiloUnavailableException).FullName, StringComparison.Ordinal)
-                && entry.ExceptionMessage?.Contains("is shutting down", StringComparison.Ordinal) == true);
+                && entry.ExceptionMessage?.Contains("is shutting down", StringComparison.Ordinal) == true)
+            || (string.Equals(entry.EventId.Name, "SelectTargetFailed", StringComparison.Ordinal)
+                && string.Equals(entry.ExceptionType, typeof(OperationCanceledException).FullName, StringComparison.Ordinal)
+                && entry.Phase.EndsWith($"-{entry.SiloName}", StringComparison.Ordinal));
     }
 
     private void WriteInPlacePhaseReport(


### PR DESCRIPTION
Fixes #10624.

During an intentional in-place silo restart, the stopping silo can emit an `Orleans.Messaging` `SelectTargetFailed` error with an `OperationCanceledException` even though the sustained workload retries successfully and directory convergence completes. The test currently treats that recovered internal cancellation as impactful and fails.

Classify the log as expected only when it is the `SelectTargetFailed` event, carries an `OperationCanceledException`, and originates from the silo named by the active restart phase. Production logging and all broader unexpected-error assertions remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10636)