### PR TITLE
feat(streaming): support stateless worker consumers

### DIFF
--- a/docs/site/src/content/docs/streaming/delivery-semantics.md
+++ b/docs/site/src/content/docs/streaming/delivery-semantics.md
@@ -1,7 +1,7 @@
 ---
 title: Stream delivery, ordering, replay, and recovery
 description: Design Orleans streaming consumers for provider-specific delivery, ordering, replay, and failure behavior.
-ms.date: 08/02/2026
+ms.date: 08/18/2026
 ms.topic: concept-article
 ---
 
@@ -39,6 +39,7 @@ Treat ordering as scoped, not global:
 - Physical partitions and queues order independently.
 - Retries, visibility timeouts, consumer failures, and rebalancing can reorder delivery.
 - A grain processes its own turns serially unless its concurrency configuration says otherwise, but that doesn't impose a total order across grains or subscriptions.
+- A stateless worker stream subscription assigns each delivery attempt to one selected activation. Concurrent deliveries and retries can run on different activations, so completion order across the worker pool is unspecified.
 
 Use event version numbers or domain sequence numbers when business logic requires ordering. A <xref:Orleans.Streams.StreamSequenceToken> represents provider position; it isn't a universal business sequence and not every provider accepts application-supplied tokens.
 

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -103,11 +103,11 @@ Clients can produce and explicitly consume streams after the provider is configu
 
 ## Stateless worker grains
 
-Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish and consume streams. A stateless worker stream consumer implements <xref:Orleans.Streams.Core.IStreamSubscriptionObserver>. Orleans installs a separate stream consumer extension on every activation and calls `OnSubscribed` when a selected activation first receives a delivery for a subscription. The grain calls `ResumeAsync` from that callback to attach the activation's observer.
+Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish and consume streams. A stateless worker stream consumer implements <xref:Orleans.Streams.Core.IStreamSubscriptionObserver>. Orleans installs a separate stream consumer extension on every activation. A delivery uses the activation's existing observer for its subscription. When no observer is attached, Orleans calls `OnSubscribed`, and the grain calls `ResumeAsync` from that callback to attach one.
 
 The subscription belongs to the stateless worker grain identity. For persistent streams, each pulling agent delivers through that identity from its silo, and normal stateless-worker placement selects one local activation for each delivery attempt. Concurrent pulling agents can therefore process items on different activations and silos. Each delivery attempt runs on one activation, providing competing-consumer execution for stateless transformations such as decoding, validation, enrichment, filtering, and forwarding.
 
-Implicit subscriptions establish the grain-level subscription from grain metadata. Explicit `SubscribeAsync` calls establish the grain-level subscription at runtime; later activations attach their local observers through `OnSubscribed`, and `UnsubscribeAsync` removes that grain-level subscription.
+Implicit subscriptions establish the grain-level subscription from grain metadata. Explicit `SubscribeAsync` calls establish the grain-level subscription at runtime and attach the calling activation's observer. A later activation attaches its local observer through `OnSubscribed` when a delivery first reaches it, and `UnsubscribeAsync` removes the grain-level subscription.
 
 Ordering is scoped to the selected activation and provider delivery path. Concurrent deliveries can complete in any order across activations. A provider retry can select a different activation, so handlers use stateless or idempotent processing and follow the provider's delivery guarantee. A stateless worker which subscribes without implementing <xref:Orleans.Streams.Core.IStreamSubscriptionObserver> receives an <xref:System.InvalidOperationException>.
 

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -103,11 +103,15 @@ Clients can produce and explicitly consume streams after the provider is configu
 
 ## Stateless worker grains
 
-Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish stream events. Orleans rejects stateless worker grain subscription attempts with an <xref:System.InvalidOperationException> because a stream consumer uses a grain extension which must bind to one activation, while a stateless worker grain identity can have multiple, replaceable activations.
+Grains marked with <xref:Orleans.Concurrency.StatelessWorkerAttribute> can publish and consume streams. A stateless worker stream consumer implements <xref:Orleans.Streams.Core.IStreamSubscriptionObserver>. Orleans installs a separate stream consumer extension on every activation and calls `OnSubscribed` when a selected activation first receives a delivery for a subscription. The grain calls `ResumeAsync` from that callback to attach the activation's observer.
 
-Use a regular grain as the stream consumer so that the stream-to-grain binding has a stable virtual identity which can own state and the subscription lifecycle. If processing after delivery is stateless and parallelizable, have that grain call stateless worker grains and await the required work before its consumer task completes. This keeps stream acknowledgment and recovery at the regular grain boundary instead of treating a multicast subscription as a competing-consumer work queue.
+The subscription belongs to the stateless worker grain identity. For persistent streams, each pulling agent delivers through that identity from its silo, and normal stateless-worker placement selects one local activation for each delivery attempt. Concurrent pulling agents can therefore process items on different activations and silos. Each delivery attempt runs on one activation, providing competing-consumer execution for stateless transformations such as decoding, validation, enrichment, filtering, and forwarding.
 
