### PR TITLE
perf(serialization): grow memory stream buffers geometrically

### DIFF
--- a/src/Orleans.Serialization/Buffers/Adaptors/MemoryStreamBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/MemoryStreamBufferWriter.cs
@@ -11,6 +11,12 @@ namespace Orleans.Serialization.Buffers.Adaptors
     {
         private readonly MemoryStream _stream;
         private const int MinRequestSize = 256;
+#if NETSTANDARD2_1
+        // Array.MaxLength is not available in the netstandard2.1 contract.
+        private const int MaxArrayLength = 0x7FFFFFC7;
+#else
+        private static readonly int MaxArrayLength = Array.MaxLength;
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemoryStreamBufferWriter"/> struct.
@@ -82,7 +88,7 @@ namespace Orleans.Serialization.Buffers.Adaptors
             if (_stream.Capacity < requiredCapacity)
             {
                 requiredCapacity = checked(position + Math.Max(sizeHint, MinRequestSize));
-                var doubledCapacity = Math.Min((long)_stream.Capacity * 2, Array.MaxLength);
+                var doubledCapacity = Math.Min((long)_stream.Capacity * 2, MaxArrayLength);
                 _stream.Capacity = Math.Max(requiredCapacity, (int)doubledCapacity);
             }
 

--- a/src/Orleans.Serialization/Buffers/Adaptors/MemoryStreamBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/MemoryStreamBufferWriter.cs
@@ -11,6 +11,7 @@ namespace Orleans.Serialization.Buffers.Adaptors
     {
         private readonly MemoryStream _stream;
         private const int MinRequestSize = 256;
+        private const int MaxArrayLength = 0x7FFFFFC7;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemoryStreamBufferWriter"/> struct.
@@ -24,41 +25,76 @@ namespace Orleans.Serialization.Buffers.Adaptors
         /// <inheritdoc />
         public void Advance(int count)
         {
-            _stream.Position += count;
+            if (count == 0)
+            {
+                return;
+            }
+
+            var position = checked((int)_stream.Position);
+            var availableCapacity = _stream.Capacity - position;
+            if (count < 0 || count > availableCapacity)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            var newPosition = position + count;
+            if (newPosition <= _stream.Length)
+            {
+                _stream.Position = newPosition;
+                return;
+            }
+
+            // Commit through MemoryStream so that it updates Length without clearing bytes
+            // which were written directly to its exposed buffer.
+            if (_stream.Position > _stream.Length)
+            {
+                _stream.SetLength(_stream.Position);
+            }
+
+            var (buffer, offset) = GetBuffer();
+            _stream.Write(buffer.AsSpan(offset + position, count));
         }
 
         /// <inheritdoc />
         public Memory<byte> GetMemory(int sizeHint = 0)
         {
-            if (sizeHint < MinRequestSize)
-            {
-                sizeHint = MinRequestSize;
-            }
-
-            if (_stream.Capacity - _stream.Position < sizeHint)
-            {
-                _stream.Capacity += sizeHint;
-                _stream.SetLength(_stream.Capacity);
-            }
-
-            return _stream.GetBuffer().AsMemory((int)_stream.Position);
+            var position = EnsureCapacity(sizeHint);
+            var (buffer, offset) = GetBuffer();
+            return buffer.AsMemory(offset + position, _stream.Capacity - position);
         }
 
         /// <inheritdoc />
         public Span<byte> GetSpan(int sizeHint = 0)
         {
-            if (sizeHint < MinRequestSize)
+            var position = EnsureCapacity(sizeHint);
+            var (buffer, offset) = GetBuffer();
+            return buffer.AsSpan(offset + position, _stream.Capacity - position);
+        }
+
+        private int EnsureCapacity(int sizeHint)
+        {
+            if (sizeHint < 0)
             {
-                sizeHint = MinRequestSize;
+                throw new ArgumentOutOfRangeException(nameof(sizeHint));
             }
 
-            if (_stream.Capacity - _stream.Position < sizeHint)
+            var position = checked((int)_stream.Position);
+            var requiredCapacity = checked(position + Math.Max(sizeHint, 1));
+            if (_stream.Capacity < requiredCapacity)
             {
-                _stream.Capacity += sizeHint;
-                _stream.SetLength(_stream.Capacity);
+                requiredCapacity = checked(position + Math.Max(sizeHint, MinRequestSize));
+                var doubledCapacity = Math.Min((long)_stream.Capacity * 2, MaxArrayLength);
+                _stream.Capacity = Math.Max(requiredCapacity, (int)doubledCapacity);
             }
 
-            return _stream.GetBuffer().AsSpan((int)_stream.Position);
+            return position;
+        }
+
+        private (byte[] Buffer, int Offset) GetBuffer()
+        {
+            var buffer = _stream.GetBuffer();
+            _ = _stream.TryGetBuffer(out var segment);
+            return (buffer, segment.Offset);
         }
     }
 }

