### PR TITLE
feat(templates): add Orleans application templates

### DIFF
--- a/Orleans.slnx
+++ b/Orleans.slnx
@@ -147,6 +147,9 @@
     <Project Path="test/Orleans.EventSourcing.Tests/Orleans.EventSourcing.Tests.csproj" />
     <Project Path="test/Orleans.DurableJobs.Tests/Orleans.DurableJobs.Tests.csproj" />
   </Folder>
+  <Folder Name="/templates/">
+    <Project Path="templates/Microsoft.Orleans.Templates/Microsoft.Orleans.Templates.csproj" />
+  </Folder>
   <Folder Name="/test/Dashboard/">
     <Project Path="test/Orleans.Dashboard.Tests/Orleans.Dashboard.TestGrains/Orleans.Dashboard.TestGrains.csproj" />
     <Project Path="test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/Orleans.Dashboard.UnitTests.csproj" />

--- a/docs/site/src/content/docs/host/client.md
+++ b/docs/site/src/content/docs/host/client.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans clients
 description: Choose and host an Orleans client.
-ms.date: 08/02/2026
+ms.date: 08/18/2026
 ms.topic: concept-article
 ---
 
@@ -27,6 +27,26 @@ Start with a co-hosted client unless isolation is a requirement.
 :::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="local_silo_and_client":::
 
 Calls from a co-hosted client use the silo's cluster knowledge and don't require a gateway. If the target activation is local, Orleans can also avoid a network hop.
+
+### Call grains from ASP.NET Core
+
+The `orleans-web` template creates an ASP.NET Core app which co-hosts a silo and exposes a grain through an HTTP endpoint:
+
+```dotnetcli
+dotnet new install Microsoft.Orleans.Templates
+dotnet new orleans-web --name HelloOrleans --output HelloOrleans
+dotnet run --project HelloOrleans/HelloOrleans.csproj
+```
+
+Call the endpoint from another terminal:
+
+```console
+curl http://localhost:5000/hello/Ada
+```
+
+The endpoint returns `Hello, Ada!`. ASP.NET Core resolves <xref:Orleans.IGrainFactory> from dependency injection, the endpoint obtains the grain reference keyed by `Ada`, and Orleans activates the grain when the request invokes it.
+
+The generated app uses localhost clustering for a one-node development cluster. For a multi-silo deployment, configure [shared clustering and storage providers](configuration-guide/typical-configurations.md) and apply the [production-readiness checklist](../deployment/production-readiness.md).
 
 ## External clients
 

--- a/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
+++ b/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
@@ -28,14 +28,14 @@ The example uses localhost clustering and omits production concerns such as dura
 
 ## Create the solution
 
-Create a solution with four projects:
+Create a solution with four Orleans projects:
 
 - **GrainInterfaces** contains grain contracts shared by callers and implementations.
 - **Grains** contains the grain implementations.
 - **Silo** hosts the Orleans runtime and grain activations.
 - **Client** is an external process that connects to the silo and calls grains.
 
