### PR TITLE
docs: add Markdown navigation overview

### DIFF
--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -12,6 +12,8 @@ import { remarkVersionZones } from './src/plugins/remark-version-zones.mjs';
 
 const sidebar = await createSidebar(new URL('./src/content/docs/toc.yml', import.meta.url));
 const buildConcurrency = Number(process.env.ORLEANS_DOCS_BUILD_CONCURRENCY) || 4;
+const markdownPageExample =
+  'https://dotnet.github.io/orleans/docs/implementation/streams-implementation.md';
 sidebar.unshift({ label: 'Documentation', link: '/docs/' });
 
 export default defineConfig({
@@ -63,7 +65,11 @@ export default defineConfig({
         starlightDotMd({
           includePatterns: ['docs', 'docs/**'],
         }),
-        starlightLlmsTxt(),
+        starlightLlmsTxt({
+          details:
+            'Every documentation page is available as Markdown. Replace the trailing `/` in a page URL with `.md` to retrieve it. ' +
+            `For example, https://dotnet.github.io/orleans/docs/implementation/streams-implementation/ becomes ${markdownPageExample}.`,
+        }),
       ],
     }),
     cleanMarkdownOutput(),

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -68,7 +68,8 @@ export default defineConfig({
         starlightLlmsTxt({
           details:
             'Every documentation page is available as Markdown. Replace the trailing `/` in a page URL with `.md` to retrieve it. ' +
-            `For example, https://dotnet.github.io/orleans/docs/implementation/streams-implementation/ becomes ${markdownPageExample}.`,
+            `For example, https://dotnet.github.io/orleans/docs/implementation/streams-implementation/ becomes ${markdownPageExample}. ` +
+            'The Documentation Overview section below links to the first two levels of conceptual documentation.',
         }),
       ],
     }),

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -69,7 +69,7 @@ export default defineConfig({
           details:
             'Every documentation page is available as Markdown. Replace the trailing `/` in a page URL with `.md` to retrieve it. ' +
             `For example, https://dotnet.github.io/orleans/docs/implementation/streams-implementation/ becomes ${markdownPageExample}. ` +
-            'The Documentation Overview section below links to the first two levels of conceptual documentation.',
+            'The Documentation Overview section below links to the first three levels of conceptual documentation.',
         }),
       ],
     }),

--- a/docs/site/scripts/audit-output.mjs
+++ b/docs/site/scripts/audit-output.mjs
@@ -44,6 +44,19 @@ for (const requiredFile of ['llms.txt', 'llms-small.txt', 'llms-full.txt']) {
   }
 }
 
+const llmsEntryPoint = path.join(distRoot, 'llms.txt');
+if (files.includes(llmsEntryPoint)) {
+  const llmsText = await readFile(llmsEntryPoint, 'utf8');
+  const markdownPageExample =
+    'https://dotnet.github.io/orleans/docs/implementation/streams-implementation.md';
+  if (!llmsText.includes('Replace the trailing `/` in a page URL with `.md`')) {
+    fail(llmsEntryPoint, 'missing per-page Markdown URL guidance');
+  }
+  if (!llmsText.includes(markdownPageExample)) {
+    fail(llmsEntryPoint, 'missing per-page Markdown URL example');
+  }
+}
+
 if (totalBytes > maxPublishedBytes) {
   failures.push(`Published site is ${(totalBytes / 1024 / 1024).toFixed(1)} MiB; limit is 1024 MiB.`);
 }

