### PR TITLE
test(runtime): make duplicate activation stress deterministic

### DIFF
--- a/test/Grains/TestGrainInterfaces/ICatalogTestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ICatalogTestGrain.cs
@@ -3,6 +3,7 @@
     public interface ICatalogTestGrain : IGrainWithIntegerKey
     {
         Task Initialize();
-        Task BlastCallNewGrains(int nGrains, long startingKey, int nCallsToEach);
+        Task<string> GetActivationId();
+        Task<string[]> GetActivationIds(int nGrains, long startingKey);
     }
 }

--- a/test/Grains/TestGrains/CatalogTestGrain.cs
+++ b/test/Grains/TestGrains/CatalogTestGrain.cs
@@ -37,6 +37,8 @@ namespace UnitTests.Grains
 
         public async Task<string[]> GetActivationIds(int nGrains, long startingKey)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(nGrains);
+
             if (Volatile.Read(ref _concurrentCallBarrier) is { } barrier)
             {
                 await barrier.SignalAndWaitAsync();

--- a/test/Grains/TestGrains/CatalogTestGrain.cs
+++ b/test/Grains/TestGrains/CatalogTestGrain.cs
@@ -4,6 +4,22 @@ namespace UnitTests.Grains
 {
     public class CatalogTestGrain : Grain, ICatalogTestGrain
     {
+        private static ConcurrentCallBarrier? _concurrentCallBarrier;
+        private readonly string _activationId = Guid.NewGuid().ToString();
+
+        public static ConcurrentCallBarrier ArmConcurrentCallBarrier(int participantCount)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(participantCount, 1);
+
+            var barrier = new ConcurrentCallBarrier(participantCount);
+            if (Interlocked.CompareExchange(ref _concurrentCallBarrier, barrier, null) is not null)
+            {
+                throw new InvalidOperationException("A concurrent call barrier is already armed.");
+            }
+
+            return barrier;
+        }
+
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             return Task.Delay(TimeSpan.FromMilliseconds(50));
@@ -14,19 +30,88 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task BlastCallNewGrains(int nGrains, long startingKey, int nCallsToEach)
+        public Task<string> GetActivationId()
         {
-            var promises = new List<Task>(nGrains * nCallsToEach);
+            return Task.FromResult(_activationId);
+        }
 
+        public async Task<string[]> GetActivationIds(int nGrains, long startingKey)
+        {
+            if (Volatile.Read(ref _concurrentCallBarrier) is { } barrier)
+            {
+                await barrier.SignalAndWaitAsync();
+            }
+
+            var promises = new Task<string>[nGrains];
             for (int i = 0; i < nGrains; i++)
             {
                 var grain = GrainFactory.GetGrain<ICatalogTestGrain>(startingKey + i);
-
-                for (int j = 0; j < nCallsToEach; j++)
-                    promises.Add(grain.Initialize());
+                promises[i] = grain.GetActivationId();
             }
 
-            return Task.WhenAll(promises);
+            return await Task.WhenAll(promises);
+        }
+
+        public sealed class ConcurrentCallBarrier : IDisposable
+        {
+            private readonly TaskCompletionSource _participantsReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly int _participantCount;
+            private int _remainingParticipants;
+            private int _disposed;
+
+            internal ConcurrentCallBarrier(int participantCount)
+            {
+                _participantCount = participantCount;
+                _remainingParticipants = participantCount;
+            }
+
+            public async Task WaitForParticipantsAsync(TimeSpan timeout, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await _participantsReady.Task.WaitAsync(timeout, cancellationToken);
+                }
+                catch (TimeoutException exception)
+                {
+                    var arrived = _participantCount - Volatile.Read(ref _remainingParticipants);
+                    throw new TimeoutException(
+                        $"Timed out waiting for concurrent catalog calls: {arrived} of {_participantCount} runners reached the barrier.",
+                        exception);
+                }
+            }
+
+            public void Release()
+            {
+                _release.TrySetResult();
+            }
+
+            internal async Task SignalAndWaitAsync()
+            {
+                var remaining = Interlocked.Decrement(ref _remainingParticipants);
+                if (remaining < 0)
+                {
+                    throw new InvalidOperationException($"More than {_participantCount} runners reached the concurrent call barrier.");
+                }
+
+                if (remaining == 0)
+                {
+                    _participantsReady.TrySetResult();
+                }
+
+                await _release.Task;
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+
+                Release();
+                Interlocked.CompareExchange(ref _concurrentCallBarrier, null, this);
+            }
         }
     }
 }

