### PR TITLE
fix(test): stabilize one-way call completion checks

### DIFF
--- a/test/Grains/TestGrainInterfaces/ITestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITestGrain.cs
@@ -56,10 +56,10 @@ namespace UnitTests.GrainInterfaces
     public interface IOneWayGrain : IGrainWithGuidKey
     {
         [OneWay]
-        Task Notify(ISimpleGrainObserver observer);
+        Task Notify();
 
         [OneWay]
-        ValueTask NotifyValueTask(ISimpleGrainObserver observer);
+        ValueTask NotifyValueTask();
 
         [OneWay]
         Task ThrowsOneWay();
@@ -67,15 +67,18 @@ namespace UnitTests.GrainInterfaces
         [OneWay]
         ValueTask ThrowsOneWayValueTask();
 
-        Task<bool> NotifyOtherGrain(IOneWayGrain otherGrain, ISimpleGrainObserver observer);
+        Task<bool> NotifyOtherGrain(IOneWayGrain otherGrain);
 
-        Task<bool> NotifyOtherGrainValueTask(IOneWayGrain otherGrain, ISimpleGrainObserver observer);
+        Task<bool> NotifyOtherGrainValueTask(IOneWayGrain otherGrain);
 
         Task<IOneWayGrain> GetOtherGrain();
 
         Task NotifyOtherGrain();
 
         Task<int> GetCount();
+
+        [AlwaysInterleave]
+        Task WaitForCount(int expectedCount);
 
         Task Deactivate();
 

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -211,6 +211,7 @@ namespace UnitTests.Grains
     {
         private readonly string _id = Guid.NewGuid().ToString();
         private int count;
+        private TaskCompletionSource<int> countChanged = CreateCountChangedSource();
         private TaskCompletionSource<string> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private IOneWayGrain? other;
         private readonly GrainLocator grainLocator;
@@ -223,35 +224,35 @@ namespace UnitTests.Grains
 
         public Task Notify()
         {
-            this.count++;
+            IncrementCount();
             return Task.CompletedTask;
         }
 
-        public Task Notify(ISimpleGrainObserver observer)
+        public ValueTask NotifyValueTask()
         {
-            this.count++;
-            observer.StateChanged(this.count - 1, this.count);
-            return Task.CompletedTask;
-        }
-
-        public ValueTask NotifyValueTask(ISimpleGrainObserver observer)
-        {
-            this.count++;
-            observer.StateChanged(this.count - 1, this.count);
+            IncrementCount();
             return default;
         }
 
-        public async Task<bool> NotifyOtherGrain(IOneWayGrain otherGrain, ISimpleGrainObserver observer)
+        public async Task WaitForCount(int expectedCount)
         {
-            var task = otherGrain.Notify(observer);
+            while (this.count < expectedCount)
+            {
+                await this.countChanged.Task;
+            }
+        }
+
+        public async Task<bool> NotifyOtherGrain(IOneWayGrain otherGrain)
+        {
+            var task = otherGrain.Notify();
             var completedSynchronously = task.Status == TaskStatus.RanToCompletion;
             await task;
             return completedSynchronously;
         }
 
-        public async Task<bool> NotifyOtherGrainValueTask(IOneWayGrain otherGrain, ISimpleGrainObserver observer)
+        public async Task<bool> NotifyOtherGrainValueTask(IOneWayGrain otherGrain)
         {
-            var task = otherGrain.NotifyValueTask(observer);
+            var task = otherGrain.NotifyValueTask();
             var completedSynchronously = task.IsCompleted;
             await task;
             return completedSynchronously;
@@ -298,9 +299,18 @@ namespace UnitTests.Grains
             return Task.FromResult<string>(null!);
         }
 
-        public Task NotifyOtherGrain() => this.other!.Notify(this.AsReference<ISimpleGrainObserver>());
+        public Task NotifyOtherGrain() => this.other!.Notify();
 
         public Task<int> GetCount() => Task.FromResult(this.count);
+
+        private static TaskCompletionSource<int> CreateCountChangedSource() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private void IncrementCount()
+        {
+            this.count++;
+            this.countChanged.TrySetResult(this.count);
+            this.countChanged = CreateCountChangedSource();
+        }
 
         public Task Deactivate()
         {

--- a/test/Orleans.DefaultCluster.Tests/OneWayCallTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/OneWayCallTests.cs
@@ -1,4 +1,3 @@
-using Orleans.Internal;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
@@ -31,13 +30,14 @@ namespace DefaultCluster.Tests.General
         public async Task OneWayMethodsReturnSynchronously_ViaClient()
         {
             var grain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
+            const int expectedCount = 1;
+            var countReached = grain.WaitForCount(expectedCount);
 
-            var observer = new SimpleGrainObserver();
-            var task = grain.Notify(this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
+            var task = grain.Notify();
             Assert.True(task.Status == TaskStatus.RanToCompletion, "Task should be synchronously completed.");
-            await WaitForNotification(observer);
+            await WaitForCount(grain, countReached, nameof(OneWayMethodsReturnSynchronously_ViaClient), expectedCount);
             var count = await grain.GetCount();
-            Assert.Equal(1, count);
+            Assert.Equal(expectedCount, count);
 
             // This should not throw.
             task = grain.ThrowsOneWay();
@@ -55,14 +55,14 @@ namespace DefaultCluster.Tests.General
         {
             var grain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
             var otherGrain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
+            const int expectedCount = 1;
+            var countReached = otherGrain.WaitForCount(expectedCount);
 
-            var observer = new SimpleGrainObserver();
-            var observerReference = this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
-            var completedSynchronously = await grain.NotifyOtherGrain(otherGrain, observerReference);
+            var completedSynchronously = await grain.NotifyOtherGrain(otherGrain);
             Assert.True(completedSynchronously, "Task should be synchronously completed.");
-            await WaitForNotification(observer);
+            await WaitForCount(otherGrain, countReached, nameof(OneWayMethodReturnSynchronously_ViaGrain), expectedCount);
             var count = await otherGrain.GetCount();
-            Assert.Equal(1, count);
+            Assert.Equal(expectedCount, count);
         }
 
         /// <summary>
@@ -75,13 +75,14 @@ namespace DefaultCluster.Tests.General
         public async Task OneWayMethodsReturnSynchronously_ViaClient_ValueTask()
         {
             var grain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
+            const int expectedCount = 1;
+            var countReached = grain.WaitForCount(expectedCount);
 
-            var observer = new SimpleGrainObserver();
-            var task = grain.NotifyValueTask(this.Client.CreateObjectReference<ISimpleGrainObserver>(observer));
+            var task = grain.NotifyValueTask();
             Assert.True(task.IsCompleted, "ValueTask should be synchronously completed.");
-            await WaitForNotification(observer);
+            await WaitForCount(grain, countReached, nameof(OneWayMethodsReturnSynchronously_ViaClient_ValueTask), expectedCount);
             var count = await grain.GetCount();
-            Assert.Equal(1, count);
+            Assert.Equal(expectedCount, count);
 
             // This should not throw.
             task = grain.ThrowsOneWayValueTask();
@@ -98,31 +99,28 @@ namespace DefaultCluster.Tests.General
         {
             var grain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
             var otherGrain = this.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
+            const int expectedCount = 1;
+            var countReached = otherGrain.WaitForCount(expectedCount);
 
-            var observer = new SimpleGrainObserver();
-            var observerReference = this.Client.CreateObjectReference<ISimpleGrainObserver>(observer);
-            var completedSynchronously = await grain.NotifyOtherGrainValueTask(otherGrain, observerReference);
+            var completedSynchronously = await grain.NotifyOtherGrainValueTask(otherGrain);
             Assert.True(completedSynchronously, "Task should be synchronously completed.");
-            await WaitForNotification(observer);
+            await WaitForCount(otherGrain, countReached, nameof(OneWayMethodReturnSynchronously_ViaGrain_ValueTask), expectedCount);
             var count = await otherGrain.GetCount();
-            Assert.Equal(1, count);
+            Assert.Equal(expectedCount, count);
         }
 
-        private static async Task WaitForNotification(SimpleGrainObserver observer)
+        private static async Task WaitForCount(IOneWayGrain grain, Task countReached, string scenario, int expectedCount)
         {
-            await observer.ReceivedValue.WaitAsync(TimeSpan.FromSeconds(10));
-
-            // Client observer registrations are weak, so keep the target rooted until the callback completes.
-            GC.KeepAlive(observer);
-        }
-
-        private class SimpleGrainObserver : ISimpleGrainObserver
-        {
-            private readonly TaskCompletionSource<int> completion = new TaskCompletionSource<int>();
-            public Task ReceivedValue => this.completion.Task;
-            public void StateChanged(int a, int b)
+            try
             {
-                this.completion.SetResult(b);
+                await countReached.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            catch (TimeoutException exception)
+            {
+                var actualCount = await grain.GetCount();
+                throw new TimeoutException(
+                    $"Timed out waiting for one-way notification. Scenario: {scenario}. Expected count: {expectedCount}. Actual count: {actualCount}.",
+                    exception);
             }
         }
     }


### PR DESCRIPTION
`OneWayMethodsReturnSynchronously_ViaClient` intermittently timed out because it relied on a one-way client observer callback as secondary evidence that the grain method executed. The client-side one-way task already completes synchronously by design, while the observer callback introduces unrelated delivery timing.

This change replaces the observer path with an `[AlwaysInterleave]` count barrier on the test grain. Each notification signals count transitions through a resettable `TaskCompletionSource` using asynchronous continuations, so the barrier works whether it arrives before or after the notification without blocking grain execution. The four one-way call scenarios retain their immediate Task/ValueTask completion assertions and await the direct grain-side count transition with contextual timeout diagnostics.

Fixes #10694
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10717)