### PR TITLE
test(runtime): preserve zero-delay cancellation path

### DIFF
--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -448,34 +448,30 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
     public async Task InterleavingGrainTaskCancellation(int delay)
     {
         var grain = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+        using var cts = new CancellationTokenSource();
+        var callId = Guid.NewGuid();
+        if (delay == 0)
+        {
+            var grainTask = grain.LongWaitInterleaving(cts.Token, TimeSpan.FromSeconds(10), callId);
+            cts.CancelAfter(delay);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+            return;
+        }
+
         var observer = new LongRunningTaskObserver();
         var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
         try
         {
-            using var cts = new CancellationTokenSource();
-            var callId = Guid.NewGuid();
-            var grainTask = delay > 0
-                ? grain.LongWaitInterleavingWithStartNotification(
-                    TimeSpan.FromSeconds(10),
-                    callId,
-                    observerReference,
-                    cts.Token)
-                : grain.LongWaitInterleaving(
-                    cts.Token,
-                    TimeSpan.FromSeconds(10),
-                    callId);
-            if (delay > 0)
-            {
-                // A timer does not guarantee that a new activation has begun executing the request.
-                await observer.WaitForCallToStart(callId);
-            }
+            var grainTask = grain.LongWaitInterleavingWithStartNotification(
+                TimeSpan.FromSeconds(10),
+                callId,
+                observerReference,
+                cts.Token);
+            await observer.WaitForCallToStart(callId);
 
             cts.CancelAfter(delay);
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
-            if (delay > 0)
-            {
-                await WaitForCallCancellation(grain, callId);
-            }
+            await WaitForCallCancellation(grain, callId);
         }
         finally
         {


### PR DESCRIPTION
## Problem

The interleaving cancellation test registers an observer object reference before branching on the cancellation delay. The zero-delay case does not use that observer, and the extra registration changes the setup and timing of the path intended to cover cancellation before execution.

## Solution

Keep the zero-delay case on the original `LongWaitInterleaving` flow and return before creating an observer reference. Delayed cases continue to use the explicit grain-start notification before cancellation and delete the observer reference in `finally`.

This applies the reviewed follow-up from closed PR #10633 on top of the root-cause fix merged in PR #10638.

Fixes #10652
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10664)