--- a/docs/site/scripts/audit-output.mjs
+++ b/docs/site/scripts/audit-output.mjs
@@ -55,6 +55,30 @@ if (files.includes(llmsEntryPoint)) {
   if (!llmsText.includes(markdownPageExample)) {
     fail(llmsEntryPoint, 'missing per-page Markdown URL example');
   }
+  if (!llmsText.includes('## Documentation Overview')) {
+    fail(llmsEntryPoint, 'missing conceptual documentation overview');
+  }
+  if (/https:\/\/dotnet\.github\.io\/orleans\/docs\/api\//.test(llmsText)) {
+    fail(llmsEntryPoint, 'documentation overview includes API reference pages');
+  }
+  const overview = llmsText.split('## Documentation Overview\n\n')[1] ?? '';
+  const overviewUrls = [
+    ...overview.matchAll(/https:\/\/dotnet\.github\.io\/orleans\/docs\/([^)\s]+)\.md/g),
+  ].map((match) => match[1]);
+  if (overviewUrls.some((url) => url.split('/').length > 2)) {
+    fail(llmsEntryPoint, 'documentation overview includes pages below the second level');
+  }
+  for (const url of overviewUrls) {
+    const overviewDirectory = path.join(distRoot, 'docs', ...url.split('/'));
+    try {
+      const children = await readdir(overviewDirectory, { withFileTypes: true });
+      if (!children.some((entry) => entry.isFile() && entry.name.endsWith('.md'))) {
+        fail(llmsEntryPoint, `documentation overview entry '${url}' is not a hub page`);
+      }
+    } catch {
+      fail(llmsEntryPoint, `documentation overview entry '${url}' is not a hub page`);
+    }
+  }
 }
 
 if (totalBytes > maxPublishedBytes) {
@@ -136,6 +160,13 @@ for (const file of renderedMarkdown) {
     if (pattern.test(markdown)) {
       fail(file, description);
     }
+  }
+  if (
+    /\]\((?:https:\/\/dotnet\.github\.io)?\/orleans\/docs\/[^)\s]*\/(?:[?#][^)]*)?\)/.test(
+      markdown,
+    )
+  ) {
+    fail(file, 'documentation link points to HTML instead of Markdown');
   }
 }
 

