### PR TITLE
fix(test): retry SQL Server database reset

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
@@ -230,7 +230,7 @@ namespace UnitTests.General
         /// </summary>
         /// <param name="databaseName">The name of the database to drop.</param>
         /// <returns>The call will be successful if the DDL query is successful. Otherwise an exception will be thrown.</returns>
-        private async Task DropDatabaseAsync(string databaseName)
+        protected virtual async Task DropDatabaseAsync(string databaseName)
         {
             await Storage.ExecuteAsync(string.Format(DropDatabaseTemplate, databaseName), command => { });
         }

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -116,6 +116,25 @@ namespace UnitTests.General
             }
         }
 
+        protected override async Task DropDatabaseAsync(string databaseName)
+        {
+            const int maxAttempts = 3;
+
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    await base.DropDatabaseAsync(databaseName);
+                    return;
+                }
+                catch (SqlException exception) when (exception.Number == 3702 && attempt < maxAttempts)
+                {
+                    Console.WriteLine("SQL Server database '{0}' remained in use after reset attempt {1}; retrying.", databaseName, attempt);
+                    PrepareForDatabaseReset(databaseName);
+                }
+            }
+        }
+
         protected override string ExistsDatabaseTemplate
         {
             get

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -12,18 +12,20 @@ public class SqlServerStorageForTestingTests
     private const string TestDatabaseName = "OrleansSqlServerSetupTest";
 
     [Fact]
-    public async Task RecreatesDatabaseWithPooledConnections()
+    public async Task RecreatesDatabaseWithActivePooledConnection()
     {
+        var storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName);
+
         for (var iteration = 0; iteration < 3; iteration++)
         {
-            var storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName);
-
             await using var connection = new SqlConnection(storage.CurrentConnectionString);
             await connection.OpenAsync();
             await using var command = connection.CreateCommand();
             command.CommandText = "SELECT 1";
 
             Assert.Equal(1, await command.ExecuteScalarAsync());
+
+            storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName);
         }
     }
 }


### PR DESCRIPTION
Fixes #10729.

SQL Server can admit a new connection after the reset command switches a test database to single-user mode and before the following drop statement executes. When a streaming test client or silo finishes releasing its pooled connection in that window, the drop fails with error 3702 and the next test fails during fixture initialization.

Retry the SQL Server reset only for error 3702. Each retry clears the administrative and target-database pools before issuing the existing rollback-immediate reset again, while unrelated SQL errors and the final failed attempt continue to surface directly. Strengthen the SQL Server reset integration test by recreating the database while a pooled connection remains active.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10744)