### PR TITLE
fix(journaling): await recovery before reporting write conflicts

### DIFF
--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -164,6 +164,8 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
         var needsRecovery = true;
+        WorkItem? recoveryTrigger = null;
+        Exception? recoveryTriggerException = null;
         while (!_shutdownCancellation.Token.IsCancellationRequested)
         {
             try
@@ -175,8 +177,20 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                 {
                     if (needsRecovery)
                     {
-                        await RecoverAsync(_shutdownCancellation.Token).ConfigureAwait(true);
-                        needsRecovery = false;
+                        try
+                        {
+                            await RecoverAsync(_shutdownCancellation.Token).ConfigureAwait(true);
+                            needsRecovery = false;
+                        }
+                        finally
+                        {
+                            if (recoveryTrigger is { } trigger)
+                            {
+                                trigger.SetException(recoveryTriggerException!);
+                                recoveryTrigger = null;
+                                recoveryTriggerException = null;
+                            }
+                        }
                     }
 
                     WorkItem workItem;
@@ -520,10 +534,16 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                             }
                         }
 
-                        workItem.SetException(exception);
                         if (IsRecoverySignal(exception))
                         {
+                            Debug.Assert(recoveryTrigger is null);
+                            recoveryTrigger = workItem;
+                            recoveryTriggerException = exception;
                             needsRecovery = true;
+                        }
+                        else
+                        {
+                            workItem.SetException(exception);
                         }
                     }
                     finally

--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -177,20 +177,9 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                 {
                     if (needsRecovery)
                     {
-                        try
-                        {
-                            await RecoverAsync(_shutdownCancellation.Token).ConfigureAwait(true);
-                            needsRecovery = false;
-                        }
-                        finally
-                        {
-                            if (recoveryTrigger is { } trigger)
-                            {
-                                trigger.SetException(recoveryTriggerException!);
-                                recoveryTrigger = null;
-                                recoveryTriggerException = null;
-                            }
-                        }
+                        await RecoverAsync(_shutdownCancellation.Token).ConfigureAwait(true);
+                        needsRecovery = false;
+                        CompleteRecoveryTrigger();
                     }
 
                     WorkItem workItem;
@@ -557,12 +546,32 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                 needsRecovery = true;
                 if (_shutdownCancellation.Token.IsCancellationRequested)
                 {
+                    CompleteRecoveryTrigger();
                     return;
                 }
 
-                FaultQueuedWorkItems(exception);
-                LogErrorProcessingWorkItems(_shared.Logger, exception);
+                try
+                {
+                    FaultQueuedWorkItems(exception);
+                    LogErrorProcessingWorkItems(_shared.Logger, exception);
+                }
+                finally
+                {
+                    CompleteRecoveryTrigger();
+                }
             }
+        }
+
+        void CompleteRecoveryTrigger()
+        {
+            if (recoveryTrigger is not { } trigger)
+            {
+                return;
+            }
+
+            trigger.SetException(recoveryTriggerException!);
+            recoveryTrigger = null;
+            recoveryTriggerException = null;
         }
     }
 

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -508,6 +508,39 @@ public class StateManagerTests : JournalingTestBase
     }
 
     [Fact]
