### PR TITLE
test(runtime): reserve fake gateway port

### DIFF
--- a/test/Orleans.Runtime.Tests/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Orleans.Runtime.Tests/ClientConnectionTests/GatewayConnectionTests.cs
@@ -121,9 +121,8 @@ namespace Tester
             var connectionCount = 0;
             var timeoutCount = 0;
 
-            // Fake Gateway
-            var gateways = await this.HostedCluster.Client!.ServiceProvider.GetRequiredService<IGatewayListProvider>().GetGateways(); // The fixture deploys the client.
-            var port = gateways.First().Port + 2;
+            // The cluster-owned allocator reserves the port for the lifetime of the fixture.
+            var (_, port) = this.HostedCluster.PortAllocator.AllocateConsecutivePortPairs(1);
             var endpoint = new IPEndPoint(IPAddress.Loopback, port);
             var evt = new SocketAsyncEventArgs();
             var gatewayManager = this.runtimeClient.ServiceProvider.GetService<TestGatewayManager>()!;
@@ -133,16 +132,15 @@ namespace Tester
                 gatewayManager.Gateways.Remove(endpoint.ToGatewayUri());
             };
 
-            // Add the fake gateway and wait the refresh from the client
-            gatewayManager.Gateways.Add(endpoint.ToGatewayUri());
-            await Task.Delay(200);
-
             using (var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
             {
-                // Start the fake gw
                 socket.Bind(endpoint);
                 socket.Listen(1);
                 socket.AcceptAsync(evt);
+
+                // Add the fake gateway and wait for the client to refresh its gateway list.
+                gatewayManager.Gateways.Add(endpoint.ToGatewayUri());
+                await Task.Delay(200);
 
                 // Make a bunch of calls
                 for (var i = 0; i < 100; i++)

--- a/test/Orleans.Runtime.Tests/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Orleans.Runtime.Tests/ClientConnectionTests/GatewayConnectionTests.cs
@@ -12,6 +12,7 @@ using Orleans.Configuration;
 using Orleans.Configuration.Internal;
 using Microsoft.Extensions.Hosting;
 using Orleans.Runtime.Messaging;
+using Orleans.TestingHost.Utils;
 
 namespace Tester
 {
@@ -122,10 +123,11 @@ namespace Tester
             var timeoutCount = 0;
 
             // The cluster-owned allocator reserves the port for the lifetime of the fixture.
-            var (_, port) = this.HostedCluster.PortAllocator.AllocateConsecutivePortPairs(1);
-            var endpoint = new IPEndPoint(IPAddress.Loopback, port);
+            var (_, gatewayPort) = this.HostedCluster.PortAllocator.AllocateConsecutivePortPairs(1);
+            var endpoint = new IPEndPoint(IPAddress.Loopback, gatewayPort);
             var evt = new SocketAsyncEventArgs();
             var gatewayManager = this.runtimeClient.ServiceProvider.GetService<TestGatewayManager>()!;
+            var clientGatewayManager = this.runtimeClient.ServiceProvider.GetRequiredService<GatewayManager>();
             evt.Completed += (sender, args) =>
             {
                 connectionCount++;
@@ -140,7 +142,11 @@ namespace Tester
 
                 // Add the fake gateway and wait for the client to refresh its gateway list.
                 gatewayManager.Gateways.Add(endpoint.ToGatewayUri());
-                await Task.Delay(200);
+                var gatewayAddress = endpoint.ToGatewayUri().ToGatewayAddress()!;
+                await TestingUtils.WaitUntilAsync(
+                    (_, _) => Task.FromResult(clientGatewayManager.IsGatewayAvailable(gatewayAddress)),
+                    TimeSpan.FromSeconds(3),
+                    TimeSpan.FromMilliseconds(20));
 
                 // Make a bunch of calls
                 for (var i = 0; i < 100; i++)


### PR DESCRIPTION
Fixes #10663

`NoReconnectionToGatewayNotReturnedByManager` now allocates its fake gateway endpoint through the cluster-owned `TestClusterPortAllocator`. The allocator retains its cross-process reservation for the fixture lifetime, and the test binds and starts listening before publishing the endpoint to the client.

This removes the arithmetic dependency on the primary gateway port and makes the fake gateway setup deterministic under parallel test execution.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10669)