### PR TITLE
feat(durable-jobs): support successful rescheduling

### DIFF
--- a/src/Orleans.DurableJobs/DurableJob.cs
+++ b/src/Orleans.DurableJobs/DurableJob.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Orleans.Runtime;
 
 namespace Orleans.DurableJobs;
@@ -60,4 +61,22 @@ public sealed class DurableJob
     /// </summary>
     [Id(7)]
     public string? TraceState { get; init; }
+
+    [Id(8)]
+    [JsonInclude]
+    internal long ExecutionGeneration { get; init; }
+
+    internal DurableJob WithExecutionGeneration(long executionGeneration) =>
+        new()
+        {
+            Id = Id,
+            Name = Name,
+            DueTime = DueTime,
+            TargetGrainId = TargetGrainId,
+            ShardId = ShardId,
+            Metadata = Metadata,
+            TraceParent = TraceParent,
+            TraceState = TraceState,
+            ExecutionGeneration = executionGeneration
+        };
 }

--- a/src/Orleans.DurableJobs/DurableJobRunResult.cs
+++ b/src/Orleans.DurableJobs/DurableJobRunResult.cs
@@ -22,13 +22,6 @@ public sealed class DurableJobRunResult
     public bool IsInProgress => Status == DurableJobRunStatus.InProgress;
 
     /// <summary>
-    /// Gets a value indicating whether the job execution remains in progress and should be polled after a delay.
-    /// </summary>
-    [Obsolete($"Use {nameof(IsInProgress)} instead.")]
-    [MemberNotNullWhen(true, nameof(PollAfterDelay))]
-    public bool IsPending => IsInProgress;
-
-    /// <summary>
     /// Gets a value indicating whether the successfully handled job requested durable rescheduling.
     /// </summary>
     [MemberNotNullWhen(true, nameof(RescheduleTime))]
@@ -94,14 +87,6 @@ public sealed class DurableJobRunResult
     }
 
     /// <summary>
-    /// Creates a result indicating the job execution remains in progress and should be polled after the specified delay.
-    /// </summary>
-    /// <param name="delay">The time to wait before polling the run again.</param>
-    /// <returns>An in-progress job result.</returns>
-    [Obsolete($"Use {nameof(InProgress)} instead.")]
-    public static DurableJobRunResult PollAfter(TimeSpan delay) => InProgress(delay);
-
-    /// <summary>
     /// Creates a result indicating that the current execution completed successfully and requested durable rescheduling.
     /// </summary>
     /// <param name="dueTime">The time at which the next execution should become due.</param>
@@ -146,12 +131,6 @@ public enum DurableJobRunStatus
     /// The job execution remains in progress and should be polled again after the specified delay.
     /// </summary>
     InProgress = 1,
-
-    /// <summary>
-    /// The job execution remains in progress and should be polled again after the specified delay.
-    /// </summary>
-    [Obsolete($"Use {nameof(InProgress)} instead.")]
-    PollAfter = InProgress,
 
     /// <summary>
     /// The job failed and should be processed through the retry policy.

--- a/src/Orleans.DurableJobs/DurableJobRunResult.cs
+++ b/src/Orleans.DurableJobs/DurableJobRunResult.cs
@@ -16,17 +16,17 @@ public sealed class DurableJobRunResult
     public bool IsFailed => Status == DurableJobRunStatus.Failed;
 
     /// <summary>
-    /// Gets a value indicating whether the job is still running and should be polled after a delay.
+    /// Gets a value indicating whether the job execution remains in progress and should be polled after a delay.
     /// </summary>
     [MemberNotNullWhen(true, nameof(PollAfterDelay))]
-    public bool IsRunning => Status == DurableJobRunStatus.Running;
+    public bool IsInProgress => Status == DurableJobRunStatus.InProgress;
 
     /// <summary>
-    /// Gets a value indicating whether the job is still running and should be polled after a delay.
+    /// Gets a value indicating whether the job execution remains in progress and should be polled after a delay.
     /// </summary>
-    [Obsolete($"Use {nameof(IsRunning)} instead.")]
+    [Obsolete($"Use {nameof(IsInProgress)} instead.")]
     [MemberNotNullWhen(true, nameof(PollAfterDelay))]
-    public bool IsPending => IsRunning;
+    public bool IsPending => IsInProgress;
 
     /// <summary>
     /// Gets a value indicating whether the successfully handled job requested durable rescheduling.
@@ -53,7 +53,7 @@ public sealed class DurableJobRunResult
     public DurableJobRunStatus Status { get; }
 
     /// <summary>
-    /// Gets the delay before the executor polls the ongoing run when <see cref="Status"/> is <see cref="DurableJobRunStatus.Running"/>.
+    /// Gets the delay before the executor polls the ongoing run when <see cref="Status"/> is <see cref="DurableJobRunStatus.InProgress"/>.
     /// </summary>
     [Id(1)]
     public TimeSpan? PollAfterDelay { get; }
@@ -78,28 +78,28 @@ public sealed class DurableJobRunResult
     public static DurableJobRunResult Completed => CompletedInstance;
 
     /// <summary>
-    /// Creates a result indicating the job is still running and should be polled after the specified delay.
+    /// Creates a result indicating the job execution remains in progress and should be polled after the specified delay.
     /// </summary>
     /// <param name="delay">The time to wait before polling the run again.</param>
-    /// <returns>A running job result.</returns>
+    /// <returns>An in-progress job result.</returns>
     /// <remarks>
     /// The executor keeps the current run and its concurrency slot active, then polls the receiver again after the delay.
     /// TODO: Add validation for minimum/maximum poll delays to prevent abuse.
     /// TODO: Consider concurrency slot management for long-running polls.
     /// </remarks>
-    public static DurableJobRunResult Running(TimeSpan delay)
+    public static DurableJobRunResult InProgress(TimeSpan delay)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(delay, TimeSpan.Zero, nameof(delay));
-        return new(DurableJobRunStatus.Running, delay, null, null);
+        return new(DurableJobRunStatus.InProgress, delay, null, null);
     }
 
     /// <summary>
-    /// Creates a result indicating the job is still running and should be polled after the specified delay.
+    /// Creates a result indicating the job execution remains in progress and should be polled after the specified delay.
     /// </summary>
     /// <param name="delay">The time to wait before polling the run again.</param>
-    /// <returns>A running job result.</returns>
-    [Obsolete($"Use {nameof(Running)} instead.")]
-    public static DurableJobRunResult PollAfter(TimeSpan delay) => Running(delay);
+    /// <returns>An in-progress job result.</returns>
+    [Obsolete($"Use {nameof(InProgress)} instead.")]
+    public static DurableJobRunResult PollAfter(TimeSpan delay) => InProgress(delay);
 
     /// <summary>
     /// Creates a result indicating that the current execution completed successfully and requested durable rescheduling.
@@ -143,15 +143,15 @@ public enum DurableJobRunStatus
     Completed = 0,
 
     /// <summary>
-    /// The job is still running and should be polled again after the specified delay.
+    /// The job execution remains in progress and should be polled again after the specified delay.
     /// </summary>
-    Running = 1,
+    InProgress = 1,
 
     /// <summary>
-    /// The job is still running and should be polled again after the specified delay.
+    /// The job execution remains in progress and should be polled again after the specified delay.
     /// </summary>
-    [Obsolete($"Use {nameof(Running)} instead.")]
-    PollAfter = Running,
+    [Obsolete($"Use {nameof(InProgress)} instead.")]
+    PollAfter = InProgress,
 
     /// <summary>
     /// The job failed and should be processed through the retry policy.

--- a/src/Orleans.DurableJobs/DurableJobRunResult.cs
+++ b/src/Orleans.DurableJobs/DurableJobRunResult.cs
@@ -16,16 +16,27 @@ public sealed class DurableJobRunResult
     public bool IsFailed => Status == DurableJobRunStatus.Failed;
 
     /// <summary>
-    /// Gets a value indicating whether the job should be polled again after a delay.
+    /// Gets a value indicating whether the job is still running and should be polled after a delay.
     /// </summary>
     [MemberNotNullWhen(true, nameof(PollAfterDelay))]
-    public bool IsPending => Status == DurableJobRunStatus.PollAfter;
+    public bool IsRunning => Status == DurableJobRunStatus.Running;
 
-    private DurableJobRunResult(DurableJobRunStatus status, TimeSpan? pollAfter, Exception? exception)
+    /// <summary>
+    /// Gets a value indicating whether the successfully handled job requested durable rescheduling.
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(RescheduleTime))]
+    public bool IsRescheduleRequested => Status == DurableJobRunStatus.RescheduleRequested && RescheduleTime is not null;
+
+    private DurableJobRunResult(
+        DurableJobRunStatus status,
+        TimeSpan? pollAfterDelay,
+        Exception? exception,
+        DateTimeOffset? rescheduleTime)
     {
         Status = status;
-        PollAfterDelay = pollAfter;
+        PollAfterDelay = pollAfterDelay;
         Exception = exception;
+        RescheduleTime = rescheduleTime;
     }
 
     /// <summary>
@@ -35,7 +46,7 @@ public sealed class DurableJobRunResult
     public DurableJobRunStatus Status { get; }
 
     /// <summary>
-    /// Gets the delay before the next status check when <see cref="Status"/> is <see cref="DurableJobRunStatus.PollAfter"/>.
+    /// Gets the delay before the executor polls the ongoing run when <see cref="Status"/> is <see cref="DurableJobRunStatus.Running"/>.
     /// </summary>
     [Id(1)]
     public TimeSpan? PollAfterDelay { get; }
@@ -46,7 +57,13 @@ public sealed class DurableJobRunResult
     [Id(2)]
     public Exception? Exception { get; }
 
-    private static readonly DurableJobRunResult CompletedInstance = new(DurableJobRunStatus.Completed, null, null);
+    /// <summary>
+    /// Gets the time at which the job should be durably rescheduled after the current execution completes successfully.
+    /// </summary>
+    [Id(3)]
+    public DateTimeOffset? RescheduleTime { get; }
+
+    private static readonly DurableJobRunResult CompletedInstance = new(DurableJobRunStatus.Completed, null, null, null);
 
     /// <summary>
     /// Gets a result indicating the job completed successfully.
@@ -54,20 +71,35 @@ public sealed class DurableJobRunResult
     public static DurableJobRunResult Completed => CompletedInstance;
 
     /// <summary>
-    /// Creates a result indicating the job should be polled again after the specified delay.
+    /// Creates a result indicating the job is still running and should be polled after the specified delay.
     /// </summary>
-    /// <param name="delay">The time to wait before checking the job status again.</param>
-    /// <returns>A poll-after job result.</returns>
+    /// <param name="delay">The time to wait before polling the run again.</param>
+    /// <returns>A running job result.</returns>
     /// <remarks>
-    /// The job will remain in an inline polling loop without being re-queued.
-    /// The polling loop will hold a concurrency slot until the job completes or fails.
+    /// The executor keeps the current run and its concurrency slot active, then polls the receiver again after the delay.
     /// TODO: Add validation for minimum/maximum poll delays to prevent abuse.
     /// TODO: Consider concurrency slot management for long-running polls.
     /// </remarks>
