### PR TITLE
docs(streaming): clarify unsubscribe lifecycle

### DIFF
--- a/docs/site/src/content/docs/streaming/snippets/streaming/ExplicitSubscriptions.cs
+++ b/docs/site/src/content/docs/streaming/snippets/streaming/ExplicitSubscriptions.cs
@@ -50,8 +50,6 @@ public sealed class ExplicitTelemetryGrain :
         {
             await handle.UnsubscribeAsync();
         }
-
-        DeactivateOnIdle();
     }
 
     public Task OnNextAsync(

--- a/docs/site/src/content/docs/streaming/snippets/streaming/ExplicitSubscriptions.cs
+++ b/docs/site/src/content/docs/streaming/snippets/streaming/ExplicitSubscriptions.cs
@@ -50,6 +50,8 @@ public sealed class ExplicitTelemetryGrain :
         {
             await handle.UnsubscribeAsync();
         }
+
+        DeactivateOnIdle();
     }
 
     public Task OnNextAsync(

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -82,7 +82,7 @@ This lifecycle is durable across cluster restarts only when the configured [`Pub
 
 #### End an explicit subscription
 
-End a subscription in a regular grain method while the activation is active, before deactivation starts. Await <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle so that the streaming runtime removes the subscription from pub/sub storage and notifies active producers before the method returns. Use <xref:Orleans.Grain.OnDeactivateAsync*> for activation-local cleanup after deactivation begins. After the unsubscribe method returns, the activation follows its normal lifecycle and Orleans cleans it up as usual. The example's `UnsubscribeAsync` method follows this sequence.
+End a subscription by awaiting <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle. The streaming runtime removes each subscription from pub/sub storage and notifies active producers before the operation completes. The example's `UnsubscribeAsync` method follows this sequence.
 
 ### Implicit subscriptions
 

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -82,9 +82,7 @@ This lifecycle is durable across cluster restarts only when the configured [`Pub
 
 #### End an explicit subscription
 
-End a subscription in a regular grain method while the activation is active. Await <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle, then call <xref:Orleans.Grain.DeactivateOnIdle*> when the activation can be released. This ordering lets the streaming runtime remove the subscription from pub/sub storage and notify active producers before grain deactivation begins.
-
-The example's `UnsubscribeAsync` method follows this sequence. <xref:Orleans.Grain.OnDeactivateAsync*> remains available for best-effort cleanup of activation-local resources. Explicit subscription records span activations, so an ordinary deactivation leaves them available for the next activation to discover and resume.
+End a subscription in a regular grain method. Await <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle so that the streaming runtime removes the subscription from pub/sub storage and notifies active producers before the method returns. The example's `UnsubscribeAsync` method follows this sequence.
 
 ### Implicit subscriptions
 

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -82,7 +82,7 @@ This lifecycle is durable across cluster restarts only when the configured [`Pub
 
 #### End an explicit subscription
 
-End a subscription in a regular grain method. Await <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle so that the streaming runtime removes the subscription from pub/sub storage and notifies active producers before the method returns. The example's `UnsubscribeAsync` method follows this sequence.
+End a subscription in a regular grain method while the activation is active, before deactivation starts. Await <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle so that the streaming runtime removes the subscription from pub/sub storage and notifies active producers before the method returns. Use <xref:Orleans.Grain.OnDeactivateAsync*> for activation-local cleanup after deactivation begins. After the unsubscribe method returns, the activation follows its normal lifecycle and Orleans cleans it up as usual. The example's `UnsubscribeAsync` method follows this sequence.
 
 ### Implicit subscriptions
 

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans streaming APIs
 description: Work with stream identities, producers, consumers, and explicit or implicit subscriptions in Orleans.
-ms.date: 08/18/2026
+ms.date: 08/19/2026
 ms.topic: concept-article
 ---
 
@@ -79,6 +79,12 @@ Use an explicit subscription when application behavior decides whether and when 
 The subscription belongs to the grain identity, not one activation. After deactivation, a later activation calls <xref:Orleans.Streams.IAsyncStream`1.GetAllSubscriptionHandles*> and <xref:Orleans.Streams.StreamSubscriptionHandle`1.ResumeAsync*> to attach its new observer instance. Call <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> to remove a subscription.
 
 This lifecycle is durable across cluster restarts only when the configured [`PubSubStore` is durable](pubsub-storage.md). A memory `PubSubStore` preserves records only while that cluster state remains available.
+
+#### End an explicit subscription
+
+End a subscription in a regular grain method while the activation is active. Await <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle, then call <xref:Orleans.Grain.DeactivateOnIdle*> when the activation can be released. This ordering lets the streaming runtime remove the subscription from pub/sub storage and notify active producers before grain deactivation begins.
+
+The example's `UnsubscribeAsync` method follows this sequence. <xref:Orleans.Grain.OnDeactivateAsync*> remains available for best-effort cleanup of activation-local resources. Explicit subscription records span activations, so an ordinary deactivation leaves them available for the next activation to discover and resume.
 
 ### Implicit subscriptions
 


### PR DESCRIPTION
## Problem

Explicit stream subscriptions outlive individual grain activations, but the documentation did not state how to end a subscription when the grain also requests deactivation. Unsubscribing from `OnDeactivateAsync` can overlap pub/sub producer coordination with activation shutdown and lead to a timeout.

## Solution

Document the supported lifecycle: resume identity-owned subscriptions during activation, unsubscribe from an active grain turn, await pub/sub coordination, and then request deactivation. Update the compiled snippet to demonstrate that ordering with current APIs.

## Rationale

This sequence relies on Orleans lifecycle guarantees and keeps durable subscription membership separate from activation-local cleanup.

Closes #4386
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10676)