### PR TITLE
docs(reminders): document DynamoDB configuration

### DIFF
--- a/docs/site/src/content/docs/grains/dynamodb-reminders.md
+++ b/docs/site/src/content/docs/grains/dynamodb-reminders.md
@@ -1,0 +1,28 @@
+---
+title: Configure Amazon DynamoDB reminders
+description: Configure durable Orleans reminder storage with Amazon DynamoDB.
+ms.date: 08/20/2026
+ms.topic: how-to
+---
+
+# Configure Amazon DynamoDB reminders
+
+Install the [`Microsoft.Orleans.Reminders.DynamoDB`](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.DynamoDB) package and call <xref:Orleans.Hosting.DynamoDBSiloBuilderReminderExtensions.UseDynamoDBReminderService*> on every silo.
+
+A silo which uses DynamoDB for both membership and reminders configures the providers independently:
+
+:::code language="csharp" source="../snippets/compiled/Grains/DynamoDBReminderSnippets.cs" id="configure_dynamodb_reminders":::
+
+<xref:Orleans.Configuration.DynamoDBClusteringOptions> and <xref:Orleans.Configuration.DynamoDBReminderStorageOptions> are separate typed options. Set the AWS region through each options instance, as shown above. A silo which uses another membership provider configures that provider alongside <xref:Orleans.Hosting.DynamoDBSiloBuilderReminderExtensions.UseDynamoDBReminderService*>.
+
+<xref:Orleans.Configuration.ClusterOptions.ServiceId> identifies the application's reminder records and must remain stable across deployments that share a reminder table. Use distinct table names for cluster membership and reminders because each provider manages a different schema.
+
+## Configure AWS credentials
+
+When <xref:Orleans.Reminders.DynamoDB.DynamoDBClientOptions.AccessKey> and <xref:Orleans.Reminders.DynamoDB.DynamoDBClientOptions.SecretKey> remain unset, the [AWS SDK for .NET credential and profile resolution chain](https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/creds-assign.html) supplies credentials. In production, prefer workload credentials such as an IAM role over long-lived keys. <xref:Orleans.Reminders.DynamoDB.DynamoDBClientOptions.ProfileName>, <xref:Orleans.Reminders.DynamoDB.DynamoDBClientOptions.AccessKey>, <xref:Orleans.Reminders.DynamoDB.DynamoDBClientOptions.SecretKey>, and <xref:Orleans.Reminders.DynamoDB.DynamoDBClientOptions.Token> support deployment environments which require explicit SDK configuration.
+
+## Configure table capacity and lifecycle
+
+The example uses on-demand capacity and an infrastructure-managed table. Set <xref:Orleans.Configuration.DynamoDBReminderStorageOptions.UseProvisionedThroughput> to `true` and configure <xref:Orleans.Configuration.DynamoDBReminderStorageOptions.ReadCapacityUnits> and <xref:Orleans.Configuration.DynamoDBReminderStorageOptions.WriteCapacityUnits> for provisioned capacity.
+
+<xref:Orleans.Configuration.DynamoDBReminderStorageOptions.CreateIfNotExists> and <xref:Orleans.Configuration.DynamoDBReminderStorageOptions.UpdateIfExists> allow the provider to create the reminder table and update its provisioned capacity. Infrastructure-managed provisioning keeps table lifecycle and capacity changes in the deployment workflow.

