### PR TITLE
fix(testing): stabilize Event Hubs resume startup

### DIFF
--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamingResumeTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamingResumeTests.cs
@@ -70,6 +70,17 @@ namespace ServiceBus.Tests.Streaming
 
         protected override void CheckPreconditionsOrThrow() => TestUtils.CheckForEventHub();
 
+        public override async ValueTask InitializeAsync()
+        {
+            await base.InitializeAsync();
+            if (!PreconditionsMet)
+            {
+                return;
+            }
+
+            await WaitForStreamProviderReadyAsync();
+        }
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             TestUtils.CheckForEventHub();

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Orleans.Configuration;
 using Orleans.Providers;
 using Orleans.TestingHost;
 
@@ -13,6 +14,8 @@ namespace Tester.StreamingTests
     [TestCategory("SlowBVT"), TestCategory("Streaming"), TestCategory("StreamingResume")]
     public class MemoryStreamResumeTests : StreamingResumeTests
     {
+        private const int TotalQueueCount = 6;
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
@@ -50,6 +53,7 @@ namespace Tester.StreamingTests
                             options.DataMaxAgeInCache = DataMaxAgeInCache;
                             options.DataMinTimeInCache = DataMinTimeInCache;
                         }));
+                        b.Configure<HashRingStreamQueueMapperOptions>(ob => ob.Configure(options => options.TotalQueueCount = TotalQueueCount));
                     });
             }
         }
@@ -59,7 +63,10 @@ namespace Tester.StreamingTests
             public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
             {
                 clientBuilder
-                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName);
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b =>
+                    {
+                        b.Configure<HashRingStreamQueueMapperOptions>(ob => ob.Configure(options => options.TotalQueueCount = TotalQueueCount));
+                    });
             }
         }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
@@ -1,11 +1,6 @@
 using Microsoft.Extensions.Configuration;
-using Orleans.Configuration;
 using Orleans.Providers;
-using Orleans.Providers.Streams.Common;
-using Orleans.Runtime;
 using Orleans.TestingHost;
-using Orleans.TestingHost.Utils;
-using Xunit;
 
 namespace Tester.StreamingTests
 {
@@ -31,48 +26,8 @@ namespace Tester.StreamingTests
             {
                 return;
             }
-            await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
-            var managementGrain = this.Client.GetGrain<IManagementGrain>(0);
-            var expectedSiloCount = this.HostedCluster.GetActiveSilos().Count();
-            await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
-                StreamProviderName,
-                (int)PersistentStreamProviderCommand.StartAgents);
-
-            // Guard against a subsequent membership notification racing the serialized StartAgents command.
-            var consecutiveReadyObservations = 0;
-            const int requiredReadyObservations = 3;
-            await TestingUtils.WaitUntilAsync(
-                async lastTry =>
-                {
-                    var states = await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
-                        StreamProviderName,
-                        (int)PersistentStreamProviderCommand.GetAgentsState);
-                    var agentCounts = await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
-                        StreamProviderName,
-                        (int)PersistentStreamProviderCommand.GetNumberRunningAgents);
-                    var runningAgentCounts = agentCounts.Select(Convert.ToInt32).ToArray();
-                    var ready = states.Length == expectedSiloCount
-                        && runningAgentCounts.Length == expectedSiloCount
-                        && states.All(state => Convert.ToInt32(state) == (int)StreamLifecycleOptions.RunState.AgentsStarted)
-                        && runningAgentCounts.Sum() == HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES;
-                    consecutiveReadyObservations = ready ? consecutiveReadyObservations + 1 : 0;
-
-                    if (lastTry)
-                    {
-                        Assert.Equal(expectedSiloCount, states.Length);
-                        Assert.Equal(expectedSiloCount, runningAgentCounts.Length);
-                        Assert.All(states, state => Assert.Equal((int)StreamLifecycleOptions.RunState.AgentsStarted, Convert.ToInt32(state)));
-                        Assert.Equal(HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES, runningAgentCounts.Sum());
-                        Assert.True(
-                            consecutiveReadyObservations >= requiredReadyObservations,
-                            $"Stream provider readiness was observed {consecutiveReadyObservations} consecutive time(s), but {requiredReadyObservations} were required.");
-                    }
-
-                    return consecutiveReadyObservations >= requiredReadyObservations;
-                },
-                TimeSpan.FromSeconds(30),
-                delayOnFail: TimeSpan.FromMilliseconds(100));
+            await WaitForStreamProviderReadyAsync();
         }
 
         #region Configuration stuff

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -1,6 +1,11 @@
 #nullable enable
 
