### PR TITLE
fix(docs): preserve reminder sidebar links

### DIFF
--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -36,9 +36,8 @@ items:
         href: grains/stateless-worker-grains.md
       - name: Timers and reminders
         href: grains/timers-and-reminders.md
-        items:
-          - name: Amazon DynamoDB
-            href: grains/reminders/dynamodb.md
+      - name: Amazon DynamoDB reminders
+        href: grains/reminders/dynamodb.md
       - name: Observers
         href: grains/observers.md
       - name: Cancellation


### PR DESCRIPTION
## Problem

The navigation entry added in #10711 combined `href` and `items`. The DocFX-to-Starlight converter treats entries with `items` as non-link groups, which removed the **Timers and reminders** overview link from the generated sidebar.

## Solution

List **Timers and reminders** and **Amazon DynamoDB reminders** as sibling links in the Grains navigation so both pages remain directly reachable.

Follow-up to #10711 and https://github.com/dotnet/orleans/pull/10711#discussion_r3825158143.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10725)