### PR TITLE
docs(reminders): clarify loading-window scalability

### DIFF
--- a/docs/site/src/content/docs/implementation/reminders.md
+++ b/docs/site/src/content/docs/implementation/reminders.md
@@ -17,7 +17,9 @@ The reminder service is a grain service attached to the consistent ring. Ownersh
 
 ## Refresh and reconciliation
 
-After the reminder table starts successfully, the service refreshes the ring range periodically. Reads are staggered and retried during initialization. Each refresh reads the range, compares the table sequence with local mutations, starts or updates entries which are now owned, and stops entries which disappeared or moved elsewhere. A local sequence prevents a concurrent registration or removal from being overwritten by an older refresh result.
+After the reminder table starts successfully, the service refreshes the ring range periodically. Reads are staggered and retried during initialization. Each refresh reads the range, compares the table sequence with local mutations, starts or updates owned entries whose next tick is within <xref:Orleans.Hosting.ReminderOptions.ReminderLoadingWindow>, and stops entries which disappeared, moved elsewhere, or no longer fall within the loading window. A local sequence prevents a concurrent registration or removal from being overwritten by an older refresh result.
+
+The reminder table contract returns every row in the owner's consistent-hash range. A refresh therefore transfers and materializes all owned rows before applying the loading window. Resident schedules scale with reminders due within the window, while refresh I/O, deserialization, and peak allocations scale with all reminders owned by the silo.
 
 Reminder ownership uses periodic reconciliation. A brief ownership overlap during membership convergence is possible; ETags, responsibility checks, and the service's delivery state converge the overlap toward the current owner.
 


### PR DESCRIPTION
## Problem

Classic reminders now retain only near-term schedules in local memory, but the implementation guide does not state that refreshes still enumerate and materialize every reminder in the silo's owned hash range. This obscures the remaining scalability boundary tracked by #947.

## Solution

Document how `ReminderLoadingWindow` bounds resident schedules and clarify that provider reads, transfer, deserialization, and peak refresh allocations continue to scale with all reminders owned by the silo.

## Rationale

This distinguishes the resident-memory improvement from the storage-side enumeration work which remains open in #947.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10737)