-    public static DurableJobRunResult PollAfter(TimeSpan delay)
+    public static DurableJobRunResult Running(TimeSpan delay)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(delay, TimeSpan.Zero, nameof(delay));
-        return new(DurableJobRunStatus.PollAfter, delay, null);
+        return new(DurableJobRunStatus.Running, delay, null, null);
+    }
+
+    /// <summary>
+    /// Creates a result indicating that the current execution completed successfully and requested durable rescheduling.
+    /// </summary>
+    /// <param name="dueTime">The time at which the next execution should become due.</param>
+    /// <returns>A durable rescheduling result.</returns>
+    /// <remarks>
+    /// Rescheduling resets the failure-attempt count, so the next dequeue count is one.
+    /// During a mixed-version rolling upgrade, callers emit this result after every durable job executor
+    /// understands <see cref="DurableJobRunStatus.RescheduleRequested"/> (serialized value 3).
+    /// This rollout order preserves compatibility with executors that understand serialized values 0 through 2.
+    /// </remarks>
+    public static DurableJobRunResult RescheduleAt(DateTimeOffset dueTime)
+    {
+        return new(DurableJobRunStatus.RescheduleRequested, null, null, dueTime);
     }
 
     /// <summary>
@@ -81,7 +113,7 @@ public sealed class DurableJobRunResult
     public static DurableJobRunResult Failed(Exception exception)
     {
         ArgumentNullException.ThrowIfNull(exception);
-        return new(DurableJobRunStatus.Failed, null, exception);
+        return new(DurableJobRunStatus.Failed, null, exception, null);
     }
 }
 
@@ -93,15 +125,24 @@ public enum DurableJobRunStatus
     /// <summary>
     /// The job completed successfully and should be removed from the queue.
     /// </summary>
-    Completed,
+    Completed = 0,
 
     /// <summary>
     /// The job is still running and should be polled again after the specified delay.
     /// </summary>
-    PollAfter,
+    Running = 1,
 
     /// <summary>
     /// The job failed and should be processed through the retry policy.
     /// </summary>
-    Failed
+    Failed = 2,
+
+    /// <summary>
+    /// The current execution completed successfully and requested durable rescheduling with its failure-attempt count reset.
+    /// </summary>
+    /// <remarks>
+    /// This value is serialized as 3. During rolling upgrades, emit it after all durable job executors support it.
+    /// Newer executors treat unknown disposition values as failures and route them through the configured retry policy.
+    /// </remarks>
+    RescheduleRequested = 3
 }

--- a/src/Orleans.DurableJobs/DurableJobRunResult.cs
+++ b/src/Orleans.DurableJobs/DurableJobRunResult.cs
@@ -22,6 +22,13 @@ public sealed class DurableJobRunResult
     public bool IsRunning => Status == DurableJobRunStatus.Running;
 
     /// <summary>
+    /// Gets a value indicating whether the job is still running and should be polled after a delay.
+    /// </summary>
+    [Obsolete($"Use {nameof(IsRunning)} instead.")]
+    [MemberNotNullWhen(true, nameof(PollAfterDelay))]
+    public bool IsPending => IsRunning;
+
+    /// <summary>
     /// Gets a value indicating whether the successfully handled job requested durable rescheduling.
     /// </summary>
     [MemberNotNullWhen(true, nameof(RescheduleTime))]
@@ -87,6 +94,14 @@ public sealed class DurableJobRunResult
     }
 
     /// <summary>
+    /// Creates a result indicating the job is still running and should be polled after the specified delay.
+    /// </summary>
+    /// <param name="delay">The time to wait before polling the run again.</param>
+    /// <returns>A running job result.</returns>
+    [Obsolete($"Use {nameof(Running)} instead.")]
+    public static DurableJobRunResult PollAfter(TimeSpan delay) => Running(delay);
+
+    /// <summary>
     /// Creates a result indicating that the current execution completed successfully and requested durable rescheduling.
     /// </summary>
     /// <param name="dueTime">The time at which the next execution should become due.</param>
@@ -131,6 +146,12 @@ public enum DurableJobRunStatus
     /// The job is still running and should be polled again after the specified delay.
     /// </summary>
     Running = 1,
+
+    /// <summary>
+    /// The job is still running and should be polled again after the specified delay.
+    /// </summary>
+    [Obsolete($"Use {nameof(Running)} instead.")]
+    PollAfter = Running,
 
     /// <summary>
     /// The job failed and should be processed through the retry policy.

--- a/src/Orleans.DurableJobs/DurableJobsInstruments.cs
+++ b/src/Orleans.DurableJobs/DurableJobsInstruments.cs
@@ -15,6 +15,7 @@ internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
     private const string StatusCompleted = "completed";
     private const string StatusFailed = "failed";
     private const string StatusRetried = "retried";
+    private const string StatusRescheduled = "rescheduled";
     private const string StatusCanceled = "canceled";
     private const string StatusError = "error";
     private const string StatusOk = "ok";
@@ -34,6 +35,7 @@ internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
     private readonly Counter<long> JobsCompleted = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-completed");
     private readonly Counter<long> JobsFailed = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-failed");
     private readonly Counter<long> JobsRetried = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-retried");
+    private readonly Counter<long> JobsRescheduled = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-rescheduled");
     private readonly Counter<long> JobsCanceled = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-canceled");
     private readonly Counter<long> ShardsProcessed = instruments.Meter.CreateCounter<long>("orleans-durablejobs-shards-processed");
     private readonly Counter<long> ScheduleJobCalls = instruments.Meter.CreateCounter<long>("orleans-durablejobs-schedule-job-calls");
@@ -84,6 +86,12 @@ internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
     {
         JobsRetried.Add(1);
         Record(JobAttemptDuration, latency, StatusRetried);
+    }
+
+    internal void OnJobRescheduled(TimeSpan latency)
+    {
+        JobsRescheduled.Add(1);
+        Record(JobAttemptDuration, latency, StatusRescheduled);
     }
 
     internal void OnJobCanceled()

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -11,9 +11,9 @@ namespace Orleans.DurableJobs;
 internal interface IDurableJobReceiverExtension : IGrainExtension
 {
     /// <summary>
-    /// Handles a durable job by either starting execution or checking the status of an already running job.
+    /// Handles a durable job by either starting execution or checking the status of an execution which remains in progress.
     /// If the job attempt identified by <see cref="IJobRunContext.Job"/> and <see cref="IJobRunContext.DequeueCount"/> has not been started, it will be executed.
-    /// If it is already running, the current status is returned.
+    /// If it remains in progress, the current status is returned.
     /// </summary>
     /// <param name="context">The context containing information about the durable job.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
@@ -112,7 +112,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
                 return LongPollGetJobStatusAsync(key, context, state);
             }
 
-            return new(DurableJobRunResult.Running(_shared.Options.JobStatusPollInterval));
+            return new(DurableJobRunResult.InProgress(_shared.Options.JobStatusPollInterval));
         }
 
         RecordCompletedJobAttempt(key, state);
@@ -144,7 +144,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
                 if (!state.Task.IsCompleted)
                 {
-                    return DurableJobRunResult.Running(_shared.Options.JobStatusPollInterval);
+                    return DurableJobRunResult.InProgress(_shared.Options.JobStatusPollInterval);
                 }
             }
 

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -108,7 +108,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
                 return LongPollGetJobStatusAsync(key, context, state);
             }
 
-            return new(DurableJobRunResult.PollAfter(_shared.Options.JobStatusPollInterval));
+            return new(DurableJobRunResult.Running(_shared.Options.JobStatusPollInterval));
         }
 
         RecordCompletedJobAttempt(key, state);
@@ -137,7 +137,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
                 if (!state.Task.IsCompleted)
                 {
-                    return DurableJobRunResult.PollAfter(_shared.Options.JobStatusPollInterval);
+                    return DurableJobRunResult.Running(_shared.Options.JobStatusPollInterval);
                 }
             }
 

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -30,7 +30,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
     private readonly IGrainContext _grain;
     private readonly DurableJobReceiverExtensionShared _shared;
-    private readonly Dictionary<(string JobId, int DequeueCount), JobAttemptState> _jobAttempts = [];
+    private readonly Dictionary<(string JobId, long ExecutionGeneration, int DequeueCount), JobAttemptState> _jobAttempts = [];
     private readonly Queue<CompletedJobAttempt> _completedJobAttempts = new();
     private int _completedJobAttemptCount;
 
@@ -96,7 +96,11 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
     }
 
-    private ValueTask<DurableJobRunResult> GetJobStatusAsync((string JobId, int DequeueCount) key, IJobRunContext context, JobAttemptState state, bool newJob)
+    private ValueTask<DurableJobRunResult> GetJobStatusAsync(
+        (string JobId, long ExecutionGeneration, int DequeueCount) key,
+        IJobRunContext context,
+        JobAttemptState state,
+        bool newJob)
     {
         // Cancellation is cooperative: only terminal task state is authoritative for job outcome.
         if (!state.Task.IsCompleted)
@@ -127,7 +131,10 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
         return ValueTask.FromCanceled<DurableJobRunResult>(new CancellationToken(canceled: true));
 
-        async ValueTask<DurableJobRunResult> LongPollGetJobStatusAsync((string JobId, int DequeueCount) key, IJobRunContext context, JobAttemptState state)
+        async ValueTask<DurableJobRunResult> LongPollGetJobStatusAsync(
+            (string JobId, long ExecutionGeneration, int DequeueCount) key,
+            IJobRunContext context,
+            JobAttemptState state)
         {
             if (!state.Task.IsCompleted)
             {
@@ -155,7 +162,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
     }
 
-    private void RecordCompletedJobAttempt((string JobId, int DequeueCount) key, JobAttemptState state)
+    private void RecordCompletedJobAttempt((string JobId, long ExecutionGeneration, int DequeueCount) key, JobAttemptState state)
     {
         if (!state.CompletionRecorded)
         {
@@ -190,16 +197,16 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
                 && state.Task.IsCompleted
                 && state.CompletedTimestamp == completedAttempt.CompletedTimestamp)
             {
-                ((ICollection<KeyValuePair<(string JobId, int DequeueCount), JobAttemptState>>)_jobAttempts).Remove(
-                    new KeyValuePair<(string JobId, int DequeueCount), JobAttemptState>(completedAttempt.Key, state));
+                ((ICollection<KeyValuePair<(string JobId, long ExecutionGeneration, int DequeueCount), JobAttemptState>>)_jobAttempts).Remove(
+                    new KeyValuePair<(string JobId, long ExecutionGeneration, int DequeueCount), JobAttemptState>(completedAttempt.Key, state));
             }
 
             _completedJobAttemptCount--;
         }
     }
 
-    private static (string JobId, int DequeueCount) GetExecutionKey(IJobRunContext context)
-        => (context.Job.Id, context.DequeueCount);
+    private static (string JobId, long ExecutionGeneration, int DequeueCount) GetExecutionKey(IJobRunContext context)
+        => (context.Job.Id, context.Job.ExecutionGeneration, context.DequeueCount);
 
     private sealed class JobAttemptState(Task<DurableJobRunResult> task)
     {
@@ -210,7 +217,9 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         public long CompletedTimestamp;
     }
 
-    private readonly record struct CompletedJobAttempt((string JobId, int DequeueCount) Key, long CompletedTimestamp);
+    private readonly record struct CompletedJobAttempt(
+        (string JobId, long ExecutionGeneration, int DequeueCount) Key,
+        long CompletedTimestamp);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error executing durable job {JobId} on grain {GrainId}")]
     private static partial void LogErrorExecutingDurableJob(ILogger logger, Exception exception, string jobId, GrainId grainId);

--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -112,7 +112,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     public void RetryJobLater(IJobRunContext jobContext, DateTimeOffset newDueTime)
     {
         ArgumentNullException.ThrowIfNull(jobContext);
-        _ = RetryJobLater(jobContext.Job.Id, newDueTime, jobContext.DequeueCount);
+        _ = RetryJobLater(jobContext.Job.Id, newDueTime, jobContext.DequeueCount, executionGeneration: null);
     }
 
     /// <summary>
@@ -123,6 +123,9 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     /// <param name="dequeueCount">The persisted dequeue count to associate with the retried job.</param>
     /// <returns>True if the job was found and rescheduled; false if the job was not found.</returns>
     public bool RetryJobLater(string jobId, DateTimeOffset newDueTime, int dequeueCount)
+        => RetryJobLater(jobId, newDueTime, dequeueCount, executionGeneration: null);
+
+    internal bool RetryJobLater(string jobId, DateTimeOffset newDueTime, int dequeueCount, long? executionGeneration)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         if (dequeueCount < 0)
@@ -147,6 +150,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 Metadata = existing.Job.Metadata,
                 TraceParent = existing.Job.TraceParent,
                 TraceState = existing.Job.TraceState,
+                ExecutionGeneration = executionGeneration ?? existing.Job.ExecutionGeneration,
             };
 
             oldBucket.RemoveJob(jobId);