+using Orleans.Configuration;
+using Orleans.Providers;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 using Orleans.Streams;
+using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
@@ -19,6 +24,52 @@ public abstract class StreamingResumeTests : TestClusterPerTest
 
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(30);
+
+    protected async Task WaitForStreamProviderReadyAsync()
+    {
+        await this.HostedCluster.WaitForLivenessToStabilizeAsync();
+
+        var managementGrain = this.Client.GetGrain<IManagementGrain>(0);
+        var expectedSiloCount = this.HostedCluster.GetActiveSilos().Count();
+        await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
+            StreamProviderName,
+            (int)PersistentStreamProviderCommand.StartAgents);
+
+        // Guard against a subsequent membership notification racing the serialized StartAgents command.
+        var consecutiveReadyObservations = 0;
+        const int requiredReadyObservations = 3;
+        await TestingUtils.WaitUntilAsync(
+            async lastTry =>
+            {
+                var states = await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
+                    StreamProviderName,
+                    (int)PersistentStreamProviderCommand.GetAgentsState);
+                var agentCounts = await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
+                    StreamProviderName,
+                    (int)PersistentStreamProviderCommand.GetNumberRunningAgents);
+                var runningAgentCounts = agentCounts.Select(Convert.ToInt32).ToArray();
+                var ready = states.Length == expectedSiloCount
+                    && runningAgentCounts.Length == expectedSiloCount
+                    && states.All(state => Convert.ToInt32(state) == (int)StreamLifecycleOptions.RunState.AgentsStarted)
+                    && runningAgentCounts.Sum() == HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES;
+                consecutiveReadyObservations = ready ? consecutiveReadyObservations + 1 : 0;
+
+                if (lastTry)
+                {
+                    Assert.Equal(expectedSiloCount, states.Length);
+                    Assert.Equal(expectedSiloCount, runningAgentCounts.Length);
+                    Assert.All(states, state => Assert.Equal((int)StreamLifecycleOptions.RunState.AgentsStarted, Convert.ToInt32(state)));
+                    Assert.Equal(HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES, runningAgentCounts.Sum());
+                    Assert.True(
+                        consecutiveReadyObservations >= requiredReadyObservations,
+                        $"Stream provider readiness was observed {consecutiveReadyObservations} consecutive time(s), but {requiredReadyObservations} were required.");
+                }
+
+                return consecutiveReadyObservations >= requiredReadyObservations;
+            },
+            WaitTimeout,
+            delayOnFail: PollInterval);
+    }
 
     [Fact]
     public virtual async Task ResumeAfterInactivity()

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -30,7 +30,15 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
         var managementGrain = this.Client.GetGrain<IManagementGrain>(0);
-        var expectedSiloCount = this.HostedCluster.GetActiveSilos().Count();
+        var activeSilos = this.HostedCluster.GetActiveSilos().ToArray();
+        var expectedSiloCount = activeSilos.Length;
+        var configuredQueueCounts = activeSilos
+            .Select(silo => this.HostedCluster.GetSiloServiceProvider(silo.SiloAddress)
+                .GetOptionsByName<HashRingStreamQueueMapperOptions>(StreamProviderName)
+                .TotalQueueCount)
+            .Distinct()
+            .ToArray();
+        var expectedQueueCount = Assert.Single(configuredQueueCounts);
         await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
             StreamProviderName,
             (int)PersistentStreamProviderCommand.StartAgents);
@@ -51,7 +59,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
                 var ready = states.Length == expectedSiloCount
                     && runningAgentCounts.Length == expectedSiloCount
                     && states.All(state => Convert.ToInt32(state) == (int)StreamLifecycleOptions.RunState.AgentsStarted)
-                    && runningAgentCounts.Sum() == HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES;
+                    && runningAgentCounts.Sum() == expectedQueueCount;
                 consecutiveReadyObservations = ready ? consecutiveReadyObservations + 1 : 0;
 
                 if (lastTry)
@@ -59,7 +67,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
                     Assert.Equal(expectedSiloCount, states.Length);
                     Assert.Equal(expectedSiloCount, runningAgentCounts.Length);
                     Assert.All(states, state => Assert.Equal((int)StreamLifecycleOptions.RunState.AgentsStarted, Convert.ToInt32(state)));
-                    Assert.Equal(HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES, runningAgentCounts.Sum());
+                    Assert.Equal(expectedQueueCount, runningAgentCounts.Sum());
                     Assert.True(
                         consecutiveReadyObservations >= requiredReadyObservations,
                         $"Stream provider readiness was observed {consecutiveReadyObservations} consecutive time(s), but {requiredReadyObservations} were required.");

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -33,12 +33,10 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var managementGrain = this.Client.GetGrain<IManagementGrain>(0);
         var activeSilos = this.HostedCluster.GetActiveSilos().ToArray();
         var expectedSiloCount = activeSilos.Length;
-        var providerQueueCounts = activeSilos
-            .Select(silo => this.HostedCluster.GetSiloServiceProvider(silo.SiloAddress)
-                .GetRequiredKeyedService<IQueueAdapterFactory>(StreamProviderName)
-                .GetStreamQueueMapper()
-                .GetAllQueues()
-                .Count())
+        var providerQueueCounts = (await Task.WhenAll(activeSilos.Select(
+            silo => GetProviderQueueCountAsync(
+                this.HostedCluster.GetSiloServiceProvider(silo.SiloAddress),
+                StreamProviderName))))
             .Distinct()
             .ToArray();
         var expectedQueueCount = Assert.Single(providerQueueCounts);