-Support for subscribing directly from stateless worker grains is tracked by [dotnet/orleans#433](https://github.com/dotnet/orleans/issues/433).
+Implicit subscriptions establish the grain-level subscription from grain metadata. Explicit `SubscribeAsync` calls establish the grain-level subscription at runtime; later activations attach their local observers through `OnSubscribed`, and `UnsubscribeAsync` removes that grain-level subscription.
+
+Ordering is scoped to the selected activation and provider delivery path. Concurrent deliveries can complete in any order across activations. A provider retry can select a different activation, so handlers use stateless or idempotent processing and follow the provider's delivery guarantee. A stateless worker which subscribes without implementing <xref:Orleans.Streams.Core.IStreamSubscriptionObserver> receives an <xref:System.InvalidOperationException>.
+
+Stateless worker observers attach with a null sequence token. The pulling agent owns progress for the live subscription as deliveries move between activations. Passing a non-null sequence token to `SubscribeAsync` or `ResumeAsync` produces an <xref:System.InvalidOperationException>. Use a regular grain consumer when application-managed rewind or checkpoint resume is required.
 
 <a id="stream-order-and-sequence-tokens"></a>
 <a id="rewindable-streams"></a>

--- a/src/Orleans.Streaming/Core/IStreamSubscriptionObserver.cs
+++ b/src/Orleans.Streaming/Core/IStreamSubscriptionObserver.cs
@@ -4,6 +4,7 @@ namespace Orleans.Streams.Core
 {
     /// <summary>
     /// When implemented by a grain, notifies the grain of any new or resuming subscriptions.
+    /// Stateless worker grains receive this notification on each activation so that every activation can attach its own observer.
     /// </summary>
     public interface IStreamSubscriptionObserver
     {

--- a/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
@@ -44,7 +44,11 @@ namespace Orleans.Hosting
             {
                 var runtime = sp.GetRequiredService<IStreamProviderRuntime>();
                 var grainContextAccessor = sp.GetRequiredService<IGrainContextAccessor>();
-                return new StreamConsumerExtension(runtime, grainContextAccessor.GrainContext?.GrainInstance as IStreamSubscriptionObserver);
+                var grainContext = grainContextAccessor.GrainContext;
+                return new StreamConsumerExtension(
+                    runtime,
+                    grainContext?.GrainInstance as IStreamSubscriptionObserver,
+                    grainContext is ActivationData { IsStatelessWorker: true });
             });
             services.AddSingleton<IStreamSubscriptionManagerAdmin>(sp =>
                 new StreamSubscriptionManagerAdmin(sp.GetRequiredService<IStreamProviderRuntime>()));

--- a/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
@@ -43,12 +43,8 @@ namespace Orleans.Hosting
             services.AddKeyedTransient<IGrainExtension>(typeof(IStreamConsumerExtension), (sp, _) =>
             {
                 var runtime = sp.GetRequiredService<IStreamProviderRuntime>();
-                var grainContextAccessor = sp.GetRequiredService<IGrainContextAccessor>();
-                var grainContext = grainContextAccessor.GrainContext;
-                return new StreamConsumerExtension(
-                    runtime,
-                    grainContext?.GrainInstance as IStreamSubscriptionObserver,
-                    grainContext is ActivationData { IsStatelessWorker: true });
+                var grainContext = sp.GetRequiredService<IGrainContextAccessor>().GrainContext;
+                return new StreamConsumerExtension(runtime, grainContext);
             });
             services.AddSingleton<IStreamSubscriptionManagerAdmin>(sp =>
                 new StreamSubscriptionManagerAdmin(sp.GetRequiredService<IStreamProviderRuntime>()));

--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Streams.Core;
@@ -242,7 +243,10 @@ namespace Orleans.Streams
                     if (myExtension == null)
                     {
                         LogDebugBindExtensionLazy(providerRuntime);
-                        (myExtension, myGrainReference) = providerRuntime.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(() => new StreamConsumerExtension(providerRuntime));
+                        (myExtension, myGrainReference) = providerRuntime.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(
+                            () => new StreamConsumerExtension(
+                                providerRuntime,
+                                providerRuntime.ServiceProvider.GetRequiredService<IGrainContextAccessor>().GrainContext));
                         LogDebugBindExtension(myExtension, myGrainReference);
                     }
                 }

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -44,13 +44,10 @@ namespace Orleans.Streams
         [NonSerialized]
         private readonly bool isStatelessWorker;
 
-        internal StreamConsumerExtension(
-            IStreamProviderRuntime providerRt,
-            IStreamSubscriptionObserver? streamSubscriptionObserver = null,
-            bool isStatelessWorker = false)
+        internal StreamConsumerExtension(IStreamProviderRuntime providerRt, IGrainContext? grainContext = null)
         {
-            this.streamSubscriptionObserver = streamSubscriptionObserver;
-            this.isStatelessWorker = isStatelessWorker;
+            streamSubscriptionObserver = grainContext?.GrainInstance as IStreamSubscriptionObserver;
+            isStatelessWorker = grainContext is ActivationData { IsStatelessWorker: true };
             providerRuntime = providerRt;
             logger = providerRt.ServiceProvider.GetRequiredService<ILogger<StreamConsumerExtension>>();
         }

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -37,17 +37,17 @@ namespace Orleans.Streams
         [Id(2)]
         private readonly ILogger logger;
         private const int MAXIMUM_ITEM_STRING_LOG_LENGTH = 128;
-        // if this extension is attached to a cosnumer grain which implements IOnSubscriptionActioner,
-        // then this will be not null, otherwise, it will be null
         [NonSerialized]
-        private readonly IStreamSubscriptionObserver? streamSubscriptionObserver;
-        [NonSerialized]
-        private readonly bool isStatelessWorker;
+        private readonly IGrainContext? _grainContext;
+
+        private IStreamSubscriptionObserver? StreamSubscriptionObserver =>
+            _grainContext?.GrainInstance as IStreamSubscriptionObserver;
+
+        private bool IsStatelessWorker => _grainContext is ActivationData { IsStatelessWorker: true };
 
         internal StreamConsumerExtension(IStreamProviderRuntime providerRt, IGrainContext? grainContext = null)
         {
-            streamSubscriptionObserver = grainContext?.GrainInstance as IStreamSubscriptionObserver;
-            isStatelessWorker = grainContext is ActivationData { IsStatelessWorker: true };
+            _grainContext = grainContext;
             providerRuntime = providerRt;
             logger = providerRt.ServiceProvider.GetRequiredService<ILogger<StreamConsumerExtension>>();
         }
@@ -61,7 +61,7 @@ namespace Orleans.Streams
             string? filterData)
         {
             if (null == stream) throw new ArgumentNullException(nameof(stream));
-            if (isStatelessWorker && token is not null)
+            if (IsStatelessWorker && token is not null)
             {
                 throw new InvalidOperationException("Stateless worker stream subscriptions use provider-managed live delivery and require a null sequence token.");
             }
@@ -78,7 +78,7 @@ namespace Orleans.Streams
                     stream,
                     token,
                     filterData,
-                    disableHandshake: isStatelessWorker);
+                    disableHandshake: IsStatelessWorker);
                 allStreamObservers[subscriptionId] = handle;
                 return handle;
             }
@@ -106,13 +106,13 @@ namespace Orleans.Streams
             {
                 return await observer.DeliverItem(item, currentToken, handshakeToken);
             }
