### PR TITLE
docs(streaming): document data adapters

### DIFF
--- a/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Queue stream implementation
 description: Understand the Orleans Azure Queue adapter, receiver acknowledgement, queue mapping, and configuration surfaces.
-ms.date: 08/02/2026
+ms.date: 08/18/2026
 ms.topic: concept-article
 ---
 
@@ -19,7 +19,7 @@ API: <xref:Orleans.Hosting.SiloBuilderExtensions.AddAzureQueueStreams*?displayPr
 
 ## Adapter behavior
 
-`AzureQueueAdapter` is read-write and not rewindable. A producer encodes the stream identity, payload, request context, and sequence metadata using an `IAzureQueueDataAdapter`, then sends an Azure Queue message to the mapped queue.
+`AzureQueueAdapter` is read-write and not rewindable. A producer encodes the stream identity, payload, and request context using an <xref:Orleans.Streams.IQueueDataAdapter`2>, then sends an Azure Queue message to the mapped queue. The receiver assigns the local sequence token used for delivery and acknowledgement.
 
 Because Azure Queue Storage does not expose a durable arbitrary stream offset, a non-null rewind token is rejected. <xref:Orleans.Providers.Streams.AzureQueue.AzureQueueDataAdapterV2> is the default encoding. Version 1 remains for compatibility with existing messages, not as the preferred format for new providers.
 
@@ -77,6 +77,6 @@ A <xref:Orleans.Configuration.AzureQueueOptions.MessageVisibilityTimeout?display
 
 ## Extension and compatibility points
 
-A custom <xref:Orleans.Streams.IQueueDataAdapter`2> can change payload encoding while retaining the Azure transport. It must preserve stream identity, request context, and any sequence information needed by consumers. Encoding changes should be versioned so a rolling cluster can read messages produced by both versions.
+A custom <xref:Orleans.Streams.IQueueDataAdapter`2> changes payload encoding while retaining the Azure transport. It preserves stream identity, the request-context values defined by the wire contract, and the sequence information used by consumers. Follow [Customize persistent-stream data formats](../../streaming/data-adapters.md) for a compiling implementation and versioned rollout guidance.
 
 Configuration binding behavior is tested by [`AzureQueueStreamProviderBuilderTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueStreamProviderBuilderTests.cs). Adapter acknowledgement and cursor behavior are covered by [`AzureQueueAdapterTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs).

--- a/docs/site/src/content/docs/streaming/custom-queue-adapter.md
+++ b/docs/site/src/content/docs/streaming/custom-queue-adapter.md
@@ -1,15 +1,17 @@
 ---
 title: Write a custom persistent-stream queue adapter
 description: Implement and register an Orleans persistent-stream queue adapter for an external queue technology.
-ms.date: 08/14/2026
+ms.date: 08/18/2026
 ms.topic: how-to
 ---
 
 # Write a custom persistent-stream queue adapter
 
-Use a custom queue adapter when Orleans doesn't include a provider for the queue technology you need. The adapter translates between Orleans stream batches and the external queue. Orleans supplies the persistent stream provider, pulling agents, subscription routing, queue balancing, and cache management.
+Use a custom queue adapter to connect the Orleans persistent-stream runtime to a queue technology with its own transport and delivery semantics. The adapter translates between Orleans stream batches and the external queue. Orleans supplies the persistent stream provider, pulling agents, subscription routing, queue balancing, and cache management.
 
-You don't create a subclass of `PersistentStreamProvider`. Register an <xref:Orleans.Streams.IQueueAdapterFactory> with `AddPersistentStreams`; Orleans creates and hosts the provider.
+When Azure Queue Storage or Azure Event Hubs already provides the required transport behavior, a [data adapter](data-adapters.md) customizes its wire format while retaining the built-in queue adapter.
+
+Register an <xref:Orleans.Streams.IQueueAdapterFactory> with `AddPersistentStreams`; Orleans creates and hosts <xref:Orleans.Providers.Streams.Common.PersistentStreamProvider>.
 
 Before implementing an adapter, understand the [persistent stream pulling architecture](../implementation/streams-implementation/index.md). In particular, decide the adapter's delivery, acknowledgement, ordering, partitioning, and rewind semantics.
 
@@ -49,7 +51,7 @@ The factory composes the adapter with queue mapping, caching, and failure handli
 
 `SimpleQueueAdapterCache` is suitable for a non-rewindable adapter whose queue remains the durability boundary. A rewindable adapter usually needs a cache and sequence-token implementation which can position cursors at retained historical messages.
 
-Checkpointing is adapter-specific, not a requirement imposed by `AddPersistentStreams`. The non-rewindable example acknowledges completed messages through its receiver and therefore has no independent checkpoint. For a retained-log transport, implement an <xref:Orleans.Streams.IStreamQueueCheckpointerFactory>, have the receiver or cache load and update the per-partition position, and register it as a named component with `ConfigureComponent`. Persist a checkpoint only after all consumers have advanced beyond the corresponding cached messages. A no-op checkpointer is suitable only when replay position is deliberately disposable.
+`AddPersistentStreams` leaves checkpointing to the adapter. The non-rewindable example acknowledges completed messages through its receiver and therefore has no independent checkpoint. For a retained-log transport, implement an <xref:Orleans.Streams.IStreamQueueCheckpointerFactory>, have the receiver or cache load and update the per-partition position, and register it as a named component with `ConfigureComponent`. Persist a checkpoint only after all consumers have advanced beyond the corresponding cached messages. A no-op checkpointer is suitable only when replay position is deliberately disposable.
 
 ## Register the provider
 
@@ -61,7 +63,7 @@ Register the same provider name and compatible mapping on Orleans clients which 
 
 :::code language="csharp" source="snippets/streaming/CustomQueueAdapter.cs" id="custom_queue_client_registration":::
 
-Keep the provider name and partition count stable. Changing either can map an existing stream to a different queue and strand previously enqueued messages. Configure durable `PubSubStore` grain storage for explicit subscriptions in production; queue durability doesn't preserve Orleans subscription records.
+Keep the provider name and partition count stable. Changing either can map an existing stream to a different queue and strand previously enqueued messages. Configure durable `PubSubStore` grain storage for explicit subscriptions in production; `PubSubStore` preserves subscription records independently from queue durability.
 
 ## Validate failure behavior
 

--- a/docs/site/src/content/docs/streaming/data-adapters.md
+++ b/docs/site/src/content/docs/streaming/data-adapters.md
@@ -1,0 +1,85 @@
+---
+title: Customize persistent-stream data formats
+description: Configure an Orleans persistent-stream data adapter for a versioned queue-message contract.
+ms.date: 08/18/2026
+ms.topic: how-to
+---
+
+# Customize persistent-stream data formats
+
+A persistent-stream data adapter translates between Orleans event batches and a provider's native queue messages. It owns the wire contract: stream identity, event type and payload encoding, schema version, and any request-context values which cross the transport boundary. The provider's queue adapter continues to own transport access, partition assignment, receive acknowledgement, caching, and recovery.
+
+Use a data adapter when the transport remains the same and the application needs a versioned payload format, needs to consume messages produced outside Orleans, or needs to publish messages which an external consumer can decode. Use a [custom queue adapter](custom-queue-adapter.md) when Orleans also needs a new transport or different queue semantics.
+
+## Choose the provider extension point
+
+The built-in providers expose these data-adapter extension points:
+
+| Provider | Data-adapter contract | Registration | Runtime outcome |
+|---|---|---|---|
+| Azure Queue Storage | <xref:Orleans.Streams.IQueueDataAdapter`2> with `string` queue messages and <xref:Orleans.Streams.IBatchContainer> batches | <xref:Orleans.Hosting.AzureQueueStreamConfiguratorExtensions.ConfigureQueueDataAdapter*> | Replaces encoding and decoding while retaining Azure Queue mapping, visibility, deletion, and non-rewindable delivery |
+| Azure Event Hubs | <xref:Orleans.Streaming.EventHubs.IEventHubDataAdapter> | <xref:Orleans.Hosting.EventHubStreamConfiguratorExtensions.UseDataAdapter*> | Replaces wire-format, stream-mapping, and cache conversion behavior while retaining Event Hubs partition reading, checkpointing, and rewindable delivery |
+
+<xref:Orleans.Streams.IQueueDataAdapter`1> defines conversion from an Orleans batch to a native queue message. <xref:Orleans.Streams.IQueueDataAdapter`2> adds conversion from a native message to the batch container delivered by Orleans. Provider-specific contracts can add the position and cache operations required by their transport.
+
+## Define a versioned contract
+
+Define the transport contract independently of CLR assembly names and Orleans serialization internals. A durable envelope normally contains:
+
+- a schema version;
+- the stream namespace and key;
+- a stable event-type identifier;
+- one or more event payloads; and
+- an explicit set of cross-process metadata.
+
+Assign each message to exactly one <xref:Orleans.Runtime.StreamId>. Keep the mapping from stream ID to physical partition stable so events for a stream retain the provider's ordering behavior. The adapter receives batches, so the envelope must preserve event order within each batch.
+
+Treat request context as an explicit contract. The example carries a string correlation ID and leaves process-local values inside the producing application.
+
+## Implement an Azure Queue data adapter
+
+The following adapter writes a versioned JSON envelope and reconstructs an <xref:Orleans.Streams.IBatchContainer> when Azure Queue Storage returns the message. The Azure Queue receiver supplies `sequenceId` at read time, and the batch uses it to create a receiver-local sequence token for each event.
+
+:::code language="csharp" source="snippets/streaming/StreamDataAdapters.cs" id="azure_queue_data_adapter":::
+
+The batch container exposes only events compatible with the requested stream type, derives per-event tokens from the queue-message sequence, and imports the metadata defined by the wire contract:
+
+:::code language="csharp" source="snippets/streaming/StreamDataAdapters.cs" id="azure_queue_batch_container":::
+
+Register the same adapter, queue service client, and physical queue names for the provider on every silo and Orleans client which uses it. Silos use the adapter for reads and writes; clients use it when publishing.
+
+:::code language="csharp" source="snippets/streaming/StreamDataAdapters.cs" id="azure_queue_data_adapter_registration":::
+
+Configure durable `PubSubStore` grain storage alongside this registration as described in [Orleans stream providers](stream-providers.md#azure-queue-storage).
+
+## Implement an Event Hubs data adapter
+
+For Event Hubs, derive from <xref:Orleans.Streaming.EventHubs.EventHubDataAdapter> when its cached-message representation and checkpoint behavior fit the application. Override:
+
+- <xref:Orleans.Streaming.EventHubs.EventHubDataAdapter.GetStreamIdentity*> to map each `EventData` instance to a stream;
+- <xref:Orleans.Streaming.EventHubs.EventHubDataAdapter.GetBatchContainer*> to decode cached payloads for Orleans consumers;
+- <xref:Orleans.Streaming.EventHubs.EventHubDataAdapter.ToQueueMessage*> to encode events published through Orleans; and
+- <xref:Orleans.Streaming.EventHubs.EventHubDataAdapter.GetPartitionKey*> to select the physical Event Hubs partition key.
+
+The adapter also participates in cache conversion and sequence positioning through <xref:Orleans.Streaming.EventHubs.IEventHubDataAdapter>. Preserve the Event Hubs offset and sequence number when constructing batch tokens so checkpoint and rewind behavior remains aligned with the partition log.
+
+Register the adapter and Event Hubs connection under the same provider name on silos and publishing clients. The silo registration also configures durable Azure Table checkpoints:
+
+:::code language="csharp" source="snippets/streaming/StreamDataAdapters.cs" id="event_hub_data_adapter_registration":::
+
+The [custom data adapter sample](https://github.com/dotnet/orleans/tree/main/samples/Streaming/CustomDataAdapter) demonstrates a read-side Event Hubs adapter for JSON messages from an external producer. See [Integrate external stream producers and consumers](external-streams.md) for the end-to-end interoperability workflow.
+
+## Evolve the wire contract
+
+Use an expand-and-contract rollout:
+
+1. Deploy readers which accept the current and next schema versions.
+1. Change writers to emit the next version.
+1. Keep the old reader until the queue or event-log retention window no longer contains the old version.
+1. Remove the old version after verifying queue depth, oldest-message age, and checkpoint position.
+
+Keep provider name, stream identity encoding, partition mapping, and sequence interpretation stable during a payload-only migration. A change to any of those values is a stream-topology or recovery migration and needs a separate cutover plan.
+
+Conversion failures surface as stream-delivery failures. Throw a descriptive exception for malformed payloads, unsupported versions, and missing routing metadata so the provider retains or replays the source message according to its delivery semantics. Monitor conversion failures and quarantine poison messages through the transport's operational process before they exhaust retention or block partition progress.
+
+Test both conversion directions with retained messages from every deployed schema version. Include heterogeneous batches, request context, duplicate delivery, malformed envelopes, unknown versions, rolling upgrades, and replay from an older Event Hubs checkpoint.

--- a/docs/site/src/content/docs/streaming/external-streams.md
+++ b/docs/site/src/content/docs/streaming/external-streams.md
@@ -1,24 +1,24 @@
 ---
 title: Integrate external stream producers and consumers
 description: Connect non-Orleans applications to Orleans streams by defining a provider-specific wire-format adapter.
-ms.date: 08/14/2026
+ms.date: 08/18/2026
 ms.topic: how-to
 ---
 
 # Integrate external stream producers and consumers
 
-Orleans streams don't define a transport-independent wire format. An external application can interoperate only when the selected [stream provider](stream-providers.md) exposes a suitable extension point and every participant agrees on:
+An Orleans persistent-stream provider maps its transport messages to logical streams through a provider-specific wire format. An external application interoperates through that format when every participant agrees on:
 
 - How transport messages map to an Orleans <xref:Orleans.Runtime.StreamId>.
 - How event types, payloads, and batches are encoded.
 - How partitioning, ordering, and sequence positions are represented.
 - Which metadata, such as request context, crosses the boundary.
 
-This integration is provider-specific. Don't assume that an external application can publish or consume the default binary messages of every persistent-stream provider.
+The provider's [data adapter](data-adapters.md) owns this boundary. Azure Event Hubs exposes the full inbound and outbound mapping required for external producers and consumers.
 
 ## Use an Event Hubs data adapter
 
-The built-in Azure Event Hubs provider supports a custom <xref:Orleans.Streaming.EventHubs.IEventHubDataAdapter>. Derive from <xref:Orleans.Streaming.EventHubs.EventHubDataAdapter> when its cache representation and checkpoint behavior are suitable, then override only the wire-format and stream-mapping behavior that your application needs.
+The built-in Azure Event Hubs provider supports a custom <xref:Orleans.Streaming.EventHubs.IEventHubDataAdapter>. Derive from <xref:Orleans.Streaming.EventHubs.EventHubDataAdapter> when its cache representation and checkpoint behavior are suitable, then override the wire-format and stream-mapping behavior defined by the external contract.
 
 Register the adapter with <xref:Orleans.Hosting.EventHubStreamConfiguratorExtensions.UseDataAdapter*>. Configure the same adapter for every silo and Orleans client that uses the provider. A silo needs it to read Event Hubs messages and to publish through Orleans streams; an Orleans client needs it when the client publishes.
 
@@ -37,18 +37,18 @@ The adapter determines logical stream identity; Event Hubs determines the physic
 ## Publish events for an external consumer
 
 1. Override `ToQueueMessage<T>` to encode Orleans events in the external consumer's agreed format.
-1. Override `GetPartitionKey` when the default stream-key partitioning doesn't match the external contract.
+1. Override `GetPartitionKey` when the external contract uses a different partition mapping.
 1. Preserve stream identity and schema-version metadata so consumers can route and decode the event without Orleans.
 1. Configure the external application as an ordinary Event Hubs consumer, preferably with a consumer group dedicated to that application.
 
-An external Event Hubs consumer isn't an Orleans stream subscription. It doesn't appear in Orleans pub-sub storage, doesn't receive Orleans subscription notifications, and doesn't acknowledge delivery to Orleans. Its delivery, checkpoint, retry, and replay behavior are controlled by Event Hubs and the external consumer.
+An external consumer participates directly in Event Hubs. Its consumer group controls delivery, checkpoint, retry, and replay behavior, while Orleans pub-sub storage and subscription notifications apply to Orleans stream subscriptions.
 
 If an adapter is intentionally one-way, fail explicitly in the unsupported conversion method. For example, an ingest-only adapter can throw <xref:System.NotSupportedException> from `ToQueueMessage<T>` rather than emitting a message in an unintended format.
 
 ## Operational requirements
 
 - Use a dedicated Event Hubs consumer group for the Orleans provider and a different group for each independent external consumer.
-- Grant producers, consumers, and checkpoint storage only the permissions they require. Don't put credentials or connection strings in event properties.
+- Grant producers, consumers, and checkpoint storage only the permissions they require. Keep credentials and connection strings in protected configuration rather than event properties.
 - Version the payload contract and deploy readers before writers when adding a new format.
 - Expect duplicate delivery and make consumers idempotent. Event Hubs retention and Orleans checkpoint persistence bound replay and recovery.
 - Monitor adapter deserialization failures, Event Hubs lag, checkpoint age, cache pressure, and poison events.

--- a/docs/site/src/content/docs/streaming/snippets/streaming/StreamDataAdapters.cs
+++ b/docs/site/src/content/docs/streaming/snippets/streaming/StreamDataAdapters.cs
@@ -1,0 +1,299 @@
+using System.Text.Json;
+using Azure.Data.Tables;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Hosting;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streaming.EventHubs;
+using Orleans.Streams;
+
+namespace Orleans.Docs.Snippets.Streaming;
+
+[GenerateSerializer, Immutable]
+public sealed class DeviceReading
+{
+    [Id(0)]
+    public required string DeviceId { get; init; }
+
+    [Id(1)]
+    public double Value { get; init; }
+}
+
+internal sealed class ExternalEventEnvelope
+{
+    public int Version { get; init; }
+
+    public required string StreamNamespace { get; init; }
+
+    public required string StreamKey { get; init; }
+
+    public required string EventType { get; init; }
+
+    public required DeviceReading[] Events { get; init; }
+
+    public string? CorrelationId { get; init; }
+}
+
+internal static class ExternalEventContract
+{
+    public const string CorrelationIdKey = "correlation-id";
+    private const int CurrentVersion = 1;
+    private const string DeviceReadingType = "device-reading";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static string Serialize<T>(
+        StreamId streamId,
+        IEnumerable<T> events,
+        Dictionary<string, object>? requestContext)
+    {
+        if (typeof(T) != typeof(DeviceReading))
+        {
+            throw new NotSupportedException(
+                $"The external event contract does not define event type {typeof(T)}.");
+        }
+
+        string? correlationId = null;
+        if (requestContext?.TryGetValue(CorrelationIdKey, out var value) == true)
+        {
+            correlationId = value as string
+                ?? throw new InvalidDataException(
+                    $"Request-context value '{CorrelationIdKey}' must be a string.");
+        }
+
+        var envelope = new ExternalEventEnvelope
+        {
+            Version = CurrentVersion,
+            StreamNamespace = streamId.GetNamespace()
+                ?? throw new InvalidOperationException(
+                    "The external event contract requires a stream namespace."),
+            StreamKey = streamId.GetKeyAsString(),
+            EventType = DeviceReadingType,
+            Events = events.Cast<DeviceReading>().ToArray(),
+            CorrelationId = correlationId,
+        };
+
+        return JsonSerializer.Serialize(envelope, JsonOptions);
+    }
+
+    public static ExternalEventEnvelope Deserialize(string message)
+    {
+        var envelope = JsonSerializer.Deserialize<ExternalEventEnvelope>(message, JsonOptions)
+            ?? throw new InvalidDataException("The queue message does not contain an event envelope.");
+
+        if (envelope.Version != CurrentVersion)
+        {
+            throw new InvalidDataException(
+                $"Unsupported event-envelope version {envelope.Version}.");
+        }
+
+        if (!string.Equals(envelope.EventType, DeviceReadingType, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Unsupported event type '{envelope.EventType}'.");
+        }
+
+        if (string.IsNullOrEmpty(envelope.StreamKey))
+        {
+            throw new InvalidDataException("The event envelope is missing its stream key.");
+        }
+
+        if (string.IsNullOrEmpty(envelope.StreamNamespace))
+        {
+            throw new InvalidDataException("The event envelope is missing its stream namespace.");
+        }
+
+        return envelope;
+    }
+}
+
+// <azure_queue_data_adapter>
+public sealed class JsonAzureQueueDataAdapter :
+    IQueueDataAdapter<string, IBatchContainer>
+{
+    public string ToQueueMessage<T>(
+        StreamId streamId,
+        IEnumerable<T> events,
+        StreamSequenceToken? token,
+        Dictionary<string, object>? requestContext)
+    {
+        if (token is not null)
+        {
+            throw new ArgumentException(
+                "The Azure Queue stream provider assigns sequence positions when messages are read.",
+                nameof(token));
+        }
+
+        return ExternalEventContract.Serialize(
+            streamId,
+            events,
+            requestContext);
+    }
+
+    public IBatchContainer FromQueueMessage(
+        string queueMessage,
+        long sequenceId)
+    {
+        var envelope = ExternalEventContract.Deserialize(queueMessage);
+        return new JsonAzureQueueBatch(
+            StreamId.Create(envelope.StreamNamespace, envelope.StreamKey),
+            envelope.Events,
+            new EventSequenceTokenV2(sequenceId),
+            envelope.CorrelationId);
+    }
+}
+// </azure_queue_data_adapter>
+
+// <azure_queue_batch_container>
+[GenerateSerializer, Immutable]
+public sealed class JsonAzureQueueBatch : IBatchContainer
+{
+    [Id(0)]
+    private readonly DeviceReading[] _events;
+
+    [Id(1)]
+    private readonly EventSequenceTokenV2 _sequenceToken;
+
+    [Id(2)]
+    private readonly string? _correlationId;
+
+    public JsonAzureQueueBatch(
+        StreamId streamId,
+        DeviceReading[] events,
+        EventSequenceTokenV2 sequenceToken,
+        string? correlationId)
+    {
+        StreamId = streamId;
+        _events = events;
+        _sequenceToken = sequenceToken;
+        _correlationId = correlationId;
+    }
+
+    [Id(3)]
+    public StreamId StreamId { get; }
+
+    public StreamSequenceToken SequenceToken => _sequenceToken;
+
+    public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
+    {
+        if (typeof(T) != typeof(DeviceReading))
+        {
+            return [];
+        }
+
+        return _events.Select(
+            (item, index) => Tuple.Create(
+                (T)(object)item,
+                (StreamSequenceToken)_sequenceToken.CreateSequenceTokenForEvent(index)));
+    }
+
+    public bool ImportRequestContext()
+    {
+        if (_correlationId is null)
+        {
+            return false;
+        }
+
+        RequestContext.Set(
+            ExternalEventContract.CorrelationIdKey,
+            _correlationId);
+        return true;
+    }
+}
+// </azure_queue_batch_container>
+
+public static class StreamDataAdapterRegistration
+{
+    private const string ProviderName = "ExternalEvents";
+
+    // <azure_queue_data_adapter_registration>
+    public static void ConfigureAzureQueueSilo(
+        ISiloBuilder builder,
+        QueueServiceClient queueServiceClient)
+    {
+        builder.AddAzureQueueStreams(
+            ProviderName,
+            (SiloAzureQueueStreamConfigurator streams) =>
+            {
+                streams.ConfigureAzureQueue(options => options.Configure(value =>
+                {
+                    value.QueueServiceClient = queueServiceClient;
+                    value.QueueNames = ["external-events-0"];
+                }));
+                streams.ConfigureQueueDataAdapter<JsonAzureQueueDataAdapter>();
+            });
+    }
+
+    public static void ConfigureAzureQueueClient(
+        IClientBuilder builder,
+        QueueServiceClient queueServiceClient)
+    {
+        builder.AddAzureQueueStreams(
+            ProviderName,
+            (ClusterClientAzureQueueStreamConfigurator streams) =>
+            {
+                streams.ConfigureAzureQueue(options => options.Configure(value =>
+                {
+                    value.QueueServiceClient = queueServiceClient;
+                    value.QueueNames = ["external-events-0"];
+                }));
+                streams.ConfigureQueueDataAdapter<JsonAzureQueueDataAdapter>();
+            });
+    }
+    // </azure_queue_data_adapter_registration>
+
+    // <event_hub_data_adapter_registration>
+    public static void ConfigureEventHubSilo(
+        ISiloBuilder builder,
+        string connectionString,
+        string eventHubName,
+        string consumerGroup,
+        TableServiceClient checkpointStore)
+    {
+        builder.AddEventHubStreams(
+            ProviderName,
+            (ISiloEventHubStreamConfigurator streams) =>
+            {
+                streams.ConfigureEventHub(options => options.Configure(value =>
+                    value.ConfigureEventHubConnection(
+                        connectionString,
+                        eventHubName,
+                        consumerGroup)));
+                streams.UseAzureTableCheckpointer(
+                    options => options.Configure(
+                        value => value.TableServiceClient = checkpointStore));
+                streams.UseDataAdapter(
+                    (services, _) =>
+                        ActivatorUtilities.CreateInstance<CustomEventHubDataAdapter>(
+                            services));
+            });
+    }
+
+    public static void ConfigureEventHubClient(
+        IClientBuilder builder,
+        string connectionString,
+        string eventHubName,
+        string consumerGroup)
+    {
+        builder.AddEventHubStreams(
+            ProviderName,
+            (IClusterClientEventHubStreamConfigurator streams) =>
+            {
+                streams.ConfigureEventHub(options => options.Configure(value =>
+                    value.ConfigureEventHubConnection(
+                        connectionString,
+                        eventHubName,
+                        consumerGroup)));
+                streams.UseDataAdapter(
+                    (services, _) =>
+                        ActivatorUtilities.CreateInstance<CustomEventHubDataAdapter>(
+                            services));
+            });
+    }
+    // </event_hub_data_adapter_registration>
+}
+
+internal sealed class CustomEventHubDataAdapter(Serializer serializer)
+    : EventHubDataAdapter(serializer);

--- a/docs/site/src/content/docs/streaming/snippets/streaming/StreamDataAdapters.cs
+++ b/docs/site/src/content/docs/streaming/snippets/streaming/StreamDataAdapters.cs
@@ -3,6 +3,7 @@ using Azure.Data.Tables;
 using Azure.Storage.Queues;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Orleans;
 using Orleans.Hosting;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;

--- a/docs/site/src/content/docs/streaming/stream-providers.md
+++ b/docs/site/src/content/docs/streaming/stream-providers.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans stream providers
 description: Compare built-in Orleans stream providers by durability, rewindability, status, and prerequisites.
-ms.date: 08/02/2026
+ms.date: 08/18/2026
 ms.topic: concept-article
 ---
 
@@ -80,4 +80,6 @@ Register [Redis Streams](https://redis.io/docs/latest/develop/data-types/streams
 
 <a id="queue-adapters"></a>
 
-<xref:Orleans.Providers.Streams.Common.PersistentStreamProvider> hosts providers built on <xref:Orleans.Streams.IQueueAdapter>. A custom adapter supplies enqueue/dequeue behavior, queue mapping, rewindability, and failure handling while Orleans supplies pulling agents, subscription routing, and caches. See [Write a custom persistent-stream queue adapter](custom-queue-adapter.md) for an implementation guide and [stream implementation architecture](../implementation/streams-implementation/index.md) for the runtime design.
+A [persistent-stream data adapter](data-adapters.md) customizes the wire format used by Azure Queue Storage or Azure Event Hubs while retaining that provider's transport, partitioning, acknowledgement, cache, and recovery behavior.
+
+<xref:Orleans.Providers.Streams.Common.PersistentStreamProvider> hosts providers built on <xref:Orleans.Streams.IQueueAdapter>. A custom queue adapter supplies enqueue/dequeue behavior, queue mapping, rewindability, and failure handling while Orleans supplies pulling agents, subscription routing, and caches. See [Write a custom persistent-stream queue adapter](custom-queue-adapter.md) for an implementation guide and [stream implementation architecture](../implementation/streams-implementation/index.md) for the runtime design.

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -140,6 +140,8 @@ items:
             href: streaming/stream-providers.md
           - name: External producers and consumers
             href: streaming/external-streams.md
+          - name: Customize stream data formats
+            href: streaming/data-adapters.md
           - name: Write a custom queue adapter
             href: streaming/custom-queue-adapter.md
           - name: Amazon Kinesis


### PR DESCRIPTION
## Problem

Orleans exposes persistent-stream data-adapter APIs for Azure Queue Storage and Azure Event Hubs, but the documentation jumps from external Event Hubs integration to implementing an entire queue adapter. Users lack focused guidance for changing an existing provider's wire format, preserving stream and sequence invariants, and evolving schemas safely.

## Solution

- Add a data-adapter guide which distinguishes data conversion from queue transport responsibilities.
- Document the Azure Queue and Event Hubs extension points, registration requirements, failure behavior, and expand-and-contract schema evolution.
- Add compiling Azure Queue conversion and batch-container snippets plus complete Azure Queue and Event Hubs provider registration.
- Add navigation and cross-links from provider, external-integration, custom-adapter, and Azure Queue implementation guidance.

## Rationale

Keeping wire-format customization at the provider data-adapter boundary preserves the built-in transport, partitioning, acknowledgement, caching, and recovery behavior. Explicit envelope and rollout guidance lets applications interoperate with external systems and read retained messages across schema changes without taking ownership of the full queue adapter.

Fixes #4621
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10645)