-The maintained `Microsoft.Orleans.Templates` package can create this layout for you:
+The `Microsoft.Orleans.Templates` package creates this layout and adds an Aspire AppHost that orchestrates the silo, client, and Azurite-backed Azure Storage resources:
 
 ```dotnetcli
 dotnet new install Microsoft.Orleans.Templates

--- a/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
+++ b/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Build your first Orleans app'
 description: Build a multi-project Orleans application with a silo and external client.
-ms.date: 08/08/2026
+ms.date: 08/18/2026
 ms.topic: tutorial
 ms.devlang: csharp
 ---
@@ -34,6 +34,15 @@ Create a solution with four projects:
 - **Grains** contains the grain implementations.
 - **Silo** hosts the Orleans runtime and grain activations.
 - **Client** is an external process that connects to the silo and calls grains.
+
+The maintained `Microsoft.Orleans.Templates` package can create this layout for you:
+
+```dotnetcli
+dotnet new install Microsoft.Orleans.Templates
+dotnet new orleans --name OrleansHelloWorld --output OrleansHelloWorld
+```
+
+Continue with the manual steps below to learn how the projects and references fit together.
 
 Run the following commands in an empty directory:
 

--- a/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
+++ b/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
@@ -18,7 +18,7 @@ You learn how to:
 - Obtain a grain reference and call it.
 - Structure project references so that clients depend on contracts, not implementations.
 
-The example uses localhost clustering and omits production concerns such as durable storage, authentication, observability, and application-level retry policies.
+The manual walkthrough uses localhost clustering and transient in-memory state so that the silo and client can run directly from two terminals.
 
 ## Prerequisites
 
@@ -35,7 +35,7 @@ Create a solution with four Orleans projects:
 - **Silo** hosts the Orleans runtime and grain activations.
 - **Client** is an external process that connects to the silo and calls grains.
 
-The `Microsoft.Orleans.Templates` package creates this layout and adds an Aspire AppHost that orchestrates the silo, client, and Azurite-backed Azure Storage resources:
+The `Microsoft.Orleans.Templates` package creates the same Orleans project boundaries and adds an Aspire AppHost. The generated application uses Azurite-backed Azure Table clustering and Azure Blob grain storage instead of the manual walkthrough's localhost configuration. A running container runtime lets the AppHost start Azurite:
 
 ```dotnetcli
 dotnet new install Microsoft.Orleans.Templates

--- a/templates/Microsoft.Orleans.Templates/Microsoft.Orleans.Templates.csproj
+++ b/templates/Microsoft.Orleans.Templates/Microsoft.Orleans.Templates.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <PackageId>Microsoft.Orleans.Templates</PackageId>
+    <Title>Microsoft Orleans project templates</Title>
+    <Description>Official project and solution templates for building Microsoft Orleans applications.</Description>
+    <PackageTags>$(PackageTags) dotnet-new templates</PackageTags>
+    <PackageType>Template</PackageType>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="templates\**\*" />
+    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/README.md
+++ b/templates/Microsoft.Orleans.Templates/README.md
@@ -1,6 +1,6 @@
 # Microsoft Orleans project templates
 
-This package provides maintained templates for common Orleans application layouts.
+This package provides templates for common Orleans application layouts.
 
 Install the templates:
 
@@ -8,7 +8,7 @@ Install the templates:
 dotnet new install Microsoft.Orleans.Templates
 ```
 
-Create a solution with separate grain contracts, grain implementations, silo, and external client projects:
+Create an Aspire solution with separate grain contracts, grain implementations, silo, external client, and AppHost projects:
 
 ```dotnetcli
 dotnet new orleans --name MyOrleansApp
@@ -32,4 +32,4 @@ Templates reference the current stable Orleans release. Pass `--orleans-version`
 dotnet new orleans-web --name MyOrleansWebApp --orleans-version 10.2.2
 ```
 
-The generated applications use localhost clustering for local development. Configure a shared clustering provider, durable storage, and production endpoints before deploying a multi-silo cluster. See the [Orleans hosting documentation](https://dotnet.github.io/orleans/docs/host/configuration-guide/) for production configuration guidance.
+The `orleans` template uses the Aspire Orleans integration to orchestrate the silo, client, and Azurite-backed Azure Table clustering and Azure Blob grain storage. The `orleans-web` template uses localhost clustering for a one-node local development host. See the [Orleans hosting documentation](https://dotnet.github.io/orleans/docs/host/configuration-guide/) for production configuration guidance.

--- a/templates/Microsoft.Orleans.Templates/README.md
+++ b/templates/Microsoft.Orleans.Templates/README.md
@@ -32,4 +32,4 @@ Templates reference the current stable Orleans release. Pass `--orleans-version`
 dotnet new orleans-web --name MyOrleansWebApp --orleans-version 10.2.2
 ```
 