-            else if(this.streamSubscriptionObserver != null)
+            else if (StreamSubscriptionObserver is { } streamSubscriptionObserver)
             {
                 var streamProvider = this.providerRuntime.ServiceProvider.GetKeyedService<IStreamProvider>(streamId.ProviderName);
-                if(streamProvider != null)
+                if (streamProvider != null)
                 {
                     var subscriptionHandlerFactory = new StreamSubscriptionHandlerFactory(streamProvider, streamId, streamId.ProviderName, subscriptionId);
-                    await this.streamSubscriptionObserver.OnSubscribed(subscriptionHandlerFactory);
+                    await streamSubscriptionObserver.OnSubscribed(subscriptionHandlerFactory);
                     //check if an observer were attached after handling the new subscription, deliver on it if attached
                     if (allStreamObservers.TryGetValue(subscriptionId, out observer))
                     {
@@ -138,13 +138,13 @@ namespace Orleans.Streams
             {
                 return await observer.DeliverBatch(batch, handshakeToken);
             }
-            else if(this.streamSubscriptionObserver != null)
+            else if (StreamSubscriptionObserver is { } streamSubscriptionObserver)
             {
                 var streamProvider = this.providerRuntime.ServiceProvider.GetKeyedService<IStreamProvider>(streamId.ProviderName);
                 if (streamProvider != null)
                 {
                     var subscriptionHandlerFactory = new StreamSubscriptionHandlerFactory(streamProvider, streamId, streamId.ProviderName, subscriptionId);
-                    await this.streamSubscriptionObserver.OnSubscribed(subscriptionHandlerFactory);
+                    await streamSubscriptionObserver.OnSubscribed(subscriptionHandlerFactory);
                     // check if an observer were attached after handling the new subscription, deliver on it if attached
                     if (allStreamObservers.TryGetValue(subscriptionId, out observer))
                     {

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -41,10 +41,16 @@ namespace Orleans.Streams
         // then this will be not null, otherwise, it will be null
         [NonSerialized]
         private readonly IStreamSubscriptionObserver? streamSubscriptionObserver;
+        [NonSerialized]
+        private readonly bool isStatelessWorker;
 
-        internal StreamConsumerExtension(IStreamProviderRuntime providerRt, IStreamSubscriptionObserver? streamSubscriptionObserver = null)
+        internal StreamConsumerExtension(
+            IStreamProviderRuntime providerRt,
+            IStreamSubscriptionObserver? streamSubscriptionObserver = null,
+            bool isStatelessWorker = false)
         {
             this.streamSubscriptionObserver = streamSubscriptionObserver;
+            this.isStatelessWorker = isStatelessWorker;
             providerRuntime = providerRt;
             logger = providerRt.ServiceProvider.GetRequiredService<ILogger<StreamConsumerExtension>>();
         }
@@ -58,13 +64,24 @@ namespace Orleans.Streams
             string? filterData)
         {
             if (null == stream) throw new ArgumentNullException(nameof(stream));
+            if (isStatelessWorker && token is not null)
+            {
+                throw new InvalidOperationException("Stateless worker stream subscriptions use provider-managed live delivery and require a null sequence token.");
+            }
 
             try
             {
                 LogDebugAddObserver(providerRuntime.ExecutingEntityIdentity(), stream.InternalStreamId);
 
                 // Note: The caller [StreamConsumer] already handles locking for Add/Remove operations, so we don't need to repeat here.
-                var handle = new StreamSubscriptionHandleImpl<T>(subscriptionId, observer, batchObserver, stream, token, filterData);
+                var handle = new StreamSubscriptionHandleImpl<T>(
+                    subscriptionId,
+                    observer,
+                    batchObserver,
+                    stream,
+                    token,
+                    filterData,
+                    disableHandshake: isStatelessWorker);
                 allStreamObservers[subscriptionId] = handle;
                 return handle;
             }

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -23,6 +23,8 @@ namespace Orleans.Streams
         private readonly GuidId subscriptionId;
         [Id(3)]
         private readonly bool isRewindable;
+        [Id(4)]
+        private readonly bool disableHandshake;
 
         [NonSerialized]
         private IAsyncObserver<T>? observer;
@@ -56,7 +58,8 @@ namespace Orleans.Streams
             IAsyncBatchObserver<T>? batchObserver,
             StreamImpl<T> streamImpl,
             StreamSequenceToken? token,
-            string? filterData)
+            string? filterData,
+            bool disableHandshake = false)
         {
             this.subscriptionId = subscriptionId ?? throw new ArgumentNullException(nameof(subscriptionId));
             this.observer = observer;
@@ -64,7 +67,8 @@ namespace Orleans.Streams
             this.streamImpl = streamImpl ?? throw new ArgumentNullException(nameof(streamImpl));
             this.filterData = filterData;
             this.isRewindable = streamImpl.IsRewindable;
-            if (IsRewindable)
+            this.disableHandshake = disableHandshake;
+            if (IsRewindable && !disableHandshake)
             {
                 expectedToken = StreamHandshakeToken.CreateStartToken(token);
             }
@@ -79,7 +83,7 @@ namespace Orleans.Streams
 
         public StreamHandshakeToken? GetSequenceToken()
         {
-            return this.expectedToken;
+            return disableHandshake ? null : expectedToken;
         }
 
         public override Task UnsubscribeAsync()
@@ -146,7 +150,7 @@ namespace Orleans.Streams
                 }
             }
 
-            if (IsRewindable)
+            if (IsRewindable && !disableHandshake)
             {
                 this.expectedToken = StreamHandshakeToken.CreateDeliveyToken(batch.SequenceToken);
             }
@@ -203,7 +207,7 @@ namespace Orleans.Streams
                 if (!this.expectedToken.Equals(handshakeToken))
                     return this.expectedToken;
             }
-            if (IsRewindable)
+            if (IsRewindable && !disableHandshake)
             {
                 this.expectedToken = StreamHandshakeToken.CreateDeliveyToken(currentToken);
             }

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -23,8 +23,6 @@ namespace Orleans.Streams
         private readonly GuidId subscriptionId;
         [Id(3)]
         private readonly bool isRewindable;
-        [Id(4)]
-        private readonly bool disableHandshake;
 
         [NonSerialized]
         private IAsyncObserver<T>? observer;
@@ -66,9 +64,8 @@ namespace Orleans.Streams
             this.batchObserver = batchObserver;
             this.streamImpl = streamImpl ?? throw new ArgumentNullException(nameof(streamImpl));
             this.filterData = filterData;
-            this.isRewindable = streamImpl.IsRewindable;
-            this.disableHandshake = disableHandshake;
-            if (IsRewindable && !disableHandshake)
+            this.isRewindable = streamImpl.IsRewindable && !disableHandshake;
+            if (IsRewindable)
             {
                 expectedToken = StreamHandshakeToken.CreateStartToken(token);
             }
@@ -83,7 +80,7 @@ namespace Orleans.Streams
 
         public StreamHandshakeToken? GetSequenceToken()
         {
-            return disableHandshake ? null : expectedToken;
+            return expectedToken;
         }
 
         public override Task UnsubscribeAsync()
@@ -150,7 +147,7 @@ namespace Orleans.Streams
                 }
             }
 
-            if (IsRewindable && !disableHandshake)
+            if (IsRewindable)
             {
                 this.expectedToken = StreamHandshakeToken.CreateDeliveyToken(batch.SequenceToken);
             }
@@ -207,7 +204,7 @@ namespace Orleans.Streams
                 if (!this.expectedToken.Equals(handshakeToken))
                     return this.expectedToken;
             }
