### PR TITLE
test(reminders): serialize fixture refreshes

### DIFF
--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -749,9 +749,12 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
     private async Task RefreshReminderServicesAsync(CancellationToken cancellationToken)
     {
-        var refreshTasks = HostedCluster.GetActiveSilos().Select(silo =>
-            silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyRefresh());
-        await Task.WhenAll(refreshTasks).WaitAsync(cancellationToken);
+        // Each refresh scans the backing reminder table. Serialize this test-only barrier so that
+        // constrained provider emulators observe the same completed-refresh invariant without an artificial query burst.
+        foreach (var silo in HostedCluster.GetActiveSilos())
+        {
+            await silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyRefresh().WaitAsync(cancellationToken);
+        }
     }
 
     private async Task SynchronizeReminderSchedulesAsync(


### PR DESCRIPTION
The deterministic reminder schedule barrier refreshed every active silo concurrently. Cosmos reminder refreshes perform range scans, so multi-silo fixtures generated an artificial cross-partition query burst against the single-process emulator; failure diagnostics showed 100% CPU before HTTP 408.

Serialize these test-only refreshes across silos. The barrier continues to guarantee that every active reminder service completes a refresh before schedule assertions, while provider emulators process one range-scan set at a time.

Fixes #10649
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10665)