### PR TITLE
fix(streaming): reject active implicit rewinds

### DIFF
--- a/docs/site/src/content/docs/streaming/delivery-semantics.md
+++ b/docs/site/src/content/docs/streaming/delivery-semantics.md
@@ -1,7 +1,7 @@
 ---
 title: Stream delivery, ordering, replay, and recovery
 description: Design Orleans streaming consumers for provider-specific delivery, ordering, replay, and failure behavior.
-ms.date: 08/18/2026
+ms.date: 08/24/2026
 ms.topic: concept-article
 ---
 
@@ -50,6 +50,8 @@ A rewindable provider can start or resume a subscription from a provider sequenc
 - Memory streams are rewindable only over their transient in-memory cache.
 - Event Hubs and Redis Streams are rewindable over retained external data.
 - Azure Queue, Amazon SQS, ADO.NET, and NATS JetStream providers aren't rewindable.
+
+Explicit subscriptions can resume from retained positions according to the provider's token semantics. An implicit subscription accepts a recovery token when an activation attaches its observer, then advances monotonically for that attachment. Once a delivery call completes successfully, resuming the active implicit handle with a sequence token throws <xref:System.InvalidOperationException>; passing `null` replaces the observer at its current position.
 
 See the [provider matrix](stream-providers.md#provider-matrix) for provider capabilities.
 

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans streaming APIs
 description: Work with stream identities, producers, consumers, and explicit or implicit subscriptions in Orleans.
-ms.date: 08/19/2026
+ms.date: 08/24/2026
 ms.topic: concept-article
 ---
 
@@ -91,6 +91,8 @@ Use an implicit subscription when a stream item should activate a grain determin
 :::code language="csharp" source="snippets/streaming/ImplicitSubscriptions.cs" id="implicit_subscription_grain":::
 
 <xref:Orleans.ImplicitStreamSubscriptionAttribute> selects stream namespaces. For each matching grain type, Orleans maps the stream key to the grain key. Implementing <xref:Orleans.Streams.Core.IStreamSubscriptionObserver> lets Orleans supply the implicit handle; call `ResumeAsync` once to attach processing logic.
+
+An implicit subscription advances monotonically while its observer remains attached. After a delivery call completes successfully, `ResumeAsync` accepts `null` to replace the observer and rejects sequence tokens which would reposition that active subscription. A newly activated grain can attach its newly supplied handle using a persisted recovery token. Use an explicit subscription when application logic intentionally repositions delivery or replays previously acknowledged events.
 
 Implicit subscriptions are declared in grain metadata. They aren't created through <xref:Orleans.Streams.IAsyncObservable`1.SubscribeAsync*>, can't be individually removed at runtime, and don't support multiple subscriptions for the same grain binding.
 

--- a/src/Orleans.Streaming/Core/StreamSubscriptionHandle.cs
+++ b/src/Orleans.Streaming/Core/StreamSubscriptionHandle.cs
@@ -46,6 +46,9 @@ namespace Orleans.Streams
         /// <returns>
         /// The new stream subscription handle.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The active implicit subscription has already completed a delivery and <paramref name="token"/> is non-null.
+        /// </exception>
         public abstract Task<StreamSubscriptionHandle<T>> ResumeAsync(IAsyncObserver<T> observer, StreamSequenceToken? token = null);
 
         /// <summary>
@@ -56,6 +59,9 @@ namespace Orleans.Streams
         /// <returns>
         /// The new stream subscription handle.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The active implicit subscription has already completed a delivery and <paramref name="token"/> is non-null.
+        /// </exception>
         public abstract Task<StreamSubscriptionHandle<T>> ResumeAsync(IAsyncBatchObserver<T> observer, StreamSequenceToken? token = null);
 
         /// <inheritdoc/>

--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -150,12 +150,21 @@ namespace Orleans.Streams
             if (token != null && !IsRewindable)
                 throw new ArgumentNullException(nameof(token), "Passing a non-null token to a non-rewindable IAsyncObservable.");
 
+            oldHandleImpl.ValidateResumeToken(token);
+
             LogDebugResumeToken(token);
             await BindExtensionLazy();
 
             LogDebugResumeRendezvous(pubSub, myGrainReference, token);
 
-            StreamSubscriptionHandle<T> newHandle = myExtension!.SetObserver(oldHandleImpl.SubscriptionId, stream, observer, batchObserver, token, null);
+            StreamSubscriptionHandle<T> newHandle = myExtension!.SetObserver(
+                oldHandleImpl.SubscriptionId,
+                stream,
+                observer,
+                batchObserver,
+                token,
+                oldHandleImpl.FilterData,
+                handshakeState: token is null ? oldHandleImpl.SharedHandshake : null);
 
             // On failure caller should be able to retry using the original handle, so invalidate old handle only if everything succeeded.
             oldHandleImpl.Invalidate();

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -58,7 +58,8 @@ namespace Orleans.Streams
             IAsyncObserver<T>? observer,
             IAsyncBatchObserver<T>? batchObserver,
             StreamSequenceToken? token,
-            string? filterData)
+            string? filterData,
+            StreamSubscriptionHandleImpl<T>.SharedHandshakeState? handshakeState = null)
         {
             if (null == stream) throw new ArgumentNullException(nameof(stream));
             if (IsStatelessWorker && token is not null)
@@ -78,7 +79,8 @@ namespace Orleans.Streams
                     stream,
                     token,
                     filterData,
-                    disableHandshake: IsStatelessWorker);
+                    disableHandshake: IsStatelessWorker,
+                    handshakeState: handshakeState);
                 allStreamObservers[subscriptionId] = handle;
                 return handle;
             }

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -29,10 +29,19 @@ namespace Orleans.Streams
         [NonSerialized]
         private IAsyncBatchObserver<T>? batchObserver;
         [NonSerialized]