-            if (IsRewindable && !disableHandshake)
+            if (IsRewindable)
             {
                 this.expectedToken = StreamHandshakeToken.CreateDeliveyToken(currentToken);
             }

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -156,14 +156,14 @@ namespace Orleans.Runtime.Providers
             {
                 if (typeof(TExtension) != typeof(StreamConsumerExtension)
                     || typeof(TExtensionInterface) != typeof(IStreamConsumerExtension)
-                    || activationData.GrainInstance is not IStreamSubscriptionObserver observer)
+                    || activationData.GrainInstance is not IStreamSubscriptionObserver)
                 {
                     throw new InvalidOperationException(
                         $"The extension {typeof(TExtension)} cannot be bound to stateless worker grain '{activationData.GrainId}'. "
                         + $"Stateless worker stream consumers must implement {typeof(IStreamSubscriptionObserver).FullName}.");
                 }
 
-                extensionFactory = () => (TExtension)(object)new StreamConsumerExtension(this, observer, isStatelessWorker: true);
+                extensionFactory = () => (TExtension)(object)new StreamConsumerExtension(this, grainContext);
             }
 
             return grainContext.GetComponent<IGrainExtensionBinder>()! // Grain contexts expose an extension binder.

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -151,7 +151,6 @@ namespace Orleans.Runtime.Providers
             where TExtensionInterface : class, IGrainExtension
         {
             var grainContext = this.grainContextAccessor.GrainContext;
-            var extensionFactory = newExtensionFunc;
             if (grainContext is ActivationData { IsStatelessWorker: true } activationData)
             {
                 if (typeof(TExtension) != typeof(StreamConsumerExtension)
@@ -162,12 +161,10 @@ namespace Orleans.Runtime.Providers
                         $"The extension {typeof(TExtension)} cannot be bound to stateless worker grain '{activationData.GrainId}'. "
                         + $"Stateless worker stream consumers must implement {typeof(IStreamSubscriptionObserver).FullName}.");
                 }
-
-                extensionFactory = () => (TExtension)(object)new StreamConsumerExtension(this, grainContext);
             }
 
             return grainContext.GetComponent<IGrainExtensionBinder>()! // Grain contexts expose an extension binder.
-                .GetOrSetExtension<TExtension, TExtensionInterface>(extensionFactory);
+                .GetOrSetExtension<TExtension, TExtensionInterface>(newExtensionFunc);
         }
 
         [LoggerMessage(

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Streams.Filtering;
+using Orleans.Streams.Core;
 using Orleans.Internal;
 
 namespace Orleans.Runtime.Providers
@@ -149,13 +150,24 @@ namespace Orleans.Runtime.Providers
             where TExtension : class, TExtensionInterface
             where TExtensionInterface : class, IGrainExtension
         {
-            if (this.grainContextAccessor.GrainContext is ActivationData activationData && activationData.IsStatelessWorker)
+            var grainContext = this.grainContextAccessor.GrainContext;
+            var extensionFactory = newExtensionFunc;
+            if (grainContext is ActivationData { IsStatelessWorker: true } activationData)
             {
-                throw new InvalidOperationException($"The extension { typeof(TExtension) } cannot be bound to a Stateless Worker.");
+                if (typeof(TExtension) != typeof(StreamConsumerExtension)
+                    || typeof(TExtensionInterface) != typeof(IStreamConsumerExtension)
+                    || activationData.GrainInstance is not IStreamSubscriptionObserver observer)
+                {
+                    throw new InvalidOperationException(
+                        $"The extension {typeof(TExtension)} cannot be bound to stateless worker grain '{activationData.GrainId}'. "
+                        + $"Stateless worker stream consumers must implement {typeof(IStreamSubscriptionObserver).FullName}.");
+                }
+
+                extensionFactory = () => (TExtension)(object)new StreamConsumerExtension(this, observer, isStatelessWorker: true);
             }
 
-            return this.grainContextAccessor.GrainContext.GetComponent<IGrainExtensionBinder>()! // Grain contexts expose an extension binder.
-                .GetOrSetExtension<TExtension, TExtensionInterface>(newExtensionFunc);
+            return grainContext.GetComponent<IGrainExtensionBinder>()! // Grain contexts expose an extension binder.
+                .GetOrSetExtension<TExtension, TExtensionInterface>(extensionFactory);
         }
 
         [LoggerMessage(

--- a/src/Orleans.Streaming/StreamConsumerGrainContextAction.cs
+++ b/src/Orleans.Streaming/StreamConsumerGrainContextAction.cs
@@ -24,13 +24,16 @@ namespace Orleans.Streams
         {
             if (context.GrainInstance is IStreamSubscriptionObserver observer)
             {
-                InstallStreamConsumerExtension(context, observer as IStreamSubscriptionObserver);
+                InstallStreamConsumerExtension(context, observer);
             }
         }
 
         private void InstallStreamConsumerExtension(IGrainContext context, IStreamSubscriptionObserver observer)
         {
-            _streamProviderRuntime.BindExtension<StreamConsumerExtension, IStreamConsumerExtension>(() => new StreamConsumerExtension(_streamProviderRuntime, observer));
+            var isStatelessWorker = context is ActivationData { IsStatelessWorker: true };
+            context.GetComponent<IGrainExtensionBinder>()! // Grain contexts expose an extension binder.
+                .GetOrSetExtension<StreamConsumerExtension, IStreamConsumerExtension>(
+                    () => new StreamConsumerExtension(_streamProviderRuntime, observer, isStatelessWorker));
         }
     }
 }

--- a/src/Orleans.Streaming/StreamConsumerGrainContextAction.cs
+++ b/src/Orleans.Streaming/StreamConsumerGrainContextAction.cs
@@ -22,18 +22,12 @@ namespace Orleans.Streams
         /// <inheritdoc/>
         public void Configure(IGrainContext context)
         {
-            if (context.GrainInstance is IStreamSubscriptionObserver observer)
+            if (context.GrainInstance is IStreamSubscriptionObserver)
             {
-                InstallStreamConsumerExtension(context, observer);
+                context.GetComponent<IGrainExtensionBinder>()! // Grain contexts expose an extension binder.
+                    .GetOrSetExtension<StreamConsumerExtension, IStreamConsumerExtension>(
+                        () => new StreamConsumerExtension(_streamProviderRuntime, context));
             }
-        }
-
-        private void InstallStreamConsumerExtension(IGrainContext context, IStreamSubscriptionObserver observer)
-        {
-            var isStatelessWorker = context is ActivationData { IsStatelessWorker: true };
-            context.GetComponent<IGrainExtensionBinder>()! // Grain contexts expose an extension binder.
-                .GetOrSetExtension<StreamConsumerExtension, IStreamConsumerExtension>(
-                    () => new StreamConsumerExtension(_streamProviderRuntime, observer, isStatelessWorker));
         }
     }
 }

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerStreamConsumerGrain.cs
@@ -11,7 +11,6 @@ namespace UnitTests.GrainInterfaces
 
     public interface IImplicitStatelessWorkerStreamConsumerGrain : IGrainWithGuidKey
     {
-        Task Ping();
     }
 
     public interface IUnsupportedStatelessWorkerStreamConsumerGrain : IGrainWithIntegerKey

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerStreamConsumerGrain.cs
@@ -2,6 +2,20 @@ namespace UnitTests.GrainInterfaces
 {
     public interface IStatelessWorkerStreamConsumerGrain : IGrainWithIntegerKey
     {
+        Task BecomeConsumer(Guid[] streamIds, string providerToUse);
+
+        Task BecomeConsumerFromToken(Guid streamId, string providerToUse);
+
+        Task<int> StopConsuming(Guid streamId, string providerToUse);
+    }
+
+    public interface IImplicitStatelessWorkerStreamConsumerGrain : IGrainWithGuidKey
+    {
+        Task Ping();
+    }
+
+    public interface IUnsupportedStatelessWorkerStreamConsumerGrain : IGrainWithIntegerKey
+    {
         Task BecomeConsumer(Guid streamId, string providerToUse);
     }
 }