--- a/src/Orleans.Serialization/Buffers/Adaptors/MemoryStreamBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/MemoryStreamBufferWriter.cs
@@ -11,7 +11,6 @@ namespace Orleans.Serialization.Buffers.Adaptors
     {
         private readonly MemoryStream _stream;
         private const int MinRequestSize = 256;
-        private const int MaxArrayLength = 0x7FFFFFC7;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemoryStreamBufferWriter"/> struct.
@@ -83,7 +82,7 @@ namespace Orleans.Serialization.Buffers.Adaptors
             if (_stream.Capacity < requiredCapacity)
             {
                 requiredCapacity = checked(position + Math.Max(sizeHint, MinRequestSize));
-                var doubledCapacity = Math.Min((long)_stream.Capacity * 2, MaxArrayLength);
+                var doubledCapacity = Math.Min((long)_stream.Capacity * 2, Array.MaxLength);
                 _stream.Capacity = Math.Max(requiredCapacity, (int)doubledCapacity);
             }
 

--- a/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
@@ -346,6 +346,139 @@ namespace Orleans.Serialization.UnitTests
 
         [Fact]
         protected override void ByteRoundTrip() => ByteRoundTripTest();
+
+        [Fact]
+        public void BufferGrowthIsGeometric()
+        {
+            using var stream = new MemoryStream();
+            var output = new MemoryStreamBufferWriter(stream);
+
+            var initialBuffer = output.GetSpan();
+            var initialCapacity = stream.Capacity;
+            output.Advance(initialBuffer.Length);
+            var expandedBuffer = output.GetSpan();
+
+            Assert.Equal(initialBuffer.Length, stream.Length);
+            Assert.True(expandedBuffer.Length >= initialBuffer.Length);
+            Assert.True(stream.Capacity >= initialCapacity * 2);
+        }
+
+        [Fact]
+        public void BufferAllocationDoesNotChangeStreamLength()
+        {
+            using var stream = new MemoryStream();
+            stream.Write([1, 2, 3, 4]);
+            stream.Position = 1;
+            var output = new MemoryStreamBufferWriter(stream);
+
+            var buffer = output.GetSpan();
+            buffer[0] = 42;
+
+            Assert.Equal(4, stream.Length);
+            output.Advance(1);
+            Assert.Equal(4, stream.Length);
+            Assert.Equal([1, 42, 3, 4], stream.ToArray());
+
+            stream.Position = stream.Length;
+            output.GetSpan()[0] = 5;
+            output.Advance(1);
+            Assert.Equal(5, stream.Length);
+            Assert.Equal([1, 42, 3, 4, 5], stream.ToArray());
+        }
+
+        [Fact]
+        public void BufferRespectsStreamOrigin()
+        {
+            var underlyingBuffer = new byte[302];
+            using var stream = new MemoryStream(underlyingBuffer, 2, 300, writable: true, publiclyVisible: true);
+            var output = new MemoryStreamBufferWriter(stream);
+
+            var buffer = output.GetSpan();
+            Assert.Equal(300, buffer.Length);
+            buffer[0] = 42;
+            output.Advance(1);
+
+            Assert.Equal(0, underlyingBuffer[0]);
+            Assert.Equal(42, underlyingBuffer[2]);
+            Assert.Equal(1, stream.Position);
+        }
+
+        [Fact]
+        public void ExistingLengthCanBeAdvancedOnReadOnlyExposedStream()
+        {
+            var underlyingBuffer = new byte[300];
+            using var stream = new MemoryStream(underlyingBuffer, 0, underlyingBuffer.Length, writable: false, publiclyVisible: true);
+            var output = new MemoryStreamBufferWriter(stream);
+
+            output.GetSpan()[0] = 42;
+            output.Advance(1);
+
+            Assert.Equal(42, underlyingBuffer[0]);
+            Assert.Equal(1, stream.Position);
+            Assert.Equal(underlyingBuffer.Length, stream.Length);
+        }
+
+        [Fact]
+        public void EmptySizeHintUsesRemainingFixedCapacity()
+        {
+            var underlyingBuffer = new byte[300];
+            using var stream = new MemoryStream(underlyingBuffer, 0, underlyingBuffer.Length, writable: true, publiclyVisible: true);
+            stream.Position = underlyingBuffer.Length - 1;
+            var output = new MemoryStreamBufferWriter(stream);
+
+            var buffer = output.GetSpan();
+
+            Assert.Equal(1, buffer.Length);
+        }
+
+        [Fact]
+        public void EmptyAdvanceDoesNotChangeStreamLength()
+        {
+            using var stream = new MemoryStream();
+            stream.Position = 5;
+            var output = new MemoryStreamBufferWriter(stream);
+
+            _ = output.GetMemory();
+            output.Advance(0);
+
+            Assert.Equal(0, stream.Length);
+            Assert.Equal(5, stream.Position);
+        }
+
+        [Fact]
+        public void AdvanceExtendsStreamAcrossGap()
+        {
+            using var stream = new MemoryStream();
+            stream.Position = 5;
+            var output = new MemoryStreamBufferWriter(stream);
+
+            output.GetSpan()[0] = 42;
+            output.Advance(1);
+
+            Assert.Equal(6, stream.Length);
+            Assert.Equal([0, 0, 0, 0, 0, 42], stream.ToArray());
+        }
+
+        [Fact]
+        public void InvalidAdvanceIsRejected()
+        {
+            using var stream = new MemoryStream();
+            var output = new MemoryStreamBufferWriter(stream);
+            var bufferLength = output.GetSpan().Length;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Advance(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.Advance(bufferLength + 1));
+        }
+
+        [Fact]
+        public void NegativeSizeHintIsRejected()
+        {
+            using var stream = new MemoryStream();
+            var output = new MemoryStreamBufferWriter(stream);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.GetMemory(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => output.GetSpan(-1));
+        }
     }
 
     [Trait("Category", "BVT")]


### PR DESCRIPTION
## Problem

`MemoryStreamBufferWriter` expanded capacity by only the current size hint and set the stream length to the allocated capacity. Incremental serialization could therefore repeatedly reallocate and copy the entire backing buffer, producing potentially quadratic work for large payloads while also including unwritten capacity in the logical stream length.

## Solution

Grow expandable memory streams geometrically while preserving the requested contiguous capacity. Commit only written bytes to the logical stream length, preserve overwrite and gap semantics, account for non-zero array origins, and retain usable capacity on fixed exposed streams.

Focused regression coverage exercises geometric growth, overwrite and append behavior, gaps, fixed and read-only exposed streams, non-zero origins, invalid advances, and size-hint validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10668)