--- a/src/Orleans.DurableJobs/JobShard.cs
+++ b/src/Orleans.DurableJobs/JobShard.cs
@@ -200,9 +200,13 @@ public abstract class JobShard : IJobShard, IResettableJobShard
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(jobContext);
-        var resetContext = new JobRunContext(jobContext.Job, jobContext.RunId, retryCount: 0);
+        var executionGeneration = checked(jobContext.Job.ExecutionGeneration + 1);
+        var resetContext = new JobRunContext(
+            jobContext.Job.WithExecutionGeneration(executionGeneration),
+            jobContext.RunId,
+            retryCount: 0);
         await PersistRetryJobAsync(resetContext, newDueTime, cancellationToken);
-        _jobQueue.RetryJobLater(jobContext.Job.Id, newDueTime, dequeueCount: 0);
+        _jobQueue.RetryJobLater(jobContext.Job.Id, newDueTime, dequeueCount: 0, executionGeneration);
     }
 
     /// <summary>

--- a/src/Orleans.DurableJobs/JobShard.cs
+++ b/src/Orleans.DurableJobs/JobShard.cs
@@ -87,6 +87,18 @@ public interface IJobShard : IAsyncDisposable
     Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Reschedules a successfully completed execution with its dequeue count reset.
+    /// </summary>
+    /// <param name="jobContext">The context of the completed execution.</param>
+    /// <param name="newDueTime">
+    /// The new due time for the job. This value supersedes <see cref="DurableJob.DueTime"/> on
+    /// <see cref="IJobRunContext.Job"/>.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Attempts to schedule a new job on this shard.
     /// </summary>
     /// <param name="request">The request containing the job scheduling parameters.</param>
@@ -99,7 +111,7 @@ public interface IJobShard : IAsyncDisposable
 /// <summary>
 /// Base implementation of <see cref="IJobShard"/> that provides common functionality for job shard implementations.
 /// </summary>
-public abstract class JobShard : IJobShard, IResettableJobShard
+public abstract class JobShard : IJobShard
 {
     private readonly InMemoryJobQueue _jobQueue;
 
@@ -194,7 +206,8 @@ public abstract class JobShard : IJobShard, IResettableJobShard
         _jobQueue.RetryJobLater(jobContext, newDueTime);
     }
 
-    async Task IResettableJobShard.RescheduleJobAsync(
+    /// <inheritdoc/>
+    public async Task RescheduleJobAsync(
         IJobRunContext jobContext,
         DateTimeOffset newDueTime,
         CancellationToken cancellationToken)
@@ -253,9 +266,4 @@ public abstract class JobShard : IJobShard, IResettableJobShard
         GC.SuppressFinalize(this);
         return default;
     }
-}
-
-internal interface IResettableJobShard
-{
-    Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
 }

--- a/src/Orleans.DurableJobs/JobShard.cs
+++ b/src/Orleans.DurableJobs/JobShard.cs
@@ -99,7 +99,7 @@ public interface IJobShard : IAsyncDisposable
 /// <summary>
 /// Base implementation of <see cref="IJobShard"/> that provides common functionality for job shard implementations.
 /// </summary>
-public abstract class JobShard : IJobShard
+public abstract class JobShard : IJobShard, IResettableJobShard
 {
     private readonly InMemoryJobQueue _jobQueue;
 
@@ -194,6 +194,17 @@ public abstract class JobShard : IJobShard
         _jobQueue.RetryJobLater(jobContext, newDueTime);
     }
 
+    async Task IResettableJobShard.RescheduleJobAsync(
+        IJobRunContext jobContext,
+        DateTimeOffset newDueTime,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(jobContext);
+        var resetContext = new JobRunContext(jobContext.Job, jobContext.RunId, retryCount: 0);
+        await PersistRetryJobAsync(resetContext, newDueTime, cancellationToken);
+        _jobQueue.RetryJobLater(jobContext.Job.Id, newDueTime, dequeueCount: 0);
+    }
+
     /// <summary>
     /// Enqueues a job into the in-memory queue with the specified dequeue count.
     /// </summary>
@@ -238,4 +249,9 @@ public abstract class JobShard : IJobShard
         GC.SuppressFinalize(this);
         return default;
     }
+}
+
+internal interface IResettableJobShard
+{
+    Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
 }

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -169,7 +169,11 @@ internal sealed class JournaledJobShard : IJobShard, IResettableJobShard
         ArgumentNullException.ThrowIfNull(jobContext);
         ThrowIfDisposed();
 
-        var operation = new RetryJobLaterOperation(jobContext, newDueTime, resetDequeueCount: true, cancellationToken);
+        var operation = new RetryJobLaterOperation(
+            jobContext,
+            newDueTime,
+            resetDequeueCount: true,
+            cancellationToken);
         try
         {
             EnqueueOperation(operation);
@@ -702,7 +706,8 @@ internal sealed class JournaledJobShard : IJobShard, IResettableJobShard
             shard._state.RetryJobLater(
                 jobContext.Job.Id,
                 newDueTime,
-                resetDequeueCount ? 0 : jobContext.DequeueCount);
+                resetDequeueCount ? 0 : jobContext.DequeueCount,
+                resetDequeueCount ? checked(jobContext.Job.ExecutionGeneration + 1) : null);
             result = true;
             return true;
         }

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -11,7 +11,7 @@ namespace Orleans.DurableJobs;
 /// <summary>
 /// Journaled implementation of <see cref="IJobShard"/> that stores shard state in Orleans journaling storage.
 /// </summary>
-internal sealed class JournaledJobShard : IJobShard, IResettableJobShard
+internal sealed class JournaledJobShard : IJobShard
 {
     private readonly JournaledJobShardState _state;
     private readonly IJournaledStateManager _stateManager;
@@ -161,7 +161,8 @@ internal sealed class JournaledJobShard : IJobShard, IResettableJobShard
         }
     }
 
-    async Task IResettableJobShard.RescheduleJobAsync(
+    /// <inheritdoc/>
+    public async Task RescheduleJobAsync(
         IJobRunContext jobContext,
         DateTimeOffset newDueTime,
         CancellationToken cancellationToken)

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -11,7 +11,7 @@ namespace Orleans.DurableJobs;
 /// <summary>
 /// Journaled implementation of <see cref="IJobShard"/> that stores shard state in Orleans journaling storage.
 /// </summary>
-internal sealed class JournaledJobShard : IJobShard
+internal sealed class JournaledJobShard : IJobShard, IResettableJobShard
 {
     private readonly JournaledJobShardState _state;
     private readonly IJournaledStateManager _stateManager;
@@ -149,7 +149,27 @@ internal sealed class JournaledJobShard : IJobShard
         ArgumentNullException.ThrowIfNull(jobContext);
         ThrowIfDisposed();
 
-        var operation = new RetryJobLaterOperation(jobContext, newDueTime, cancellationToken);
+        var operation = new RetryJobLaterOperation(jobContext, newDueTime, resetDequeueCount: false, cancellationToken);
+        try
+        {
+            EnqueueOperation(operation);
+            await operation.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            operation.Dispose();
+        }
+    }
+
+    async Task IResettableJobShard.RescheduleJobAsync(
+        IJobRunContext jobContext,
+        DateTimeOffset newDueTime,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(jobContext);
+        ThrowIfDisposed();
+
+        var operation = new RetryJobLaterOperation(jobContext, newDueTime, resetDequeueCount: true, cancellationToken);
         try
         {
             EnqueueOperation(operation);
@@ -668,14 +688,21 @@ internal sealed class JournaledJobShard : IJobShard
         }
     }
 
-    private sealed class RetryJobLaterOperation(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken)
+    private sealed class RetryJobLaterOperation(
+        IJobRunContext jobContext,
+        DateTimeOffset newDueTime,
+        bool resetDequeueCount,
+        CancellationToken cancellationToken)
         : PendingMutationOperation<bool>(cancellationToken)
     {
         protected override bool NotOwnedResult => true;
 
         protected override bool Apply(JournaledJobShard shard, out bool result)
         {
-            shard._state.RetryJobLater(jobContext, newDueTime);
+            shard._state.RetryJobLater(
+                jobContext.Job.Id,
+                newDueTime,
+                resetDequeueCount ? 0 : jobContext.DequeueCount);
             result = true;
             return true;
         }

--- a/src/Orleans.DurableJobs/JournaledJobShardState.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShardState.cs
@@ -104,16 +104,19 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
     public bool RetryJobLater(IJobRunContext jobContext, DateTimeOffset newDueTime)
     {
         ArgumentNullException.ThrowIfNull(jobContext);
-        return RetryJobLater(jobContext.Job.Id, newDueTime, jobContext.DequeueCount);
+        return RetryJobLater(jobContext.Job.Id, newDueTime, jobContext.DequeueCount, executionGeneration: null);
     }
 
     public bool RetryJobLater(string jobId, DateTimeOffset newDueTime, int dequeueCount)
+        => RetryJobLater(jobId, newDueTime, dequeueCount, executionGeneration: null);
+
+    public bool RetryJobLater(string jobId, DateTimeOffset newDueTime, int dequeueCount, long? executionGeneration)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         ValidateDequeueCount(dequeueCount);
 
-        Write(DurableJobShardJournalRecord.ForRetry(jobId, newDueTime, dequeueCount));
-        return ApplyRetry(jobId, newDueTime, dequeueCount);
+        Write(DurableJobShardJournalRecord.ForRetry(jobId, newDueTime, dequeueCount, executionGeneration));
+        return ApplyRetry(jobId, newDueTime, dequeueCount, executionGeneration);
     }
 
     public void MarkAsComplete()
@@ -156,7 +159,7 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
                 break;
             case DurableJobShardJournalRecordKind.Retry:
                 var retry = GetRequired(record.Retry, nameof(record.Retry));
-                ApplyRetry(retry.JobId, retry.DueTime, retry.DequeueCount);
+                ApplyRetry(retry.JobId, retry.DueTime, retry.DequeueCount, retry.ExecutionGeneration);
                 break;
             case DurableJobShardJournalRecordKind.Snapshot:
                 ApplySnapshot(GetRequired(record.Snapshot, nameof(record.Snapshot)));
@@ -195,10 +198,10 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
 
     private bool ApplyRemove(string jobId) => _jobQueue.CancelJob(jobId);
 
-    private bool ApplyRetry(string jobId, DateTimeOffset dueTime, int dequeueCount)
+    private bool ApplyRetry(string jobId, DateTimeOffset dueTime, int dequeueCount, long? executionGeneration)
     {
         ValidateDequeueCount(dequeueCount);
-        return _jobQueue.RetryJobLater(jobId, dueTime, dequeueCount);
+        return _jobQueue.RetryJobLater(jobId, dueTime, dequeueCount, executionGeneration);
     }
 
     private void ApplySnapshot(DurableJobShardSnapshot snapshot)
@@ -289,7 +292,11 @@ internal sealed class DurableJobShardJournalRecord
         };
     }
 