--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Linq;
 using Orleans.Concurrency;
 using Orleans.Providers.Streams.Common;
 using Orleans.Streams;

--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -18,10 +18,11 @@ namespace UnitTests.Grains
         private TaskCompletionSource _deliveriesReleased = CreateCompletionSource();
         private TaskCompletionSource _deliveryTargetReached = CreateCompletionSource();
         private int _blockDeliveries;
+        private int _deliveryCount;
         private int _expectedDeliveries;
         private int _waitingDeliveryCount;
 
-        public int DeliveryCount => _deliveryCounts.Values.Sum();
+        public int DeliveryCount => Volatile.Read(ref _deliveryCount);
 
         public int DeliveryActivationCount => _deliveryCounts.Count;
 
@@ -42,6 +43,7 @@ namespace UnitTests.Grains
 
             _deliveryCounts.Clear();
             _observerCounts.Clear();
+            Interlocked.Exchange(ref _deliveryCount, 0);
             _expectedDeliveries = expectedDeliveries;
             Volatile.Write(ref _blockDeliveries, blockDeliveries ? 1 : 0);
             _blockedDeliveriesReached = CreateCompletionSource();
@@ -62,7 +64,7 @@ namespace UnitTests.Grains
         internal async Task RecordDelivery(Guid activationId)
         {
             _deliveryCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
-            if (_deliveryCounts.Values.Sum() >= _expectedDeliveries)
+            if (Interlocked.Increment(ref _deliveryCount) >= _expectedDeliveries)
             {
                 _deliveryTargetReached.TrySetResult();
             }

--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
 using Orleans.Providers.Streams.Common;
 using Orleans.Streams;
@@ -14,10 +13,9 @@ namespace UnitTests.Grains
         private readonly ConcurrentDictionary<Guid, int> _deliveryCounts = new();
         private readonly ConcurrentDictionary<Guid, int> _observerCounts = new();
         private readonly SemaphoreSlim _deliverySemaphore = new(0);
-        private TaskCompletionSource _blockedDeliveriesReached = CreateCompletionSource();
         private TaskCompletionSource _deliveriesReleased = CreateCompletionSource();
         private TaskCompletionSource _deliveryTargetReached = CreateCompletionSource();
-        private int _blockDeliveries;
+        private bool _blockDeliveries;
         private int _deliveryCount;
         private int _expectedDeliveries;
         private int _waitingDeliveryCount;
@@ -45,38 +43,35 @@ namespace UnitTests.Grains
             _observerCounts.Clear();
             Interlocked.Exchange(ref _deliveryCount, 0);
             _expectedDeliveries = expectedDeliveries;
-            Volatile.Write(ref _blockDeliveries, blockDeliveries ? 1 : 0);
-            _blockedDeliveriesReached = CreateCompletionSource();
+            Volatile.Write(ref _blockDeliveries, blockDeliveries);
             _deliveriesReleased = CreateCompletionSource();
             _deliveryTargetReached = CreateCompletionSource();
         }
 
         public Task WaitForDeliveriesAsync(TimeSpan timeout) => _deliveryTargetReached.Task.WaitAsync(timeout);
 
-        public Task WaitForBlockedDeliveriesAsync(TimeSpan timeout) => _blockedDeliveriesReached.Task.WaitAsync(timeout);
-
         public Task WaitForReleasedDeliveriesAsync(TimeSpan timeout) => _deliveriesReleased.Task.WaitAsync(timeout);
 
