### PR TITLE
fix(testing): make wait deadline tests deterministic

### DIFF
--- a/src/Orleans.TestingHost/Orleans.TestingHost.csproj
+++ b/src/Orleans.TestingHost/Orleans.TestingHost.csproj
@@ -28,5 +28,6 @@
     <InternalsVisibleTo Include="Orleans.Persistence.Firestore.Tests" />
     <InternalsVisibleTo Include="Orleans.Streaming.Tests" />
     <InternalsVisibleTo Include="Orleans.Streaming.Kinesis.Tests" />
+    <InternalsVisibleTo Include="Orleans.TestingHost.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -79,11 +79,19 @@ namespace Orleans.TestingHost.Utils
         /// <returns>A task representing the operation.</returns>
         /// <exception cref="TimeoutException">The predicate did not succeed before the timeout elapsed.</exception>
         public static Task WaitUntilAsync(Func<bool,Task<bool>> predicate, TimeSpan timeout, TimeSpan? delayOnFail = null)
+            => WaitUntilAsync(predicate, timeout, delayOnFail, TimeProvider.System);
+
+        internal static Task WaitUntilAsync(
+            Func<bool, Task<bool>> predicate,
+            TimeSpan timeout,
+            TimeSpan? delayOnFail,
+            TimeProvider timeProvider)
         {
             ArgumentNullException.ThrowIfNull(predicate);
+            ArgumentNullException.ThrowIfNull(timeProvider);
 
             var predicateName = $"{predicate.Method.DeclaringType?.FullName ?? "<unknown>"}.{predicate.Method.Name}";
-            return WaitUntilAsync((lastTry, _) => predicate(lastTry), timeout, delayOnFail, default, predicateName);
+            return WaitUntilAsync((lastTry, _) => predicate(lastTry), timeout, delayOnFail, default, timeProvider, predicateName);
         }
 
         /// <summary>Run the predicate until it succeeds or times out.</summary>
@@ -97,16 +105,32 @@ namespace Orleans.TestingHost.Utils
         /// <param name="predicateExpression">The expression supplied for <paramref name="predicate"/>.</param>
         /// <returns>A task representing the operation.</returns>
         /// <exception cref="TimeoutException">The predicate did not succeed before the timeout elapsed.</exception>