-    public static DurableJobShardJournalRecord ForRetry(string jobId, DateTimeOffset dueTime, int dequeueCount)
+    public static DurableJobShardJournalRecord ForRetry(
+        string jobId,
+        DateTimeOffset dueTime,
+        int dequeueCount,
+        long? executionGeneration = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
 
@@ -300,7 +307,8 @@ internal sealed class DurableJobShardJournalRecord
             {
                 JobId = jobId,
                 DueTime = dueTime,
-                DequeueCount = dequeueCount
+                DequeueCount = dequeueCount,
+                ExecutionGeneration = executionGeneration
             }
         };
     }
@@ -345,6 +353,9 @@ internal sealed class DurableJobShardRetryOperation
 
     [Id(2)]
     public int DequeueCount { get; init; }
+
+    [Id(3)]
+    public long? ExecutionGeneration { get; init; }
 }
 
 [GenerateSerializer]

--- a/src/Orleans.DurableJobs/ShardExecutor.Log.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.Log.cs
@@ -43,6 +43,12 @@ internal sealed partial class ShardExecutor
     private static partial void LogRetryingJob(ILogger logger, string jobId, string jobName, DateTimeOffset retryTime, int dequeueCount);
 
     [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Rescheduling job {JobId} (Name: '{JobName}') at {RescheduleTime}"
+    )]
+    private static partial void LogReschedulingJob(ILogger logger, string jobId, string jobName, DateTimeOffset rescheduleTime);
+
+    [LoggerMessage(
         Level = LogLevel.Debug,
         Message = "Polling job {JobId} (Name: '{JobName}') - will check status again in {PollDelay}"
     )]

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -254,7 +254,7 @@ internal sealed partial class ShardExecutor
                 var result = await target.HandleDurableJobAsync(jobContext, cancellationToken);
 
                 // Handle the result based on status
-                while (result.IsPending)
+                while (result.IsRunning)
                 {
                     // Enter polling loop
                     LogPollingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, result.PollAfterDelay.Value);
@@ -264,22 +264,49 @@ internal sealed partial class ShardExecutor
                     result = await target.HandleDurableJobAsync(jobContext, cancellationToken);
                 }
 
-                if (result.Status == DurableJobRunStatus.Completed)
+                switch (result.Status)
                 {
-                    await shard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
-                    LogJobExecutedSuccessfully(_logger, jobContext.Job.Id, jobContext.Job.Name);
-                    _durableJobsInstruments.OnJobCompleted(_timeProvider.GetElapsedTime(attemptStartTimestamp));
-                    activity?.SetTag(ActivityTagKeys.DurableJobStatus, "completed");
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                }
-                else if (result.IsFailed)
-                {
-                    // Handle failed result through retry policy
-                    LogJobFailedWithResult(_logger, jobContext.Job.Id, jobContext.Job.Name);
-                    failureException = result.Exception;
+                    case DurableJobRunStatus.Completed:
+                        await shard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
+                        LogJobExecutedSuccessfully(_logger, jobContext.Job.Id, jobContext.Job.Name);
+                        _durableJobsInstruments.OnJobCompleted(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                        activity?.SetTag(ActivityTagKeys.DurableJobStatus, "completed");
+                        activity?.SetStatus(ActivityStatusCode.Ok);
+                        break;
+                    case DurableJobRunStatus.RescheduleRequested when result.RescheduleTime is { } rescheduleTime:
+                        if (shard is not IResettableJobShard resettableShard)
+                        {
+                            throw new ResettableJobShardNotSupportedException(shard.GetType());
+                        }
+
+                        LogReschedulingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, rescheduleTime);
+                        await resettableShard.RescheduleJobAsync(jobContext, rescheduleTime, cancellationToken);
+                        _durableJobsInstruments.OnJobRescheduled(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                        activity?.SetTag(ActivityTagKeys.DurableJobStatus, "rescheduled");
+                        activity?.SetStatus(ActivityStatusCode.Ok);
+                        break;
+                    case DurableJobRunStatus.RescheduleRequested:
+                        failureException = new InvalidOperationException(
+                            $"Durable job '{jobContext.Job.Id}' returned RescheduleRequested without a reschedule time.");
+                        LogErrorExecutingJob(_logger, failureException, jobContext.Job.Id);
+                        break;
+                    case DurableJobRunStatus.Failed when result.Exception is { } exception:
+                        LogJobFailedWithResult(_logger, jobContext.Job.Id, jobContext.Job.Name);
+                        failureException = exception;
+                        break;
+                    case DurableJobRunStatus.Failed:
+                        failureException = new InvalidOperationException(
+                            $"Durable job '{jobContext.Job.Id}' returned Failed without an exception.");
+                        LogErrorExecutingJob(_logger, failureException, jobContext.Job.Id);
+                        break;
+                    default:
+                        failureException = new InvalidOperationException(
+                            $"Durable job '{jobContext.Job.Id}' returned unsupported status value {(int)result.Status}.");
+                        LogErrorExecutingJob(_logger, failureException, jobContext.Job.Id);
+                        break;
                 }
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not OperationCanceledException and not ResettableJobShardNotSupportedException)
             {
                 LogErrorExecutingJob(_logger, ex, jobContext.Job.Id);
                 failureException = ex;
@@ -305,6 +332,7 @@ internal sealed partial class ShardExecutor
                     DurableJobsDiagnostics.SetError(activity, failureException);
                 }
             }
+
         }
         catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {
@@ -323,4 +351,9 @@ internal sealed partial class ShardExecutor
             runningTasks?.TryRemove(jobContext.Job.Id, out _);
         }
     }
+
+    private sealed class ResettableJobShardNotSupportedException(Type shardType)
+        : NotSupportedException(
+            $"Job shard implementation '{shardType}' does not support successful reset-rescheduling. "
+            + "RescheduleRequested cannot be processed without changing failure-attempt semantics.");
 }

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -254,7 +254,7 @@ internal sealed partial class ShardExecutor
                 var result = await target.HandleDurableJobAsync(jobContext, cancellationToken);
 
                 // Handle the result based on status
-                while (result.IsRunning)
+                while (result.IsInProgress)
                 {
                     // Enter polling loop
                     LogPollingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, result.PollAfterDelay.Value);

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -274,13 +274,8 @@ internal sealed partial class ShardExecutor
                         activity?.SetStatus(ActivityStatusCode.Ok);
                         break;
                     case DurableJobRunStatus.RescheduleRequested when result.RescheduleTime is { } rescheduleTime:
-                        if (shard is not IResettableJobShard resettableShard)
-                        {
-                            throw new ResettableJobShardNotSupportedException(shard.GetType());
-                        }
-
                         LogReschedulingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, rescheduleTime);
-                        await resettableShard.RescheduleJobAsync(jobContext, rescheduleTime, cancellationToken);
+                        await shard.RescheduleJobAsync(jobContext, rescheduleTime, cancellationToken);
                         _durableJobsInstruments.OnJobRescheduled(_timeProvider.GetElapsedTime(attemptStartTimestamp));
                         activity?.SetTag(ActivityTagKeys.DurableJobStatus, "rescheduled");
                         activity?.SetStatus(ActivityStatusCode.Ok);
@@ -306,7 +301,7 @@ internal sealed partial class ShardExecutor
                         break;
                 }
             }
-            catch (Exception ex) when (ex is not OperationCanceledException and not ResettableJobShardNotSupportedException)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 LogErrorExecutingJob(_logger, ex, jobContext.Job.Id);
                 failureException = ex;
@@ -352,8 +347,4 @@ internal sealed partial class ShardExecutor
         }
     }
 
-    private sealed class ResettableJobShardNotSupportedException(Type shardType)
-        : NotSupportedException(
-            $"Job shard implementation '{shardType}' does not support successful reset-rescheduling. "
-            + "RescheduleRequested cannot be processed without changing failure-attempt semantics.");
 }

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -50,10 +50,6 @@ namespace Orleans.DurableJobs
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Exception")]
         public bool IsFailed { get { throw null; } }
 
-        [System.Obsolete("Use IsInProgress instead.")]
-        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "PollAfterDelay")]
-        public bool IsPending { get { throw null; } }
-
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "PollAfterDelay")]
         public bool IsInProgress { get { throw null; } }
 
@@ -71,9 +67,6 @@ namespace Orleans.DurableJobs
 
         public static DurableJobRunResult Failed(System.Exception exception) { throw null; }
 
-        [System.Obsolete("Use InProgress instead.")]
-        public static DurableJobRunResult PollAfter(System.TimeSpan delay) { throw null; }
-
         public static DurableJobRunResult InProgress(System.TimeSpan delay) { throw null; }
 
         public static DurableJobRunResult RescheduleAt(System.DateTimeOffset dueTime) { throw null; }
@@ -83,8 +76,6 @@ namespace Orleans.DurableJobs
     {
         Completed = 0,
         InProgress = 1,
-        [System.Obsolete("Use InProgress instead.")]
-        PollAfter = 1,
         Failed = 2,
         RescheduleRequested = 3
     }

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -50,15 +50,15 @@ namespace Orleans.DurableJobs
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Exception")]
         public bool IsFailed { get { throw null; } }
 
-        [System.Obsolete("Use IsRunning instead.")]
+        [System.Obsolete("Use IsInProgress instead.")]
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "PollAfterDelay")]
         public bool IsPending { get { throw null; } }
 
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "PollAfterDelay")]
+        public bool IsInProgress { get { throw null; } }
+
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "RescheduleTime")]
         public bool IsRescheduleRequested { get { throw null; } }
-
-        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "PollAfterDelay")]
-        public bool IsRunning { get { throw null; } }
 
         [Id(1)]
         public System.TimeSpan? PollAfterDelay { get { throw null; } }
@@ -71,19 +71,19 @@ namespace Orleans.DurableJobs
 
         public static DurableJobRunResult Failed(System.Exception exception) { throw null; }
 
-        [System.Obsolete("Use Running instead.")]
+        [System.Obsolete("Use InProgress instead.")]
         public static DurableJobRunResult PollAfter(System.TimeSpan delay) { throw null; }
 
-        public static DurableJobRunResult RescheduleAt(System.DateTimeOffset dueTime) { throw null; }
+        public static DurableJobRunResult InProgress(System.TimeSpan delay) { throw null; }
 
