### PR TITLE
test(reminders): restore joined silos

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -187,31 +187,7 @@ namespace Tester.AzureUtils.TimerTests
         [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_2J_MultiGrainMultiReminders()
         {
-            IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            IReminderTestGrain2 g3 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
-
-            await Test_Reminders_MultiGrainMultiReminders(
-                async cancellationToken =>
-                {
-                    await using (await PauseReminderTimeAsync(cancellationToken))
-                    {
-                        log.LogInformation("Starting 2 extra silos");
-                        await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
-                            2,
-                            cancellationToken,
-                            startAdditionalSiloOnNewPort: true);
-                    }
-                },
-                cts.Token,
-                g1,
-                g2,
-                g3,
-                g4,
-                g5);
+            await Test_Reminders_2J_MultiGrainMultiReminders();
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -150,31 +150,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [SkippableFact, TestCategory("Functional")]
     public async Task Rem_Azure_2J_MultiGrainMultiReminders()
     {
-        IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        IReminderTestGrain2 g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        IReminderTestGrain2 g3 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        IReminderTestGrain2 g4 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        IReminderTestGrain2 g5 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
-
-        await Test_Reminders_MultiGrainMultiReminders(
-            async cancellationToken =>
-            {
-                await using (await PauseReminderTimeAsync(cancellationToken))
-                {
-                    log.LogInformation("Starting 2 extra silos");
-                    await StartAdditionalSilosAndWaitForReminderServicesAsync(
-                        2,
-                        cancellationToken,
-                        startAdditionalSiloOnNewPort: true);
-                }
-            },
-            cts.Token,
-            g1,
-            g2,
-            g3,
-            g4,
-            g5);
+        await Test_Reminders_2J_MultiGrainMultiReminders();
     }
 
     [TestSuite("Functional")]

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -232,10 +232,10 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             if (startSilosTask is not null)
             {
-                using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
                 try
                 {
-                    await startSilosTask.WaitAsync(cleanupCts.Token);
+                    using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
+                    await startSilosTask.WaitAsync(startupCompletionCts.Token);
                 }
                 catch (Exception exception)
                 {
@@ -247,6 +247,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                     .ToArray();
                 if (additionalSilos.Length > 0)
                 {
+                    using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
                     await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
                     await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
                 }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -199,6 +199,61 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
     }
 
+    public async Task Test_Reminders_2J_MultiGrainMultiReminders()
+    {
+        IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        IReminderTestGrain2 g3 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
+        using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
+        Task<List<InProcessSiloHandle>>? startSilosTask = null;
+        try
+        {
+            await Test_Reminders_MultiGrainMultiReminders(
+                async cancellationToken =>
+                {
+                    await using (await PauseReminderTimeAsync(cancellationToken))
+                    {
+                        log.LogInformation("Starting 2 extra silos");
+                        startSilosTask = StartAdditionalSilosAsync(2, startAdditionalSiloOnNewPort: true);
+                        await WaitForAdditionalSilosAndReminderServicesAsync(startSilosTask, cancellationToken);
+                    }
+                },
+                cts.Token,
+                g1,
+                g2,
+                g3,
+                g4,
+                g5);
+        }
+        finally
+        {
+            if (startSilosTask is not null)
+            {
+                using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
+                try
+                {
+                    await startSilosTask.WaitAsync(cleanupCts.Token);
+                }
+                catch (Exception exception)
+                {
+                    log.LogInformation(exception, "Additional silo startup did not complete successfully before cleanup.");
+                }
+
+                var additionalSilos = HostedCluster.GetActiveSilos()
+                    .Where(silo => !initialSilos.Contains(silo))
+                    .ToArray();
+                if (additionalSilos.Length > 0)
+                {
+                    await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
+                    await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
+                }
+            }
+        }
+    }
+
     public async Task Test_Reminders_ReminderNotFound()
     {
         IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -253,7 +308,15 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         CancellationToken cancellationToken,
         bool startAdditionalSiloOnNewPort = false)
     {
-        var result = await StartAdditionalSilosAsync(silosToStart, startAdditionalSiloOnNewPort).WaitAsync(cancellationToken);
+        var startSilosTask = StartAdditionalSilosAsync(silosToStart, startAdditionalSiloOnNewPort);
+        return await WaitForAdditionalSilosAndReminderServicesAsync(startSilosTask, cancellationToken);
+    }
+
+    private async Task<List<InProcessSiloHandle>> WaitForAdditionalSilosAndReminderServicesAsync(
+        Task<List<InProcessSiloHandle>> startSilosTask,
+        CancellationToken cancellationToken)
+    {
+        var result = await startSilosTask.WaitAsync(cancellationToken);
         var reminderServicesStarted = result.Select(silo =>
             observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress));
         await Task.WhenAll(


### PR DESCRIPTION
## Problem

The Azure two-join reminder test left both joined silos active in its shared class fixture. Later restart tests therefore began with four silos, expanded to six, and could time out while refreshing every active reminder service.

## Solution

Move the two-join scenario into a shared cleanup-aware helper. It records the baseline topology, waits for any partial startup to settle, and stops every added silo in `finally`. Azure Table and Cosmos reminder suites now use the same helper.

## Rationale

Topology-mutating reminder tests now return the shared fixture to its baseline without relaxing reminder ownership, refresh, or restart assertions.

Fixes #10706
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10709)