### PR TITLE
docs(streaming): resolve stateless worker subscription guidance

### DIFF
--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans streaming APIs
 description: Work with stream identities, producers, consumers, and explicit or implicit subscriptions in Orleans.
-ms.date: 08/08/2026
+ms.date: 08/18/2026
 ms.topic: concept-article
 ---
 
@@ -99,11 +99,9 @@ Clients can produce and explicitly consume streams after the provider is configu
 
 ## Stateless worker grains
 
-Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish stream events, but they can't subscribe to streams. A stream consumer uses a grain extension which must bind to one activation, while a stateless worker grain identity can have multiple activations. Orleans therefore rejects a subscription attempt from a stateless worker grain with an <xref:System.InvalidOperationException>.
+Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish stream events. Orleans rejects subscription attempts from them with an <xref:System.InvalidOperationException> because a stream consumer uses a grain extension which must bind to one activation, while a stateless worker grain identity can have multiple replaceable activations.
 
 Use a regular grain as the stream consumer so that the stream-to-grain binding has a stable virtual identity which can own state and the subscription lifecycle. If processing after delivery is stateless and parallelizable, have that grain call stateless worker grains and await the required work before its consumer task completes. This keeps stream acknowledgment and recovery at the regular grain boundary instead of treating a multicast subscription as a competing-consumer work queue.
-
-Support for subscribing directly from stateless worker grains is tracked by [dotnet/orleans#433](https://github.com/dotnet/orleans/issues/433).
 
 <a id="stream-order-and-sequence-tokens"></a>
 <a id="rewindable-streams"></a>

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -103,6 +103,8 @@ Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publi
 
 Use a regular grain as the stream consumer so that the stream-to-grain binding has a stable virtual identity which can own state and the subscription lifecycle. If processing after delivery is stateless and parallelizable, have that grain call stateless worker grains and await the required work before its consumer task completes. This keeps stream acknowledgment and recovery at the regular grain boundary instead of treating a multicast subscription as a competing-consumer work queue.
 
+Support for subscribing directly from stateless worker grains is tracked by [dotnet/orleans#433](https://github.com/dotnet/orleans/issues/433).
+
 <a id="stream-order-and-sequence-tokens"></a>
 <a id="rewindable-streams"></a>
 

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -99,7 +99,7 @@ Clients can produce and explicitly consume streams after the provider is configu
 
 ## Stateless worker grains
 
-Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish stream events. Orleans rejects subscription attempts from them with an <xref:System.InvalidOperationException> because a stream consumer uses a grain extension which must bind to one activation, while a stateless worker grain identity can have multiple replaceable activations.
+Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish stream events. Orleans rejects stateless worker grain subscription attempts with an <xref:System.InvalidOperationException> because a stream consumer uses a grain extension which must bind to one activation, while a stateless worker grain identity can have multiple, replaceable activations.
 
 Use a regular grain as the stream consumer so that the stream-to-grain binding has a stable virtual identity which can own state and the subscription lifecycle. If processing after delivery is stateless and parallelizable, have that grain call stateless worker grains and await the required work before its consumer task completes. This keeps stream acknowledgment and recovery at the regular grain boundary instead of treating a multicast subscription as a competing-consumer work queue.
 


### PR DESCRIPTION
## Problem

The streaming guide needed precise guidance for stateless worker grains: Orleans rejects stream subscription binding for these grains, while the historical discussion in #433 contained descriptions of behavior which no longer match the enforced runtime invariant.

## Solution

Describe the runtime rejection in terms of the activation-binding invariant, clarify that stateless-worker activations are replaceable, and document the supported regular-consumer-grain handoff to stateless workers. Retain #433 as the historical implementation tracker while the focused design proposal continues in #10653.

Related to #433 and #10653.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10654)