### PR TITLE
test(runtime): keep one-way observers alive

### DIFF
--- a/test/Orleans.DefaultCluster.Tests/OneWayCallTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/OneWayCallTests.cs
@@ -35,7 +35,7 @@ namespace DefaultCluster.Tests.General
             var observer = new SimpleGrainObserver();
             var task = grain.Notify(this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
             Assert.True(task.Status == TaskStatus.RanToCompletion, "Task should be synchronously completed.");
-            await observer.ReceivedValue.WaitAsync(TimeSpan.FromSeconds(10));
+            await WaitForNotification(observer);
             var count = await grain.GetCount();
             Assert.Equal(1, count);
 
@@ -60,7 +60,7 @@ namespace DefaultCluster.Tests.General
             var observerReference = this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
             var completedSynchronously = await grain.NotifyOtherGrain(otherGrain, observerReference);
             Assert.True(completedSynchronously, "Task should be synchronously completed.");
-            await observer.ReceivedValue.WaitAsync(TimeSpan.FromSeconds(10));
+            await WaitForNotification(observer);
             var count = await otherGrain.GetCount();
             Assert.Equal(1, count);
         }
@@ -79,7 +79,7 @@ namespace DefaultCluster.Tests.General
             var observer = new SimpleGrainObserver();
             var task = grain.NotifyValueTask(this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
             Assert.True(task.IsCompleted, "ValueTask should be synchronously completed.");
-            await observer.ReceivedValue.WaitAsync(TimeSpan.FromSeconds(10));
+            await WaitForNotification(observer);
             var count = await grain.GetCount();
             Assert.Equal(1, count);
 
@@ -103,9 +103,17 @@ namespace DefaultCluster.Tests.General
             var observerReference = this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
             var completedSynchronously = await grain.NotifyOtherGrainValueTask(otherGrain, observerReference);
             Assert.True(completedSynchronously, "Task should be synchronously completed.");
-            await observer.ReceivedValue.WaitAsync(TimeSpan.FromSeconds(10));
+            await WaitForNotification(observer);
             var count = await otherGrain.GetCount();
             Assert.Equal(1, count);
+        }
+
+        private static async Task WaitForNotification(SimpleGrainObserver observer)
+        {
+            await observer.ReceivedValue.WaitAsync(TimeSpan.FromSeconds(10));
+
+            // Client observer registrations are weak, so keep the target rooted until the callback completes.
+            GC.KeepAlive(observer);
         }
 
         private class SimpleGrainObserver : ISimpleGrainObserver


### PR DESCRIPTION
Fixes #10694

Client observer registrations retain observer targets weakly. These tests awaited a task owned by the observer without keeping the observer itself strongly reachable, so garbage collection could remove the callback target before the one-way call arrived.

Keep each observer rooted through callback completion while preserving the synchronous-return and execution assertions for Task and ValueTask calls from clients and grains.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10707)