--- a/docs/site/scripts/audit-output.mjs
+++ b/docs/site/scripts/audit-output.mjs
@@ -58,10 +58,10 @@ if (files.includes(llmsEntryPoint)) {
   if (!llmsText.includes('## Documentation Overview')) {
     fail(llmsEntryPoint, 'missing conceptual documentation overview');
   }
-  if (/\/orleans\/docs\/api\//.test(llmsText)) {
+  const overview = llmsText.split('## Documentation Overview\n\n')[1] ?? '';
+  if (/\/orleans\/docs\/api\//.test(overview)) {
     fail(llmsEntryPoint, 'documentation overview includes API reference pages');
   }
-  const overview = llmsText.split('## Documentation Overview\n\n')[1] ?? '';
   const overviewUrls = [
     ...overview.matchAll(/\/orleans\/docs\/([^)\s]+)\.md/g),
   ].map((match) => match[1]);

--- a/docs/site/scripts/audit-output.mjs
+++ b/docs/site/scripts/audit-output.mjs
@@ -65,10 +65,20 @@ if (files.includes(llmsEntryPoint)) {
   const overviewUrls = [
     ...overview.matchAll(/\/orleans\/docs\/([^)\s]+)\.md/g),
   ].map((match) => match[1]);
-  if (overviewUrls.some((url) => url.split('/').length > 2)) {
-    fail(llmsEntryPoint, 'documentation overview includes pages below the second level');
+  if (overviewUrls.some((url) => url.split('/').length > 3)) {
+    fail(llmsEntryPoint, 'documentation overview includes pages below the third level');
   }
+  const overviewUrlSet = new Set(overviewUrls);
   for (const url of overviewUrls) {
+    const segments = url.split('/');
+    if (segments.length === 3) {
+      const parentUrl = segments.slice(0, -1).join('/');
+      if (!overviewUrlSet.has(parentUrl)) {
+        fail(llmsEntryPoint, `third-level overview entry '${url}' has no parent hub`);
+      }
+      continue;
+    }
+
     const overviewDirectory = path.join(distRoot, 'docs', ...url.split('/'));
     try {
       const children = await readdir(overviewDirectory, { withFileTypes: true });

--- a/docs/site/scripts/audit-output.mjs
+++ b/docs/site/scripts/audit-output.mjs
@@ -58,12 +58,12 @@ if (files.includes(llmsEntryPoint)) {
   if (!llmsText.includes('## Documentation Overview')) {
     fail(llmsEntryPoint, 'missing conceptual documentation overview');
   }
-  if (/https:\/\/dotnet\.github\.io\/orleans\/docs\/api\//.test(llmsText)) {
+  if (/\/orleans\/docs\/api\//.test(llmsText)) {
     fail(llmsEntryPoint, 'documentation overview includes API reference pages');
   }
   const overview = llmsText.split('## Documentation Overview\n\n')[1] ?? '';
   const overviewUrls = [
-    ...overview.matchAll(/https:\/\/dotnet\.github\.io\/orleans\/docs\/([^)\s]+)\.md/g),
+    ...overview.matchAll(/\/orleans\/docs\/([^)\s]+)\.md/g),
   ].map((match) => match[1]);
   if (overviewUrls.some((url) => url.split('/').length > 2)) {
     fail(llmsEntryPoint, 'documentation overview includes pages below the second level');

--- a/docs/site/src/plugins/clean-markdown-output.mjs
+++ b/docs/site/src/plugins/clean-markdown-output.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { cleanStarlightMarkdown } from 'tidymd';
 
 const mdxComment = /\{\/\*[\s\S]*?\*\/\}\s*/g;
+const markdownLink = /(?<!!)\[([^\]]+)\]\(([^)\s]+)\)/g;
 
 async function pathExists(candidate) {
   try {
@@ -29,11 +30,38 @@ async function collectMarkdown(directory) {
   return files;
 }
 
+async function hasMarkdownChildren(directory) {
+  if (!(await pathExists(directory))) {
+    return false;
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true });
+  return entries.some((entry) => entry.isFile() && entry.name.endsWith('.md'));
+}
+
 export function cleanPublishedMarkdown(source) {
-  return cleanStarlightMarkdown(source, {
+  const markdown = cleanStarlightMarkdown(source, {
     frontmatter: 'title-as-heading',
     internalLinks: { mode: 'preserve' },
   }).replace(mdxComment, '');
+  return rewriteDocumentationLinks(markdown);
+}
+
+export function rewriteDocumentationLinks(markdown) {
+  return markdown.replace(markdownLink, (link, label, href) => {
+    const match =
+      /^(https:\/\/dotnet\.github\.io)?(\/orleans\/docs(?:\/[^?#]*)?)([?#].*)?$/.exec(href);
+    if (!match) {
+      return link;
+    }
+
+    const [, origin = '', pathname, suffix = ''] = match;
+    if (!pathname.endsWith('/')) {
+      return link;
+    }
+
+    return `[${label}](${origin}${pathname.slice(0, -1)}.md${suffix})`;
+  });
 }
 
 export async function cleanMarkdownOutputDirectory(outputRoot) {
@@ -55,13 +83,92 @@ export async function cleanMarkdownOutputDirectory(outputRoot) {
   return files.length;
 }
 
+export async function publishMarkdownOverview(outputRoot, site) {
+  const root = path.resolve(outputRoot);
+  const docsRoot = path.join(root, 'docs');
+  const files = (await pathExists(docsRoot)) ? await collectMarkdown(docsRoot) : [];
+  const docsIndex = path.join(root, 'docs.md');
+  if (await pathExists(docsIndex)) {
+    files.push(docsIndex);
+  }
+
+  const overviewFiles = [];
+  for (const file of files) {
+    if (file === docsIndex) {
+      overviewFiles.push(file);
+      continue;
+    }
+
+    const relativePath = path.relative(docsRoot, file).replaceAll('\\', '/');
+    const ownsChildPages = await hasMarkdownChildren(
+      file.slice(0, -path.extname(file).length),
+    );
+    if (relativePath.split('/').length <= 2 && ownsChildPages) {
+      overviewFiles.push(file);
+    }
+  }
+  const overviewPaths = new Set(overviewFiles.map((file) => path.resolve(file)));
+  const entries = await Promise.all(
+    overviewFiles.map(async (file) => {
+      const markdown = await readFile(file, 'utf8');
+      const title = /^# (.+)$/m.exec(markdown)?.[1];
+      if (!title) {
+        throw new Error(`Cannot add '${path.relative(root, file)}' to llms.txt overview: missing H1.`);
+      }
+
+      const relativePath = path.relative(root, file).replaceAll('\\', '/');
+      const docsRelativeSegments = path.relative(docsRoot, file).split(path.sep);
+      let depth = file === docsIndex ? 0 : docsRelativeSegments.length;
+      if (depth === 2) {
+        const parentPage = path.join(docsRoot, `${docsRelativeSegments[0]}.md`);
+        if (!overviewPaths.has(path.resolve(parentPage))) {
+          depth = 1;
+        }
+      }
+      return {
+        depth,
+        title,
+        url: new URL(relativePath, site).href,
+      };
+    }),
+  );
+  entries.sort((left, right) => left.url.localeCompare(right.url));
+
+  const llmsPath = path.join(root, 'llms.txt');
+  const llmsText = await readFile(llmsPath, 'utf8');
+  const links = entries
+    .map((entry) => `${'  '.repeat(entry.depth)}- [${entry.title}](${entry.url})`)
+    .join('\n');
+  await writeFile(
+    llmsPath,
+    `${llmsText.trimEnd()}\n\n## Documentation Overview\n\n${links}\n`,
+    'utf8',
+  );
+
+  return entries.length;
+}
+
 export function cleanMarkdownOutput() {
+  let site;
+
   return {
     name: 'orleans-clean-markdown-output',
     hooks: {
+      'astro:config:done': ({ config }) => {
+        if (!config.site) {
+          throw new Error('The Orleans documentation site URL is required for Markdown output.');
+        }
+
+        site = config.site;
+      },
       'astro:build:done': async ({ dir, logger }) => {
-        const count = await cleanMarkdownOutputDirectory(fileURLToPath(dir));
+        const outputRoot = fileURLToPath(dir);
+        const count = await cleanMarkdownOutputDirectory(outputRoot);
+        const overviewCount = await publishMarkdownOverview(outputRoot, site);
         logger.info(`Cleaned ${count} rendered Markdown page${count === 1 ? '' : 's'}.`);
+        logger.info(
+          `Published ${overviewCount} Markdown overview entr${overviewCount === 1 ? 'y' : 'ies'}.`,
+        );
       },
     },
   };

--- a/docs/site/src/plugins/clean-markdown-output.mjs
+++ b/docs/site/src/plugins/clean-markdown-output.mjs
@@ -108,6 +108,42 @@ export async function publishMarkdownOverview(outputRoot, site) {
     }
   }
   const overviewPaths = new Set(overviewFiles.map((file) => path.resolve(file)));
+  for (const file of files) {
+    const relativePath = path.relative(docsRoot, file).replaceAll('\\', '/');
+    if (relativePath.split('/').length !== 3) {
+      continue;
+    }
+
+    const parentPage = `${path.dirname(file)}.md`;
+    if (overviewPaths.has(path.resolve(parentPage))) {
+      overviewFiles.push(file);
+      overviewPaths.add(path.resolve(file));
+    }
+  }
+  const depthByPath = new Map();
+  depthByPath.set(path.resolve(docsIndex), 0);
+  function getOverviewDepth(file) {
+    const resolvedFile = path.resolve(file);
+    const existingDepth = depthByPath.get(resolvedFile);
+    if (existingDepth !== undefined) {
+      return existingDepth;
+    }
+    const docsRelativeSegments = path.relative(docsRoot, file).split(path.sep);
+    if (docsRelativeSegments.length === 1) {
+      depthByPath.set(resolvedFile, 1);
+      return 1;
+    }
+
+    const parentPage = `${path.dirname(file)}.md`;
+    const depth = overviewPaths.has(path.resolve(parentPage))
+      ? getOverviewDepth(parentPage) + 1
+      : 1;
+    depthByPath.set(resolvedFile, depth);
+    return depth;
+  }
+  for (const file of overviewFiles) {
+    getOverviewDepth(file);
+  }
   const entries = await Promise.all(
     overviewFiles.map(async (file) => {
       const markdown = await readFile(file, 'utf8');
@@ -117,16 +153,8 @@ export async function publishMarkdownOverview(outputRoot, site) {
       }
 
       const relativePath = path.relative(root, file).replaceAll('\\', '/');
-      const docsRelativeSegments = path.relative(docsRoot, file).split(path.sep);
-      let depth = file === docsIndex ? 0 : docsRelativeSegments.length;
-      if (depth === 2) {
-        const parentPage = path.join(docsRoot, `${docsRelativeSegments[0]}.md`);
-        if (!overviewPaths.has(path.resolve(parentPage))) {
-          depth = 1;
-        }
-      }
       return {
-        depth,
+        depth: depthByPath.get(path.resolve(file)) ?? 0,
         title,
         url: new URL(relativePath, site).pathname,
       };

--- a/docs/site/src/plugins/clean-markdown-output.mjs
+++ b/docs/site/src/plugins/clean-markdown-output.mjs
@@ -128,7 +128,7 @@ export async function publishMarkdownOverview(outputRoot, site) {
       return {
         depth,
         title,
-        url: new URL(relativePath, site).href,
+        url: new URL(relativePath, site).pathname,
       };
     }),
   );

--- a/docs/site/tests/clean-markdown-output.test.mjs
+++ b/docs/site/tests/clean-markdown-output.test.mjs
@@ -6,6 +6,7 @@ import { afterEach, describe, test } from 'vitest';
 import {
   cleanMarkdownOutputDirectory,
   cleanPublishedMarkdown,
+  publishMarkdownOverview,
 } from '../src/plugins/clean-markdown-output.mjs';
 
 const temporaryDirectories = [];
@@ -23,6 +24,10 @@ title: Orleans clients
 description: Choose and host an Orleans client.
 ---
 
+[Client configuration](/orleans/docs/host/configuration-guide/client-configuration/)
+[Streams](https://dotnet.github.io/orleans/docs/streaming/#providers)
+[External](https://learn.microsoft.com/dotnet/)
+
 {/* Source: snippets/HostingExamples.cs; region: local_silo_and_client */}
 \`\`\`csharp
 builder.UseOrleans();
@@ -33,6 +38,15 @@ builder.UseOrleans();
 
     assert.match(markdown, /^# Orleans clients/m);
     assert.match(markdown, /builder\.UseOrleans\(\);/);
+    assert.match(
+      markdown,
+      /\[Client configuration\]\(\/orleans\/docs\/host\/configuration-guide\/client-configuration\.md\)/,
+    );
+    assert.match(
+      markdown,
+      /\[Streams\]\(https:\/\/dotnet\.github\.io\/orleans\/docs\/streaming\.md#providers\)/,
+    );
+    assert.match(markdown, /\[External\]\(https:\/\/learn\.microsoft\.com\/dotnet\/\)/);
     assert.doesNotMatch(markdown, /^---$/m);
     assert.doesNotMatch(markdown, /\{\/\*/);
   });
@@ -50,5 +64,47 @@ builder.UseOrleans();
     assert.equal(await cleanMarkdownOutputDirectory(outputRoot), 1);
     assert.equal(await readFile(conceptual, 'utf8'), '# Orleans clients\n\nContent');
     assert.equal(await readFile(api, 'utf8'), '# API\n');
+  });
+
+  test('adds a two-level conceptual overview to llms.txt', async () => {
+    const outputRoot = await mkdtemp(path.join(os.tmpdir(), 'orleans-docs-overview-'));
+    temporaryDirectories.push(outputRoot);
+    const docsIndex = path.join(outputRoot, 'docs.md');
+    const grains = path.join(outputRoot, 'docs', 'grains.md');
+    const eventSourcing = path.join(outputRoot, 'docs', 'grains', 'event-sourcing.md');
+    const details = path.join(outputRoot, 'docs', 'grains', 'event-sourcing', 'details.md');
+    const grainIdentity = path.join(outputRoot, 'docs', 'grains', 'grain-identity.md');
+    const api = path.join(outputRoot, 'docs', 'api', 'csharp.md');
+    await mkdir(path.dirname(grains), { recursive: true });
+    await mkdir(path.dirname(eventSourcing), { recursive: true });
+    await mkdir(path.dirname(details), { recursive: true });
+    await mkdir(path.dirname(api), { recursive: true });
+    await writeFile(docsIndex, '# Orleans documentation\n');
+    await writeFile(grains, '# Grains\n');
+    await writeFile(eventSourcing, '# Event sourcing\n');
+    await writeFile(details, '# Event sourcing details\n');
+    await writeFile(grainIdentity, '# Grain identity\n');
+    await writeFile(api, '# API\n');
+    await writeFile(path.join(outputRoot, 'llms.txt'), '# Microsoft Orleans\n');
+
+    assert.equal(
+      await publishMarkdownOverview(outputRoot, new URL('https://dotnet.github.io/orleans/')),
+      3,
+    );
+    const llmsText = await readFile(path.join(outputRoot, 'llms.txt'), 'utf8');
+    assert.match(llmsText, /## Documentation Overview/);
+    assert.match(
+      llmsText,
+      /- \[Orleans documentation\]\(https:\/\/dotnet\.github\.io\/orleans\/docs\.md\)/,
+    );
+    assert.match(
+      llmsText,
+      /  - \[Grains\]\(https:\/\/dotnet\.github\.io\/orleans\/docs\/grains\.md\)/,
+    );
+    assert.match(
+      llmsText,
+      /    - \[Event sourcing\]\(https:\/\/dotnet\.github\.io\/orleans\/docs\/grains\/event-sourcing\.md\)/,
+    );
+    assert.doesNotMatch(llmsText, /Event sourcing details|Grain identity|\[API\]/);
   });
 });

--- a/docs/site/tests/clean-markdown-output.test.mjs
+++ b/docs/site/tests/clean-markdown-output.test.mjs
@@ -95,15 +95,15 @@ builder.UseOrleans();
     assert.match(llmsText, /## Documentation Overview/);
     assert.match(
       llmsText,
-      /- \[Orleans documentation\]\(https:\/\/dotnet\.github\.io\/orleans\/docs\.md\)/,
+      /- \[Orleans documentation\]\(\/orleans\/docs\.md\)/,
     );
     assert.match(
       llmsText,
-      /  - \[Grains\]\(https:\/\/dotnet\.github\.io\/orleans\/docs\/grains\.md\)/,
+      /  - \[Grains\]\(\/orleans\/docs\/grains\.md\)/,
     );
     assert.match(
       llmsText,
-      /    - \[Event sourcing\]\(https:\/\/dotnet\.github\.io\/orleans\/docs\/grains\/event-sourcing\.md\)/,
+      /    - \[Event sourcing\]\(\/orleans\/docs\/grains\/event-sourcing\.md\)/,
     );
     assert.doesNotMatch(llmsText, /Event sourcing details|Grain identity|\[API\]/);
   });

--- a/docs/site/tests/clean-markdown-output.test.mjs
+++ b/docs/site/tests/clean-markdown-output.test.mjs
@@ -66,7 +66,7 @@ builder.UseOrleans();
     assert.equal(await readFile(api, 'utf8'), '# API\n');
   });
 
-  test('adds a two-level conceptual overview to llms.txt', async () => {
+  test('adds a three-level conceptual overview to llms.txt', async () => {
     const outputRoot = await mkdtemp(path.join(os.tmpdir(), 'orleans-docs-overview-'));
     temporaryDirectories.push(outputRoot);
     const docsIndex = path.join(outputRoot, 'docs.md');
@@ -89,7 +89,7 @@ builder.UseOrleans();
 
     assert.equal(
       await publishMarkdownOverview(outputRoot, new URL('https://dotnet.github.io/orleans/')),
-      3,
+      4,
     );
     const llmsText = await readFile(path.join(outputRoot, 'llms.txt'), 'utf8');
     assert.match(llmsText, /## Documentation Overview/);
@@ -105,6 +105,10 @@ builder.UseOrleans();
       llmsText,
       /    - \[Event sourcing\]\(\/orleans\/docs\/grains\/event-sourcing\.md\)/,
     );
-    assert.doesNotMatch(llmsText, /Event sourcing details|Grain identity|\[API\]/);
+    assert.match(
+      llmsText,
+      /      - \[Event sourcing details\]\(\/orleans\/docs\/grains\/event-sourcing\/details\.md\)/,
+    );
+    assert.doesNotMatch(llmsText, /Grain identity|\[API\]/);
   });
 });


### PR DESCRIPTION
## Problem

Page-level Markdown is discoverable by changing a documentation URL suffix, but agents need a compact entry-point overview and Markdown-to-Markdown navigation.

## Solution

- explain the `.md` URL convention in `llms.txt`
- add a curated three-level overview: the docs root, conceptual hub pages, and direct children of nested hubs
- exclude API reference pages and avoid enumerating unrelated conceptual leaf pages
- use root-relative URLs in the overview to reduce token usage
- rewrite internal documentation links in generated Markdown to their corresponding `.md` URLs
- audit overview depth, parent relationships, API exclusion, and Markdown link targets

## Rationale

The overview gives agents enough structure to choose an area without consuming context on every conceptual or API reference page. Third-level entries intentionally include direct child pages beneath selected nested hubs. Once an agent opens a page, links continue through the machine-readable Markdown graph.