### PR TITLE
feat(durable-jobs): add grain-scoped feature handlers

### DIFF
--- a/docs/site/src/content/docs/host/monitoring/metrics-catalog.md
+++ b/docs/site/src/content/docs/host/monitoring/metrics-catalog.md
@@ -206,30 +206,30 @@ Failure and exception counters can both increment for one operation. Duration co
 
 | Instrument | Type | Unit | Attributes | Description |
 |---|---|---|---|---|
-| `orleans-durablejobs-cancel-job-call-duration` | H | `ms` | `status` | Duration of cancel-job API calls, split by `ok`, `not_found`, `canceled`, or `error`. |
-| `orleans-durablejobs-cancel-job-calls` | C | Calls, implicit | `status` | Completed cancel-job API calls by outcome. |
-| `orleans-durablejobs-handler-execution-duration` | H | `ms` | `status` | Duration of completed handler executions, split by `completed`, `canceled`, or `failed`. |
+| `orleans-durablejobs-cancel-job-call-duration` | H | `ms` | `status` | Duration of `CancelAsync` calls, split by `cancellation_requested`, `not_found`, `operation_canceled`, or `error`. |
+| `orleans-durablejobs-cancel-job-calls` | C | Calls, implicit | `status` | Completed `CancelAsync` calls by request outcome. |
+| `orleans-durablejobs-handler-execution-duration` | H | `ms` | `status` | Duration of completed handler executions, split by `completed`, `attempt_canceled`, or `failed`. |
 | `orleans-durablejobs-handler-executions` | C | Executions, implicit | `status` | Handler executions which reached a terminal outcome. |
 | `orleans-durablejobs-handler-executions-started` | C | Executions, implicit | - | Durable-job handler executions started. |
-| `orleans-durablejobs-job-attempt-duration` | H | `ms` | `status` | Duration of job attempts ending as `completed`, `failed`, or `retried`. |
+| `orleans-durablejobs-job-attempt-duration` | H | `ms` | `status` | Duration of job attempts ending as `completed`, `failed`, `retried`, or `rescheduled`. |
 | `orleans-durablejobs-job-attempts-started` | C | Attempts, implicit | - | Durable-job attempts started. |
 | `orleans-durablejobs-job-dispatch-lag` | H | `ms` | - | Delay between a job's due time and the start of its attempt. |
 | `orleans-durablejobs-job-schedule-duration` | H | `ms` | - | Time required to persist and schedule a job. |
-| `orleans-durablejobs-jobs-canceled` | C | Jobs, implicit | - | Durable jobs canceled. |
+| `orleans-durablejobs-job-cancellation-requests` | C | Requests, implicit | - | Durable job cancellation requests which were durably recorded. |
 | `orleans-durablejobs-jobs-completed` | C | Jobs, implicit | - | Durable jobs completed successfully. |
 | `orleans-durablejobs-jobs-failed` | C | Jobs, implicit | - | Durable-job attempts recorded as failed. |
 | `orleans-durablejobs-jobs-retried` | C | Jobs, implicit | - | Durable-job attempts scheduled for retry. |
 | `orleans-durablejobs-jobs-scheduled` | C | Jobs, implicit | - | Durable jobs successfully scheduled. |
 | `orleans-durablejobs-ownership-check-duration` | H | `ms` | - | Duration of shard-ownership checks. |
-| `orleans-durablejobs-schedule-job-call-duration` | H | `ms` | `status` | Duration of schedule-job API calls, split by `ok`, `canceled`, or `error`. |
+| `orleans-durablejobs-schedule-job-call-duration` | H | `ms` | `status` | Duration of schedule-job API calls, split by `ok`, `operation_canceled`, or `error`. |
 | `orleans-durablejobs-schedule-job-calls` | C | Calls, implicit | `status` | Completed schedule-job API calls by outcome. |
 | `orleans-durablejobs-shard-batch-bytes` | H | `bytes` | - | Serialized byte size of durable-job shard mutation batches. |
 | `orleans-durablejobs-shard-batch-mutations` | H | Mutations, implicit | - | Mutation count in durable-job shard batches. |
 | `orleans-durablejobs-shard-pending-depth` | H | Mutations, implicit | - | Pending mutation operations collected into each shard batch immediately before processing. |
-| `orleans-durablejobs-shard-processing-duration` | H | `ms` | `status` | Shard processing duration, split by `completed`, `canceled`, or `error`. |
+| `orleans-durablejobs-shard-processing-duration` | H | `ms` | `status` | Shard processing duration, split by `completed`, `attempt_canceled`, or `error`. |
 | `orleans-durablejobs-shards-processed` | C | Shards, implicit | `status` | Shard processing passes completed by outcome. |
 | `orleans-durablejobs-storage-batch-size` | H | Mutations, implicit | `status` | Applied shard mutations included in each state-write attempt, split by outcome. |
-| `orleans-durablejobs-storage-batches` | C | Batches, implicit | `status` | Durable-job storage batches written, canceled, or failed. |
+| `orleans-durablejobs-storage-batches` | C | Batches, implicit | `status` | Durable-job storage batches split by `ok`, `operation_canceled`, or `error`. |
 | `orleans-durablejobs-stripe-distribution` | C | Assignments, implicit | `stripe` | Job assignments by durable-job stripe number. |
 
 ## Journaling

--- a/src/Azure/Orleans.DurableJobs.AzureStorage/README.md
+++ b/src/Azure/Orleans.DurableJobs.AzureStorage/README.md
@@ -119,7 +119,7 @@ using Orleans.DurableJobs;
 public interface IEmailGrain : IGrainWithStringKey
 {
     Task ScheduleEmail(string subject, string body, DateTimeOffset sendTime);
-    Task CancelScheduledEmail();
+    Task CancelScheduledEmail(CancellationToken requestCancellationToken);
 }
 
 public class EmailGrain : Grain, IEmailGrain, IDurableJobHandler
@@ -127,7 +127,7 @@ public class EmailGrain : Grain, IEmailGrain, IDurableJobHandler
     private readonly ILocalDurableJobManager _jobManager;
     private readonly IEmailService _emailService;
     private readonly ILogger<EmailGrain> _logger;
-    private IDurableJob? _durableEmailJob;
+    private DurableJob? _durableEmailJob;
 
     public EmailGrain(
         ILocalDurableJobManager jobManager,
@@ -163,7 +163,7 @@ public class EmailGrain : Grain, IEmailGrain, IDurableJobHandler
             emailAddress, sendTime, _durableEmailJob.Id);
     }
 
-    public async Task CancelScheduledEmail()
+    public async Task CancelScheduledEmail(CancellationToken requestCancellationToken)
     {
         if (_durableEmailJob is null)
         {
@@ -171,19 +171,24 @@ public class EmailGrain : Grain, IEmailGrain, IDurableJobHandler
             return;
         }
 
-        var canceled = await _jobManager.TryCancelDurableJobAsync(_durableEmailJob);
-        if (canceled)
+        var cancellationRequested = await _jobManager.CancelAsync(_durableEmailJob, requestCancellationToken);
+        if (cancellationRequested)
         {
-            _logger.LogInformation("Email job {JobId} canceled successfully", _durableEmailJob.Id);
+            _logger.LogInformation(
+                "Email job {JobId} cancellation request recorded; no future attempt will start",
+                _durableEmailJob.Id);
+            // An already-running attempt may still complete.
             _durableEmailJob = null;
         }
         else
         {
-            _logger.LogWarning("Failed to cancel email job {JobId} (may have already executed)", _durableEmailJob.Id);
+            _logger.LogWarning(
+                "Cancellation request was not recorded for email job {JobId} (it may have already completed)",
+                _durableEmailJob.Id);
         }
     }
 
-    public async Task ExecuteJobAsync(IDurableJobContext context, CancellationToken cancellationToken)
+    public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var emailAddress = this.GetPrimaryKeyString();
         var subject = context.Job.Metadata?["Subject"];
@@ -195,7 +200,7 @@ public class EmailGrain : Grain, IEmailGrain, IDurableJobHandler
 
         try
         {
-            await _emailService.SendEmailAsync(emailAddress, subject, body, cancellationToken);
+            await _emailService.SendEmailAsync(emailAddress, subject, body, attemptCancellationToken);
             _logger.LogInformation("Email sent successfully to {EmailAddress}", emailAddress);
             _durableEmailJob = null;
         }
@@ -289,7 +294,7 @@ public class OrderGrain : Grain, IOrderGrain, IDurableJobHandler
         _logger.LogInformation("Order {OrderId} canceled", orderId);
     }
 
-    public async Task ExecuteJobAsync(IDurableJobContext context, CancellationToken cancellationToken)
+    public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var step = context.Job.Metadata!["Step"];
         var orderId = this.GetPrimaryKey();
@@ -301,11 +306,11 @@ public class OrderGrain : Grain, IOrderGrain, IDurableJobHandler
         switch (step)
         {
             case "PaymentReminder":
-                await HandlePaymentReminder(context, cancellationToken);
+                await HandlePaymentReminder(context, attemptCancellationToken);
                 break;
 
             case "OrderExpiration":
-                await HandleOrderExpiration(cancellationToken);
+                await HandleOrderExpiration(attemptCancellationToken);
                 break;
 
             default:
@@ -314,10 +319,10 @@ public class OrderGrain : Grain, IOrderGrain, IDurableJobHandler
         }
     }
 
-    private async Task HandlePaymentReminder(IDurableJobContext context, CancellationToken ct)
+    private async Task HandlePaymentReminder(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var orderId = this.GetPrimaryKey();
-        var order = await _orderService.GetOrderAsync(orderId, ct);
+        var order = await _orderService.GetOrderAsync(orderId, attemptCancellationToken);
         
         if (order?.Status == OrderStatus.Pending)
         {
@@ -339,14 +344,14 @@ public class OrderGrain : Grain, IOrderGrain, IDurableJobHandler
         }
     }
 
-    private async Task HandleOrderExpiration(CancellationToken ct)
+    private async Task HandleOrderExpiration(CancellationToken attemptCancellationToken)
     {
         var orderId = this.GetPrimaryKey();
-        var order = await _orderService.GetOrderAsync(orderId, ct);
+        var order = await _orderService.GetOrderAsync(orderId, attemptCancellationToken);
         
         if (order?.Status == OrderStatus.Pending)
         {
-            await _orderService.CancelOrderAsync(orderId, ct);
+            await _orderService.CancelOrderAsync(orderId, attemptCancellationToken);
             _logger.LogInformation("Order {OrderId} expired and canceled", orderId);
 
             // Notify customer

--- a/src/Orleans.DurableJobs/DurableJobsInstruments.cs
+++ b/src/Orleans.DurableJobs/DurableJobsInstruments.cs
@@ -16,7 +16,9 @@ internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
     private const string StatusFailed = "failed";
     private const string StatusRetried = "retried";
     private const string StatusRescheduled = "rescheduled";
-    private const string StatusCanceled = "canceled";
+    private const string StatusAttemptCanceled = "attempt_canceled";
+    private const string StatusCancellationRequested = "cancellation_requested";
+    private const string StatusOperationCanceled = "operation_canceled";
     private const string StatusError = "error";
     private const string StatusOk = "ok";
     private const string StatusNotFound = "not_found";
@@ -36,7 +38,7 @@ internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
     private readonly Counter<long> JobsFailed = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-failed");
     private readonly Counter<long> JobsRetried = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-retried");
     private readonly Counter<long> JobsRescheduled = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-rescheduled");
-    private readonly Counter<long> JobsCanceled = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-canceled");
+    private readonly Counter<long> JobCancellationRequests = instruments.Meter.CreateCounter<long>("orleans-durablejobs-job-cancellation-requests");
     private readonly Counter<long> ShardsProcessed = instruments.Meter.CreateCounter<long>("orleans-durablejobs-shards-processed");
     private readonly Counter<long> ScheduleJobCalls = instruments.Meter.CreateCounter<long>("orleans-durablejobs-schedule-job-calls");
     private readonly Counter<long> CancelJobCalls = instruments.Meter.CreateCounter<long>("orleans-durablejobs-cancel-job-calls");
@@ -94,20 +96,21 @@ internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
         Record(JobAttemptDuration, latency, StatusRescheduled);
     }
 
-    internal void OnJobCanceled()
+    internal void OnJobCancellationRequested()
     {
-        JobsCanceled.Add(1);
+        JobCancellationRequests.Add(1);
     }
 
     internal void OnScheduleJobCallSucceeded(TimeSpan latency) => OnScheduleJobCall(latency, StatusOk);
 
-    internal void OnScheduleJobCallCanceled(TimeSpan latency) => OnScheduleJobCall(latency, StatusCanceled);
+    internal void OnScheduleJobCallCanceled(TimeSpan latency) => OnScheduleJobCall(latency, StatusOperationCanceled);
 
     internal void OnScheduleJobCallFailed(TimeSpan latency) => OnScheduleJobCall(latency, StatusError);
 
-    internal void OnCancelJobCall(TimeSpan latency, bool canceledJob) => OnCancelJobCall(latency, canceledJob ? StatusOk : StatusNotFound);
+    internal void OnCancelJobCall(TimeSpan latency, bool cancellationRequested) =>
+        OnCancelJobCall(latency, cancellationRequested ? StatusCancellationRequested : StatusNotFound);
 
-    internal void OnCancelJobCallCanceled(TimeSpan latency) => OnCancelJobCall(latency, StatusCanceled);
+    internal void OnCancelJobCallCanceled(TimeSpan latency) => OnCancelJobCall(latency, StatusOperationCanceled);
 
     internal void OnCancelJobCallFailed(TimeSpan latency) => OnCancelJobCall(latency, StatusError);
 
@@ -118,20 +121,20 @@ internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
 
     internal void OnHandlerExecutionCompleted(TimeSpan latency) => OnHandlerExecution(latency, StatusCompleted);
 
-    internal void OnHandlerExecutionCanceled(TimeSpan latency) => OnHandlerExecution(latency, StatusCanceled);
+    internal void OnHandlerExecutionAttemptCanceled(TimeSpan latency) => OnHandlerExecution(latency, StatusAttemptCanceled);
 
     internal void OnHandlerExecutionFailed(TimeSpan latency) => OnHandlerExecution(latency, StatusFailed);
 
-    internal void OnShardProcessed(TimeSpan latency, bool canceled, bool error)
+    internal void OnShardProcessed(TimeSpan latency, bool attemptCanceled, bool error)
     {
-        var status = error ? StatusError : canceled ? StatusCanceled : StatusCompleted;
+        var status = error ? StatusError : attemptCanceled ? StatusAttemptCanceled : StatusCompleted;
         ShardsProcessed.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
         Record(ShardProcessingDuration, latency, status);
     }
 
-    internal void OnStorageBatchWritten(long operationCount, bool canceled, bool error)
+    internal void OnStorageBatchWritten(long operationCount, bool operationCanceled, bool error)
     {
-        var status = error ? StatusError : canceled ? StatusCanceled : StatusOk;
+        var status = error ? StatusError : operationCanceled ? StatusOperationCanceled : StatusOk;
         var tags = new KeyValuePair<string, object?>[] { new(StatusTagName, status) };
         StorageBatches.Add(1, tags);
         if (StorageBatchSize.Enabled)

--- a/src/Orleans.DurableJobs/HandlerExecutionTracker.cs
+++ b/src/Orleans.DurableJobs/HandlerExecutionTracker.cs
@@ -7,7 +7,7 @@ namespace Orleans.DurableJobs;
 /// Tracks a single invocation of <see cref="IDurableJobHandler.ExecuteJobAsync"/>, recording the
 /// associated metrics via <see cref="DurableJobsInstruments"/> and the distributed-tracing activity
 /// via <see cref="DurableJobsDiagnostics"/>. Callers must record exactly one terminal telemetry outcome
-/// using <see cref="RecordResult"/>, <see cref="Completed"/>, <see cref="Canceled"/>, or <see cref="Failed"/>
+/// using <see cref="RecordResult"/>, <see cref="Completed"/>, <see cref="AttemptCanceled"/>, or <see cref="Failed"/>
 /// before disposal.
 /// </summary>
 internal readonly struct HandlerExecutionTracker : IDisposable
@@ -57,12 +57,12 @@ internal readonly struct HandlerExecutionTracker : IDisposable
     }
 
     /// <summary>
-    /// Records a canceled handler execution. The activity status is left unchanged so that
+    /// Records cooperative cancellation of the current handler execution attempt. The activity status is left unchanged so that
     /// disposal preserves the default (unset) status, matching the behaviour of the original implementation.
     /// </summary>
-    public void Canceled()
+    public void AttemptCanceled()
     {
-        _durableJobsInstruments.OnHandlerExecutionCanceled(_timeProvider.GetElapsedTime(_startTimestamp));
+        _durableJobsInstruments.OnHandlerExecutionAttemptCanceled(_timeProvider.GetElapsedTime(_startTimestamp));
     }
 
     /// <summary>

--- a/src/Orleans.DurableJobs/HandlerExecutionTracker.cs
+++ b/src/Orleans.DurableJobs/HandlerExecutionTracker.cs
@@ -6,8 +6,9 @@ namespace Orleans.DurableJobs;
 /// <summary>
 /// Tracks a single invocation of <see cref="IDurableJobHandler.ExecuteJobAsync"/>, recording the
 /// associated metrics via <see cref="DurableJobsInstruments"/> and the distributed-tracing activity
-/// via <see cref="DurableJobsDiagnostics"/>. Callers must call exactly one of <see cref="Completed"/>,
-/// <see cref="Canceled"/>, or <see cref="Failed"/> before disposal.
+/// via <see cref="DurableJobsDiagnostics"/>. Callers must record exactly one terminal telemetry outcome
+/// using <see cref="RecordResult"/>, <see cref="Completed"/>, <see cref="Canceled"/>, or <see cref="Failed"/>
+/// before disposal.
 /// </summary>
 internal readonly struct HandlerExecutionTracker : IDisposable
 {
@@ -27,6 +28,23 @@ internal readonly struct HandlerExecutionTracker : IDisposable
         _startTimestamp = timeProvider.GetTimestamp();
         _durableJobsInstruments.OnHandlerExecutionStarted();
         _activity = DurableJobsDiagnostics.StartHandlerActivity(context.Job, context.DequeueCount, context.RunId);
+    }
+
+    /// <summary>
+    /// Records failed telemetry for a failed result and completed telemetry for every non-failed disposition.
+    /// </summary>
+    public void RecordResult(DurableJobRunResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.IsFailed)
+        {
+            Failed(result.Exception);
+        }
+        else
+        {
+            Completed();
+        }
     }
 
     /// <summary>

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
@@ -36,6 +36,12 @@ public static class DurableJobsExtensions
             return;
         }
 
+        if (services.Any(service => service.ServiceType == typeof(IDurableJobHandlerRegistry)))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(IDurableJobHandlerRegistry)} is DurableJobs infrastructure and cannot be replaced or decorated.");
+        }
+
         services.TryAddSingleton<DurableJobsInstruments>();
         services.AddSingleton<IConfigurationValidator, DurableJobsOptionsValidator>();
         services.AddSingleton<IConfigurationValidator, DurableJobsJournalingConfigurationValidator>();
@@ -43,6 +49,7 @@ public static class DurableJobsExtensions
         services.AddSingleton<LocalDurableJobManager>();
         services.AddFromExisting<ILocalDurableJobManager, LocalDurableJobManager>();
         services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, LocalDurableJobManager>();
+        services.AddScoped<IDurableJobHandlerRegistry, DurableJobHandlerRegistry>();
         services.AddSingleton(sp => new DurableJobReceiverExtensionShared(
             sp.GetRequiredService<ILogger<DurableJobReceiverExtension>>(),
             sp.GetRequiredService<IOptions<DurableJobsOptions>>(),
@@ -52,9 +59,17 @@ public static class DurableJobsExtensions
         services.AddKeyedTransient<IGrainExtension>(typeof(IDurableJobReceiverExtension), (sp, _) =>
         {
             var grainContextAccessor = sp.GetRequiredService<IGrainContextAccessor>();
+            var registry = sp.GetRequiredService<IDurableJobHandlerRegistry>();
+            if (registry is not DurableJobHandlerRegistry lookup)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(IDurableJobHandlerRegistry)} is DurableJobs infrastructure and cannot be replaced or decorated.");
+            }
+
             return new DurableJobReceiverExtension(
                 grainContextAccessor.GrainContext,
-                sp.GetRequiredService<DurableJobReceiverExtensionShared>());
+                sp.GetRequiredService<DurableJobReceiverExtensionShared>(),
+                lookup);
         });
     }
 

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
@@ -44,8 +44,9 @@ public sealed class DurableJobsOptions
     public TimeSpan JobStatusPollInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Gets or sets how long a grain activation retains completed durable job execution identities
-    /// to suppress delayed duplicate deliveries. Default: 10 minutes.
+    /// Gets or sets how long a grain activation retains completed durable job attempt identities
+    /// to suppress delayed duplicate deliveries. An attempt is identified by job ID, execution generation,
+    /// and dequeue count. Default: 10 minutes.
     /// </summary>
     /// <remarks>
     /// Deduplication is also bounded to the most recent 65,536 completed executions per activation.

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
@@ -44,6 +44,17 @@ public sealed class DurableJobsOptions
     public TimeSpan JobStatusPollInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
+    /// Gets or sets how long a grain activation retains completed durable job execution identities
+    /// to suppress delayed duplicate deliveries. Default: 10 minutes.
+    /// </summary>
+    /// <remarks>
+    /// Deduplication is also bounded to the most recent 65,536 completed executions per activation.
+    /// This horizon covers duplicate deliveries which arrive at the same activation. Application-specific
+    /// durable state provides deduplication across activation failure or migration.
+    /// </remarks>
+    public TimeSpan CompletedJobAttemptRetentionPeriod { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
     /// Gets or sets the maximum number of jobs that can be executed concurrently on a single silo.
     /// Default: 10,000 × processor count.
     /// </summary>
@@ -204,6 +215,10 @@ public sealed partial class DurableJobsOptionsValidator : IConfigurationValidato
         if (options.JobStatusPollInterval <= TimeSpan.Zero)
         {
             throw new OrleansConfigurationException("DurableJobsOptions.JobStatusPollInterval must be greater than zero.");
+        }
+        if (options.CompletedJobAttemptRetentionPeriod <= TimeSpan.Zero)
+        {
+            throw new OrleansConfigurationException("DurableJobsOptions.CompletedJobAttemptRetentionPeriod must be greater than zero.");
         }
         if (options.ShouldRetry is null)
         {

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
@@ -44,18 +44,6 @@ public sealed class DurableJobsOptions
     public TimeSpan JobStatusPollInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Gets or sets how long a grain activation retains completed durable job attempt identities
-    /// to suppress delayed duplicate deliveries. An attempt is identified by job ID, execution generation,
-    /// and dequeue count. Default: 10 minutes.
-    /// </summary>
-    /// <remarks>
-    /// Deduplication is also bounded to the most recent 65,536 completed executions per activation.
-    /// This horizon covers duplicate deliveries which arrive at the same activation. Application-specific
-    /// durable state provides deduplication across activation failure or migration.
-    /// </remarks>
-    public TimeSpan CompletedJobAttemptRetentionPeriod { get; set; } = TimeSpan.FromMinutes(10);
-
-    /// <summary>
     /// Gets or sets the maximum number of jobs that can be executed concurrently on a single silo.
     /// Default: 10,000 × processor count.
     /// </summary>
@@ -216,10 +204,6 @@ public sealed partial class DurableJobsOptionsValidator : IConfigurationValidato
         if (options.JobStatusPollInterval <= TimeSpan.Zero)
         {
             throw new OrleansConfigurationException("DurableJobsOptions.JobStatusPollInterval must be greater than zero.");
-        }
-        if (options.CompletedJobAttemptRetentionPeriod <= TimeSpan.Zero)
-        {
-            throw new OrleansConfigurationException("DurableJobsOptions.CompletedJobAttemptRetentionPeriod must be greater than zero.");
         }
         if (options.ShouldRetry is null)
         {

--- a/src/Orleans.DurableJobs/IDurableJobHandler.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandler.cs
@@ -78,14 +78,18 @@ internal class JobRunContext : IJobRunContext
 /// <code>
 /// public class MyGrain : Grain, IDurableJobHandler
 /// {
-///     public Task ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+///     public Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
 ///     {
 ///         // Process the durable job
 ///         var jobName = context.Job.Name;
 ///         var dueTime = context.Job.DueTime;
-///         
+///
+///         // This token requests cancellation of this execution attempt, for example during silo shutdown.
+///         // The durable job remains eligible for another attempt on another host.
+///         attemptCancellationToken.ThrowIfCancellationRequested();
+///
 ///         // Perform job logic here
-///         
+///
 ///         return Task.CompletedTask;
 ///     }
 /// }
@@ -98,7 +102,10 @@ public interface IDurableJobHandler
     /// Executes the durable job with the provided context.
     /// </summary>
     /// <param name="context">The context containing information about the durable job execution.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <param name="attemptCancellationToken">
+    /// A token which cooperatively requests cancellation of the current execution attempt.
+    /// Attempt cancellation does not cancel the durable job itself; the job remains eligible for another attempt.
+    /// </param>
     /// <returns>A task that represents the asynchronous job execution operation.</returns>
     /// <remarks>
     /// <para>
@@ -110,6 +117,10 @@ public interface IDurableJobHandler
     /// If the method throws an exception and a retry policy is configured, the job may be retried.
     /// The <see cref="IJobRunContext.DequeueCount"/> property can be used to determine if this is a retry attempt.
     /// </para>
+    /// <para>
+    /// Durable job cancellation is requested through <see cref="ILocalDurableJobManager.CancelAsync"/>.
+    /// That request prevents future attempts but does not forcibly stop an already-running attempt.
+    /// </para>
     /// </remarks>
-    Task ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken);
+    Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken);
 }

--- a/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
@@ -39,11 +39,11 @@ public interface IDurableJobFeatureHandler
     /// </summary>
     /// <remarks>
     /// Implementations must be deterministic and side-effect free. This method can be called more than once
-    /// for the same durable job.
+    /// for the same durable job name.
     /// </remarks>
-    /// <param name="job">The durable job.</param>
-    /// <returns><see langword="true"/> when this handler handles the job; otherwise, <see langword="false"/>.</returns>
-    bool CanHandle(DurableJob job);
+    /// <param name="jobName">The durable job name.</param>
+    /// <returns><see langword="true"/> when this handler handles the job name; otherwise, <see langword="false"/>.</returns>
+    bool CanHandle(string jobName);
 
     /// <summary>
     /// Executes a durable job and returns its explicit disposition.
@@ -59,7 +59,7 @@ public interface IDurableJobFeatureHandler
 
 internal interface IDurableJobHandlerLookup
 {
-    bool TryGetHandler(DurableJob job, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler);
+    bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler);
 }
 
 internal sealed class DurableJobHandlerRegistry : IDurableJobHandlerRegistry, IDurableJobHandlerLookup
@@ -81,14 +81,14 @@ internal sealed class DurableJobHandlerRegistry : IDurableJobHandlerRegistry, ID
         _handlers.Add(handler);
     }
 
