### PR TITLE
fix(codegen): use test host framework references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,6 @@
     <PackageVersion Include="Microsoft.Build" Version="17.10.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.5.0" />

--- a/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGenerator.Model;
 using Orleans.Serialization;

--- a/test/Orleans.CodeGenerator.Tests/Orleans.CodeGenerator.Tests.csproj
+++ b/test/Orleans.CodeGenerator.Tests/Orleans.CodeGenerator.Tests.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
@@ -2,7 +2,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGenerator.Diagnostics;
 using Orleans.Serialization;

--- a/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
+++ b/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
@@ -14,6 +14,9 @@ namespace Orleans.CodeGenerator.Tests;
 /// </summary>
 internal static class TestCompilationHelper
 {
+    private static readonly StringComparer PathComparer = OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
     private static readonly ImmutableArray<MetadataReference> FrameworkReferences = CreateFrameworkReferences();
 
     /// <summary>
@@ -49,12 +52,39 @@ internal static class TestCompilationHelper
     {
         var trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")
             ?? throw new InvalidOperationException("The test host must provide trusted platform assemblies.");
-        var frameworkDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
 
-        return trustedPlatformAssemblies
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Where(path => Path.GetDirectoryName(path) == frameworkDirectory)
+        return GetFrameworkAssemblyPaths(trustedPlatformAssemblies, typeof(object).Assembly.Location)
             .Select(static path => (MetadataReference)MetadataReference.CreateFromFile(path))
             .ToImmutableArray();
+    }
+
+    internal static ImmutableArray<string> GetFrameworkAssemblyPaths(
+        string trustedPlatformAssemblies,
+        string frameworkAssemblyPath)
+    {
+        if (string.IsNullOrWhiteSpace(trustedPlatformAssemblies))
+        {
+            throw new InvalidOperationException("The test host must provide trusted platform assemblies.");
+        }
+
+        var frameworkDirectory = Path.GetDirectoryName(frameworkAssemblyPath);
+        if (string.IsNullOrWhiteSpace(frameworkDirectory))
+        {
+            throw new InvalidOperationException("The test host framework directory must be available.");
+        }
+
+        frameworkDirectory = Path.GetFullPath(frameworkDirectory);
+        var frameworkAssemblyPaths = trustedPlatformAssemblies
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(path => PathComparer.Equals(Path.GetDirectoryName(Path.GetFullPath(path)), frameworkDirectory))
+            .ToImmutableArray();
+
+        if (frameworkAssemblyPaths.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                $"The trusted platform assemblies must include references from '{frameworkDirectory}'.");
+        }
+
+        return frameworkAssemblyPaths;
     }
 }

--- a/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
+++ b/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization;
 
