### PR TITLE
fix(docs): preserve angle brackets in code

### DIFF
--- a/docs/site/scripts/lib/docfx.mjs
+++ b/docs/site/scripts/lib/docfx.mjs
@@ -6,6 +6,7 @@ import { collectIncludeTargets as collectIncludeTargetsWithoutYaml } from './inc
 import {
   lineOverlapsRanges,
   markdownBlockquoteLineRanges,
+  markdownCodeOffsetRanges,
   markdownDirectiveProtectedLineRanges,
   markdownLiteralLineRanges,
 } from './markdown-ranges.mjs';
@@ -1366,12 +1367,22 @@ function escapeMdxAngles(source) {
     `<(?!\\/?(?:${htmlTags})\\b|https?:\\/\\/|mailto:)(?=[A-Za-z\\d=/])`,
     'gi',
   );
-  return source
-    .replace(/<(https?:\/\/[^>]+)>/g, '[$1]($1)')
-    .replace(/<mailto:([^>]+)>/g, '[$1](mailto:$1)')
-    .replace(pattern, '&lt;')
-    .replace(/<(br|hr)\s*>/gi, '<$1 />')
-    .replace(/<(img|input|source)(\b[^>]*?)(?<!\/)>/gi, '<$1$2 />');
+  const transform = (value) =>
+    value
+      .replace(/<(https?:\/\/[^>]+)>/g, '[$1]($1)')
+      .replace(/<mailto:([^>]+)>/g, '[$1](mailto:$1)')
+      .replace(pattern, '&lt;')
+      .replace(/<(br|hr)\s*>/gi, '<$1 />')
+      .replace(/<(img|input|source)(\b[^>]*?)(?<!\/)>/gi, '<$1$2 />');
+  const ranges = markdownCodeOffsetRanges(source);
+  const chunks = [];
+  let offset = 0;
+  for (const [start, end] of ranges) {
+    chunks.push(transform(source.slice(offset, start)), source.slice(start, end));
+    offset = end;
+  }
+  chunks.push(transform(source.slice(offset)));
+  return chunks.join('');
 }
 
 function stripHtmlTags(value) {
@@ -1491,11 +1502,10 @@ export async function convertDocfxMarkdown({
   body = tabs.source;
   body = normalizeFenceLanguages(body);
   body = transformOutsideCodeFences(body, (line) => {
-    const converted = convertXrefs(convertLinks(line, sourcePath, sourceRoot), uidMap);
-    return escapeMdxAngles(converted)
-      .replace(/<([A-Z][A-Za-z\d_, ]*)>/g, '&lt;$1&gt;')
+    return convertXrefs(convertLinks(line, sourcePath, sourceRoot), uidMap)
       .replace(/<a\s+name="([^"]+)"><\/a>/gi, '<span id="$1"></span>');
   });
+  body = escapeMdxAngles(body);
   body = convertHtmlCommentsForMdx(body);
   const extractedTitle = extractPageTitle(body, metadataTitle);
   body = extractedTitle.body.trim();

--- a/docs/site/scripts/lib/markdown-ranges.mjs
+++ b/docs/site/scripts/lib/markdown-ranges.mjs
@@ -340,6 +340,25 @@ function markdownAstLineRanges(source, acceptedTypes) {
   return ranges;
 }
 
+function markdownAstOffsetRanges(source, acceptedTypes) {
+  const ranges = [];
+  const pending = [fromMarkdown(source)];
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (
+      acceptedTypes.has(node.type) &&
+      Number.isInteger(node.position?.start.offset) &&
+      Number.isInteger(node.position?.end.offset)
+    ) {
+      ranges.push([node.position.start.offset, node.position.end.offset]);
+    }
+    if (Array.isArray(node.children)) {
+      pending.push(...node.children);
+    }
+  }
+  return ranges.sort((left, right) => left[0] - right[0]);
+}
+
 export function markdownBlockquoteLineRanges(source) {
   return fromMarkdown
     ? markdownAstLineRanges(source, new Set(['blockquote']))
@@ -350,6 +369,12 @@ export function markdownLiteralLineRanges(source) {
   return fromMarkdown
     ? markdownAstLineRanges(source, new Set(['code', 'html', 'inlineCode']))
     : fallbackProtectedLineRanges(source);
+}
+
+export function markdownCodeOffsetRanges(source) {
+  return fromMarkdown
+    ? markdownAstOffsetRanges(source, new Set(['code', 'inlineCode']))
+    : [];
 }
 
 export function lineOverlapsRanges(line, ranges) {

--- a/docs/site/tests/docfx.test.mjs
+++ b/docs/site/tests/docfx.test.mjs
@@ -284,6 +284,30 @@ describe('DocFX conversion', () => {
     expect(converted).toContain('List&lt;T> outside.');
   });
 
+  test('preserves angle brackets in inline code while escaping prose for MDX', async () => {
+    const directory = await temporaryDirectory();
+    const sourcePath = path.join(directory, 'guide.md');
+    const converted = await convertDocfxMarkdown({
+      source: [
+        '---',
+        'title: Inline code',
+        '---',
+        'Use `IGrainFactory.GetGrain<TGrainInterface>(key)` with <TGrainInterface>.',
+        'Use ``Map<`key`, TValue>`` and `Dictionary<string, List<int>>`.',
+      ].join('\n'),
+      sourcePath,
+      sourceRoot: directory,
+    });
+
+    expect(converted).toContain(
+      'Use `IGrainFactory.GetGrain<TGrainInterface>(key)` with &lt;TGrainInterface>.',
+    );
+    expect(converted).toContain(
+      'Use ``Map<`key`, TValue>`` and `Dictionary<string, List<int>>`.',
+    );
+    expect(converted).not.toContain('GetGrain&lt;TGrainInterface>');
+  });
+
   test.each([
     ['tilde fence', '~~~~text', '~~~~'],
     ['longer tilde close', '~~~text', '~~~~~'],


### PR DESCRIPTION
## Summary

Preserve Markdown inline code and code blocks while escaping angle brackets for MDX. The converter now uses Markdown AST offsets to transform prose independently, so generic signatures such as `IGrainFactory.GetGrain<TGrainInterface>(key)` render correctly across the documentation site.

Add regression coverage for generic signatures, nested generics, multi-backtick code spans, and mixed prose/code lines.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10658)