-    public bool TryGetHandler(DurableJob job, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
+    public bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
     {
-        ArgumentNullException.ThrowIfNull(job);
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
 
         handler = null;
         foreach (var candidate in _handlers)
         {
-            if (!candidate.CanHandle(job))
+            if (!candidate.CanHandle(jobName))
             {
                 continue;
             }
@@ -96,7 +96,7 @@ internal sealed class DurableJobHandlerRegistry : IDurableJobHandlerRegistry, ID
             if (handler is not null)
             {
                 throw new InvalidOperationException(
-                    $"Multiple durable job feature handlers match job '{job.Name}': "
+                    $"Multiple durable job feature handlers match job '{jobName}': "
                     + $"'{handler.GetType().FullName}' and '{candidate.GetType().FullName}'.");
             }
 

--- a/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
@@ -30,9 +30,10 @@ public interface IDurableJobHandlerRegistry
 /// Handles a framework-owned durable job for a grain activation.
 /// </summary>
 /// <remarks>
-/// Delivery is at least once. Duplicate deliveries of the same job attempt are suppressed by the receiving
-/// activation for the configured completed-attempt retention period, subject to its bounded cache.
-/// Application-specific durable state provides deduplication across activation failure or migration.
+/// Delivery is at least once. The receiving activation identifies an attempt by job ID, execution generation,
+/// and dequeue count, suppressing duplicate deliveries for the configured completed-attempt retention period,
+/// subject to its bounded cache. Application-specific durable state provides deduplication across activation
+/// failure or migration.
 /// </remarks>
 public interface IDurableJobFeatureHandler
 {

--- a/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
@@ -30,10 +30,8 @@ public interface IDurableJobHandlerRegistry
 /// Handles a framework-owned durable job for a grain activation.
 /// </summary>
 /// <remarks>
-/// Delivery is at least once. The receiving activation identifies an attempt by job ID, execution generation,
-/// and dequeue count, suppressing duplicate deliveries for the configured completed-attempt retention period,
-/// subject to its bounded cache. Application-specific durable state provides deduplication across activation
-/// failure or migration.
+/// Delivery is at least once. The handler determines the durable job disposition and owns any
+/// application-specific idempotency required when a completed invocation is delivered again.
 /// </remarks>
 public interface IDurableJobFeatureHandler
 {

--- a/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.DurableJobs;
+
+/// <summary>
+/// Registers framework-owned durable job handlers for a grain activation.
+/// </summary>
+/// <remarks>
+/// Registrations are activation-scoped and job names are compared using <see cref="StringComparer.Ordinal"/>.
+/// A registered feature handler takes precedence over <see cref="IDurableJobHandler"/> for the same job name.
+/// The DurableJobs dependency injection registration is an infrastructure service and does not support
+/// replacement or decoration. Replacing it is rejected explicitly when DurableJobs is configured or the
+/// receiver is resolved so that registrations cannot be silently disconnected from dispatch.
+/// </remarks>
+public interface IDurableJobHandlerRegistry
+{
+    /// <summary>
+    /// Registers <paramref name="handler"/> for jobs with the supplied name.
+    /// </summary>
+    /// <param name="jobName">The case-sensitive durable job name.</param>
+    /// <param name="handler">The activation-scoped feature handler.</param>
+    /// <exception cref="InvalidOperationException">A handler is already registered for <paramref name="jobName"/>.</exception>
+    void Register(string jobName, IDurableJobFeatureHandler handler);
+}
+
+/// <summary>
+/// Handles a framework-owned durable job for a grain activation.
+/// </summary>
+/// <remarks>
+/// Delivery is at least once. Duplicate deliveries of the same job attempt are suppressed by the receiving
+/// activation for the configured completed-attempt retention period, subject to its bounded cache.
+/// Application-specific durable state provides deduplication across activation failure or migration.
+/// </remarks>
+public interface IDurableJobFeatureHandler
+{
+    /// <summary>
+    /// Executes a durable job and returns its explicit disposition.
+    /// </summary>
+    /// <param name="context">The durable job execution context.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>The completed, polling, or failed disposition.</returns>
+    ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken);
+}
+
+internal interface IDurableJobHandlerLookup
+{
+    bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler);
+}
+
+internal sealed class DurableJobHandlerRegistry : IDurableJobHandlerRegistry, IDurableJobHandlerLookup
+{
+    private readonly Dictionary<string, IDurableJobFeatureHandler> _handlers = new(StringComparer.Ordinal);
+
+    public void Register(string jobName, IDurableJobFeatureHandler handler)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        if (!_handlers.TryAdd(jobName, handler))
+        {
+            throw new InvalidOperationException($"A durable job feature handler is already registered for '{jobName}'.");
+        }
+    }
+
+    public bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler) =>
+        _handlers.TryGetValue(jobName, out handler);
+}

--- a/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
@@ -9,8 +9,8 @@ namespace Orleans.DurableJobs;
 /// Registers framework-owned durable job handlers for a grain activation.
 /// </summary>
 /// <remarks>
-/// Registrations are activation-scoped and job names are compared using <see cref="StringComparer.Ordinal"/>.
-/// A registered feature handler takes precedence over <see cref="IDurableJobHandler"/> for the same job name.
+/// Registrations are activation-scoped. A matching feature handler takes precedence over
+/// <see cref="IDurableJobHandler"/>. Multiple matching feature handlers are rejected as ambiguous.
 /// The DurableJobs dependency injection registration is an infrastructure service and does not support
 /// replacement or decoration. Replacing it is rejected explicitly when DurableJobs is configured or the
 /// receiver is resolved so that registrations cannot be silently disconnected from dispatch.
@@ -18,12 +18,11 @@ namespace Orleans.DurableJobs;
 public interface IDurableJobHandlerRegistry
 {
     /// <summary>
-    /// Registers <paramref name="handler"/> for jobs with the supplied name.
+    /// Registers <paramref name="handler"/> for this grain activation.
     /// </summary>
-    /// <param name="jobName">The case-sensitive durable job name.</param>
     /// <param name="handler">The activation-scoped feature handler.</param>
-    /// <exception cref="InvalidOperationException">A handler is already registered for <paramref name="jobName"/>.</exception>
-    void Register(string jobName, IDurableJobFeatureHandler handler);
+    /// <exception cref="InvalidOperationException">The handler is already registered.</exception>
+    void Register(IDurableJobFeatureHandler handler);
 }
 
 /// <summary>
@@ -35,6 +34,17 @@ public interface IDurableJobHandlerRegistry
 /// </remarks>
 public interface IDurableJobFeatureHandler
 {
+    /// <summary>
+    /// Determines whether this handler handles the supplied durable job.
+    /// </summary>
+    /// <remarks>
+    /// Implementations must be deterministic and side-effect free. This method can be called more than once
+    /// for the same durable job.
+    /// </remarks>
+    /// <param name="job">The durable job.</param>
+    /// <returns><see langword="true"/> when this handler handles the job; otherwise, <see langword="false"/>.</returns>
+    bool CanHandle(DurableJob job);
+
     /// <summary>
     /// Executes a durable job and returns its explicit disposition.
     /// </summary>
@@ -49,24 +59,50 @@ public interface IDurableJobFeatureHandler
 
 internal interface IDurableJobHandlerLookup
 {
-    bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler);
+    bool TryGetHandler(DurableJob job, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler);
 }
 
 internal sealed class DurableJobHandlerRegistry : IDurableJobHandlerRegistry, IDurableJobHandlerLookup
 {
-    private readonly Dictionary<string, IDurableJobFeatureHandler> _handlers = new(StringComparer.Ordinal);
+    private readonly List<IDurableJobFeatureHandler> _handlers = [];
 
-    public void Register(string jobName, IDurableJobFeatureHandler handler)
+    public void Register(IDurableJobFeatureHandler handler)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
         ArgumentNullException.ThrowIfNull(handler);
 
-        if (!_handlers.TryAdd(jobName, handler))
+        foreach (var registeredHandler in _handlers)
         {
-            throw new InvalidOperationException($"A durable job feature handler is already registered for '{jobName}'.");
+            if (ReferenceEquals(registeredHandler, handler))
+            {
+                throw new InvalidOperationException("The durable job feature handler is already registered.");
+            }
         }
+
+        _handlers.Add(handler);
     }
 
-    public bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler) =>
-        _handlers.TryGetValue(jobName, out handler);
+    public bool TryGetHandler(DurableJob job, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+
+        handler = null;
+        foreach (var candidate in _handlers)
+        {
+            if (!candidate.CanHandle(job))
+            {
+                continue;
+            }
+
+            if (handler is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Multiple durable job feature handlers match job '{job.Name}': "
+                    + $"'{handler.GetType().FullName}' and '{candidate.GetType().FullName}'.");
+            }
+
+            handler = candidate;
+        }
+
+        return handler is not null;
+    }
 }

--- a/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandlerRegistry.cs
@@ -39,9 +39,12 @@ public interface IDurableJobFeatureHandler
     /// Executes a durable job and returns its explicit disposition.
     /// </summary>
     /// <param name="context">The durable job execution context.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <param name="attemptCancellationToken">
+    /// A token which cooperatively requests cancellation of the current execution attempt.
+    /// The durable job remains eligible for another attempt.
+    /// </param>
     /// <returns>The completed, polling, or failed disposition.</returns>
-    ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken);
+    ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken);
 }
 
 internal interface IDurableJobHandlerLookup

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -11,8 +11,8 @@ internal interface IDurableJobReceiverExtension : IGrainExtension
 {
     /// <summary>
     /// Handles a durable job by either starting execution or checking the status of an execution which remains in progress.
-    /// If the job attempt identified by <see cref="IJobRunContext.Job"/> and <see cref="IJobRunContext.DequeueCount"/> has not been started, it will be executed.
-    /// If it remains in progress, the current status is returned.
+    /// Concurrent deliveries for the same job attempt share the active invocation. Once an invocation reaches
+    /// a terminal disposition, a later delivery starts a new invocation.
     /// </summary>
     /// <param name="context">The context containing information about the durable job.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
@@ -24,13 +24,10 @@ internal interface IDurableJobReceiverExtension : IGrainExtension
 /// <inheritdoc />
 internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverExtension
 {
-    private const int MaxCompletedJobAttempts = 65_536;
     private readonly IGrainContext _grain;
     private readonly DurableJobReceiverExtensionShared _shared;
     private readonly IDurableJobHandlerLookup _featureHandlers;
     private readonly Dictionary<(string JobId, long ExecutionGeneration, int DequeueCount), JobAttemptState> _jobAttempts = [];
-    private readonly Queue<CompletedJobAttempt> _completedJobAttempts = new();
-    private int _completedJobAttemptCount;
 
     public DurableJobReceiverExtension(
         IGrainContext grain,
@@ -48,8 +45,6 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     /// <inheritdoc />
     public ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken)
     {
-        PruneCompletedJobAttempts();
-
         var key = GetExecutionKey(context);
         var newJob = false;
         if (!_jobAttempts.TryGetValue(key, out var state))
@@ -163,7 +158,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             return new(GetSuccessfulResult(key, state));
         }
 
-        RecordCompletedJobAttempt(key, state);
+        RemoveJobAttempt(key, state);
 
         if (state.Task.IsFaulted)
         {
@@ -194,7 +189,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
             if (state.Task.IsFaulted)
             {
-                RecordCompletedJobAttempt(key, state);
+                RemoveJobAttempt(key, state);
                 var ex = state.Task.Exception!.InnerException ?? state.Task.Exception;
                 LogErrorExecutingDurableJob(_shared.Logger, ex, context.Job.Id, _grain.GrainId);
                 return DurableJobRunResult.Failed(ex);
@@ -202,7 +197,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
             if (state.Task.IsCanceled)
             {
-                RecordCompletedJobAttempt(key, state);
+                RemoveJobAttempt(key, state);
                 return await state.Task;
             }
 
@@ -226,52 +221,17 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
         else
         {
-            RecordCompletedJobAttempt(key, state);
+            RemoveJobAttempt(key, state);
         }
 
         return result;
     }
 
-    private void RecordCompletedJobAttempt((string JobId, long ExecutionGeneration, int DequeueCount) key, JobAttemptState state)
+    private void RemoveJobAttempt((string JobId, long ExecutionGeneration, int DequeueCount) key, JobAttemptState state)
     {
-        if (!state.CompletionRecorded)
+        if (_jobAttempts.TryGetValue(key, out var current) && ReferenceEquals(current, state))
         {
-            state.CompletionRecorded = true;
-            var completedTimestamp = _shared.TimeProvider.GetTimestamp();
-            state.CompletedTimestamp = completedTimestamp;
-            _completedJobAttempts.Enqueue(new CompletedJobAttempt(key, completedTimestamp));
-            _completedJobAttemptCount++;
-        }
-
-        PruneCompletedJobAttempts();
-    }
-
-    private void PruneCompletedJobAttempts()
-    {
-        var now = _shared.TimeProvider.GetTimestamp();
-        while (_completedJobAttempts.TryPeek(out var completedAttempt))
-        {
-            var expired = _shared.TimeProvider.GetElapsedTime(completedAttempt.CompletedTimestamp, now) >= _shared.Options.CompletedJobAttemptRetentionPeriod;
-            var overLimit = _completedJobAttemptCount > MaxCompletedJobAttempts;
-            if (!expired && !overLimit)
-            {
-                return;
-            }
-
-            if (!_completedJobAttempts.TryDequeue(out completedAttempt))
-            {
-                return;
-            }
-
-            if (_jobAttempts.TryGetValue(completedAttempt.Key, out var state)
-                && state.Task.IsCompleted
-                && state.CompletedTimestamp == completedAttempt.CompletedTimestamp)
-            {
-                ((ICollection<KeyValuePair<(string JobId, long ExecutionGeneration, int DequeueCount), JobAttemptState>>)_jobAttempts).Remove(
-                    new KeyValuePair<(string JobId, long ExecutionGeneration, int DequeueCount), JobAttemptState>(completedAttempt.Key, state));
-            }
-
-            _completedJobAttemptCount--;
+            _jobAttempts.Remove(key);
         }
     }
 
@@ -282,20 +242,12 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     {
         public Task<DurableJobRunResult> Task { get; } = task;
 
-        public bool CompletionRecorded;
-
-        public long CompletedTimestamp;
-
         public bool PollRequested;
 
         public long PollTimestamp;
 
         public TimeSpan PollAfterDelay;
     }
-
-    private readonly record struct CompletedJobAttempt(
-        (string JobId, long ExecutionGeneration, int DequeueCount) Key,
-        long CompletedTimestamp);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error executing durable job {JobId} on grain {GrainId}")]
     private static partial void LogErrorExecutingDurableJob(ILogger logger, Exception exception, string jobId, GrainId grainId);

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -79,7 +79,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
     private Task<DurableJobRunResult> StartJob(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
-        if (_featureHandlers.TryGetHandler(context.Job, out var featureHandler))
+        if (_featureHandlers.TryGetHandler(context.Job.Name, out var featureHandler))
         {
             return ExecuteFeatureHandlerAsync(featureHandler, context, attemptCancellationToken);
         }
@@ -93,44 +93,41 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         return ExecuteHandlerAsync(handler, context, attemptCancellationToken);
     }
 
-    private async Task<DurableJobRunResult> ExecuteFeatureHandlerAsync(
+    private Task<DurableJobRunResult> ExecuteFeatureHandlerAsync(
         IDurableJobFeatureHandler handler,
         IJobRunContext context,
-        CancellationToken attemptCancellationToken)
-    {
-        using var tracker = _shared.BeginHandlerExecution(context);
-        try
-        {
-            var result = await handler.ExecuteJobAsync(context, attemptCancellationToken)
-                ?? throw new InvalidOperationException(
-                    $"Durable job feature handler for '{context.Job.Name}' returned a null result.");
-            tracker.RecordResult(result);
-            return result;
-        }
-        catch (OperationCanceledException) when (attemptCancellationToken.IsCancellationRequested)
-        {
-            tracker.AttemptCanceled();
-            throw;
-        }
-        catch (Exception exception)
-        {
-            tracker.Failed(exception);
-            LogErrorExecutingDurableJob(_shared.Logger, exception, context.Job.Id, _grain.GrainId);
-            return DurableJobRunResult.Failed(exception);
-        }
-    }
+        CancellationToken attemptCancellationToken) =>
+        ExecuteHandlerAsync(
+            context,
+            attemptCancellationToken,
+            () => handler.ExecuteJobAsync(context, attemptCancellationToken));
 
-    private async Task<DurableJobRunResult> ExecuteHandlerAsync(
+    private Task<DurableJobRunResult> ExecuteHandlerAsync(
         IDurableJobHandler handler,
         IJobRunContext context,
         CancellationToken attemptCancellationToken)
     {
+        return ExecuteHandlerAsync(context, attemptCancellationToken, ExecuteAsync);
+
+        async ValueTask<DurableJobRunResult> ExecuteAsync()
+        {
+            await handler.ExecuteJobAsync(context, attemptCancellationToken);
+            return DurableJobRunResult.Completed;
+        }
+    }
+
+    private async Task<DurableJobRunResult> ExecuteHandlerAsync(
+        IJobRunContext context,
+        CancellationToken attemptCancellationToken,
+        Func<ValueTask<DurableJobRunResult>> execute)
+    {
         using var tracker = _shared.BeginHandlerExecution(context);
         try
         {
-            await handler.ExecuteJobAsync(context, attemptCancellationToken);
-            tracker.Completed();
-            return DurableJobRunResult.Completed;
+            var result = await execute()
+                ?? throw new InvalidOperationException($"Durable job handler for '{context.Job.Name}' returned a null result.");
+            tracker.RecordResult(result);
+            return result;
         }
         catch (OperationCanceledException) when (attemptCancellationToken.IsCancellationRequested)
         {

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -252,6 +252,12 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     private static (string JobId, long ExecutionGeneration, int DequeueCount) GetExecutionKey(IJobRunContext context)
         => (context.Job.Id, context.Job.ExecutionGeneration, context.DequeueCount);
 
+    internal sealed class TestAccessor(DurableJobReceiverExtension extension)
+    {
+        public Task<DurableJobRunResult>? GetAttemptTask(IJobRunContext context) =>
+            extension._jobAttempts.TryGetValue(GetExecutionKey(context), out var state) ? state.Task : null;
+    }
+
     private sealed class JobAttemptState(Task<DurableJobRunResult> task)
     {
         public Task<DurableJobRunResult> Task { get; } = task;

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -26,21 +26,24 @@ internal interface IDurableJobReceiverExtension : IGrainExtension
 internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverExtension
 {
     private const int MaxCompletedJobAttempts = 65_536;
-    private static readonly TimeSpan CompletedJobAttemptRetention = TimeSpan.FromMinutes(1);
-
     private readonly IGrainContext _grain;
     private readonly DurableJobReceiverExtensionShared _shared;
+    private readonly IDurableJobHandlerLookup _featureHandlers;
     private readonly Dictionary<(string JobId, long ExecutionGeneration, int DequeueCount), JobAttemptState> _jobAttempts = [];
     private readonly Queue<CompletedJobAttempt> _completedJobAttempts = new();
     private int _completedJobAttemptCount;
 
-    public DurableJobReceiverExtension(IGrainContext grain, DurableJobReceiverExtensionShared shared)
+    public DurableJobReceiverExtension(
+        IGrainContext grain,
+        DurableJobReceiverExtensionShared shared,
+        IDurableJobHandlerLookup? featureHandlers = null)
     {
         ArgumentNullException.ThrowIfNull(grain);
         ArgumentNullException.ThrowIfNull(shared);
 
         _grain = grain;
         _shared = shared;
+        _featureHandlers = featureHandlers ?? new DurableJobHandlerRegistry();
     }
 
     /// <inheritdoc />
@@ -51,19 +54,34 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         var key = GetExecutionKey(context);
         JobAttemptState state;
         ref var stateRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_jobAttempts, key, out var exists);
+        var newJob = !exists;
         if (!exists)
         {
             Debug.Assert(stateRef is null);
             stateRef = new JobAttemptState(StartJob(context, cancellationToken));
         }
+        else if (stateRef is { } existingState && IsReadyToPoll(existingState))
+        {
+            stateRef = new JobAttemptState(StartJob(context, cancellationToken));
+            newJob = true;
+        }
 
         Debug.Assert(stateRef is not null);
         state = stateRef;
-        return GetJobStatusAsync(key, context, state, newJob: !exists);
+        return GetJobStatusAsync(key, context, state, newJob);
     }
+
+    private bool IsReadyToPoll(JobAttemptState state) =>
+        state.PollRequested
+        && _shared.TimeProvider.GetElapsedTime(state.PollTimestamp, _shared.TimeProvider.GetTimestamp()) >= state.PollAfterDelay;
 
     private Task<DurableJobRunResult> StartJob(IJobRunContext context, CancellationToken cancellationToken)
     {
+        if (_featureHandlers.TryGetHandler(context.Job.Name, out var featureHandler))
+        {
+            return ExecuteFeatureHandlerAsync(featureHandler, context, cancellationToken);
+        }
+
         if (_grain.GrainInstance is not IDurableJobHandler handler)
         {
             LogGrainDoesNotImplementHandler(_shared.Logger, _grain.GrainId);
@@ -71,6 +89,33 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
 
         return ExecuteHandlerAsync(handler, context, cancellationToken);
+    }
+
+    private async Task<DurableJobRunResult> ExecuteFeatureHandlerAsync(
+        IDurableJobFeatureHandler handler,
+        IJobRunContext context,
+        CancellationToken cancellationToken)
+    {
+        using var tracker = _shared.BeginHandlerExecution(context);
+        try
+        {
+            var result = await handler.ExecuteJobAsync(context, cancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"Durable job feature handler for '{context.Job.Name}' returned a null result.");
+            tracker.Completed();
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            tracker.Canceled();
+            throw;
+        }
+        catch (Exception exception)
+        {
+            tracker.Failed(exception);
+            LogErrorExecutingDurableJob(_shared.Logger, exception, context.Job.Id, _grain.GrainId);
+            return DurableJobRunResult.Failed(exception);
+        }
     }
 
     private async Task<DurableJobRunResult> ExecuteHandlerAsync(IDurableJobHandler handler, IJobRunContext context, CancellationToken cancellationToken)
@@ -115,12 +160,12 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             return new(DurableJobRunResult.InProgress(_shared.Options.JobStatusPollInterval));
         }
 
-        RecordCompletedJobAttempt(key, state);
-
         if (state.Task.IsCompletedSuccessfully)
         {
-            return new(state.Task);
+            return new(GetSuccessfulResult(key, state));
         }
+
+        RecordCompletedJobAttempt(key, state);
 
         if (state.Task.IsFaulted)
         {
@@ -140,7 +185,8 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             {
                 using var cts = new CancellationTokenSource();
                 var longPollDuration = TimeSpan.FromTicks(Math.Min(_shared.MessagingOptions.ResponseTimeout.Divide(2).Ticks, _shared.Options.JobStatusPollInterval.Ticks));
-                await Task.WhenAny(Task.Delay(longPollDuration, cts.Token), state.Task);
+                await Task.WhenAny(Task.Delay(longPollDuration, _shared.TimeProvider, cts.Token), state.Task);
+                cts.Cancel();
 
                 if (!state.Task.IsCompleted)
                 {
@@ -148,18 +194,44 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
                 }
             }
 
-            RecordCompletedJobAttempt(key, state);
-
             if (state.Task.IsFaulted)
             {
+                RecordCompletedJobAttempt(key, state);
                 var ex = state.Task.Exception!.InnerException ?? state.Task.Exception;
                 LogErrorExecutingDurableJob(_shared.Logger, ex, context.Job.Id, _grain.GrainId);
                 return DurableJobRunResult.Failed(ex);
             }
 
-            // Completed successfully or canceled.
-            return await state.Task;
+            if (state.Task.IsCanceled)
+            {
+                RecordCompletedJobAttempt(key, state);
+                return await state.Task;
+            }
+
+            return GetSuccessfulResult(key, state);
         }
+    }
+
+    private DurableJobRunResult GetSuccessfulResult(
+        (string JobId, long ExecutionGeneration, int DequeueCount) key,
+        JobAttemptState state)
+    {
+        var result = state.Task.Result;
+        if (result.IsPending)
+        {
+            if (!state.PollRequested)
+            {
+                state.PollRequested = true;
+                state.PollTimestamp = _shared.TimeProvider.GetTimestamp();
+                state.PollAfterDelay = result.PollAfterDelay.Value;
+            }
+        }
+        else
+        {
+            RecordCompletedJobAttempt(key, state);
+        }
+
+        return result;
     }
 
     private void RecordCompletedJobAttempt((string JobId, long ExecutionGeneration, int DequeueCount) key, JobAttemptState state)
@@ -181,7 +253,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         var now = _shared.TimeProvider.GetTimestamp();
         while (_completedJobAttempts.TryPeek(out var completedAttempt))
         {
-            var expired = _shared.TimeProvider.GetElapsedTime(completedAttempt.CompletedTimestamp, now) >= CompletedJobAttemptRetention;
+            var expired = _shared.TimeProvider.GetElapsedTime(completedAttempt.CompletedTimestamp, now) >= _shared.Options.CompletedJobAttemptRetentionPeriod;
             var overLimit = _completedJobAttemptCount > MaxCompletedJobAttempts;
             if (!expired && !overLimit)
             {
@@ -215,6 +287,12 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         public bool CompletionRecorded;
 
         public long CompletedTimestamp;
+
+        public bool PollRequested;
+
+        public long PollTimestamp;
+
+        public TimeSpan PollAfterDelay;
     }
 
     private readonly record struct CompletedJobAttempt(

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -100,7 +100,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             var result = await handler.ExecuteJobAsync(context, cancellationToken)
                 ?? throw new InvalidOperationException(
                     $"Durable job feature handler for '{context.Job.Name}' returned a null result.");
-            tracker.Completed();
+            tracker.RecordResult(result);
             return result;
         }
         catch (OperationCanceledException)

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
 
@@ -52,22 +51,21 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         PruneCompletedJobAttempts();
 
         var key = GetExecutionKey(context);
-        JobAttemptState state;
-        ref var stateRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_jobAttempts, key, out var exists);
-        var newJob = !exists;
-        if (!exists)
+        var newJob = false;
+        if (!_jobAttempts.TryGetValue(key, out var state))
         {
-            Debug.Assert(stateRef is null);
-            stateRef = new JobAttemptState(StartJob(context, cancellationToken));
+            state = new JobAttemptState(StartJob(context, cancellationToken));
+            _jobAttempts.Add(key, state);
+            newJob = true;
         }
-        else if (stateRef is { } existingState && IsReadyToPoll(existingState))
+        else if (IsReadyToPoll(state))
         {
-            stateRef = new JobAttemptState(StartJob(context, cancellationToken));
+            state = new JobAttemptState(StartJob(context, cancellationToken));
+            _jobAttempts[key] = state;
             newJob = true;
         }
 
-        Debug.Assert(stateRef is not null);
-        state = stateRef;
+        Debug.Assert(state is not null);
         return GetJobStatusAsync(key, context, state, newJob);
     }
 

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -217,7 +217,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         JobAttemptState state)
     {
         var result = state.Task.Result;
-        if (result.IsPending)
+        if (result.IsInProgress)
         {
             if (!state.PollRequested)
             {

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -79,7 +79,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
     private Task<DurableJobRunResult> StartJob(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
-        if (_featureHandlers.TryGetHandler(context.Job.Name, out var featureHandler))
+        if (_featureHandlers.TryGetHandler(context.Job, out var featureHandler))
         {
             return ExecuteFeatureHandlerAsync(featureHandler, context, attemptCancellationToken);
         }

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -48,6 +48,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     /// <inheritdoc />
     public ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(context);
         var key = GetExecutionKey(context);
         var newJob = false;
         if (!_jobAttempts.TryGetValue(key, out var state))

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -70,7 +70,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
 
         Debug.Assert(state is not null);
-        return GetJobStatusAsync(key, context, state, newJob);
+        return GetJobStatusAsync(key, context, state, newJob, attemptCancellationToken);
     }
 
     private bool IsReadyToPoll(JobAttemptState state) =>
@@ -150,7 +150,8 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         (string JobId, long ExecutionGeneration, int DequeueCount) key,
         IJobRunContext context,
         JobAttemptState state,
-        bool newJob)
+        bool newJob,
+        CancellationToken attemptCancellationToken)
     {
         // Cancellation is cooperative: only terminal task state is authoritative for job outcome.
         if (!state.Task.IsCompleted)
@@ -159,7 +160,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             {
                 // For the first attempt, to reduce RPC, we wait for the polling interval or half the response timeout for the task to complete.
                 // This saves a back-and-forth for the common case where a job completes quickly.
-                return LongPollGetJobStatusAsync(key, context, state);
+                return LongPollGetJobStatusAsync(key, context, state, attemptCancellationToken);
             }
 
             return new(DurableJobRunResult.InProgress(_shared.Options.JobStatusPollInterval));
@@ -184,11 +185,12 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         async ValueTask<DurableJobRunResult> LongPollGetJobStatusAsync(
             (string JobId, long ExecutionGeneration, int DequeueCount) key,
             IJobRunContext context,
-            JobAttemptState state)
+            JobAttemptState state,
+            CancellationToken attemptCancellationToken)
         {
             if (!state.Task.IsCompleted)
             {
-                using var cts = new CancellationTokenSource();
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(attemptCancellationToken);
                 var longPollDuration = TimeSpan.FromTicks(Math.Min(_shared.MessagingOptions.ResponseTimeout.Divide(2).Ticks, _shared.Options.JobStatusPollInterval.Ticks));
                 await Task.WhenAny(Task.Delay(longPollDuration, _shared.TimeProvider, cts.Token), state.Task);
                 cts.Cancel();

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -15,10 +15,13 @@ internal interface IDurableJobReceiverExtension : IGrainExtension
     /// a terminal disposition, a later delivery starts a new invocation.
     /// </summary>
     /// <param name="context">The context containing information about the durable job.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <param name="attemptCancellationToken">
+    /// A token which cooperatively requests cancellation of this execution attempt.
+    /// Attempt cancellation leaves the durable job eligible for redelivery.
+    /// </param>
     /// <returns>A task that represents the asynchronous operation and contains the job execution result.</returns>
     [AlwaysInterleave]
-    ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken);
+    ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken);
 }
 
 /// <inheritdoc />
@@ -43,19 +46,25 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     }
 
     /// <inheritdoc />
-    public ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+    public ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var key = GetExecutionKey(context);
         var newJob = false;
         if (!_jobAttempts.TryGetValue(key, out var state))
         {
-            state = new JobAttemptState(StartJob(context, cancellationToken));
+            state = new JobAttemptState(StartJob(context, attemptCancellationToken));
             _jobAttempts.Add(key, state);
+            newJob = true;
+        }
+        else if (state.Task.IsCanceled && !attemptCancellationToken.IsCancellationRequested)
+        {
+            state = new JobAttemptState(StartJob(context, attemptCancellationToken));
+            _jobAttempts[key] = state;
             newJob = true;
         }
         else if (IsReadyToPoll(state))
         {
-            state = new JobAttemptState(StartJob(context, cancellationToken));
+            state = new JobAttemptState(StartJob(context, attemptCancellationToken));
             _jobAttempts[key] = state;
             newJob = true;
         }
@@ -68,11 +77,11 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         state.PollRequested
         && _shared.TimeProvider.GetElapsedTime(state.PollTimestamp, _shared.TimeProvider.GetTimestamp()) >= state.PollAfterDelay;
 
-    private Task<DurableJobRunResult> StartJob(IJobRunContext context, CancellationToken cancellationToken)
+    private Task<DurableJobRunResult> StartJob(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         if (_featureHandlers.TryGetHandler(context.Job.Name, out var featureHandler))
         {
-            return ExecuteFeatureHandlerAsync(featureHandler, context, cancellationToken);
+            return ExecuteFeatureHandlerAsync(featureHandler, context, attemptCancellationToken);
         }
 
         if (_grain.GrainInstance is not IDurableJobHandler handler)
@@ -81,26 +90,26 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             throw new InvalidOperationException($"Grain {_grain.GrainId} does not implement IDurableJobHandler");
         }
 
-        return ExecuteHandlerAsync(handler, context, cancellationToken);
+        return ExecuteHandlerAsync(handler, context, attemptCancellationToken);
     }
 
     private async Task<DurableJobRunResult> ExecuteFeatureHandlerAsync(
         IDurableJobFeatureHandler handler,
         IJobRunContext context,
-        CancellationToken cancellationToken)
+        CancellationToken attemptCancellationToken)
     {
         using var tracker = _shared.BeginHandlerExecution(context);
         try
         {
-            var result = await handler.ExecuteJobAsync(context, cancellationToken)
+            var result = await handler.ExecuteJobAsync(context, attemptCancellationToken)
                 ?? throw new InvalidOperationException(
                     $"Durable job feature handler for '{context.Job.Name}' returned a null result.");
             tracker.RecordResult(result);
             return result;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (attemptCancellationToken.IsCancellationRequested)
         {
-            tracker.Canceled();
+            tracker.AttemptCanceled();
             throw;
         }
         catch (Exception exception)
@@ -111,19 +120,22 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
     }
 
-    private async Task<DurableJobRunResult> ExecuteHandlerAsync(IDurableJobHandler handler, IJobRunContext context, CancellationToken cancellationToken)
+    private async Task<DurableJobRunResult> ExecuteHandlerAsync(
+        IDurableJobHandler handler,
+        IJobRunContext context,
+        CancellationToken attemptCancellationToken)
     {
         using var tracker = _shared.BeginHandlerExecution(context);
         try
         {
-            await handler.ExecuteJobAsync(context, cancellationToken);
+            await handler.ExecuteJobAsync(context, attemptCancellationToken);
             tracker.Completed();
             return DurableJobRunResult.Completed;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (attemptCancellationToken.IsCancellationRequested)
         {
-            // Cancellation can be retried.
-            tracker.Canceled();
+            // Attempt cancellation leaves the durable job eligible for redelivery.
+            tracker.AttemptCanceled();
             throw;
         }
         catch (Exception exception)

--- a/src/Orleans.DurableJobs/ILocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/ILocalDurableJobManager.cs
@@ -17,6 +17,7 @@ public interface ILocalDurableJobManager
     /// <param name="request">The request containing the job scheduling parameters.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns the durable job.</returns>
+    /// <exception cref="ArgumentException"><see cref="ScheduleJobRequest.JobName"/> is null, empty, or whitespace.</exception>
     Task<DurableJob> ScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Orleans.DurableJobs/ILocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/ILocalDurableJobManager.cs
@@ -32,6 +32,7 @@ public interface ILocalDurableJobManager
     /// the cancellation request was durably recorded, preventing future attempts; otherwise, <see langword="false"/>.
     /// An already-running attempt is cooperatively independent of this request and may still complete.
     /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="job"/> is <see langword="null"/>.</exception>
     Task<bool> CancelAsync(DurableJob job, CancellationToken requestCancellationToken);
 }
 

--- a/src/Orleans.DurableJobs/ILocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/ILocalDurableJobManager.cs
@@ -20,15 +20,21 @@ public interface ILocalDurableJobManager
     Task<DurableJob> ScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Attempts to cancel a previously scheduled durable job.
+    /// Requests cancellation of a previously scheduled durable job.
     /// </summary>
-    /// <param name="job">The durable job to cancel.</param>
-    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation that returns <see langword="true"/> if the job was successfully canceled; otherwise, <see langword="false"/>.</returns>
-    Task<bool> TryCancelDurableJobAsync(DurableJob job, CancellationToken cancellationToken);
+    /// <param name="job">The durable job for which cancellation is requested.</param>
+    /// <param name="requestCancellationToken">
+    /// A token which cancels this request operation. It does not cancel a job execution attempt.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation. The result is <see langword="true"/> when
+    /// the cancellation request was durably recorded, preventing future attempts; otherwise, <see langword="false"/>.
+    /// An already-running attempt is cooperatively independent of this request and may still complete.
+    /// </returns>
+    Task<bool> CancelAsync(DurableJob job, CancellationToken requestCancellationToken);
 }
 
 internal interface ILocalDurableJobManagerSystemTarget : ISystemTarget
 {
-    Task<bool> TryCancelDurableJobAsync(DurableJob job, CancellationToken cancellationToken);
+    Task<bool> CancelAsync(DurableJob job, CancellationToken requestCancellationToken);
 }

--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -75,14 +75,14 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     }
 
     /// <summary>
