### PR TITLE
docs: clarify production deployment walkthrough

### DIFF
--- a/docs/site/src/content/docs/deployment/index.md
+++ b/docs/site/src/content/docs/deployment/index.md
@@ -25,7 +25,7 @@ See [Server configuration](../host/configuration-guide/server-configuration.md) 
 
 ## Follow the deployment walkthrough
 
-[Build and deploy a production-shaped Orleans application](../tutorials-and-samples/production-application.md) takes you from an empty directory to a running multi-process cluster, then through code-based production configuration, deployment, observability, and verification. It uses a maintained sample whose application code, infrastructure, and deployment workflow are validated together.
+[Deploy an Orleans application to Azure Container Apps](../tutorials-and-samples/production-application.md) takes you from an empty directory to a running multi-process cluster, then through code-based production configuration, deployment, observability, and verification. The sample's application code, infrastructure, and deployment workflow are validated together.
 
 For an existing application, use the walkthrough as a sequence:
 
@@ -52,7 +52,7 @@ Use these articles together:
 
 ## Choose a platform
 
-- [Production-shaped walkthrough and Azure Container Apps sample](../tutorials-and-samples/production-application.md)
+- [Azure Container Apps deployment walkthrough and sample](../tutorials-and-samples/production-application.md)
 - [Containers across multiple hosts](containers.md)
 - [Kubernetes](kubernetes.md)
 - [Service Fabric](service-fabric.md)

--- a/docs/site/src/content/docs/deployment/index.md
+++ b/docs/site/src/content/docs/deployment/index.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy and operate Orleans
 description: Plan, deploy, and operate an Orleans application in production.
-ms.date: 08/15/2026
+ms.date: 08/19/2026
 ms.topic: overview
 ---
 
