### PR TITLE
ci: publish .NET test results on pull requests

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,32 @@
+name: .NET Test Results
+
+on:
+  workflow_run:
+    workflows:
+      - .NET CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    name: Report test results
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish test results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          artifact: /test_output_(.*)/
+          name: Test Results ($1)
+          path: "**/*.trx"
+          reporter: dotnet-trx
+          use-actions-summary: false
+          list-suites: failed
+          list-tests: failed
+          max-annotations: 50
+          fail-on-empty: true


### PR DESCRIPTION
GitHub Actions currently archives the MTP-generated TRX files, but GitHub does not ingest test result artifacts into pull request checks. Test outcomes therefore remain visible only inside the workflow artifacts.

This adds a `workflow_run` reporter for completed `.NET CI` pull request runs. It reads the existing `test_output_*` artifacts and creates per-job check runs with result counts, failed test details, and annotations.

The reporter runs from the default branch with narrowly scoped `actions: read` and `checks: write` permissions. This preserves read-only CI execution for fork pull requests while allowing the trusted reporting workflow to publish their results. The action is pinned to the v3.0.0 commit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10730)