-    /// Cancels a durable job by removing it from the queue.
+    /// Removes a durable job from the queue.
     /// </summary>
-    /// <param name="jobId">The unique identifier of the job to cancel.</param>
+    /// <param name="jobId">The unique identifier of the job to remove.</param>
     /// <returns>True if the job was found and removed; false if the job was not found.</returns>
     /// <remarks>
     /// The job's bucket remains in the priority queue until processed, but the job itself is removed immediately.
     /// </remarks>
-    public bool CancelJob(string jobId)
+    public bool RemoveJob(string jobId)
     {
         lock (_syncLock)
         {
@@ -97,6 +97,18 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             }
 
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns whether the queue still contains the supplied durable job.
+    /// </summary>
+    public bool ContainsJob(string jobId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+        lock (_syncLock)
+        {
+            return _jobsIdToBucket.ContainsKey(jobId);
         }
     }
 
@@ -262,7 +274,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 // Process all jobs in the bucket outside the lock for better concurrency
                 foreach (var (job, dequeueCount) in jobsToYield)
                 {
-                    // Verify job hasn't been cancelled while we were processing
+                    // Verify the job has not been removed while we were processing.
                     bool shouldYield;
                     lock (_syncLock)
                     {

--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -84,6 +84,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     /// </remarks>
     public bool RemoveJob(string jobId)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         lock (_syncLock)
         {
             if (_jobsIdToBucket.TryGetValue(jobId, out var bucket))

--- a/src/Orleans.DurableJobs/JobShard.cs
+++ b/src/Orleans.DurableJobs/JobShard.cs
@@ -217,6 +217,7 @@ public abstract class JobShard : IJobShard
     /// <inheritdoc/>
     public async Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
     {
+        request.Validate();
         await _mutationLock.WaitAsync(cancellationToken);
         try
         {

--- a/src/Orleans.DurableJobs/JobShard.cs
+++ b/src/Orleans.DurableJobs/JobShard.cs
@@ -54,6 +54,20 @@ public interface IJobShard : IAsyncDisposable
     IAsyncEnumerable<IJobRunContext> ConsumeDurableJobsAsync();
 
     /// <summary>
+    /// Attempts to reserve a dequeued durable job for execution.
+    /// </summary>
+    /// <param name="jobContext">The dequeued job context.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// A task containing <see cref="DurableJobMutationResult.Applied"/> when the attempt may start,
+    /// <see cref="DurableJobMutationResult.JobNotFound"/> when cancellation or completion removed the job first,
+    /// or <see cref="DurableJobMutationResult.OwnershipLost"/> when this shard is no longer locally owned.
+    /// </returns>
+    Task<DurableJobMutationResult> TryStartAttemptAsync(
+        IJobRunContext jobContext,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Gets the number of jobs currently scheduled in this shard.
     /// </summary>
     /// <returns>A task that represents the asynchronous operation. The task result contains the job count.</returns>
@@ -71,8 +85,8 @@ public interface IJobShard : IAsyncDisposable
     /// </summary>
     /// <param name="jobId">The unique identifier of the job to remove.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains true if the job was successfully removed, or false if the job was not found.</returns>
-    Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken);
+    /// <returns>A task containing the durable mutation outcome.</returns>
+    Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Reschedules a job to be retried at a later time.
@@ -83,8 +97,11 @@ public interface IJobShard : IAsyncDisposable
     /// <see cref="IJobRunContext.Job"/>.
     /// </param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
+    /// <returns>A task containing the durable mutation outcome.</returns>
+    Task<DurableJobMutationResult> RetryJobLaterAsync(
+        IJobRunContext jobContext,
+        DateTimeOffset newDueTime,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Reschedules a successfully completed execution with its dequeue count reset.
@@ -95,8 +112,11 @@ public interface IJobShard : IAsyncDisposable
     /// <see cref="IJobRunContext.Job"/>.
     /// </param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
+    /// <returns>A task containing the durable mutation outcome.</returns>
+    Task<DurableJobMutationResult> RescheduleJobAsync(
+        IJobRunContext jobContext,
+        DateTimeOffset newDueTime,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Attempts to schedule a new job on this shard.
@@ -109,11 +129,33 @@ public interface IJobShard : IAsyncDisposable
 }
 
 /// <summary>
+/// Describes the outcome of an attempt to mutate a durable job after execution.
+/// </summary>
+public enum DurableJobMutationResult
+{
+    /// <summary>
+    /// The mutation was durably applied.
+    /// </summary>
+    Applied,
+
+    /// <summary>
+    /// The job was no longer present, typically because cancellation or completion removed it first.
+    /// </summary>
+    JobNotFound,
+
+    /// <summary>
+    /// The local silo no longer owned the shard, so the mutation was not applied.
+    /// </summary>
+    OwnershipLost
+}
+
+/// <summary>
 /// Base implementation of <see cref="IJobShard"/> that provides common functionality for job shard implementations.
 /// </summary>
 public abstract class JobShard : IJobShard
 {
     private readonly InMemoryJobQueue _jobQueue;
+    private readonly SemaphoreSlim _mutationLock = new(1, 1);
 
     /// <inheritdoc/>
     public string Id { get; protected set; }
@@ -154,72 +196,154 @@ public abstract class JobShard : IJobShard
     }
 
     /// <inheritdoc/>
+    public async Task<DurableJobMutationResult> TryStartAttemptAsync(
+        IJobRunContext jobContext,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(jobContext);
+        await _mutationLock.WaitAsync(cancellationToken);
+        try
+        {
+            return _jobQueue.ContainsJob(jobContext.Job.Id)
+                ? DurableJobMutationResult.Applied
+                : DurableJobMutationResult.JobNotFound;
+        }
+        finally
+        {
+            _mutationLock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
     {
-        if (IsAddingCompleted)
+        await _mutationLock.WaitAsync(cancellationToken);
+        try
         {
-            return null;
+            if (IsAddingCompleted)
+            {
+                return null;
+            }
+
+            if (request.DueTime < StartTime || request.DueTime > EndTime)
+            {
+                throw new ArgumentOutOfRangeException(nameof(request), "Scheduled time is out of shard bounds.");
+            }
+
+            var jobId = Guid.NewGuid().ToString();
+            var job = new DurableJob
+            {
+                Id = jobId,
+                TargetGrainId = request.Target,
+                Name = request.JobName,
+                DueTime = request.DueTime,
+                ShardId = Id,
+                Metadata = request.Metadata,
+                TraceParent = request.TraceParent,
+                TraceState = request.TraceState,
+            };
+
+            await PersistAddJobAsync(job, cancellationToken);
+            _jobQueue.Enqueue(job, 0);
+            return job;
         }
-
-        if (request.DueTime < StartTime || request.DueTime > EndTime)
+        finally
         {
-            throw new ArgumentOutOfRangeException(nameof(request), "Scheduled time is out of shard bounds.");
+            _mutationLock.Release();
         }
+    }
 
-        var jobId = Guid.NewGuid().ToString();
-        var job = new DurableJob
+    /// <inheritdoc/>
+    public async Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken)
+    {
+        await _mutationLock.WaitAsync(cancellationToken);
+        try
         {
-            Id = jobId,
-            TargetGrainId = request.Target,
-            Name = request.JobName,
-            DueTime = request.DueTime,
-            ShardId = Id,
-            Metadata = request.Metadata,
-            TraceParent = request.TraceParent,
-            TraceState = request.TraceState,
-        };
+            if (!_jobQueue.ContainsJob(jobId))
+            {
+                return DurableJobMutationResult.JobNotFound;
+            }
 
-        await PersistAddJobAsync(job, cancellationToken);
-        _jobQueue.Enqueue(job, 0);
-        return job;
+            await PersistRemoveJobAsync(jobId, cancellationToken);
+            return _jobQueue.RemoveJob(jobId)
+                ? DurableJobMutationResult.Applied
+                : DurableJobMutationResult.JobNotFound;
+        }
+        finally
+        {
+            _mutationLock.Release();
+        }
     }
 
     /// <inheritdoc/>
-    public async Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken)
+    public async Task MarkAsCompleteAsync(CancellationToken cancellationToken)
     {
-        await PersistRemoveJobAsync(jobId, cancellationToken);
-        return _jobQueue.CancelJob(jobId);
+        await _mutationLock.WaitAsync(cancellationToken);
+        try
+        {
+            IsAddingCompleted = true;
+            _jobQueue.MarkAsComplete();
+        }
+        finally
+        {
+            _mutationLock.Release();
+        }
     }
 
     /// <inheritdoc/>
-    public Task MarkAsCompleteAsync(CancellationToken cancellationToken)
+    public async Task<DurableJobMutationResult> RetryJobLaterAsync(
+        IJobRunContext jobContext,
+        DateTimeOffset newDueTime,
+        CancellationToken cancellationToken)
     {
-        IsAddingCompleted = true;
-        _jobQueue.MarkAsComplete();
-        return Task.CompletedTask;
+        await _mutationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!_jobQueue.ContainsJob(jobContext.Job.Id))
+            {
+                return DurableJobMutationResult.JobNotFound;
+            }
+
+            await PersistRetryJobAsync(jobContext, newDueTime, cancellationToken);
+            return _jobQueue.RetryJobLater(jobContext.Job.Id, newDueTime, jobContext.DequeueCount)
+                ? DurableJobMutationResult.Applied
+                : DurableJobMutationResult.JobNotFound;
+        }
+        finally
+        {
+            _mutationLock.Release();
+        }
     }
 
     /// <inheritdoc/>
-    public async Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken)
-    {
-        await PersistRetryJobAsync(jobContext, newDueTime, cancellationToken);
-        _jobQueue.RetryJobLater(jobContext, newDueTime);
-    }
-
-    /// <inheritdoc/>
-    public async Task RescheduleJobAsync(
+    public async Task<DurableJobMutationResult> RescheduleJobAsync(
         IJobRunContext jobContext,
         DateTimeOffset newDueTime,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(jobContext);
-        var executionGeneration = checked(jobContext.Job.ExecutionGeneration + 1);
-        var resetContext = new JobRunContext(
-            jobContext.Job.WithExecutionGeneration(executionGeneration),
-            jobContext.RunId,
-            retryCount: 0);
-        await PersistRetryJobAsync(resetContext, newDueTime, cancellationToken);
-        _jobQueue.RetryJobLater(jobContext.Job.Id, newDueTime, dequeueCount: 0, executionGeneration);
+        await _mutationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!_jobQueue.ContainsJob(jobContext.Job.Id))
+            {
+                return DurableJobMutationResult.JobNotFound;
+            }
+
+            var executionGeneration = checked(jobContext.Job.ExecutionGeneration + 1);
+            var resetContext = new JobRunContext(
+                jobContext.Job.WithExecutionGeneration(executionGeneration),
+                jobContext.RunId,
+                retryCount: 0);
+            await PersistRetryJobAsync(resetContext, newDueTime, cancellationToken);
+            return _jobQueue.RetryJobLater(jobContext.Job.Id, newDueTime, dequeueCount: 0, executionGeneration)
+                ? DurableJobMutationResult.Applied
+                : DurableJobMutationResult.JobNotFound;
+        }
+        finally
+        {
+            _mutationLock.Release();
+        }
     }
 
     /// <summary>

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -212,6 +212,7 @@ internal sealed class JournaledJobShard : IJobShard
     /// <inheritdoc/>
     public async Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
     {
+        request.Validate();
         ThrowIfDisposed();
 
         var operation = new ScheduleJobOperation(request, cancellationToken);

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -126,7 +126,27 @@ internal sealed class JournaledJobShard : IJobShard
     }
 
     /// <inheritdoc/>
-    public async Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken)
+    public async Task<DurableJobMutationResult> TryStartAttemptAsync(
+        IJobRunContext jobContext,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(jobContext);
+        ThrowIfDisposed();
+
+        var operation = new StartAttemptOperation(jobContext.Job.Id, cancellationToken);
+        try
+        {
+            EnqueueOperation(operation);
+            return await operation.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            operation.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         ThrowIfDisposed();
@@ -144,7 +164,10 @@ internal sealed class JournaledJobShard : IJobShard
     }
 
     /// <inheritdoc/>
-    public async Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken)
+    public async Task<DurableJobMutationResult> RetryJobLaterAsync(
+        IJobRunContext jobContext,
+        DateTimeOffset newDueTime,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(jobContext);
         ThrowIfDisposed();
@@ -153,7 +176,7 @@ internal sealed class JournaledJobShard : IJobShard
         try
         {
             EnqueueOperation(operation);
-            await operation.Task.ConfigureAwait(false);
+            return await operation.Task.ConfigureAwait(false);
         }
         finally
         {
@@ -162,7 +185,7 @@ internal sealed class JournaledJobShard : IJobShard
     }
 
     /// <inheritdoc/>
-    public async Task RescheduleJobAsync(
+    public async Task<DurableJobMutationResult> RescheduleJobAsync(
         IJobRunContext jobContext,
         DateTimeOffset newDueTime,
         CancellationToken cancellationToken)
@@ -178,7 +201,7 @@ internal sealed class JournaledJobShard : IJobShard
         try
         {
             EnqueueOperation(operation);
-            await operation.Task.ConfigureAwait(false);
+            return await operation.Task.ConfigureAwait(false);
         }
         finally
         {
@@ -438,7 +461,7 @@ internal sealed class JournaledJobShard : IJobShard
             {
                 using var batchActivity = DurableJobsDiagnostics.StartPersistBatchActivity(appliedOperations, Id);
                 await _stateManager.WriteStateAsync(_shutdownCancellation.Token).ConfigureAwait(false);
-                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: false);
+                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, operationCanceled: false, error: false);
                 batchActivity?.SetStatus(System.Diagnostics.ActivityStatusCode.Ok);
                 foreach (var operation in appliedOperations)
                 {
@@ -447,7 +470,7 @@ internal sealed class JournaledJobShard : IJobShard
             }
             catch (OperationCanceledException exception) when (_shutdownCancellation.IsCancellationRequested)
             {
-                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: true, error: false);
+                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, operationCanceled: true, error: false);
                 foreach (var operation in appliedOperations)
                 {
                     operation.TrySetCanceled(exception.CancellationToken);
@@ -455,7 +478,7 @@ internal sealed class JournaledJobShard : IJobShard
             }
             catch (Exception exception)
             {
-                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: true);
+                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, operationCanceled: false, error: true);
                 foreach (var operation in appliedOperations)
                 {
                     operation.TrySetException(exception);
@@ -682,14 +705,30 @@ internal sealed class JournaledJobShard : IJobShard
     }
 
     private sealed class RemoveJobOperation(string jobId, CancellationToken cancellationToken)
-        : PendingMutationOperation<bool>(cancellationToken)
+        : PendingMutationOperation<DurableJobMutationResult>(cancellationToken)
     {
-        protected override bool NotOwnedResult => false;
+        protected override DurableJobMutationResult NotOwnedResult => DurableJobMutationResult.OwnershipLost;
 
-        protected override bool Apply(JournaledJobShard shard, out bool result)
+        protected override bool Apply(JournaledJobShard shard, out DurableJobMutationResult result)
         {
-            result = shard._state.RemoveJob(jobId);
-            return true;
+            result = shard._state.RemoveJob(jobId)
+                ? DurableJobMutationResult.Applied
+                : DurableJobMutationResult.JobNotFound;
+            return result == DurableJobMutationResult.Applied;
+        }
+    }
+
+    private sealed class StartAttemptOperation(string jobId, CancellationToken cancellationToken)
+        : PendingMutationOperation<DurableJobMutationResult>(cancellationToken)
+    {
+        protected override DurableJobMutationResult NotOwnedResult => DurableJobMutationResult.OwnershipLost;
+
+        protected override bool Apply(JournaledJobShard shard, out DurableJobMutationResult result)
+        {
+            result = shard._state.ContainsJob(jobId)
+                ? DurableJobMutationResult.Applied
+                : DurableJobMutationResult.JobNotFound;
+            return false;
         }
     }
 
@@ -698,19 +737,20 @@ internal sealed class JournaledJobShard : IJobShard
         DateTimeOffset newDueTime,
         bool resetDequeueCount,
         CancellationToken cancellationToken)
-        : PendingMutationOperation<bool>(cancellationToken)
+        : PendingMutationOperation<DurableJobMutationResult>(cancellationToken)
     {
-        protected override bool NotOwnedResult => true;
+        protected override DurableJobMutationResult NotOwnedResult => DurableJobMutationResult.OwnershipLost;
 
-        protected override bool Apply(JournaledJobShard shard, out bool result)
+        protected override bool Apply(JournaledJobShard shard, out DurableJobMutationResult result)
         {
-            shard._state.RetryJobLater(
+            result = shard._state.RetryJobLater(
                 jobContext.Job.Id,
                 newDueTime,
                 resetDequeueCount ? 0 : jobContext.DequeueCount,
-                resetDequeueCount ? checked(jobContext.Job.ExecutionGeneration + 1) : null);
-            result = true;
-            return true;
+                resetDequeueCount ? checked(jobContext.Job.ExecutionGeneration + 1) : null)
+                ? DurableJobMutationResult.Applied
+                : DurableJobMutationResult.JobNotFound;
+            return result == DurableJobMutationResult.Applied;
         }
     }
 

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -384,6 +384,7 @@ internal sealed class JournaledJobShard : IJobShard
     {
         var startedOperations = new List<PendingMutationOperation>(operations.Count);
         var appliedOperations = new List<PendingMutationOperation>(operations.Count);
+        var operationsAwaitingWrite = new List<PendingMutationOperation>(operations.Count);
 
         try
         {
@@ -434,9 +435,15 @@ internal sealed class JournaledJobShard : IJobShard
             {
                 try
                 {
-                    if (operation.Apply(this))
+                    var hasPendingWrite = appliedOperations.Count > 0;
+                    if (operation.Apply(this, hasPendingWrite))
                     {
                         appliedOperations.Add(operation);
+                        operationsAwaitingWrite.Add(operation);
+                    }
+                    else if (hasPendingWrite && !operation.Completion.IsCompleted)
+                    {
+                        operationsAwaitingWrite.Add(operation);
                     }
                 }
                 catch (Exception exception)
@@ -463,7 +470,7 @@ internal sealed class JournaledJobShard : IJobShard
                 await _stateManager.WriteStateAsync(_shutdownCancellation.Token).ConfigureAwait(false);
                 _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, operationCanceled: false, error: false);
                 batchActivity?.SetStatus(System.Diagnostics.ActivityStatusCode.Ok);
-                foreach (var operation in appliedOperations)
+                foreach (var operation in operationsAwaitingWrite)
                 {
                     operation.CompleteAfterWrite();
                 }
@@ -471,7 +478,7 @@ internal sealed class JournaledJobShard : IJobShard
             catch (OperationCanceledException exception) when (_shutdownCancellation.IsCancellationRequested)
             {
                 _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, operationCanceled: true, error: false);
-                foreach (var operation in appliedOperations)
+                foreach (var operation in operationsAwaitingWrite)
                 {
                     operation.TrySetCanceled(exception.CancellationToken);
                 }
@@ -479,7 +486,7 @@ internal sealed class JournaledJobShard : IJobShard
             catch (Exception exception)
             {
                 _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, operationCanceled: false, error: true);
-                foreach (var operation in appliedOperations)
+                foreach (var operation in operationsAwaitingWrite)
                 {
                     operation.TrySetException(exception);
                 }
@@ -637,7 +644,7 @@ internal sealed class JournaledJobShard : IJobShard
 
         public abstract void CompleteNotOwned();
 
-        public abstract bool Apply(JournaledJobShard shard);
+        public abstract bool Apply(JournaledJobShard shard, bool deferCompletion);
 
         public abstract void CompleteAfterWrite();
     }
@@ -665,10 +672,10 @@ internal sealed class JournaledJobShard : IJobShard
 
         public override void CompleteNotOwned() => _completion.TrySetResult(NotOwnedResult);
 
-        public override bool Apply(JournaledJobShard shard)
+        public override bool Apply(JournaledJobShard shard, bool deferCompletion)
         {
             var writeRequired = Apply(shard, out _result);
-            if (!writeRequired)
+            if (!writeRequired && !deferCompletion)
             {
                 _completion.TrySetResult(_result);
             }

--- a/src/Orleans.DurableJobs/JournaledJobShardState.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShardState.cs
@@ -62,6 +62,8 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
 
     public int Count => _jobQueue.Count;
 
+    public bool ContainsJob(string jobId) => _jobQueue.ContainsJob(jobId);
+
     public IAsyncEnumerable<IJobRunContext> ConsumeDurableJobsAsync() => _jobQueue;
 
     public DurableJob? TryScheduleJob(ScheduleJobRequest request)
@@ -96,6 +98,10 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
     public bool RemoveJob(string jobId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+        if (!_jobQueue.ContainsJob(jobId))
+        {
+            return false;
+        }
 
         Write(DurableJobShardJournalRecord.ForRemove(jobId));
         return ApplyRemove(jobId);
@@ -114,6 +120,10 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         ValidateDequeueCount(dequeueCount);
+        if (!_jobQueue.ContainsJob(jobId))
+        {
+            return false;
+        }
 
         Write(DurableJobShardJournalRecord.ForRetry(jobId, newDueTime, dequeueCount, executionGeneration));
         return ApplyRetry(jobId, newDueTime, dequeueCount, executionGeneration);
@@ -196,7 +206,7 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
 
     private void ApplySchedule(DurableJob job) => _jobQueue.Enqueue(job, dequeueCount: 0);
 
-    private bool ApplyRemove(string jobId) => _jobQueue.CancelJob(jobId);
+    private bool ApplyRemove(string jobId) => _jobQueue.RemoveJob(jobId);
 
     private bool ApplyRetry(string jobId, DateTimeOffset dueTime, int dequeueCount, long? executionGeneration)
     {

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
@@ -44,21 +44,21 @@ internal partial class LocalDurableJobManager
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Attempting to cancel job {JobId} (Name: '{JobName}') in shard {ShardId}"
+        Message = "Requesting cancellation of job {JobId} (Name: '{JobName}') in shard {ShardId}"
     )]
-    private static partial void LogCancellingJob(ILogger logger, string jobId, string jobName, string shardId);
+    private static partial void LogRequestingJobCancellation(ILogger logger, string jobId, string jobName, string shardId);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Failed to cancel job {JobId} (Name: '{JobName}') - shard {ShardId} not found in cache"
+        Message = "Cancellation request for job {JobId} (Name: '{JobName}') was not recorded because shard {ShardId} was not found"
     )]
