### PR TITLE
fix(streaming): defer acknowledgements for batched delivery

### DIFF
--- a/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCacheCursor.cs
+++ b/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCacheCursor.cs
@@ -9,12 +9,13 @@ namespace Orleans.Providers.Streams.Common
     /// <summary>
     /// Cursor into a simple queue cache.
     /// </summary>
-    public partial class SimpleQueueCacheCursor : IQueueCacheCursor
+    public partial class SimpleQueueCacheCursor : IQueueCacheCursor, IQueueCacheCursorBatchDelivery
     {
         private readonly StreamId streamId;
         private readonly SimpleQueueCache cache;
         private readonly ILogger logger;
         private IBatchContainer? current; // this is a pointer to the current element in the cache. It is what will be returned by GetCurrent().
+        private DeliveryBatch? deliveryBatch;
 
         // This is also a pointer to the current element in the cache. It differs from current, in
         // that current is just the batch, and is null before the first call to MoveNext after
@@ -76,6 +77,7 @@ namespace Orleans.Providers.Streams.Common
             if (current == null && IsSet && IsInStream(Element!.Value.Batch)) // IsSet is true, so Element is non-null.
             {
                 current = Element!.Value.Batch;
+                deliveryBatch?.Track(Element);
                 return true;
             }
 
@@ -89,6 +91,7 @@ namespace Orleans.Providers.Streams.Common
             if (!IsInStream(next))
                 return false;
 
+            deliveryBatch?.Track(Element!);
             return true;
         }
 
@@ -108,6 +111,26 @@ namespace Orleans.Providers.Streams.Common
             {
                 Element!.Value.DeliveryFailure = true; // IsSet is true, so Element is non-null.
             }
+        }
+
+        IDisposable IQueueCacheCursorBatchDelivery.ProtectDeliveryBatch()
+        {
+            if (deliveryBatch is not null)
+            {
+                throw new InvalidOperationException("A delivery batch is already active for this cursor.");
+            }
+
+            return deliveryBatch = new DeliveryBatch(this);
+        }
+
+        void IQueueCacheCursorBatchDelivery.RecordDeliveryFailure(IBatchContainer batch)
+        {
+            if (deliveryBatch is null)
+            {
+                throw new InvalidOperationException("No delivery batch is active for this cursor.");
+            }
+
+            deliveryBatch.RecordDeliveryFailure(batch);
         }
 
         private bool IsInStream(IBatchContainer? batchContainer)
