### PR TITLE
fix(test): synchronize manual repartitioning rounds

### DIFF
--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/CustomToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/CustomToleranceTests.cs
@@ -73,7 +73,7 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
 
         Assert.Equal(Silo2, await x.GetAddress()); // X remains in silo 2
 
-        await Silo1Repartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
 
         // At this point the layout is like follows:
 
@@ -99,7 +99,7 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
 
         await LogEdgesAsync(Silo1Repartitioner);
         await LogEdgesAsync(Silo2Repartitioner);
-        await Silo1Repartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
         await Test();
 
         // To make extra sure, we now trigger 's2_rebalancer', which again should yield to no further migrations.
@@ -113,7 +113,7 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
             i++;
         }
 
-        await Silo2Repartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo2Repartitioner);
 
         await Test();
 

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
@@ -22,6 +22,8 @@ namespace UnitTests.ActivationRepartitioningTests;
 [TestCategory("Functional"), TestCategory("ActivationRepartitioning")]
 public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : RepartitioningTestBase<DefaultToleranceTests.Fixture>(fixture), IClassFixture<DefaultToleranceTests.Fixture>
 {
+    private static readonly TimeSpan MigrationTimeout = TimeSpan.FromSeconds(10);
+
     [Fact]
     public async Task A_ShouldMoveToSilo2__B_And_C_ShouldStayOnSilo2()
     {
@@ -49,13 +51,12 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo2, b_host);
         Assert.Equal(Silo2, c_host);
 
-        await Silo1Repartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
 
-        do
-        {
-            a_host = await a.GetAddress();
-        }
-        while (a_host == Silo1);
+        await WaitForConditionAsync(
+            async () => (a_host = await a.GetAddress()) != Silo1,
+            MigrationTimeout,
+            () => $"Expected A to move from {Silo1}, but it remained on {a_host}.");
 
         // refresh
         a_host = await a.GetAddress();
@@ -99,13 +100,12 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo1, b_host);
         Assert.Equal(Silo2, c_host);
 
-        await Silo1Repartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
 
-        do
-        {
-            c_host = await c.GetAddress();
-        }
-        while (c_host == Silo2);
+        await WaitForConditionAsync(
+            async () => (c_host = await c.GetAddress()) != Silo2,
+            MigrationTimeout,
+            () => $"Expected C to move from {Silo2}, but it remained on {c_host}.");
 
         // refresh
         a_host = await a.GetAddress();
@@ -149,14 +149,17 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo1, b_host);
         Assert.Equal(Silo2, c_host);
 
-        await Silo1Repartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
 
-        do
-        {
-            a_host = await a.GetAddress();
-            b_host = await b.GetAddress();
-        }
-        while (a_host == Silo1 || b_host == Silo1);
+        await WaitForConditionAsync(
+            async () =>
+            {
+                a_host = await a.GetAddress();
+                b_host = await b.GetAddress();
+                return a_host != Silo1 && b_host != Silo1;
+            },
+            MigrationTimeout,
+            () => $"Expected A and B to move from {Silo1}, but A was on {a_host} and B was on {b_host}.");
 
         // refresh
         a_host = await a.GetAddress();
@@ -201,14 +204,17 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo2, c_host);
         Assert.Equal(Silo2, d_host);
 
-        await Silo1Repartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
 
-        do
-        {
-            a_host = await a.GetAddress();
-            c_host = await c.GetAddress();
-        }
-        while (a_host == Silo1 && c_host == Silo2);
+        await WaitForConditionAsync(
+            async () =>
+            {
+                a_host = await a.GetAddress();
+                c_host = await c.GetAddress();
+                return a_host != Silo1 || c_host != Silo2;
+            },
+            MigrationTimeout,
+            () => $"Expected A to move from {Silo1} or C to move from {Silo2}, but A was on {a_host} and C was on {c_host}.");
 
         // refresh
         a_host = await a.GetAddress();
@@ -352,9 +358,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(receiverSilo, sr2_host);
         Assert.Equal(pullingAgentSilo, sr3_host);
 
-        await receiverRepartitioner.FlushBuffers();
-        await pullingAgentRepartitioner.FlushBuffers();
-        await receiverRepartitioner.TriggerExchangeRequest();
+        await TriggerExchangeRequestAfterFlushingBuffers(receiverRepartitioner);
 
         stopwatch.Restart();
 

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/RepartitioningTestBase.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/RepartitioningTestBase.cs
@@ -1,6 +1,7 @@
 using Orleans.Placement.Repartitioning;
 using Orleans.Runtime;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestExtensions;
 using Xunit;
 
@@ -45,6 +46,29 @@ public abstract class RepartitioningTestBase<TFixture> : IAsyncLifetime where TF
         await Silo1Repartitioner.ResetCounters();
         await Silo2Repartitioner.ResetCounters();
     }
+
+    private protected async ValueTask TriggerExchangeRequestAfterFlushingBuffers(IActivationRepartitionerSystemTarget repartitioner)
+    {
+        await Silo1Repartitioner.FlushBuffers();
+        await Silo2Repartitioner.FlushBuffers();
+        await repartitioner.TriggerExchangeRequest();
+    }
+
+    private protected static Task WaitForConditionAsync(Func<Task<bool>> predicate, TimeSpan timeout, Func<string> timeoutMessage)
+        => TestingUtils.WaitUntilAsync(
+            async (lastTry, _) =>
+            {
+                var succeeded = await predicate();
+                if (lastTry)
+                {
+                    Assert.True(succeeded, timeoutMessage());
+                }
+
+                return succeeded;
+            },
+            timeout,
+            TimeSpan.FromMilliseconds(10),
+            TestContext.Current.CancellationToken);
 
     public async Task AdjustActivationCountOffsets()
     {


### PR DESCRIPTION
The activation repartitioning tolerance tests manually trigger exchange rounds immediately after generating grain-call edges. Edge processing is asynchronous, so some rounds observed incomplete state and the tests waited for the fixture's 299-300 second automatic round. This affected 5 of 52 observations across [3052573](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052573&view=results), [3053002](https://dev.azure.com/dnceng/internal/_build/results?buildId=3053002&view=results), [3053212](https://dev.azure.com/dnceng/internal/_build/results?buildId=3053212&view=results), [3053236](https://dev.azure.com/dnceng/internal/_build/results?buildId=3053236&view=results), and [3053501](https://dev.azure.com/dnceng/internal/_build/results?buildId=3053501&view=results).

This change establishes the edge-processing boundary by flushing both repartitioner buffers before every manual exchange in the tolerance fixtures. It also bounds placement waits at ten seconds and reports the observed silo addresses when a migration transition is missing.

The complete `DefaultToleranceTests` and `CustomToleranceTests` fixtures passed 10 consecutive runs on each of `net8.0` and `net10.0` (120 test executions).

Fixes #10731
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10732)