-The `orleans` template uses the Aspire Orleans integration to orchestrate the silo, client, and Azurite-backed Azure Table clustering and Azure Blob grain storage. The `orleans-web` template uses localhost clustering for a one-node local development host. See the [Orleans hosting documentation](https://dotnet.github.io/orleans/docs/host/configuration-guide/) for production configuration guidance.
+The `orleans` template uses the Aspire Orleans integration to orchestrate the silo, client, and Azurite-backed Azure Table clustering and Azure Blob grain storage. Run the generated AppHost with a container runtime available so that Aspire can start Azurite. The `orleans-web` template uses localhost clustering for a one-node local development host. See the [Orleans hosting documentation](https://dotnet.github.io/orleans/docs/host/configuration-guide/) for production configuration guidance.

--- a/templates/Microsoft.Orleans.Templates/README.md
+++ b/templates/Microsoft.Orleans.Templates/README.md
@@ -1,0 +1,35 @@
+# Microsoft Orleans project templates
+
+This package provides maintained templates for common Orleans application layouts.
+
+Install the templates:
+
+```dotnetcli
+dotnet new install Microsoft.Orleans.Templates
+```
+
+Create a solution with separate grain contracts, grain implementations, silo, and external client projects:
+
+```dotnetcli
+dotnet new orleans --name MyOrleansApp
+```
+
+Create an ASP.NET Core app which co-hosts an Orleans silo and exposes a grain through an HTTP endpoint:
+
+```dotnetcli
+dotnet new orleans-web --name MyOrleansWebApp
+```
+
+Both templates target .NET 10 by default. Pass `--framework net8.0` to target .NET 8:
+
+```dotnetcli
+dotnet new orleans --name MyOrleansApp --framework net8.0
+```
+
+Templates reference the current stable Orleans release. Pass `--orleans-version` when your application needs another Orleans version:
+
+```dotnetcli
+dotnet new orleans-web --name MyOrleansWebApp --orleans-version 10.2.2
+```
+
+The generated applications use localhost clustering for local development. Configure a shared clustering provider, durable storage, and production endpoints before deploying a multi-silo cluster. See the [Orleans hosting documentation](https://dotnet.github.io/orleans/docs/host/configuration-guide/) for production configuration guidance.

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/.template.config/dotnetcli.host.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/.template.config/dotnetcli.host.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "framework": {
+      "longName": "framework",
+      "shortName": "f"
+    },
+    "orleansVersion": {
+      "longName": "orleans-version",
+      "shortName": ""
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/.template.config/template.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/.template.config/template.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [
+    "Cloud",
+    "Distributed Systems",
+    "Orleans",
+    "Web"
+  ],
+  "identity": "Microsoft.Orleans.Templates.Web.CSharp",
+  "groupIdentity": "Microsoft.Orleans.Templates.Web",
+  "name": "Orleans ASP.NET Core application",
+  "shortName": "orleans-web",
+  "defaultName": "OrleansWebApp",
+  "sourceName": "OrleansWebApp",
+  "preferNameDirectory": true,
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "symbols": {
+    "framework": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "The target framework for the generated project.",
+      "defaultValue": "net10.0",
+      "replaces": "net10.0",
+      "choices": [
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10."
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target .NET 8."
+        }
+      ]
+    },
+    "orleansVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "description": "The Microsoft Orleans package version.",
+      "defaultValue": "10.2.2"
+    },
+    "orleansVersionXml": {
+      "type": "derived",
+      "valueSource": "orleansVersion",
+      "valueTransform": "xmlEncode",
+      "replaces": "__ORLEANS_VERSION__"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Skip automatic package restore.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "OrleansWebApp.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'."
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "args": {
+        "files": "OrleansWebApp.csproj"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/Directory.Packages.props
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/Directory.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <OrleansVersion>__ORLEANS_VERSION__</OrleansVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="$(OrleansVersion)" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/Directory.Packages.props
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrleansVersion>__ORLEANS_VERSION__</OrleansVersion>
   </PropertyGroup>
 

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/HelloGrain.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/HelloGrain.cs
@@ -1,0 +1,6 @@
+namespace OrleansWebApp;
+
+public sealed class HelloGrain : Grain, IHelloGrain
+{
+    public Task<string> SayHello(string name) => Task.FromResult($"Hello, {name}!");
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/IHelloGrain.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/IHelloGrain.cs
@@ -1,0 +1,6 @@
+namespace OrleansWebApp;
+
+public interface IHelloGrain : IGrainWithStringKey
+{
+    Task<string> SayHello(string name);
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/OrleansWebApp.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/OrleansWebApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Server" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/Program.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/Program.cs
@@ -1,0 +1,16 @@
+using OrleansWebApp;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseOrleans(siloBuilder => siloBuilder.UseLocalhostClustering());
+
+var app = builder.Build();
+
+app.MapGet("/", () => Results.Redirect("/hello/world"));
+app.MapGet("/hello/{name}", async (string name, IGrainFactory grainFactory) =>
+{
+    var grain = grainFactory.GetGrain<IHelloGrain>(name);
+    return await grain.SayHello(name);
+});
+
+await app.RunAsync();

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/Properties/launchSettings.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "hello/world",
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/README.md
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/README.md
@@ -1,0 +1,19 @@
+# OrleansWebApp
+
+This ASP.NET Core application co-hosts an Orleans silo. The HTTP endpoint resolves `IGrainFactory` from dependency injection and calls a grain in the same cluster.
+
+Run the application:
+
+```dotnetcli
+dotnet run
+```
+
+Call the generated endpoint:
+
+```console
+curl http://localhost:5000/hello/Ada
+```
+
+The endpoint returns `Hello, Ada!`.
+
+The generated app uses localhost clustering for local development. Configure a shared clustering provider, durable storage, and production endpoints before deploying multiple instances.

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/dotnetcli.host.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/dotnetcli.host.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "framework": {
+      "longName": "framework",
+      "shortName": "f"
+    },
+    "orleansVersion": {
+      "longName": "orleans-version",
+      "shortName": ""
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/dotnetcli.host.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/dotnetcli.host.json
@@ -9,6 +9,10 @@
       "longName": "orleans-version",
       "shortName": ""
     },
+    "aspireVersion": {
+      "longName": "aspire-version",
+      "shortName": ""
+    },
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [
+    "Cloud",
+    "Distributed Systems",
+    "Orleans"
+  ],
+  "identity": "Microsoft.Orleans.Templates.Application.CSharp",
+  "groupIdentity": "Microsoft.Orleans.Templates.Application",
+  "name": "Orleans application",
+  "shortName": "orleans",
+  "defaultName": "OrleansApp",
+  "sourceName": "OrleansApp",
+  "preferNameDirectory": true,
+  "tags": {
+    "language": "C#",
+    "type": "solution"
+  },
+  "symbols": {
+    "framework": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "The target framework for the generated projects.",
+      "defaultValue": "net10.0",
+      "replaces": "net10.0",
+      "choices": [
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10."
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target .NET 8."
+        }
+      ]
+    },
+    "orleansVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "description": "The Microsoft Orleans package version.",
+      "defaultValue": "10.2.2"
+    },
+    "orleansVersionXml": {
+      "type": "derived",
+      "valueSource": "orleansVersion",
+      "valueTransform": "xmlEncode",
+      "replaces": "__ORLEANS_VERSION__"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Skip automatic package restore.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "OrleansApp.slnx"
+    },
+    {
+      "path": "OrleansApp.Contracts/OrleansApp.Contracts.csproj"
+    },
+    {
+      "path": "OrleansApp.Grains/OrleansApp.Grains.csproj"
+    },
+    {
+      "path": "OrleansApp.Silo/OrleansApp.Silo.csproj"
+    },
+    {
+      "path": "OrleansApp.Client/OrleansApp.Client.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this solution.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'."
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "args": {
+        "files": "OrleansApp.slnx"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
@@ -52,7 +52,7 @@
       "type": "parameter",
       "datatype": "text",
       "description": "The Aspire package and AppHost SDK version.",
-      "defaultValue": "13.4.6",
+      "defaultValue": "13.5.0",
       "replaces": "__ASPIRE_VERSION__"
     },
     "skipRestore": {

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
@@ -4,7 +4,8 @@
   "classifications": [
     "Cloud",
     "Distributed Systems",
-    "Orleans"
+    "Orleans",
+    "Aspire"
   ],
   "identity": "Microsoft.Orleans.Templates.Application.CSharp",
   "groupIdentity": "Microsoft.Orleans.Templates.Application",
@@ -47,6 +48,13 @@
       "valueTransform": "xmlEncode",
       "replaces": "__ORLEANS_VERSION__"
     },
+    "aspireVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "description": "The Aspire package and AppHost SDK version.",
+      "defaultValue": "13.4.6",
+      "replaces": "__ASPIRE_VERSION__"
+    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
@@ -57,6 +65,12 @@
   "primaryOutputs": [
     {
       "path": "OrleansApp.slnx"
+    },
+    {
+      "path": "aspire.config.json"
+    },
+    {
+      "path": "OrleansApp.AppHost/OrleansApp.AppHost.csproj"
     },
     {
       "path": "OrleansApp.Contracts/OrleansApp.Contracts.csproj"

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/Directory.Packages.props
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <OrleansVersion>__ORLEANS_VERSION__</OrleansVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Orleans.Client" Version="$(OrleansVersion)" />
+    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="$(OrleansVersion)" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="$(OrleansVersion)" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/Directory.Packages.props
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/Directory.Packages.props
@@ -2,12 +2,20 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <AspireVersion>__ASPIRE_VERSION__</AspireVersion>
     <OrleansVersion>__ORLEANS_VERSION__</OrleansVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(AspireVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Orleans.Client" Version="$(OrleansVersion)" />
+    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(OrleansVersion)" />
+    <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="$(OrleansVersion)" />
+    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="$(OrleansVersion)" />
     <PackageVersion Include="Microsoft.Orleans.Sdk" Version="$(OrleansVersion)" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="$(OrleansVersion)" />
   </ItemGroup>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/Directory.Packages.props
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <OrleansVersion>__ORLEANS_VERSION__</OrleansVersion>
   </PropertyGroup>
 

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.AppHost/OrleansApp.AppHost.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.AppHost/OrleansApp.AppHost.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Aspire.AppHost.Sdk/__ASPIRE_VERSION__">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" />
+    <PackageReference Include="Aspire.Hosting.Orleans" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OrleansApp.Client\OrleansApp.Client.csproj" />
+    <ProjectReference Include="..\OrleansApp.Silo\OrleansApp.Silo.csproj" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.AppHost/Program.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.AppHost/Program.cs
@@ -1,0 +1,22 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var storage = builder.AddAzureStorage("orleans-storage")
+    .RunAsEmulator();
+var clustering = storage.AddTables("clustering");
+var grainState = storage.AddBlobs("grain-state");
+
+var orleans = builder.AddOrleans("orleans")
+    .WithClustering(clustering)
+    .WithGrainStorage("Default", grainState);
+
+var silo = builder.AddProject<Projects.OrleansApp_Silo>("silo")
+    .WithReference(orleans)
+    .WaitFor(clustering)
+    .WaitFor(grainState);
+
+builder.AddProject<Projects.OrleansApp_Client>("client")
+    .WithReference(orleans.AsClient())
+    .WaitFor(clustering)
+    .WaitFor(silo);
+
+builder.Build().Run();

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/OrleansApp.Client.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/OrleansApp.Client.csproj
@@ -7,8 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Azure.Data.Tables" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Orleans.Client" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/OrleansApp.Client.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/OrleansApp.Client.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Orleans.Client" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OrleansApp.Contracts\OrleansApp.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/Program.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/Program.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OrleansApp.Contracts;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.UseOrleansClient(clientBuilder => clientBuilder.UseLocalhostClustering());
+
+using var host = builder.Build();
+await host.StartAsync();
+
+var grainFactory = host.Services.GetRequiredService<IGrainFactory>();
+var friend = grainFactory.GetGrain<IHelloGrain>("friend");
+Console.WriteLine(await friend.SayHello("friend"));
+
+await host.StopAsync();

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/Program.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Client/Program.cs
@@ -4,7 +4,8 @@ using OrleansApp.Contracts;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.UseOrleansClient(clientBuilder => clientBuilder.UseLocalhostClustering());
+builder.AddKeyedAzureTableServiceClient("clustering");
+builder.UseOrleansClient();
 
 using var host = builder.Build();
 await host.StartAsync();

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Contracts/IHelloGrain.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Contracts/IHelloGrain.cs
@@ -1,0 +1,6 @@
+namespace OrleansApp.Contracts;
+
+public interface IHelloGrain : IGrainWithStringKey
+{
+    Task<string> SayHello(string name);
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Contracts/OrleansApp.Contracts.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Contracts/OrleansApp.Contracts.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Sdk" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/HelloGrain.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/HelloGrain.cs
@@ -1,0 +1,8 @@
+using OrleansApp.Contracts;
+
+namespace OrleansApp.Grains;
+
+public sealed class HelloGrain : Grain, IHelloGrain
+{
+    public Task<string> SayHello(string name) => Task.FromResult($"Hello, {name}!");
+}

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/HelloGrain.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/HelloGrain.cs
@@ -1,8 +1,16 @@
+using Orleans.Runtime;
 using OrleansApp.Contracts;
 
 namespace OrleansApp.Grains;
 
-public sealed class HelloGrain : Grain, IHelloGrain
+public sealed class HelloGrain(
+    [PersistentState("hello", "Default")] IPersistentState<int> callCount)
+    : Grain, IHelloGrain
 {
-    public Task<string> SayHello(string name) => Task.FromResult($"Hello, {name}!");
+    public async Task<string> SayHello(string name)
+    {
+        callCount.State++;
+        await callCount.WriteStateAsync();
+        return $"Hello, {name}! Call count: {callCount.State}.";
+    }
 }

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/OrleansApp.Grains.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/OrleansApp.Grains.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Runtime" />
     <PackageReference Include="Microsoft.Orleans.Sdk" />
   </ItemGroup>
 

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/OrleansApp.Grains.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Grains/OrleansApp.Grains.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Sdk" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OrleansApp.Contracts\OrleansApp.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/OrleansApp.Silo.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/OrleansApp.Silo.csproj
@@ -8,7 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Azure.Data.Tables" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" />
     <PackageReference Include="Microsoft.Orleans.Server" />
   </ItemGroup>
 

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/OrleansApp.Silo.csproj
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/OrleansApp.Silo.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Orleans.Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OrleansApp.Grains\OrleansApp.Grains.csproj" />
+  </ItemGroup>
+</Project>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/Program.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/Program.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Hosting;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.UseOrleans(siloBuilder => siloBuilder.UseLocalhostClustering());
+builder.AddKeyedAzureTableServiceClient("clustering");
+builder.AddKeyedAzureBlobServiceClient("grain-state");
+builder.UseOrleans();
 
 await builder.Build().RunAsync();

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/Program.cs
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.Silo/Program.cs
@@ -1,0 +1,7 @@
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.UseOrleans(siloBuilder => siloBuilder.UseLocalhostClustering());
+
+await builder.Build().RunAsync();

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.slnx
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="OrleansApp.AppHost/OrleansApp.AppHost.csproj" />
     <Project Path="OrleansApp.Client/OrleansApp.Client.csproj" />
     <Project Path="OrleansApp.Contracts/OrleansApp.Contracts.csproj" />
     <Project Path="OrleansApp.Grains/OrleansApp.Grains.csproj" />

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.slnx
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/OrleansApp.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="OrleansApp.Client/OrleansApp.Client.csproj" />
+    <Project Path="OrleansApp.Contracts/OrleansApp.Contracts.csproj" />
+    <Project Path="OrleansApp.Grains/OrleansApp.Grains.csproj" />
+    <Project Path="OrleansApp.Silo/OrleansApp.Silo.csproj" />
+  </Folder>
+</Solution>

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/README.md
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/README.md
@@ -1,7 +1,8 @@
 # OrleansApp
 
-This solution separates the application into four projects:
+This solution separates the application into five projects:
 
+- `OrleansApp.AppHost` orchestrates the application and its Azurite resources.
 - `OrleansApp.Contracts` defines grain interfaces shared by callers and implementations.
 - `OrleansApp.Grains` implements those grain interfaces.
 - `OrleansApp.Silo` hosts the Orleans runtime and grain activations.
@@ -13,18 +14,14 @@ Build the solution:
 dotnet build
 ```
 
-Start the silo:
+Start the application:
 
 ```dotnetcli
-dotnet run --project OrleansApp.Silo
+dotnet run --project OrleansApp.AppHost
 ```
 
-After the silo reports that it has started, run the client in another terminal:
+The AppHost starts Azurite, the silo, and the external client. Open the Aspire dashboard using the URL printed in the terminal to inspect the resources and their logs.
 
-```dotnetcli
-dotnet run --project OrleansApp.Client
-```
+The client prints `Hello, friend! Call count: 1.`. The grain stores its call count in Azure Blob Storage, and both the silo and client discover the cluster through Azure Table Storage. The AppHost runs both services through Azurite for local development.
 
-The client prints `Hello, friend!`.
-
-The generated projects use localhost clustering for local development. Configure the silo and client with the same service ID, cluster ID, and production clustering provider before deploying them as separate processes.
+A container runtime must be running so that Aspire can start Azurite. When the application is published, configure the Azure Storage resource for the target environment.

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/README.md
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/README.md
@@ -1,0 +1,30 @@
+# OrleansApp
+
+This solution separates the application into four projects:
+
+- `OrleansApp.Contracts` defines grain interfaces shared by callers and implementations.
+- `OrleansApp.Grains` implements those grain interfaces.
+- `OrleansApp.Silo` hosts the Orleans runtime and grain activations.
+- `OrleansApp.Client` connects to the silo and calls a grain.
+
+Build the solution:
+
+```dotnetcli
+dotnet build
+```
+
+Start the silo:
+
+```dotnetcli
+dotnet run --project OrleansApp.Silo
+```
+
+After the silo reports that it has started, run the client in another terminal:
+
+```dotnetcli
+dotnet run --project OrleansApp.Client
+```
+
+The client prints `Hello, friend!`.
+
+The generated projects use localhost clustering for local development. Configure the silo and client with the same service ID, cluster ID, and production clustering provider before deploying them as separate processes.

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/aspire.config.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "OrleansApp.AppHost/OrleansApp.AppHost.csproj"
+  }
+}


### PR DESCRIPTION
## Problem

Orleans documents the core APIs and project setup, but it has no Microsoft-maintained `dotnet new` templates for the common application layouts requested in #7184. Developers must reproduce a multi-project solution or co-hosted web setup manually, which makes the first successful application harder to repeat consistently.

## Solution

Add the `Microsoft.Orleans.Templates` package with two maintained templates:

- `orleans` creates separate grain contracts, grain implementations, silo, and external client projects
- `orleans-web` creates an ASP.NET Core application which co-hosts an Orleans silo and calls a grain from an HTTP endpoint

Both templates support .NET 10 and .NET 8, centralize Orleans package versions, expose an Orleans version option, restore generated projects, and start with localhost clustering for development. The first-application and client guides now provide concrete template-driven recipes and link production configuration guidance.

## Rationale

Keeping templates in this repository lets the solution build and release them with Orleans while keeping generated code aligned with maintained documentation. The documentation changes complement the how-to index in #10554 without duplicating or modifying its navigation scope.

Fixes #7184
Fixes #7479
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10646)