### PR TITLE
fix(transactions): release locks when cancel precedes prepare

### DIFF
--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -192,7 +192,7 @@ namespace Orleans.Transactions.State
         {
             if (currentGroup == null || !currentGroup.TryGetValue(transactionId, out TransactionRecord<TState>? record))
             {
-                return (TransactionalStatus.BrokenLock, new TransactionRecord<TState>());
+                return (TransactionalStatus.BrokenLock, new TransactionRecord<TState> { TransactionId = transactionId });
             }
             else if (record.NumberReads != accessCount.Reads
                    || record.NumberWrites != accessCount.Writes)

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -588,6 +588,10 @@ namespace Orleans.Transactions.State
 
             if (pos == -1)
             {
+                // Cancel can overtake the one-way prepare message. Release the pre-prepare lock so a
+                // late prepare observes a broken lock and completes without persisting a remote commit.
+                this.RWLock.Rollback(transactionId);
+                this.RWLock.Notify();
                 TransactionDiagnosticEvents.EmitTransactionCancelCompleted(
                     resource,
                     transactionId,

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -63,7 +63,7 @@ public class TransactionRecoveryLatencyTests
     }
 
     [Fact]
-    public async Task CancelBeforePrepareCausesLatePrepareToRetainTransactionId()
+    public async Task CancelBeforePrepareBreaksPrePrepareLockAndRetainsTransactionId()
     {
         var resource = CreateParticipant("resource", ParticipantId.Role.Resource);
         var queue = new GatedCancelTransactionQueue(resource, new TestActivationLifetime());

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -63,7 +63,7 @@ public class TransactionRecoveryLatencyTests
     }
 
     [Fact]
-    public async Task CancelBeforePrepareReleasesPrePrepareLock()
+    public async Task CancelBeforePrepareCausesLatePrepareToRetainTransactionId()
     {
         var resource = CreateParticipant("resource", ParticipantId.Role.Resource);
         var queue = new GatedCancelTransactionQueue(resource, new TestActivationLifetime());
@@ -81,8 +81,9 @@ public class TransactionRecoveryLatencyTests
 
         await queue.NotifyOfCancel(transactionId, timeStamp, TransactionalStatus.CascadingAbort);
 
-        var (status, _) = await queue.RWLock.ValidateLock(transactionId, accessCount);
+        var (status, record) = await queue.RWLock.ValidateLock(transactionId, accessCount);
         Assert.Equal(TransactionalStatus.BrokenLock, status);
+        Assert.Equal(transactionId, record.TransactionId);
     }
 
     [Fact]

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -63,6 +63,29 @@ public class TransactionRecoveryLatencyTests
     }
 
     [Fact]
+    public async Task CancelBeforePrepareReleasesPrePrepareLock()
+    {
+        var resource = CreateParticipant("resource", ParticipantId.Role.Resource);
+        var queue = new GatedCancelTransactionQueue(resource, new TestActivationLifetime());
+        var transactionId = Guid.NewGuid();
+        var timeStamp = new DateTime(2026, 8, 8, 12, 0, 0, DateTimeKind.Utc);
+        var accessCount = new AccessCounter { Writes = 1 };
+
+        await queue.RWLock.EnterLock(
+            transactionId,
+            timeStamp,
+            default,
+            isRead: false,
+            exclusiveLock: false,
+            static () => 0);
+
+        await queue.NotifyOfCancel(transactionId, timeStamp, TransactionalStatus.CascadingAbort);
+
+        var (status, _) = await queue.RWLock.ValidateLock(transactionId, accessCount);
+        Assert.Equal(TransactionalStatus.BrokenLock, status);
+    }
+
+    [Fact]
     public void StorageBatchTracksCommittedTransactionIds()
     {
         var firstTransactionId = Guid.NewGuid();


### PR DESCRIPTION
## Problem
A transaction manager can abort while participant prepare messages are still in flight. The cancel fan-out can arrive first, and the participant previously treated a missing commit-queue entry as already complete while retaining its pre-prepare lock. A late prepare then persisted an orphaned remote commit, blocking later transactions until the 60-second recovery ping and allowing repeated recovery probes to extend the stall.

## Solution
Release and service the participant lock when a cancel arrives before the prepare has entered the commit queue. The late prepare then observes a broken lock and completes through the abort path without creating durable pending state. Add focused coverage for the cancel-before-prepare ordering.

## Rationale
Transaction IDs are unique and lock rollback is idempotent, so the same path remains safe for duplicate or already-completed cancels while closing the ordering gap that produced the recovery cascade.

Closes #10714
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10743)