@@ -15,26 +14,17 @@ namespace Orleans.CodeGenerator.Tests;
 /// </summary>
 internal static class TestCompilationHelper
 {
+    private static readonly ImmutableArray<MetadataReference> FrameworkReferences = CreateFrameworkReferences();
+
     /// <summary>
     /// Creates a <see cref="CSharpCompilation"/> with the .NET framework and Orleans assembly references.
     /// </summary>
-    public static async Task<CSharpCompilation> CreateCompilation(
+    public static Task<CSharpCompilation> CreateCompilation(
         string sourceCode,
         string assemblyName = "TestProject",
         params MetadataReference[] additionalReferences)
     {
-#if NET10_0_OR_GREATER
-        var net10References = new ReferenceAssemblies(
-            "net10.0",
-            new PackageIdentity("Microsoft.NETCore.App.Ref", "10.0.0"),
-            Path.Combine("ref", "net10.0"));
-
-        var references = await net10References.ResolveAsync(LanguageNames.CSharp, default);
-#else
-        var references = await ReferenceAssemblies.Net.Net80.ResolveAsync(LanguageNames.CSharp, default);
-#endif
-
-        references = references.AddRange(
+        var references = FrameworkReferences.AddRange(
             MetadataReference.CreateFromFile(typeof(GrainId).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(IClusterClientLifecycle).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(IGrainActivator).Assembly.Location),
@@ -48,6 +38,23 @@ internal static class TestCompilationHelper
         }
 
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
-        return CSharpCompilation.Create(assemblyName, [syntaxTree], references, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        return Task.FromResult(CSharpCompilation.Create(
+            assemblyName,
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)));
+    }
+
+    private static ImmutableArray<MetadataReference> CreateFrameworkReferences()
+    {
+        var trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")
+            ?? throw new InvalidOperationException("The test host must provide trusted platform assemblies.");
+        var frameworkDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location);
+
+        return trustedPlatformAssemblies
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(path => Path.GetDirectoryName(path) == frameworkDirectory)
+            .Select(static path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToImmutableArray();
     }
 }

--- a/test/Orleans.CodeGenerator.Tests/TestCompilationHelperTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/TestCompilationHelperTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+
+namespace Orleans.CodeGenerator.Tests;
+
+public class TestCompilationHelperTests
+{
+    [Fact]
+    public void GetFrameworkAssemblyPathsUsesPlatformPathComparer()
+    {
+        var frameworkDirectory = Path.Combine(Path.GetTempPath(), "Framework");
+        var frameworkAssemblyPath = Path.Combine(frameworkDirectory, "System.Private.CoreLib.dll");
+        var matchingDirectory = OperatingSystem.IsWindows() ? frameworkDirectory.ToUpperInvariant() : frameworkDirectory;
+        var matchingAssemblyPath = Path.Combine(matchingDirectory, "System.Runtime.dll");
+        var otherAssemblyPath = Path.Combine(Path.GetTempPath(), "Other", "System.Runtime.dll");
+        var trustedPlatformAssemblies = $"{matchingAssemblyPath}{Path.PathSeparator}{otherAssemblyPath}";
+
+        var result = TestCompilationHelper.GetFrameworkAssemblyPaths(
+            trustedPlatformAssemblies,
+            frameworkAssemblyPath);
+
+        Assert.Equal(matchingAssemblyPath, Assert.Single(result));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("System.Private.CoreLib.dll")]
+    public void GetFrameworkAssemblyPathsRequiresFrameworkDirectory(string frameworkAssemblyPath)
+    {
+        var trustedPlatformAssemblies = Path.Combine(Path.GetTempPath(), "Framework", "System.Runtime.dll");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => TestCompilationHelper.GetFrameworkAssemblyPaths(
+                trustedPlatformAssemblies,
+                frameworkAssemblyPath));
+
+        Assert.Equal("The test host framework directory must be available.", exception.Message);
+    }
+
+    [Fact]
+    public void GetFrameworkAssemblyPathsRequiresMatchingReferences()
+    {
+        var frameworkAssemblyPath = Path.Combine(
+            Path.GetTempPath(),
+            "Framework",
+            "System.Private.CoreLib.dll");
+        var trustedPlatformAssemblies = Path.Combine(Path.GetTempPath(), "Other", "System.Runtime.dll");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => TestCompilationHelper.GetFrameworkAssemblyPaths(
+                trustedPlatformAssemblies,
+                frameworkAssemblyPath));
+
+        Assert.StartsWith("The trusted platform assemblies must include references from", exception.Message);
+    }
+}


### PR DESCRIPTION
## Problem

Code-generator tests resolved target-framework reference assemblies from NuGet.org while tests were running, so restricted CI test hosts failed before exercising generator behavior.

## Solution

Build and cache framework metadata references from the current test host's `TRUSTED_PLATFORM_ASSEMBLIES`, restricted to the runtime framework directory. The helper continues to append the explicit Orleans references and caller-supplied references, so application dependencies from the test host do not affect generator inputs.

The Roslyn source-generator testing package and its namespace imports are removed now that the helper no longer uses `ReferenceAssemblies`.

Fixes #10683
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10691)