### PR TITLE
test(reminders): re-enable multi-grain join test

### DIFF
--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -166,25 +166,36 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
-
-        await Test_Reminders_MultiGrainMultiReminders(
-            async cancellationToken =>
-            {
-                await using (await PauseReminderTimeAsync(cancellationToken))
+        InProcessSiloHandle? additionalSilo = null;
+        try
+        {
+            await Test_Reminders_MultiGrainMultiReminders(
+                async cancellationToken =>
                 {
-                    log.LogInformation("Starting another silo");
-                    await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
-                        1,
-                        cancellationToken,
-                        startAdditionalSiloOnNewPort: true);
-                }
-            },
-            cts.Token,
-            g1,
-            g2,
-            g3,
-            g4,
-            g5);
+                    await using (await PauseReminderTimeAsync(cancellationToken))
+                    {
+                        log.LogInformation("Starting another silo");
+                        additionalSilo = Assert.Single(await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
+                            1,
+                            cancellationToken,
+                            startAdditionalSiloOnNewPort: true));
+                    }
+                },
+                cts.Token,
+                g1,
+                g2,
+                g3,
+                g4,
+                g5);
+        }
+        finally
+        {
+            if (additionalSilo is not null)
+            {
+                await StopSiloAsync(additionalSilo);
+                await WaitForLivenessToStabilizeAsync();
+            }
+        }
     }
 
     public async Task Test_Reminders_ReminderNotFound()

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -192,8 +192,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             if (additionalSilo is not null)
             {
-                await StopSiloAsync(additionalSilo);
-                await WaitForLivenessToStabilizeAsync();
+                await StopSiloAsync(additionalSilo).WaitAsync(cts.Token);
+                await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
             }
         }
     }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -192,8 +192,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             if (additionalSilo is not null)
             {
-                await StopSiloAsync(additionalSilo).WaitAsync(cts.Token);
-                await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
+                using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
+                await StopSiloAsync(additionalSilo).WaitAsync(cleanupCts.Token);
+                await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
             }
         }
     }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -618,7 +618,7 @@ namespace UnitTests.TimerTests
         /// <summary>
         /// Tests single join scenario with multiple grains and multiple reminders.
         /// </summary>
-        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/4318")]
+        [Fact]
         public async Task Rem_Grain_1J_MultiGrainMultiReminders()
         {
             await Test_Reminders_1J_MultiGrainMultiReminders();


### PR DESCRIPTION
## Problem

`Rem_Grain_1J_MultiGrainMultiReminders` has remained skipped since 2018 because reminder ownership could overlap during a silo join, producing tag mismatches and duplicate ticks. The same signature recurred in the SQL provider tests before #10612.

PR #10612 restored the ownership invariant: a registration received by a stale owner is persisted without creating a local schedule, and the current owner reconciles it before fake time advances.

## Solution

Re-enable the historical grain-based regression test. Stop the silo added by the join scenario in a `finally` block and wait for membership to stabilize, preserving the shared fixture's one-silo topology for subsequent tests.

## Rationale

This exercises the original multi-grain, multi-reminder join scenario against the current reminder implementation without retries or relaxed assertions. The exact test passed 50 consecutive runs across net8.0 and net10.0, and the complete shared fixture passed 20 consecutive runs across both frameworks.

Fixes #4318
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10666)