--- a/test/Orleans.Runtime.Tests/DuplicateActivationsTests.cs
+++ b/test/Orleans.Runtime.Tests/DuplicateActivationsTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.CatalogTests
         /// Each activation returns its unique identifier so that the test can verify
         /// that every request for a target grain was handled by the same activation.
         /// </summary>
-        [Fact, TestCategory("Catalog"), TestCategory("Functional")]
+        [Fact]
         public async Task DuplicateActivations()
         {
             const int nRunnerGrains = 100;    // Number of grains making concurrent calls
@@ -55,7 +55,7 @@ namespace UnitTests.CatalogTests
             var promises = new List<Task>(nRunnerGrains);
             for (int i = 0; i < nRunnerGrains; i++)
             {
-                runnerGrains[i] = this.fixture.GrainFactory.GetGrain<ICatalogTestGrain>(-i);
+                runnerGrains[i] = this.fixture.GrainFactory.GetGrain<ICatalogTestGrain>(-(i + 1));
                 promises.Add(runnerGrains[i].Initialize());
             }
 

--- a/test/Orleans.Runtime.Tests/DuplicateActivationsTests.cs
+++ b/test/Orleans.Runtime.Tests/DuplicateActivationsTests.cs
@@ -88,7 +88,7 @@ namespace UnitTests.CatalogTests
 
                 Assert.True(
                     activationIds.Count == 1,
-                    $"Target grain {startingKey + targetIndex} was handled by {activationIds.Count} activations: {string.Join(", ", activationIds)}");
+                    $"Target grain {startingKey + targetIndex} was handled by {activationIds.Count} activations: {string.Join(", ", activationIds.Order())}");
             }
         }
     }

--- a/test/Orleans.Runtime.Tests/DuplicateActivationsTests.cs
+++ b/test/Orleans.Runtime.Tests/DuplicateActivationsTests.cs
@@ -1,7 +1,7 @@
-using Orleans.Configuration;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
 using Xunit;
 
 namespace UnitTests.CatalogTests
@@ -14,7 +14,7 @@ namespace UnitTests.CatalogTests
     /// simultaneously make calls to the same set of target grains.
     /// 
     /// The catalog is responsible for ensuring that concurrent activation requests for the same grain
-    /// don't result in multiple activations within a single silo.
+    /// result in one activation across the cluster.
     /// </summary>
     [TestSuite("Functional")]
     [TestProvider("None")]
@@ -25,22 +25,7 @@ namespace UnitTests.CatalogTests
 
         public class Fixture : BaseTestClusterFixture
         {
-            protected override void ConfigureTestCluster(TestClusterBuilder builder)
-            {
-                builder.AddSiloBuilderConfigurator<SiloConfigurator>();
-            }
         }