-        public void ReleaseDeliveries(int count) => _deliverySemaphore.Release(count);
+        public void ReleaseDeliveries() => _deliverySemaphore.Release(_expectedDeliveries);
 
         internal void RecordObserver(Guid activationId) => _observerCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
 
         internal async Task RecordDelivery(Guid activationId)
         {
             _deliveryCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
-            if (Interlocked.Increment(ref _deliveryCount) >= _expectedDeliveries)
+            var deliveryCount = Interlocked.Increment(ref _deliveryCount);
+            if (!Volatile.Read(ref _blockDeliveries))
             {
-                _deliveryTargetReached.TrySetResult();
-            }
-
-            if (Volatile.Read(ref _blockDeliveries) == 0)
-            {
+                if (deliveryCount >= _expectedDeliveries)
+                {
+                    _deliveryTargetReached.TrySetResult();
+                }
                 return;
             }
 
             if (Interlocked.Increment(ref _waitingDeliveryCount) >= _expectedDeliveries)
             {
-                _blockedDeliveriesReached.TrySetResult();
+                _deliveryTargetReached.TrySetResult();
             }
 
             try
@@ -104,14 +99,10 @@ namespace UnitTests.Grains
         public const string ExplicitStreamNamespace = "StatelessWorkerStreamingNamespace";
 
         private readonly Guid _activationId = Guid.NewGuid();
-        private readonly ILogger _logger;
         private readonly StatelessWorkerStreamConsumerState _state;
 
-        public StatelessWorkerStreamConsumerGrain(
-            ILoggerFactory loggerFactory,
-            StatelessWorkerStreamConsumerState state)
+        public StatelessWorkerStreamConsumerGrain(StatelessWorkerStreamConsumerState state)
         {
-            _logger = loggerFactory.CreateLogger($"{GetType().Name}-{IdentityString}");
             _state = state;
         }
 
@@ -151,11 +142,6 @@ namespace UnitTests.Grains
 
         public async Task OnSubscribed(IStreamSubscriptionHandleFactory handleFactory)
         {
-            _logger.LogInformation(
-                "Attaching activation {ActivationId} to stream {ProviderName}/{StreamId}",
-                _activationId,
-                handleFactory.ProviderName,
-                handleFactory.StreamId);
             _state.RecordObserver(_activationId);
             await handleFactory.Create<string>().ResumeAsync(OnNextAsync, OnErrorAsync, OnCompletedAsync);
         }
@@ -176,8 +162,6 @@ namespace UnitTests.Grains
         {
             _state = state;
         }
-
-        public Task Ping() => Task.CompletedTask;
 
         public async Task OnSubscribed(IStreamSubscriptionHandleFactory handleFactory)
         {

--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -1,33 +1,201 @@
+using System.Collections.Concurrent;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
+using Orleans.Providers.Streams.Common;
 using Orleans.Streams;
+using Orleans.Streams.Core;
 using UnitTests.GrainInterfaces;
 
 namespace UnitTests.Grains
 {
-    [StatelessWorker(MaxLocalWorkers)]
-    public class StatelessWorkerStreamConsumerGrain : Grain, IStatelessWorkerStreamConsumerGrain
+    public sealed class StatelessWorkerStreamConsumerState
     {
-        internal const int MaxLocalWorkers = 1;
-        internal const string StreamNamespace = "StatelessWorkerStreamingNamespace";
+        private readonly ConcurrentDictionary<Guid, int> _deliveryCounts = new();
+        private readonly ConcurrentDictionary<Guid, int> _observerCounts = new();
+        private readonly SemaphoreSlim _deliverySemaphore = new(0);
+        private TaskCompletionSource _blockedDeliveriesReached = CreateCompletionSource();
+        private TaskCompletionSource _deliveriesReleased = CreateCompletionSource();
+        private TaskCompletionSource _deliveryTargetReached = CreateCompletionSource();
+        private int _blockDeliveries;
+        private int _expectedDeliveries;
+        private int _waitingDeliveryCount;
 
-        private readonly ILogger logger;
+        public int DeliveryCount => _deliveryCounts.Values.Sum();
 
-        public StatelessWorkerStreamConsumerGrain(ILoggerFactory loggerFactory)
+        public int DeliveryActivationCount => _deliveryCounts.Count;
+
+        public int ObserverActivationCount => _observerCounts.Count;
+
+        public int WaitingDeliveryCount => Volatile.Read(ref _waitingDeliveryCount);
+
+        public void Reset(int expectedDeliveries, bool blockDeliveries = false)
         {
-            this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
+            if (WaitingDeliveryCount != 0)
+            {
+                throw new InvalidOperationException("All blocked stream deliveries must be released before resetting the test state.");
+            }
+
+            while (_deliverySemaphore.Wait(0))
+            {
+            }
+
+            _deliveryCounts.Clear();
+            _observerCounts.Clear();
+            _expectedDeliveries = expectedDeliveries;
+            Volatile.Write(ref _blockDeliveries, blockDeliveries ? 1 : 0);
+            _blockedDeliveriesReached = CreateCompletionSource();
+            _deliveriesReleased = CreateCompletionSource();
+            _deliveryTargetReached = CreateCompletionSource();
+        }
+
+        public Task WaitForDeliveriesAsync(TimeSpan timeout) => _deliveryTargetReached.Task.WaitAsync(timeout);
+
+        public Task WaitForBlockedDeliveriesAsync(TimeSpan timeout) => _blockedDeliveriesReached.Task.WaitAsync(timeout);
+
+        public Task WaitForReleasedDeliveriesAsync(TimeSpan timeout) => _deliveriesReleased.Task.WaitAsync(timeout);
+
+        public void ReleaseDeliveries(int count) => _deliverySemaphore.Release(count);
+
+        internal void RecordObserver(Guid activationId) => _observerCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
+
+        internal async Task RecordDelivery(Guid activationId)
+        {
+            _deliveryCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
+            if (_deliveryCounts.Values.Sum() >= _expectedDeliveries)
+            {
+                _deliveryTargetReached.TrySetResult();
+            }
+
+            if (Volatile.Read(ref _blockDeliveries) == 0)
+            {
+                return;
+            }
+
+            if (Interlocked.Increment(ref _waitingDeliveryCount) >= _expectedDeliveries)
+            {
+                _blockedDeliveriesReached.TrySetResult();
+            }
+
+            try
+            {
+                await _deliverySemaphore.WaitAsync();
+            }
+            finally
+            {
+                if (Interlocked.Decrement(ref _waitingDeliveryCount) == 0)
+                {
+                    _deliveriesReleased.TrySetResult();
+                }
+            }
+        }
+
+        private static TaskCompletionSource CreateCompletionSource() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    [StatelessWorker(MaxLocalWorkers)]
+    public class StatelessWorkerStreamConsumerGrain
+        : Grain, IStatelessWorkerStreamConsumerGrain, IStreamSubscriptionObserver, IAsyncObserver<string>
+    {
+        public const int MaxLocalWorkers = 4;
+        public const string ExplicitStreamNamespace = "StatelessWorkerStreamingNamespace";
+
+        private readonly Guid _activationId = Guid.NewGuid();
+        private readonly ILogger _logger;
+        private readonly StatelessWorkerStreamConsumerState _state;
+
+        public StatelessWorkerStreamConsumerGrain(
+            ILoggerFactory loggerFactory,
+            StatelessWorkerStreamConsumerState state)
+        {
+            _logger = loggerFactory.CreateLogger($"{GetType().Name}-{IdentityString}");
+            _state = state;
         }
 
         public Task OnCompletedAsync() => Task.CompletedTask;
 
         public Task OnErrorAsync(Exception ex) => Task.CompletedTask;
 
-        public Task OnNextAsync(string item, StreamSequenceToken? token = null) => Task.CompletedTask;
+        public Task OnNextAsync(string item, StreamSequenceToken? token = null) => _state.RecordDelivery(_activationId);
 
+        public async Task BecomeConsumer(Guid[] streamIds, string providerToUse)
+        {
+            foreach (var streamId in streamIds)
+            {
+                var stream = this.GetStreamProvider(providerToUse).GetStream<string>(ExplicitStreamNamespace, streamId);
+                _ = await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, OnCompletedAsync);
+                _state.RecordObserver(_activationId);
+            }
+        }
+
+        public async Task BecomeConsumerFromToken(Guid streamId, string providerToUse)
+        {
+            var stream = this.GetStreamProvider(providerToUse).GetStream<string>(ExplicitStreamNamespace, streamId);
+            _ = await stream.SubscribeAsync(this, new EventSequenceToken(0));
+        }
+
+        public async Task<int> StopConsuming(Guid streamId, string providerToUse)
+        {
+            var stream = this.GetStreamProvider(providerToUse).GetStream<string>(ExplicitStreamNamespace, streamId);
+            var handles = await stream.GetAllSubscriptionHandles();
+            foreach (var handle in handles)
+            {
+                await handle.UnsubscribeAsync();
+            }
+
+            return handles.Count;
+        }
+
+        public async Task OnSubscribed(IStreamSubscriptionHandleFactory handleFactory)
+        {
+            _logger.LogInformation(
+                "Attaching activation {ActivationId} to stream {ProviderName}/{StreamId}",
+                _activationId,
+                handleFactory.ProviderName,
+                handleFactory.StreamId);
+            _state.RecordObserver(_activationId);
+            await handleFactory.Create<string>().ResumeAsync(OnNextAsync, OnErrorAsync, OnCompletedAsync);
+        }
+    }
+
+    [StatelessWorker(MaxLocalWorkers)]
+    [ImplicitStreamSubscription(StreamNamespace)]
+    public class ImplicitStatelessWorkerStreamConsumerGrain
+        : Grain, IImplicitStatelessWorkerStreamConsumerGrain, IStreamSubscriptionObserver
+    {
+        public const int MaxLocalWorkers = 4;
+        public const string StreamNamespace = "ImplicitStatelessWorkerStreamingNamespace";
+
+        private readonly Guid _activationId = Guid.NewGuid();
+        private readonly StatelessWorkerStreamConsumerState _state;
+
+        public ImplicitStatelessWorkerStreamConsumerGrain(StatelessWorkerStreamConsumerState state)
+        {
+            _state = state;
+        }
+
+        public Task Ping() => Task.CompletedTask;
+
+        public async Task OnSubscribed(IStreamSubscriptionHandleFactory handleFactory)
+        {
+            _state.RecordObserver(_activationId);
+            await handleFactory.Create<string>().ResumeAsync(
+                (item, token) => _state.RecordDelivery(_activationId),
+                static exception => Task.CompletedTask,
+                static () => Task.CompletedTask);
+        }
+    }
+
+    [StatelessWorker]
+    public class UnsupportedStatelessWorkerStreamConsumerGrain
+        : Grain, IUnsupportedStatelessWorkerStreamConsumerGrain
+    {
         public async Task BecomeConsumer(Guid streamId, string providerToUse)
         {
-            var stream = this.GetStreamProvider(providerToUse).GetStream<string>(StreamNamespace, streamId);
-            _ = await stream.SubscribeAsync(OnNextAsync, OnErrorAsync, OnCompletedAsync);
+            var stream = this.GetStreamProvider(providerToUse)
+                .GetStream<string>(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId);
+            _ = await stream.SubscribeAsync(static (item, token) => Task.CompletedTask);
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
@@ -1,9 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
 using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Streams;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
 using Xunit;
 
 namespace UnitTests.StreamingTests
@@ -19,12 +23,11 @@ namespace UnitTests.StreamingTests
     {
         private readonly Fixture fixture;
 
-        private readonly ILogger logger;
-
         public class Fixture : BaseTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
+                builder.Options.InitialSilosCount = 1;
                 builder.AddSiloBuilderConfigurator<SiloConfigurator>();
                 builder.AddClientBuilderConfigurator<ClientConfiguretor>();
             }
@@ -33,8 +36,11 @@ namespace UnitTests.StreamingTests
             {
                 public void Configure(ISiloBuilder hostBuilder)
                 {
-                    hostBuilder.AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProvider)
-                         .AddMemoryGrainStorage("PubSubStore");
+                    hostBuilder.AddMemoryStreams<DefaultMemoryMessageBodySerializer>(
+                            StreamProvider,
+                            streams => streams.ConfigurePartitioning(PartitionCount))
+                        .AddMemoryGrainStorage("PubSubStore");
+                    hostBuilder.Services.AddSingleton<StatelessWorkerStreamConsumerState>();
                 }
             }
 
@@ -42,56 +48,119 @@ namespace UnitTests.StreamingTests
             {
                 public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
                 {
-                    clientBuilder.AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProvider);
+                    clientBuilder.AddMemoryStreams<DefaultMemoryMessageBodySerializer>(
+                        StreamProvider,
+                        streams => streams.ConfigurePartitioning(PartitionCount));
                 }
             }
         }
 
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+        private const int PartitionCount = 4;
         private const string StreamProvider = StreamTestsConstants.MEMORY_STREAM_PROVIDER_NAME;
 
         public StatelessWorkersStreamTests(Fixture fixture)
         {
             this.fixture = fixture;
-            logger = this.fixture.Logger;
         }
 
         [Fact, TestCategory("Functional")]
-        public async Task SubscribeToStream_FromStatelessWorker_Fail()
+        public async Task ExplicitSubscription_DeliversToStatelessWorker_AndCanBeRemovedAtGrainScope()
         {
-            this.logger.LogInformation($"************************ { nameof(SubscribeToStream_FromStatelessWorker_Fail) } *********************************");
-            var runner = new StatelessWorkersStreamTestsRunner(StreamProvider, this.logger, this.fixture.HostedCluster);
-            await Assert.ThrowsAsync<InvalidOperationException>( () => runner.BecomeConsumer(Guid.NewGuid()));
-        }
-    }
+            var state = GetConsumerState();
+            state.Reset(expectedDeliveries: 1);
+            var streamId = Guid.NewGuid();
+            var consumer = fixture.GrainFactory.GetGrain<IStatelessWorkerStreamConsumerGrain>(0);
 
-    /// <summary>
-    /// Test runner class for executing stateless worker stream tests with producer and consumer functionality.
-    /// </summary>
-    public class StatelessWorkersStreamTestsRunner
-    {
-        private const string StreamNamespace = "SampleStreamNamespace";
+            await consumer.BecomeConsumer([streamId], StreamProvider);
+            await GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId).OnNextAsync("first");
+            await state.WaitForDeliveriesAsync(Timeout);
 
-        private readonly string streamProvider;
-        private readonly ILogger logger;
-        private readonly TestCluster cluster;
-
-        public StatelessWorkersStreamTestsRunner(string streamProvider, ILogger logger, TestCluster cluster)
-        {
-            this.streamProvider = streamProvider;
-            this.logger = logger;
-            this.cluster = cluster;
+            Assert.Equal(1, state.DeliveryCount);
+            Assert.Equal(1, await consumer.StopConsuming(streamId, StreamProvider));
+            Assert.Equal(0, await consumer.StopConsuming(streamId, StreamProvider));
         }
 
-        public async Task BecomeConsumer(Guid streamId)
+        [Fact, TestCategory("Functional")]
+        public async Task ImplicitSubscription_AttachesObserverBeforeFirstDelivery()
         {
-            var consumer = this.cluster.GrainFactory!.GetGrain<IStatelessWorkerStreamConsumerGrain>(0);
-            await consumer.BecomeConsumer(streamId, streamProvider);
+            var state = GetConsumerState();
+            state.Reset(expectedDeliveries: 1);
+            var streamId = Guid.NewGuid();
+
+            await GetStream(ImplicitStatelessWorkerStreamConsumerGrain.StreamNamespace, streamId).OnNextAsync("first");
+            await state.WaitForDeliveriesAsync(Timeout);
+
+            Assert.Equal(1, state.DeliveryCount);
+            Assert.Equal(1, state.ObserverActivationCount);
         }
 
-        public async Task ProduceMessage(Guid streamId)
+        [Fact, TestCategory("Functional")]
+        public async Task ConcurrentQueueDeliveries_UseMultipleLocalWorkerActivations()
         {
-            var producer = this.cluster.GrainFactory!.GetGrain<IStatelessWorkerStreamProducerGrain>(0);
-            await producer.Produce(streamId, streamProvider, string.Empty);
+            var state = GetConsumerState();
+            state.Reset(expectedDeliveries: PartitionCount, blockDeliveries: true);
+            var streamIds = CreateStreamIdsForDistinctQueues();
+            var consumer = fixture.GrainFactory.GetGrain<IStatelessWorkerStreamConsumerGrain>(1);
+            await consumer.BecomeConsumer(streamIds, StreamProvider);
+
+            await Task.WhenAll(streamIds.Select((streamId, index) =>
+                GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId)
+                    .OnNextAsync($"item-{index}")));
+            await state.WaitForBlockedDeliveriesAsync(Timeout);
+
+            Assert.Equal(PartitionCount, state.WaitingDeliveryCount);
+            Assert.Equal(PartitionCount, state.DeliveryActivationCount);
+            Assert.Equal(PartitionCount, state.ObserverActivationCount);
+
+            state.ReleaseDeliveries(PartitionCount);
+            await state.WaitForReleasedDeliveriesAsync(Timeout);
+            Assert.Equal(PartitionCount, state.DeliveryCount);
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task SubscribeToStream_FromStatelessWorkerWithoutSubscriptionObserver_Fails()
+        {
+            var consumer = fixture.GrainFactory.GetGrain<IUnsupportedStatelessWorkerStreamConsumerGrain>(0);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => consumer.BecomeConsumer(Guid.NewGuid(), StreamProvider));
+
+            Assert.Contains(typeof(Orleans.Streams.Core.IStreamSubscriptionObserver).FullName!, exception.Message);
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task SubscribeToStream_FromStatelessWorkerWithSequenceToken_Fails()
+        {
+            var consumer = fixture.GrainFactory.GetGrain<IStatelessWorkerStreamConsumerGrain>(2);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => consumer.BecomeConsumerFromToken(Guid.NewGuid(), StreamProvider));
+
+            Assert.Contains("null sequence token", exception.Message);
+        }
+
+        private StatelessWorkerStreamConsumerState GetConsumerState() =>
+            fixture.HostedCluster.GetSiloServiceProvider().GetRequiredService<StatelessWorkerStreamConsumerState>();
+
+        private IAsyncStream<string> GetStream(string streamNamespace, Guid streamId) =>
+            fixture.Client.GetStreamProvider(StreamProvider).GetStream<string>(streamNamespace, streamId);
+
+        private static Guid[] CreateStreamIdsForDistinctQueues()
+        {
+            var mapper = new HashRingBasedStreamQueueMapper(
+                new HashRingStreamQueueMapperOptions { TotalQueueCount = PartitionCount },
+                StreamProvider);
+            var result = new Dictionary<QueueId, Guid>();
+            while (result.Count < PartitionCount)
+            {
+                var streamId = Guid.NewGuid();
+                var queueId = mapper.GetQueueForStream(
+                    StreamId.Create(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId));
+                result.TryAdd(queueId, streamId);
+            }
+
+            return result.Values.ToArray();
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
@@ -152,7 +152,7 @@ namespace UnitTests.StreamingTests
                 new HashRingStreamQueueMapperOptions { TotalQueueCount = PartitionCount },
                 StreamProvider);
             var result = new Dictionary<QueueId, Guid>();