@@ -23,6 +23,18 @@ Configure a silo on the [.NET Generic Host](https://learn.microsoft.com/dotnet/c
 
 See [Server configuration](../host/configuration-guide/server-configuration.md) and [Client configuration](../host/configuration-guide/client-configuration.md) for compiled examples.
 
+## Follow the deployment walkthrough
+
+[Build and deploy a production-shaped Orleans application](../tutorials-and-samples/production-application.md) takes you from an empty directory to a running multi-process cluster, then through code-based production configuration, deployment, observability, and verification. It uses a maintained sample whose application code, infrastructure, and deployment workflow are validated together.
+
+For an existing application, use the walkthrough as a sequence:
+
+1. Host silos and external clients on the .NET Generic Host.
+1. Configure cluster identity, providers, credentials, and endpoints in code from deployment-supplied configuration.
+1. Choose a platform which gives every silo a unique, directly reachable endpoint.
+1. Deploy multiple silos with health probes, telemetry, resource policies, and a graceful termination deadline.
+1. Verify membership, TCP reachability, grain calls, provider state, failure behavior, and rolling replacement before admitting production traffic.
+
 <a id="production-configurations"></a>
 
 ## Operations track
@@ -40,6 +52,7 @@ Use these articles together:
 
 ## Choose a platform
 
+- [Production-shaped walkthrough and Azure Container Apps sample](../tutorials-and-samples/production-application.md)
 - [Containers across multiple hosts](containers.md)
 - [Kubernetes](kubernetes.md)
 - [Service Fabric](service-fabric.md)

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -24,7 +24,7 @@ items:
         href: tutorials-and-samples/adventure.md
       - name: Build custom grain storage
         href: tutorials-and-samples/custom-grain-storage.md
-      - name: Build and deploy a production-shaped application
+      - name: Deploy an Orleans application to Azure Container Apps
         href: tutorials-and-samples/production-application.md
       - name: Test an Orleans application end to end
         href: tutorials-and-samples/testing-walkthrough.md

--- a/docs/site/src/content/docs/tutorials-and-samples/index.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/index.md
@@ -24,7 +24,7 @@ For a more typical project structure, [Build your first Orleans app](../quicksta
 
 | Tutorial | What it teaches |
 | --- | --- |
-| [Build and deploy a production-shaped application](production-application.md) | Run, deploy, observe, and verify a multi-process Orleans application. |
+| [Deploy an Orleans application to Azure Container Apps](production-application.md) | Run, deploy, observe, and verify a multi-process Orleans application. |
 | [Test an Orleans application end to end](testing-walkthrough.md) | Progress from a first cluster test to reusable fixtures and topology changes. |
 | [Build and recover a streaming application](streaming-walkthrough.md) | Follow events through a real provider and verify recovery from checkpoints. |
 | [Custom grain storage](custom-grain-storage.md) | Implement and register an <xref:Orleans.Storage.IGrainStorage> provider. |

--- a/docs/site/src/content/docs/tutorials-and-samples/production-application.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/production-application.md
@@ -1,7 +1,7 @@
 ---
 title: Build and deploy a production-shaped Orleans application
 description: Run, inspect, deploy, and verify a multi-process Orleans application on Azure Container Apps.
-ms.date: 08/11/2026
+ms.date: 08/19/2026
 ms.topic: tutorial
 ---
 
@@ -69,6 +69,37 @@ Development uses a storage emulator. Deployed processes use <xref:Azure.Identity
 Every deployed silo has a unique advertised silo and gateway endpoint. Azure Container Apps assigns the documented endpoint at the app boundary, so the sample deploys each silo as a separate one-replica Container App. Add capacity by adding silo apps with unused ports.
 
 Review the sample's [deployment README](https://github.com/dotnet/orleans/blob/main/samples/Deployment/AzureContainerApps/README.md) and `Azure/bootstrap.bicep` before assigning roles. The privileged bootstrap and routine deployment are deliberately separate.
+
+### Configure the host in code
+
+Orleans production configuration is composed on the .NET Generic Host. The [sample silo host](https://github.com/dotnet/orleans/blob/main/samples/Deployment/AzureContainerApps/Silo/Program.cs) reads deployment values through <xref:Microsoft.Extensions.Configuration.IConfiguration>, calls <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*>, and configures cluster identity, endpoints, and Azure Table Storage clustering on the resulting <xref:Orleans.Hosting.ISiloBuilder>.
+
+The same pattern can register durable grain storage in an application which persists grain state:
+
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="container_apps_storage_usings":::
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="configure_container_apps_storage":::
+
+`ServiceId` remains stable for the application. `ClusterId` identifies the deployment environment or blue-green cluster. Every silo and external client uses the same values and the same clustering backend. The host reads provider endpoints and cluster identity from deployment configuration and fails startup when required values are absent.
+
+Listening endpoints describe where the process accepts connections. Advertised endpoints identify the unique address and ports which other silos and clients use to reach that process:
+
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="container_endpoint_usings":::
+:::code language="csharp" source="../snippets/compiled/Deployment/DeploymentSnippets.cs" id="configure_container_endpoints":::
+
+The deployment platform supplies these values for each silo. The sample's [endpoint configuration](https://github.com/dotnet/orleans/blob/main/samples/Deployment/AzureContainerApps/Infrastructure/OrleansEndpointConfigurationExtensions.cs) applies the same model to the private address and unique port pair allocated to each one-replica Container App.
+
+### Choose a deployment model
+
+Use the platform guide whose network and lifecycle guarantees match the target environment:
+
+| Target | Recommended model |
+| --- | --- |
+| Kubernetes | Advertise each pod IP, allow direct pod-to-pod TCP, and use a production clustering provider. |
+| Managed container platform | Give each silo a documented per-instance address or a unique private address and port pair. |
+| Virtual machines or bare metal | Advertise stable private addresses and supervise the .NET host as a long-running service. |
+| Azure App Service | Use the maintained multi-instance sample and its private per-instance port mapping. |
+
+See [Platform requirements](../deployment/platform-guides.md) before adapting the sample to another host. The invariant is that every membership entry names one silo endpoint which all other silos can reach directly.
 
 ## Deploy
 

--- a/docs/site/src/content/docs/tutorials-and-samples/production-application.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/production-application.md
@@ -97,7 +97,7 @@ Use the platform guide whose network and lifecycle guarantees match the target e
 | Kubernetes | Advertise each pod IP, allow direct pod-to-pod TCP, and use a production clustering provider. |
 | Managed container platform | Give each silo a documented per-instance address or a unique private address and port pair. |
 | Virtual machines or bare metal | Advertise stable private addresses and supervise the .NET host as a long-running service. |
-| Azure App Service | Use the maintained multi-instance sample and its private per-instance port mapping. |
+| Azure App Service | Use the multi-instance sample and its private per-instance port mapping. |
 
 See [Platform requirements](../deployment/platform-guides.md) before adapting the sample to another host. The invariant is that every membership entry names one silo endpoint which all other silos can reach directly.
 

--- a/docs/site/src/content/docs/tutorials-and-samples/production-application.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/production-application.md
@@ -1,13 +1,13 @@
 ---
-title: Build and deploy a production-shaped Orleans application
+title: Deploy an Orleans application to Azure Container Apps
 description: Run, inspect, deploy, and verify a multi-process Orleans application on Azure Container Apps.
 ms.date: 08/19/2026
 ms.topic: tutorial
 ---
 
-# Build and deploy a production-shaped Orleans application
+# Deploy an Orleans application to Azure Container Apps
 
-This walkthrough takes you from an empty directory to a deployed, observable Orleans cluster. You use the maintained [Azure Container Apps sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps) so that the application, infrastructure, and deployment workflow stay buildable together.
+This walkthrough takes you from an empty directory to a deployed, observable Orleans cluster using the [Azure Container Apps sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps). The application, infrastructure, and deployment workflow are versioned and validated together.
 
 The finished system has dedicated silos, an HTTP API and worker client, Azure Table Storage clustering, managed identity, health probes, Application Insights, and an Orleans Dashboard. This sample demonstrates clustering and deployment; add a grain-storage provider to persist application state.
 


### PR DESCRIPTION
## Summary

- link the deployment hub directly to the maintained production-shaped walkthrough
- document the current .NET Generic Host configuration path for cluster identity, providers, credentials, and endpoints
- connect code-based configuration to the supported networking models for Kubernetes, managed containers, virtual machines, and Azure App Service

This makes the modern, validated sample and current production recommendations discoverable from the deployment entry point while preserving the detailed operational reference.

Closes #2084
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10677)