-    private static partial void LogJobCancellationFailed(ILogger logger, string jobId, string jobName, string shardId);
+    private static partial void LogJobCancellationRequestNotRecorded(ILogger logger, string jobId, string jobName, string shardId);
 
     [LoggerMessage(
         Level = LogLevel.Information,
-        Message = "Job {JobId} (Name: '{JobName}') cancelled from shard {ShardId}"
+        Message = "Cancellation requested for job {JobId} (Name: '{JobName}') in shard {ShardId}; future attempts are disabled"
     )]
-    private static partial void LogJobCancelled(ILogger logger, string jobId, string jobName, string shardId);
+    private static partial void LogJobCancellationRequested(ILogger logger, string jobId, string jobName, string shardId);
 
     [LoggerMessage(
         Level = LogLevel.Error,

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
@@ -50,7 +50,7 @@ internal partial class LocalDurableJobManager
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Cancellation request for job {JobId} (Name: '{JobName}') was not recorded because shard {ShardId} was not found"
+        Message = "Cancellation request for job {JobId} (Name: '{JobName}') was not recorded for shard {ShardId}"
     )]
     private static partial void LogJobCancellationRequestNotRecorded(ILogger logger, string jobId, string jobName, string shardId);
 

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -82,7 +82,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         request = EnsureScheduleRequestHasTraceContext(request, activity);
         try
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(request.JobName, nameof(request.JobName));
+            request.Validate();
             LogSchedulingJob(_logger, request.JobName, request.Target, request.DueTime);
 
             var shardKey = GetWritableShardKey(request);

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -251,49 +251,60 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         {
             LogRequestingJobCancellation(_logger, job.Id, job.Name, job.ShardId);
 
-            if (_shardCache.TryGetValue(job.ShardId, out var shard))
+            for (var routingAttempt = 0; routingAttempt < 2; routingAttempt++)
             {
-                if (!await _shardManager.IsShardOwnedByLocalSiloAsync(job.ShardId, requestCancellationToken))
+                if (_shardCache.TryGetValue(job.ShardId, out var shard))
+                {
+                    if (!await _shardManager.IsShardOwnedByLocalSiloAsync(job.ShardId, requestCancellationToken))
+                    {
+                        var entry = new KeyValuePair<string, IJobShard>(job.ShardId, shard);
+                        ((ICollection<KeyValuePair<string, IJobShard>>)_shardCache).Remove(entry);
+                    }
+                    else
+                    {
+                        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken, _cts.Token);
+                        var removeResult = await shard.RemoveJobAsync(job.Id, linkedCts.Token);
+                        var cancellationRequested = removeResult == DurableJobMutationResult.Applied;
+                        if (cancellationRequested)
+                        {
+                            LogJobCancellationRequested(_logger, job.Id, job.Name, job.ShardId);
+                            _durableJobsInstruments.OnJobCancellationRequested();
+                        }
+                        else
+                        {
+                            LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
+                        }
+
+                        _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested);
+                        return cancellationRequested;
+                    }
+                }
+
+                var owner = await _shardManager.GetShardOwnerAsync(job.ShardId, requestCancellationToken);
+                if (owner is null)
+                {
+                    break;
+                }
+
+                if (owner.Equals(Silo))
+                {
+                    continue;
+                }
+
+                var remote = _grainFactory.GetSystemTarget<ILocalDurableJobManagerSystemTarget>(JobManagerGrainType, owner);
+                var routed = await remote.CancelAsync(job, requestCancellationToken);
+                if (!routed)
                 {
                     LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
-                    _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested: false);
-                    return false;
                 }
 
-                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken, _cts.Token);
-                var removeResult = await shard.RemoveJobAsync(job.Id, linkedCts.Token);
-                var cancellationRequested = removeResult == DurableJobMutationResult.Applied;
-                if (cancellationRequested)
-                {
-                    LogJobCancellationRequested(_logger, job.Id, job.Name, job.ShardId);
-                    _durableJobsInstruments.OnJobCancellationRequested();
-                }
-                else
-                {
-                    LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
-                }
-
-                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested);
-                return cancellationRequested;
+                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), routed);
+                return routed;
             }
 
-            var owner = await _shardManager.GetShardOwnerAsync(job.ShardId, requestCancellationToken);
-            if (owner is null || owner.Equals(Silo))
-            {
-                LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
-                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested: false);
-                return false;
-            }
-
-            var remote = _grainFactory.GetSystemTarget<ILocalDurableJobManagerSystemTarget>(JobManagerGrainType, owner);
-            var routed = await remote.CancelAsync(job, requestCancellationToken);
-            if (!routed)
-            {
-                LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
-            }
-
-            _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), routed);
-            return routed;
+            LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
+            _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested: false);
+            return false;
         }
         catch (OperationCanceledException)
         {

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -82,6 +82,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         request = EnsureScheduleRequestHasTraceContext(request, activity);
         try
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(request.JobName, nameof(request.JobName));
             LogSchedulingJob(_logger, request.JobName, request.Target, request.DueTime);
 
             var shardKey = GetWritableShardKey(request);

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -244,47 +244,52 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     }
 
     /// <inheritdoc/>
-    public async Task<bool> TryCancelDurableJobAsync(DurableJob job, CancellationToken cancellationToken)
+    public async Task<bool> CancelAsync(DurableJob job, CancellationToken requestCancellationToken)
     {
         var startTimestamp = _timeProvider.GetTimestamp();
         try
         {
-            LogCancellingJob(_logger, job.Id, job.Name, job.ShardId);
+            LogRequestingJobCancellation(_logger, job.Id, job.Name, job.ShardId);
 
             if (_shardCache.TryGetValue(job.ShardId, out var shard))
             {
-                if (!await _shardManager.IsShardOwnedByLocalSiloAsync(job.ShardId, cancellationToken))
+                if (!await _shardManager.IsShardOwnedByLocalSiloAsync(job.ShardId, requestCancellationToken))
                 {
-                    LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
-                    _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
+                    LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
+                    _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested: false);
                     return false;
                 }
 
-                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
-                var wasRemoved = await shard.RemoveJobAsync(job.Id, linkedCts.Token);
-                LogJobCancelled(_logger, job.Id, job.Name, job.ShardId);
-                if (wasRemoved)
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(requestCancellationToken, _cts.Token);
+                var removeResult = await shard.RemoveJobAsync(job.Id, linkedCts.Token);
+                var cancellationRequested = removeResult == DurableJobMutationResult.Applied;
+                if (cancellationRequested)
                 {
-                    _durableJobsInstruments.OnJobCanceled();
+                    LogJobCancellationRequested(_logger, job.Id, job.Name, job.ShardId);
+                    _durableJobsInstruments.OnJobCancellationRequested();
+                }
+                else
+                {
+                    LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
                 }
 
-                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), wasRemoved);
-                return wasRemoved;
+                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested);
+                return cancellationRequested;
             }
 
-            var owner = await _shardManager.GetShardOwnerAsync(job.ShardId, cancellationToken);
+            var owner = await _shardManager.GetShardOwnerAsync(job.ShardId, requestCancellationToken);
             if (owner is null || owner.Equals(Silo))
             {
-                LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
-                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
+                LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
+                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), cancellationRequested: false);
                 return false;
             }
 
             var remote = _grainFactory.GetSystemTarget<ILocalDurableJobManagerSystemTarget>(JobManagerGrainType, owner);