-            while (result.Count < PartitionCount)
+            for (var attempt = 0; attempt < 1_000 && result.Count < PartitionCount; attempt++)
             {
                 var streamId = Guid.NewGuid();
                 var queueId = mapper.GetQueueForStream(
@@ -160,6 +160,7 @@ namespace UnitTests.StreamingTests
                 result.TryAdd(queueId, streamId);
             }
 
+            Assert.Equal(PartitionCount, result.Count);
             return result.Values.ToArray();
         }
     }

--- a/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
@@ -107,6 +107,7 @@ namespace UnitTests.StreamingTests
             await Task.WhenAll(streamIds.Select((streamId, index) =>
                 GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId)
                     .OnNextAsync($"item-{index}")));
+            await state.WaitForDeliveriesAsync(Timeout);
             await state.WaitForBlockedDeliveriesAsync(Timeout);
 
             Assert.Equal(PartitionCount, state.WaitingDeliveryCount);

--- a/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
@@ -108,13 +108,12 @@ namespace UnitTests.StreamingTests
                 GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId)
                     .OnNextAsync($"item-{index}")));
             await state.WaitForDeliveriesAsync(Timeout);
-            await state.WaitForBlockedDeliveriesAsync(Timeout);
 
             Assert.Equal(PartitionCount, state.WaitingDeliveryCount);
             Assert.Equal(PartitionCount, state.DeliveryActivationCount);
             Assert.Equal(PartitionCount, state.ObserverActivationCount);
 
