### PR TITLE
test(adonet): await SQL Server session drain

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -32,7 +32,7 @@ namespace UnitTests.General
         protected override async Task WaitForDatabaseReadyAsync()
         {
             const int maxAttempts = 3;
-            var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
+            var databaseConnectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
             {
                 Pooling = false,
                 ConnectTimeout = 5
@@ -42,19 +42,49 @@ namespace UnitTests.General
             {
                 try
                 {
-                    await using var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
+                    await using var connection = new SqlConnection(databaseConnectionStringBuilder.ConnectionString);
                     await connection.OpenAsync();
                     await using var command = connection.CreateCommand();
                     command.CommandText = "SELECT 1";
                     command.CommandTimeout = 5;
                     _ = await command.ExecuteScalarAsync();
-                    return;
                 }
                 catch (SqlException exception) when (exception.Number == 18456 && exception.State == 1 && attempt < maxAttempts)
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(250));
+                    continue;
                 }
+
+                break;
             }
+
+            // The first schema batch enables snapshot isolation and requires exclusive database access.
+            var administrativeConnectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
+            {
+                InitialCatalog = "master",
+                Pooling = false,
+                ConnectTimeout = 5
+            };
+
+            await using var administrativeConnection = new SqlConnection(administrativeConnectionStringBuilder.ConnectionString);
+            await administrativeConnection.OpenAsync();
+            await using var readinessCommand = administrativeConnection.CreateCommand();
+            readinessCommand.CommandText = """
+                DECLARE @DatabaseId INT = DB_ID(@DatabaseName);
+                WHILE EXISTS
+                (
+                    SELECT 1
+                    FROM sys.dm_exec_sessions
+                    WHERE database_id = @DatabaseId
+                      AND session_id <> @@SPID
+                )
+                BEGIN
+                    WAITFOR DELAY '00:00:00.050';
+                END;
+                """;
+            readinessCommand.CommandTimeout = 5;
+            readinessCommand.Parameters.AddWithValue("DatabaseName", databaseConnectionStringBuilder.InitialCatalog);
+            await readinessCommand.ExecuteNonQueryAsync();
         }
 
         public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -82,7 +82,7 @@ namespace UnitTests.General
                     WAITFOR DELAY '00:00:00.050';
                 END;
                 """;
-            readinessCommand.CommandTimeout = 5;
+            readinessCommand.CommandTimeout = 30;
             readinessCommand.Parameters.AddWithValue("DatabaseName", databaseConnectionStringBuilder.InitialCatalog);
             await readinessCommand.ExecuteNonQueryAsync();
         }


### PR DESCRIPTION
Fixes #10688.

The reported poisoned-message test timed out during fixture initialization, before its test body ran. Failure diagnostics show that the recreated database started successfully, then the first schema batch waited for 30 seconds while enabling `READ_COMMITTED_SNAPSHOT`. SQL Server requires exclusive database access for that transition, while the readiness probe had only established that a target-database query could complete.

Extend SQL Server readiness to establish the schema setup invariant directly: after authenticating against the recreated database, query from a non-pooled `master` connection until the target database has no active sessions. Schema initialization then begins with the exclusive access its snapshot-isolation batch requires. The readiness command allows 30 seconds for the observed exclusive-access transition while retaining 5-second connection and initial-probe timeouts, localizing future session-drain failures to the reset boundary instead of attributing them to whichever test initializes next.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10704)