### PR TITLE
test: stabilize interleaving cancellation test

### DIFF
--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -448,14 +448,38 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
     public async Task InterleavingGrainTaskCancellation(int delay)
     {
         var grain = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource();
-        var callId = Guid.NewGuid();
-        var grainTask = grain.LongWaitInterleaving(cts.Token, TimeSpan.FromSeconds(10), callId);
-        cts.CancelAfter(delay);
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
-        if (delay > 0)
+        var observer = new LongRunningTaskObserver();
+        var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
+        try
         {
-            await WaitForCallCancellation(grain, callId);
+            using var cts = new CancellationTokenSource();
+            var callId = Guid.NewGuid();
+            var grainTask = delay > 0
+                ? grain.LongWaitInterleavingWithStartNotification(
+                    TimeSpan.FromSeconds(10),
+                    callId,
+                    observerReference,
+                    cts.Token)
+                : grain.LongWaitInterleaving(
+                    cts.Token,
+                    TimeSpan.FromSeconds(10),
+                    callId);
+            if (delay > 0)
+            {
+                // A timer does not guarantee that a new activation has begun executing the request.
+                await observer.WaitForCallToStart(callId);
+            }
+
+            cts.CancelAfter(delay);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+            if (delay > 0)
+            {
+                await WaitForCallCancellation(grain, callId);
+            }
+        }
+        finally
+        {
+            fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
         }
     }
 


### PR DESCRIPTION
## Problem

`InterleavingGrainTaskCancellation(delay: 10)` could cancel before the grain method began executing. The call was canceled correctly, but the method's catch block never ran to publish the cancellation record, so the test waited until its independent five-minute acknowledgement timeout canceled the watch stream.

## Solution

For delayed cases, invoke the start-notifying interleaving method and wait for its explicit start signal before scheduling cancellation. Keep the zero-delay path unchanged so cancellation-before-execution remains covered, and release the observer reference in all outcomes.

This follows the synchronization pattern already used by the related grain and concurrent cancellation tests.

Fixes #10615
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10638)