### PR TITLE
test(durable-jobs): isolate Azure storage per test

### DIFF
--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageBlobDurableJobsTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageBlobDurableJobsTests.cs
@@ -54,7 +54,7 @@ public class AzureStorageBlobDurableJobsTests : TestClusterPerTest
         }
     }
 
-    internal static string GetContainerName(string serviceId) => $"durablejobs-tests-{serviceId}";
+    internal static string GetContainerName(string serviceId) => $"durablejobs-tests-{serviceId.ToLowerInvariant()}";
 
     private static BlobContainerClient CreateContainerClient(string containerName)
     {

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageBlobDurableJobsTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageBlobDurableJobsTests.cs
@@ -1,4 +1,6 @@
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Journaling;
@@ -16,6 +18,7 @@ namespace Tester.AzureUtils.DurableJobs;
 public class AzureStorageBlobDurableJobsTests : TestClusterPerTest
 {
     private DurableJobTestsRunner _runner = null!;
+    private string? _containerName;
 
     protected override void CheckPreconditionsOrThrow() => TestUtils.CheckForAzureStorage();
 
@@ -31,7 +34,33 @@ public class AzureStorageBlobDurableJobsTests : TestClusterPerTest
 
     protected override void ConfigureTestCluster(TestClusterBuilder builder)
     {
+        _containerName = GetContainerName(builder.Options.ServiceId);
         builder.AddSiloBuilderConfigurator<SiloHostConfigurator>();
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await base.DisposeAsync();
+        }
+        finally
+        {
+            if (_containerName is not null)
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await CreateContainerClient(_containerName).DeleteIfExistsAsync(cancellationToken: cts.Token);
+            }
+        }
+    }
+
+    internal static string GetContainerName(string serviceId) => $"durablejobs-tests-{serviceId}";
+
+    private static BlobContainerClient CreateContainerClient(string containerName)
+    {
+        return TestDefaultConfiguration.UseAadAuthentication
+            ? new BlobContainerClient(new Uri(TestDefaultConfiguration.DataBlobUri, containerName), TestDefaultConfiguration.TokenCredential)
+            : new BlobContainerClient(TestDefaultConfiguration.DataConnectionString, containerName);
     }
 
     public class SiloHostConfigurator : ISiloConfigurator
@@ -41,6 +70,11 @@ public class AzureStorageBlobDurableJobsTests : TestClusterPerTest
             hostBuilder
                 .UseAzureBlobDurableJobs(options => options.ConfigureTestDefaults())
                 .AddMemoryGrainStorageAsDefault();
+
+            hostBuilder.Services
+                .AddOptions<AzureBlobJournalStorageOptions>()
+                .Configure<IOptions<ClusterOptions>>(
+                    static (options, clusterOptions) => options.ContainerName = GetContainerName(clusterOptions.Value.ServiceId));
         }
     }
 

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
@@ -18,6 +18,17 @@ namespace Tester.AzureUtils.DurableJobs;
 public class AzureStorageDurableJobsConfigurationTests
 {
     [Fact]
+    public void DurableJobsTestContainerNamesAreScopedByServiceId()
+    {
+        var first = AzureStorageBlobDurableJobsTests.GetContainerName("service-a");
+        var second = AzureStorageBlobDurableJobsTests.GetContainerName("service-b");
+
+        Assert.Equal("durablejobs-tests-service-a", first);
+        Assert.Equal("durablejobs-tests-service-b", second);
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
     public void UseAzureBlobDurableJobs_ConfiguresDurableJobsJsonMetadata()
     {
         var builder = new TestSiloBuilder();

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
@@ -25,6 +25,7 @@ public class AzureStorageDurableJobsConfigurationTests
 
         Assert.Equal("durablejobs-tests-service-a", first);
         Assert.Equal("durablejobs-tests-service-b", second);
+        Assert.Equal("durablejobs-tests-service-a", AzureStorageBlobDurableJobsTests.GetContainerName("Service-A"));
         Assert.NotEqual(first, second);
     }
 


### PR DESCRIPTION
## Problem

`AzureStorageBlobDurableJobsTests` used the default Azure journal container for every per-test cluster. Journals left by earlier tests were therefore visible to later clusters. In the failing run, the `ConcurrentScheduling` cluster adopted old shards, including a previously exhausted job, while all 20 newly scheduled jobs remained unobserved.

## Solution

Scope the Azure journal container to the test cluster's unique Orleans service ID, configure every silo in that cluster with the same container, and delete the container after the cluster shuts down. Add a focused configuration test for the service-ID-derived container names.

## Rationale

A durable-jobs journal catalog belongs to one cluster lifecycle. Per-test storage preserves that ownership boundary, prevents stale shard adoption from consuming startup processing, and keeps the concurrency test focused on jobs scheduled by its own cluster.

Closes #10713
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10740)