### PR TITLE
docs: show UseOrleans host configuration

### DIFF
--- a/docs/site/src/content/docs/host/configuration-guide/index.md
+++ b/docs/site/src/content/docs/host/configuration-guide/index.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans configuration guide
 description: Configure Orleans silos, clients, providers, and endpoints.
-ms.date: 08/02/2026
+ms.date: 08/18/2026
 ms.topic: overview
 ---
 
@@ -24,7 +24,13 @@ For a first local process, see [Local development configuration](local-developme
 
 ## Programmatic configuration
 
-Configure Orleans through <xref:Orleans.Hosting.ISiloBuilder> or <xref:Orleans.Hosting.IClientBuilder>. Provider extension methods validate configuration when the host starts. Prefer programmatic configuration when credentials require SDK objects such as <xref:Azure.Core.TokenCredential>, when configuration is computed, or when compile-time discoverability is important.
+Create the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with <xref:Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder*>, call <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> to add a silo, then build and run the host:
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="run_silo":::
+
+Starting the host starts the silo and its co-hosted <xref:Orleans.IClusterClient>. The client is available through dependency injection, and stopping the host coordinates a [graceful Orleans shutdown](shutting-down-orleans.md).
+
+Configure the silo through the <xref:Orleans.Hosting.ISiloBuilder> passed to `UseOrleans`. External client processes use <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> and configure the <xref:Orleans.Hosting.IClientBuilder> passed to it. Provider extension methods validate configuration when the host starts. Programmatic configuration supports credentials supplied as SDK objects such as <xref:Azure.Core.TokenCredential>, computed configuration, and compile-time API discovery.
 
 See [Server configuration](server-configuration.md) and [Client configuration](client-configuration.md) for compiled examples.
 


### PR DESCRIPTION
## Problem

The configuration guide names `UseOrleans` but does not show the complete modern Generic Host startup flow. Readers need a copyable `Host.CreateApplicationBuilder` example and the lifecycle behavior that replaces the legacy `SiloHostBuilder` guidance tracked by #5932.

## Solution

Add the existing compiled hosting snippet to the configuration guide and explain that host startup starts the silo and co-hosted client, exposes the client through dependency injection, and coordinates graceful Orleans shutdown when the host stops. Point external client processes to `UseOrleansClient` and its `IClientBuilder`.

## Rationale

Keeping startup guidance on the configuration landing page makes the current entry point explicit while reusing a validated snippet and remaining compatible with the broader deployment and security guidance in #10554.

Fixes #5932
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10647)