-        public static async Task WaitUntilAsync(
+        public static Task WaitUntilAsync(
             Func<bool, CancellationToken, Task<bool>> predicate,
             TimeSpan timeout,
             TimeSpan? delayOnFail = null,
             CancellationToken cancellationToken = default,
             [CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
+            => WaitUntilAsync(predicate, timeout, delayOnFail, cancellationToken, TimeProvider.System, predicateExpression);
+
+        internal static async Task WaitUntilAsync(
+            Func<bool, CancellationToken, Task<bool>> predicate,
+            TimeSpan timeout,
+            TimeSpan? delayOnFail,
+            CancellationToken cancellationToken,
+            TimeProvider timeProvider,
+            [CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
         {
             ArgumentNullException.ThrowIfNull(predicate);
+            ArgumentNullException.ThrowIfNull(timeProvider);
 
-            if (!await WaitUntilSucceededAsync(predicate, timeout, delayOnFail, cancellationToken, invokeFinalAttempt: true))
+            if (!await WaitUntilSucceededAsync(
+                predicate,
+                timeout,
+                delayOnFail,
+                cancellationToken,
+                invokeFinalAttempt: true,
+                timeProvider))
             {
                 throw new TimeoutException(
                     $"The condition evaluated by '{predicateExpression ?? "<unknown>"}' was not satisfied within {timeout} "
@@ -128,7 +152,25 @@ namespace Orleans.TestingHost.Utils
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(predicate);
-            return await WaitUntilSucceededAsync((_, token) => predicate(token), timeout, delayOnFail, cancellationToken, invokeFinalAttempt: false);
+            return await WaitUntilSucceededAsync(predicate, timeout, delayOnFail, cancellationToken, TimeProvider.System);
+        }
+
+        internal static async Task<bool> WaitUntilSucceededAsync(
+            Func<CancellationToken, Task<bool>> predicate,
+            TimeSpan timeout,
+            TimeSpan? delayOnFail,
+            CancellationToken cancellationToken,
+            TimeProvider timeProvider)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
+            ArgumentNullException.ThrowIfNull(timeProvider);
+            return await WaitUntilSucceededAsync(
+                (_, token) => predicate(token),
+                timeout,
+                delayOnFail,
+                cancellationToken,
+                invokeFinalAttempt: false,
+                timeProvider);
         }
 
         private static async Task<bool> WaitUntilSucceededAsync(
@@ -136,7 +178,8 @@ namespace Orleans.TestingHost.Utils
             TimeSpan timeout,
             TimeSpan? delayOnFail,
             CancellationToken cancellationToken,
-            bool invokeFinalAttempt)
+            bool invokeFinalAttempt,
+            TimeProvider timeProvider)
         {
             ArgumentNullException.ThrowIfNull(predicate);
             ArgumentOutOfRangeException.ThrowIfLessThan(timeout, TimeSpan.Zero);
@@ -145,15 +188,15 @@ namespace Orleans.TestingHost.Utils
             ArgumentOutOfRangeException.ThrowIfLessThan(retryDelay, TimeSpan.Zero);
 
             cancellationToken.ThrowIfCancellationRequested();
-            var startedAt = Stopwatch.GetTimestamp();
-            using var deadlineCancellation = new CancellationTokenSource(timeout);
+            var startedAt = timeProvider.GetTimestamp();
+            using var deadlineCancellation = new CancellationTokenSource(timeout, timeProvider);
             using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadlineCancellation.Token);
             var finalAttempt = false;
             var finalAttemptWindow = retryDelay > TimeSpan.Zero ? retryDelay : TimeSpan.FromMilliseconds(10);
 
-            while (Stopwatch.GetElapsedTime(startedAt) < timeout)
+            while (timeProvider.GetElapsedTime(startedAt) < timeout)
             {
-                if (deadlineCancellation.IsCancellationRequested || Stopwatch.GetElapsedTime(startedAt) >= timeout)
+                if (deadlineCancellation.IsCancellationRequested || timeProvider.GetElapsedTime(startedAt) >= timeout)
                 {
                     return false;
                 }
@@ -169,7 +212,7 @@ namespace Orleans.TestingHost.Utils
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
-                var elapsed = Stopwatch.GetElapsedTime(startedAt);
+                var elapsed = timeProvider.GetElapsedTime(startedAt);
                 if (elapsed >= timeout)
                 {
                     return false;
@@ -185,7 +228,7 @@ namespace Orleans.TestingHost.Utils
                 {
                     try
                     {
-                        await Task.Delay(remaining, linkedCancellation.Token);
+                        await Task.Delay(remaining, timeProvider, linkedCancellation.Token);
                     }
                     catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                     {
@@ -213,7 +256,7 @@ namespace Orleans.TestingHost.Utils
 
                 try
                 {
-                    await Task.Delay(delay, linkedCancellation.Token);
+                    await Task.Delay(delay, timeProvider, linkedCancellation.Token);
                 }
                 catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Orleans.TestingHost.Tests.csproj
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Orleans.TestingHost.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Time.Testing;
 using Orleans.TestingHost.Utils;
 using Xunit;
 
@@ -55,29 +56,80 @@ public class TestingUtilsTests
     [Fact]
     public async Task WaitUntilSucceededAsync_ReturnsFalseAtDeadline()
     {
-        var result = await TestingUtils.WaitUntilSucceededAsync(
-            _ => Task.FromResult(false),
-            TimeSpan.FromMilliseconds(50),
-            TimeSpan.FromSeconds(1),
-            TestContext.Current.CancellationToken);
+        var timeProvider = new FakeTimeProvider();
+        var timeout = TimeSpan.FromSeconds(1);
+        var predicateInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        Assert.False(result);
+        var waitTask = TestingUtils.WaitUntilSucceededAsync(
+            _ =>
+            {
+                predicateInvoked.SetResult();
+                return Task.FromResult(false);
+            },
+            timeout,
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken,
+            timeProvider);
+
+        await predicateInvoked.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(timeout);
+
+        Assert.False(await waitTask);
     }
 
     [Fact]
-    public async Task WaitUntilSucceededAsync_LongPredicateCrossingDeadlineDoesNotSucceed()
+    public async Task WaitUntilSucceededAsync_PredicateCompletingBeforeDeadlineSucceeds()
     {
-        var predicateSettled = false;
+        var timeProvider = new FakeTimeProvider();
+        var timeout = TimeSpan.FromSeconds(1);
+        var predicateStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePredicate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var result = await TestingUtils.WaitUntilSucceededAsync(
+        var waitTask = TestingUtils.WaitUntilSucceededAsync(
             async _ =>
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                predicateStarted.SetResult();
+                await releasePredicate.Task;
+                return true;
+            },
+            timeout,
+            delayOnFail: null,
+            TestContext.Current.CancellationToken,
+            timeProvider);
+
+        await predicateStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(timeout - TimeSpan.FromTicks(1));
+        releasePredicate.SetResult();
+
+        Assert.True(await waitTask);
+    }
+
+    [Fact]
+    public async Task WaitUntilSucceededAsync_PredicateCompletingAtDeadlineDoesNotSucceed()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var timeout = TimeSpan.FromSeconds(1);
+        var predicateStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePredicate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var predicateSettled = false;
+
+        var waitTask = TestingUtils.WaitUntilSucceededAsync(
+            async _ =>
+            {
+                predicateStarted.SetResult();
+                await releasePredicate.Task;
                 predicateSettled = true;
                 return true;
             },
-            TimeSpan.FromMilliseconds(25),
-            cancellationToken: TestContext.Current.CancellationToken);
+            timeout,
+            delayOnFail: null,
+            TestContext.Current.CancellationToken,
+            timeProvider);
+
+        await predicateStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(timeout);
+        releasePredicate.SetResult();
+        var result = await waitTask;
 
         Assert.False(result);
         Assert.True(predicateSettled);
@@ -86,19 +138,30 @@ public class TestingUtilsTests
     [Fact]
     public async Task WaitUntilAsync_LegacyOverloadDoesNotInvokePredicateAfterDeadline()
     {
+        var timeProvider = new FakeTimeProvider();
+        var timeout = TimeSpan.FromSeconds(1);
+        var predicateStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePredicate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var calls = 0;
 
 #pragma warning disable xUnit1051 // This test verifies the legacy overload's deadline behavior.
-        var exception = await Assert.ThrowsAsync<TimeoutException>(() => TestingUtils.WaitUntilAsync(
+        var waitTask = TestingUtils.WaitUntilAsync(
             async (bool _) =>
             {
                 calls++;
-                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                predicateStarted.SetResult();
+                await releasePredicate.Task;
                 return false;
             },
-            TimeSpan.FromMilliseconds(25),
-            TimeSpan.FromSeconds(1)));
+            timeout,
+            TimeSpan.FromSeconds(1),
+            timeProvider);
 #pragma warning restore xUnit1051
+
+        await predicateStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(timeout);
+        releasePredicate.SetResult();
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => waitTask);
 
         Assert.Equal(1, calls);
         Assert.Contains(nameof(TestingUtilsTests), exception.Message);
@@ -133,17 +196,27 @@ public class TestingUtilsTests
     [Fact]
     public async Task WaitUntilAsync_PropagatesDeadlineCancellationAndReportsPredicateExpression()
     {
+        var timeProvider = new FakeTimeProvider();
+        var timeout = TimeSpan.FromSeconds(1);
+        var predicateStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var calls = 0;
 
-        var exception = await Assert.ThrowsAsync<TimeoutException>(() => TestingUtils.WaitUntilAsync(
+        var waitTask = TestingUtils.WaitUntilAsync(
             async (_, cancellationToken) =>
             {
                 calls++;
+                predicateStarted.SetResult();
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 return false;
             },
-            TimeSpan.FromMilliseconds(25),
-            cancellationToken: TestContext.Current.CancellationToken));
+            timeout,
+            delayOnFail: null,
+            TestContext.Current.CancellationToken,
+            timeProvider);
+
+        await predicateStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(timeout);
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => waitTask);
 
         Assert.Equal(1, calls);
         Assert.Contains("async (_, cancellationToken) =>", exception.Message);


### PR DESCRIPTION
Closes #10728

The reported failure occurred because the 25 ms test budget could expire before the first predicate invocation under CI load, so the test sometimes skipped the predicate-crossing path it intended to verify.

This change routes the helper's monotonic timestamps, deadline cancellation, and retry delays through an internal `TimeProvider` seam while production continues to use `TimeProvider.System`. The deadline tests use `FakeTimeProvider` plus explicit predicate barriers to cover completion immediately before the deadline, completion at the deadline, legacy predicate settlement, and deadline-token propagation.

The resulting invariant is deterministic: a predicate completion succeeds only while elapsed monotonic time is strictly less than the configured timeout.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10738)