-        public static DurableJobRunResult Running(System.TimeSpan delay) { throw null; }
+        public static DurableJobRunResult RescheduleAt(System.DateTimeOffset dueTime) { throw null; }
     }
 
     public enum DurableJobRunStatus
     {
         Completed = 0,
-        Running = 1,
-        [System.Obsolete("Use Running instead.")]
+        InProgress = 1,
+        [System.Obsolete("Use InProgress instead.")]
         PollAfter = 1,
         Failed = 2,
         RescheduleRequested = 3

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -50,6 +50,10 @@ namespace Orleans.DurableJobs
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Exception")]
         public bool IsFailed { get { throw null; } }
 
+        [System.Obsolete("Use IsRunning instead.")]
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "PollAfterDelay")]
+        public bool IsPending { get { throw null; } }
+
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "RescheduleTime")]
         public bool IsRescheduleRequested { get { throw null; } }
 
@@ -67,6 +71,9 @@ namespace Orleans.DurableJobs
 
         public static DurableJobRunResult Failed(System.Exception exception) { throw null; }
 
+        [System.Obsolete("Use Running instead.")]
+        public static DurableJobRunResult PollAfter(System.TimeSpan delay) { throw null; }
+
         public static DurableJobRunResult RescheduleAt(System.DateTimeOffset dueTime) { throw null; }
 
         public static DurableJobRunResult Running(System.TimeSpan delay) { throw null; }
@@ -76,6 +83,8 @@ namespace Orleans.DurableJobs
     {
         Completed = 0,
         Running = 1,
+        [System.Obsolete("Use Running instead.")]
+        PollAfter = 1,
         Failed = 2,
         RescheduleRequested = 3
     }

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -50,25 +50,34 @@ namespace Orleans.DurableJobs
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Exception")]
         public bool IsFailed { get { throw null; } }
 
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "RescheduleTime")]
+        public bool IsRescheduleRequested { get { throw null; } }
+
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "PollAfterDelay")]
-        public bool IsPending { get { throw null; } }
+        public bool IsRunning { get { throw null; } }
 
         [Id(1)]
         public System.TimeSpan? PollAfterDelay { get { throw null; } }
+
+        [Id(3)]
+        public System.DateTimeOffset? RescheduleTime { get { throw null; } }
 
         [Id(0)]
         public DurableJobRunStatus Status { get { throw null; } }
 
         public static DurableJobRunResult Failed(System.Exception exception) { throw null; }
 
-        public static DurableJobRunResult PollAfter(System.TimeSpan delay) { throw null; }
+        public static DurableJobRunResult RescheduleAt(System.DateTimeOffset dueTime) { throw null; }
+
+        public static DurableJobRunResult Running(System.TimeSpan delay) { throw null; }
     }
 
     public enum DurableJobRunStatus
     {
         Completed = 0,
-        PollAfter = 1,
-        Failed = 2
+        Running = 1,
+        Failed = 2,
+        RescheduleRequested = 3
     }
 
     public static partial class DurableJobTimeProviderNames

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -115,6 +115,7 @@ namespace Orleans.DurableJobs
         System.Threading.Tasks.ValueTask<int> GetJobCountAsync();
         System.Threading.Tasks.Task MarkAsCompleteAsync(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<bool> RemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task RescheduleJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task RetryJobLaterAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, System.Threading.CancellationToken cancellationToken);
     }
@@ -153,6 +154,8 @@ namespace Orleans.DurableJobs
         protected abstract System.Threading.Tasks.Task PersistRemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task PersistRetryJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
         public System.Threading.Tasks.Task<bool> RemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task RescheduleJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task RetryJobLaterAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken) { throw null; }
 

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -29,7 +29,7 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenTokenIsCanceledButExecutionIsStillRunning_RemainsPending()
+    public async Task HandleDurableJobAsync_WhenTokenIsCanceledButExecutionIsStillRunning_RemainsRunning()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler = Substitute.For<IDurableJobHandler>();
@@ -44,15 +44,15 @@ public class DurableJobReceiverExtensionTests
         var first = await extension.HandleDurableJobAsync(context, cts.Token);
         var second = await extension.HandleDurableJobAsync(context, cts.Token);
 
-        Assert.True(first.IsPending);
-        Assert.True(second.IsPending);
+        Assert.True(first.IsRunning);
+        Assert.True(second.IsRunning);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
         executionTask.SetResult(true);
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenExecutionIsPending_UsesConfiguredPollInterval()
+    public async Task HandleDurableJobAsync_WhenExecutionIsRunning_UsesConfiguredPollInterval()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler = Substitute.For<IDurableJobHandler>();
@@ -65,7 +65,7 @@ public class DurableJobReceiverExtensionTests
 
         var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
 
-        Assert.True(result.IsPending);
+        Assert.True(result.IsRunning);
         Assert.Equal(pollInterval, result.PollAfterDelay);
 
         executionTask.SetResult(true);
@@ -87,7 +87,7 @@ public class DurableJobReceiverExtensionTests
         var second = await extension.HandleDurableJobAsync(secondNotification, CancellationToken.None);
 
         Assert.False(first.IsCompleted);
-        Assert.True(second.IsPending);
+        Assert.True(second.IsRunning);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
         executionTask.SetResult(true);
@@ -104,12 +104,6 @@ public class DurableJobReceiverExtensionTests
         var retryResult = await extension.HandleDurableJobAsync(nextAttempt, CancellationToken.None);
         Assert.Equal(DurableJobRunStatus.Completed, retryResult.Status);
         await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public void DurableJobRunResult_Failed_ThrowsForNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => DurableJobRunResult.Failed(null!));
     }
 
     private static DurableJobReceiverExtension CreateExtension(IDurableJobHandler handler, TimeSpan? jobStatusPollInterval = null)

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -106,6 +106,22 @@ public class DurableJobReceiverExtensionTests
         await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task HandleDurableJobAsync_WhenExecutionGenerationChanges_StartsNewExecution()
+    {
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var extension = CreateExtension(handler);
+        var firstRun = CreateJobContext("run-1", executionGeneration: 0);
+        var rescheduledRun = CreateJobContext("run-2", executionGeneration: 1);
+
+        Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(firstRun, CancellationToken.None)).Status);
+        Assert.Equal(DurableJobRunStatus.Completed, (await extension.HandleDurableJobAsync(rescheduledRun, CancellationToken.None)).Status);
+        await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+    }
+
     private static DurableJobReceiverExtension CreateExtension(IDurableJobHandler handler, TimeSpan? jobStatusPollInterval = null)
     {
         var grainContext = Substitute.For<IGrainContext>();
@@ -119,7 +135,11 @@ public class DurableJobReceiverExtensionTests
         return new DurableJobReceiverExtension(grainContext, shared);
     }
 
-    private static IJobRunContext CreateJobContext(string runId, string jobId = "job-1", int dequeueCount = 1)
+    private static IJobRunContext CreateJobContext(
+        string runId,
+        string jobId = "job-1",
+        int dequeueCount = 1,
+        long executionGeneration = 0)
     {
         var context = Substitute.For<IJobRunContext>();
         context.RunId.Returns(runId);
@@ -130,7 +150,8 @@ public class DurableJobReceiverExtensionTests
             Name = jobId,
             DueTime = DateTimeOffset.UtcNow,
             TargetGrainId = GrainId.Create("test", "grain-1"),
-            ShardId = "shard-1"
+            ShardId = "shard-1",
+            ExecutionGeneration = executionGeneration
         });
 
         return context;

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -44,15 +44,15 @@ public class DurableJobReceiverExtensionTests
         var first = await extension.HandleDurableJobAsync(context, cts.Token);
         var second = await extension.HandleDurableJobAsync(context, cts.Token);
 
-        Assert.True(first.IsRunning);
-        Assert.True(second.IsRunning);
+        Assert.True(first.IsInProgress);
+        Assert.True(second.IsInProgress);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
         executionTask.SetResult(true);
     }
 
     [Fact]
-    public async Task HandleDurableJobAsync_WhenExecutionIsRunning_UsesConfiguredPollInterval()
+    public async Task HandleDurableJobAsync_WhenExecutionIsInProgress_UsesConfiguredPollInterval()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var handler = Substitute.For<IDurableJobHandler>();
@@ -65,7 +65,7 @@ public class DurableJobReceiverExtensionTests
 
         var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
 
-        Assert.True(result.IsRunning);
+        Assert.True(result.IsInProgress);
         Assert.Equal(pollInterval, result.PollAfterDelay);
 
         executionTask.SetResult(true);
@@ -87,7 +87,7 @@ public class DurableJobReceiverExtensionTests
         var second = await extension.HandleDurableJobAsync(secondNotification, CancellationToken.None);
 
         Assert.False(first.IsCompleted);
-        Assert.True(second.IsRunning);
+        Assert.True(second.IsInProgress);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 
         executionTask.SetResult(true);

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
@@ -14,7 +14,7 @@ public class DurableJobRunResultTests
     public void StatusValuesAndSerializedMemberIdsRemainCompatible()
     {
         Assert.Equal(0, (int)DurableJobRunStatus.Completed);
-        Assert.Equal(1, (int)DurableJobRunStatus.Running);
+        Assert.Equal(1, (int)DurableJobRunStatus.InProgress);
         Assert.Equal(2, (int)DurableJobRunStatus.Failed);
         Assert.Equal(3, (int)DurableJobRunStatus.RescheduleRequested);
 
@@ -30,7 +30,7 @@ public class DurableJobRunResultTests
         var result = DurableJobRunResult.Completed;
 
         Assert.Equal(DurableJobRunStatus.Completed, result.Status);
-        Assert.False(result.IsRunning);
+        Assert.False(result.IsInProgress);
         Assert.False(result.IsFailed);
         Assert.False(result.IsRescheduleRequested);
         Assert.Null(result.PollAfterDelay);
@@ -39,34 +39,34 @@ public class DurableJobRunResultTests
     }
 
     [Fact]
-    public void Running_RequiresPositiveDelayAndExposesPollDelay()
+    public void InProgress_RequiresPositiveDelayAndExposesPollDelay()
     {
         var delay = TimeSpan.FromSeconds(5);
 
-        var result = DurableJobRunResult.Running(delay);
+        var result = DurableJobRunResult.InProgress(delay);
 
-        Assert.Equal(DurableJobRunStatus.Running, result.Status);
-        Assert.True(result.IsRunning);
+        Assert.Equal(DurableJobRunStatus.InProgress, result.Status);
+        Assert.True(result.IsInProgress);
         Assert.Equal(delay, result.PollAfterDelay);
         Assert.False(result.IsFailed);
         Assert.False(result.IsRescheduleRequested);
         Assert.Null(result.Exception);
         Assert.Null(result.RescheduleTime);
-        Assert.Throws<ArgumentOutOfRangeException>(() => DurableJobRunResult.Running(TimeSpan.Zero));
-        Assert.Throws<ArgumentOutOfRangeException>(() => DurableJobRunResult.Running(TimeSpan.FromTicks(-1)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DurableJobRunResult.InProgress(TimeSpan.Zero));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DurableJobRunResult.InProgress(TimeSpan.FromTicks(-1)));
     }
 
     [Fact]
-    public void PollAfterCompatibilityMembers_ForwardToRunning()
+    public void PollAfterCompatibilityMembers_ForwardToInProgress()
     {
 #pragma warning disable CS0618 // Verify compatibility members remain functional.
         var delay = TimeSpan.FromSeconds(5);
         var result = DurableJobRunResult.PollAfter(delay);
 
-        Assert.Equal(DurableJobRunStatus.Running, result.Status);
-        Assert.Equal(DurableJobRunStatus.Running, DurableJobRunStatus.PollAfter);
+        Assert.Equal(DurableJobRunStatus.InProgress, result.Status);
+        Assert.Equal(DurableJobRunStatus.InProgress, DurableJobRunStatus.PollAfter);
         Assert.True(result.IsPending);
-        Assert.True(result.IsRunning);
+        Assert.True(result.IsInProgress);
         Assert.Equal(delay, result.PollAfterDelay);
 #pragma warning restore CS0618
     }
