### PR TITLE
fix(tests): stabilize reminder tick condition test

### DIFF
--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using Orleans.Runtime;
 using Orleans.Testing.Reminders;
+using TestExtensions;
 using Xunit;
 using ReminderEvents = Orleans.Reminders.Diagnostics.ReminderEvents;
 
@@ -87,6 +88,7 @@ public class ReminderEventsTests
     public async Task ReminderDiagnosticObserver_WaitsForTickCondition_UntilConditionIsSatisfied()
     {
         using var observer = ReminderDiagnosticObserver.Create();
+        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var now = DateTime.UtcNow;
@@ -107,7 +109,7 @@ public class ReminderEventsTests
 
                 return Task.FromResult(currentCheck >= 3);
             },
-            CancellationToken.None,
+            cancellation.Token,
             reminderName);
 
         Assert.False(waitTask.IsCompleted);
@@ -119,7 +121,7 @@ public class ReminderEventsTests
             new TickStatus(now, period, now),
             siloAddress);
 
-        await secondConditionCheck.Task;
+        await secondConditionCheck.Task.WaitAsync(cancellation.Token);
         Assert.False(waitTask.IsCompleted);
 
         ReminderEvents.EmitTickCompleted(

--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -87,21 +87,31 @@ public class ReminderEventsTests
     public async Task ReminderDiagnosticObserver_WaitsForTickCondition_UntilConditionIsSatisfied()
     {
         using var observer = ReminderDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var now = DateTime.UtcNow;
         var period = TimeSpan.FromSeconds(5);
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14003), 4);
-        var acceptedTickCount = 0;
+        var secondConditionCheck = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var conditionCheckCount = 0;
 
         var waitTask = observer.WaitForTickConditionAsync(
             grainId,
-            _ => Task.FromResult(acceptedTickCount >= 1),
-            cts.Token,
+            _ =>
+            {
+                var currentCheck = Interlocked.Increment(ref conditionCheckCount);
+                if (currentCheck == 2)
+                {
+                    secondConditionCheck.TrySetResult();
+                }
+
+                return Task.FromResult(currentCheck >= 3);
+            },
+            CancellationToken.None,
             reminderName);
 
         Assert.False(waitTask.IsCompleted);
+        Assert.Equal(1, conditionCheckCount);
 
         ReminderEvents.EmitTickCompleted(
             grainId,
@@ -109,16 +119,17 @@ public class ReminderEventsTests
             new TickStatus(now, period, now),
             siloAddress);
 
+        await secondConditionCheck.Task;
         Assert.False(waitTask.IsCompleted);
 
-        acceptedTickCount = 1;
         ReminderEvents.EmitTickCompleted(
             grainId,
             reminderName,
             new TickStatus(now, period, now.Add(period)),
             siloAddress);
 
-        await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+        await waitTask;
+        Assert.Equal(3, conditionCheckCount);
     }
 
     [TestSuite("BVT")]


### PR DESCRIPTION
Fixes #10687.

`WaitForTickConditionAsync` records matching ticks synchronously and resumes condition evaluation through asynchronous continuations. The regression test raced those continuations against one-second cancellation and wait timers, so scheduler pressure on macOS could time out despite the expected ticks being recorded.

Use the condition invocation itself as the phase barrier. The test now confirms each tick causes the next condition evaluation before emitting the following tick, and completes when the third evaluation accepts the condition. This directly verifies the observer invariant without depending on scheduler timing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10703)