### PR TITLE
fix(persistence): flow grain storage cancellation tokens

### DIFF
--- a/docs/site/src/content/docs/tutorials-and-samples/custom-grain-storage.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/custom-grain-storage.md
@@ -31,6 +31,8 @@ All three methods receive the same arguments:
 | `grainState` | The state container Orleans passes to the provider. Its <xref:Orleans.IGrainState`1.State> property contains the application state, <xref:Orleans.IGrainState`1.ETag> carries the provider's optimistic-concurrency token, and <xref:Orleans.IGrainState`1.RecordExists> indicates whether the record exists. A read populates these properties; a write or clear updates them to reflect the completed operation. |
 | `T` | The declared .NET type of the state payload. Use `T` (or `typeof(T)`) for serialization and type metadata. It isn't a record identifier and can be shared by many grains and named state records. |
 
+Each operation also has an overload which accepts a `CancellationToken`. Orleans passes the caller's token through to that overload, so providers can propagate cancellation to their backend client. Parameterless storage operations use `CancellationToken.None`. The interface's default cancellation-overload implementations delegate to the corresponding overloads shown in this tutorial, preserving compatibility for existing providers.
+
 Therefore, `stateName` and `grainState.State?.GetType().Name` aren't interchangeable. The first identifies one of a grain's logical state records and is stable independently of the payload implementation. The second is only the runtime type name of the current payload; it can be `null`, can differ from `typeof(T)` when polymorphism is involved, and can change during a refactoring. The sample uses `stateName` and `grainId` for identity and delegates payload type handling to the configured serializer.
 
 The <xref:Orleans.ILifecycleParticipant`1.Participate*?displayProperty=nameWithType> method subscribes to the silo's lifecycle.

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -116,7 +116,7 @@ namespace Orleans.Storage
         public Task Close(CancellationToken ct) => Task.CompletedTask;
 
         /// <summary> Read state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ReadStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             if (this.storage == null) throw new ArgumentException("GrainState-Table property not initialized");
@@ -157,7 +157,7 @@ namespace Orleans.Storage
         }
 
         /// <summary> Write state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.WriteStateAsync{T}"/>
+        /// <see cref="IGrainStorage.WriteStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             if (this.storage == null) throw new ArgumentException("GrainState-Table property not initialized");
@@ -264,7 +264,7 @@ namespace Orleans.Storage
         /// for this grain will be deleted / removed, otherwise the table row will be
         /// cleared by overwriting with default / null values.
         /// </remarks>
-        /// <see cref="IGrainStorage.ClearStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             if (this.storage == null) throw new ArgumentException("GrainState-Table property not initialized");

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -145,7 +145,7 @@ namespace Orleans.Storage
         }
 
         /// <summary>Clear state data function for this storage provider.</summary>
-        /// <see cref="IGrainStorage.ClearStateAsync{T}"/>.
+        /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/>.
         public async Task ClearStateAsync<T>(string grainType, GrainId grainReference, IGrainState<T> grainState)
         {
             //It assumed these parameters are always valid. If not, an exception will be thrown,
@@ -213,7 +213,7 @@ namespace Orleans.Storage
 
 
         /// <summary> Read state data function for this storage provider.</summary>
-        /// <see cref="IGrainStorage.ReadStateAsync{T}"/>.
+        /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainId, IGrainState{T})"/>.
         public async Task ReadStateAsync<T>(string grainType, GrainId grainReference, IGrainState<T> grainState)
         {
             //It assumed these parameters are always valid. If not, an exception will be thrown, even if not as clear
@@ -278,7 +278,7 @@ namespace Orleans.Storage
 
 
         /// <summary> Write state data function for this storage provider.</summary>
-        /// <see cref="IGrainStorage.WriteStateAsync{T}"/>
+        /// <see cref="IGrainStorage.WriteStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task WriteStateAsync<T>(string grainType, GrainId grainReference, IGrainState<T> grainState)
         {
             //It assumed these parameters are always valid. If not, an exception will be thrown, even if not as clear

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -45,7 +45,7 @@ namespace Orleans.Storage
         }
 
         /// <summary> Read state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ReadStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
@@ -95,7 +95,7 @@ namespace Orleans.Storage
         private static string GetBlobName(string grainType, GrainId grainId) => $"{grainType}-{grainId}.json";
 
         /// <summary> Write state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.WriteStateAsync{T}"/>
+        /// <see cref="IGrainStorage.WriteStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);
@@ -128,7 +128,7 @@ namespace Orleans.Storage
         }
 
         /// <summary> Clear / Delete state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ClearStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             var blobName = GetBlobName(grainType, grainId);

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorageOptions.cs
@@ -57,7 +57,7 @@ namespace Orleans.Configuration
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to delete the state when <see cref="IGrainStorage.ClearStateAsync"/> is called.  Defaults to true.
+        /// Gets or sets a value indicating whether to delete the state when <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/> is called.  Defaults to true.
         /// </summary>
         public bool DeleteStateOnClear { get; set; } = true;
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -61,7 +61,7 @@ namespace Orleans.Storage
         }
 
         /// <summary> Read state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ReadStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
@@ -87,7 +87,7 @@ namespace Orleans.Storage
         }
 
         /// <summary> Write state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.WriteStateAsync{T}"/>
+        /// <see cref="IGrainStorage.WriteStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
@@ -121,7 +121,7 @@ namespace Orleans.Storage
         /// for this grain will be deleted / removed, otherwise the table row will be
         /// cleared by overwriting with default / null values.
         /// </remarks>
-        /// <see cref="IGrainStorage.ClearStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");

--- a/src/Orleans.Core/Providers/IGrainStorage.cs
+++ b/src/Orleans.Core/Providers/IGrainStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using System.Net;
@@ -19,6 +20,17 @@ namespace Orleans.Storage
         /// <returns>Completion promise for the Read operation on the specified grain.</returns>
         Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState);
 
+        /// <summary>Read data function for this storage instance.</summary>
+        /// <param name="stateName">Name of the state for this grain.</param>
+        /// <param name="grainId">Grain ID.</param>
+        /// <param name="grainState">State data object to be populated for this grain.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <typeparam name="T">The grain state type.</typeparam>
+        /// <returns>Completion promise for the Read operation on the specified grain.</returns>
+        /// <remarks>The default implementation delegates to the overload without a cancellation token.</remarks>
+        Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken)
+            => ReadStateAsync(stateName, grainId, grainState);
+
         /// <summary>Write data function for this storage instance.</summary>
         /// <param name="stateName">Name of the state for this grain</param>
         /// <param name="grainId">Grain ID</param>
@@ -27,6 +39,17 @@ namespace Orleans.Storage
         /// <returns>Completion promise for the Write operation on the specified grain.</returns>
         Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState);
 
+        /// <summary>Write data function for this storage instance.</summary>
+        /// <param name="stateName">Name of the state for this grain.</param>
+        /// <param name="grainId">Grain ID.</param>
+        /// <param name="grainState">State data object to be written for this grain.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <typeparam name="T">The grain state type.</typeparam>
+        /// <returns>Completion promise for the Write operation on the specified grain.</returns>
+        /// <remarks>The default implementation delegates to the overload without a cancellation token.</remarks>
+        Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken)
+            => WriteStateAsync(stateName, grainId, grainState);
+
         /// <summary>Delete / Clear data function for this storage instance.</summary>
         /// <param name="stateName">Name of the state for this grain</param>
         /// <param name="grainId">Grain ID</param>
@@ -34,6 +57,17 @@ namespace Orleans.Storage
         /// <typeparam name="T">The grain state type.</typeparam>
         /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
         Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState);
+
+        /// <summary>Delete / Clear data function for this storage instance.</summary>
+        /// <param name="stateName">Name of the state for this grain.</param>
+        /// <param name="grainId">Grain ID.</param>
+        /// <param name="grainState">Copy of last-known state data object for this grain.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <typeparam name="T">The grain state type.</typeparam>
+        /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
+        /// <remarks>The default implementation delegates to the overload without a cancellation token.</remarks>
+        Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState, CancellationToken cancellationToken)
+            => ClearStateAsync(stateName, grainId, grainState);
     }
 
     /// <summary>

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
@@ -67,21 +67,21 @@ namespace Orleans.Storage
         }
 
         /// <summary> Read state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ReadStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             return MakeFixedLatencyCall(() => baseGranStorage.ReadStateAsync(grainType, grainId, grainState));
         }
 
         /// <summary> Write state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.WriteStateAsync{T}"/>
+        /// <see cref="IGrainStorage.WriteStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
            return MakeFixedLatencyCall(() => baseGranStorage.WriteStateAsync(grainType, grainId, grainState));
         }
 
         /// <summary> Delete / Clear state data function for this storage provider. </summary>
-        /// <see cref="IGrainStorage.ClearStateAsync{T}"/>
+        /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/>
         public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             return MakeFixedLatencyCall(() => baseGranStorage.ClearStateAsync(grainType, grainId, grainState));

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Diagnostics;
@@ -78,7 +79,12 @@ namespace Orleans.Core
         }
 
         /// <inheritdoc />
-        public async Task ReadStateAsync()
+        public Task ReadStateAsync() => ReadStateAsync(CancellationToken.None);
+
+        /// <inheritdoc />
+        Task IStorage.ReadStateAsync(CancellationToken cancellationToken) => ReadStateAsync(cancellationToken);
+
+        private async Task ReadStateAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -101,9 +107,13 @@ namespace Orleans.Core
                 activity?.SetTag(ActivityTagKeys.StorageStateType, _shared.StateTypeName);
 
                 var sw = ValueStopwatch.StartNew();
-                await _shared.Store.ReadStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
+                await _shared.Store.ReadStateAsync(_shared.Name, _grainContext.GrainId, GrainState, cancellationToken);
                 IsStateInitialized = true;
                 _storageInstruments.OnStorageRead(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exc)
             {
@@ -113,7 +123,12 @@ namespace Orleans.Core
         }
 
         /// <inheritdoc />
-        public async Task WriteStateAsync()
+        public Task WriteStateAsync() => WriteStateAsync(CancellationToken.None);
+
+        /// <inheritdoc />
+        Task IStorage.WriteStateAsync(CancellationToken cancellationToken) => WriteStateAsync(cancellationToken);
+
+        private async Task WriteStateAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -135,8 +150,12 @@ namespace Orleans.Core
                 activity?.SetTag(ActivityTagKeys.StorageStateType, _shared.StateTypeName);
 
                 var sw = ValueStopwatch.StartNew();
-                await _shared.Store.WriteStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
+                await _shared.Store.WriteStateAsync(_shared.Name, _grainContext.GrainId, GrainState, cancellationToken);
                 _storageInstruments.OnStorageWrite(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exc)
             {
@@ -146,7 +165,12 @@ namespace Orleans.Core
         }
 
         /// <inheritdoc />
-        public async Task ClearStateAsync()
+        public Task ClearStateAsync() => ClearStateAsync(CancellationToken.None);
+
+        /// <inheritdoc />
+        Task IStorage.ClearStateAsync(CancellationToken cancellationToken) => ClearStateAsync(cancellationToken);
+
+        private async Task ClearStateAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -170,11 +194,15 @@ namespace Orleans.Core
                 var sw = ValueStopwatch.StartNew();
 
                 // Clear state in external storage
-                await _shared.Store.ClearStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
+                await _shared.Store.ClearStateAsync(_shared.Name, _grainContext.GrainId, GrainState, cancellationToken);
                 sw.Stop();
 
                 // Update counters
                 _storageInstruments.OnStorageDelete(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exc)
             {

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -1875,8 +1875,11 @@ namespace Orleans.Storage
     public partial interface IGrainStorage
     {
         System.Threading.Tasks.Task ClearStateAsync<T>(string stateName, Runtime.GrainId grainId, IGrainState<T> grainState);
+        System.Threading.Tasks.Task ClearStateAsync<T>(string stateName, Runtime.GrainId grainId, IGrainState<T> grainState, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task ReadStateAsync<T>(string stateName, Runtime.GrainId grainId, IGrainState<T> grainState);
+        System.Threading.Tasks.Task ReadStateAsync<T>(string stateName, Runtime.GrainId grainId, IGrainState<T> grainState, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task WriteStateAsync<T>(string stateName, Runtime.GrainId grainId, IGrainState<T> grainState);
+        System.Threading.Tasks.Task WriteStateAsync<T>(string stateName, Runtime.GrainId grainId, IGrainState<T> grainState, System.Threading.CancellationToken cancellationToken);
     }
 
     public partial interface IGrainStorageSerializer

--- a/test/Orleans.Core.Tests/Storage/StateStorageBridgeCancellationTests.cs
+++ b/test/Orleans.Core.Tests/Storage/StateStorageBridgeCancellationTests.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Core;
+using Orleans.Placement;
+using Orleans.Runtime;
+using Orleans.Runtime.Scheduler;
+using Orleans.Serialization.Activators;
+using Orleans.Serialization.Serializers;
+using Orleans.Storage;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Storage;
+
+[TestCategory("BVT"), TestCategory("Storage")]
+public class StateStorageBridgeCancellationTests
+{
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task IGrainStorage_CancellationOverload_DelegatesToLegacyOverload(StorageOperation operation)
+    {
+        IGrainStorage storage = new LegacyGrainStorage();
+        var grainId = GrainId.Create("state-storage-bridge-test", Guid.NewGuid().ToString("N"));
+        IGrainState<TestState> grainState = new GrainState<TestState>(new());
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await InvokeAsync(storage, operation, grainId, grainState, cancellation.Token);
+
+        var legacyStorage = Assert.IsType<LegacyGrainStorage>(storage);
+        Assert.Equal(1, legacyStorage.CallCount);
+        Assert.Equal(operation, legacyStorage.LastOperation);
+        Assert.Equal("state", legacyStorage.LastStateName);
+        Assert.Equal(grainId, legacyStorage.LastGrainId);
+        Assert.Same(grainState, legacyStorage.LastGrainState);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task IStorage_CancellationOverload_PassesTokenToGrainStorage(StorageOperation operation)
+    {
+        using var context = TestGrainContext.Create();
+        var grainStorage = new RecordingGrainStorage();
+        IStorage storage = CreateBridge(context, grainStorage);
+        using var cancellation = new CancellationTokenSource();
+
+        await RunInGrainContextAsync(
+            context,
+            () => InvokeAsync(storage, operation, cancellation.Token));
+
+        AssertProviderInvocation(grainStorage, context, operation, cancellation.Token);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task IStorage_ParameterlessOverload_PassesNoneToGrainStorage(StorageOperation operation)
+    {
+        using var context = TestGrainContext.Create();
+        var grainStorage = new RecordingGrainStorage();
+        IStorage storage = CreateBridge(context, grainStorage);
+
+        await RunInGrainContextAsync(context, () => InvokeAsync(storage, operation));
+
+        AssertProviderInvocation(grainStorage, context, operation, CancellationToken.None);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task IStorage_CallerCancellation_PropagatesProviderException(StorageOperation operation)
+    {
+        using var context = TestGrainContext.Create();
+        var grainStorage = new RecordingGrainStorage();
+        IStorage storage = CreateBridge(context, grainStorage);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var expected = new OperationCanceledException(cancellation.Token);
+        grainStorage.ExceptionToThrow = expected;
+
+        var actual = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => RunInGrainContextAsync(
+                context,
+                () => InvokeAsync(storage, operation, cancellation.Token)));
+
+        Assert.Same(expected, actual);
+        Assert.Equal(cancellation.Token, actual.CancellationToken);
+        AssertProviderInvocation(grainStorage, context, operation, cancellation.Token);
+    }
+
+    private static StateStorageBridge<TestState> CreateBridge(
+        TestGrainContext context,
+        RecordingGrainStorage storage)
+        => new("state", context, storage);
+
+    private static void AssertProviderInvocation(
+        RecordingGrainStorage storage,
+        TestGrainContext context,
+        StorageOperation operation,
+        CancellationToken expectedCancellationToken)
+    {
+        Assert.Equal(1, storage.CallCount);
+        Assert.Equal(operation, storage.LastOperation);
+        Assert.Equal("state", storage.LastStateName);
+        Assert.Equal(context.GrainId, storage.LastGrainId);
+        Assert.IsAssignableFrom<IGrainState<TestState>>(storage.LastGrainState);
+        Assert.True(storage.UsedCancellationOverload);
+        Assert.Equal(expectedCancellationToken, storage.LastCancellationToken);
+    }
+
+    private static Task InvokeAsync(
+        IGrainStorage storage,
+        StorageOperation operation,
+        GrainId grainId,
+        IGrainState<TestState> grainState,
+        CancellationToken cancellationToken)
+        => operation switch
+        {
+            StorageOperation.Read => storage.ReadStateAsync("state", grainId, grainState, cancellationToken),
+            StorageOperation.Write => storage.WriteStateAsync("state", grainId, grainState, cancellationToken),
+            StorageOperation.Clear => storage.ClearStateAsync("state", grainId, grainState, cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+
+    private static Task InvokeAsync(
+        IStorage storage,
+        StorageOperation operation,
+        CancellationToken cancellationToken)
+        => operation switch
+        {
+            StorageOperation.Read => storage.ReadStateAsync(cancellationToken),
+            StorageOperation.Write => storage.WriteStateAsync(cancellationToken),
+            StorageOperation.Clear => storage.ClearStateAsync(cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+
+    private static Task InvokeAsync(IStorage storage, StorageOperation operation)
+        => operation switch
+        {
+            StorageOperation.Read => storage.ReadStateAsync(),
+            StorageOperation.Write => storage.WriteStateAsync(),
+            StorageOperation.Clear => storage.ClearStateAsync(),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+
+    private static Task RunInGrainContextAsync(TestGrainContext context, Func<Task> action)
+        => Task.Factory.StartNew(
+            action,
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            context.WorkItemGroup.TaskScheduler).Unwrap();
+
+    public enum StorageOperation
+    {
+        Read,
+        Write,
+        Clear
+    }
+
+    public sealed class TestState
+    {
+    }
+
+    private sealed class TestActivatorProvider : IActivatorProvider
+    {
+        public IActivator<T> GetActivator<T>() => new TestActivator<T>();
+    }
+
+    private sealed class TestActivator<T> : IActivator<T>
+    {
+        public T Create() => Activator.CreateInstance<T>();
+    }
+
+    private sealed class LegacyGrainStorage : IGrainStorage
+    {
+        public int CallCount { get; private set; }
+
+        public StorageOperation LastOperation { get; private set; }
+
+        public string LastStateName { get; private set; } = null!;
+
+        public GrainId LastGrainId { get; private set; }
+
+        public object LastGrainState { get; private set; } = null!;
+
+        public Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+            => Record(StorageOperation.Read, stateName, grainId, grainState);
+
+        public Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+            => Record(StorageOperation.Write, stateName, grainId, grainState);
+
+        public Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+            => Record(StorageOperation.Clear, stateName, grainId, grainState);
+
+        private Task Record<T>(
+            StorageOperation operation,
+            string stateName,
+            GrainId grainId,
+            IGrainState<T> grainState)
+        {
+            CallCount++;
+            LastOperation = operation;
+            LastStateName = stateName;
+            LastGrainId = grainId;
+            LastGrainState = grainState;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingGrainStorage : IGrainStorage
+    {
+        public int CallCount { get; private set; }
+
+        public StorageOperation LastOperation { get; private set; }
+
+        public string LastStateName { get; private set; } = null!;
+
+        public GrainId LastGrainId { get; private set; }
+
+        public object LastGrainState { get; private set; } = null!;
+
+        public bool UsedCancellationOverload { get; private set; }
+
+        public CancellationToken LastCancellationToken { get; private set; }
+
+        public OperationCanceledException? ExceptionToThrow { get; set; }
+
+        public Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+            => Record(StorageOperation.Read, stateName, grainId, grainState, false, CancellationToken.None);
+
+        public Task ReadStateAsync<T>(
+            string stateName,
+            GrainId grainId,
+            IGrainState<T> grainState,
+            CancellationToken cancellationToken)
+            => Record(StorageOperation.Read, stateName, grainId, grainState, true, cancellationToken);
+
+        public Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+            => Record(StorageOperation.Write, stateName, grainId, grainState, false, CancellationToken.None);
+
+        public Task WriteStateAsync<T>(
+            string stateName,
+            GrainId grainId,
+            IGrainState<T> grainState,
+            CancellationToken cancellationToken)
+            => Record(StorageOperation.Write, stateName, grainId, grainState, true, cancellationToken);
+
+        public Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+            => Record(StorageOperation.Clear, stateName, grainId, grainState, false, CancellationToken.None);
+
+        public Task ClearStateAsync<T>(
+            string stateName,
+            GrainId grainId,
+            IGrainState<T> grainState,
+            CancellationToken cancellationToken)
+            => Record(StorageOperation.Clear, stateName, grainId, grainState, true, cancellationToken);
+
+        private Task Record<T>(
+            StorageOperation operation,
+            string stateName,
+            GrainId grainId,
+            IGrainState<T> grainState,
+            bool usedCancellationOverload,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            LastOperation = operation;
+            LastStateName = stateName;
+            LastGrainId = grainId;
+            LastGrainState = grainState;
+            UsedCancellationOverload = usedCancellationOverload;
+            LastCancellationToken = cancellationToken;
+            return ExceptionToThrow is { } exception
+                ? Task.FromException(exception)
+                : Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestGrainContext : IGrainContext, IDisposable
+    {
+        private ServiceProvider _activationServices = null!;
+
+        private TestGrainContext()
+        {
+        }
+
+        public static TestGrainContext Create()
+        {
+            var context = new TestGrainContext();
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddLogging();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<SchedulerInstruments>();
+            services.AddSingleton<StorageInstruments>();
+            services.AddSingleton<IActivatorProvider, TestActivatorProvider>();
+            services.AddSingleton<StateStorageBridgeSharedMap>();
+            services.Configure<SchedulingOptions>(options =>
+            {
+                options.DelayWarningThreshold = TimeSpan.FromMilliseconds(100);
+                options.ActivationSchedulingQuantum = TimeSpan.FromMilliseconds(100);
+                options.TurnWarningLengthThreshold = TimeSpan.FromMilliseconds(100);
+                options.StoppedActivationWarningInterval = TimeSpan.FromMilliseconds(200);
+            });
+
+            context._activationServices = services.BuildServiceProvider();
+            var loggerFactory = context._activationServices.GetRequiredService<ILoggerFactory>();
+            context.ObservableLifecycle = new GrainLifecycle(loggerFactory.CreateLogger<GrainLifecycle>());
+            context.WorkItemGroup = new WorkItemGroup(
+                context,
+                context._activationServices.GetRequiredService<IOptions<SchedulingOptions>>(),
+                context._activationServices.GetRequiredService<SchedulerInstruments>());
+
+            return context;
+        }
+
+        public WorkItemGroup WorkItemGroup { get; private set; } = null!;
+
+        public GrainReference GrainReference => throw new NotImplementedException();
+
+        public GrainId GrainId { get; } = GrainId.Create(
+            "state-storage-bridge-test",
+            Guid.NewGuid().ToString("N"));
+
+        public IAddressable GrainInstance => throw new NotImplementedException();
+
+        public ActivationId ActivationId => throw new NotImplementedException();
+
+        public GrainAddress Address => throw new NotImplementedException();
+
+        public IServiceProvider ActivationServices => _activationServices;
+
+        public IDictionary<object, object> Items { get; } = new Dictionary<object, object>();
+
+        public IGrainLifecycle ObservableLifecycle { get; private set; } = null!;
+
+        public IWorkItemScheduler Scheduler => WorkItemGroup;
+
+        public bool IsExemptFromCollection => false;
+
+        public PlacementStrategy PlacementStrategy => throw new NotImplementedException();
+
+        object IGrainContext.GrainInstance => throw new NotImplementedException();
+
+        public void Activate(
+            Dictionary<string, object>? requestContext,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public void Deactivate(
+            DeactivationReason deactivationReason,
+            CancellationToken cancellationToken)
+        {
+        }
+
+        public Task Deactivated => Task.CompletedTask;
+
+        public void Dispose()
+        {
+            (Scheduler as IDisposable)?.Dispose();
+            _activationServices.Dispose();
+        }
+
+        public object GetComponent(Type componentType) => throw new NotImplementedException();
+
+        public object GetTarget() => throw new NotImplementedException();
+
+        public void ReceiveMessage(object message) => throw new NotImplementedException();
+
+        public void SetComponent<TComponent>(TComponent? value) where TComponent : class
+            => throw new NotImplementedException();
+
+        bool IEquatable<IGrainContext>.Equals(IGrainContext? other) => ReferenceEquals(this, other);
+
+        void IGrainContext.Rehydrate(IRehydrationContext context) => throw new NotImplementedException();
+
+        void IGrainContext.Migrate(
+            Dictionary<string, object>? requestContext,
+            CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Summary

Grain persistence exposes cancellation-aware `IStorage` operations, but `StateStorageBridge` previously invoked only the cancellation-free `IGrainStorage` methods. Storage providers therefore could not receive the caller's cancellation token.

This change adds cancellation-token overloads to `IGrainStorage` and forwards tokens through `StateStorageBridge`. Parameterless operations pass `CancellationToken.None`, and caller-requested cancellation propagates without storage-failure wrapping.

The new interface methods use default implementations which delegate to the existing overloads, preserving compatibility for storage providers while allowing providers to opt into backend cancellation. The provider-authoring documentation, public API surface, XML references, and focused cancellation coverage are updated accordingly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10641)