-            var routed = await remote.TryCancelDurableJobAsync(job, cancellationToken);
+            var routed = await remote.CancelAsync(job, requestCancellationToken);
             if (!routed)
             {
-                LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
+                LogJobCancellationRequestNotRecorded(_logger, job.Id, job.Name, job.ShardId);
             }
 
             _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), routed);

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -247,6 +247,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     /// <inheritdoc/>
     public async Task<bool> CancelAsync(DurableJob job, CancellationToken requestCancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(job);
         var startTimestamp = _timeProvider.GetTimestamp();
         try
         {

--- a/src/Orleans.DurableJobs/OrleansContracts.txt
+++ b/src/Orleans.DurableJobs/OrleansContracts.txt
@@ -6,6 +6,6 @@ interface [GrainInterfaceType("Orleans.DurableJobs.IDurableJobReceiverExtension"
   HandleDurableJobAsync(Orleans.DurableJobs.IJobRunContext, System.Threading.CancellationToken) -> ValueTask<Orleans.DurableJobs.DurableJobRunResult>
 
 interface [GrainInterfaceType("Orleans.DurableJobs.ILocalDurableJobManagerSystemTarget")] Orleans.DurableJobs.ILocalDurableJobManagerSystemTarget [Version(0)]
-  TryCancelDurableJobAsync(Orleans.DurableJobs.DurableJob, System.Threading.CancellationToken) -> Task<bool>
+  CancelAsync(Orleans.DurableJobs.DurableJob, System.Threading.CancellationToken) -> Task<bool>
 
 class [GrainType("localdurablejobmanager")] Orleans.DurableJobs.LocalDurableJobManager

--- a/src/Orleans.DurableJobs/README.md
+++ b/src/Orleans.DurableJobs/README.md
@@ -9,7 +9,7 @@ Microsoft Orleans Durable Jobs provides a distributed, scalable system for sched
 - **Distributed**: Jobs are automatically distributed and rebalanced across silos
 - **Reliable**: Failed jobs can be automatically retried with configurable policies
 - **Rich Metadata**: Associate custom metadata with each job
-- **Cancellable**: Jobs can be canceled before execution
+- **Durably cancellable**: Cancellation requests prevent future attempts; an already-running attempt may still complete
 
 ## Getting Started
 
@@ -113,14 +113,14 @@ using Orleans.DurableJobs;
 public interface INotificationGrain : IGrainWithStringKey
 {
     Task ScheduleNotification(string message, DateTimeOffset sendTime);
-    Task CancelScheduledNotification();
+    Task CancelScheduledNotification(CancellationToken requestCancellationToken);
 }
 
 public class NotificationGrain : Grain, INotificationGrain, IDurableJobHandler
 {
     private readonly ILocalDurableJobManager _jobManager;
     private readonly ILogger<NotificationGrain> _logger;
-    private IDurableJob? _durableJob;
+    private DurableJob? _durableJob;
 
     public NotificationGrain(
         ILocalDurableJobManager jobManager,
@@ -153,7 +153,7 @@ public class NotificationGrain : Grain, INotificationGrain, IDurableJobHandler
             userId, sendTime, _durableJob.Id);
     }
 
-    public async Task CancelScheduledNotification()
+    public async Task CancelScheduledNotification(CancellationToken requestCancellationToken)
     {
         if (_durableJob is null)
         {
@@ -161,17 +161,21 @@ public class NotificationGrain : Grain, INotificationGrain, IDurableJobHandler
             return;
         }
 
-        var canceled = await _jobManager.TryCancelDurableJobAsync(_durableJob);
-        _logger.LogInformation("Notification {JobId} canceled: {Canceled}", _durableJob.Id, canceled);
-        
-        if (canceled)
+        var cancellationRequested = await _jobManager.CancelAsync(_durableJob, requestCancellationToken);
+        _logger.LogInformation(
+            "Notification {JobId} cancellation request recorded: {CancellationRequested}",
+            _durableJob.Id,
+            cancellationRequested);
+
+        if (cancellationRequested)
         {
+            // No future attempt will start. An already-running attempt may still complete.
             _durableJob = null;
         }
     }
 
     // This method is called when the durable job executes
-    public Task ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+    public Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var userId = this.GetPrimaryKeyString();
         var message = context.Job.Metadata?["Message"];
@@ -262,7 +266,7 @@ public class OrderGrain : Grain, IOrderGrain, IDurableJobHandler
         await _orderService.CancelOrderAsync(orderId);
     }
 
-    public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+    public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var step = context.Job.Metadata!["Step"];
         var orderId = this.GetPrimaryKey();
@@ -270,16 +274,16 @@ public class OrderGrain : Grain, IOrderGrain, IDurableJobHandler
         switch (step)
         {
             case "DeliveryReminder":
-                await HandleDeliveryReminder(context, cancellationToken);
+                await HandleDeliveryReminder(context, attemptCancellationToken);
                 break;
 
             case "OrderExpiration":
-                await HandleOrderExpiration(cancellationToken);
+                await HandleOrderExpiration(attemptCancellationToken);
                 break;
         }
     }
 
-    private async Task HandleDeliveryReminder(IJobRunContext context, CancellationToken ct)
+    private async Task HandleDeliveryReminder(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var customerId = context.Job.Metadata!["CustomerId"];
         var orderNumber = context.Job.Metadata["OrderNumber"];
@@ -290,14 +294,14 @@ public class OrderGrain : Grain, IOrderGrain, IDurableJobHandler
             DateTimeOffset.UtcNow);
     }
 
-    private async Task HandleOrderExpiration(CancellationToken ct)
+    private async Task HandleOrderExpiration(CancellationToken attemptCancellationToken)
     {
         var orderId = this.GetPrimaryKey();
-        var order = await _orderService.GetOrderAsync(orderId, ct);
+        var order = await _orderService.GetOrderAsync(orderId, attemptCancellationToken);
         
         if (order?.Status == OrderStatus.Pending)
         {
-            await _orderService.CancelOrderAsync(orderId, ct);
+            await _orderService.CancelOrderAsync(orderId, attemptCancellationToken);
             _logger.LogInformation("Order {OrderId} expired and canceled", orderId);
         }
     }
@@ -313,7 +317,7 @@ public class PaymentProcessorGrain : Grain, IDurableJobHandler
     private readonly IPaymentService _paymentService;
     private readonly ILogger<PaymentProcessorGrain> _logger;
 
-    public Task ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+    public Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         var paymentId = context.Job.Metadata?["PaymentId"];
         
@@ -323,7 +327,7 @@ public class PaymentProcessorGrain : Grain, IDurableJobHandler
 
         try
         {
-            await _paymentService.ProcessPaymentAsync(paymentId, cancellationToken);
+            await _paymentService.ProcessPaymentAsync(paymentId, attemptCancellationToken);
             return Task.CompletedTask;
         }
         catch (TransientException ex)
@@ -346,7 +350,7 @@ public class WorkflowGrain : Grain, IDurableJobHandler
 {
     private readonly Dictionary<string, TaskCompletionSource> _pendingJobs = new();
 
-    public async Task<IDurableJob> ScheduleWorkflowStep(string stepName, DateTimeOffset executeAt)
+    public async Task<DurableJob> ScheduleWorkflowStep(string stepName, DateTimeOffset executeAt)
     {
         var job = await _jobManager.ScheduleJobAsync(
             new ScheduleJobRequest
@@ -371,7 +375,7 @@ public class WorkflowGrain : Grain, IDurableJobHandler
         }
     }
 
-    public Task ExecuteJobAsync(IDurableJobContext context, CancellationToken cancellationToken)
+    public Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
     {
         // Execute the workflow step...
         
@@ -426,7 +430,7 @@ public class WorkflowGrain : Grain, IDurableJobHandler
 |----------|------|---------|-------------|
 | `ShardDuration` | `TimeSpan` | 1 minute | Duration of each job shard. Smaller values reduce latency but increase overhead. |
 | `MaxConcurrentJobsPerSilo` | `int` | 100 | Maximum number of jobs that can execute simultaneously on a silo. |
-| `ShouldRetry` | `Func<IDurableJobContext, Exception, DateTimeOffset?>` | 3 retries with exp. backoff | Determines if a failed job should be retried. Return the new due time or `null` to not retry. |
+| `ShouldRetry` | `Func<IJobRunContext, Exception, DateTimeOffset?>` | 3 retries with exp. backoff | Determines if a failed job should be retried. Return the new due time or `null` to not retry. |
 
 ## Best Practices
 
@@ -437,7 +441,7 @@ public class WorkflowGrain : Grain, IDurableJobHandler
 
 2. **Implement Idempotent Job Handlers**: Jobs may be retried, ensure handlers are idempotent
    ```csharp
-   public async Task ExecuteJobAsync(IDurableJobContext context, CancellationToken ct)
+   public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
    {
        var jobId = context.Job.Id;
        // Check if already processed
@@ -460,9 +464,9 @@ public class WorkflowGrain : Grain, IDurableJobHandler
 
 4. **Handle Cancellation**: Respect the cancellation token
    ```csharp
-   public async Task ExecuteJobAsync(IDurableJobContext context, CancellationToken ct)
+   public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken)
    {
-       await SomeLongRunningOperation(ct);
+       await SomeLongRunningOperation(attemptCancellationToken);
    }
    ```
 

--- a/src/Orleans.DurableJobs/ScheduleJobRequest.cs
+++ b/src/Orleans.DurableJobs/ScheduleJobRequest.cs
@@ -15,7 +15,7 @@ public readonly struct ScheduleJobRequest
     public required GrainId Target { get; init; }
 
     /// <summary>
-    /// Gets the name of the job for identification purposes.
+    /// Gets the non-empty name of the job for identification and handler routing.
     /// </summary>
     public required string JobName { get; init; }
 

--- a/src/Orleans.DurableJobs/ScheduleJobRequest.cs
+++ b/src/Orleans.DurableJobs/ScheduleJobRequest.cs
@@ -40,4 +40,7 @@ public readonly struct ScheduleJobRequest
     /// If <see langword="null"/>, the value of <see cref="System.Diagnostics.Activity.Current"/> at the time <see cref="ILocalDurableJobManager.ScheduleJobAsync"/> is invoked will be used.
     /// </summary>
     public string? TraceState { get; init; }
+
+    internal void Validate() =>
+        ArgumentException.ThrowIfNullOrWhiteSpace(JobName, nameof(JobName));
 }

--- a/src/Orleans.DurableJobs/ShardExecutor.Log.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.Log.cs
@@ -50,6 +50,17 @@ internal sealed partial class ShardExecutor
 
     [LoggerMessage(
         Level = LogLevel.Debug,
+        Message = "Did not apply {Mutation} for job {JobId} (Name: '{JobName}'): {MutationResult}"
+    )]
+    private static partial void LogJobMutationNotApplied(
+        ILogger logger,
+        string jobId,
+        string jobName,
+        string mutation,
+        DurableJobMutationResult mutationResult);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
         Message = "Polling job {JobId} (Name: '{JobName}') - will check status again in {PollDelay}"
     )]
     private static partial void LogPollingJob(ILogger logger, string jobId, string jobName, TimeSpan pollDelay);
@@ -74,9 +85,15 @@ internal sealed partial class ShardExecutor
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Shard {ShardId} processing cancelled"
+        Message = "Shard {ShardId} processing stopped after attempt cancellation was requested"
     )]
-    private static partial void LogShardCancelled(ILogger logger, string shardId);
+    private static partial void LogShardAttemptCanceled(ILogger logger, string shardId);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Shard {ShardId} processing stopped after ownership was lost"
+    )]
+    private static partial void LogShardOwnershipLost(ILogger logger, string shardId);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -59,14 +59,28 @@ internal sealed partial class ShardExecutor
     }
 
     /// <summary>
-    /// Runs a shard, processing all jobs within it until completion or cancellation.
+    /// Runs a shard, processing all jobs within it until completion or attempt cancellation.
     /// </summary>
     /// <param name="shard">The shard to execute.</param>
-    /// <param name="cancellationToken">Cancellation token to stop processing.</param>
+    /// <param name="attemptCancellationToken">
+    /// A token which cooperatively requests cancellation of the current shard and job execution attempts.
+    /// Durable jobs remain eligible for processing by another owner.
+    /// </param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public async Task RunShardAsync(IJobShard shard, CancellationToken cancellationToken)
+    public async Task RunShardAsync(IJobShard shard, CancellationToken attemptCancellationToken)
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding | ConfigureAwaitOptions.ContinueOnCapturedContext);
+        using var shardAttemptCancellation = CancellationTokenSource.CreateLinkedTokenSource(attemptCancellationToken);
+        var shardAttemptCancellationToken = shardAttemptCancellation.Token;
+        var ownershipLost = 0;
+
+        void NotifyOwnershipLost()
+        {
+            if (Interlocked.Exchange(ref ownershipLost, 1) == 0)
+            {
+                shardAttemptCancellation.Cancel();
+            }
+        }
 
         EnsureSlowStartRampUpStarted();
 
@@ -74,7 +88,7 @@ internal sealed partial class ShardExecutor
         var taskFailures = new ConcurrentQueue<ExceptionDispatchInfo>();
         var processingStarted = false;
         var processingStartTimestamp = 0L;
-        var canceled = false;
+        var attemptCanceled = false;
         var error = false;
         try
         {
@@ -84,7 +98,7 @@ internal sealed partial class ShardExecutor
                 // Wait until the shard's start time
                 var delay = shard.StartTime - now;
                 LogWaitingForShardStartTime(_logger, shard.Id, delay, shard.StartTime);
-                await Task.Delay(delay, _timeProvider, cancellationToken);
+                await Task.Delay(delay, _timeProvider, shardAttemptCancellationToken);
             }
 
             LogBeginProcessingShard(_logger, shard.Id);
@@ -92,24 +106,66 @@ internal sealed partial class ShardExecutor
             processingStartTimestamp = _timeProvider.GetTimestamp();
 
             // Process all jobs in the shard
-            await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
+            await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(shardAttemptCancellationToken))
             {
-                await WaitForOverloadToClearAsync(shard.Id, cancellationToken);
+                await WaitForOverloadToClearAsync(shard.Id, shardAttemptCancellationToken);
 
                 // Wait for concurrency slot
-                await _jobConcurrencyLimiter.WaitAsync(cancellationToken);
+                await _jobConcurrencyLimiter.WaitAsync(shardAttemptCancellationToken);
 
-                // Start processing the job. ExecuteJobAsync will release the semaphore when done and remove itself from the tasks dictionary
-                tasks[jobContext.Job.Id] = ExecuteJobAsync(jobContext, shard, tasks, taskFailures, cancellationToken);
+                var attemptStarted = false;
+                try
+                {
+                    var startResult = await shard.TryStartAttemptAsync(jobContext, shardAttemptCancellationToken);
+                    if (startResult == DurableJobMutationResult.JobNotFound)
+                    {
+                        continue;
+                    }
+
+                    if (startResult == DurableJobMutationResult.OwnershipLost)
+                    {
+                        NotifyOwnershipLost();
+                        shardAttemptCancellationToken.ThrowIfCancellationRequested();
+                    }
+
+                    if (startResult != DurableJobMutationResult.Applied)
+                    {
+                        throw new InvalidOperationException($"Unsupported durable job mutation result: {startResult}.");
+                    }
+
+                    // ExecuteJobAsync owns the concurrency slot after this point.
+                    tasks[jobContext.RunId] = ExecuteJobAsync(
+                        jobContext,
+                        shard,
+                        tasks,
+                        taskFailures,
+                        shardAttemptCancellationToken,
+                        NotifyOwnershipLost);
+                    attemptStarted = true;
+                }
+                finally
+                {
+                    if (!attemptStarted)
+                    {
+                        _jobConcurrencyLimiter.Release();
+                    }
+                }
             }
 
             LogCompletedProcessingShard(_logger, shard.Id);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (shardAttemptCancellationToken.IsCancellationRequested)
         {
-            canceled = true;
-            LogShardCancelled(_logger, shard.Id);
-            throw;
+            attemptCanceled = true;
+            if (Volatile.Read(ref ownershipLost) != 0)
+            {
+                LogShardOwnershipLost(_logger, shard.Id);
+            }
+            else
+            {
+                LogShardAttemptCanceled(_logger, shard.Id);
+                throw;
+            }
         }
         catch
         {
@@ -127,15 +183,25 @@ internal sealed partial class ShardExecutor
                     failure.Throw();
                 }
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (shardAttemptCancellationToken.IsCancellationRequested)
             {
-                if (!canceled)
+                if (!attemptCanceled)
                 {
-                    canceled = true;
-                    LogShardCancelled(_logger, shard.Id);
+                    attemptCanceled = true;
+                    if (Volatile.Read(ref ownershipLost) != 0)
+                    {
+                        LogShardOwnershipLost(_logger, shard.Id);
+                    }
+                    else
+                    {
+                        LogShardAttemptCanceled(_logger, shard.Id);
+                    }
                 }
 
-                throw;
+                if (Volatile.Read(ref ownershipLost) == 0)
+                {
+                    throw;
+                }
             }
             catch
             {
@@ -146,7 +212,16 @@ internal sealed partial class ShardExecutor
             {
                 if (processingStarted)
                 {
-                    _durableJobsInstruments.OnShardProcessed(_timeProvider.GetElapsedTime(processingStartTimestamp), canceled, error);
+                    if (!attemptCanceled && Volatile.Read(ref ownershipLost) != 0)
+                    {
+                        attemptCanceled = true;
+                        LogShardOwnershipLost(_logger, shard.Id);
+                    }
+
+                    _durableJobsInstruments.OnShardProcessed(
+                        _timeProvider.GetElapsedTime(processingStartTimestamp),
+                        attemptCanceled,
+                        error);
                 }
             }
         }
@@ -234,7 +309,8 @@ internal sealed partial class ShardExecutor
         IJobShard shard,
         ConcurrentDictionary<string, Task>? runningTasks,
         ConcurrentQueue<ExceptionDispatchInfo> taskFailures,
-        CancellationToken cancellationToken)
+        CancellationToken attemptCancellationToken,
+        Action notifyOwnershipLost)
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
 
@@ -247,11 +323,12 @@ internal sealed partial class ShardExecutor
         {
             try
             {
+                attemptCancellationToken.ThrowIfCancellationRequested();
                 LogExecutingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, jobContext.Job.TargetGrainId, jobContext.Job.DueTime);
 
                 var target = _grainFactory.GetGrain<IDurableJobReceiverExtension>(jobContext.Job.TargetGrainId);
 
-                var result = await target.HandleDurableJobAsync(jobContext, cancellationToken);
+                var result = await target.HandleDurableJobAsync(jobContext, attemptCancellationToken);
 
                 // Handle the result based on status
                 while (result.IsInProgress)
@@ -259,26 +336,71 @@ internal sealed partial class ShardExecutor
                     // Enter polling loop
                     LogPollingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, result.PollAfterDelay.Value);
 
-                    await Task.Delay(result.PollAfterDelay.Value, _timeProvider, cancellationToken);
+                    await Task.Delay(result.PollAfterDelay.Value, _timeProvider, attemptCancellationToken);
 
-                    result = await target.HandleDurableJobAsync(jobContext, cancellationToken);
+                    result = await target.HandleDurableJobAsync(jobContext, attemptCancellationToken);
                 }
 
                 switch (result.Status)
                 {
                     case DurableJobRunStatus.Completed:
-                        await shard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
-                        LogJobExecutedSuccessfully(_logger, jobContext.Job.Id, jobContext.Job.Name);
-                        _durableJobsInstruments.OnJobCompleted(_timeProvider.GetElapsedTime(attemptStartTimestamp));
-                        activity?.SetTag(ActivityTagKeys.DurableJobStatus, "completed");
-                        activity?.SetStatus(ActivityStatusCode.Ok);
+                        var removeResult = await shard.RemoveJobAsync(jobContext.Job.Id, attemptCancellationToken);
+                        if (removeResult == DurableJobMutationResult.Applied)
+                        {
+                            LogJobExecutedSuccessfully(_logger, jobContext.Job.Id, jobContext.Job.Name);
+                            _durableJobsInstruments.OnJobCompleted(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                            activity?.SetTag(ActivityTagKeys.DurableJobStatus, "completed");
+                            activity?.SetStatus(ActivityStatusCode.Ok);
+                        }
+                        else if (removeResult == DurableJobMutationResult.JobNotFound)
+                        {
+                            LogJobMutationNotApplied(
+                                _logger,
+                                jobContext.Job.Id,
+                                jobContext.Job.Name,
+                                "completion",
+                                removeResult);
+                            activity?.SetTag(ActivityTagKeys.DurableJobStatus, "cancellation_requested");
+                        }
+                        else
+                        {
+                            LogJobMutationNotApplied(
+                                _logger,
+                                jobContext.Job.Id,
+                                jobContext.Job.Name,
+                                "completion",
+                                removeResult);
+                            activity?.SetTag(ActivityTagKeys.DurableJobStatus, "ownership_lost");
+                            notifyOwnershipLost();
+                        }
                         break;
                     case DurableJobRunStatus.RescheduleRequested when result.RescheduleTime is { } rescheduleTime:
-                        LogReschedulingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, rescheduleTime);
-                        await shard.RescheduleJobAsync(jobContext, rescheduleTime, cancellationToken);
-                        _durableJobsInstruments.OnJobRescheduled(_timeProvider.GetElapsedTime(attemptStartTimestamp));
-                        activity?.SetTag(ActivityTagKeys.DurableJobStatus, "rescheduled");
-                        activity?.SetStatus(ActivityStatusCode.Ok);
+                        var rescheduleResult = await shard.RescheduleJobAsync(jobContext, rescheduleTime, attemptCancellationToken);
+                        if (rescheduleResult == DurableJobMutationResult.Applied)
+                        {
+                            LogReschedulingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, rescheduleTime);
+                            _durableJobsInstruments.OnJobRescheduled(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                            activity?.SetTag(ActivityTagKeys.DurableJobStatus, "rescheduled");
+                            activity?.SetStatus(ActivityStatusCode.Ok);
+                        }
+                        else
+                        {
+                            LogJobMutationNotApplied(
+                                _logger,
+                                jobContext.Job.Id,
+                                jobContext.Job.Name,
+                                "reschedule",
+                                rescheduleResult);
+                            activity?.SetTag(
+                                ActivityTagKeys.DurableJobStatus,
+                                rescheduleResult == DurableJobMutationResult.JobNotFound
+                                    ? "cancellation_requested"
+                                    : "ownership_lost");
+                            if (rescheduleResult == DurableJobMutationResult.OwnershipLost)
+                            {
+                                notifyOwnershipLost();
+                            }
+                        }
                         break;
                     case DurableJobRunStatus.RescheduleRequested:
                         failureException = new InvalidOperationException(
@@ -301,7 +423,11 @@ internal sealed partial class ShardExecutor
                         break;
                 }
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (OperationCanceledException) when (attemptCancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
             {
                 LogErrorExecutingJob(_logger, ex, jobContext.Job.Id);
                 failureException = ex;
@@ -313,11 +439,32 @@ internal sealed partial class ShardExecutor
                 var retryTime = _options.ShouldRetry(jobContext, failureException);
                 if (retryTime is not null)
                 {
-                    LogRetryingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, retryTime.Value, jobContext.DequeueCount);
-                    await shard.RetryJobLaterAsync(jobContext, retryTime.Value, cancellationToken);
-                    _durableJobsInstruments.OnJobRetried(_timeProvider.GetElapsedTime(attemptStartTimestamp));
-                    activity?.SetTag(ActivityTagKeys.DurableJobStatus, "retried");
-                    DurableJobsDiagnostics.SetError(activity, failureException);
+                    var retryResult = await shard.RetryJobLaterAsync(jobContext, retryTime.Value, attemptCancellationToken);
+                    if (retryResult == DurableJobMutationResult.Applied)
+                    {
+                        LogRetryingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, retryTime.Value, jobContext.DequeueCount);
+                        _durableJobsInstruments.OnJobRetried(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                        activity?.SetTag(ActivityTagKeys.DurableJobStatus, "retried");
+                        DurableJobsDiagnostics.SetError(activity, failureException);
+                    }
+                    else
+                    {
+                        LogJobMutationNotApplied(
+                            _logger,
+                            jobContext.Job.Id,
+                            jobContext.Job.Name,
+                            "retry",
+                            retryResult);
+                        activity?.SetTag(
+                            ActivityTagKeys.DurableJobStatus,
+                            retryResult == DurableJobMutationResult.JobNotFound
+                                ? "cancellation_requested"
+                                : "ownership_lost");
+                        if (retryResult == DurableJobMutationResult.OwnershipLost)
+                        {
+                            notifyOwnershipLost();
+                        }
+                    }
                 }
                 else
                 {
@@ -329,9 +476,9 @@ internal sealed partial class ShardExecutor
             }
 
         }
-        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (attemptCancellationToken.IsCancellationRequested)
         {
-            activity?.SetTag(ActivityTagKeys.DurableJobStatus, "canceled");
+            activity?.SetTag(ActivityTagKeys.DurableJobStatus, "attempt_canceled");
             taskFailures.Enqueue(ExceptionDispatchInfo.Capture(exception));
         }
         catch (Exception exception)
@@ -343,7 +490,7 @@ internal sealed partial class ShardExecutor
         {
             // Cleanup must happen even when retry persistence throws, otherwise slots leak and shard processing can stall.
             _jobConcurrencyLimiter.Release();
-            runningTasks?.TryRemove(jobContext.Job.Id, out _);
+            runningTasks?.TryRemove(jobContext.RunId, out _);
         }
     }
 

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -37,6 +37,13 @@ namespace Orleans.DurableJobs
         public string? TraceState { get { throw null; } init { } }
     }
 
+    public enum DurableJobMutationResult
+    {
+        Applied = 0,
+        JobNotFound = 1,
+        OwnershipLost = 2,
+    }
+
     [GenerateSerializer]
     public sealed partial class DurableJobRunResult
     {
@@ -87,12 +94,12 @@ namespace Orleans.DurableJobs
 
     public partial interface IDurableJobFeatureHandler
     {
-        System.Threading.Tasks.ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken attemptCancellationToken);
     }
 
     public partial interface IDurableJobHandler
     {
-        System.Threading.Tasks.Task ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken attemptCancellationToken);
     }
 
     public partial interface IDurableJobHandlerRegistry
@@ -124,16 +131,17 @@ namespace Orleans.DurableJobs
         System.Collections.Generic.IAsyncEnumerable<IJobRunContext> ConsumeDurableJobsAsync();
         System.Threading.Tasks.ValueTask<int> GetJobCountAsync();
         System.Threading.Tasks.Task MarkAsCompleteAsync(System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<bool> RemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task RescheduleJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task RetryJobLaterAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<DurableJobMutationResult> RemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, System.Threading.CancellationToken cancellationToken);
     }
 
     public partial interface ILocalDurableJobManager
     {
+        System.Threading.Tasks.Task<bool> CancelAsync(DurableJob job, System.Threading.CancellationToken requestCancellationToken);
         System.Threading.Tasks.Task<DurableJob> ScheduleJobAsync(ScheduleJobRequest request, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<bool> TryCancelDurableJobAsync(DurableJob job, System.Threading.CancellationToken cancellationToken);
     }
 
     public abstract partial class JobShard : IJobShard, System.IAsyncDisposable
@@ -163,11 +171,13 @@ namespace Orleans.DurableJobs
         protected abstract System.Threading.Tasks.Task PersistAddJobAsync(DurableJob job, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task PersistRemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task PersistRetryJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
-        public System.Threading.Tasks.Task<bool> RemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<DurableJobMutationResult> RemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken) { throw null; }
 
-        public System.Threading.Tasks.Task RescheduleJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken) { throw null; }
 
-        public System.Threading.Tasks.Task RetryJobLaterAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, System.Threading.CancellationToken cancellationToken) { throw null; }
     }

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -214,8 +214,6 @@ namespace Orleans.Hosting
 
     public sealed partial class DurableJobsOptions
     {
-        public System.TimeSpan CompletedJobAttemptRetentionPeriod { get { throw null; } set { } }
-
         public bool ConcurrencySlowStartEnabled { get { throw null; } set { } }
 
         public System.TimeSpan JobStatusPollInterval { get { throw null; } set { } }

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -85,9 +85,19 @@ namespace Orleans.DurableJobs
         public const string DurableJobs = "Orleans.DurableJobs";
     }
 
+    public partial interface IDurableJobFeatureHandler
+    {
+        System.Threading.Tasks.ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken cancellationToken);
+    }
+
     public partial interface IDurableJobHandler
     {
         System.Threading.Tasks.Task ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IDurableJobHandlerRegistry
+    {
+        void Register(string jobName, IDurableJobFeatureHandler handler);
     }
 
     public partial interface IJobRunContext
@@ -204,6 +214,8 @@ namespace Orleans.Hosting
 
     public sealed partial class DurableJobsOptions
     {
+        public System.TimeSpan CompletedJobAttemptRetentionPeriod { get { throw null; } set { } }
+
         public bool ConcurrencySlowStartEnabled { get { throw null; } set { } }
 
         public System.TimeSpan JobStatusPollInterval { get { throw null; } set { } }

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -94,6 +94,8 @@ namespace Orleans.DurableJobs
 
     public partial interface IDurableJobFeatureHandler
     {
+        bool CanHandle(DurableJob job);
+
         System.Threading.Tasks.ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken attemptCancellationToken);
     }
 
@@ -104,7 +106,7 @@ namespace Orleans.DurableJobs
 
     public partial interface IDurableJobHandlerRegistry
     {
-        void Register(string jobName, IDurableJobFeatureHandler handler);
+        void Register(IDurableJobFeatureHandler handler);
     }
 
     public partial interface IJobRunContext

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -94,7 +94,7 @@ namespace Orleans.DurableJobs
 
     public partial interface IDurableJobFeatureHandler
     {
-        bool CanHandle(DurableJob job);
+        bool CanHandle(string jobName);
 
         System.Threading.Tasks.ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, System.Threading.CancellationToken attemptCancellationToken);
     }

--- a/test/Grains/TestGrainInterfaces/IDurableJobGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IDurableJobGrain.cs
@@ -12,7 +12,7 @@ public interface IDurableJobGrain : IGrainWithStringKey
 {
     Task<DurableJob> ScheduleJobAsync(string jobName, DateTimeOffset scheduledTime, IReadOnlyDictionary<string, string>? metadata = null);
 
-    Task<bool> TryCancelJobAsync(DurableJob job);
+    Task<bool> CancelAsync(DurableJob job);
 
     Task<bool> HasJobRan(string jobId);
 

--- a/test/Grains/TestGrains/DurableJobGrain.cs
+++ b/test/Grains/TestGrains/DurableJobGrain.cs
@@ -69,9 +69,9 @@ public class DurableJobGrain : Grain, IDurableJobGrain, IDurableJobHandler
         await taskResult.Task;
     }
 
-    public async Task<bool> TryCancelJobAsync(DurableJob job)
+    public async Task<bool> CancelAsync(DurableJob job)
     {
-        return await _localDurableJobManager.TryCancelDurableJobAsync(job, CancellationToken.None);
+        return await _localDurableJobManager.CancelAsync(job, CancellationToken.None);
     }
 
     public Task<DateTimeOffset> GetJobExecutionTime(string jobId)

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -23,6 +23,17 @@ namespace NonSilo.Tests.ScheduledJobs;
 public class DurableJobReceiverExtensionTests
 {
     [Fact]
+    public void HandleDurableJobAsync_NullContext_Throws()
+    {
+        var extension = CreateExtension(Substitute.For<IDurableJobHandler>());
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => extension.HandleDurableJobAsync(null!, CancellationToken.None));
+
+        Assert.Equal("context", exception.ParamName);
+    }
+
+    [Fact]
     public async Task HandleDurableJobAsync_WhenHandlerCancelsWithoutAttemptCancellation_ReturnsFailure()
     {
         var exception = new OperationCanceledException("Handler-specific cancellation");

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -23,16 +23,68 @@ namespace NonSilo.Tests.ScheduledJobs;
 public class DurableJobReceiverExtensionTests
 {
     [Fact]
-    public async Task HandleDurableJobAsync_WhenExecutionTaskIsCanceled_PropagatesCancellation()
+    public async Task HandleDurableJobAsync_WhenHandlerCancelsWithoutAttemptCancellation_ReturnsFailure()
     {
+        var exception = new OperationCanceledException("Handler-specific cancellation");
         var handler = Substitute.For<IDurableJobHandler>();
         handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromCanceled(new CancellationToken(canceled: true)));
+            .Returns(Task.FromException(exception));
 
         var extension = CreateExtension(handler);
         var context = CreateJobContext("run-1");
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => extension.HandleDurableJobAsync(context, CancellationToken.None).AsTask());
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Same(exception, result.Exception);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenAttemptCancellationIsRequested_PropagatesCancellation()
+    {
+        using var attemptCancellation = new CancellationTokenSource();
+        attemptCancellation.Cancel();
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), attemptCancellation.Token)
+            .Returns(Task.FromCanceled(attemptCancellation.Token));
+
+        var extension = CreateExtension(handler);
+        var context = CreateJobContext("run-1");
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => extension.HandleDurableJobAsync(context, attemptCancellation.Token).AsTask());
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenCanceledAttemptIsRedeliveredWithActiveToken_StartsNewAttempt()
+    {
+        using var telemetry = new HandlerTelemetryCapture("run-1");
+        using var firstAttemptCancellation = new CancellationTokenSource();
+        var invocationCount = 0;
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+                Interlocked.Increment(ref invocationCount) == 1
+                    ? WaitForAttemptCancellationAsync(call.ArgAt<CancellationToken>(1))
+                    : Task.CompletedTask);
+        var extension = CreateExtension(
+            handler,
+            jobStatusPollInterval: TimeSpan.FromMilliseconds(1),
+            durableJobsInstruments: telemetry.Instruments);
+        var context = CreateJobContext("run-1");
+
+        var initial = await extension.HandleDurableJobAsync(context, firstAttemptCancellation.Token);
+        Assert.True(initial.IsInProgress);
+        firstAttemptCancellation.Cancel();
+        await telemetry.TrackedHandlerStopped.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var redelivery = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.Equal(DurableJobRunStatus.Completed, redelivery.Status);
+        await handler.Received(2).ExecuteJobAsync(context, Arg.Any<CancellationToken>());
+
+        static async Task WaitForAttemptCancellationAsync(CancellationToken attemptCancellationToken) =>
+            await Task.Delay(Timeout.InfiniteTimeSpan, attemptCancellationToken);
     }
 
     [Fact]
@@ -46,7 +98,7 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenTokenIsCanceledButExecutionIsStillRunning_RemainsRunning()
+    public async Task HandleDurableJobAsync_WhenAttemptCancellationIsRequestedButExecutionIsStillRunning_RemainsRunning()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler = Substitute.For<IDurableJobHandler>();
@@ -284,7 +336,7 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenFeatureHandlerCancels_RecordsCancellationTelemetryOnce()
+    public async Task HandleDurableJobAsync_WhenFeatureAttemptCancellationIsRequested_RecordsAttemptCancellationTelemetryOnce()
     {
         using var telemetry = new HandlerTelemetryCapture();
         using var cancellation = new CancellationTokenSource();
@@ -302,13 +354,36 @@ public class DurableJobReceiverExtensionTests
         var secondContext = CreateJobContext("run-canceled-2", jobName: "feature");
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => extension.HandleDurableJobAsync(firstContext, CancellationToken.None).AsTask());
+            () => extension.HandleDurableJobAsync(firstContext, cancellation.Token).AsTask());
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => extension.HandleDurableJobAsync(secondContext, CancellationToken.None).AsTask());
+            () => extension.HandleDurableJobAsync(secondContext, cancellation.Token).AsTask());
 
         await featureHandler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
-        telemetry.AssertOutcome(firstContext.RunId, "canceled", ActivityStatusCode.Unset, expectedInvocationCount: 2);
-        telemetry.AssertOutcome(secondContext.RunId, "canceled", ActivityStatusCode.Unset, expectedInvocationCount: 2);
+        telemetry.AssertOutcome(firstContext.RunId, "attempt_canceled", ActivityStatusCode.Unset, expectedInvocationCount: 2);
+        telemetry.AssertOutcome(secondContext.RunId, "attempt_canceled", ActivityStatusCode.Unset, expectedInvocationCount: 2);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenFeatureHandlerCancelsWithoutAttemptCancellation_RecordsFailureTelemetryOnce()
+    {
+        using var telemetry = new HandlerTelemetryCapture();
+        var exception = new OperationCanceledException("Handler-specific cancellation");
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<DurableJobRunResult>(exception));
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("feature", featureHandler);
+        var extension = CreateExtension(
+            Substitute.For<IDurableJobHandler>(),
+            registry: registry,
+            durableJobsInstruments: telemetry.Instruments);
+        var context = CreateJobContext("run-handler-canceled", jobName: "feature");
+
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Same(exception, result.Exception);
+        telemetry.AssertOutcome(context.RunId, "failed", ActivityStatusCode.Error, exception);
     }
 
     [Fact]
@@ -523,9 +598,13 @@ public class DurableJobReceiverExtensionTests
         private readonly ActivityListener _activityListener;
         private readonly MetricCollector<long> _startedCollector;
         private readonly MetricCollector<long> _executionCollector;
+        private readonly string? _trackedRunId;
+        private readonly TaskCompletionSource _trackedHandlerStopped =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public HandlerTelemetryCapture()
+        public HandlerTelemetryCapture(string? trackedRunId = null)
         {
+            _trackedRunId = trackedRunId;
             var services = new ServiceCollection();
             services.AddMetrics();
             _serviceProvider = services.BuildServiceProvider();
@@ -544,12 +623,23 @@ public class DurableJobReceiverExtensionTests
                 ShouldListenTo = static source => ReferenceEquals(source, DurableJobsDiagnostics.Source),
                 Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
                 SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
-                ActivityStopped = activity => _activities.Enqueue(activity)
+                ActivityStopped = activity =>
+                {
+                    _activities.Enqueue(activity);
+                    if (_trackedRunId is not null
+                        && activity.GetTagItem(ActivityTagKeys.DurableJobRunId) is string runId
+                        && runId == _trackedRunId)
+                    {
+                        _trackedHandlerStopped.TrySetResult();
+                    }
+                }
             };
             ActivitySource.AddActivityListener(_activityListener);
         }
 
         public DurableJobsInstruments Instruments { get; }
+
+        public Task TrackedHandlerStopped => _trackedHandlerStopped.Task;
 
         public void AssertOutcome(
             string runId,

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
@@ -6,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Orleans.Configuration;
+using Orleans.Diagnostics;
 using Orleans.DurableJobs;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -214,17 +217,55 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenFeatureHandlerReturnsNull_RecordsOnlyFailure()
+    public async Task HandleDurableJobAsync_WhenFeatureHandlerReturnsFailed_RecordsFailureTelemetryOnce()
     {
-        var services = new ServiceCollection();
-        services.AddMetrics();
-        using var serviceProvider = services.BuildServiceProvider();
-        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
-        var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
-        using var executionCollector = new MetricCollector<long>(
-            meterFactory,
-            "Microsoft.Orleans",
-            "orleans-durablejobs-handler-executions");
+        using var telemetry = new HandlerTelemetryCapture();
+        var exception = new InvalidOperationException("Explicit feature failure");
+        var expected = DurableJobRunResult.Failed(exception);
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(expected));
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("feature", featureHandler);
+        var extension = CreateExtension(
+            Substitute.For<IDurableJobHandler>(),
+            registry: registry,
+            durableJobsInstruments: telemetry.Instruments);
+        var context = CreateJobContext("run-explicit-failure", jobName: "feature");
+
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.Same(expected, result);
+        telemetry.AssertOutcome(context.RunId, "failed", ActivityStatusCode.Error, exception);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenFeatureHandlerThrows_RecordsFailureTelemetryOnce()
+    {
+        using var telemetry = new HandlerTelemetryCapture();
+        var exception = new InvalidOperationException("Thrown feature failure");
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<DurableJobRunResult>(exception));
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("feature", featureHandler);
+        var extension = CreateExtension(
+            Substitute.For<IDurableJobHandler>(),
+            registry: registry,
+            durableJobsInstruments: telemetry.Instruments);
+        var context = CreateJobContext("run-thrown-failure", jobName: "feature");
+
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Same(exception, result.Exception);
+        telemetry.AssertOutcome(context.RunId, "failed", ActivityStatusCode.Error, exception);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenFeatureHandlerReturnsNull_RecordsFailureTelemetryOnce()
+    {
+        using var telemetry = new HandlerTelemetryCapture();
         var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult<DurableJobRunResult>(null!));
@@ -233,15 +274,76 @@ public class DurableJobReceiverExtensionTests
         var extension = CreateExtension(
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
-            durableJobsInstruments: instruments);
-        var context = CreateJobContext("run-1", jobName: "feature");
+            durableJobsInstruments: telemetry.Instruments);
+        var context = CreateJobContext("run-null-result", jobName: "feature");
 
         var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
 
-        Assert.Equal(DurableJobRunStatus.Failed, result.Status);
-        var measurement = Assert.Single(executionCollector.GetMeasurementSnapshot());
-        Assert.Equal(1, measurement.Value);
-        Assert.Equal("failed", measurement.Tags["status"]);
+        Assert.True(result.IsFailed);
+        var exception = Assert.IsType<InvalidOperationException>(result.Exception);
+        telemetry.AssertOutcome(context.RunId, "failed", ActivityStatusCode.Error, exception);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenFeatureHandlerCancels_RecordsCancellationTelemetryOnce()
+    {
+        using var telemetry = new HandlerTelemetryCapture();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromCanceled<DurableJobRunResult>(cancellation.Token));
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("feature", featureHandler);
+        var extension = CreateExtension(
+            Substitute.For<IDurableJobHandler>(),
+            registry: registry,
+            durableJobsInstruments: telemetry.Instruments);
+        var context = CreateJobContext("run-canceled", jobName: "feature");
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => extension.HandleDurableJobAsync(context, CancellationToken.None).AsTask());
+
+        telemetry.AssertOutcome(context.RunId, "canceled", ActivityStatusCode.Unset);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenFeatureHandlerReturnsSuccessfulDisposition_RecordsCompletedTelemetryOnce()
+    {
+        using var telemetry = new HandlerTelemetryCapture();
+        var outcomes = new[]
+        {
+            (RunId: "run-completed", Result: DurableJobRunResult.Completed),
+            (RunId: "run-in-progress", Result: DurableJobRunResult.InProgress(TimeSpan.FromSeconds(1))),
+            (RunId: "run-rescheduled", Result: DurableJobRunResult.RescheduleAt(DateTimeOffset.UtcNow.AddHours(1)))
+        };
+
+        foreach (var outcome in outcomes)
+        {
+            var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+            featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+                .Returns(ValueTask.FromResult(outcome.Result));
+            var registry = new DurableJobHandlerRegistry();
+            registry.Register("feature", featureHandler);
+            var extension = CreateExtension(
+                Substitute.For<IDurableJobHandler>(),
+                registry: registry,
+                durableJobsInstruments: telemetry.Instruments);
+            var context = CreateJobContext(outcome.RunId, jobName: "feature");
+
+            var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+            Assert.Same(outcome.Result, result);
+        }
+
+        foreach (var outcome in outcomes)
+        {
+            telemetry.AssertOutcome(
+                outcome.RunId,
+                "completed",
+                ActivityStatusCode.Ok,
+                expectedInvocationCount: outcomes.Length);
+        }
     }
 
     [Fact]
@@ -398,6 +500,88 @@ public class DurableJobReceiverExtensionTests
                     Interlocked.Decrement(ref _owner._activeTimerCount);
                 }
             }
+        }
+    }
+
+    private sealed class HandlerTelemetryCapture : IDisposable
+    {
+        private readonly ConcurrentQueue<Activity> _activities = new();
+        private readonly ServiceProvider _serviceProvider;
+        private readonly ActivityListener _activityListener;
+        private readonly MetricCollector<long> _startedCollector;
+        private readonly MetricCollector<long> _executionCollector;
+
+        public HandlerTelemetryCapture()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            _serviceProvider = services.BuildServiceProvider();
+            var meterFactory = _serviceProvider.GetRequiredService<IMeterFactory>();
+            Instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
+            _startedCollector = new MetricCollector<long>(
+                meterFactory,
+                "Microsoft.Orleans",
+                "orleans-durablejobs-handler-executions-started");
+            _executionCollector = new MetricCollector<long>(
+                meterFactory,
+                "Microsoft.Orleans",
+                "orleans-durablejobs-handler-executions");
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = static source => ReferenceEquals(source, DurableJobsDiagnostics.Source),
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => _activities.Enqueue(activity)
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+        }
+
+        public DurableJobsInstruments Instruments { get; }
+
+        public void AssertOutcome(
+            string runId,
+            string expectedMetricStatus,
+            ActivityStatusCode expectedActivityStatus,
+            Exception? exception = null,
+            int expectedInvocationCount = 1)
+        {
+            var started = _startedCollector.GetMeasurementSnapshot();
+            Assert.Equal(expectedInvocationCount, started.Count);
+            Assert.All(started, static measurement => Assert.Equal(1, measurement.Value));
+            var executions = _executionCollector.GetMeasurementSnapshot();
+            Assert.Equal(expectedInvocationCount, executions.Count);
+            Assert.All(executions, measurement =>
+            {
+                Assert.Equal(1, measurement.Value);
+                Assert.Equal(expectedMetricStatus, measurement.Tags["status"]);
+            });
+
+            var activity = Assert.Single(
+                _activities,
+                activity => activity.OperationName == DurableJobsDiagnostics.ActivityExecuteJobHandler
+                    && activity.GetTagItem(ActivityTagKeys.DurableJobRunId) is string activityRunId
+                    && activityRunId == runId);
+            Assert.Equal(expectedActivityStatus, activity.Status);
+            if (exception is null)
+            {
+                Assert.Null(activity.GetTagItem(ActivityTagKeys.ExceptionType));
+                Assert.Null(activity.GetTagItem(ActivityTagKeys.ExceptionMessage));
+                Assert.Null(activity.StatusDescription);
+            }
+            else
+            {
+                Assert.Equal(exception.GetType().FullName, activity.GetTagItem(ActivityTagKeys.ExceptionType));
+                Assert.Equal(exception.Message, activity.GetTagItem(ActivityTagKeys.ExceptionMessage));
+                Assert.Equal(exception.Message, activity.StatusDescription);
+            }
+        }
+
+        public void Dispose()
+        {
+            _activityListener.Dispose();
+            _executionCollector.Dispose();
+            _startedCollector.Dispose();
+            _serviceProvider.Dispose();
         }
     }
 }

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -220,7 +220,7 @@ public class DurableJobReceiverExtensionTests
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler);
         var extension = CreateExtension(grainHandler, registry: registry);
         var context = CreateJobContext("run-1", jobName: "feature");
 
@@ -238,7 +238,7 @@ public class DurableJobReceiverExtensionTests
         grainHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
         var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("other-feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler, static job => job.Name == "other-feature");
         var extension = CreateExtension(grainHandler, registry: registry);
         var context = CreateJobContext("run-1", jobName: "grain-job");
 
@@ -247,6 +247,27 @@ public class DurableJobReceiverExtensionTests
         Assert.Equal(DurableJobRunStatus.Completed, result.Status);
         await grainHandler.Received(1).ExecuteJobAsync(context, Arg.Any<CancellationToken>());
         await featureHandler.DidNotReceive().ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void HandleDurableJobAsync_WhenMultipleFeatureHandlersMatch_RejectsAmbiguousDispatch()
+    {
+        var grainHandler = Substitute.For<IDurableJobHandler>();
+        var firstFeatureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        var secondFeatureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        var registry = new DurableJobHandlerRegistry();
+        RegisterFeatureHandler(registry, firstFeatureHandler);
+        RegisterFeatureHandler(registry, secondFeatureHandler);
+        var extension = CreateExtension(grainHandler, registry: registry);
+        var context = CreateJobContext("run-1", jobName: "feature");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => extension.HandleDurableJobAsync(context, CancellationToken.None));
+
+        Assert.Contains("Multiple durable job feature handlers match job 'feature'", exception.Message, StringComparison.Ordinal);
+        grainHandler.DidNotReceive().ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        firstFeatureHandler.DidNotReceive().ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        secondFeatureHandler.DidNotReceive().ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -259,7 +280,7 @@ public class DurableJobReceiverExtensionTests
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(expected));
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler);
         var extension = CreateExtension(
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
@@ -286,7 +307,7 @@ public class DurableJobReceiverExtensionTests
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromException<DurableJobRunResult>(exception));
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler);
         var extension = CreateExtension(
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
@@ -314,7 +335,7 @@ public class DurableJobReceiverExtensionTests
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult<DurableJobRunResult>(null!));
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler);
         var extension = CreateExtension(
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
@@ -345,7 +366,7 @@ public class DurableJobReceiverExtensionTests
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromCanceled<DurableJobRunResult>(cancellation.Token));
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler);
         var extension = CreateExtension(
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
@@ -372,7 +393,7 @@ public class DurableJobReceiverExtensionTests
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromException<DurableJobRunResult>(exception));
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler);
         var extension = CreateExtension(
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
@@ -404,7 +425,7 @@ public class DurableJobReceiverExtensionTests
             featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
                 .Returns(ValueTask.FromResult(outcome.Result));
             var registry = new DurableJobHandlerRegistry();
-            registry.Register("feature", featureHandler);
+            RegisterFeatureHandler(registry, featureHandler);
             var extension = CreateExtension(
                 Substitute.For<IDurableJobHandler>(),
                 registry: registry,
@@ -447,7 +468,7 @@ public class DurableJobReceiverExtensionTests
         featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(_ => ExecuteAsync());
         var registry = new DurableJobHandlerRegistry();
-        registry.Register("feature", featureHandler);
+        RegisterFeatureHandler(registry, featureHandler);
         var extension = CreateExtension(
             Substitute.For<IDurableJobHandler>(),
             jobStatusPollInterval: TimeSpan.FromSeconds(1),
@@ -485,6 +506,16 @@ public class DurableJobReceiverExtensionTests
             await releaseSecondInvocation.Task;
             return DurableJobRunResult.Completed;
         }
+    }
+
+    private static void RegisterFeatureHandler(
+        DurableJobHandlerRegistry registry,
+        IDurableJobFeatureHandler handler,
+        Func<DurableJob, bool>? canHandle = null)
+    {
+        canHandle ??= static job => job.Name == "feature";
+        handler.CanHandle(Arg.Any<DurableJob>()).Returns(call => canHandle(call.Arg<DurableJob>()));
+        registry.Register(handler);
     }
 
     private static DurableJobReceiverExtension CreateExtension(

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -671,9 +671,10 @@ public class DurableJobReceiverExtensionTests
                 meterFactory,
                 "Microsoft.Orleans",
                 "orleans-durablejobs-handler-executions");
+            var activitySource = DurableJobsDiagnostics.Source;
             _activityListener = new ActivityListener
             {
-                ShouldListenTo = static source => ReferenceEquals(source, DurableJobsDiagnostics.Source),
+                ShouldListenTo = source => ReferenceEquals(source, activitySource),
                 Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
                 SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
                 ActivityStopped = activity =>

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -98,23 +98,34 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenAttemptCancellationIsRequestedButExecutionIsStillRunning_RemainsRunning()
+    public async Task HandleDurableJobAsync_WhenAttemptCancellationIsRequestedButExecutionIsStillRunning_EndsLongPollAndRemainsRunning()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler = Substitute.For<IDurableJobHandler>();
         handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(executionTask.Task);
 
-        var extension = CreateExtension(handler);
+        var timeProvider = new TimerTrackingFakeTimeProvider(DateTimeOffset.UtcNow);
+        var extension = CreateExtension(
+            handler,
+            jobStatusPollInterval: TimeSpan.FromHours(1),
+            timeProvider: timeProvider);
         var context = CreateJobContext("run-1");
         using var cts = new CancellationTokenSource();
-        cts.Cancel();
 
-        var first = await extension.HandleDurableJobAsync(context, cts.Token);
+        var firstCall = extension.HandleDurableJobAsync(context, cts.Token).AsTask();
+        await timeProvider.TimerCreated;
+        Assert.False(firstCall.IsCompleted);
+        Assert.Equal(1, timeProvider.ActiveTimerCount);
+
+        cts.Cancel();
+        var first = await firstCall.WaitAsync(TimeSpan.FromSeconds(5));
         var second = await extension.HandleDurableJobAsync(context, cts.Token);
 
         Assert.True(first.IsInProgress);
         Assert.True(second.IsInProgress);
+        Assert.Equal(0, timeProvider.ActiveTimerCount);
+        Assert.False(executionTask.Task.IsCompleted);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
         executionTask.SetResult(true);

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -235,7 +235,7 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_FeaturePollAfterReinvokesAfterDelayWithoutConcurrentDuplicates()
+    public async Task HandleDurableJobAsync_FeatureInProgressReinvokesAfterDelayWithoutConcurrentDuplicates()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
         var secondInvocationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -256,8 +256,8 @@ public class DurableJobReceiverExtensionTests
         var first = await extension.HandleDurableJobAsync(context, CancellationToken.None);
         var duplicateBeforeDue = await extension.HandleDurableJobAsync(context, CancellationToken.None);
 
-        Assert.Equal(DurableJobRunStatus.PollAfter, first.Status);
-        Assert.Equal(DurableJobRunStatus.PollAfter, duplicateBeforeDue.Status);
+        Assert.Equal(DurableJobRunStatus.InProgress, first.Status);
+        Assert.Equal(DurableJobRunStatus.InProgress, duplicateBeforeDue.Status);
         Assert.Equal(1, Volatile.Read(ref invocationCount));
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
@@ -265,7 +265,7 @@ public class DurableJobReceiverExtensionTests
         await secondInvocationStarted.Task;
         var concurrentDuplicate = await extension.HandleDurableJobAsync(context, CancellationToken.None);
 
-        Assert.True(concurrentDuplicate.IsPending);
+        Assert.True(concurrentDuplicate.IsInProgress);
         Assert.Equal(2, Volatile.Read(ref invocationCount));
 
         releaseSecondInvocation.SetResult();
@@ -276,7 +276,7 @@ public class DurableJobReceiverExtensionTests
         {
             if (Interlocked.Increment(ref invocationCount) == 1)
             {
-                return DurableJobRunResult.PollAfter(TimeSpan.FromSeconds(5));
+                return DurableJobRunResult.InProgress(TimeSpan.FromSeconds(5));
             }
 
             secondInvocationStarted.SetResult();

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Orleans.Configuration;
 using Orleans.DurableJobs;
@@ -72,7 +76,28 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenSameJobAttemptHasDifferentRunIds_DeduplicatesExecution()
+    public async Task HandleDurableJobAsync_WhenExecutionCompletesDuringLongPoll_CancelsTimeout()
+    {
+        var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(executionTask.Task);
+        var timeProvider = new TimerTrackingFakeTimeProvider(DateTimeOffset.UtcNow);
+        var extension = CreateExtension(handler, TimeSpan.FromMinutes(1), timeProvider);
+        var context = CreateJobContext("run-1");
+
+        var resultTask = extension.HandleDurableJobAsync(context, CancellationToken.None).AsTask();
+        await timeProvider.TimerCreated;
+        Assert.Equal(1, timeProvider.ActiveTimerCount);
+
+        executionTask.SetResult(true);
+
+        Assert.Equal(DurableJobRunStatus.Completed, (await resultTask).Status);
+        Assert.Equal(0, timeProvider.ActiveTimerCount);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_DeduplicatesDifferentRunIdsForSameJobAttempt()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler = Substitute.For<IDurableJobHandler>();
@@ -122,24 +147,174 @@ public class DurableJobReceiverExtensionTests
         await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
     }
 
-    private static DurableJobReceiverExtension CreateExtension(IDurableJobHandler handler, TimeSpan? jobStatusPollInterval = null)
+    [Fact]
+    public async Task HandleDurableJobAsync_DeduplicatesDelayedDuplicateWithinConfiguredRetentionHorizon()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        var extension = CreateExtension(
+            handler,
+            timeProvider: timeProvider,
+            completedAttemptRetentionPeriod: TimeSpan.FromHours(1));
+        var context = CreateJobContext("run-1");
+
+        Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(context, CancellationToken.None)).Status);
+        timeProvider.Advance(TimeSpan.FromMinutes(59));
+        Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(context, CancellationToken.None)).Status);
+
+        await handler.Received(1).ExecuteJobAsync(context, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_FeatureNameMatchTakesPrecedenceOverGrainHandler()
+    {
+        var grainHandler = Substitute.For<IDurableJobHandler>();
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("feature", featureHandler);
+        var extension = CreateExtension(grainHandler, registry: registry);
+        var context = CreateJobContext("run-1", jobName: "feature");
+
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.Equal(DurableJobRunStatus.Completed, result.Status);
+        await featureHandler.Received(1).ExecuteJobAsync(context, Arg.Any<CancellationToken>());
+        await grainHandler.DidNotReceive().ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_UnregisteredFeatureNameFallsBackToGrainHandler()
+    {
+        var grainHandler = Substitute.For<IDurableJobHandler>();
+        grainHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("other-feature", featureHandler);
+        var extension = CreateExtension(grainHandler, registry: registry);
+        var context = CreateJobContext("run-1", jobName: "grain-job");
+
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.Equal(DurableJobRunStatus.Completed, result.Status);
+        await grainHandler.Received(1).ExecuteJobAsync(context, Arg.Any<CancellationToken>());
+        await featureHandler.DidNotReceive().ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenFeatureHandlerReturnsNull_RecordsOnlyFailure()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
+        using var executionCollector = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-handler-executions");
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<DurableJobRunResult>(null!));
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("feature", featureHandler);
+        var extension = CreateExtension(
+            Substitute.For<IDurableJobHandler>(),
+            registry: registry,
+            durableJobsInstruments: instruments);
+        var context = CreateJobContext("run-1", jobName: "feature");
+
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.Equal(DurableJobRunStatus.Failed, result.Status);
+        var measurement = Assert.Single(executionCollector.GetMeasurementSnapshot());
+        Assert.Equal(1, measurement.Value);
+        Assert.Equal("failed", measurement.Tags["status"]);
+    }
+
+    [Fact]
+    public async Task HandleDurableJobAsync_FeaturePollAfterReinvokesAfterDelayWithoutConcurrentDuplicates()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var secondInvocationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondInvocation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocationCount = 0;
+        var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
+        featureHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ExecuteAsync());
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register("feature", featureHandler);
+        var extension = CreateExtension(
+            Substitute.For<IDurableJobHandler>(),
+            jobStatusPollInterval: TimeSpan.FromSeconds(1),
+            timeProvider: timeProvider,
+            registry: registry);
+        var context = CreateJobContext("run-1", jobName: "feature");
+
+        var first = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+        var duplicateBeforeDue = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.Equal(DurableJobRunStatus.PollAfter, first.Status);
+        Assert.Equal(DurableJobRunStatus.PollAfter, duplicateBeforeDue.Status);
+        Assert.Equal(1, Volatile.Read(ref invocationCount));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+        var continuation = extension.HandleDurableJobAsync(context, CancellationToken.None);
+        await secondInvocationStarted.Task;
+        var concurrentDuplicate = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.True(concurrentDuplicate.IsPending);
+        Assert.Equal(2, Volatile.Read(ref invocationCount));
+
+        releaseSecondInvocation.SetResult();
+        Assert.Equal(DurableJobRunStatus.Completed, (await continuation).Status);
+        await featureHandler.Received(2).ExecuteJobAsync(context, Arg.Any<CancellationToken>());
+
+        async ValueTask<DurableJobRunResult> ExecuteAsync()
+        {
+            if (Interlocked.Increment(ref invocationCount) == 1)
+            {
+                return DurableJobRunResult.PollAfter(TimeSpan.FromSeconds(5));
+            }
+
+            secondInvocationStarted.SetResult();
+            await releaseSecondInvocation.Task;
+            return DurableJobRunResult.Completed;
+        }
+    }
+
+    private static DurableJobReceiverExtension CreateExtension(
+        IDurableJobHandler handler,
+        TimeSpan? jobStatusPollInterval = null,
+        TimeProvider? timeProvider = null,
+        TimeSpan? completedAttemptRetentionPeriod = null,
+        DurableJobHandlerRegistry? registry = null,
+        DurableJobsInstruments? durableJobsInstruments = null)
     {
         var grainContext = Substitute.For<IGrainContext>();
         grainContext.GrainInstance.Returns(handler);
         grainContext.GrainId.Returns(GrainId.Create("test", "grain-1"));
         var shared = new DurableJobReceiverExtensionShared(
             NullLogger<DurableJobReceiverExtension>.Instance,
-            Options.Create(new DurableJobsOptions { JobStatusPollInterval = jobStatusPollInterval ?? TimeSpan.FromSeconds(1) }),
+            Options.Create(new DurableJobsOptions
+            {
+                JobStatusPollInterval = jobStatusPollInterval ?? TimeSpan.FromSeconds(1),
+                CompletedJobAttemptRetentionPeriod = completedAttemptRetentionPeriod ?? TimeSpan.FromMinutes(10)
+            }),
             Options.Create(new SiloMessagingOptions()),
-            TimeProvider.System);
-        return new DurableJobReceiverExtension(grainContext, shared);
+            timeProvider ?? TimeProvider.System,
+            durableJobsInstruments);
+        return new DurableJobReceiverExtension(grainContext, shared, registry);
     }
 
     private static IJobRunContext CreateJobContext(
         string runId,
         string jobId = "job-1",
         int dequeueCount = 1,
-        long executionGeneration = 0)
+        long executionGeneration = 0,
+        string? jobName = null)
     {
         var context = Substitute.For<IJobRunContext>();
         context.RunId.Returns(runId);
@@ -147,7 +322,7 @@ public class DurableJobReceiverExtensionTests
         context.Job.Returns(new DurableJob
         {
             Id = jobId,
-            Name = jobId,
+            Name = jobName ?? jobId,
             DueTime = DateTimeOffset.UtcNow,
             TargetGrainId = GrainId.Create("test", "grain-1"),
             ShardId = "shard-1",
@@ -155,5 +330,64 @@ public class DurableJobReceiverExtensionTests
         });
 
         return context;
+    }
+
+    private sealed class TimerTrackingFakeTimeProvider(DateTimeOffset startDateTime) : FakeTimeProvider(startDateTime)
+    {
+        private readonly TaskCompletionSource _timerCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _activeTimerCount;
+
+        public int ActiveTimerCount => Volatile.Read(ref _activeTimerCount);
+
+        public Task TimerCreated => _timerCreated.Task;
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = base.CreateTimer(callback, state, dueTime, period);
+            Interlocked.Increment(ref _activeTimerCount);
+            _timerCreated.TrySetResult();
+            return new TrackingTimer(this, timer);
+        }
+
+        private sealed class TrackingTimer(TimerTrackingFakeTimeProvider owner, ITimer timer) : ITimer
+        {
+            private readonly TimerTrackingFakeTimeProvider _owner = owner;
+            private readonly ITimer _timer = timer;
+            private int _disposed;
+
+            public bool Change(TimeSpan dueTime, TimeSpan period) => _timer.Change(dueTime, period);
+
+            public void Dispose()
+            {
+                try
+                {
+                    _timer.Dispose();
+                }
+                finally
+                {
+                    CompleteDisposal();
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                try
+                {
+                    await _timer.DisposeAsync();
+                }
+                finally
+                {
+                    CompleteDisposal();
+                }
+            }
+
+            private void CompleteDisposal()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                {
+                    Interlocked.Decrement(ref _owner._activeTimerCount);
+                }
+            }
+        }
     }
 }

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -110,7 +110,7 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_DeduplicatesDifferentRunIdsForSameJobAttempt()
+    public async Task HandleDurableJobAsync_CoalescesActiveDeliveriesAndReexecutesAfterCompletion()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler = Substitute.For<IDurableJobHandler>();
@@ -134,14 +134,14 @@ public class DurableJobReceiverExtensionTests
         Assert.Equal(DurableJobRunStatus.Completed, completed.Status);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
-        var duplicateAfterCompletion = await extension.HandleDurableJobAsync(secondNotification, CancellationToken.None);
-        Assert.Equal(DurableJobRunStatus.Completed, duplicateAfterCompletion.Status);
-        await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        var redeliveryAfterCompletion = await extension.HandleDurableJobAsync(secondNotification, CancellationToken.None);
+        Assert.Equal(DurableJobRunStatus.Completed, redeliveryAfterCompletion.Status);
+        await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
         var nextAttempt = CreateJobContext("run-3", jobId: "job-1", dequeueCount: 2);
         var retryResult = await extension.HandleDurableJobAsync(nextAttempt, CancellationToken.None);
         Assert.Equal(DurableJobRunStatus.Completed, retryResult.Status);
-        await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        await handler.Received(3).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -158,25 +158,6 @@ public class DurableJobReceiverExtensionTests
         Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(firstRun, CancellationToken.None)).Status);
         Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(rescheduledRun, CancellationToken.None)).Status);
         await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task HandleDurableJobAsync_DeduplicatesDelayedDuplicateWithinConfiguredRetentionHorizon()
-    {
-        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
-        var handler = Substitute.For<IDurableJobHandler>();
-        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
-        var extension = CreateExtension(
-            handler,
-            timeProvider: timeProvider,
-            completedAttemptRetentionPeriod: TimeSpan.FromHours(1));
-        var context = CreateJobContext("run-1");
-
-        Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(context, CancellationToken.None)).Status);
-        timeProvider.Advance(TimeSpan.FromMinutes(59));
-        Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(context, CancellationToken.None)).Status);
-
-        await handler.Received(1).ExecuteJobAsync(context, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -231,12 +212,17 @@ public class DurableJobReceiverExtensionTests
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
             durableJobsInstruments: telemetry.Instruments);
-        var context = CreateJobContext("run-explicit-failure", jobName: "feature");
+        var firstContext = CreateJobContext("run-explicit-failure-1", jobName: "feature");
+        var secondContext = CreateJobContext("run-explicit-failure-2", jobName: "feature");
 
-        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+        var firstResult = await extension.HandleDurableJobAsync(firstContext, CancellationToken.None);
+        var secondResult = await extension.HandleDurableJobAsync(secondContext, CancellationToken.None);
 
-        Assert.Same(expected, result);
-        telemetry.AssertOutcome(context.RunId, "failed", ActivityStatusCode.Error, exception);
+        Assert.Same(expected, firstResult);
+        Assert.Same(expected, secondResult);
+        await featureHandler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        telemetry.AssertOutcome(firstContext.RunId, "failed", ActivityStatusCode.Error, exception, expectedInvocationCount: 2);
+        telemetry.AssertOutcome(secondContext.RunId, "failed", ActivityStatusCode.Error, exception, expectedInvocationCount: 2);
     }
 
     [Fact]
@@ -253,13 +239,19 @@ public class DurableJobReceiverExtensionTests
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
             durableJobsInstruments: telemetry.Instruments);
-        var context = CreateJobContext("run-thrown-failure", jobName: "feature");
+        var firstContext = CreateJobContext("run-thrown-failure-1", jobName: "feature");
+        var secondContext = CreateJobContext("run-thrown-failure-2", jobName: "feature");
 
-        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+        var firstResult = await extension.HandleDurableJobAsync(firstContext, CancellationToken.None);
+        var secondResult = await extension.HandleDurableJobAsync(secondContext, CancellationToken.None);
 
-        Assert.True(result.IsFailed);
-        Assert.Same(exception, result.Exception);
-        telemetry.AssertOutcome(context.RunId, "failed", ActivityStatusCode.Error, exception);
+        Assert.True(firstResult.IsFailed);
+        Assert.True(secondResult.IsFailed);
+        Assert.Same(exception, firstResult.Exception);
+        Assert.Same(exception, secondResult.Exception);
+        await featureHandler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        telemetry.AssertOutcome(firstContext.RunId, "failed", ActivityStatusCode.Error, exception, expectedInvocationCount: 2);
+        telemetry.AssertOutcome(secondContext.RunId, "failed", ActivityStatusCode.Error, exception, expectedInvocationCount: 2);
     }
 
     [Fact]
@@ -275,13 +267,20 @@ public class DurableJobReceiverExtensionTests
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
             durableJobsInstruments: telemetry.Instruments);
-        var context = CreateJobContext("run-null-result", jobName: "feature");
+        var firstContext = CreateJobContext("run-null-result-1", jobName: "feature");
+        var secondContext = CreateJobContext("run-null-result-2", jobName: "feature");
 
-        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+        var firstResult = await extension.HandleDurableJobAsync(firstContext, CancellationToken.None);
+        var secondResult = await extension.HandleDurableJobAsync(secondContext, CancellationToken.None);
 
-        Assert.True(result.IsFailed);
-        var exception = Assert.IsType<InvalidOperationException>(result.Exception);
-        telemetry.AssertOutcome(context.RunId, "failed", ActivityStatusCode.Error, exception);
+        Assert.True(firstResult.IsFailed);
+        Assert.True(secondResult.IsFailed);
+        var firstException = Assert.IsType<InvalidOperationException>(firstResult.Exception);
+        var secondException = Assert.IsType<InvalidOperationException>(secondResult.Exception);
+        Assert.Equal(firstException.Message, secondException.Message);
+        await featureHandler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        telemetry.AssertOutcome(firstContext.RunId, "failed", ActivityStatusCode.Error, firstException, expectedInvocationCount: 2);
+        telemetry.AssertOutcome(secondContext.RunId, "failed", ActivityStatusCode.Error, secondException, expectedInvocationCount: 2);
     }
 
     [Fact]
@@ -299,12 +298,17 @@ public class DurableJobReceiverExtensionTests
             Substitute.For<IDurableJobHandler>(),
             registry: registry,
             durableJobsInstruments: telemetry.Instruments);
-        var context = CreateJobContext("run-canceled", jobName: "feature");
+        var firstContext = CreateJobContext("run-canceled-1", jobName: "feature");
+        var secondContext = CreateJobContext("run-canceled-2", jobName: "feature");
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => extension.HandleDurableJobAsync(context, CancellationToken.None).AsTask());
+            () => extension.HandleDurableJobAsync(firstContext, CancellationToken.None).AsTask());
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => extension.HandleDurableJobAsync(secondContext, CancellationToken.None).AsTask());
 
-        telemetry.AssertOutcome(context.RunId, "canceled", ActivityStatusCode.Unset);
+        await featureHandler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+        telemetry.AssertOutcome(firstContext.RunId, "canceled", ActivityStatusCode.Unset, expectedInvocationCount: 2);
+        telemetry.AssertOutcome(secondContext.RunId, "canceled", ActivityStatusCode.Unset, expectedInvocationCount: 2);
     }
 
     [Fact]
@@ -313,10 +317,11 @@ public class DurableJobReceiverExtensionTests
         using var telemetry = new HandlerTelemetryCapture();
         var outcomes = new[]
         {
-            (RunId: "run-completed", Result: DurableJobRunResult.Completed),
-            (RunId: "run-in-progress", Result: DurableJobRunResult.InProgress(TimeSpan.FromSeconds(1))),
-            (RunId: "run-rescheduled", Result: DurableJobRunResult.RescheduleAt(DateTimeOffset.UtcNow.AddHours(1)))
+            (RunIds: new[] { "run-completed-1", "run-completed-2" }, Result: DurableJobRunResult.Completed),
+            (RunIds: new[] { "run-in-progress" }, Result: DurableJobRunResult.InProgress(TimeSpan.FromSeconds(1))),
+            (RunIds: new[] { "run-rescheduled-1", "run-rescheduled-2" }, Result: DurableJobRunResult.RescheduleAt(DateTimeOffset.UtcNow.AddHours(1)))
         };
+        var expectedInvocationCount = outcomes.Sum(static outcome => outcome.RunIds.Length);
 
         foreach (var outcome in outcomes)
         {
@@ -329,20 +334,30 @@ public class DurableJobReceiverExtensionTests
                 Substitute.For<IDurableJobHandler>(),
                 registry: registry,
                 durableJobsInstruments: telemetry.Instruments);
-            var context = CreateJobContext(outcome.RunId, jobName: "feature");
 
-            var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+            foreach (var runId in outcome.RunIds)
+            {
+                var context = CreateJobContext(runId, jobName: "feature");
+                var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
 
-            Assert.Same(outcome.Result, result);
+                Assert.Same(outcome.Result, result);
+            }
+
+            await featureHandler.Received(outcome.RunIds.Length).ExecuteJobAsync(
+                Arg.Any<IJobRunContext>(),
+                Arg.Any<CancellationToken>());
         }
 
         foreach (var outcome in outcomes)
         {
-            telemetry.AssertOutcome(
-                outcome.RunId,
-                "completed",
-                ActivityStatusCode.Ok,
-                expectedInvocationCount: outcomes.Length);
+            foreach (var runId in outcome.RunIds)
+            {
+                telemetry.AssertOutcome(
+                    runId,
+                    "completed",
+                    ActivityStatusCode.Ok,
+                    expectedInvocationCount: expectedInvocationCount);
+            }
         }
     }
 
@@ -401,7 +416,6 @@ public class DurableJobReceiverExtensionTests
         object handler,
         TimeSpan? jobStatusPollInterval = null,
         TimeProvider? timeProvider = null,
-        TimeSpan? completedAttemptRetentionPeriod = null,
         DurableJobHandlerRegistry? registry = null,
         DurableJobsInstruments? durableJobsInstruments = null)
     {
@@ -412,8 +426,7 @@ public class DurableJobReceiverExtensionTests
             NullLogger<DurableJobReceiverExtension>.Instance,
             Options.Create(new DurableJobsOptions
             {
-                JobStatusPollInterval = jobStatusPollInterval ?? TimeSpan.FromSeconds(1),
-                CompletedJobAttemptRetentionPeriod = completedAttemptRetentionPeriod ?? TimeSpan.FromMinutes(10)
+                JobStatusPollInterval = jobStatusPollInterval ?? TimeSpan.FromSeconds(1)
             }),
             Options.Create(new SiloMessagingOptions()),
             timeProvider ?? TimeProvider.System,

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -249,7 +249,7 @@ public class DurableJobReceiverExtensionTests
         grainHandler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
         var featureHandler = Substitute.For<IDurableJobFeatureHandler>();
         var registry = new DurableJobHandlerRegistry();
-        RegisterFeatureHandler(registry, featureHandler, static job => job.Name == "other-feature");
+        RegisterFeatureHandler(registry, featureHandler, static jobName => jobName == "other-feature");
         var extension = CreateExtension(grainHandler, registry: registry);
         var context = CreateJobContext("run-1", jobName: "grain-job");
 
@@ -522,10 +522,10 @@ public class DurableJobReceiverExtensionTests
     private static void RegisterFeatureHandler(
         DurableJobHandlerRegistry registry,
         IDurableJobFeatureHandler handler,
-        Func<DurableJob, bool>? canHandle = null)
+        Func<string, bool>? canHandle = null)
     {
-        canHandle ??= static job => job.Name == "feature";
-        handler.CanHandle(Arg.Any<DurableJob>()).Returns(call => canHandle(call.Arg<DurableJob>()));
+        canHandle ??= static jobName => jobName == "feature";
+        handler.CanHandle(Arg.Any<string>()).Returns(call => canHandle(call.Arg<string>()));
         registry.Register(handler);
     }
 

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -58,7 +58,6 @@ public class DurableJobReceiverExtensionTests
     [Fact]
     public async Task HandleDurableJobAsync_WhenCanceledAttemptIsRedeliveredWithActiveToken_StartsNewAttempt()
     {
-        using var telemetry = new HandlerTelemetryCapture("run-1");
         using var firstAttemptCancellation = new CancellationTokenSource();
         var invocationCount = 0;
         var handler = Substitute.For<IDurableJobHandler>();
@@ -67,16 +66,17 @@ public class DurableJobReceiverExtensionTests
                 Interlocked.Increment(ref invocationCount) == 1
                     ? WaitForAttemptCancellationAsync(call.ArgAt<CancellationToken>(1))
                     : Task.CompletedTask);
-        var extension = CreateExtension(
-            handler,
-            jobStatusPollInterval: TimeSpan.FromMilliseconds(1),
-            durableJobsInstruments: telemetry.Instruments);
+        var extension = CreateExtension(handler, jobStatusPollInterval: TimeSpan.FromMilliseconds(1));
         var context = CreateJobContext("run-1");
 
         var initial = await extension.HandleDurableJobAsync(context, firstAttemptCancellation.Token);
         Assert.True(initial.IsInProgress);
+        var attemptTask = new DurableJobReceiverExtension.TestAccessor(extension).GetAttemptTask(context);
+        Assert.NotNull(attemptTask);
+
         firstAttemptCancellation.Cancel();
-        await telemetry.TrackedHandlerStopped.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => attemptTask!.WaitAsync(TimeSpan.FromSeconds(5)));
 
         var redelivery = await extension.HandleDurableJobAsync(context, CancellationToken.None);
 

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -33,6 +33,16 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
+    public void HandleDurableJobAsync_WhenHandlerResolutionFails_DoesNotPoisonAttemptCache()
+    {
+        var extension = CreateExtension(new object());
+        var context = CreateJobContext("run-1");
+
+        Assert.Throws<InvalidOperationException>(() => extension.HandleDurableJobAsync(context, CancellationToken.None));
+        Assert.Throws<InvalidOperationException>(() => extension.HandleDurableJobAsync(context, CancellationToken.None));
+    }
+
+    [Fact]
     public async Task HandleDurableJobAsync_WhenTokenIsCanceledButExecutionIsStillRunning_RemainsRunning()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -286,7 +296,7 @@ public class DurableJobReceiverExtensionTests
     }
 
     private static DurableJobReceiverExtension CreateExtension(
-        IDurableJobHandler handler,
+        object handler,
         TimeSpan? jobStatusPollInterval = null,
         TimeProvider? timeProvider = null,
         TimeSpan? completedAttemptRetentionPeriod = null,

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobsExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobsExtensionsTests.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Orleans.DurableJobs;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Xunit;
+
+namespace NonSilo.Tests.ScheduledJobs;
+
+[TestCategory("BVT"), TestCategory("DurableJobs")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("DurableJobs")]
+public class DurableJobsExtensionsTests
+{
+    [Fact]
+    public async Task AddDurableJobs_RegistryAndReceiverShareScope_WhileSeparateScopesAreIsolated()
+    {
+        var grainContext = Substitute.For<IGrainContext>();
+        grainContext.GrainId.Returns(GrainId.Create("test", "grain-1"));
+        grainContext.GrainInstance.Returns(new object());
+        var grainContextAccessor = Substitute.For<IGrainContextAccessor>();
+        grainContextAccessor.GrainContext.Returns(grainContext);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton(grainContextAccessor);
+        services.AddDurableJobs();
+
+        using var provider = services.BuildServiceProvider();
+        using var scopeA = provider.CreateScope();
+        using var scopeB = provider.CreateScope();
+        var registryA = scopeA.ServiceProvider.GetRequiredService<IDurableJobHandlerRegistry>();
+        var registryB = scopeB.ServiceProvider.GetRequiredService<IDurableJobHandlerRegistry>();
+        var handlerA = Substitute.For<IDurableJobFeatureHandler>();
+        var handlerB = Substitute.For<IDurableJobFeatureHandler>();
+        handlerA.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
+        handlerB.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
+        registryA.Register("feature", handlerA);
+        registryB.Register("feature", handlerB);
+
+        var extensionA = scopeA.ServiceProvider.GetRequiredKeyedService<IGrainExtension>(typeof(IDurableJobReceiverExtension));
+        var extensionB = scopeB.ServiceProvider.GetRequiredKeyedService<IGrainExtension>(typeof(IDurableJobReceiverExtension));
+        var contextA = CreateContext("run-a");
+        var contextB = CreateContext("run-b");
+
+        Assert.NotSame(registryA, registryB);
+        Assert.Equal(
+            DurableJobRunStatus.Completed,
+            (await ((IDurableJobReceiverExtension)extensionA).HandleDurableJobAsync(contextA, CancellationToken.None)).Status);
+        Assert.Equal(
+            DurableJobRunStatus.Completed,
+            (await ((IDurableJobReceiverExtension)extensionB).HandleDurableJobAsync(contextB, CancellationToken.None)).Status);
+        await handlerA.Received(1).ExecuteJobAsync(contextA, Arg.Any<CancellationToken>());
+        await handlerA.DidNotReceive().ExecuteJobAsync(contextB, Arg.Any<CancellationToken>());
+        await handlerB.Received(1).ExecuteJobAsync(contextB, Arg.Any<CancellationToken>());
+        await handlerB.DidNotReceive().ExecuteJobAsync(contextA, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void AddDurableJobs_WhenRegistryIsPreRegistered_RejectsReplacement()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IDurableJobHandlerRegistry, ReplacementRegistry>();
+
+        var exception = Assert.Throws<InvalidOperationException>(services.AddDurableJobs);
+
+        Assert.Contains("cannot be replaced or decorated", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReceiverResolution_WhenRegistryIsDecoratedAfterConfiguration_FailsExplicitly()
+    {
+        var grainContextAccessor = Substitute.For<IGrainContextAccessor>();
+        grainContextAccessor.GrainContext.Returns(Substitute.For<IGrainContext>());
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton(grainContextAccessor);
+        services.AddDurableJobs();
+        services.AddScoped<IDurableJobHandlerRegistry, ReplacementRegistry>();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => scope.ServiceProvider.GetRequiredKeyedService<IGrainExtension>(typeof(IDurableJobReceiverExtension)));
+
+        Assert.Contains("cannot be replaced or decorated", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReceiverResolution_WhenRegistryReplacementImplementsLookup_FailsExplicitly()
+    {
+        var grainContextAccessor = Substitute.For<IGrainContextAccessor>();
+        grainContextAccessor.GrainContext.Returns(Substitute.For<IGrainContext>());
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton(grainContextAccessor);
+        services.AddDurableJobs();
+        services.AddScoped<IDurableJobHandlerRegistry, LookupReplacementRegistry>();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => scope.ServiceProvider.GetRequiredKeyedService<IGrainExtension>(typeof(IDurableJobReceiverExtension)));
+
+        Assert.Contains("cannot be replaced or decorated", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static IJobRunContext CreateContext(string runId)
+    {
+        var context = Substitute.For<IJobRunContext>();
+        context.RunId.Returns(runId);
+        context.DequeueCount.Returns(1);
+        context.Job.Returns(new DurableJob
+        {
+            Id = "job-1",
+            Name = "feature",
+            DueTime = DateTimeOffset.UtcNow,
+            TargetGrainId = GrainId.Create("test", "grain-1"),
+            ShardId = "shard-1"
+        });
+        return context;
+    }
+
+    private sealed class ReplacementRegistry : IDurableJobHandlerRegistry
+    {
+        public void Register(string jobName, IDurableJobFeatureHandler handler)
+        {
+        }
+    }
+
+    private sealed class LookupReplacementRegistry : IDurableJobHandlerRegistry, IDurableJobHandlerLookup
+    {
+        public void Register(string jobName, IDurableJobFeatureHandler handler)
+        {
+        }
+
+        public bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
+        {
+            handler = null;
+            return false;
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobsExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobsExtensionsTests.cs
@@ -41,8 +41,10 @@ public class DurableJobsExtensionsTests
             .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
         handlerB.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
-        registryA.Register("feature", handlerA);
-        registryB.Register("feature", handlerB);
+        handlerA.CanHandle(Arg.Is<DurableJob>(static job => job.Name == "feature")).Returns(true);
+        handlerB.CanHandle(Arg.Is<DurableJob>(static job => job.Name == "feature")).Returns(true);
+        registryA.Register(handlerA);
+        registryB.Register(handlerB);
 
         var extensionA = scopeA.ServiceProvider.GetRequiredKeyedService<IGrainExtension>(typeof(IDurableJobReceiverExtension));
         var extensionB = scopeB.ServiceProvider.GetRequiredKeyedService<IGrainExtension>(typeof(IDurableJobReceiverExtension));
@@ -135,18 +137,18 @@ public class DurableJobsExtensionsTests
 
     private sealed class ReplacementRegistry : IDurableJobHandlerRegistry
     {
-        public void Register(string jobName, IDurableJobFeatureHandler handler)
+        public void Register(IDurableJobFeatureHandler handler)
         {
         }
     }
 
     private sealed class LookupReplacementRegistry : IDurableJobHandlerRegistry, IDurableJobHandlerLookup
     {
-        public void Register(string jobName, IDurableJobFeatureHandler handler)
+        public void Register(IDurableJobFeatureHandler handler)
         {
         }
 
-        public bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
+        public bool TryGetHandler(DurableJob job, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
         {
             handler = null;
             return false;

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobsExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobsExtensionsTests.cs
@@ -41,8 +41,8 @@ public class DurableJobsExtensionsTests
             .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
         handlerB.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(DurableJobRunResult.Completed));
-        handlerA.CanHandle(Arg.Is<DurableJob>(static job => job.Name == "feature")).Returns(true);
-        handlerB.CanHandle(Arg.Is<DurableJob>(static job => job.Name == "feature")).Returns(true);
+        handlerA.CanHandle("feature").Returns(true);
+        handlerB.CanHandle("feature").Returns(true);
         registryA.Register(handlerA);
         registryB.Register(handlerB);
 
@@ -148,7 +148,7 @@ public class DurableJobsExtensionsTests
         {
         }
 
-        public bool TryGetHandler(DurableJob job, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
+        public bool TryGetHandler(string jobName, [NotNullWhen(true)] out IDurableJobFeatureHandler? handler)
         {
             handler = null;
             return false;

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobsInstrumentsTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobsInstrumentsTests.cs
@@ -42,4 +42,53 @@ public class DurableJobsInstrumentsTests
         Assert.Equal(18, Assert.Single(attemptDurations, static measurement => measurement.Tags["status"] is "rescheduled").Value);
         Assert.Equal(1, Assert.Single(stripeCollector.GetMeasurementSnapshot()).Value);
     }
+
+    [Fact]
+    public void DurableJobsInstruments_DistinguishesTaskRequestOperationAndAttemptCancellation()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
+        using var taskCancellationRequests = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-job-cancellation-requests");
+        using var cancellationRequestCalls = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-cancel-job-calls");
+        using var handlerExecutions = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-handler-executions");
+        using var shardsProcessed = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-shards-processed");
+
+        instruments.OnJobCancellationRequested();
+        instruments.OnCancelJobCall(TimeSpan.FromMilliseconds(1), cancellationRequested: true);
+        instruments.OnCancelJobCallCanceled(TimeSpan.FromMilliseconds(1));
+        instruments.OnHandlerExecutionAttemptCanceled(TimeSpan.FromMilliseconds(1));
+        instruments.OnShardProcessed(TimeSpan.FromMilliseconds(1), attemptCanceled: true, error: false);
+
+        Assert.Equal(1, Assert.Single(taskCancellationRequests.GetMeasurementSnapshot()).Value);
+        var requestCalls = cancellationRequestCalls.GetMeasurementSnapshot();
+        Assert.Equal(2, requestCalls.Count);
+        Assert.Equal(
+            1,
+            Assert.Single(requestCalls, static measurement => measurement.Tags["status"] is "cancellation_requested").Value);
+        Assert.Equal(
+            1,
+            Assert.Single(requestCalls, static measurement => measurement.Tags["status"] is "operation_canceled").Value);
+        Assert.Equal(
+            "attempt_canceled",
+            Assert.Single(handlerExecutions.GetMeasurementSnapshot()).Tags["status"]);
+        Assert.Equal(
+            "attempt_canceled",
+            Assert.Single(shardsProcessed.GetMeasurementSnapshot()).Tags["status"]);
+    }
 }

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -165,20 +165,20 @@ public class InMemoryJobQueueTests
     }
 
     [Fact]
-    public void CancelJob_RemovesJobFromQueue()
+    public void RemoveJob_RemovesJobFromQueue()
     {
         var queue = new InMemoryJobQueue();
         var job = CreateJob("job1", DateTimeOffset.UtcNow.AddSeconds(5));
 
         queue.Enqueue(job, 0);
-        var removed = queue.CancelJob("job1");
+        var removed = queue.RemoveJob("job1");
 
         Assert.True(removed);
         Assert.Equal(0, queue.Count);
     }
 
     [Fact]
-    public async Task CancelJob_PreventsJobFromBeingDequeued()
+    public async Task RemoveJob_PreventsJobFromBeingDequeued()
     {
         var queue = new InMemoryJobQueue();
         var job1 = CreateJob("job1", DateTimeOffset.UtcNow.AddMilliseconds(-100));
@@ -186,7 +186,7 @@ public class InMemoryJobQueueTests
 
         queue.Enqueue(job1, 0);
         queue.Enqueue(job2, 0);
-        queue.CancelJob("job1");
+        queue.RemoveJob("job1");
         queue.MarkAsComplete();
 
         var results = new List<string>();
@@ -201,14 +201,32 @@ public class InMemoryJobQueueTests
     }
 
     [Fact]
-    public void CancelJob_NonExistentJob_DoesNotThrow()
+    public void RemoveJob_NonExistentJob_DoesNotThrow()
     {
         var queue = new InMemoryJobQueue();
 
-        var removed = queue.CancelJob("non-existent-job");
+        var removed = queue.RemoveJob("non-existent-job");
 
         Assert.False(removed);
         Assert.Equal(0, queue.Count);
+    }
+
+    [Fact]
+    public async Task RetryJobLater_AfterCancel_DoesNotResurrectJob()
+    {
+        var queue = new InMemoryJobQueue();
+        var job = CreateJob("job1", DateTimeOffset.UtcNow.AddMilliseconds(-100));
+        queue.Enqueue(job, 0);
+        await using var enumerator = queue.GetAsyncEnumerator(CancellationToken.None);
+        Assert.True(await enumerator.MoveNextAsync());
+        var attempt = enumerator.Current;
+
+        Assert.True(queue.RemoveJob(job.Id));
+        queue.RetryJobLater(attempt, DateTimeOffset.UtcNow.AddMilliseconds(-50));
+        queue.MarkAsComplete();
+
+        Assert.Equal(0, queue.Count);
+        Assert.False(await enumerator.MoveNextAsync());
     }
 
     [Fact]
@@ -288,8 +306,8 @@ public class InMemoryJobQueueTests
 
         queue.Enqueue(job1, 0);
         queue.Enqueue(job2, 0);
-        queue.CancelJob("job1");
-        queue.CancelJob("job2");
+        queue.RemoveJob("job1");
+        queue.RemoveJob("job2");
         queue.MarkAsComplete();
 
         var results = new List<IJobRunContext>();
@@ -384,7 +402,7 @@ public class InMemoryJobQueueTests
         // the bucket already dequeued from _queue.
         Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Equal("job1", enumerator.Current.Job.Name);
-        queue.CancelJob(enumerator.Current.Job.Id);
+        queue.RemoveJob(enumerator.Current.Job.Id);
 
         // Enqueue a second job at the same DueTime. With the bug, this would target the
         // already-dequeued bucket and never become visible to the enumerator.
@@ -393,7 +411,7 @@ public class InMemoryJobQueueTests
 
         Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Equal("job2", enumerator.Current.Job.Name);
-        queue.CancelJob(enumerator.Current.Job.Id);
+        queue.RemoveJob(enumerator.Current.Job.Id);
 
         Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
     }
@@ -414,7 +432,7 @@ public class InMemoryJobQueueTests
 
         Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Equal("job1", enumerator.Current.Job.Name);
-        queue.CancelJob(enumerator.Current.Job.Id);
+        queue.RemoveJob(enumerator.Current.Job.Id);
 
         // job1 has been yielded and removed; a new job at the same DueTime must be visible
         // to the next MoveNextAsync.
@@ -424,7 +442,7 @@ public class InMemoryJobQueueTests
 
         Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Equal("job2", enumerator.Current.Job.Name);
-        queue.CancelJob(enumerator.Current.Job.Id);
+        queue.RemoveJob(enumerator.Current.Job.Id);
 
         Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
     }

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -211,6 +211,19 @@ public class InMemoryJobQueueTests
         Assert.Equal(0, queue.Count);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void RemoveJob_InvalidJobId_Throws(string? jobId)
+    {
+        var queue = new InMemoryJobQueue();
+
+        var exception = Assert.ThrowsAny<ArgumentException>(() => queue.RemoveJob(jobId!));
+
+        Assert.Equal("jobId", exception.ParamName);
+    }
+
     [Fact]
     public async Task RetryJobLater_AfterCancel_DoesNotResurrectJob()
     {

--- a/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
@@ -13,6 +13,27 @@ namespace NonSilo.Tests.DurableJobs;
 [TestCategory("DurableJobs")]
 public class JobShardTests
 {
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task TryScheduleJobAsync_InvalidJobName_Throws(string? jobName)
+    {
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(1);
+        var shard = new TestJobShard(dueTime.AddMinutes(-1), dueTime.AddMinutes(1));
+        var request = new ScheduleJobRequest
+        {
+            Target = GrainId.Create("test", "job"),
+            JobName = jobName!,
+            DueTime = dueTime
+        };
+
+        var exception = await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => shard.TryScheduleJobAsync(request, CancellationToken.None));
+
+        Assert.Equal("JobName", exception.ParamName);
+    }
+
     [Fact]
     public async Task TryScheduleJobAsync_ForwardsCompleteJobForPersistence()
     {

--- a/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
@@ -97,6 +97,71 @@ public class JobShardTests
         Assert.Equal(1, retryShard.PersistedRetryContext!.DequeueCount);
     }
 
+    [Fact]
+    public async Task RetryJobLaterAsync_AfterCancellationRequest_DoesNotResurrectJob()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shard = await CreateShardWithDueJobAsync("canceled", now);
+        var attempt = await ConsumeNextAsync(shard);
+
+        Assert.Equal(
+            DurableJobMutationResult.Applied,
+            await shard.RemoveJobAsync(attempt.Job.Id, CancellationToken.None));
+        await shard.RetryJobLaterAsync(attempt, now.AddSeconds(-1), CancellationToken.None);
+        await shard.MarkAsCompleteAsync(CancellationToken.None);
+
+        Assert.Equal(0, await shard.GetJobCountAsync());
+        Assert.Null(shard.PersistedRetryContext);
+        await using var enumerator = shard.ConsumeDurableJobsAsync().GetAsyncEnumerator(CancellationToken.None);
+        Assert.False(await enumerator.MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task AttemptCancellation_WithoutRemoval_PreservesJob()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shard = await CreateShardWithDueJobAsync("attempt-canceled", now);
+
+        var firstAttempt = await ConsumeNextAsync(shard);
+
+        Assert.Equal("attempt-canceled", firstAttempt.Job.Name);
+        Assert.Equal(1, await shard.GetJobCountAsync());
+    }
+
+    [Fact]
+    public async Task MarkAsCompleteAsync_WaitsForInFlightSchedulePersistence()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var shard = new GateableJobShard(now.AddMinutes(-1), now.AddMinutes(1));
+        var scheduleTask = shard.TryScheduleJobAsync(
+            new ScheduleJobRequest
+            {
+                Target = GrainId.Create("test", "job"),
+                JobName = "job",
+                DueTime = now
+            },
+            CancellationToken.None);
+
+        await shard.PersistAddStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var completionTask = shard.MarkAsCompleteAsync(CancellationToken.None);
+
+        Assert.False(completionTask.IsCompleted);
+        shard.AllowPersistAdd.SetResult();
+
+        Assert.NotNull(await scheduleTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        await completionTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(shard.IsAddingCompleted);
+        Assert.Equal(1, await shard.GetJobCountAsync());
+        Assert.Null(await shard.TryScheduleJobAsync(
+            new ScheduleJobRequest
+            {
+                Target = GrainId.Create("test", "later"),
+                JobName = "later",
+                DueTime = now
+            },
+            CancellationToken.None));
+    }
+
     private static async Task<TestJobShard> CreateShardWithDueJobAsync(string id, DateTimeOffset now)
     {
         var shard = new TestJobShard(now.AddHours(-1), now.AddHours(1));
@@ -141,5 +206,30 @@ public class JobShardTests
             PersistedRetryTime = newDueTime;
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class GateableJobShard(DateTimeOffset startTime, DateTimeOffset endTime)
+        : JobShard("gateable-shard", startTime, endTime)
+    {
+        public TaskCompletionSource PersistAddStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowPersistAdd { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task PersistAddJobAsync(DurableJob job, CancellationToken cancellationToken)
+        {
+            PersistAddStarted.TrySetResult();
+            await AllowPersistAdd.Task.WaitAsync(cancellationToken);
+        }
+
+        protected override Task PersistRemoveJobAsync(string jobId, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        protected override Task PersistRetryJobAsync(
+            IJobRunContext jobContext,
+            DateTimeOffset newDueTime,
+            CancellationToken cancellationToken) =>
+            Task.CompletedTask;
     }
 }

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -386,6 +386,84 @@ public class LocalDurableJobManagerTests
     }
 
     [Fact]
+    public async Task CancelAsync_WhenCachedShardOwnershipMoved_RoutesToCurrentOwner()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var owner = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5001), 0);
+        var shardManager = new TestJobShardManager
+        {
+            IsLocallyOwned = false,
+            ShardOwner = owner
+        };
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        var remoteManager = Substitute.For<ILocalDurableJobManagerSystemTarget>();
+        remoteManager.CancelAsync(Arg.Any<DurableJob>(), Arg.Any<CancellationToken>()).Returns(true);
+        grainFactory.GetSystemTarget<ILocalDurableJobManagerSystemTarget>(
+                LocalDurableJobManager.JobManagerGrainType,
+                owner)
+            .Returns(remoteManager);
+        var manager = CreateManager(shardManager, timeProvider, options, grainFactory);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow();
+        var shard = CreateSubstituteShard("cancellation-shard", shardKey, shardKey.Add(options.ShardDuration));
+        accessor.AddWritableShard(shardKey, shard);
+        var job = new DurableJob
+        {
+            Id = "job-1",
+            Name = "job",
+            DueTime = shardKey,
+            TargetGrainId = GrainId.Create("test", "job"),
+            ShardId = shard.Id
+        };
+
+        var cancellationRequested = await manager.CancelAsync(job, CancellationToken.None);
+
+        Assert.True(cancellationRequested);
+        Assert.False(accessor.HasCachedShard(shard.Id));
+        await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await remoteManager.Received(1).CancelAsync(job, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelAsync_WhenOwnershipReturnsLocally_UsesReplacementCachedShard()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var localOwner = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5000), 0);
+        var shardManager = new TestJobShardManager { IsLocallyOwned = false };
+        var manager = CreateManager(shardManager, timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow();
+        var staleShard = CreateSubstituteShard("cancellation-shard", shardKey, shardKey.Add(options.ShardDuration));
+        var replacementShard = CreateSubstituteShard("cancellation-shard", shardKey, shardKey.Add(options.ShardDuration));
+        replacementShard.RemoveJobAsync("job-1", Arg.Any<CancellationToken>())
+            .Returns(DurableJobMutationResult.Applied);
+        accessor.AddWritableShard(shardKey, staleShard);
+        shardManager.GetShardOwner = (_, _) =>
+        {
+            accessor.AddWritableShard(shardKey, replacementShard);
+            shardManager.IsLocallyOwned = true;
+            return ValueTask.FromResult<SiloAddress?>(localOwner);
+        };
+        var job = new DurableJob
+        {
+            Id = "job-1",
+            Name = "job",
+            DueTime = shardKey,
+            TargetGrainId = GrainId.Create("test", "job"),
+            ShardId = staleShard.Id
+        };
+
+        var cancellationRequested = await manager.CancelAsync(job, CancellationToken.None);
+
+        Assert.True(cancellationRequested);
+        Assert.True(accessor.HasCachedShard(replacementShard.Id));
+        await staleShard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await replacementShard.Received(1).RemoveJobAsync(job.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ScheduleJobAsync_WhenShardStripingEnabled_DistributesJobsAcrossWritableShards()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
@@ -1250,6 +1328,12 @@ public class LocalDurableJobManagerTests
 
         public Func<DateTimeOffset, DateTimeOffset, IDictionary<string, string>, CancellationToken, Task<IJobShard>>? CreateShard { get; set; }
 
+        public Func<string, CancellationToken, ValueTask<SiloAddress?>>? GetShardOwner { get; set; }
+
+        public bool IsLocallyOwned { get; set; } = true;
+
+        public SiloAddress? ShardOwner { get; set; }
+
         public int CreateShardCallCount { get; private set; }
 
         public DateTimeOffset LastMaxDueTime { get; private set; }
@@ -1273,6 +1357,14 @@ public class LocalDurableJobManagerTests
             UnregisteredShards.Add(shard);
             return Task.CompletedTask;
         }
+
+        internal override ValueTask<SiloAddress?> GetShardOwnerAsync(string shardId, CancellationToken cancellationToken) =>
+            GetShardOwner is { } getShardOwner
+                ? getShardOwner(shardId, cancellationToken)
+                : ValueTask.FromResult(ShardOwner);
+
+        internal override ValueTask<bool> IsShardOwnedByLocalSiloAsync(string shardId, CancellationToken cancellationToken) =>
+            ValueTask.FromResult(IsLocallyOwned);
     }
 
     private sealed class TestLocalSiloDetails(SiloAddress siloAddress) : ILocalSiloDetails

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -746,6 +746,27 @@ public class LocalDurableJobManagerTests
         MaxConcurrentJobsPerSilo = 10
     };
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task ScheduleJobAsync_InvalidJobName_Throws(string? jobName)
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var manager = CreateManager(new TestJobShardManager(), timeProvider, CreateOptions());
+        var request = new ScheduleJobRequest
+        {
+            Target = GrainId.Create("test", "target"),
+            JobName = jobName!,
+            DueTime = timeProvider.GetUtcNow()
+        };
+
+        var exception = await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => manager.ScheduleJobAsync(request, CancellationToken.None));
+
+        Assert.Equal("JobName", exception.ParamName);
+    }
+
     private static LocalDurableJobManager CreateManager(
         JobShardManager shardManager,
         FakeTimeProvider timeProvider,

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -386,6 +386,18 @@ public class LocalDurableJobManagerTests
     }
 
     [Fact]
+    public async Task CancelAsync_NullJob_Throws()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var manager = CreateManager(new TestJobShardManager(), timeProvider, CreateOptions());
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => manager.CancelAsync(null!, CancellationToken.None));
+
+        Assert.Equal("job", exception.ParamName);
+    }
+
+    [Fact]
     public async Task CancelAsync_WhenCachedShardOwnershipMoved_RoutesToCurrentOwner()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -360,6 +360,32 @@ public class LocalDurableJobManagerTests
     }
 
     [Fact]
+    public async Task CancelAsync_WhenRemoveSucceeds_ReportsCancellationRequestAccepted()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var manager = CreateManager(new TestJobShardManager(), timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow();
+        var shard = CreateSubstituteShard("cancellation-shard", shardKey, shardKey.Add(options.ShardDuration));
+        shard.RemoveJobAsync("job-1", Arg.Any<CancellationToken>()).Returns(DurableJobMutationResult.Applied);
+        accessor.AddWritableShard(shardKey, shard);
+        var job = new DurableJob
+        {
+            Id = "job-1",
+            Name = "job",
+            DueTime = shardKey,
+            TargetGrainId = GrainId.Create("test", "job"),
+            ShardId = shard.Id
+        };
+
+        var cancellationRequested = await manager.CancelAsync(job, CancellationToken.None);
+
+        Assert.True(cancellationRequested);
+        await shard.Received(1).RemoveJobAsync(job.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ScheduleJobAsync_WhenShardStripingEnabled_DistributesJobsAcrossWritableShards()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
@@ -834,13 +860,16 @@ public class LocalDurableJobManagerTests
 
         public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
 
+        public Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, CancellationToken cancellationToken) =>
+            Task.FromResult(DurableJobMutationResult.Applied);
+
         public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
+        public Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.JobNotFound);
 
-        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
-        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => Task.FromResult<DurableJob?>(null);
 
@@ -872,13 +901,16 @@ public class LocalDurableJobManagerTests
 
         public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
 
+        public Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, CancellationToken cancellationToken) =>
+            Task.FromResult(DurableJobMutationResult.Applied);
+
         public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
+        public Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.JobNotFound);
 
-        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
-        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => Task.FromResult<DurableJob?>(null);
 
@@ -942,6 +974,9 @@ public class LocalDurableJobManagerTests
 
         public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
 
+        public Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, CancellationToken cancellationToken) =>
+            Task.FromResult(DurableJobMutationResult.Applied);
+
         public Task MarkAsCompleteAsync(CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref MarkAsCompleteCallCount);
@@ -949,11 +984,11 @@ public class LocalDurableJobManagerTests
             return Task.CompletedTask;
         }
 
-        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
+        public Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.JobNotFound);
 
-        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
-        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => Task.FromResult<DurableJob?>(null);
 
@@ -993,13 +1028,16 @@ public class LocalDurableJobManagerTests
 
         public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(_scheduledJob.Task.IsCompleted ? 1 : 0);
 
+        public Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, CancellationToken cancellationToken) =>
+            Task.FromResult(DurableJobMutationResult.Applied);
+
         public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(true);
+        public Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
-        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
-        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
         {
@@ -1044,13 +1082,16 @@ public class LocalDurableJobManagerTests
 
         public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
 
+        public Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, CancellationToken cancellationToken) =>
+            Task.FromResult(DurableJobMutationResult.Applied);
+
         public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
 
-        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+        public Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
 
-        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+        public Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
 
-        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+        public Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
 
@@ -1079,13 +1120,16 @@ public class LocalDurableJobManagerTests
 
         public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
 
+        public Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, CancellationToken cancellationToken) =>
+            Task.FromResult(DurableJobMutationResult.Applied);
+
         public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
+        public Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.JobNotFound);
 
-        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
-        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
         {
@@ -1134,6 +1178,9 @@ public class LocalDurableJobManagerTests
 
         public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
 
+        public Task<DurableJobMutationResult> TryStartAttemptAsync(IJobRunContext jobContext, CancellationToken cancellationToken) =>
+            Task.FromResult(DurableJobMutationResult.Applied);
+
         public async Task MarkAsCompleteAsync(CancellationToken cancellationToken)
         {
             await _lock.WaitAsync(cancellationToken);
@@ -1148,11 +1195,11 @@ public class LocalDurableJobManagerTests
             }
         }
 
-        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
+        public Task<DurableJobMutationResult> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.JobNotFound);
 
-        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
-        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<DurableJobMutationResult> RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.FromResult(DurableJobMutationResult.Applied);
 
         public async Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
         {

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -1,5 +1,8 @@
-using System.Runtime.CompilerServices;
+using System.Diagnostics.Metrics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -424,6 +427,7 @@ public class ShardExecutorTests
             {
                 retryPersistenceStarted.TrySetResult();
                 await failRetryPersistence.Task;
+                return DurableJobMutationResult.Applied;
             });
 
         var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance);
@@ -444,11 +448,17 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenExecutionIsCanceled_DoesNotRetryOrRemove()
+    public async Task RunShardAsync_WhenHandlerCancelsWithoutAttemptCancellation_UsesFailureRetryPolicy()
     {
+        var retryPolicyInvoked = false;
         var options = CreateOptions(
             maxConcurrentJobs: 10,
-            shouldRetry: (context, ex) => DateTimeOffset.UtcNow.AddSeconds(1)
+            shouldRetry: (_, exception) =>
+            {
+                retryPolicyInvoked = true;
+                Assert.IsType<TaskCanceledException>(exception);
+                return DateTimeOffset.UtcNow.AddSeconds(1);
+            }
         );
         var overloadDetector = CreateOverloadDetector(isOverloaded: false);
         var jobs = CreateJobs(1);
@@ -456,11 +466,124 @@ public class ShardExecutorTests
         var grainFactory = CreateGrainFactoryWithCanceledExecution();
         var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => executor.RunShardAsync(shard, cts.Token));
+        await executor.RunShardAsync(shard, CancellationToken.None);
 
-        await shard.DidNotReceive().RetryJobLaterAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        Assert.True(retryPolicyInvoked);
+        await shard.Received(1).RetryJobLaterAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
         await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunShardAsync_WhenAttemptCancellationIsRequested_DoesNotRetryOrRemove()
+    {
+        var retryPolicyInvoked = false;
+        var options = CreateOptions(
+            maxConcurrentJobs: 10,
+            shouldRetry: (_, _) =>
+            {
+                retryPolicyInvoked = true;
+                return DateTimeOffset.UtcNow.AddSeconds(1);
+            });
+        var overloadDetector = CreateOverloadDetector(isOverloaded: false);
+        var jobs = CreateJobs(1);
+        var shard = CreateJobShard(jobs);
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        var attemptStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(call => ExecuteAsync(call.ArgAt<CancellationToken>(1)));
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance);
+        using var attemptCancellation = new CancellationTokenSource();
+
+        var runTask = executor.RunShardAsync(shard, attemptCancellation.Token);
+        await attemptStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        attemptCancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask);
+        Assert.False(retryPolicyInvoked);
+        await shard.DidNotReceive().RetryJobLaterAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+        await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        async ValueTask<DurableJobRunResult> ExecuteAsync(CancellationToken attemptCancellationToken)
+        {
+            attemptStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, attemptCancellationToken);
+            return DurableJobRunResult.Completed;
+        }
+    }
+
+    [Fact]
+    public async Task RunShardAsync_WhenCompletionLosesOwnership_StopsDispatchingShard()
+    {
+        var options = CreateOptions(maxConcurrentJobs: 1);
+        var shard = CreateJobShard(CreateJobs(2));
+        shard.RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(DurableJobMutationResult.OwnershipLost);
+        var grainFactory = CreateGrainFactory();
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(DurableJobRunResult.Completed);
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
+        using var shardsProcessed = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-shards-processed");
+        var executor = new ShardExecutor(
+            grainFactory,
+            options,
+            CreateOverloadDetector(isOverloaded: false),
+            NullLogger<ShardExecutor>.Instance,
+            durableJobsInstruments: instruments);
+
+        await executor.RunShardAsync(shard, CancellationToken.None);
+
+        await extension.Received(1).HandleDurableJobAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<CancellationToken>());
+        await shard.Received(1).RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        Assert.Equal(
+            "attempt_canceled",
+            Assert.Single(shardsProcessed.GetMeasurementSnapshot()).Tags["status"]);
+    }
+
+    [Fact]
+    public async Task RunShardAsync_WhenCancellationWinsBeforeAttemptReservation_DoesNotStartHandler()
+    {
+        var options = CreateOptions(maxConcurrentJobs: 1);
+        var shard = CreateJobShard(CreateJobs(1));
+        shard.TryStartAttemptAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(DurableJobMutationResult.JobNotFound);
+        var grainFactory = CreateGrainFactory();
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var executor = new ShardExecutor(
+            grainFactory,
+            options,
+            CreateOverloadDetector(isOverloaded: false),
+            NullLogger<ShardExecutor>.Instance);
+
+        await executor.RunShardAsync(shard, CancellationToken.None);
+
+        await extension.DidNotReceive().HandleDurableJobAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<CancellationToken>());
+        await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await shard.DidNotReceive().RetryJobLaterAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -499,6 +622,86 @@ public class ShardExecutorTests
             Arg.Any<DateTimeOffset>(),
             Arg.Any<CancellationToken>());
         await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(DurableJobMutationResult.JobNotFound)]
+    [InlineData(DurableJobMutationResult.OwnershipLost)]
+    public async Task RunShardAsync_WhenRetryIsNotApplied_DoesNotRecordRetry(DurableJobMutationResult mutationResult)
+    {
+        var options = CreateOptions(
+            maxConcurrentJobs: 1,
+            shouldRetry: (_, _) => DateTimeOffset.UtcNow.AddMinutes(1));
+        var shard = CreateJobShard(CreateJobs(1));
+        shard.RetryJobLaterAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(mutationResult);
+        var grainFactory = CreateGrainFactory();
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(DurableJobRunResult.Failed(new InvalidOperationException("failed")));
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
+        using var retried = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-jobs-retried");
+        var executor = new ShardExecutor(
+            grainFactory,
+            options,
+            CreateOverloadDetector(isOverloaded: false),
+            NullLogger<ShardExecutor>.Instance,
+            durableJobsInstruments: instruments);
+
+        await executor.RunShardAsync(shard, CancellationToken.None);
+
+        await shard.Received(1).RetryJobLaterAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+        Assert.Empty(retried.GetMeasurementSnapshot());
+    }
+
+    [Theory]
+    [InlineData(DurableJobMutationResult.JobNotFound)]
+    [InlineData(DurableJobMutationResult.OwnershipLost)]
+    public async Task RunShardAsync_WhenRescheduleIsNotApplied_DoesNotRecordReschedule(DurableJobMutationResult mutationResult)
+    {
+        var options = CreateOptions(maxConcurrentJobs: 1);
+        var shard = CreateJobShard(CreateJobs(1));
+        shard.RescheduleJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(mutationResult);
+        var grainFactory = CreateGrainFactory();
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(DurableJobRunResult.RescheduleAt(DateTimeOffset.UtcNow.AddMinutes(1)));
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
+        using var rescheduled = new MetricCollector<long>(
+            meterFactory,
+            "Microsoft.Orleans",
+            "orleans-durablejobs-jobs-rescheduled");
+        var executor = new ShardExecutor(
+            grainFactory,
+            options,
+            CreateOverloadDetector(isOverloaded: false),
+            NullLogger<ShardExecutor>.Instance,
+            durableJobsInstruments: instruments);
+
+        await executor.RunShardAsync(shard, CancellationToken.None);
+
+        await shard.Received(1).RescheduleJobAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+        Assert.Empty(rescheduled.GetMeasurementSnapshot());
     }
 
     [Fact]
@@ -735,7 +938,11 @@ public class ShardExecutorTests
         shard.ConsumeDurableJobsAsync().Returns(callInfo => CreateJobContexts(jobs, firstJobRegistered));
 
         shard.RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
+            .Returns(Task.FromResult(DurableJobMutationResult.Applied));
+        shard.RetryJobLaterAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(DurableJobMutationResult.Applied));
+        shard.RescheduleJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(DurableJobMutationResult.Applied));
 
         return shard;
     }
@@ -751,7 +958,11 @@ public class ShardExecutorTests
         shard.ConsumeDurableJobsAsync().Returns(callInfo => CreateJobContextsWithDelay(jobs, yieldDelay));
 
         shard.RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
+            .Returns(Task.FromResult(DurableJobMutationResult.Applied));
+        shard.RetryJobLaterAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(DurableJobMutationResult.Applied));
+        shard.RescheduleJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(DurableJobMutationResult.Applied));
 
         return shard;
     }

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobFeatureHandlerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobFeatureHandlerTests.cs
@@ -14,15 +14,15 @@ public class DurableJobFeatureHandlerTests
     public void Registry_SelectsHandlerUsingHandlerOwnedMatching()
     {
         var registry = new DurableJobHandlerRegistry();
-        var lower = new TestHandler(static job => job.Name.StartsWith("feature.", StringComparison.Ordinal));
-        var upper = new TestHandler(static job => job.Name.StartsWith("Feature.", StringComparison.Ordinal));
+        var lower = new TestHandler(static jobName => jobName.StartsWith("feature.", StringComparison.Ordinal));
+        var upper = new TestHandler(static jobName => jobName.StartsWith("Feature.", StringComparison.Ordinal));
 
         registry.Register(lower);
         registry.Register(upper);
 
-        Assert.True(registry.TryGetHandler(CreateJob("feature.cleanup"), out var resolvedLower));
-        Assert.True(registry.TryGetHandler(CreateJob("Feature.cleanup"), out var resolvedUpper));
-        Assert.False(registry.TryGetHandler(CreateJob("other.cleanup"), out var unresolved));
+        Assert.True(registry.TryGetHandler("feature.cleanup", out var resolvedLower));
+        Assert.True(registry.TryGetHandler("Feature.cleanup", out var resolvedUpper));
+        Assert.False(registry.TryGetHandler("other.cleanup", out var unresolved));
         Assert.Same(lower, resolvedLower);
         Assert.Same(upper, resolvedUpper);
         Assert.Null(unresolved);
@@ -43,28 +43,18 @@ public class DurableJobFeatureHandlerTests
     public void Registry_RejectsAmbiguousMatches()
     {
         var registry = new DurableJobHandlerRegistry();
-        registry.Register(new TestHandler(static job => job.Name.StartsWith("feature.", StringComparison.Ordinal)));
-        registry.Register(new TestHandler(static job => job.Name.EndsWith(".cleanup", StringComparison.Ordinal)));
+        registry.Register(new TestHandler(static jobName => jobName.StartsWith("feature.", StringComparison.Ordinal)));
+        registry.Register(new TestHandler(static jobName => jobName.EndsWith(".cleanup", StringComparison.Ordinal)));
 
         var exception = Assert.Throws<InvalidOperationException>(
-            () => registry.TryGetHandler(CreateJob("feature.cleanup"), out _));
+            () => registry.TryGetHandler("feature.cleanup", out _));
 
         Assert.Contains("Multiple durable job feature handlers match job 'feature.cleanup'", exception.Message, StringComparison.Ordinal);
     }
 
-    private static DurableJob CreateJob(string name) =>
-        new()
-        {
-            Id = "job-1",
-            Name = name,
-            DueTime = DateTimeOffset.UtcNow,
-            TargetGrainId = GrainId.Create("test", "grain-1"),
-            ShardId = "shard-1"
-        };
-
-    private sealed class TestHandler(Func<DurableJob, bool> canHandle) : IDurableJobFeatureHandler
+    private sealed class TestHandler(Func<string, bool> canHandle) : IDurableJobFeatureHandler
     {
-        public bool CanHandle(DurableJob job) => canHandle(job);
+        public bool CanHandle(string jobName) => canHandle(jobName);
 
         public ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken) =>
             ValueTask.FromResult(DurableJobRunResult.Completed);

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobFeatureHandlerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobFeatureHandlerTests.cs
@@ -1,0 +1,35 @@
+using Orleans;
+using Orleans.DurableJobs;
+using Xunit;
+
+namespace Tester.DurableJobs;
+
+[TestCategory("BVT"), TestCategory("DurableJobs")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("DurableJobs")]
+public class DurableJobFeatureHandlerTests
+{
+    [Fact]
+    public void Registry_UsesOrdinalNamesAndRejectsExactDuplicates()
+    {
+        var registry = new DurableJobHandlerRegistry();
+        var lower = new TestHandler();
+        var upper = new TestHandler();
+
+        registry.Register("feature", lower);
+        registry.Register("Feature", upper);
+
+        Assert.True(registry.TryGetHandler("feature", out var resolvedLower));
+        Assert.True(registry.TryGetHandler("Feature", out var resolvedUpper));
+        Assert.Same(lower, resolvedLower);
+        Assert.Same(upper, resolvedUpper);
+        Assert.Throws<InvalidOperationException>(() => registry.Register("feature", new TestHandler()));
+    }
+
+    private sealed class TestHandler : IDurableJobFeatureHandler
+    {
+        public ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken) =>
+            ValueTask.FromResult(DurableJobRunResult.Completed);
+    }
+}

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobFeatureHandlerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobFeatureHandlerTests.cs
@@ -11,24 +11,61 @@ namespace Tester.DurableJobs;
 public class DurableJobFeatureHandlerTests
 {
     [Fact]
-    public void Registry_UsesOrdinalNamesAndRejectsExactDuplicates()
+    public void Registry_SelectsHandlerUsingHandlerOwnedMatching()
     {
         var registry = new DurableJobHandlerRegistry();
-        var lower = new TestHandler();
-        var upper = new TestHandler();
+        var lower = new TestHandler(static job => job.Name.StartsWith("feature.", StringComparison.Ordinal));
+        var upper = new TestHandler(static job => job.Name.StartsWith("Feature.", StringComparison.Ordinal));
 
-        registry.Register("feature", lower);
-        registry.Register("Feature", upper);
+        registry.Register(lower);
+        registry.Register(upper);
 
-        Assert.True(registry.TryGetHandler("feature", out var resolvedLower));
-        Assert.True(registry.TryGetHandler("Feature", out var resolvedUpper));
+        Assert.True(registry.TryGetHandler(CreateJob("feature.cleanup"), out var resolvedLower));
+        Assert.True(registry.TryGetHandler(CreateJob("Feature.cleanup"), out var resolvedUpper));
+        Assert.False(registry.TryGetHandler(CreateJob("other.cleanup"), out var unresolved));
         Assert.Same(lower, resolvedLower);
         Assert.Same(upper, resolvedUpper);
-        Assert.Throws<InvalidOperationException>(() => registry.Register("feature", new TestHandler()));
+        Assert.Null(unresolved);
     }
 
-    private sealed class TestHandler : IDurableJobFeatureHandler
+    [Fact]
+    public void Registry_RejectsDuplicateHandlerRegistration()
     {
+        var registry = new DurableJobHandlerRegistry();
+        var handler = new TestHandler(static _ => true);
+
+        registry.Register(handler);
+
+        Assert.Throws<InvalidOperationException>(() => registry.Register(handler));
+    }
+
+    [Fact]
+    public void Registry_RejectsAmbiguousMatches()
+    {
+        var registry = new DurableJobHandlerRegistry();
+        registry.Register(new TestHandler(static job => job.Name.StartsWith("feature.", StringComparison.Ordinal)));
+        registry.Register(new TestHandler(static job => job.Name.EndsWith(".cleanup", StringComparison.Ordinal)));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => registry.TryGetHandler(CreateJob("feature.cleanup"), out _));
+
+        Assert.Contains("Multiple durable job feature handlers match job 'feature.cleanup'", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static DurableJob CreateJob(string name) =>
+        new()
+        {
+            Id = "job-1",
+            Name = name,
+            DueTime = DateTimeOffset.UtcNow,
+            TargetGrainId = GrainId.Create("test", "grain-1"),
+            ShardId = "shard-1"
+        };
+
+    private sealed class TestHandler(Func<DurableJob, bool> canHandle) : IDurableJobFeatureHandler
+    {
+        public bool CanHandle(DurableJob job) => canHandle(job);
+
         public ValueTask<DurableJobRunResult> ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken) =>
             ValueTask.FromResult(DurableJobRunResult.Completed);
     }

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/DurableJobTestsRunner.cs
@@ -36,8 +36,8 @@ public class DurableJobTestsRunner
         var job3 = await grain.ScheduleJobAsync("TestJob3", dueTime.AddSeconds(4)).WaitAsync(cancellationToken);
         var job4 = await grain.ScheduleJobAsync("TestJob4", dueTime).WaitAsync(cancellationToken);
         var job5 = await grain.ScheduleJobAsync("TestJob5", dueTime.AddSeconds(1)).WaitAsync(cancellationToken);
-        var canceledJob = await grain.ScheduleJobAsync("CanceledJob", dueTime.AddSeconds(2)).WaitAsync(cancellationToken);
-        Assert.True(await grain.TryCancelJobAsync(canceledJob).WaitAsync(cancellationToken));
+        var cancellationRequestedJob = await grain.ScheduleJobAsync("CancellationRequestedJob", dueTime.AddSeconds(2)).WaitAsync(cancellationToken);
+        Assert.True(await grain.CancelAsync(cancellationRequestedJob).WaitAsync(cancellationToken));
         // Wait for the job to run
         foreach (var job in new[] { job1, job2, job3, job4, job5 })
         {
@@ -50,8 +50,8 @@ public class DurableJobTestsRunner
                 Assert.Fail($"The durable job {job.Name} did not run within the expected time.");
             }
         }
-        // Verify the canceled job did not run
-        Assert.False(await grain.HasJobRan(canceledJob.Id).WaitAsync(cancellationToken));
+        // Verify the job with a durable cancellation request did not run.
+        Assert.False(await grain.HasJobRan(cancellationRequestedJob.Id).WaitAsync(cancellationToken));
     }
 
     public async Task JobExecutionOrder(CancellationToken cancellationToken)
@@ -180,8 +180,8 @@ public class DurableJobTestsRunner
             TargetGrainId = job.TargetGrainId
         };
 
-        var cancelResult = await grain.TryCancelJobAsync(fakeJob).WaitAsync(cancellationToken);
-        Assert.False(cancelResult);
+        var cancellationRequested = await grain.CancelAsync(fakeJob).WaitAsync(cancellationToken);
+        Assert.False(cancellationRequested);
 
         await Task.Delay(100, cancellationToken);
         Assert.False(await grain.HasJobRan(fakeJob.Id).WaitAsync(cancellationToken));
@@ -197,8 +197,8 @@ public class DurableJobTestsRunner
         await grain.WaitForJobToRun(job.Id).WaitAsync(cancellationToken);
         Assert.True(await grain.HasJobRan(job.Id).WaitAsync(cancellationToken));
 
-        var cancelResult = await grain.TryCancelJobAsync(job).WaitAsync(cancellationToken);
-        Assert.False(cancelResult);
+        var cancellationRequested = await grain.CancelAsync(job).WaitAsync(cancellationToken);
+        Assert.False(cancellationRequested);
     }
 
     public async Task ConcurrentScheduling(CancellationToken cancellationToken)

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -152,6 +152,27 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     }
 
     [Fact]
+    public async Task AttemptCancellationPreservesJobForReassignment()
+    {
+        await using var scope = await fixture.CreateScopeAsync();
+        var first = scope.CreateManager(scope.ActiveSilo);
+        var second = scope.CreateManager(scope.SecondActiveSilo);
+        var now = scope.Now;
+        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), Metadata("purpose", "attempt-cancellation"), CancellationToken.None);
+        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "attempt-canceled-job");
+        var firstAttempt = await TakeOneAsync(shard);
+
+        await first.UnregisterShardAsync(shard, CancellationToken.None);
+
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
+        var secondAttempt = await TakeOneAsync(reassigned);
+
+        Assert.Equal(job!.Id, secondAttempt.Job.Id);
+        Assert.NotEqual(firstAttempt.RunId, secondAttempt.RunId);
+        Assert.Equal(1, secondAttempt.DequeueCount);
+    }
+
+    [Fact]
     public async Task RetryLaterPersistsThroughShardReassignment()
     {
         await using var scope = await fixture.CreateScopeAsync();
@@ -207,10 +228,15 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
         var cancelDuringRun = await ScheduleJobAsync(shard, now.AddMinutes(-2), "cancel-during");
         var remaining = await ScheduleJobAsync(shard, now.AddMinutes(-1), "remaining");
 
-        Assert.True(await shard.RemoveJobAsync(cancelBeforeRun!.Id, CancellationToken.None));
+        Assert.Equal(
+            DurableJobMutationResult.Applied,
+            await shard.RemoveJobAsync(cancelBeforeRun!.Id, CancellationToken.None));
         var running = await TakeOneAsync(shard);
         Assert.Equal(cancelDuringRun!.Id, running.Job.Id);
-        Assert.True(await shard.RemoveJobAsync(running.Job.Id, CancellationToken.None));
+        Assert.Equal(
+            DurableJobMutationResult.Applied,
+            await shard.RemoveJobAsync(running.Job.Id, CancellationToken.None));
+        await shard.RetryJobLaterAsync(running, now.AddMinutes(-1), CancellationToken.None);
         await first.UnregisterShardAsync(shard, CancellationToken.None);
 
         var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -9,6 +9,29 @@ namespace Orleans.DurableJobs.Tests;
 [TestCategory("BVT")]
 public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fixture)
 {
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task TryScheduleJobAsync_InvalidJobName_Throws(string? jobName)
+    {
+        await using var scope = await fixture.CreateScopeAsync();
+        var manager = scope.CreateManager(scope.ActiveSilo);
+        var now = scope.Now;
+        var shard = await manager.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), CancellationToken.None);
+        var request = new ScheduleJobRequest
+        {
+            Target = GrainId.Create("durable-job-test", "target"),
+            JobName = jobName!,
+            DueTime = now.AddMinutes(1)
+        };
+
+        var exception = await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => shard.TryScheduleJobAsync(request, CancellationToken.None));
+
+        Assert.Equal("JobName", exception.ParamName);
+    }
+
     [Fact]
     public async Task ShardCreationAndAssignmentUsesDistinctShardIdsForSameWindow()
     {

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
@@ -289,6 +289,44 @@ public class JournaledJobShardManagerTests
     }
 
     [Fact]
+    public async Task AttemptReservation_WaitsForPrecedingRemovalToPersist()
+    {
+        var storageProvider = new CountingJournalStorageProvider(delayAppends: false);
+        using var services = CreateServices(storageProvider);
+        var membership = new TestClusterMembershipService();
+        var silo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5018), 0);
+        membership.SetSiloStatus(silo, SiloStatus.Active);
+        var manager = CreateManager(
+            services,
+            membership,
+            silo,
+            new DurableJobsOptions { ShardBatchLingerDelay = TimeSpan.FromMilliseconds(100) });
+        var start = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var shard = await manager.CreateShardAsync(
+            start,
+            start.AddHours(1),
+            new Dictionary<string, string> { ["Purpose"] = "AttemptReservationPersistence" },
+            CancellationToken.None);
+        var scheduled = await ScheduleJobAsync(shard, "attempt-reservation-persistence");
+        await using var enumerator = shard.ConsumeDurableJobsAsync().GetAsyncEnumerator(TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        var jobContext = enumerator.Current;
+
+        storageProvider.BlockAppends();
+        var removeTask = shard.RemoveJobAsync(scheduled.Id, CancellationToken.None);
+        var startAttemptTask = shard.TryStartAttemptAsync(jobContext, CancellationToken.None);
+
+        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.False(startAttemptTask.IsCompleted);
+
+        storageProvider.AllowAppends();
+        Assert.Equal(DurableJobMutationResult.Applied, await removeTask);
+        Assert.Equal(DurableJobMutationResult.JobNotFound, await startAttemptTask);
+
+        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+    }
+
+    [Fact]
     public async Task DeadOwnerShard_IsAdoptedClosedAndReplayedFromJournal()
     {
         var storageProvider = new VolatileJournalStorageProvider();
@@ -548,25 +586,48 @@ public class JournaledJobShardManagerTests
     private sealed class CountingJournalStorageProvider : IJournalStorageProvider, IJournalStorageCatalog
     {
         private readonly VolatileJournalStorageProvider _inner = new();
-        private readonly bool _delayAppends;
-        private readonly TaskCompletionSource _appendStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource _allowAppends = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly object _appendGate = new();
+        private bool _delayAppends;
+        private TaskCompletionSource _appendStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource _allowAppends = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _appendCount;
 
         public CountingJournalStorageProvider(bool delayAppends)
         {
             _delayAppends = delayAppends;
-            if (!delayAppends)
+        }
+
+        public Task AppendStarted
+        {
+            get
             {
-                _allowAppends.SetResult();
+                lock (_appendGate)
+                {
+                    return _appendStarted.Task;
+                }
             }
         }
 
-        public Task AppendStarted => _appendStarted.Task;
-
         public int AppendCount => Volatile.Read(ref _appendCount);
 
-        public void AllowAppends() => _allowAppends.TrySetResult();
+        public void BlockAppends()
+        {
+            lock (_appendGate)
+            {
+                _appendStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                _allowAppends = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                _delayAppends = true;
+            }
+        }
+
+        public void AllowAppends()
+        {
+            lock (_appendGate)
+            {
+                _delayAppends = false;
+                _allowAppends.TrySetResult();
+            }
+        }
 
         public IJournalStorage CreateStorage(JournalId journalId) => new CountingJournalStorage(this, _inner.CreateStorage(journalId));
 
@@ -576,10 +637,16 @@ public class JournaledJobShardManagerTests
         private async ValueTask OnAppendAsync(CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref _appendCount);
-            _appendStarted.TrySetResult();
-            if (_delayAppends)
+            Task? waitTask;
+            lock (_appendGate)
             {
-                await _allowAppends.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                _appendStarted.TrySetResult();
+                waitTask = _delayAppends ? _allowAppends.Task : null;
+            }
+
+            if (waitTask is not null)
+            {
+                await waitTask.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
@@ -158,7 +158,9 @@ public class JournaledJobShardManagerTests
         await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
         {
             Assert.Equal(scheduled.Id, jobContext.Job.Id);
-            Assert.True(await shard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None));
+            Assert.Equal(
+                DurableJobMutationResult.Applied,
+                await shard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None));
         }
 
         Assert.Equal(0, await shard.GetJobCountAsync());
@@ -650,7 +652,9 @@ public class JournaledJobShardManagerTests
         await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(cts.Token))
         {
             consumed++;
-            Assert.True(await shard.RemoveJobAsync(jobContext.Job.Id, cts.Token));
+            Assert.Equal(
+                DurableJobMutationResult.Applied,
+                await shard.RemoveJobAsync(jobContext.Job.Id, cts.Token));
             if (consumed == expectedJobs)
             {
                 break;


### PR DESCRIPTION
## Problem

DurableJobs currently requires the grain itself to own every job handler. Framework features need activation-local dispatch without changing the grain's public contract. Cancellation also needs distinct semantics for the durable task and its current execution attempt.

## Solution

- Add activation-scoped `IDurableJobHandlerRegistry` and `IDurableJobFeatureHandler`. Each feature handler is registered once and owns deterministic, side-effect-free name matching through `CanHandle(string jobName)`, supporting exact names, prefixes, or regexes.
- Preserve `IDurableJobHandler` as the safe grain-author contract: successful return completes the job and exceptions follow retry policy. Feature handlers are the advanced contract which returns an explicit `DurableJobRunResult`. Both contracts flow through one centralized cancellation, exception, result, metrics, and tracing path.
- Route a uniquely matching job to its feature handler. Jobs with no feature match fall back to `IDurableJobHandler`; overlapping feature matches fail explicitly as ambiguous. Job names are validated before persistence at manager and shard boundaries.
- Identify active attempts by `(JobId, ExecutionGeneration, DequeueCount)`, which remains stable across duplicate delivery even when `RunId` changes. Concurrent deliveries share the active invocation; once it reaches a terminal disposition, a later delivery starts a new invocation.
- Treat `InProgress` as non-terminal: duplicate calls share the current invocation, and the feature handler is invoked again after its requested delay.
- Define `CancelAsync` as a durable task cancellation request. A `true` result means removal was durably applied, preventing future attempts; an already-running attempt may still complete cooperatively.
- Define `attemptCancellationToken` as cooperative cancellation of only the current attempt. Host shutdown or ownership loss stops that attempt while preserving the task for reassignment. Active long polls end promptly on the request while a handler which has not stopped remains active.
- Order attempt reservation and task mutations through the shard so cancellation, start, completion, retry, reschedule, and ownership loss have deterministic outcomes. State-dependent mutation results wait for preceding journal writes, and explicit `DurableJobMutationResult` values prevent suppressed or unowned mutations from being reported as successful.
- Report cancellation requests, request-operation cancellation, attempt cancellation, and failure as distinct outcomes. Ownership loss cancels the current attempt, is tagged `attempt_canceled` in shard metrics, and is identified explicitly in logs and mutation activities.
- Keep the registry infrastructure-owned so dispatch and registration remain connected.

## Rationale

The simple grain contract makes completion and failure difficult to misuse. The advanced feature contract exposes polling and rescheduling only to components which deliberately opt into the DurableJobs disposition model. Feature handlers compose with existing execution and retry behavior while claiming grain-scoped work using stable name-matching rules. Durable task cancellation governs future delivery; attempt cancellation governs only the current host execution. Handlers own any application-specific idempotency needed when a terminal invocation is delivered again.