-
-        public class SiloConfigurator : ISiloConfigurator
-        {
-            public void Configure(ISiloBuilder hostBuilder)
-            {
-                // Increase response timeout to accommodate the high load during stress testing
-                // This prevents timeouts that could interfere with duplicate activation detection
-                hostBuilder.Configure<SiloMessagingOptions>(options => options.ResponseTimeout = TimeSpan.FromMinutes(1));
-            }
-        }
-
 
         public DuplicateActivationsTests(Fixture fixture)
         {
@@ -49,12 +34,12 @@ namespace UnitTests.CatalogTests
 
         /// <summary>
         /// Stress test for duplicate activation prevention.
-        /// Creates 100 runner grains that each make 100 calls to 10 target grains.
-        /// This generates 10,000 concurrent requests to just 10 grains, creating
-        /// extreme contention that tests the catalog's synchronization mechanisms.
+        /// Creates 100 runner grains that concurrently call the same 10 target grains.
+        /// This generates 1,000 concurrent requests for previously inactive grains,
+        /// creating contention in the catalog's activation synchronization.
         /// 
-        /// If duplicate activations occur, the target grains will detect this and throw exceptions.
-        /// The test passes only if all calls complete without any duplicate activation errors.
+        /// Each activation returns its unique identifier so that the test can verify
+        /// that every request for a target grain was handled by the same activation.
         /// </summary>
         [Fact, TestCategory("Catalog"), TestCategory("Functional")]
         public async Task DuplicateActivations()
@@ -62,7 +47,6 @@ namespace UnitTests.CatalogTests
             const int nRunnerGrains = 100;    // Number of grains making concurrent calls
             const int nTargetGrain = 10;      // Number of target grains (high contention)
             const int startingKey = 1000;     // Starting grain ID for target grains
-            const int nCallsToEach = 100;     // Calls each runner makes to each target
 
             var runnerGrains = new ICatalogTestGrain[nRunnerGrains];
 
@@ -76,17 +60,36 @@ namespace UnitTests.CatalogTests
             }
 
             await Task.WhenAll(promises);
-            promises.Clear();
 
             // Phase 2: All runners simultaneously blast calls to the same target grains
-            // This creates massive concurrent activation pressure on the catalog
+            // This creates concurrent activation pressure on the catalog
+            using var callBarrier = CatalogTestGrain.ArmConcurrentCallBarrier(nRunnerGrains);
+            var participantsReady = callBarrier.WaitForParticipantsAsync(
+                TimeSpan.FromSeconds(30),
+                TestContext.Current.CancellationToken);
+            var activationIdPromises = new List<Task<string[]>>(nRunnerGrains);
             for (int i = 0; i < nRunnerGrains; i++)
             {
-                promises.Add(runnerGrains[i].BlastCallNewGrains(nTargetGrain, startingKey, nCallsToEach));
+                activationIdPromises.Add(runnerGrains[i].GetActivationIds(nTargetGrain, startingKey));
             }
 
-            // If any duplicate activations occur, the grains will detect and report them
-            await Task.WhenAll(promises);
+            await participantsReady;
+            callBarrier.Release();
+            var activationIdsByRunner = await Task.WhenAll(activationIdPromises);
+            Assert.All(activationIdsByRunner, activationIds => Assert.Equal(nTargetGrain, activationIds.Length));
+
+            for (int targetIndex = 0; targetIndex < nTargetGrain; targetIndex++)
+            {
+                var activationIds = new HashSet<string>();
+                foreach (var activationIdsForRunner in activationIdsByRunner)
+                {
+                    activationIds.Add(activationIdsForRunner[targetIndex]);
+                }
+
+                Assert.True(
+                    activationIds.Count == 1,
+                    $"Target grain {startingKey + targetIndex} was handled by {activationIds.Count} activations: {string.Join(", ", activationIds)}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`DuplicateActivationsTests.DuplicateActivations` generated 100,000 requests against 10 target grains and waited for every target queue to drain. The client retained its default 30-second response timeout after the historical client timeout configuration was lost during the 2019 test-host migration, so loaded Functional jobs could time out even when activation deduplication behaved correctly.

## Solution

- synchronize all 100 runner grains at an explicit release barrier before they target inactive grains
- issue one request per runner and target, preserving 100-way activation contention while removing unrelated queue-drain load
- return a per-instance activation identifier and assert that every response for each target came from one activation
- remove the silo response-timeout override

## Rationale

The test now measures the single-activation guarantee directly and deterministically instead of using request throughput as a proxy. It retains 1,000 concurrent requests across 10 inactive grains without relying on longer timeouts.

Closes #10734
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10742)