-            state.ReleaseDeliveries(PartitionCount);
+            state.ReleaseDeliveries();
             await state.WaitForReleasedDeliveriesAsync(Timeout);
             Assert.Equal(PartitionCount, state.DeliveryCount);
         }


### PR DESCRIPTION
## Problem

Stateless worker grains currently reject stream consumer extension binding, forcing applications to route stream deliveries through a regular grain before parallel stateless processing.

## Solution

- Allow stream consumer extension binding only for stateless workers which implement `IStreamSubscriptionObserver`.
- Install activation-local observers lazily through `OnSubscribed` while retaining grain-level implicit and explicit subscription ownership.
- Route concurrent deliveries through normal local stateless-worker selection as competing-consumer work.
- Keep the pulling agent authoritative for live delivery progress by requiring null sequence tokens for stateless worker subscriptions.
- Document locality, ordering, retry, subscription lifecycle, and token semantics.
- Cover implicit and explicit subscriptions, grain-scope unsubscribe, concurrent activation scale-out, and unsupported contracts.

## Rationale

Each delivery attempt targets the stateless worker grain identity and executes on one selected local activation. This removes the extra regular-grain hop while preserving provider delivery and retry behavior. Activation-local rewind handshakes are disabled because delivery can move between workers; applications which require checkpoint resume continue to use a regular grain consumer.

Closes #433
Closes #10653

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10657)