--- a/docs/site/src/content/docs/grains/reminders/dynamodb.md
+++ b/docs/site/src/content/docs/grains/reminders/dynamodb.md
@@ -11,7 +11,7 @@ Install the [`Microsoft.Orleans.Reminders.DynamoDB`](https://www.nuget.org/packa
 
 A silo which uses DynamoDB for both membership and reminders configures the providers independently:
 
-:::code language="csharp" source="../snippets/compiled/Grains/DynamoDBReminderSnippets.cs" id="configure_dynamodb_reminders":::
+:::code language="csharp" source="../../snippets/compiled/Grains/DynamoDBReminderSnippets.cs" id="configure_dynamodb_reminders":::
 
 <xref:Orleans.Configuration.DynamoDBClusteringOptions> and <xref:Orleans.Configuration.DynamoDBReminderStorageOptions> are separate typed options. Set the AWS region through each options instance, as shown above. A silo which uses another membership provider configures that provider alongside <xref:Orleans.Hosting.DynamoDBSiloBuilderReminderExtensions.UseDynamoDBReminderService*>.
 

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -1,7 +1,7 @@
 ---
 title: Grain timers and reminders
 description: Schedule activation-scoped and durable periodic work in Orleans.
-ms.date: 08/13/2026
+ms.date: 08/20/2026
 ms.topic: concept-article
 ---
 
@@ -72,7 +72,7 @@ There is no special `period` value that means "fire once and never again." To mo
 
 Every silo must configure a reminder provider. Production deployments should use a durable provider such as Azure Table, ADO.NET, Redis, or [Cosmos DB](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Cosmos). In-memory reminders are suitable only for local development and tests because definitions are lost when the cluster stops.
 
-The provider-specific configuration is covered by each reminder provider package. For a compiled in-repository configuration example, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
+Configure each provider through the API supplied by its package. See [Configure Amazon DynamoDB reminders](dynamodb-reminders.md) for a compiled example which configures DynamoDB clustering and reminder storage independently. For other compiled in-repository examples, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
 
 ## POCO grains
 

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -72,7 +72,7 @@ There is no special `period` value that means "fire once and never again." To mo
 
 Every silo must configure a reminder provider. Production deployments should use a durable provider such as Azure Table, ADO.NET, Redis, or [Cosmos DB](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Cosmos). In-memory reminders are suitable only for local development and tests because definitions are lost when the cluster stops.
 
-Configure each provider through the API supplied by its package. See [Configure Amazon DynamoDB reminders](dynamodb-reminders.md) for a compiled example which configures DynamoDB clustering and reminder storage independently. For other compiled in-repository examples, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
+Configure each provider through the API supplied by its package. See [Configure Amazon DynamoDB reminders](reminders/dynamodb.md) for a compiled example which configures DynamoDB clustering and reminder storage independently. For other compiled in-repository examples, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
 
 ## POCO grains
 

--- a/docs/site/src/content/docs/how-to/index.md
+++ b/docs/site/src/content/docs/how-to/index.md
@@ -37,7 +37,7 @@ If you are learning Orleans from an empty directory, start with the [tutorials a
 
 - [Persist grain state](../grains/grain-persistence/index.md)
 - [Add reminders and timers](../grains/timers-and-reminders.md)
-- [Configure Amazon DynamoDB reminders](../grains/dynamodb-reminders.md)
+- [Configure Amazon DynamoDB reminders](../grains/reminders/dynamodb.md)
 - [Configure streams](../streaming/stream-providers.md)
 - [Use response streaming](../grains/response-streaming.md)
 - [Use stateless worker grains](../grains/stateless-worker-grains.md)

--- a/docs/site/src/content/docs/how-to/index.md
+++ b/docs/site/src/content/docs/how-to/index.md
@@ -37,6 +37,7 @@ If you are learning Orleans from an empty directory, start with the [tutorials a
 
 - [Persist grain state](../grains/grain-persistence/index.md)
 - [Add reminders and timers](../grains/timers-and-reminders.md)
+- [Configure Amazon DynamoDB reminders](../grains/dynamodb-reminders.md)
 - [Configure streams](../streaming/stream-providers.md)
 - [Use response streaming](../grains/response-streaming.md)
 - [Use stateless worker grains](../grains/stateless-worker-grains.md)

--- a/docs/site/src/content/docs/snippets/compiled/CompiledDocumentationSnippets.csproj
+++ b/docs/site/src/content/docs/snippets/compiled/CompiledDocumentationSnippets.csproj
@@ -12,7 +12,9 @@
     <ProjectReference Include="$(RepositoryRoot)src\Dashboard\Orleans.Dashboard\Orleans.Dashboard.csproj" />
     <ProjectReference Include="$(RepositoryRoot)src\AdoNet\Orleans.Clustering.AdoNet\Orleans.Clustering.AdoNet.csproj" />
     <ProjectReference Include="$(RepositoryRoot)src\AdoNet\Orleans.Persistence.AdoNet\Orleans.Persistence.AdoNet.csproj" />
+    <ProjectReference Include="$(RepositoryRoot)src\AWS\Orleans.Clustering.DynamoDB\Orleans.Clustering.DynamoDB.csproj" />
     <ProjectReference Include="$(RepositoryRoot)src\AWS\Orleans.Persistence.DynamoDB\Orleans.Persistence.DynamoDB.csproj" />
+    <ProjectReference Include="$(RepositoryRoot)src\AWS\Orleans.Reminders.DynamoDB\Orleans.Reminders.DynamoDB.csproj" />
     <ProjectReference Include="$(RepositoryRoot)src\Azure\Orleans.Clustering.Cosmos\Orleans.Clustering.Cosmos.csproj" />
     <ProjectReference Include="$(RepositoryRoot)src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
     <ProjectReference Include="$(RepositoryRoot)src\Azure\Orleans.Persistence.Cosmos\Orleans.Persistence.Cosmos.csproj" />

--- a/docs/site/src/content/docs/snippets/compiled/Grains/DynamoDBReminderSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Grains/DynamoDBReminderSnippets.cs
@@ -28,6 +28,7 @@ internal static class DynamoDBReminderConfiguration
                 options.TableName = "OrleansReminders";
                 options.UseProvisionedThroughput = false;
                 options.CreateIfNotExists = false;
+                options.UpdateIfExists = false;
             });
         // </configure_dynamodb_reminders>
     }

