### PR TITLE
docs: publish machine-readable Markdown

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -27,6 +27,12 @@ npm run build
 npm run preview
 ```
 
+The production build publishes `/llms.txt`, `/llms-small.txt`, and
+`/llms-full.txt`. Each documentation page also has a rendered Markdown companion
+at the page URL with a `.md` suffix. These companions use the same prepared
+content collection entries as Starlight, so includes, code directives, xrefs,
+and DocFX transformations have already been applied.
+
 Run the focused conversion tests, Astro type checks, strict snippet expansion,
 source-quality and aggregate project policy audits, Starlight link validation,
 Pagefind indexing, and production build with:

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -2,9 +2,11 @@ import { unified } from '@astrojs/markdown-remark';
 import starlight from '@astrojs/starlight';
 import { defineConfig } from 'astro/config';
 import remarkDirective from 'remark-directive';
+import starlightDotMd from 'starlight-dot-md';
 import starlightLinksValidator from 'starlight-links-validator';
 import starlightLlmsTxt from 'starlight-llms-txt';
 import { createSidebar } from './scripts/lib/docfx.mjs';
+import { cleanMarkdownOutput } from './src/plugins/clean-markdown-output.mjs';
 import { remarkMermaid } from './src/plugins/remark-mermaid.mjs';
 import { remarkVersionZones } from './src/plugins/remark-version-zones.mjs';
 
@@ -58,9 +60,13 @@ export default defineConfig({
           errorOnRelativeLinks: false,
           exclude: ['/orleans/docs/api/csharp/**'],
         }),
+        starlightDotMd({
+          includePatterns: ['docs', 'docs/**'],
+        }),
         starlightLlmsTxt(),
       ],
     }),
+    cleanMarkdownOutput(),
   ],
   markdown: {
     processor: unified({

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -19,8 +19,10 @@
         "parse5": "7.3.0",
         "remark-directive": "4.0.0",
         "sharp": "0.35.3",
+        "starlight-dot-md": "0.2.1",
         "starlight-links-validator": "0.25.2",
         "starlight-llms-txt": "0.11.0",
+        "tidymd": "0.1.0",
         "yaml": "2.9.0"
       },
       "devDependencies": {
@@ -8265,6 +8267,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/starlight-dot-md": {
+      "version": "0.2.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/starlight-dot-md/-/starlight-dot-md-0.2.1.tgz",
+      "integrity": "sha1-WXm4mdzejLrqYfG49O1gYz/21IQ=",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "4.0.4",
+        "yaml": "2.8.3"
+      },
+      "peerDependencies": {
+        "astro": ">=5.0.0"
+      }
+    },
+    "node_modules/starlight-dot-md/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha1-/W9eAKFDCG4HTf/kySS4+yk7BYk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/starlight-dot-md/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha1-oNa9Lvs90DxZNwIjcBg05gQJvX0=",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/starlight-links-validator": {
       "version": "0.25.2",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/starlight-links-validator/-/starlight-links-validator-0.25.2.tgz",
@@ -8462,6 +8504,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tidymd": {
+      "version": "0.1.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tidymd/-/tidymd-0.1.0.tgz",
+      "integrity": "sha1-2mB1zCHSVk2cn//gdtPafFLf3D4=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/dlcastillop"
       }
     },
     "node_modules/tiny-inflate": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -34,8 +34,10 @@
     "parse5": "7.3.0",
     "remark-directive": "4.0.0",
     "sharp": "0.35.3",
+    "starlight-dot-md": "0.2.1",
     "starlight-links-validator": "0.25.2",
     "starlight-llms-txt": "0.11.0",
+    "tidymd": "0.1.0",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/docs/site/scripts/audit-output.mjs
+++ b/docs/site/scripts/audit-output.mjs
@@ -37,6 +37,13 @@ const totalBytes = (await Promise.all(files.map(async (file) => (await stat(file
   (total, size) => total + size,
   0,
 );
+
+for (const requiredFile of ['llms.txt', 'llms-small.txt', 'llms-full.txt']) {
+  if (!files.includes(path.join(distRoot, requiredFile))) {
+    failures.push(`Missing generated ${requiredFile}.`);
+  }
+}
+
 if (totalBytes > maxPublishedBytes) {
   failures.push(`Published site is ${(totalBytes / 1024 / 1024).toFixed(1)} MiB; limit is 1024 MiB.`);
 }
@@ -86,6 +93,35 @@ for (const file of apiMarkdown) {
   }
   if (/^# .*\.op_[A-Za-z]/m.test(markdown)) {
     fail(file, 'CLR operator metadata name leaked into heading');
+  }
+}
+
+const renderedMarkdown = files.filter(
+  (file) =>
+    file.endsWith('.md') &&
+    !relative(file).startsWith('docs/api/csharp/') &&
+    path.basename(file) !== 'index.md',
+);
+if (renderedMarkdown.length === 0) {
+  failures.push('No rendered Markdown pages were generated.');
+}
+for (const file of renderedMarkdown) {
+  const markdown = await readFile(file, 'utf8');
+  if (!/^# .+/m.test(markdown)) {
+    fail(file, 'rendered Markdown has no H1');
+  }
+  for (const [pattern, description] of [
+    [/\[!INCLUDE\b/i, 'unconverted INCLUDE directive'],
+    [/:::\s*code\b/i, 'unconverted code directive'],
+    [/<xref:|\(xref:/i, 'unconverted xref'],
+    [/^\s*import\s+.+\s+from\s+['"]/m, 'MDX import'],
+    [/<\/?(?:Aside|Card|CardGrid|Steps|TabItem|Tabs)\b/, 'Starlight MDX component'],
+    [/\{\/\*/, 'MDX comment'],
+    [/<!doctype html>|<html\b/i, 'HTML document emitted as Markdown'],
+  ]) {
+    if (pattern.test(markdown)) {
+      fail(file, description);
+    }
   }
 }
 

--- a/docs/site/scripts/audit-output.mjs
+++ b/docs/site/scripts/audit-output.mjs
@@ -83,9 +83,12 @@ for (const file of files.filter((candidate) => candidate.endsWith('.html'))) {
   }
 }
 
-const apiMarkdown = files.filter(
-  (file) => file.endsWith('.md') && relative(file).startsWith('docs/api/csharp/'),
-);
+function isApiMarkdown(file) {
+  const filePath = relative(file);
+  return filePath === 'docs/api/csharp.md' || filePath.startsWith('docs/api/csharp/');
+}
+
+const apiMarkdown = files.filter((file) => file.endsWith('.md') && isApiMarkdown(file));
 for (const file of apiMarkdown) {
   const markdown = await readFile(file, 'utf8');
   if (/\bconst\s+static\b/.test(markdown)) {
@@ -98,9 +101,7 @@ for (const file of apiMarkdown) {
 
 const renderedMarkdown = files.filter(
   (file) =>
-    file.endsWith('.md') &&
-    !relative(file).startsWith('docs/api/csharp/') &&
-    path.basename(file) !== 'index.md',
+    file.endsWith('.md') && !isApiMarkdown(file) && path.basename(file) !== 'index.md',
 );
 if (renderedMarkdown.length === 0) {
   failures.push('No rendered Markdown pages were generated.');

--- a/docs/site/src/plugins/clean-markdown-output.mjs
+++ b/docs/site/src/plugins/clean-markdown-output.mjs
@@ -1,0 +1,68 @@
+import { access, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cleanStarlightMarkdown } from 'tidymd';
+
+const mdxComment = /\{\/\*[\s\S]*?\*\/\}\s*/g;
+
+async function pathExists(candidate) {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectMarkdown(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== 'api') {
+        files.push(...(await collectMarkdown(entryPath)));
+      }
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+export function cleanPublishedMarkdown(source) {
+  return cleanStarlightMarkdown(source, {
+    frontmatter: 'title-as-heading',
+    internalLinks: { mode: 'preserve' },
+  }).replace(mdxComment, '');
+}
+
+export async function cleanMarkdownOutputDirectory(outputRoot) {
+  const root = path.resolve(outputRoot);
+  const docsRoot = path.join(root, 'docs');
+  const files = (await pathExists(docsRoot)) ? await collectMarkdown(docsRoot) : [];
+  const docsIndex = path.join(root, 'docs.md');
+  if (await pathExists(docsIndex)) {
+    files.push(docsIndex);
+  }
+
+  await Promise.all(
+    files.map(async (file) => {
+      const source = await readFile(file, 'utf8');
+      await writeFile(file, cleanPublishedMarkdown(source), 'utf8');
+    }),
+  );
+
+  return files.length;
+}
+
+export function cleanMarkdownOutput() {
+  return {
+    name: 'orleans-clean-markdown-output',
+    hooks: {
+      'astro:build:done': async ({ dir, logger }) => {
+        const count = await cleanMarkdownOutputDirectory(fileURLToPath(dir));
+        logger.info(`Cleaned ${count} rendered Markdown page${count === 1 ? '' : 's'}.`);
+      },
+    },
+  };
+}

--- a/docs/site/tests/clean-markdown-output.test.mjs
+++ b/docs/site/tests/clean-markdown-output.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, test } from 'vitest';
+import {
+  cleanMarkdownOutputDirectory,
+  cleanPublishedMarkdown,
+} from '../src/plugins/clean-markdown-output.mjs';
+
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+  );
+});
+
+describe('published Markdown cleaning', () => {
+  test('converts prepared Starlight content to plain Markdown', () => {
+    const source = `---
+title: Orleans clients
+description: Choose and host an Orleans client.
+---
+
+{/* Source: snippets/HostingExamples.cs; region: local_silo_and_client */}
+\`\`\`csharp
+builder.UseOrleans();
+\`\`\`
+`;
+
+    const markdown = cleanPublishedMarkdown(source);
+
+    assert.match(markdown, /^# Orleans clients/m);
+    assert.match(markdown, /builder\.UseOrleans\(\);/);
+    assert.doesNotMatch(markdown, /^---$/m);
+    assert.doesNotMatch(markdown, /\{\/\*/);
+  });
+
+  test('cleans documentation routes without changing API Markdown', async () => {
+    const outputRoot = await mkdtemp(path.join(os.tmpdir(), 'orleans-docs-markdown-'));
+    temporaryDirectories.push(outputRoot);
+    const conceptual = path.join(outputRoot, 'docs', 'host', 'client.md');
+    const api = path.join(outputRoot, 'docs', 'api', 'csharp.md');
+    await mkdir(path.dirname(conceptual), { recursive: true });
+    await mkdir(path.dirname(api), { recursive: true });
+    await writeFile(conceptual, '---\ntitle: Orleans clients\n---\n\nContent\n');
+    await writeFile(api, '# API\n');
+
+    assert.equal(await cleanMarkdownOutputDirectory(outputRoot), 1);
+    assert.equal(await readFile(conceptual, 'utf8'), '# Orleans clients\n\nContent');
+    assert.equal(await readFile(api, 'utf8'), '# API\n');
+  });
+});

--- a/docs/site/tests/clean-markdown-output.test.mjs
+++ b/docs/site/tests/clean-markdown-output.test.mjs
@@ -12,7 +12,7 @@ const temporaryDirectories = [];
 
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
   );
 });
 


### PR DESCRIPTION
## Problem

The documentation site exposes aggregate `llms.txt` corpora, but GitHub Pages cannot negotiate `text/markdown` responses for individual pages. Agents need stable, page-level Markdown URLs with resolved Orleans documentation syntax.

## Solution

- publish every documentation page at the equivalent `.md` URL using `starlight-dot-md`
- clean generated Starlight content with `tidymd` so titles, snippets, includes, xrefs, and MDX components become machine-readable Markdown
- audit the generated `llms*.txt` files and page-level Markdown for missing headings or unresolved directives

## Rationale

The generated Markdown reuses the existing DocFX-to-Starlight preparation pipeline instead of introducing a second renderer, keeping HTML and Markdown output aligned.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10656)