### PR TITLE
fix(docs): redirect obsolete running application guide

### DIFF
--- a/docs/site/src/data/redirects.json
+++ b/docs/site/src/data/redirects.json
@@ -1,4 +1,5 @@
 {
+  "/orleans/Documentation/Getting-Started-With-Orleans/Running-the-Application.html": "/orleans/docs/quickstarts/build-your-first-orleans-app/",
   "/orleans/Tutorials/Minimal-Orleans-Application.html": "/orleans/docs/tutorials-and-samples/hello-world/",
   "/orleans/Tutorials/Running-in-a-Stand-alone-Silo.html": "/orleans/docs/quickstarts/build-your-first-orleans-app/",
   "/orleans/docs/tutorials-and-samples/tutorial-1/": "/orleans/docs/quickstarts/build-your-first-orleans-app/",

--- a/docs/site/tests/redirects.test.mjs
+++ b/docs/site/tests/redirects.test.mjs
@@ -13,6 +13,11 @@ describe('legacy redirects', () => {
     expect(
       redirects['/orleans/Tutorials/Running-in-a-Stand-alone-Silo.html'],
     ).toBe('/orleans/docs/quickstarts/build-your-first-orleans-app/');
+    expect(
+      redirects[
+        '/orleans/Documentation/Getting-Started-With-Orleans/Running-the-Application.html'
+      ],
+    ).toBe('/orleans/docs/quickstarts/build-your-first-orleans-app/');
   });
 
   test('routes the Azure Web Apps legacy page to the restored App Service guide', async () => {


### PR DESCRIPTION
The legacy Running the Application URL cited by the issue no longer describes the current Orleans hosting model. Route that URL to the maintained .NET 10 multi-project tutorial and cover the mapping with the legacy redirect test.

Closes #4416