+    public async Task StateManager_WriteStateAsync_RetriesRecoveryAfterRepeatedFailures()
+    {
+        var storage = new CapturingStorage();
+        var sut = CreateTestSystem(storage: storage);
+        var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
+
+        await sut.Lifecycle.OnStart();
+        dictionary.Add("first", 1);
+        await sut.Manager.WriteStateAsync(CancellationToken.None);
+
+        var conflict = new InconsistentStateException("Expected storage write conflict.");
+        var firstRecoveryFailure = new IOException("Expected first recovery failure.");
+        storage.NextAppendException = conflict;
+        storage.NextReadException = firstRecoveryFailure;
+        dictionary.Add("second", 2);
+
+        var conflictException = await Assert.ThrowsAsync<InconsistentStateException>(
+            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+        Assert.Same(conflict, conflictException);
+
+        var secondRecoveryFailure = new IOException("Expected second recovery failure.");
+        storage.NextReadException = secondRecoveryFailure;
+        var recoveryException = await Assert.ThrowsAsync<IOException>(
+            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+        Assert.Same(secondRecoveryFailure, recoveryException);
+
+        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(dictionary.ContainsKey("first"));
+        Assert.False(dictionary.ContainsKey("second"));
+    }
+
+    [Fact]
     public async Task StateManager_WriteStateAsync_CoalescesQueuedWrites()
     {
         var storage = new CapturingStorage();
@@ -1520,6 +1553,8 @@ public class StateManagerTests : JournalingTestBase
 
         public Exception? NextAppendException { get; set; }
 
+        public Exception? NextReadException { get; set; }
+
         public bool BlockNextRead { get; set; }
 
         public TaskCompletionSource BlockedReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1541,6 +1576,12 @@ public class StateManagerTests : JournalingTestBase
         public async ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(consumer);
+
+            if (NextReadException is { } exception)
+            {
+                NextReadException = null;
+                throw exception;
+            }
 
             if (BlockNextRead)
             {

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -526,13 +526,13 @@ public class StateManagerTests : JournalingTestBase
         dictionary.Add("second", 2);
 
         var conflictException = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10)));
         Assert.Same(conflict, conflictException);
 
         var secondRecoveryFailure = new IOException("Expected second recovery failure.");
         storage.NextReadException = secondRecoveryFailure;
         var recoveryException = await Assert.ThrowsAsync<IOException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10)));
         Assert.Same(secondRecoveryFailure, recoveryException);
 
         await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -450,10 +450,15 @@ public class StateManagerTests : JournalingTestBase
 
         var expected = new InconsistentStateException("Expected storage write conflict.");
         storage.NextAppendException = expected;
+        storage.BlockNextRead = true;
         dictionary.Add("second", 2);
 
-        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+        var failedWrite = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
+        await storage.BlockedReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(failedWrite.IsCompleted);
+
+        storage.AllowBlockedRead.SetResult();
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(() => failedWrite);
         Assert.Same(expected, exception);
 
         await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
@@ -1515,6 +1520,12 @@ public class StateManagerTests : JournalingTestBase
 
         public Exception? NextAppendException { get; set; }
 
+        public bool BlockNextRead { get; set; }
+
+        public TaskCompletionSource BlockedReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowBlockedRead { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public int ReadConsumeCount { get; private set; }
 
         public void ResetReadConsumeCount() => ReadConsumeCount = 0;
@@ -1527,9 +1538,16 @@ public class StateManagerTests : JournalingTestBase
 
         public TaskCompletionSource AllowReplace { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
+        public async ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(consumer);
+
+            if (BlockNextRead)
+            {
+                BlockNextRead = false;
+                BlockedReadStarted.SetResult();
+                await AllowBlockedRead.Task.WaitAsync(cancellationToken);
+            }
 
             if (ConcatenateReads)
             {
@@ -1558,11 +1576,10 @@ public class StateManagerTests : JournalingTestBase
                     consumer.Complete(metadata: null);
                 }
 
-                return default;
+                return;
             }
 
             consumer.Read(GetSegments(), metadata: null, complete: true);
-            return default;
 
             IEnumerable<ReadOnlyMemory<byte>> GetSegments()
             {

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -458,7 +458,8 @@ public class StateManagerTests : JournalingTestBase
         Assert.False(failedWrite.IsCompleted);
 
         storage.AllowBlockedRead.SetResult();
-        var exception = await Assert.ThrowsAsync<InconsistentStateException>(() => failedWrite);
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
+            () => failedWrite.WaitAsync(TimeSpan.FromSeconds(10)));
         Assert.Same(expected, exception);
 
         await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
## Problem
A journal append conflict completed its caller-facing `WriteStateAsync` task before the state manager performed the required recovery. A sequential follow-up write could therefore race the recovery loop and, when recovery fencing was active, fail with `Journaled state writes are unavailable while recovery is in progress.`

A failed recovery also needs a complete generation boundary: queued work must be faulted and recovery must remain required before the original conflict caller can enqueue a retry.

## Solution
Defer completion of the conflicting write until the automatically-triggered recovery reaches a terminal outcome and its failure cleanup completes. The caller still receives the original `InconsistentStateException`, while a sequential retry begins only after the manager is ready for the next recovery generation.

The focused tests now:
- block a successful recovery read and assert that the conflict remains unobservable until recovery is released;
- fail recovery twice, verify each later caller initiates a fresh attempt, and confirm writes resume after recovery succeeds.

## Rationale
The work loop owns persistence and recovery ordering. Publishing each result after its complete recovery generation preserves that serialization boundary, keeps concurrent recovery fencing meaningful, and avoids timeouts, retries, or test-only scheduling assumptions.

Closes #10727