@@ -130,8 +153,75 @@ namespace Orleans.Providers.Streams.Common
         {
             if (disposing)
             {
+                deliveryBatch?.Dispose();
                 cache.UnsetCursor(this, null);
                 current = null;
+            }
+        }
+
+        private sealed class DeliveryBatch : IDisposable
+        {
+            private readonly SimpleQueueCacheCursor owner;
+            private readonly CacheBucket? pinnedBucket;
+            private readonly LinkedListNode<SimpleQueueCacheItem>? firstElement;
+            private LinkedListNode<SimpleQueueCacheItem>? lastElement;
+            private bool disposed;
+
+            public DeliveryBatch(SimpleQueueCacheCursor owner)
+            {
+                this.owner = owner;
+                firstElement = owner.Element;
+                pinnedBucket = firstElement?.Value.CacheBucket;
+                pinnedBucket?.UpdateNumCursors(1);
+            }
+
+            public void Track(LinkedListNode<SimpleQueueCacheItem> item)
+            {
+                ObjectDisposedException.ThrowIf(disposed, this);
+                lastElement = item;
+            }
+
+            public void RecordDeliveryFailure(IBatchContainer batch)
+            {
+                ObjectDisposedException.ThrowIf(disposed, this);
+
+                if (batch is IBatchContainerBatch batchGroup)
+                {
+                    foreach (var item in batchGroup.BatchContainers)
+                    {
+                        RecordDeliveryFailure(item);
+                    }
+                }
+                else
+                {
+                    for (var item = firstElement; item is not null; item = item.Previous)
+                    {
+                        if (ReferenceEquals(item.Value.Batch, batch))
+                        {
+                            item.Value.DeliveryFailure = true;
+                            return;
+                        }
+
+                        if (ReferenceEquals(item, lastElement))
+                        {
+                            break;
+                        }
+                    }
+
+                    throw new InvalidOperationException("The failed delivery was not read by this cursor.");
+                }
+            }
+
+            public void Dispose()
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+                owner.deliveryBatch = null;
+                pinnedBucket?.UpdateNumCursors(-1);
             }
         }
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -841,6 +841,10 @@ namespace Orleans.Streams
                 var deliveredAny = false;
                 while (!IsShutdown && consumerData.Cursor is not null)
                 {
+                    var batchCursor = options.BatchContainerBatchSize > 1
+                        ? consumerData.Cursor as IQueueCacheCursorBatchDelivery
+                        : null;
+                    using var deliveryBatch = batchCursor?.ProtectDeliveryBatch();
                     ConsumerBatch nextBatch = default;
                     Exception? exceptionOccured = null;
                     try
@@ -927,7 +931,15 @@ namespace Orleans.Streams
                     }
                     catch (Exception exc)
                     {
-                        consumerData.Cursor?.RecordDeliveryFailure();
+                        if (batchCursor is not null && nextBatch.Batch is not null)
+                        {
+                            batchCursor.RecordDeliveryFailure(nextBatch.Batch);
+                        }
+                        else
+                        {
+                            consumerData.Cursor?.RecordDeliveryFailure();
+                        }
+
                         LogErrorDeliveringMessages(consumerData.StreamId, exc);
 
                         exceptionOccured = exc is ClientNotAvailableException

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCacheCursorBatchDelivery.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCacheCursorBatchDelivery.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Orleans.Streams;
+
+internal interface IQueueCacheCursorBatchDelivery
+{
+    IDisposable ProtectDeliveryBatch();
+
+    void RecordDeliveryFailure(IBatchContainer batch);
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -223,7 +223,106 @@ namespace UnitTests.StreamingTests
             Assert.Empty(await testAccessor.GetPubSubCache());
         }
 
-        private static PersistentStreamPullingAgent CreateAgent(IStreamPubSub? pubSub, QueueId queueId, IQueueAdapterReceiver? receiver = null, IQueueAdapterCache? queueAdapterCache = null, TimeProvider? timeProvider = null)
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task ReadFromQueue_DoesNotAcknowledgeBatchedMessagesDuringConsumerDelivery()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var firstToken = new EventSequenceTokenV2(1);
+            var secondToken = new EventSequenceTokenV2(2);
+            var messages = new List<IBatchContainer>
+            {
+                new TestBatchContainer(streamId, firstToken),
+                new TestBatchContainer(streamId, secondToken),
+            };
+
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(
+                    Task.FromResult<IList<IBatchContainer>>(messages),
+                    Task.FromResult<IList<IBatchContainer>>([]),
+                    Task.FromResult<IList<IBatchContainer>>([]));
+            receiver.MessagesDeliveredAsync(Arg.Any<IList<IBatchContainer>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.CompletedTask);
+
+            var queueCache = new SimpleQueueCache(cacheSize: 10, NullLogger.Instance);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var options = new StreamPullingAgentOptions { BatchContainerBatchSize = 2 };
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache, options: options);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await testAccessor.RegisterStream(qualifiedStreamId, firstToken, DateTime.UtcNow);
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            var firstConsumer = new RecordingConsumer();
+            var firstConsumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                qualifiedStreamId,
+                firstConsumer,
+                filterData: null,
+                now: DateTime.UtcNow);
+            firstConsumerData.IsRegistered = true;
+            firstConsumerData.Cursor = queueCache.GetCacheCursor(streamId, firstToken);
+            var secondConsumer = new RecordingConsumer();
+            var secondConsumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                qualifiedStreamId,
+                secondConsumer,
+                filterData: null,
+                now: DateTime.UtcNow);
+            secondConsumerData.IsRegistered = true;
+            secondConsumerData.Cursor = queueCache.GetCacheCursor(streamId, firstToken);
+
+            Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 10));
+            await Task.WhenAll(firstConsumer.Delivered.Task, secondConsumer.Delivered.Task).WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.False(await testAccessor.ReadFromQueue(queueId, receiver, 10));
+            await receiver.DidNotReceive().MessagesDeliveredAsync(
+                Arg.Any<IList<IBatchContainer>>(),
+                Arg.Any<CancellationToken>());
+
+            firstConsumer.ReleaseDelivery();
+            await WaitForInactive(firstConsumerData);
+            Assert.False(await testAccessor.ReadFromQueue(queueId, receiver, 10));
+            await receiver.DidNotReceive().MessagesDeliveredAsync(
+                Arg.Any<IList<IBatchContainer>>(),
+                Arg.Any<CancellationToken>());
+
+            secondConsumer.ReleaseDelivery();
+            await WaitForInactive(secondConsumerData);
+            Assert.False(await testAccessor.ReadFromQueue(queueId, receiver, 10));
+            await receiver.Received(1).MessagesDeliveredAsync(
+                Arg.Is<IList<IBatchContainer>>(items => items.Count == messages.Count),
+                Arg.Any<CancellationToken>());
+
+            static async Task WaitForInactive(StreamConsumerData consumerData)
+            {
+                var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+                while (consumerData.State != StreamConsumerDataState.Inactive && DateTime.UtcNow < timeout)
+                {
+                    await Task.Delay(10);
+                }
+
+                Assert.Equal(StreamConsumerDataState.Inactive, consumerData.State);
+            }
+        }
+
+        private static PersistentStreamPullingAgent CreateAgent(
+            IStreamPubSub? pubSub,
+            QueueId queueId,
+            IQueueAdapterReceiver? receiver = null,
+            IQueueAdapterCache? queueAdapterCache = null,
+            TimeProvider? timeProvider = null,
+            StreamPullingAgentOptions? options = null)
         {
             var siloAddress = SiloAddress.New(IPAddress.Loopback, 11111, 1);
             var localSiloDetails = Substitute.For<ILocalSiloDetails>();
@@ -262,7 +361,7 @@ namespace UnitTests.StreamingTests
                 pubSub!,
                 new NoOpStreamFilter(),
                 queueId,
-                new StreamPullingAgentOptions(),
+                options ?? new StreamPullingAgentOptions(),
                 queueAdapter,
                 queueAdapterCache!,
                 new NoOpStreamDeliveryFailureHandler(),


### PR DESCRIPTION
Fixes #903.

`BatchContainerBatchSize > 1` advances each consumer cursor across every included queue message before awaiting the combined delivery. With `SimpleQueueCache`, that can leave the oldest bucket without a cursor while delivery is still in flight, allowing `MessagesDeliveredAsync` to acknowledge and delete those messages prematurely.

Keep the earliest cache bucket pinned for the lifetime of each combined consumer delivery. The last consumer completion releases the final pin, allowing purge and acknowledgement. Failed combined deliveries mark every contained cache item so each remains eligible for redelivery.

The regression uses two consumers blocked inside combined delivery and proves acknowledgement occurs only after both complete.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10655)