### PR TITLE
docs: split grain timers and reminders into focused pages

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -109,8 +109,9 @@ tutorial into a reference or burying architecture detail inside a how-to.
 ## Sources and generated output
 
 - Register every new page in `docs/site/src/content/docs/toc.yml` under the
-  section that matches its documentation type. An unlisted page is effectively
-  unpublished.
+  section that matches its documentation type. A compatibility page retained
+  only for stable inbound routes can set `navigation: hidden`; link it to the
+  current focused pages.
 - Keep recursive includes within the documentation source tree. Missing,
   circular, traversal, absolute, drive-relative, or symlink-escaping includes
   are invalid. Edit the include source and ensure active includes participate in

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -44,9 +44,10 @@ npm run validate
 The source audit reports a rule ID, file, line, and remediation. It enforces:
 
 - Orleans 10 guidance outside migration pages and explicitly versioned compatibility zones.
-- Exactly one `toc.yml` entry per maintained conceptual page, with `includes` and
-  snippet support files excluded; Architecture and internals and Event Sourcing
-  remain first-class navigation sections.
+- Exactly one `toc.yml` entry per maintained conceptual page, with `includes`,
+  snippet support files, and compatibility routes marked `navigation: hidden`
+  excluded; Architecture and internals and Event Sourcing remain first-class
+  navigation sections.
 - Package and stream-provider inventories against source project metadata,
   activity sources and lifecycle stages against source/API constants, documented
   metric names against `InstrumentNames.cs`, and sample paths against