-        private StreamHandshakeToken? expectedToken;
+        private SharedHandshakeState? handshakeState;
+        private StreamHandshakeToken? expectedToken
+        {
+            get => SharedHandshake.Token;
+            set => SharedHandshake.Token = value;
+        }
+
         internal bool IsValid { get { return streamImpl != null; } }
         internal GuidId SubscriptionId { get { return subscriptionId; } }
         internal bool IsRewindable { get { return isRewindable; } }
+        internal string? FilterData { get { return filterData; } }
+        internal bool HasObserver { get { return observer is not null || batchObserver is not null; } }
+        internal SharedHandshakeState SharedHandshake => handshakeState ??= new();
 
         public override string ProviderName { get { return this.streamImpl!.ProviderName; } }
         public override StreamId StreamId { get { return streamImpl!.StreamId; } }
@@ -57,17 +66,19 @@ namespace Orleans.Streams
             StreamImpl<T> streamImpl,
             StreamSequenceToken? token,
             string? filterData,
-            bool disableHandshake = false)
+            bool disableHandshake = false,
+            SharedHandshakeState? handshakeState = null)
         {
             this.subscriptionId = subscriptionId ?? throw new ArgumentNullException(nameof(subscriptionId));
             this.observer = observer;
             this.batchObserver = batchObserver;
             this.streamImpl = streamImpl ?? throw new ArgumentNullException(nameof(streamImpl));
             this.filterData = filterData;
+            this.handshakeState = handshakeState;
             this.isRewindable = streamImpl.IsRewindable && !disableHandshake;
             if (IsRewindable)
             {
-                expectedToken = StreamHandshakeToken.CreateStartToken(token);
+                expectedToken ??= StreamHandshakeToken.CreateStartToken(token);
             }
         }
 
@@ -81,6 +92,34 @@ namespace Orleans.Streams
         public StreamHandshakeToken? GetSequenceToken()
         {
             return expectedToken;
+        }
+
+        internal void ValidateResumeToken(StreamSequenceToken? token)
+            => ValidateResumeToken(subscriptionId, HasObserver, expectedToken, token);
+
+        internal static void ValidateResumeToken(
+            GuidId subscriptionId,
+            bool hasObserver,
+            StreamHandshakeToken? expectedToken,
+            StreamSequenceToken? token)
+        {
+            // A DeliveryToken is recorded only after the complete delivery call succeeds.
+            if (token is null
+                || !hasObserver
+                || !SubscriptionMarker.IsImplicitSubscription(subscriptionId.Guid)
+                || expectedToken is not DeliveryToken deliveryToken)
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"An active implicit stream subscription cannot resume from token {token} because it has already completed delivery through token {deliveryToken.Token}. "
+                + "Implicit subscriptions advance monotonically within an activation.");
+        }
+
+        internal sealed class SharedHandshakeState
+        {
+            public StreamHandshakeToken? Token { get; set; }
         }
 
         public override Task UnsubscribeAsync()

