### PR TITLE
fix(templates): use shipped Orleans package version

### DIFF
--- a/templates/Microsoft.Orleans.Templates/Microsoft.Orleans.Templates.csproj
+++ b/templates/Microsoft.Orleans.Templates/Microsoft.Orleans.Templates.csproj
@@ -1,4 +1,40 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <UsingTask
+    TaskName="SetOrleansTemplatePackageVersion"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <ManifestPath ParameterType="System.String" Required="true" />
+      <DevelopmentVersion ParameterType="System.String" Required="true" />
+      <PackageVersion ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        var contents = File.ReadAllText(ManifestPath);
+        var developmentDefault = $"\"defaultValue\": \"{DevelopmentVersion}\"";
+        var packageDefault = $"\"defaultValue\": \"{PackageVersion}\"";
+        var defaultIndex = contents.IndexOf(developmentDefault, StringComparison.Ordinal);
+
+        if (defaultIndex < 0
+            || contents.IndexOf(developmentDefault, defaultIndex + developmentDefault.Length, StringComparison.Ordinal) >= 0)
+        {
+            Log.LogError(
+                $"Template manifest '{ManifestPath}' must contain exactly one default Orleans version '{DevelopmentVersion}'.");
+        }
+        else
+        {
+            contents = contents.Remove(defaultIndex, developmentDefault.Length).Insert(defaultIndex, packageDefault);
+            File.WriteAllText(ManifestPath, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Microsoft.Orleans.Templates</PackageId>
@@ -16,11 +52,44 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PrepareTemplateManifestsForPack</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="templates\**\*" />
-    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+    <Content
+      Include="templates\**\*"
+      Exclude="templates\**\bin\**;templates\**\obj\**;templates\**\.template.config\template.json" />
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <Target Name="PrepareTemplateManifestsForPack">
+    <PropertyGroup>
+      <_TemplatePackRoot>$(IntermediateOutputPath)template-pack\</_TemplatePackRoot>
+      <_TemplateDevelopmentOrleansVersion>10.0.0-dev</_TemplateDevelopmentOrleansVersion>
+      <_OrleansTemplateManifest>$(_TemplatePackRoot)templates\orleans\.template.config\template.json</_OrleansTemplateManifest>
+      <_OrleansWebTemplateManifest>$(_TemplatePackRoot)templates\orleans-web\.template.config\template.json</_OrleansWebTemplateManifest>
+    </PropertyGroup>
+
+    <Copy
+      SourceFiles="templates\orleans\.template.config\template.json;templates\orleans-web\.template.config\template.json"
+      DestinationFiles="$(_OrleansTemplateManifest);$(_OrleansWebTemplateManifest)" />
+    <SetOrleansTemplatePackageVersion
+      ManifestPath="$(_OrleansTemplateManifest)"
+      DevelopmentVersion="$(_TemplateDevelopmentOrleansVersion)"
+      PackageVersion="$(PackageVersion)" />
+    <SetOrleansTemplatePackageVersion
+      ManifestPath="$(_OrleansWebTemplateManifest)"
+      DevelopmentVersion="$(_TemplateDevelopmentOrleansVersion)"
+      PackageVersion="$(PackageVersion)" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile
+        Include="$(_OrleansTemplateManifest)"
+        PackagePath="content\templates\orleans\.template.config\template.json" />
+      <TfmSpecificPackageFile
+        Include="$(_OrleansWebTemplateManifest)"
+        PackagePath="content\templates\orleans-web\.template.config\template.json" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/templates/Microsoft.Orleans.Templates/README.md
+++ b/templates/Microsoft.Orleans.Templates/README.md
@@ -26,7 +26,7 @@ Both templates target .NET 10 by default. Pass `--framework net8.0` to target .N
 dotnet new orleans --name MyOrleansApp --framework net8.0
 ```
 
-Templates reference the current stable Orleans release. Pass `--orleans-version` when your application needs another Orleans version:
+Templates reference the Orleans version shipped with the template package, including prerelease versions. Pass `--orleans-version` to select another Orleans version:
 
 ```dotnetcli
 dotnet new orleans-web --name MyOrleansWebApp --orleans-version 10.2.2

--- a/templates/Microsoft.Orleans.Templates/templates/orleans-web/.template.config/template.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans-web/.template.config/template.json
@@ -40,7 +40,7 @@
       "type": "parameter",
       "datatype": "text",
       "description": "The Microsoft Orleans package version.",
-      "defaultValue": "10.2.2"
+      "defaultValue": "10.0.0-dev"
     },
     "orleansVersionXml": {
       "type": "derived",

--- a/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
+++ b/templates/Microsoft.Orleans.Templates/templates/orleans/.template.config/template.json
@@ -40,7 +40,7 @@
       "type": "parameter",
       "datatype": "text",
       "description": "The Microsoft Orleans package version.",
-      "defaultValue": "10.2.2"
+      "defaultValue": "10.0.0-dev"
     },
     "orleansVersionXml": {
       "type": "derived",


### PR DESCRIPTION
## Problem

The `orleans` and `orleans-web` templates hard-code Orleans 10.2.2, so newly generated projects can reference a release older than the installed template package.

## Solution

Stage both template manifests through the NuGet pack extension point and set their default Orleans version from `$(PackageVersion)`. The checked-in manifests use the repository's `10.0.0-dev` version for local template development, while packed artifacts inherit their exact package version, including prerelease labels.

The pack target validates that each manifest contains exactly one expected development default before replacing it, so manifest drift fails packaging instead of silently shipping a stale version.

The template README now documents that generated projects default to the Orleans version shipped with the template package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10690)