--- a/docs/site/src/content/docs/snippets/compiled/Grains/DynamoDBReminderSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Grains/DynamoDBReminderSnippets.cs
@@ -1,0 +1,34 @@
+using Orleans.Configuration;
+using Orleans.Hosting;
+
+namespace Documentation.Grains.Reminders.DynamoDB;
+
+internal static class DynamoDBReminderConfiguration
+{
+    internal static void Configure(ISiloBuilder siloBuilder)
+    {
+        const string region = "us-west-2";
+
+        // <configure_dynamodb_reminders>
+        siloBuilder
+            .Configure<ClusterOptions>(options =>
+            {
+                options.ClusterId = "production";
+                options.ServiceId = "my-application";
+            })
+            .UseDynamoDBClustering(options =>
+            {
+                options.Service = region;
+                options.TableName = "OrleansCluster";
+                options.UseProvisionedThroughput = false;
+            })
+            .UseDynamoDBReminderService(options =>
+            {
+                options.Service = region;
+                options.TableName = "OrleansReminders";
+                options.UseProvisionedThroughput = false;
+                options.CreateIfNotExists = false;
+            });
+        // </configure_dynamodb_reminders>
+    }
+}

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -36,6 +36,8 @@ items:
         href: grains/stateless-worker-grains.md
       - name: Timers and reminders
         href: grains/timers-and-reminders.md
+      - name: Configure DynamoDB reminders
+        href: grains/dynamodb-reminders.md
       - name: Observers
         href: grains/observers.md
       - name: Cancellation

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -36,8 +36,9 @@ items:
         href: grains/stateless-worker-grains.md
       - name: Timers and reminders
         href: grains/timers-and-reminders.md
-      - name: Configure DynamoDB reminders
-        href: grains/dynamodb-reminders.md
+        items:
+          - name: Amazon DynamoDB
+            href: grains/reminders/dynamodb.md
       - name: Observers
         href: grains/observers.md
       - name: Cancellation

--- a/src/AWS/Orleans.Reminders.DynamoDB/README.md
+++ b/src/AWS/Orleans.Reminders.DynamoDB/README.md
@@ -25,9 +25,7 @@ var builder = Host.CreateApplicationBuilder(args)
             // Configure DynamoDB as reminder storage
             .UseDynamoDBReminderService(options =>
             {
-                options.AccessKey = "YOUR_AWS_ACCESS_KEY";
-                options.SecretKey = "YOUR_AWS_SECRET_KEY";
-                options.Region = "us-east-1";
+                options.Service = "us-east-1";
                 options.TableName = "OrleansReminders";
                 options.CreateIfNotExists = true;
             });
@@ -101,7 +99,8 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
-- [Reminders and Timers](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
+- [Configure Amazon DynamoDB reminders](https://dotnet.github.io/orleans/docs/grains/dynamodb-reminders/)
+- [Grain timers and reminders](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
 - [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/index.html)
 
 ## Feedback & Contributing

--- a/src/AWS/Orleans.Reminders.DynamoDB/README.md
+++ b/src/AWS/Orleans.Reminders.DynamoDB/README.md
@@ -27,7 +27,9 @@ var builder = Host.CreateApplicationBuilder(args)
             {
                 options.Service = "us-east-1";
                 options.TableName = "OrleansReminders";
-                options.CreateIfNotExists = true;
+                options.UseProvisionedThroughput = false;
+                options.CreateIfNotExists = false;
+                options.UpdateIfExists = false;
             });
     });
 
@@ -46,6 +48,8 @@ Console.WriteLine("Reminder started!");
 // Keep the host running until the application is shut down
 await host.WaitForShutdownAsync();
 ```
+
+`UseDynamoDBReminderService` configures reminder storage independently from the cluster membership provider. The AWS SDK credential and profile resolution chain supplies credentials when the reminder options omit explicit keys. This example uses on-demand capacity and an infrastructure-managed table.
 
 ## Example - Using Reminders in a Grain
 ```csharp
@@ -99,7 +103,7 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
-- [Configure Amazon DynamoDB reminders](https://dotnet.github.io/orleans/docs/grains/dynamodb-reminders/)
+- [Configure Amazon DynamoDB reminders](https://dotnet.github.io/orleans/docs/grains/reminders/dynamodb/)
 - [Grain timers and reminders](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
 - [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/index.html)
 


### PR DESCRIPTION
## Problem

The DynamoDB reminder documentation did not clearly show the current typed-options configuration path or explain that clustering and reminder storage use separate provider options.

## Solution

- add a focused DynamoDB reminder configuration guide
- include a compiled example configuring clustering and reminders independently
- document credential resolution, stable service identity, table separation, capacity, and lifecycle settings
- correct the DynamoDB reminder package README to use the current `Service` option

Closes #4656
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10711)