@@ -80,6 +78,13 @@ public abstract class StreamingResumeTests : TestClusterPerTest
             },
             WaitTimeout,
             delayOnFail: PollInterval);
+    }
+
+    internal static async Task<int> GetProviderQueueCountAsync(IServiceProvider services, string streamProviderName)
+    {
+        var adapterFactory = services.GetRequiredKeyedService<IQueueAdapterFactory>(streamProviderName);
+        await adapterFactory.CreateAdapter(CancellationToken.None);
+        return adapterFactory.GetStreamQueueMapper().GetAllQueues().Count();
     }
 
     [Fact]

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Orleans.Providers;
 using Orleans.Providers.Streams.Common;
@@ -32,13 +33,15 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var managementGrain = this.Client.GetGrain<IManagementGrain>(0);
         var activeSilos = this.HostedCluster.GetActiveSilos().ToArray();
         var expectedSiloCount = activeSilos.Length;
-        var configuredQueueCounts = activeSilos
+        var providerQueueCounts = activeSilos
             .Select(silo => this.HostedCluster.GetSiloServiceProvider(silo.SiloAddress)
-                .GetOptionsByName<HashRingStreamQueueMapperOptions>(StreamProviderName)
-                .TotalQueueCount)
+                .GetRequiredKeyedService<IQueueAdapterFactory>(StreamProviderName)
+                .GetStreamQueueMapper()
+                .GetAllQueues()
+                .Count())
             .Distinct()
             .ToArray();
-        var expectedQueueCount = Assert.Single(configuredQueueCounts);
+        var expectedQueueCount = Assert.Single(providerQueueCounts);
         await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
             StreamProviderName,
             (int)PersistentStreamProviderCommand.StartAgents);

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTestsTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTestsTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.Streams;
+using Xunit;
+
+namespace Tester.StreamingTests;
+
+public class StreamingResumeTestsTests
+{
+    private const string StreamProviderName = "LazyStreamProvider";
+
+    [Fact]
+    public async Task GetProviderQueueCountAsync_InitializesLazyAdapterFactory()
+    {
+        var adapter = Substitute.For<IQueueAdapter>();
+        var mapper = new HashRingBasedStreamQueueMapper(
+            new HashRingStreamQueueMapperOptions { TotalQueueCount = 3 },
+            StreamProviderName);
+        var adapterFactory = new LazyQueueAdapterFactory(adapter, mapper);
+        using var services = new ServiceCollection()
+            .AddKeyedSingleton<IQueueAdapterFactory>(StreamProviderName, adapterFactory)
+            .BuildServiceProvider();
+
+        var queueCount = await StreamingResumeTests.GetProviderQueueCountAsync(services, StreamProviderName);
+
+        Assert.True(adapterFactory.AdapterCreated);
+        Assert.Equal(3, queueCount);
+    }
+
+    private sealed class LazyQueueAdapterFactory(IQueueAdapter adapter, IStreamQueueMapper mapper) : IQueueAdapterFactory
+    {
+        public bool AdapterCreated { get; private set; }
+
+        public Task<IQueueAdapter> CreateAdapter()
+        {
+            AdapterCreated = true;
+            return Task.FromResult(adapter);
+        }
+
+        public IQueueAdapterCache GetQueueAdapterCache() => Substitute.For<IQueueAdapterCache>();
+
+        public IStreamQueueMapper GetStreamQueueMapper()
+        {
+            Assert.True(AdapterCreated);
+            return mapper;
+        }
+
+        public Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId)
+            => Task.FromResult(Substitute.For<IStreamFailureHandler>());
+    }
+}


### PR DESCRIPTION
## Problem

`EHStreamingResumeTests.ResumeAfterDeactivation` can publish its first event while the consistent-ring queue balancer is still transferring Event Hubs pulling-agent ownership during cluster startup. Event Hubs receivers begin at the latest position, so publishing before ownership and receiver pumps settle can leave the test with zero deliveries. The failed CI artifact timed out on the initial delivery, before deactivation, and its silo logs show queue transfer occurring immediately before the client began.

## Solution

Factor the existing resume-test provider readiness barrier into `StreamingResumeTests` and apply it to the Event Hubs fixture. Initialization now waits for cluster liveness, serializes `StartAgents` behind pending queue-distribution work, and requires stable provider state and the full queue count before tests publish. The memory fixture reuses the same helper.

## Rationale

This synchronizes the test with the pulling-provider startup invariant instead of extending delivery timeouts. It follows the established fix for the equivalent memory-stream startup race in #10466.

Fixes #10735
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10741)