@@ -81,7 +81,7 @@ public class DurableJobRunResultTests
         Assert.Equal(DurableJobRunStatus.Failed, result.Status);
         Assert.True(result.IsFailed);
         Assert.Same(exception, result.Exception);
-        Assert.False(result.IsRunning);
+        Assert.False(result.IsInProgress);
         Assert.False(result.IsRescheduleRequested);
         Assert.Null(result.PollAfterDelay);
         Assert.Null(result.RescheduleTime);
@@ -99,7 +99,7 @@ public class DurableJobRunResultTests
         Assert.True(result.IsRescheduleRequested);
         Assert.Equal(dueTime, result.RescheduleTime);
         Assert.False(result.IsFailed);
-        Assert.False(result.IsRunning);
+        Assert.False(result.IsInProgress);
         Assert.Null(result.PollAfterDelay);
         Assert.Null(result.Exception);
     }

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using Orleans.DurableJobs;
+using Xunit;
+
+namespace NonSilo.Tests.DurableJobs;
+
+[TestCategory("BVT"), TestCategory("DurableJobs")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("DurableJobs")]
+public class DurableJobRunResultTests
+{
+    [Fact]
+    public void StatusValuesAndSerializedMemberIdsRemainCompatible()
+    {
+        Assert.Equal(0, (int)DurableJobRunStatus.Completed);
+        Assert.Equal(1, (int)DurableJobRunStatus.Running);
+        Assert.Equal(2, (int)DurableJobRunStatus.Failed);
+        Assert.Equal(3, (int)DurableJobRunStatus.RescheduleRequested);
+
+        Assert.Equal(0u, GetId(nameof(DurableJobRunResult.Status)));
+        Assert.Equal(1u, GetId(nameof(DurableJobRunResult.PollAfterDelay)));
+        Assert.Equal(2u, GetId(nameof(DurableJobRunResult.Exception)));
+        Assert.Equal(3u, GetId(nameof(DurableJobRunResult.RescheduleTime)));
+    }
+
+    [Fact]
+    public void Completed_HasOnlyCompletedStatus()
+    {
+        var result = DurableJobRunResult.Completed;
+
+        Assert.Equal(DurableJobRunStatus.Completed, result.Status);
+        Assert.False(result.IsRunning);
+        Assert.False(result.IsFailed);
+        Assert.False(result.IsRescheduleRequested);
+        Assert.Null(result.PollAfterDelay);
+        Assert.Null(result.Exception);
+        Assert.Null(result.RescheduleTime);
+    }
+
+    [Fact]
+    public void Running_RequiresPositiveDelayAndExposesPollDelay()
+    {
+        var delay = TimeSpan.FromSeconds(5);
+
+        var result = DurableJobRunResult.Running(delay);
+
+        Assert.Equal(DurableJobRunStatus.Running, result.Status);
+        Assert.True(result.IsRunning);
+        Assert.Equal(delay, result.PollAfterDelay);
+        Assert.False(result.IsFailed);
+        Assert.False(result.IsRescheduleRequested);
+        Assert.Null(result.Exception);
+        Assert.Null(result.RescheduleTime);
+        Assert.Throws<ArgumentOutOfRangeException>(() => DurableJobRunResult.Running(TimeSpan.Zero));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DurableJobRunResult.Running(TimeSpan.FromTicks(-1)));
+    }
+
+    [Fact]
+    public void Failed_RequiresExceptionAndExposesFailure()
+    {
+        var exception = new InvalidOperationException("failed");
+
+        var result = DurableJobRunResult.Failed(exception);
+
+        Assert.Equal(DurableJobRunStatus.Failed, result.Status);
+        Assert.True(result.IsFailed);
+        Assert.Same(exception, result.Exception);
+        Assert.False(result.IsRunning);
+        Assert.False(result.IsRescheduleRequested);
+        Assert.Null(result.PollAfterDelay);
+        Assert.Null(result.RescheduleTime);
+        Assert.Throws<ArgumentNullException>(() => DurableJobRunResult.Failed(null!));
+    }
+
+    [Fact]
+    public void RescheduleAt_CreatesSuccessfulDurableRescheduleResult()
+    {
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(1);
+
+        var result = DurableJobRunResult.RescheduleAt(dueTime);
+
+        Assert.Equal(DurableJobRunStatus.RescheduleRequested, result.Status);
+        Assert.True(result.IsRescheduleRequested);
+        Assert.Equal(dueTime, result.RescheduleTime);
+        Assert.False(result.IsFailed);
+        Assert.False(result.IsRunning);
+        Assert.Null(result.PollAfterDelay);
+        Assert.Null(result.Exception);
+    }
+
+    [Fact]
+    public void IsRescheduleRequested_RequiresRescheduleTime()
+    {
+        var result = CreateResult(DurableJobRunStatus.RescheduleRequested);
+
+        Assert.False(result.IsRescheduleRequested);
+        Assert.Null(result.RescheduleTime);
+    }
+
+    private static uint GetId(string propertyName) =>
+        Assert.Single(
+            typeof(DurableJobRunResult)
+                .GetProperty(propertyName)!
+                .GetCustomAttributes(typeof(IdAttribute), inherit: false)
+                .Cast<IdAttribute>()).Id;
+
+    private static DurableJobRunResult CreateResult(DurableJobRunStatus status) =>
+        (DurableJobRunResult)Activator.CreateInstance(
+            typeof(DurableJobRunResult),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: [status, null, null, null],
+            culture: null)!;
+}

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
@@ -57,21 +57,6 @@ public class DurableJobRunResultTests
     }
 
     [Fact]
-    public void PollAfterCompatibilityMembers_ForwardToInProgress()
-    {
-#pragma warning disable CS0618 // Verify compatibility members remain functional.
-        var delay = TimeSpan.FromSeconds(5);
-        var result = DurableJobRunResult.PollAfter(delay);
-
-        Assert.Equal(DurableJobRunStatus.InProgress, result.Status);
-        Assert.Equal(DurableJobRunStatus.InProgress, DurableJobRunStatus.PollAfter);
-        Assert.True(result.IsPending);
-        Assert.True(result.IsInProgress);
-        Assert.Equal(delay, result.PollAfterDelay);
-#pragma warning restore CS0618
-    }
-
-    [Fact]
     public void Failed_RequiresExceptionAndExposesFailure()
     {
         var exception = new InvalidOperationException("failed");

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobRunResultTests.cs
@@ -57,6 +57,21 @@ public class DurableJobRunResultTests
     }
 
     [Fact]
