### PR TITLE
test: reduce shutdown test timeout

### DIFF
--- a/test/Orleans.Runtime.Tests/Forwarding/ShutdownSiloTests.cs
+++ b/test/Orleans.Runtime.Tests/Forwarding/ShutdownSiloTests.cs
@@ -24,7 +24,7 @@ namespace Tester.Forwarding
         public const int NumberOfSilos = 2;
 
         public static readonly TimeSpan DeactivationTimeout = TimeSpan.FromSeconds(3);
-        private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(7);
         private static readonly TimeSpan PendingRequestTimerDueTime = TimeSpan.FromSeconds(2);
         private static readonly TimeSpan StuckActivationTimerDueTime = TimeSpan.FromMinutes(5);
         private static readonly TimeSpan TimerReadinessTimeout = TimeSpan.FromMinutes(1);


### PR DESCRIPTION
## Problem

`SiloGracefulShutdown_StuckTimers` and `SiloGracefulShutdown_StuckActivation` each take approximately 120 seconds because the test fixture configures a two-minute host shutdown timeout. Across the 24-hour CI scan, both tests passed all 18 observations but consumed about 72 aggregate test-minutes and added roughly four minutes to each serialized framework run.

Evidence: [3051645](https://dev.azure.com/dnceng/internal/_build/results?buildId=3051645&view=results), [3052037](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052037&view=results), [3052072](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052072&view=results), [3052117](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052117&view=results), [3052152](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052152&view=results), [3052449](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052449&view=results), [3052508](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052508&view=results), [3052512](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052512&view=results), and [3052520](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052520&view=results).

## Solution

Restore the test-specific shutdown timeout to seven seconds. This remains longer than the three-second deactivation timeout, preserves the forced-shutdown behavior and diagnostic readiness assertions, and reduces both tests to the intended bounded duration.

Validated against Azurite on `net8.0` and `net10.0`: both affected tests pass and complete in 7–8 seconds each.

Fixes #10697
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10698)