--- a/test/Grains/TestGrainInterfaces/IImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IImplicitSubscriptionCounterGrain.cs
@@ -9,6 +9,10 @@ namespace UnitTests.GrainInterfaces
         Task Deactivate();
 
         Task DeactivateOnEvent(bool deactivate);
+
+        Task ReplaceObserverOnNextEvent();
+
+        Task RewindToFirstToken();
     }
 
     public interface IFastImplicitSubscriptionCounterGrain : IImplicitSubscriptionCounterGrain

--- a/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
@@ -10,6 +10,8 @@ namespace UnitTests.Grains
     {
         private readonly ILogger logger;
         private bool deactivateOnEvent;
+        private bool replaceObserverOnEvent;
+        private StreamSubscriptionHandle<byte[]>? streamHandle;
 
         [GenerateSerializer]
         public class MyState
@@ -20,6 +22,8 @@ namespace UnitTests.Grains
             public int ErrorCounter { get; set; }
             [Id(2)]
             public StreamSequenceToken? Token { get; set; }
+            [Id(3)]
+            public StreamSequenceToken? FirstToken { get; set; }
         }
 
         public ImplicitSubscriptionCounterGrain(ILoggerFactory loggerFactory)
@@ -57,28 +61,7 @@ namespace UnitTests.Grains
         {
             this.logger.LogInformation($"OnSubscribed: {handleFactory.ProviderName}/{handleFactory.StreamId}");
 
-            await handleFactory.Create<byte[]>().ResumeAsync(OnNext, OnError, OnCompleted, this.State.Token);
-
-            async Task OnNext(byte[] value, StreamSequenceToken? token)
-            {
-                this.logger.LogInformation("Received: [{Value} {Token}]", value, token);
-                this.State.EventCounter++;
-                this.State.Token = token;
-                await this.WriteStateAsync();
-                if (this.deactivateOnEvent)
-                {
-                    this.DeactivateOnIdle();
-                }
-            }
-
-            async Task OnError(Exception ex)
-            {
-                this.logger.LogError("Error: {Exception}", ex);
-                this.State.ErrorCounter++;
-                await this.WriteStateAsync();
-            }
-
-            Task OnCompleted() => Task.CompletedTask;
+            this.streamHandle = await handleFactory.Create<byte[]>().ResumeAsync(OnNext, OnError, OnCompleted, this.State.Token);
         }
 
         public Task DeactivateOnEvent(bool deactivate)
@@ -86,6 +69,50 @@ namespace UnitTests.Grains
             this.deactivateOnEvent = deactivate;
             return Task.CompletedTask;
         }
+
+        public Task ReplaceObserverOnNextEvent()
+        {
+            this.replaceObserverOnEvent = true;
+            return Task.CompletedTask;
+        }
+
+        public async Task RewindToFirstToken()
+        {
+            if (this.streamHandle is null || this.State.FirstToken is null)
+            {
+                throw new InvalidOperationException("The stream must deliver an event before it can rewind.");
+            }
+
+            this.streamHandle = await this.streamHandle.ResumeAsync(OnNext, OnError, OnCompleted, this.State.FirstToken);
+        }
+
+        private async Task OnNext(byte[] value, StreamSequenceToken? token)
+        {
+            this.logger.LogInformation("Received: [{Value} {Token}]", value, token);
+            this.State.EventCounter++;
+            this.State.Token = token;
+            this.State.FirstToken ??= token;
+            await this.WriteStateAsync();
+            if (this.replaceObserverOnEvent)
+            {
+                this.replaceObserverOnEvent = false;
+                this.streamHandle = await this.streamHandle!.ResumeAsync(OnNext, OnError, OnCompleted);
+            }
+
+            if (this.deactivateOnEvent)
+            {
+                this.DeactivateOnIdle();
+            }
+        }
+
+        private async Task OnError(Exception ex)
+        {
+            this.logger.LogError("Error: {Exception}", ex);
+            this.State.ErrorCounter++;
+            await this.WriteStateAsync();
+        }
+
+        private static Task OnCompleted() => Task.CompletedTask;
     }
 
     [ImplicitStreamSubscription("FastSlowImplicitSubscriptionCounterGrain")]

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
@@ -1,7 +1,13 @@
 using Microsoft.Extensions.Configuration;
 using Orleans.Configuration;
 using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
 
 namespace Tester.StreamingTests
 {
@@ -31,6 +37,94 @@ namespace Tester.StreamingTests
             }
 
             await WaitForStreamProviderReadyAsync();