+    public void PollAfterCompatibilityMembers_ForwardToRunning()
+    {
+#pragma warning disable CS0618 // Verify compatibility members remain functional.
+        var delay = TimeSpan.FromSeconds(5);
+        var result = DurableJobRunResult.PollAfter(delay);
+
+        Assert.Equal(DurableJobRunStatus.Running, result.Status);
+        Assert.Equal(DurableJobRunStatus.Running, DurableJobRunStatus.PollAfter);
+        Assert.True(result.IsPending);
+        Assert.True(result.IsRunning);
+        Assert.Equal(delay, result.PollAfterDelay);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
     public void Failed_RequiresExceptionAndExposesFailure()
     {
         var exception = new InvalidOperationException("failed");

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobsInstrumentsTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobsInstrumentsTests.cs
@@ -23,13 +23,23 @@ public class DurableJobsInstrumentsTests
         var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
         using var scheduledCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-jobs-scheduled");
         using var scheduleDurationCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-job-schedule-duration");
+        using var retriedCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-jobs-retried");
+        using var rescheduledCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-jobs-rescheduled");
+        using var attemptDurationCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-job-attempt-duration");
         using var stripeCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-stripe-distribution");
 
         instruments.OnJobScheduled(TimeSpan.FromMilliseconds(12));
+        instruments.OnJobRetried(TimeSpan.FromMilliseconds(15));
+        instruments.OnJobRescheduled(TimeSpan.FromMilliseconds(18));
         instruments.OnStripeAssigned(3);
 
         Assert.Equal(1, Assert.Single(scheduledCollector.GetMeasurementSnapshot()).Value);
         Assert.Equal(12, Assert.Single(scheduleDurationCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(retriedCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(rescheduledCollector.GetMeasurementSnapshot()).Value);
+        var attemptDurations = attemptDurationCollector.GetMeasurementSnapshot();
+        Assert.Equal(15, Assert.Single(attemptDurations, static measurement => measurement.Tags["status"] is "retried").Value);
+        Assert.Equal(18, Assert.Single(attemptDurations, static measurement => measurement.Tags["status"] is "rescheduled").Value);
         Assert.Equal(1, Assert.Single(stripeCollector.GetMeasurementSnapshot()).Value);
     }
 }

--- a/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
@@ -84,6 +84,7 @@ public class JobShardTests
         var rescheduledRun = await ConsumeNextAsync(resetShard);
         Assert.Equal(1, rescheduledRun.DequeueCount);
         Assert.NotEqual(resetRun.RunId, rescheduledRun.RunId);
+        Assert.Equal(resetRun.Job.ExecutionGeneration + 1, rescheduledRun.Job.ExecutionGeneration);
         Assert.Equal(0, resetShard.PersistedRetryContext!.DequeueCount);
 
         var retryShard = await CreateShardWithDueJobAsync("retry", now);

--- a/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
@@ -72,6 +72,51 @@ public class JobShardTests
         Assert.Equal(3, persistedContext.DequeueCount);
     }
 
+    [Fact]
+    public async Task SuccessfulRescheduleResetsDequeueCountAndCreatesNewRunId()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var resetShard = await CreateShardWithDueJobAsync("reset", now);
+        var resetRun = await ConsumeNextAsync(resetShard);
+
+        await ((IResettableJobShard)resetShard).RescheduleJobAsync(resetRun, now.AddSeconds(-1), CancellationToken.None);
+
+        var rescheduledRun = await ConsumeNextAsync(resetShard);
+        Assert.Equal(1, rescheduledRun.DequeueCount);
+        Assert.NotEqual(resetRun.RunId, rescheduledRun.RunId);
+        Assert.Equal(0, resetShard.PersistedRetryContext!.DequeueCount);
+
+        var retryShard = await CreateShardWithDueJobAsync("retry", now);
+        var firstFailure = await ConsumeNextAsync(retryShard);
+
+        await retryShard.RetryJobLaterAsync(firstFailure, now.AddSeconds(-1), CancellationToken.None);
+
+        var retriedRun = await ConsumeNextAsync(retryShard);
+        Assert.Equal(2, retriedRun.DequeueCount);
+        Assert.Equal(1, retryShard.PersistedRetryContext!.DequeueCount);
+    }
+
+    private static async Task<TestJobShard> CreateShardWithDueJobAsync(string id, DateTimeOffset now)
+    {
+        var shard = new TestJobShard(now.AddHours(-1), now.AddHours(1));
+        Assert.NotNull(await shard.TryScheduleJobAsync(
+            new ScheduleJobRequest
+            {
+                Target = GrainId.Create("test", id),
+                JobName = id,
+                DueTime = now.AddSeconds(-2)
+            },
+            CancellationToken.None));
+        return shard;
+    }
+
+    private static async Task<IJobRunContext> ConsumeNextAsync(IJobShard shard)
+    {
+        await using var enumerator = shard.ConsumeDurableJobsAsync().GetAsyncEnumerator(CancellationToken.None);
+        Assert.True(await enumerator.MoveNextAsync());
+        return enumerator.Current;
+    }
+
     private sealed class TestJobShard(DateTimeOffset startTime, DateTimeOffset endTime)
         : JobShard("shard", startTime, endTime)
     {

--- a/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
@@ -79,7 +79,7 @@ public class JobShardTests
         var resetShard = await CreateShardWithDueJobAsync("reset", now);
         var resetRun = await ConsumeNextAsync(resetShard);
 
-        await ((IResettableJobShard)resetShard).RescheduleJobAsync(resetRun, now.AddSeconds(-1), CancellationToken.None);
+        await resetShard.RescheduleJobAsync(resetRun, now.AddSeconds(-1), CancellationToken.None);
 
         var rescheduledRun = await ConsumeNextAsync(resetShard);
         Assert.Equal(1, rescheduledRun.DequeueCount);

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -840,6 +840,8 @@ public class LocalDurableJobManagerTests
 
         public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
 
+        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => Task.FromResult<DurableJob?>(null);
 
         public async ValueTask DisposeAsync()
@@ -875,6 +877,8 @@ public class LocalDurableJobManagerTests
         public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
 
         public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => Task.FromResult<DurableJob?>(null);
 
@@ -949,6 +953,8 @@ public class LocalDurableJobManagerTests
 
         public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
 
+        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => Task.FromResult<DurableJob?>(null);
 
         public ValueTask DisposeAsync()
@@ -992,6 +998,8 @@ public class LocalDurableJobManagerTests
         public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(true);
 
         public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
         {
@@ -1042,6 +1050,8 @@ public class LocalDurableJobManagerTests
 
         public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
 
+        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
@@ -1074,6 +1084,8 @@ public class LocalDurableJobManagerTests
         public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
 
         public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
         {
@@ -1139,6 +1151,8 @@ public class LocalDurableJobManagerTests
         public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
 
         public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RescheduleJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public async Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
         {

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -490,7 +490,7 @@ public class ShardExecutorTests
         await executor.RunShardAsync(shard, CancellationToken.None);
 
         Assert.False(retryPolicyInvoked);
-        await ((IResettableJobShard)shard).Received(1).RescheduleJobAsync(
+        await shard.Received(1).RescheduleJobAsync(
             Arg.Any<IJobRunContext>(),
             rescheduleTime,
             Arg.Any<CancellationToken>());
@@ -530,42 +530,7 @@ public class ShardExecutorTests
         Assert.IsType<InvalidOperationException>(retryException);
         Assert.Contains("unsupported status value 99", retryException.Message, StringComparison.Ordinal);
         await shard.Received(1).RetryJobLaterAsync(Arg.Any<IJobRunContext>(), retryTime, Arg.Any<CancellationToken>());
-        await ((IResettableJobShard)shard).DidNotReceive().RescheduleJobAsync(
-            Arg.Any<IJobRunContext>(),
-            Arg.Any<DateTimeOffset>(),
-            Arg.Any<CancellationToken>());
-        await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task RunShardAsync_RescheduleAtOnLegacyShardFailsExplicitlyWithoutFailureRetry()
-    {
-        var retryPolicyInvoked = false;
-        var options = CreateOptions(
-            maxConcurrentJobs: 1,
-            shouldRetry: (_, _) =>
-            {
-                retryPolicyInvoked = true;
-                return DateTimeOffset.UtcNow.AddMinutes(1);
-            });
-        var shard = CreateJobShard(CreateJobs(1), supportsResetReschedule: false);
-        var grainFactory = CreateGrainFactory();
-        var extension = Substitute.For<IDurableJobReceiverExtension>();
-        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
-            .Returns(DurableJobRunResult.RescheduleAt(DateTimeOffset.UtcNow.AddMinutes(5)));
-        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
-        var executor = new ShardExecutor(
-            grainFactory,
-            options,
-            CreateOverloadDetector(isOverloaded: false),
-            NullLogger<ShardExecutor>.Instance);
-
-        var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(
-            () => executor.RunShardAsync(shard, CancellationToken.None));
-
-        Assert.Contains("does not support successful reset-rescheduling", exception.Message, StringComparison.Ordinal);
-        Assert.False(retryPolicyInvoked);
-        await shard.DidNotReceive().RetryJobLaterAsync(
+        await shard.DidNotReceive().RescheduleJobAsync(
             Arg.Any<IJobRunContext>(),
             Arg.Any<DateTimeOffset>(),
             Arg.Any<CancellationToken>());
@@ -760,12 +725,9 @@ public class ShardExecutorTests
         List<DurableJob> jobs, 
         DateTimeOffset? startTime = null,
         DateTimeOffset? endTime = null,
-        TaskCompletionSource? firstJobRegistered = null,
-        bool supportsResetReschedule = true)
+        TaskCompletionSource? firstJobRegistered = null)
     {
-        var shard = supportsResetReschedule
-            ? Substitute.For<IJobShard, IResettableJobShard>()
-            : Substitute.For<IJobShard>();
+        var shard = Substitute.For<IJobShard>();
         shard.Id.Returns("shard-1");
         shard.StartTime.Returns(startTime ?? DateTimeOffset.UtcNow.AddMinutes(-10));
         shard.EndTime.Returns(endTime ?? DateTimeOffset.UtcNow.AddMinutes(10));

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -384,7 +384,7 @@ public class ShardExecutorTests
 
         await executor.RunShardAsync(shard, CancellationToken.None);
 
-        // Verify HandleDurableJobAsync was called 4 times (1 initial + 2 PollAfter + 1 Failed)
+        // Verify HandleDurableJobAsync was called 4 times (1 initial + 2 in-progress results + 1 failure)
         Assert.Equal(4, callBox.Value);
         
         // Verify job was scheduled for retry (not removed)
@@ -939,7 +939,7 @@ public class ShardExecutorTests
         
         var extension = Substitute.For<IDurableJobReceiverExtension>();
         
-        // First 3 calls return PollAfter, 4th returns Completed
+        // First 3 calls return InProgress, 4th returns Completed
         extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
@@ -963,7 +963,7 @@ public class ShardExecutorTests
         
         var extension = Substitute.For<IDurableJobReceiverExtension>();
         
-        // First 3 calls return PollAfter, 4th returns Failed
+        // First 3 calls return InProgress, 4th returns Failed
         extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
@@ -990,7 +990,7 @@ public class ShardExecutorTests
         
         var extension = Substitute.For<IDurableJobReceiverExtension>();
         
-        // First 3 calls return PollAfter (recording timestamps after the initial call), 4th returns Completed
+        // First 3 calls return InProgress (recording timestamps after the initial call), 4th returns Completed
         extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -274,7 +274,7 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenJobReturnsRunning_EntersPollingLoopUntilCompletion()
+    public async Task RunShardAsync_WhenJobReturnsInProgress_EntersPollingLoopUntilCompletion()
     {
         var options = CreateOptions(maxConcurrentJobs: 10);
         var overloadDetector = CreateOverloadDetector(isOverloaded: false);
@@ -295,7 +295,7 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenJobReturnsRunning_UsesTimeProvider()
+    public async Task RunShardAsync_WhenJobReturnsInProgress_UsesTimeProvider()
     {
         var timeProvider = new TimerTrackingFakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
         var options = CreateOptions(maxConcurrentJobs: 10);
@@ -314,7 +314,7 @@ public class ShardExecutorTests
                 if (currentCall == 1)
                 {
                     firstCall.SetResult();
-                    return DurableJobRunResult.Running(TimeSpan.FromSeconds(5));
+                    return DurableJobRunResult.InProgress(TimeSpan.FromSeconds(5));
                 }
 
                 secondCall.SetResult();
@@ -368,7 +368,7 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenJobReturnsRunningThenFails_HandlesFailureCorrectly()
+    public async Task RunShardAsync_WhenJobReturnsInProgressThenFails_HandlesFailureCorrectly()
     {
         var options = CreateOptions(
             maxConcurrentJobs: 10,
@@ -946,7 +946,7 @@ public class ShardExecutorTests
                 var currentCall = Interlocked.Increment(ref callBox.Value);
                 if (currentCall < 4)
                 {
-                    return DurableJobRunResult.Running(TimeSpan.FromMilliseconds(10));
+                    return DurableJobRunResult.InProgress(TimeSpan.FromMilliseconds(10));
                 }
                 return DurableJobRunResult.Completed;
             });
@@ -970,7 +970,7 @@ public class ShardExecutorTests
                 var currentCall = Interlocked.Increment(ref callBox.Value);
                 if (currentCall < 4)
                 {
-                    return DurableJobRunResult.Running(TimeSpan.FromMilliseconds(10));
+                    return DurableJobRunResult.InProgress(TimeSpan.FromMilliseconds(10));
                 }
                 var exception = new InvalidOperationException("Job failed after polling");
                 return DurableJobRunResult.Failed(exception);
@@ -1005,7 +1005,7 @@ public class ShardExecutorTests
                 
                 if (currentCall < 4)
                 {
-                    return DurableJobRunResult.Running(TimeSpan.FromMilliseconds(pollDelayMs));
+                    return DurableJobRunResult.InProgress(TimeSpan.FromMilliseconds(pollDelayMs));
                 }
                 return DurableJobRunResult.Completed;
             });

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Reflection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -273,7 +274,7 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenJobReturnsPollAfter_EntersPollingLoopUntilCompletion()
+    public async Task RunShardAsync_WhenJobReturnsRunning_EntersPollingLoopUntilCompletion()
     {
         var options = CreateOptions(maxConcurrentJobs: 10);
         var overloadDetector = CreateOverloadDetector(isOverloaded: false);
@@ -294,7 +295,7 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenJobReturnsPollAfter_UsesTimeProvider()
+    public async Task RunShardAsync_WhenJobReturnsRunning_UsesTimeProvider()
     {
         var timeProvider = new TimerTrackingFakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
         var options = CreateOptions(maxConcurrentJobs: 10);
@@ -313,7 +314,7 @@ public class ShardExecutorTests
                 if (currentCall == 1)
                 {
                     firstCall.SetResult();
-                    return DurableJobRunResult.PollAfter(TimeSpan.FromSeconds(5));
+                    return DurableJobRunResult.Running(TimeSpan.FromSeconds(5));
                 }
 
                 secondCall.SetResult();
@@ -367,7 +368,7 @@ public class ShardExecutorTests
     }
 
     [Fact]
-    public async Task RunShardAsync_WhenJobReturnsPollAfterThenFails_HandlesFailureCorrectly()
+    public async Task RunShardAsync_WhenJobReturnsRunningThenFails_HandlesFailureCorrectly()
     {
         var options = CreateOptions(
             maxConcurrentJobs: 10,
@@ -461,6 +462,123 @@ public class ShardExecutorTests
         await shard.DidNotReceive().RetryJobLaterAsync(Arg.Any<IJobRunContext>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
         await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task RunShardAsync_RescheduleAtReschedulesWithoutInvokingFailureRetryPolicy()
+    {
+        var retryPolicyInvoked = false;
+        var options = CreateOptions(
+            maxConcurrentJobs: 1,
+            shouldRetry: (_, _) =>
+            {
+                retryPolicyInvoked = true;
+                return null;
+            });
+        var shard = CreateJobShard(CreateJobs(1));
+        var grainFactory = CreateGrainFactory();
+        var rescheduleTime = DateTimeOffset.UtcNow.AddMinutes(5);
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(DurableJobRunResult.RescheduleAt(rescheduleTime));
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var executor = new ShardExecutor(
+            grainFactory,
+            options,
+            CreateOverloadDetector(isOverloaded: false),
+            NullLogger<ShardExecutor>.Instance);
+
+        await executor.RunShardAsync(shard, CancellationToken.None);
+
+        Assert.False(retryPolicyInvoked);
+        await ((IResettableJobShard)shard).Received(1).RescheduleJobAsync(
+            Arg.Any<IJobRunContext>(),
+            rescheduleTime,
+            Arg.Any<CancellationToken>());
+        await shard.DidNotReceive().RetryJobLaterAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+        await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunShardAsync_UnknownStatusFlowsThroughFailureRetryPolicy()
+    {
+        Exception? retryException = null;
+        var retryTime = DateTimeOffset.UtcNow.AddMinutes(1);
+        var options = CreateOptions(
+            maxConcurrentJobs: 1,
+            shouldRetry: (_, exception) =>
+            {
+                retryException = exception;
+                return retryTime;
+            });
+        var shard = CreateJobShard(CreateJobs(1));
+        var grainFactory = CreateGrainFactory();
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(CreateResult((DurableJobRunStatus)99));
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var executor = new ShardExecutor(
+            grainFactory,
+            options,
+            CreateOverloadDetector(isOverloaded: false),
+            NullLogger<ShardExecutor>.Instance);
+
+        await executor.RunShardAsync(shard, CancellationToken.None);
+
+        Assert.IsType<InvalidOperationException>(retryException);
+        Assert.Contains("unsupported status value 99", retryException.Message, StringComparison.Ordinal);
+        await shard.Received(1).RetryJobLaterAsync(Arg.Any<IJobRunContext>(), retryTime, Arg.Any<CancellationToken>());
+        await ((IResettableJobShard)shard).DidNotReceive().RescheduleJobAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+        await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunShardAsync_RescheduleAtOnLegacyShardFailsExplicitlyWithoutFailureRetry()
+    {
+        var retryPolicyInvoked = false;
+        var options = CreateOptions(
+            maxConcurrentJobs: 1,
+            shouldRetry: (_, _) =>
+            {
+                retryPolicyInvoked = true;
+                return DateTimeOffset.UtcNow.AddMinutes(1);
+            });
+        var shard = CreateJobShard(CreateJobs(1), supportsResetReschedule: false);
+        var grainFactory = CreateGrainFactory();
+        var extension = Substitute.For<IDurableJobReceiverExtension>();
+        extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(DurableJobRunResult.RescheduleAt(DateTimeOffset.UtcNow.AddMinutes(5)));
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        var executor = new ShardExecutor(
+            grainFactory,
+            options,
+            CreateOverloadDetector(isOverloaded: false),
+            NullLogger<ShardExecutor>.Instance);
+
+        var exception = await Assert.ThrowsAnyAsync<NotSupportedException>(
+            () => executor.RunShardAsync(shard, CancellationToken.None));
+
+        Assert.Contains("does not support successful reset-rescheduling", exception.Message, StringComparison.Ordinal);
+        Assert.False(retryPolicyInvoked);
+        await shard.DidNotReceive().RetryJobLaterAsync(
+            Arg.Any<IJobRunContext>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+        await shard.DidNotReceive().RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private static DurableJobRunResult CreateResult(DurableJobRunStatus status) =>
+        (DurableJobRunResult)Activator.CreateInstance(
+            typeof(DurableJobRunResult),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: [status, null, null, null],
+            culture: null)!;
 
     [Fact]
     public async Task RunShardAsync_WithSlowStart_GraduallyIncreasesConcurrency()
@@ -642,9 +760,12 @@ public class ShardExecutorTests
         List<DurableJob> jobs, 
         DateTimeOffset? startTime = null,
         DateTimeOffset? endTime = null,
-        TaskCompletionSource? firstJobRegistered = null)
+        TaskCompletionSource? firstJobRegistered = null,
+        bool supportsResetReschedule = true)
     {
-        var shard = Substitute.For<IJobShard>();
+        var shard = supportsResetReschedule
+            ? Substitute.For<IJobShard, IResettableJobShard>()
+            : Substitute.For<IJobShard>();
         shard.Id.Returns("shard-1");
         shard.StartTime.Returns(startTime ?? DateTimeOffset.UtcNow.AddMinutes(-10));
         shard.EndTime.Returns(endTime ?? DateTimeOffset.UtcNow.AddMinutes(10));
@@ -825,7 +946,7 @@ public class ShardExecutorTests
                 var currentCall = Interlocked.Increment(ref callBox.Value);
                 if (currentCall < 4)
                 {
-                    return DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(10));
+                    return DurableJobRunResult.Running(TimeSpan.FromMilliseconds(10));
                 }
                 return DurableJobRunResult.Completed;
             });
@@ -849,7 +970,7 @@ public class ShardExecutorTests
                 var currentCall = Interlocked.Increment(ref callBox.Value);
                 if (currentCall < 4)
                 {
-                    return DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(10));
+                    return DurableJobRunResult.Running(TimeSpan.FromMilliseconds(10));
                 }
                 var exception = new InvalidOperationException("Job failed after polling");
                 return DurableJobRunResult.Failed(exception);
@@ -884,7 +1005,7 @@ public class ShardExecutorTests
                 
                 if (currentCall < 4)
                 {
-                    return DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(pollDelayMs));
+                    return DurableJobRunResult.Running(TimeSpan.FromMilliseconds(pollDelayMs));
                 }
                 return DurableJobRunResult.Completed;
             });

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -173,6 +173,29 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     }
 
     [SkippableFact]
+    public async Task SuccessfulReschedulePersistsResetAttemptThroughShardReassignment()
+    {
+        await using var scope = await fixture.CreateScopeAsync();
+        var first = scope.CreateManager(scope.ActiveSilo);
+        var second = scope.CreateManager(scope.SecondActiveSilo);
+        var now = scope.Now;
+        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), CancellationToken.None);
+        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "rescheduled-job");
+        var run = await TakeOneAsync(shard);
+
+        var resettableShard = Assert.IsAssignableFrom<IResettableJobShard>(shard);
+        await resettableShard.RescheduleJobAsync(run, now.AddMinutes(-1), CancellationToken.None);
+        await first.UnregisterShardAsync(shard, CancellationToken.None);
+
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
+        var rescheduled = await TakeOneAsync(reassigned);
+
+        Assert.Equal(job!.Id, rescheduled.Job.Id);
+        Assert.Equal(1, rescheduled.DequeueCount);
+        Assert.NotEqual(run.RunId, rescheduled.RunId);
+    }
+
+    [SkippableFact]
     public async Task CancellationsBeforeAndDuringProcessingPersistAfterReassignment()
     {
         await using var scope = await fixture.CreateScopeAsync();

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -193,6 +193,7 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
         Assert.Equal(job!.Id, rescheduled.Job.Id);
         Assert.Equal(1, rescheduled.DequeueCount);
         Assert.NotEqual(run.RunId, rescheduled.RunId);
+        Assert.Equal(run.Job.ExecutionGeneration + 1, rescheduled.Job.ExecutionGeneration);
     }
 
     [SkippableFact]

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -183,8 +183,7 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
         var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "rescheduled-job");
         var run = await TakeOneAsync(shard);
 
-        var resettableShard = Assert.IsAssignableFrom<IResettableJobShard>(shard);
-        await resettableShard.RescheduleJobAsync(run, now.AddMinutes(-1), CancellationToken.None);
+        await shard.RescheduleJobAsync(run, now.AddMinutes(-1), CancellationToken.None);
         await first.UnregisterShardAsync(shard, CancellationToken.None);
 
         var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardStateTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardStateTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.Json;
 using Orleans.DurableJobs;
 using Orleans.Runtime;
 using Xunit;
@@ -82,6 +83,54 @@ public class JournaledJobShardStateTests
         var entry = Assert.Single(state.CaptureSnapshot().Jobs);
         Assert.Equal(shardId.Value, entry.Job.ShardId);
         Assert.Equal(retryDueTime, entry.Job.DueTime);
+    }
+
+    [Fact]
+    public void Replay_RestoresSuccessfulRescheduleGeneration()
+    {
+        var shardId = new JobShardId("shard-generation");
+        var start = DateTimeOffset.UtcNow;
+        var state = new JournaledJobShardState(shardId, start, start.AddHours(1));
+        var job = CreateJob(shardId, "job-1", "job", start.AddMinutes(1));
+
+        state.Apply(DurableJobShardJournalRecord.ForSchedule(job));
+        state.Apply(DurableJobShardJournalRecord.ForRetry(
+            job.Id,
+            start.AddMinutes(2),
+            dequeueCount: 0,
+            executionGeneration: 1));
+
+        var entry = Assert.Single(state.CaptureSnapshot().Jobs);
+        Assert.Equal(1, entry.Job.ExecutionGeneration);
+        Assert.Equal(0, entry.DequeueCount);
+    }
+
+    [Fact]
+    public void JsonSnapshot_RoundTripsSuccessfulRescheduleGeneration()
+    {
+        var shardId = new JobShardId("shard-json-generation");
+        var start = DateTimeOffset.UtcNow;
+        var state = new JournaledJobShardState(shardId, start, start.AddHours(1));
+        var job = CreateJob(shardId, "job-1", "job", start.AddMinutes(1));
+
+        state.Apply(DurableJobShardJournalRecord.ForSchedule(job));
+        state.Apply(DurableJobShardJournalRecord.ForRetry(
+            job.Id,
+            start.AddMinutes(2),
+            dequeueCount: 0,
+            executionGeneration: 1));
+
+        var json = JsonSerializer.Serialize(
+            state.CaptureSnapshot(),
+            DurableJobsJsonContext.Default.DurableJobShardSnapshot);
+        var snapshot = JsonSerializer.Deserialize(
+            json,
+            DurableJobsJsonContext.Default.DurableJobShardSnapshot);
+
+        Assert.NotNull(snapshot);
+        var entry = Assert.Single(snapshot.Jobs);
+        Assert.Equal(1, entry.Job.ExecutionGeneration);
+        Assert.Equal(0, entry.DequeueCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Durable job execution results distinguish completion, active polling, and failure, but cannot represent a successful execution which requests another durable run. Treating that outcome as a retry mixes success with failure policy and retry telemetry.

## Solution

Clarify the serialized execution-status names and add `RescheduleAt` as a successful terminal outcome for the current run. The executor routes that outcome through `IJobShard.RescheduleJobAsync`, resets the persisted dequeue count, and records dedicated rescheduling logs and metrics. The in-memory and journaled shard implementations persist the reset execution generation and dequeue state. Unknown serialized status values continue through the configured failure retry policy, and the public guidance defines the rolling-upgrade order for serialized value 3.

## Rationale

Durable Jobs is pre-release, so the shard contract directly represents both failure retries and successful rescheduling. This preserves their distinct semantics and gives each successful rescheduled execution a fresh run identity and first-attempt dequeue count.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10716)