### PR TITLE
fix(testing): scope streaming resume wait deadlines

### DIFF
--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -169,7 +169,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
 
                 return actual == expected;
             },
-            TimeSpan.FromSeconds(30),
+            WaitTimeout,
             delayOnFail: PollInterval);
     }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -18,6 +18,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     protected const string StreamProviderName = "StreamingCacheMissTests";
 
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(30);
 
     [SkippableFact]
     public virtual async Task ResumeAfterInactivity()
@@ -34,7 +35,6 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     protected virtual async Task ResumeAfterInactivityImpl(bool waitForCacheToFlush)
     {
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
         var key = Guid.NewGuid();
         var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
@@ -43,9 +43,9 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var interestingData = new byte[1] { 1 };
 
         await stream.OnNextAsync(interestingData);
-        await observer.WaitForItemDeliveryCountAsync(streamId, 1, StreamProviderName, cts.Token);
+        await WaitForItemDeliveryCountAsync(observer, streamId, 1);
         await WaitForEventCounterAsync(grain, 1);
-        await observer.WaitForStreamInactiveAsync(streamId, StreamProviderName, cts.Token);
+        await WaitForStreamInactiveAsync(observer, streamId);
 
         if (waitForCacheToFlush)
         {
@@ -59,7 +59,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
 
             // Wait for the last other stream to go inactive, ensuring cache flush
             var lastOtherStreamId = StreamId.Create(nameof(IImplicitSubscriptionCounterGrain), lastOtherKey);
-            await observer.WaitForStreamInactiveAsync(lastOtherStreamId, StreamProviderName, cts.Token);
+            await WaitForStreamInactiveAsync(observer, lastOtherStreamId);
 
             for (var i = 0; i < 5; i++)
             {
@@ -69,7 +69,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         }
 
         await stream.OnNextAsync(interestingData);
-        await observer.WaitForItemDeliveryCountAsync(streamId, 2, StreamProviderName, cts.Token);
+        await WaitForItemDeliveryCountAsync(observer, streamId, 2);
         await WaitForEventCounterAsync(grain, 2);
 
         Assert.Equal(0, await grain.GetErrorCounter());
@@ -79,7 +79,6 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     public virtual async Task ResumeAfterDeactivation()
     {
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
         var key = Guid.NewGuid();
         var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
@@ -88,13 +87,13 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var interestingData = new byte[1] { 1 };
 
         await stream.OnNextAsync(interestingData);
-        await observer.WaitForItemDeliveryCountAsync(streamId, 1, StreamProviderName, cts.Token);
+        await WaitForItemDeliveryCountAsync(observer, streamId, 1);
         await WaitForEventCounterAsync(grain, 1);
-        await observer.WaitForStreamInactiveAsync(streamId, StreamProviderName, cts.Token);
+        await WaitForStreamInactiveAsync(observer, streamId);
         await grain.Deactivate();
 
         await stream.OnNextAsync(interestingData);
-        await observer.WaitForItemDeliveryCountAsync(streamId, 2, StreamProviderName, cts.Token);
+        await WaitForItemDeliveryCountAsync(observer, streamId, 2);
         await WaitForEventCounterAsync(grain, 2);
 
         Assert.Equal(0, await grain.GetErrorCounter());
@@ -104,7 +103,6 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     public virtual async Task ResumeAfterDeactivationActiveStream()
     {
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
         var key = Guid.NewGuid();
         var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
@@ -119,13 +117,13 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         await otherStream.OnNextAsync(interestingData);
         await otherStream.OnNextAsync(interestingData);
         await stream.OnNextAsync(interestingData);
-        await observer.WaitForItemDeliveryCountAsync(streamId, 2, StreamProviderName, cts.Token);
+        await WaitForItemDeliveryCountAsync(observer, streamId, 2);
         await WaitForEventCounterAsync(grain, 2);
-        await observer.WaitForStreamInactiveAsync(streamId, StreamProviderName, cts.Token);
+        await WaitForStreamInactiveAsync(observer, streamId);
         await grain.Deactivate();
 
         await stream.OnNextAsync(interestingData);
-        await observer.WaitForItemDeliveryCountAsync(streamId, 3, StreamProviderName, cts.Token);
+        await WaitForItemDeliveryCountAsync(observer, streamId, 3);
         await WaitForEventCounterAsync(grain, 3);
 
         Assert.Equal(0, await grain.GetErrorCounter());
@@ -173,5 +171,17 @@ public abstract class StreamingResumeTests : TestClusterPerTest
             },
             TimeSpan.FromSeconds(30),
             delayOnFail: PollInterval);
+    }
+
+    private static async Task WaitForItemDeliveryCountAsync(StreamingDiagnosticObserver observer, StreamId streamId, int expectedCount)
+    {
+        using var cts = new CancellationTokenSource(WaitTimeout);
+        await observer.WaitForItemDeliveryCountAsync(streamId, expectedCount, StreamProviderName, cts.Token);
+    }
+
+    private static async Task WaitForStreamInactiveAsync(StreamingDiagnosticObserver observer, StreamId streamId)
+    {
+        using var cts = new CancellationTokenSource(WaitTimeout);
+        await observer.WaitForStreamInactiveAsync(streamId, StreamProviderName, cts.Token);
     }
 }


### PR DESCRIPTION
## Summary
- give each streaming resume delivery and inactivity transition its own 30-second deadline
- preserve the existing timeout threshold while preventing earlier phases from consuming later phases' wait budget
- apply the shared phase-scoped contract to memory, Redis, Event Hubs, and the related deactivation resume scenarios

## Rationale
#9990 replaced independent inactivity delays with diagnostic waits but created one cancellation token at test start for the whole scenario. `ResumeAfterInactivityNotInCache` requires two separate inactivity transitions, plus provider work between them. The reported memory, Redis, and Event Hubs failures all expired in the second inactivity wait at line 62, exactly 30 seconds after the test body began, so that transition received only the first phase's remaining budget.

`StreamingDiagnosticObserver` replays past events, and the memory provider startup barrier from #10466 was already present in the failing run. Scoping the existing deadline to each operation therefore addresses the common wait-budget root cause without extending any individual wait.

Addresses #10661
Addresses #10667
Addresses #10689

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10671)