### PR TITLE
Update vulnerable SSH.NET and nanoid dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -95,8 +95,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
     <PackageVersion Include="protobuf-net" Version="3.2.56" />
-    <PackageVersion Include="SpanJson" Version="4.2.1" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
+    <PackageVersion Include="SpanJson" Version="4.2.1" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="StackExchange.Redis" Version="2.11.0" />
     <PackageVersion Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,6 +96,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
     <PackageVersion Include="protobuf-net" Version="3.2.56" />
     <PackageVersion Include="SpanJson" Version="4.2.1" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="StackExchange.Redis" Version="2.11.0" />
     <PackageVersion Include="StructureMap.Microsoft.DependencyInjection" Version="2.0.0" />

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -7138,9 +7138,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
+      "version": "3.3.18",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=",
       "funding": [
         {
           "type": "github",

--- a/src/Dashboard/Orleans.Dashboard.App/package-lock.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package-lock.json
@@ -3707,9 +3707,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- pin SSH.NET to 2026.0.0
- update nanoid from 3.3.17 to 3.3.18 in the docs and dashboard lockfiles
- address CVE-2026-48798 and CVE-2026-67213

## Validation
- targeted Cassandra and Consul project builds passed
- docs tests passed (225 tests)
- dashboard production build passed

Docker-backed Cassandra and Consul integration tests could not run locally because Docker was unavailable; GitHub CI will provide that coverage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10678)