+        }
+
+        [Fact]
+        public async Task ActiveImplicitSubscriptionRejectsRewindAndContinuesForward()
+        {
+            using var observer = StreamingDiagnosticObserver.Create();
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
+            var key = Guid.NewGuid();
+            var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
+            var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
+            var streamId = StreamId.Create(nameof(IImplicitSubscriptionCounterGrain), key);
+
+            for (var i = 0; i < 5; i++)
+            {
+                await stream.OnNextAsync([1]);
+            }
+
+            await observer.WaitForItemDeliveryCountAsync(streamId, 5, StreamProviderName, cancellation.Token);
+            await WaitForEventCount(5);
+            await observer.WaitForStreamInactiveAsync(streamId, StreamProviderName, cancellation.Token);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => grain.RewindToFirstToken());
+            Assert.Contains("Implicit subscriptions advance monotonically", exception.Message);
+
+            await stream.OnNextAsync([1]);
+            await observer.WaitForItemDeliveryCountAsync(streamId, 6, StreamProviderName, cancellation.Token);
+            await WaitForEventCount(6);
+            Assert.Equal(0, await grain.GetErrorCounter());
+
+            Task WaitForEventCount(int expected)
+            {
+                return TestingUtils.WaitUntilAsync(
+                    async (lastTry, cancellationToken) =>
+                    {
+                        var actual = await grain.GetEventCounter(cancellationToken);
+                        if (lastTry)
+                        {
+                            Assert.Equal(expected, actual);
+                        }
+
+                        return actual == expected;
+                    },
+                    TimeSpan.FromSeconds(30),
+                    delayOnFail: TimeSpan.FromMilliseconds(100),
+                    cancellationToken: cancellation.Token);
+            }
+        }
+
+        [Fact]
+        public async Task ObserverReplacementDuringFirstDeliveryPreservesRewindRejection()
+        {
+            using var observer = StreamingDiagnosticObserver.Create();
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
+            var key = Guid.NewGuid();
+            var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
+            var grain = this.Client.GetGrain<IImplicitSubscriptionCounterGrain>(key);
+            var streamId = StreamId.Create(nameof(IImplicitSubscriptionCounterGrain), key);
+
+            await grain.ReplaceObserverOnNextEvent();
+            await stream.OnNextAsync([1]);
+            await observer.WaitForItemDeliveryCountAsync(streamId, 1, StreamProviderName, cancellation.Token);
+            await WaitForEventCount(1);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => grain.RewindToFirstToken());
+
+            await stream.OnNextAsync([1]);
+            await observer.WaitForItemDeliveryCountAsync(streamId, 2, StreamProviderName, cancellation.Token);
+            await WaitForEventCount(2);
+
+            Task WaitForEventCount(int expected)
+            {
+                return TestingUtils.WaitUntilAsync(
+                    async (lastTry, cancellationToken) =>
+                    {
+                        var actual = await grain.GetEventCounter(cancellationToken);
+                        if (lastTry)
+                        {
+                            Assert.Equal(expected, actual);
+                        }
+
+                        return actual == expected;
+                    },
+                    TimeSpan.FromSeconds(30),
+                    delayOnFail: TimeSpan.FromMilliseconds(100),
+                    cancellationToken: cancellation.Token);
+            }
         }
 
         #region Configuration stuff

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamSubscriptionHandleImplTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamSubscriptionHandleImplTests.cs
@@ -1,0 +1,77 @@
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+public class StreamSubscriptionHandleImplTests
+{
+    [Fact]
+    public void ActiveImplicitSubscriptionRejectsOlderAcknowledgedToken()
+    {
+        var acknowledgedToken = new EventSequenceTokenV2(10);
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: true);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => StreamSubscriptionHandleImpl<int>.ValidateResumeToken(
+                subscriptionId,
+                hasObserver: true,
+                StreamHandshakeToken.CreateDeliveyToken(acknowledgedToken),
+                new EventSequenceTokenV2(9)));
+
+        Assert.Contains("Implicit subscriptions advance monotonically", exception.Message);
+    }
+
+    [Fact]
+    public void ActiveImplicitSubscriptionRejectsNewerTokenAfterAcknowledgement()
+    {
+        var acknowledgedToken = new EventSequenceTokenV2(10);
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: true);
+
+        Assert.Throws<InvalidOperationException>(
+            () => StreamSubscriptionHandleImpl<int>.ValidateResumeToken(
+                subscriptionId,
+                hasObserver: true,
+                StreamHandshakeToken.CreateDeliveyToken(acknowledgedToken),
+                new EventSequenceTokenV2(11)));
+    }
+
+    [Fact]
+    public void ActiveImplicitSubscriptionAllowsObserverReplacementWithoutToken()
+    {
+        StreamSubscriptionHandleImpl<int>.ValidateResumeToken(
+            CreateSubscriptionId(implicitSubscription: true),
+            hasObserver: true,
+            StreamHandshakeToken.CreateDeliveyToken(new EventSequenceTokenV2(10)),
+            token: null);
+    }
+
+    [Fact]
+    public void ActiveExplicitSubscriptionAllowsOlderAcknowledgedToken()
+    {
+        StreamSubscriptionHandleImpl<int>.ValidateResumeToken(
+            CreateSubscriptionId(implicitSubscription: false),
+            hasObserver: true,
+            StreamHandshakeToken.CreateDeliveyToken(new EventSequenceTokenV2(10)),
+            new EventSequenceTokenV2(9));
+    }
+
+    [Fact]
+    public void ReconstructedImplicitSubscriptionAllowsRecoveryToken()
+    {
+        StreamSubscriptionHandleImpl<int>.ValidateResumeToken(
+            CreateSubscriptionId(implicitSubscription: true),
+            hasObserver: false,
+            StreamHandshakeToken.CreateDeliveyToken(new EventSequenceTokenV2(10)),
+            new EventSequenceTokenV2(9));
+    }
+
+    private static GuidId CreateSubscriptionId(bool implicitSubscription)
+    {
+        var subscriptionGuid = implicitSubscription
+            ? SubscriptionMarker.MarkAsImplictSubscriptionId(Guid.NewGuid())
+            : SubscriptionMarker.MarkAsExplicitSubscriptionId(Guid.NewGuid());
+        return GuidId.GetGuidId(subscriptionGuid);
+    }
+}


### PR DESCRIPTION
## Problem

An active implicit stream subscription could request an earlier sequence token after it had already completed delivery. Implicit pub/sub is stateless, so it has no authoritative producer coordination for repositioning that live subscription. The request could appear to succeed and then wait for unrelated stream activity.

## Solution

- make each active implicit subscription attachment monotonic after its first successful delivery
- reject non-null `ResumeAsync` tokens locally before replacing the observer
- preserve the current handshake position and filter when `ResumeAsync(null)` replaces an observer, including replacement from inside a delivery callback
- continue accepting persisted recovery tokens on newly supplied, observerless implicit handles after activation
- retain token-based repositioning for explicit subscriptions
- document the lifecycle boundary and cover direct, replacement, recovery, and forward-delivery behavior

## Rationale

This gives unsupported post-processing rewinds an immediate, deterministic result while preserving the stateless implicit pub/sub design. Applications which intentionally reposition an active subscription use explicit subscriptions, whose pub/sub protocol coordinates that operation.

Fixes #901

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10662)