--- a/docs/site/scripts/lib/source-quality.mjs
+++ b/docs/site/scripts/lib/source-quality.mjs
@@ -9,6 +9,7 @@ import {
   collectIncludeTargets,
   isDocumentationFragmentMarkdown,
   readTocItems,
+  splitFrontmatter,
 } from './docfx.mjs';
 
 const renderedOrleansReleasePatterns = [
@@ -22,6 +23,10 @@ const execFileAsync = promisify(execFile);
 
 function toPosix(value) {
   return value.split(path.sep).join('/');
+}
+
+export function isNavigationHidden(source) {
+  return splitFrontmatter(source).metadata.navigation === 'hidden';
 }
 
 async function walk(directory, predicate = () => true) {
@@ -948,10 +953,14 @@ export async function auditDocumentationSources({
   const { includeTargets, auditedMarkdown } = contentAudit;
   const pages = [];
   const allMarkdownPaths = [];
+  const navigationExcludedPaths = [];
   for (const file of markdownFiles) {
     const relativePath = toPosix(path.relative(sourceRoot, file));
     allMarkdownPaths.push(relativePath);
     const page = auditedMarkdown.find((item) => item.file === path.resolve(file));
+    if (isNavigationHidden(page.source)) {
+      navigationExcludedPaths.push(relativePath);
+    }
     if (
       includeTargets.has(path.resolve(file)) ||
       isDocumentationFragmentMarkdown(relativePath)
@@ -973,7 +982,8 @@ export async function auditDocumentationSources({
             includeTargets.has(path.resolve(file)) ||
             isDocumentationFragmentMarkdown(toPosix(path.relative(sourceRoot, file))),
         )
-        .map((file) => toPosix(path.relative(sourceRoot, file))),
+        .map((file) => toPosix(path.relative(sourceRoot, file)))
+        .concat(navigationExcludedPaths),
       tocItems,
       tocSource,
     }),

--- a/docs/site/src/content/docs/grains/external-tasks-and-grains.md
+++ b/docs/site/src/content/docs/grains/external-tasks-and-grains.md
@@ -1,7 +1,7 @@
 ---
 title: External tasks and grain scheduling
 description: Safely use asynchronous libraries, CPU work, and blocking APIs from Orleans grains.
-ms.date: 08/07/2026
+ms.date: 08/21/2026
 ms.topic: concept-article
 ---
 
@@ -41,7 +41,7 @@ Don't use `ConfigureAwait(false)` directly in grain methods. It can resume the c
 If an advanced integration passes an async delegate to <xref:System.Threading.Tasks.TaskFactory.StartNew*>, unwrap the nested task:
 
 :::code language="csharp" source="../snippets/compiled/Grains/GeneralSnippets.cs" id="start_async_worker":::
-Don't start unobserved background work that outlives the request. Use [grain timers](timers-and-reminders.md), reminders, a durable job abstraction, or a hosted service depending on the required lifetime and reliability.
+Keep background work under an observed runtime mechanism. Use [grain timers](timers.md), [reminders](reminders.md), a durable job abstraction, or a hosted service according to the required lifetime and reliability.
 
 ## Reentrancy still applies
 

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -88,7 +88,6 @@ Most grains only need a contract, an implementation, a stable key, and regular r
 
 - [Request scheduling and reentrancy](request-scheduling.md)
 - [Response streaming with IAsyncEnumerable](response-streaming.md)
-- [Timers and reminders overview](timers-and-reminders.md)
 - [Grain timers](timers.md)
 - [Reminders](reminders.md)
 - [Observers](observers.md)

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -1,7 +1,7 @@
 ---
 title: Develop Orleans grains
 description: Define grain contracts, implement grains, and call them in Orleans.
-ms.date: 08/20/2026
+ms.date: 08/21/2026
 ms.topic: article
 ---
 
@@ -88,7 +88,9 @@ Most grains only need a contract, an implementation, a stable key, and regular r
 
 - [Request scheduling and reentrancy](request-scheduling.md)
 - [Response streaming with IAsyncEnumerable](response-streaming.md)
-- [Timers and reminders](timers-and-reminders.md)
+- [Timers and reminders overview](timers-and-reminders.md)
+- [Grain timers](timers.md)
+- [Reminders](reminders.md)
 - [Observers](observers.md)
 - [Grain placement](grain-placement.md)
 - [Stateless worker grains](stateless-worker-grains.md)

--- a/docs/site/src/content/docs/grains/reminders.md
+++ b/docs/site/src/content/docs/grains/reminders.md
@@ -1,0 +1,86 @@
+---
+title: Reminders
+description: Schedule durable periodic grain work which survives activation and cluster lifecycle changes.
+ms.date: 08/21/2026
+ms.topic: concept-article
+---
+
+# Reminders
+
+A reminder stores a periodic schedule for one logical grain. The configured reminder provider preserves the definition, and Orleans delivers ticks through normal grain request scheduling. A tick activates the grain when it has no current activation.
+
+Use a reminder for work whose schedule must survive activation changes and cluster restarts. Reminders suit periods measured in minutes, hours, or days. A reminder can wake a grain which then creates a [grain timer](timers.md) for finer-grained activation-scoped work.
+
+## Receive reminder ticks
+
+A grain receiving reminders implements <xref:Orleans.IRemindable>:
+
+:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="remindable_report_grain":::
+
+Orleans invokes <xref:Orleans.IRemindable.ReceiveReminder*> with the reminder name and <xref:Orleans.Runtime.TickStatus>. The callback executes as a grain request and follows the grain's scheduling and reentrancy rules.
+
+## Register or update a reminder
+
+Register a named reminder from the grain:
+
+:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="register_reminder":::
+
+<xref:Orleans.GrainReminderExtensions.RegisterOrUpdateReminder*> creates the durable definition. Registering the same name again replaces its due time and period.
+
+The returned <xref:Orleans.Runtime.IGrainReminder> is a handle to the current registration. Persist the reminder name in application state and retrieve a current handle after activation when needed.
+
+## Retrieve or remove a reminder
+
+Retrieve the current handle and unregister the reminder:
+
+:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="unregister_reminder":::
+
+Use <xref:Orleans.GrainReminderExtensions.GetReminder*> for one named reminder and <xref:Orleans.GrainReminderExtensions.GetReminders*> for all reminders registered by the grain.
+
+## Reminder behavior
+
+The reminder provider durably stores each definition. The responsible silo loads the definition, calculates occurrences from its persisted start time and period, and sends tick requests to the grain.
+
+Individual tick messages are transient. Cluster unavailability or ownership movement can leave a scheduled occurrence undelivered, while the durable definition continues producing later occurrences. Ownership convergence can also produce duplicate callback execution. Process each callback idempotently and reconcile work from durable business state.
+
+<xref:Orleans.Runtime.TickStatus.FirstTickTime> and <xref:Orleans.Runtime.TickStatus.Period> identify the theoretical schedule. <xref:Orleans.Runtime.TickStatus.CurrentTickTime> records when the runtime initiated the current delivery. Applications can compare those values with persisted progress to detect and reconcile missed occurrences.
+
+Orleans delivers reminders to one activation of the grain identity. Delivery activates the grain when needed, including after the previous activation was collected or its silo stopped.
+
+## Reminder timing constraints
+
+Reminder registration accepts schedules with these boundaries:
+
+- `dueTime` is <xref:System.TimeSpan.Zero> or greater. Zero schedules the first tick immediately.
+- `dueTime` fits within the remaining <xref:System.DateTime> range from registration time.
+- `period` is positive and at least <xref:Orleans.Hosting.ReminderOptions.MinimumReminderPeriod?displayProperty=nameWithType>.
+- The default minimum period is one minute.
+
+The runtime rejects negative values and <xref:System.Threading.Timeout.InfiniteTimeSpan>. It also rejects a `dueTime` which places the first tick after <xref:System.DateTime.MaxValue>.
+
+For one scheduled execution, register a valid positive period and unregister the reminder in its first callback after the durable work succeeds.
+
+## Configure reminder storage
+
+Every silo configures the same reminder provider so ownership can move across the cluster. Production deployments use a durable provider such as Azure Table, ADO.NET, Redis, Amazon DynamoDB, or [Cosmos DB](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Cosmos). The in-memory provider stores definitions for the lifetime of the cluster and supports local development and tests.
+
+Configure each provider through the API supplied by its package. See [Configure Amazon DynamoDB reminders](reminders/dynamodb.md) for a compiled example which configures DynamoDB clustering and reminder storage independently. When composing resources with Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
+
+The reminder table is part of silo startup. Provider availability and consistency determine whether the service can load, update, and reconcile registrations. See [Reminder implementation](../implementation/reminders.md) for ownership, refresh, and delivery internals.
+
+## POCO grains
+
+Grains implementing <xref:Orleans.IGrainBase> directly use the same <xref:Orleans.GrainReminderExtensions> APIs. Inject <xref:Orleans.Timers.IReminderRegistry> when infrastructure code needs lower-level access through the current grain context.
+
+See [POCO grains](../migration-guide.md#poco-grains-and-igrainbase) for the interface-only grain model.
+
+## Troubleshoot reminders
+
+| Observed behavior | Runtime behavior and action |
+|---|---|
+| Registration reports that the reminder service is not configured. | Configure one reminder provider on every silo before registering reminders. |
+| Registration rejects the period. | Use a positive period at or above <xref:Orleans.Hosting.ReminderOptions.MinimumReminderPeriod?displayProperty=nameWithType>. |
+| A tick arrives after a long cluster interruption. | Reconcile the theoretical schedule in <xref:Orleans.Runtime.TickStatus> with durable progress and process the outstanding business work. |
+| The callback executes more than once for the same business interval. | Reminder ownership converges during membership changes. Use an idempotency key or durable completion marker for each interval. |
+| Definitions disappear after a full cluster restart. | The in-memory provider scopes definitions to the cluster lifetime. Configure a durable production provider. |
+| High-frequency work needs sub-minute intervals. | Use the reminder to activate the grain, then register a [grain timer](timers.md) for the active phase. |

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -1,79 +1,49 @@
 ---
 title: Grain timers and reminders
-description: Schedule activation-scoped and durable periodic work in Orleans.
-ms.date: 08/20/2026
+description: Choose between activation-scoped grain timers and durable reminders in Orleans.
+ms.date: 08/21/2026
 ms.topic: concept-article
 ---
 
 # Grain timers and reminders
 
-Orleans provides two mechanisms for periodic grain work:
+Orleans schedules periodic grain work through two mechanisms with distinct ownership and durability guarantees:
 
-- **Grain timers** belong to one activation. They stop when that activation deactivates or its silo fails.
-- **Reminders** belong to a logical grain. Their definitions are stored and can reactivate the grain after deactivation or cluster restart.
+| Mechanism | Owner | Schedule storage | Activation behavior | Typical cadence |
+|---|---|---|---|---|
+| [Grain timer](timers.md) | One grain activation | Activation memory | Executes on the current activation and ends with it | Frequent work while an activation is active |
+| [Reminder](reminders.md) | One logical grain | Configured reminder provider | Activates the grain when a tick is delivered and resumes after cluster recovery | Work measured in minutes, hours, or days |
 
-Use a timer for frequent, activation-scoped work. Use a reminder when the schedule must survive activation changes and occasional missed ticks are acceptable.
+Choose a grain timer when the work belongs to the current activation. Choose a reminder when the schedule belongs to the grain identity and must survive activation and cluster lifecycle changes.
 
 ## Grain timers
 
-Register timers with <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. <xref:Orleans.Grain.RegisterTimer*> is obsolete.
+Grain timers execute callbacks as grain turns on one activation. The runtime schedules the next tick after the current callback completes, so a timer callback never overlaps itself.
 
-:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="grain_timer":::
-<xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> returns <xref:Orleans.Runtime.IGrainTimer>. Dispose it to stop the timer, or call <xref:Orleans.Runtime.IGrainTimer.Change*> to change its due time and period.
+See [Grain timers](timers.md) for registration, callback scheduling, interleaving, activation lifetime, cancellation, and troubleshooting.
 
-### Timer behavior
+<a id="timer-behavior"></a>
 
-<xref:Orleans.Runtime.GrainTimerCreationOptions> controls scheduling:
-
-| Property | Default | Behavior |
-|---|---:|---|
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.DueTime> | Required | Delay before the first callback. |
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.Period> | Required | Delay from callback completion until the next callback. |
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> | `false` | Whether callbacks can interleave with other grain requests. |
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> | `false` | Whether timer activity extends activation lifetime. |
-
-A timer callback never overlaps itself. Orleans waits for the callback task to complete before measuring the next period. Exceptions are logged, and later ticks continue.
-
-The callback token is canceled when the timer is disposed or the grain begins deactivating. Timer callbacks execute as grain turns, participate in call filters and tracing, and don't interleave with other requests unless configured or allowed by the grain's reentrancy settings.
+The [timer behavior reference](timers.md#timer-behavior) describes the guarantees controlled by <xref:Orleans.Runtime.GrainTimerCreationOptions>.
 
 ## Reminders
 
-A grain receiving reminders implements <xref:Orleans.IRemindable>:
+Reminders persist a schedule for a logical grain. Reminder delivery follows normal grain request scheduling and activates the grain when needed. The provider preserves the schedule while each tick is generated and delivered by the runtime.
 
-:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="remindable_report_grain":::
-Register or update a reminder from the grain:
+See [Reminders](reminders.md) for registration, durable scheduling, timing constraints, provider configuration, missed-tick reconciliation, and troubleshooting.
 
-:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="register_reminder":::
-Cancel it explicitly:
+<a id="reminder-behavior"></a>
 
-:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="unregister_reminder":::
-Store the reminder name, not the <xref:Orleans.Runtime.IGrainReminder> handle, across activations. Handles aren't guaranteed to remain valid beyond the activation that retrieved them.
+The [reminder delivery reference](reminders.md#reminder-behavior) explains durable definitions, volatile tick delivery, reactivation, and recovery.
 
-### Reminder behavior
+<a id="reminder-timing-constraints"></a>
 
-Reminder definitions are durable, but individual tick messages aren't. If the cluster is unavailable at a scheduled time, that occurrence can be missed. The next scheduled tick still occurs. Reminder delivery follows normal grain request scheduling and can activate an inactive grain.
-
-Reminders are intended for periods measured in minutes, hours, or days, not high-frequency scheduling. A common pattern is for a reminder to wake a grain and create a finer-grained local timer.
-
-### Reminder timing constraints
-
-Reminder timing is subject to the following constraints:
-
-- `dueTime` must be greater than or equal to `TimeSpan.Zero`; a zero `dueTime` means the first tick is scheduled immediately.
-- `dueTime` cannot be negative or <xref:System.Threading.Timeout.InfiniteTimeSpan>.
-- `period` must be greater than `TimeSpan.Zero`.
-- `period` cannot be negative, zero, or <xref:System.Threading.Timeout.InfiniteTimeSpan>.
-- The runtime rejects `period` values below the lower bound configured by <xref:Orleans.Hosting.ReminderOptions.MinimumReminderPeriod?displayProperty=nameWithType> (default: one minute).
-- `dueTime` is also bounded by the remaining <xref:System.DateTime> range from the time of registration. A value which would place the first tick after <xref:System.DateTime.MaxValue> is rejected rather than clamped. Later occurrences are scheduled from the persisted start time and period.
-
-There is no special `period` value that means "fire once and never again." To model a one-shot reminder, create a valid reminder with a positive `period`, then unregister it in the first callback or after the first tick. `TimeSpan.Zero` and negative values are rejected by the runtime rather than treated as a one-shot schedule.
+The [reminder timing constraints](reminders.md#reminder-timing-constraints) define valid due times and periods.
 
 ## Configure reminder storage
 
-Every silo must configure a reminder provider. Production deployments should use a durable provider such as Azure Table, ADO.NET, Redis, or [Cosmos DB](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Cosmos). In-memory reminders are suitable only for local development and tests because definitions are lost when the cluster stops.
-
-Configure each provider through the API supplied by its package. See [Configure Amazon DynamoDB reminders](reminders/dynamodb.md) for a compiled example which configures DynamoDB clustering and reminder storage independently. For other compiled in-repository examples, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
+Every silo configures one reminder provider. See [Configure reminder storage](reminders.md#configure-reminder-storage) for production providers, development configuration, and provider-specific guidance.
 
 ## POCO grains
 
-Grains implementing <xref:Orleans.IGrainBase> directly can use the same extension APIs. Inject <xref:Orleans.Timers.ITimerRegistry> or <xref:Orleans.Timers.IReminderRegistry> when lower-level registration is required. See [POCO grains](../migration-guide.md#poco-grains-and-igrainbase) for the interface-only grain model.
+Grains implementing <xref:Orleans.IGrainBase> directly use the same timer and reminder extension APIs. The dedicated [grain timer](timers.md#poco-grains) and [reminder](reminders.md#poco-grains) pages describe the lower-level registries available through dependency injection.

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -3,6 +3,7 @@ title: Grain timers and reminders
 description: Choose between activation-scoped grain timers and durable reminders in Orleans.
 ms.date: 08/21/2026
 ms.topic: concept-article
+navigation: hidden
 ---
 
 # Grain timers and reminders

--- a/docs/site/src/content/docs/grains/timers.md
+++ b/docs/site/src/content/docs/grains/timers.md
@@ -1,0 +1,77 @@
+---
+title: Grain timers
+description: Schedule activation-scoped periodic work as Orleans grain turns.
+ms.date: 08/21/2026
+ms.topic: concept-article
+---
+
+# Grain timers
+
+A grain timer schedules periodic work for one grain activation. Each callback executes as a grain turn on that activation and follows Orleans request scheduling, tracing, and grain call filter behavior. The runtime owns the timer for the activation lifetime and discards it when the activation deactivates.
+
+Use a grain timer for frequent work whose lifetime and state belong to the current activation. Use a [reminder](reminders.md) when the schedule belongs to the logical grain and must survive activation or cluster lifecycle changes.
+
+## Register a grain timer
+
+Register timers with <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. <xref:Orleans.Grain.RegisterTimer*> is obsolete.
+
+:::code language="csharp" source="../snippets/compiled/Grains/WorkersAndTimersSnippets.cs" id="grain_timer":::
+
+<xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> returns <xref:Orleans.Runtime.IGrainTimer>. Keep the handle when the activation needs to change or stop the schedule.
+
+## Timer behavior
+
+<xref:Orleans.Runtime.GrainTimerCreationOptions> controls the initial schedule and callback behavior:
+
+| Property | Default | Runtime behavior |
+|---|---:|---|
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.DueTime> | Required | Delays the first callback. <xref:System.TimeSpan.Zero> schedules it immediately, and <xref:System.Threading.Timeout.InfiniteTimeSpan> leaves the timer paused. |
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.Period> | Required | Delays the next callback after the current callback completes. <xref:System.Threading.Timeout.InfiniteTimeSpan> creates a single scheduled callback. |
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> | `false` | Applies the grain's normal reentrancy rules. `true` allows the callback to interleave with other grain calls and timers. |
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> | `false` | Controls whether each callback extends the activation's idle lifetime. |
+
+### Callback scheduling
+
+A timer callback never overlaps itself. Orleans waits for the callback task to complete and then measures the period before scheduling the next callback. Callback duration therefore adds to the interval between callback starts.
+
+Timer callbacks are local-only messages addressed to their activation. They participate in normal turn scheduling and stay on the activation which registered them.
+
+### Interleaving
+
+With <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> set to `false`, the callback follows the grain's reentrancy configuration like a grain method call. A non-reentrant grain processes the callback without interleaving it with other requests. A reentrant grain can interleave the callback according to its scheduling rules.
+
+Set <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> to `true` when the callback can safely observe grain state changing across awaits while other turns execute.
+
+### Activation lifetime
+
+Timer callbacks leave the activation's idle lifetime unchanged by default. Orleans can collect an otherwise idle activation, which ends all timers owned by that activation.
+
+With <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> set to `true`, each callback extends the activation lifetime. A period shorter than the configured idle collection period keeps the activation active through successive callbacks. Infrequent callbacks still allow collection between ticks.
+
+## Change or stop a timer
+
+Call <xref:Orleans.Runtime.IGrainTimer.Change*> to replace the due time and period. The new due time schedules the next callback, and the new period applies after that callback completes. A change made inside a running callback takes effect after the callback completes.
+
+Dispose <xref:Orleans.Runtime.IGrainTimer> to cancel its callback token and stop future callbacks. Orleans also cancels the token and disposes the timer when the activation begins deactivating.
+
+## Handle callback failures
+
+Orleans logs exceptions returned by a timer callback and schedules the next callback after the configured period. Keep application state consistent before allowing an exception to escape, and use grain state or another durable store when recovery must span activation failure.
+
+The callback's <xref:System.Threading.CancellationToken> signals timer disposal and activation shutdown. Observe it in asynchronous work so deactivation can complete promptly.
+
+## POCO grains
+
+Grains implementing <xref:Orleans.IGrainBase> directly use <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. Inject <xref:Orleans.Timers.ITimerRegistry> when infrastructure code needs lower-level registration through the current <xref:Orleans.Runtime.IGrainContext>.
+
+See [POCO grains](../migration-guide.md#poco-grains-and-igrainbase) for the interface-only grain model.
+
+## Troubleshoot grain timers
+
+| Observed behavior | Runtime behavior and action |
+|---|---|
+| The timer ends after activation collection or silo failure. | The timer belongs to that activation. Register it during activation setup, or use a [reminder](reminders.md) for a schedule which survives activation changes. |
+| Callback starts drift later than wall-clock intervals. | Orleans measures the period after callback completion. Shorten the callback, adjust the period, or model wall-clock scheduling with durable application state. |
+| Other grain calls execute while the callback awaits. | The grain is reentrant or the timer enables <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave>. Protect invariants across await points or use non-interleaved scheduling. |
+| An idle activation remains active. | <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> extends its lifetime on each callback. Set it to `false` when collection should follow the normal idle timeout. |
+| A callback exception appears repeatedly. | Orleans logs the exception and continues the schedule. Make the callback converge from durable state, then resolve the underlying failure. |

--- a/docs/site/src/content/docs/how-to/index.md
+++ b/docs/site/src/content/docs/how-to/index.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans how-to guides
 description: Task-oriented recipes for configuring, deploying, and operating Orleans applications.
-ms.date: 08/11/2026
+ms.date: 08/21/2026
 ms.topic: how-to
 ---
 
@@ -36,7 +36,8 @@ If you are learning Orleans from an empty directory, start with the [tutorials a
 ## Use Orleans features
 
 - [Persist grain state](../grains/grain-persistence/index.md)
-- [Add reminders and timers](../grains/timers-and-reminders.md)
+- [Schedule activation-scoped work with grain timers](../grains/timers.md)
+- [Schedule durable work with reminders](../grains/reminders.md)
 - [Configure Amazon DynamoDB reminders](../grains/reminders/dynamodb.md)
 - [Configure streams](../streaming/stream-providers.md)
 - [Use response streaming](../grains/response-streaming.md)

--- a/docs/site/src/content/docs/implementation/reminders.md
+++ b/docs/site/src/content/docs/implementation/reminders.md
@@ -1,7 +1,7 @@
 ---
 title: Reminder implementation
 description: Explain reminder ownership, durable table reconciliation, scheduling, and delivery behavior inside Orleans.
-ms.date: 08/11/2026
+ms.date: 08/21/2026
 ms.topic: concept-article
 ---
 
@@ -31,6 +31,6 @@ The provider durably stores the schedule, while owners generate individual ticks
 
 The in-memory table is suitable for development only. Production tables provide the durability and concurrency behavior required for ownership changes, but their consistency and availability characteristics remain provider-specific. Table startup is part of silo lifecycle initialization; failure to open the configured table prevents normal reminder service startup.
 
-The [timers and reminders guide](../grains/timers-and-reminders.md) covers registration usage. Reminder persistence, ring movement, refresh intervals, and callback failures determine observed scheduling behavior.
+The [reminders guide](../grains/reminders.md) covers registration and application behavior. Reminder persistence, ring movement, refresh intervals, and callback failures determine observed scheduling behavior.
 
 Source: [`LocalReminderService`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Reminders/ReminderService/LocalReminderService.cs), [`ReminderRegistry`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Reminders/ReminderService/ReminderRegistry.cs), and [`IReminderTable`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs).

--- a/docs/site/src/content/docs/migration/8-to-10.md
+++ b/docs/site/src/content/docs/migration/8-to-10.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade Orleans 8.x to 10.x
 description: Upgrade an Orleans 8 application through Orleans 9.2 to Orleans 10 with validated compatibility checkpoints.
-ms.date: 08/07/2026
+ms.date: 08/21/2026
 ms.topic: how-to
 ---
 
@@ -33,7 +33,7 @@ When translating an old timer and preserving its interleaving behavior:
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="grain_timer":::
 
-For the full timer behavior matrix, see [Timers and reminders](../grains/timers-and-reminders.md#timer-behavior).
+For the full timer behavior matrix, see [Grain timers](../grains/timers.md#timer-behavior).
 
 ## Validate the Orleans 9.2 checkpoint
 

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -35,9 +35,15 @@ items:
       - name: Stateless worker grains
         href: grains/stateless-worker-grains.md
       - name: Timers and reminders
-        href: grains/timers-and-reminders.md
-      - name: Amazon DynamoDB reminders
-        href: grains/reminders/dynamodb.md
+        items:
+          - name: Overview
+            href: grains/timers-and-reminders.md
+          - name: Grain timers
+            href: grains/timers.md
+          - name: Reminders
+            href: grains/reminders.md
+          - name: Amazon DynamoDB reminders
+            href: grains/reminders/dynamodb.md
       - name: Observers
         href: grains/observers.md
       - name: Cancellation

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -34,13 +34,11 @@ items:
         href: grains/grainservices.md
       - name: Stateless worker grains
         href: grains/stateless-worker-grains.md
-      - name: Timers and reminders
+      - name: Grain timers
+        href: grains/timers.md
+      - name: Reminders
         items:
           - name: Overview
-            href: grains/timers-and-reminders.md
-          - name: Grain timers
-            href: grains/timers.md
-          - name: Reminders
             href: grains/reminders.md
           - name: Amazon DynamoDB reminders
             href: grains/reminders/dynamodb.md

--- a/docs/site/tests/source-quality.test.mjs
+++ b/docs/site/tests/source-quality.test.mjs
@@ -8,6 +8,7 @@ import {
   collectPackageProjects,
   collectCsharpFences,
   findReleaseVersionIssues,
+  isNavigationHidden,
   parseDocumentedPackageTable,
   validateCsharpFences,
   validatePackageInventory,
@@ -976,6 +977,15 @@ describe('documentation source quality', () => {
         "Navigation target 'overview.md' appears 2 times.",
       ]),
     );
+  });
+
+  test('recognizes pages retained outside navigation', () => {
+    expect(
+      isNavigationHidden(
+        '---\ntitle: Compatibility page\nnavigation: hidden\n---\n\n# Compatibility page\n',
+      ),
+    ).toBe(true);
+    expect(isNavigationHidden('---\ntitle: Current page\n---\n\n# Current page\n')).toBe(false);
   });
 
   test('requires durable architecture and Event Sourcing navigation sections', () => {


### PR DESCRIPTION
## Problem

The grain timers and reminders article combines two scheduling mechanisms with different ownership, durability, timing, and failure semantics, limiting the guidance available for each mechanism.

## Solution

- Retain the existing URL and anchors as a hidden compatibility route for inbound links.
- Add focused grain timer and reminder pages covering lifecycle, scheduling guarantees, configuration, failure behavior, and troubleshooting.
- List grain timers directly in navigation and expand reminders to show its overview and provider pages.
- Update grain, how-to, migration, and implementation links to the focused pages.

## Rationale

Separating the mechanisms gives each runtime model enough space for precise operational guidance while preserving stable inbound URLs and compiled examples.

Fixes #10719

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10745)