### PR TITLE
fix(docs): preserve code without markdown parser

### DIFF
--- a/docs/site/scripts/lib/docfx.mjs
+++ b/docs/site/scripts/lib/docfx.mjs
@@ -1360,7 +1360,55 @@ function convertHtmlCommentsForMdx(source) {
   );
 }
 
-function escapeMdxAngles(source) {
+function transformOutsideInlineCode(source, transform) {
+  const chunks = [];
+  let offset = 0;
+  let opening = 0;
+  while (opening < source.length) {
+    opening = source.indexOf('`', opening);
+    if (opening < 0) {
+      break;
+    }
+    let openingEnd = opening + 1;
+    while (source[openingEnd] === '`') {
+      openingEnd += 1;
+    }
+    let precedingBackslashes = 0;
+    for (let index = opening - 1; source[index] === '\\'; index -= 1) {
+      precedingBackslashes += 1;
+    }
+    if (precedingBackslashes % 2 === 1) {
+      opening = openingEnd;
+      continue;
+    }
+    const delimiterLength = openingEnd - opening;
+    let closing = openingEnd;
+    while (closing < source.length) {
+      closing = source.indexOf('`', closing);
+      if (closing < 0) {
+        break;
+      }
+      let closingEnd = closing + 1;
+      while (source[closingEnd] === '`') {
+        closingEnd += 1;
+      }
+      if (closingEnd - closing === delimiterLength) {
+        chunks.push(transform(source.slice(offset, opening)), source.slice(opening, closingEnd));
+        offset = closingEnd;
+        opening = closingEnd;
+        break;
+      }
+      closing = closingEnd;
+    }
+    if (closing < 0) {
+      opening = openingEnd;
+    }
+  }
+  chunks.push(transform(source.slice(offset)));
+  return chunks.join('');
+}
+
+export function escapeMdxAngles(source, options = {}) {
   const htmlTags =
     'a|abbr|b|blockquote|br|code|dd|details|div|dl|dt|em|hr|i|iframe|img|input|kbd|li|ol|p|pre|source|span|strong|sub|summary|sup|tabitem|table|tabs|tbody|td|th|thead|tr|ul';
   const pattern = new RegExp(
@@ -1374,7 +1422,12 @@ function escapeMdxAngles(source) {
       .replace(pattern, '&lt;')
       .replace(/<(br|hr)\s*>/gi, '<$1 />')
       .replace(/<(img|input|source)(\b[^>]*?)(?<!\/)>/gi, '<$1$2 />');
-  const ranges = markdownCodeOffsetRanges(source);
+  const ranges = markdownCodeOffsetRanges(source, options);
+  if (!ranges) {
+    return transformOutsideCodeBlocks(source, (segment) =>
+      transformOutsideInlineCode(segment, transform),
+    );
+  }
   const chunks = [];
   let offset = 0;
   for (const [start, end] of ranges) {

--- a/docs/site/scripts/lib/markdown-ranges.mjs
+++ b/docs/site/scripts/lib/markdown-ranges.mjs
@@ -371,10 +371,10 @@ export function markdownLiteralLineRanges(source) {
     : fallbackProtectedLineRanges(source);
 }
 
-export function markdownCodeOffsetRanges(source) {
-  return fromMarkdown
+export function markdownCodeOffsetRanges(source, options = {}) {
+  return fromMarkdown && !options.dependencyFree
     ? markdownAstOffsetRanges(source, new Set(['code', 'inlineCode']))
-    : [];
+    : undefined;
 }
 
 export function lineOverlapsRanges(line, ranges) {

--- a/docs/site/tests/docfx.test.mjs
+++ b/docs/site/tests/docfx.test.mjs
@@ -8,6 +8,7 @@ import {
   convertDocfxMarkdown,
   convertHubYaml,
   createSidebar,
+  escapeMdxAngles,
   isSnippetSupportMarkdown,
 } from '../scripts/lib/docfx.mjs';
 
@@ -306,6 +307,27 @@ describe('DocFX conversion', () => {
       'Use ``Map<`key`, TValue>`` and `Dictionary<string, List<int>>`.',
     );
     expect(converted).not.toContain('GetGrain&lt;TGrainInterface>');
+  });
+
+  test('preserves code angle brackets without the Markdown AST parser', () => {
+    const converted = escapeMdxAngles(
+      [
+        'Use `GetGrain<TGrainInterface>(key)` with <TGrainInterface>.',
+        'Use ``Map<`key`, TValue>``.',
+        'A literal \\`name<T>\\` remains prose.',
+        '```csharp',
+        'List<T> values;',
+        '```',
+      ].join('\n'),
+      { dependencyFree: true },
+    );
+
+    expect(converted).toContain(
+      'Use `GetGrain<TGrainInterface>(key)` with &lt;TGrainInterface>.',
+    );
+    expect(converted).toContain('Use ``Map<`key`, TValue>``.');
+    expect(converted).toContain('A literal \\`name&lt;T>\\` remains prose.');
+    expect(converted).toContain('```csharp\nList<T> values;\n```');
   });
 
   test.each([


### PR DESCRIPTION
## Summary

Preserve fenced blocks and inline code when the optional Markdown AST parser is unavailable, while continuing to escape angle brackets in prose. The dependency-free scanner handles multi-backtick spans and escaped backtick literals.

This follows up on #10658 and addresses the unresolved review feedback from that PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10660)