### PR TITLE
docs: add deployment guides for supported hosting targets

### DIFF
--- a/docs/site/src/content/docs/deployment/azure-app-service.md
+++ b/docs/site/src/content/docs/deployment/azure-app-service.md
@@ -1,0 +1,66 @@
+---
+title: Host Orleans on Azure App Service
+description: Choose and operate the supported Orleans topology on Windows or Linux Azure App Service.
+ms.date: 08/21/2026
+ms.topic: overview
+ms.custom: devops
+---
+
+# Host Orleans on Azure App Service
+
+Azure App Service can host Orleans by cohosting one silo with the application on every worker in a dedicated multi-instance plan. Each worker advertises its private instance address and a dynamically allocated private port. Azure Table Storage provides shared cluster membership and durable grain state in the maintained sample.
+
+Choose the operating-system guide for the target plan:
+
+| Target | Use this guide | Platform-specific behavior |
+| --- | --- | --- |
+| Windows App Service | [Deploy Orleans to Azure App Service on Windows](deploy-to-azure-app-service.md) | IIS integration, Windows paths and process model, and the Windows App Service Authentication module |
+| Linux App Service | [Deploy Orleans to Azure App Service on Linux](deploy-to-azure-app-service-linux.md) | Built-in Linux .NET stack, container startup deadlines and paths, and the App Service Authentication ambassador sidecar |
+
+Both guides use the same application, Bicep modules, staging-slot workflow, managed identity, health endpoints, and operational model.
+
+## Supported topology
+
+The maintained topology uses:
+
+- A dedicated Premium v3 App Service plan with at least three workers in the maintained sample.
+- One application process and one Orleans silo on every worker.
+- `WEBSITE_PRIVATE_IP` and an allocated `WEBSITE_PRIVATE_PORTS` value as the advertised silo endpoint.
+- A cohosted local Orleans client, with the Orleans gateway disabled.
+- Azure Table Storage for clustering and grain state, authorized by managed identity.
+- Separate production and staging cluster IDs with a shared stable service ID.
+
+The App Service front end handles HTTP traffic. Orleans silo connections use the private per-worker endpoints. If trusted external Orleans clients are required, allocate and validate a second private port for the gateway and ensure every client network can route to every advertised gateway mapping.
+
+## Qualify the target environment
+
+App Service publishes the private instance settings used by the sample. The application validates their presence during startup and advertises the resulting endpoint.
+
+Establish production evidence on the selected operating system, region, plan tier, networking configuration, and scale:
+
+1. Scale to at least three workers.
+1. Confirm every worker receives a distinct private address and the required private port count.
+1. Match each active Orleans membership row to one worker instance.
+1. Test bidirectional TCP connectivity among every advertised silo endpoint.
+1. Repeat the checks during scale-out, scale-in, worker replacement, restart, and slot swap.
+
+Regional virtual network integration supplies the private worker address and outbound virtual-network path. The allocated private ports establish the target-specific inbound silo path. Keep the integration subnets sized for planned scale, upgrades, and worker replacement.
+
+App Service distributes multiple plan workers across platform fault domains. For an availability objective that includes zone failure, enable [App Service zone redundancy](https://learn.microsoft.com/azure/reliability/reliability-app-service) on a supported Premium plan and confirm that the selected region, scale unit, tier, and worker count meet the platform requirements. The maintained sample creates multiple Premium v3 workers but leaves zone redundancy as an environment-specific production adaptation.
+
+## Production checklist
+
+Use the detailed Windows or Linux guide to complete each outcome.
+
+| Concern | App Service outcome |
+| --- | --- |
+| Topology and networking | Every worker advertises its private instance address and allocated silo port, and every worker can connect to every active membership endpoint. |
+| Dependencies and data | Azure Table clustering and durable grain state use environment-specific tables. Applications configure reminder and stream providers explicitly when those features are used. |
+| Identity and secrets | A user-assigned managed identity receives narrow data-plane roles. App Service Authentication and deployment identities remain separate, and secrets use protected settings or Key Vault references. |
+| Health and lifecycle | Startup warm-up and `/health/ready` complete after Orleans starts. Readiness becomes unavailable before host shutdown, and the host uses the available App Service termination interval. |
+| Scaling and resilience | The plan retains the tested minimum worker count and spare capacity. Fault-domain distribution and any required zone redundancy are documented. Scale, replacement, zone or worker loss, and dependency-failure behavior are validated under load. |
+| Upgrades and rollback | Compatible releases warm in a staging slot and join the production cluster during swap. Incompatible releases use a separate app and cluster ID. |
+| Observability and incidents | Application Insights, Log Analytics, Orleans telemetry, App Service instance metadata, membership evidence, and slot operations are correlated. |
+| Infrastructure delivery | Bicep and the GitHub OIDC workflow create reproducible infrastructure and deploy immutable application artifacts through staging. |
+
+Complete the [production-readiness checklist](production-readiness.md), [Topology, networking, and clustering](networking.md), [Health and observability](health-and-observability.md), [Capacity planning and scaling](capacity-planning.md), [Graceful shutdown and upgrades](upgrades.md), and [Troubleshoot deployments](troubleshooting-deployments.md) guidance for the target environment.

--- a/docs/site/src/content/docs/deployment/azure-app-service.md
+++ b/docs/site/src/content/docs/deployment/azure-app-service.md
@@ -25,7 +25,7 @@ The maintained topology uses:
 
 - A dedicated Premium v3 App Service plan with at least three workers in the maintained sample.
 - One application process and one Orleans silo on every worker.
-- `WEBSITE_PRIVATE_IP` and an allocated `WEBSITE_PRIVATE_PORTS` value as the advertised silo endpoint.
+- `WEBSITE_PRIVATE_IP` and the first port in the comma-separated `WEBSITE_PRIVATE_PORTS` allocation as the advertised silo endpoint.
 - A cohosted local Orleans client, with the Orleans gateway disabled.
 - Azure Table Storage for clustering and grain state, authorized by managed identity.
 - Separate production and staging cluster IDs with a shared stable service ID.

--- a/docs/site/src/content/docs/deployment/azure-kubernetes-service.md
+++ b/docs/site/src/content/docs/deployment/azure-kubernetes-service.md
@@ -1,0 +1,163 @@
+---
+title: Host Orleans on Azure Kubernetes Service
+description: Deploy and operate an Orleans cluster on AKS with direct pod networking, workload identity, zone-aware placement, autoscaling, and controlled upgrades.
+ms.date: 08/21/2026
+ms.topic: how-to
+ms.custom: devops
+---
+
+# Host Orleans on Azure Kubernetes Service
+
+Azure Kubernetes Service (AKS) provides managed Kubernetes control-plane operations while Orleans runs as an application workload. Use one silo per pod, advertise the pod IP supplied by the Kubernetes downward API, and use an external production clustering provider.
+
+Start with the platform-neutral [Kubernetes guide](kubernetes.md) for the Orleans `Deployment`, endpoint configuration, probes, resources, disruption budget, and graceful shutdown baseline. This guide applies Azure networking, identity, availability, scaling, upgrades, and observability to that workload.
+
+## Choose the AKS operating model
+
+[AKS Automatic](https://learn.microsoft.com/azure/aks/intro-aks-automatic) provides managed production defaults for networking, node pools, security, and upgrades. [AKS Standard](https://learn.microsoft.com/azure/aks/what-is-aks) provides direct control over network address management, node pools, upgrade policy, and cluster features.
+
+Choose AKS Standard when external Orleans clients require direct routes to gateway pod IPs or when the workload needs custom node-pool, network, or upgrade controls. Record the selected cluster mode and the Orleans-specific settings that remain application-owned:
+
+- Production clustering, grain storage, reminder, stream, and grain-directory providers.
+- Pod endpoint configuration, cluster identity, health endpoints, and shutdown behavior.
+- Resource requests, scaling thresholds, disruption policy, and minimum silo count.
+- Application compatibility, deployment sequencing, rollback, and disaster recovery.
+
+## Choose an AKS network model
+
+Orleans silos require direct pod-to-pod TCP connectivity. [Azure CNI Powered by Cilium](https://learn.microsoft.com/azure/aks/azure-cni-powered-by-cilium) supports this path and enforces Kubernetes network policies.
+
+Select the IP address management model from the Orleans client topology:
+
+| AKS network model | Silo-to-silo path | Orleans client placement |
+| --- | --- | --- |
+| [Azure CNI Overlay](https://learn.microsoft.com/azure/aks/concepts-network-azure-cni-overlay) | Pods communicate directly across the cluster overlay using pod IPs. | Run Orleans clients inside the AKS cluster. Endpoints outside the cluster reach application ingress or Kubernetes services rather than overlay pod IPs. |
+| [Azure CNI Pod Subnet](https://learn.microsoft.com/azure/aks/concepts-network-azure-cni-pod-subnet) | Pods receive virtual-network addresses from a delegated pod subnet. | Use when trusted clients in peered virtual networks or connected on-premises networks require direct routes to every advertised gateway pod IP. |
+
+Configure the silo from `POD_NAME` and `POD_IP` exactly as shown in [Host Orleans on Kubernetes](kubernetes.md#configure-the-silo). Advertise the pod IP, listen on all pod interfaces, and keep the silo and gateway ports stable across pods.
+
+A Kubernetes `Service`, ingress controller, or [Application Gateway for Containers](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) can expose HTTP or gRPC application traffic. Orleans clients continue to discover and dial the individual gateway pod IPs stored in membership.
+
+## Create the private network boundary
+
+A [private AKS cluster](https://learn.microsoft.com/azure/aks/private-clusters) gives the Kubernetes API server a private endpoint. Combine the private control plane with:
+
+- Private node and pod subnets sized for ordinary scale, upgrade surge, and failure recovery.
+- Nonoverlapping pod, service, node, peered-network, VPN, and ExpressRoute address spaces.
+- Private endpoints or approved egress paths for clustering, state, reminder, stream, registry, telemetry, and secret dependencies.
+- Network policies which allow silo-to-silo TCP, client-to-gateway TCP, DNS, health probes, and the exact provider egress destinations.
+- Private DNS resolution for the API server and every private Azure dependency.
+
+Restrict the silo port to the Orleans workload and the gateway port to trusted Orleans clients. Use [Orleans Transport Layer Security](../host/transport-layer-security.md) when the network boundary requires workload-level authentication and encryption.
+
+Validate the effective policy from each workload identity and network. A network policy can allow pod traffic while a subnet security rule, firewall, private endpoint policy, or route table blocks the same path.
+
+## Configure workload identity and dependencies
+
+[Microsoft Entra Workload ID](https://learn.microsoft.com/azure/aks/workload-identity-overview) federates a Kubernetes service account with a Microsoft Entra identity. AKS Automatic preconfigures the cluster OIDC issuer and workload-identity capability. Enable both features on AKS Standard, then assign a dedicated service account to each workload role.
+
+Use separate runtime identities for silos, clients, and operational jobs when their permissions differ. Grant each identity the narrowest data-plane roles for:
+
+- The clustering membership store.
+- Named grain storage providers.
+- Reminder and stream providers.
+- Key Vault secrets and certificates.
+- Telemetry export when the application authenticates directly to the destination.
+
+Azure Table Storage is a common clustering provider. ADO.NET or Redis can also fit an existing managed dependency strategy. Select providers using [Topology, networking, and clustering](networking.md#choose-a-clustering-provider), and configure durable state, reminders, and streams independently. A healthy membership table establishes discovery; each application data dependency retains its own durability and recovery requirements.
+
+Use Key Vault references, the Secrets Store CSI Driver, or direct workload-identity access for secrets and certificates. Set rotation and expiry alerts and verify that a rotated value reaches new and existing pods according to the application lifecycle.
+
+AKS pulls container images before the pod workload identity is available. For Azure Container Registry, grant the AKS kubelet identity `AcrPull`, or `Container Registry Repository Reader` for a registry using repository-scoped ABAC permissions. See [Integrate Azure Container Registry with AKS](https://learn.microsoft.com/azure/aks/cluster-container-registry-integration).
+
+## Distribute silos across failure domains
+
+Create a dedicated user node pool for the Orleans workload when isolation, VM sizing, scaling, or maintenance policy differs from system components. AKS keeps a Linux system node pool for critical cluster services; application user pools can use separate labels, taints, and autoscaling bounds. See [Create node pools in AKS](https://learn.microsoft.com/azure/aks/create-node-pools).
+
+In a region with [AKS availability-zone support](https://learn.microsoft.com/azure/aks/reliability-availability-zones-configure):
+
+1. Create zone-spanning or zone-aligned user node pools with VM sizes available in every selected zone.
+1. Run at least three silo replicas when the tested availability target requires one ready silo per zone.
+1. Add `topologySpreadConstraints` using `topology.kubernetes.io/zone` and `kubernetes.io/hostname`.
+1. Add pod anti-affinity so the scheduler distributes silos across nodes.
+1. Keep enough quota, subnet addresses, and surge capacity to replace nodes while one zone or node pool is unavailable.
+
+Kubernetes scheduling constraints establish the requested distribution when eligible capacity exists. Verify the actual pod-to-zone placement after deployment and during node-pool upgrades.
+
+Zone-spanning providers complete the design. Configure the clustering, state, reminder, stream, registry, Key Vault, and telemetry services for the same availability objective, and test the application's behavior when one dependency zone is unavailable.
+
+## Configure health, shutdown, and disruption policy
+
+Use the startup, readiness, and liveness behavior from [Host Orleans on Kubernetes](kubernetes.md#health-probes):
+
+- Startup succeeds after configuration is valid, listeners are bound, required initialization completes, and the silo joins the intended cluster.
+- Readiness becomes false before shutdown and whenever the application cannot safely accept new work.
+- Liveness reports local process progress and remains independent from shared remote dependencies.
+
+Set `terminationGracePeriodSeconds` longer than the measured .NET host shutdown timeout. AKS node drains and workload replacement then give the host time to report unready, stop application work, and let Orleans leave membership.
+
+A `PodDisruptionBudget` limits simultaneous voluntary eviction. It preserves a ready-silo floor during node drain and upgrade when enough schedulable capacity exists. Node failure and zone loss remain abrupt failure paths, so size the cluster to serve load after those events.
+
+Use a rolling update with `maxUnavailable: 0`, bounded surge, and `minReadySeconds` for compatible versions. Make probe timing, progress deadlines, PDBs, node drain timeouts, and host shutdown timeouts mutually consistent so each rollout either progresses with capacity or pauses visibly.
+
+## Scale pods and nodes
+
+Orleans placement uses the silos currently active in membership. An application or platform autoscaler changes the number of silo pods, and the [AKS cluster autoscaler](https://learn.microsoft.com/azure/aks/cluster-autoscaler) adds or removes nodes when pods become unschedulable or nodes can be drained safely.
+
+Configure the two layers together:
+
+- Keep the minimum silo replica count at the tested capacity and redundancy floor.
+- Scale silo pods from application signals such as sustained CPU, queue depth, request latency, rejection rate, or a bounded custom metric.
+- Keep resource requests representative so pending pods accurately signal node demand.
+- Give the node-pool autoscaler enough maximum capacity, quota, and subnet address space for recovery and rollout surge.
+- Use stabilization windows and gradual scale-in so membership, activation movement, and provider load settle between removals.
+- Keep system and Orleans user node-pool policies independent.
+
+The node autoscaler manages AKS virtual machine scale-set capacity. Preserve its ownership of scale settings rather than applying independent virtual machine scale-set autoscaling.
+
+Load-test a burst which adds pods and nodes, loss of one silo and one node, a controlled scale-in, and provider slowdown. Confirm that the application remains within latency and rejection objectives throughout the sequence.
+
+## Plan application and AKS upgrades
+
+Application rolling upgrades temporarily mix old and new silos in one cluster. Maintain compatibility for grain interfaces, serializers, persisted state, reminders, streams, provider schemas, and external side effects. Use a separate `ClusterId` and traffic migration for an incompatible release.
+
+AKS also upgrades the Kubernetes control plane and node pools. Use [AKS upgrade options](https://learn.microsoft.com/azure/aks/upgrade-options) and planned maintenance to:
+
+1. Validate Kubernetes API compatibility and the Orleans workload in a representative preproduction cluster.
+1. Preserve quota, subnet addresses, and node-pool surge capacity.
+1. Drain a bounded number of nodes while the PDB and rollout policy retain ready silos.
+1. Monitor membership, reactivation load, provider latency, request outcomes, and pod placement.
+1. Pause when capacity or application thresholds are exceeded.
+
+Test rollback while mixed application versions and state written by the new version exist. For cluster-level changes which cannot roll back in place, provision a second AKS cluster with a distinct Orleans `ClusterId`, validate it, and migrate application traffic using the [blue-green guidance](upgrades.md#blue-green-upgrades).
+
+## Configure observability and incident access
+
+Export Orleans logs, .NET metrics, distributed traces, Kubernetes events, container logs, and AKS control-plane diagnostics to central systems. [Azure Monitor managed service for Prometheus](https://learn.microsoft.com/azure/azure-monitor/metrics/prometheus-metrics-overview) and [Azure Managed Grafana](https://learn.microsoft.com/azure/managed-grafana/overview) can provide the Azure-managed metrics path.
+
+Correlate:
+
+- AKS cluster, namespace, node pool, node, zone, pod, deployment, and replica set.
+- Orleans service ID, cluster ID, silo name, advertised endpoints, and application version.
+- Container image digest, deployment operation, provider request, and workload identity.
+
+Alert on sustained user impact, reduced ready-silo count, failed or blocked rollouts, pending pods, node pressure, restart loops, membership churn, provider throttling, credential expiry, and exhausted capacity.
+
+Keep incident access available through the private cluster boundary. Operators need a tested path to run `kubectl`, inspect membership, test every advertised endpoint, query providers, and retrieve previous container logs during a partial outage. See [Troubleshoot deployments](troubleshooting-deployments.md#kubernetes-checks).
+
+## Validate the production deployment
+
+Complete these checks before production traffic and after material network, identity, node-pool, or upgrade-policy changes:
+
+1. Confirm that every active silo membership row contains the expected pod IP and unique silo and gateway ports.
+1. Test TCP connectivity from every silo pod to every advertised silo endpoint.
+1. Test every advertised gateway endpoint from each Orleans client network.
+1. Verify network-policy enforcement and provider access using the workload identities assigned to silos and clients.
+1. Confirm actual pod distribution across nodes and zones.
+1. Replace one silo pod under load and verify graceful membership departure and activation recovery.
+1. Drain one node and verify the disruption budget, termination deadline, replacement scheduling, and capacity floor.
+1. Exercise pod scale-out, node scale-out, gradual scale-in, and one-zone or one-node-pool capacity loss.
+1. Perform a compatible rolling deployment and rollback.
+1. Restore durable application data in an isolated cluster and validate the recovery runbook.
+
+Record the effective manifests, cluster network model, service and pod CIDRs, node-pool configuration, identities, role assignments, provider namespaces, probe thresholds, shutdown deadlines, scaling bounds, and operational commands. Finish the shared [production-readiness checklist](production-readiness.md).

--- a/docs/site/src/content/docs/deployment/choose-deployment-target.md
+++ b/docs/site/src/content/docs/deployment/choose-deployment-target.md
@@ -1,0 +1,94 @@
+---
+title: Choose a deployment target
+description: Compare supported Orleans hosting topologies, networking models, scaling controls, and operational responsibilities.
+ms.date: 08/21/2026
+ms.topic: concept-article
+ms.custom: devops
+---
+
+# Choose a deployment target
+
+Orleans runs on platforms that give each silo a unique, directly reachable TCP endpoint and coordinate process lifecycle with the .NET host. Choose the platform whose supported networking model, scaling controls, failure-domain placement, and operational ownership match the application.
+
+Use the [platform requirements](platform-guides.md) as an acceptance gate against the application's availability objective. Then use these matrices to select a maintained deployment guide.
+
+## Target matrix
+
+| Target | Supported Orleans topology | Endpoint identity and client reachability | Scaling and failure domains | Operational ownership | Common provider choices |
+| --- | --- | --- | --- | --- | --- |
+| [Azure Kubernetes Service (AKS)](azure-kubernetes-service.md) | One silo per pod in a `Deployment`; separate in-cluster clients or cohosted application endpoints | Silos advertise pod IPs. In-cluster clients reach pod gateway endpoints directly. Azure CNI Pod Subnet extends direct pod routing to connected networks when external Orleans clients require it. | Horizontal pod scaling, node-pool autoscaling, availability zones, topology spread, disruption budgets, and controlled rolling replacement | Azure operates the control plane; the application team owns workload manifests, capacity, providers, upgrades, and recovery | Azure Table Storage or ADO.NET for clustering; application-selected durable storage, reminders, and streams |
+| [Kubernetes](kubernetes.md) | One silo per pod with explicit pod name and pod IP configuration | Silos advertise pod IPs. Clients run on a network that can route to every advertised gateway pod IP. | Deployment replicas, cluster-specific node scaling, topology spread, disruption budgets, and rolling updates | Shared between the Kubernetes operator and application team | A highly available provider already operated near the cluster |
+| [Azure Container Apps](deploy-to-azure-container-apps.md) | One silo replica per Container App, with multiple silo apps in one internal environment | Every silo app receives a unique TCP silo and gateway port pair on the environment's private static IP | Scale by adding or removing one-replica silo apps. Replacement apps provide controlled rollout. This topology provides app-resource and process redundancy without a documented cross-zone placement guarantee. Use AKS when zonal placement is part of the availability objective. | Azure operates hosts and the environment; the application team owns the bounded app topology, port allocation, and replacement workflow | Azure Table Storage for clustering and optional grain state; other Azure data services where supported by the application |
+| [Azure App Service](azure-app-service.md) | One cohosted silo per App Service worker | Each worker advertises `WEBSITE_PRIVATE_IP` and its allocated private port. Trusted application clients use validated private gateway mappings when enabled. | App Service distributes multiple workers across fault domains. Supported Premium plans can enable zone redundancy. Deployment slots provide compatible release rollout. | Azure operates workers and the front end; the application team validates private endpoint behavior, slot compatibility, zone configuration, and capacity | Azure Table Storage for clustering and grain state in the maintained sample |
+| [Service Fabric](service-fabric.md) | One silo per unpartitioned stateless Reliable Service instance | Each instance advertises its node address and runtime-allocated silo and gateway ports | Stateless instance count, fault domains, update domains, monitored rolling upgrades, and application health policies | Service Fabric manages placement and lifecycle; the application owns the Reliable Service integration and Orleans providers | Azure Table Storage in the compiled example; another supported external provider when appropriate |
+
+## Compare lifecycle and release mechanisms
+
+| Target | Health and termination mechanism | Upgrade and rollback mechanism |
+| --- | --- | --- |
+| AKS | Application-owned startup, readiness, and liveness probes; Kubernetes pod termination grace period; PDB-governed voluntary eviction | Deployment rolling update plus node-pool surge and drain controls; isolated AKS cluster and Orleans cluster ID for incompatible changes |
+| Kubernetes | Application-owned probes, orchestrator termination grace period, and disruption policy | Deployment or controller rollout with bounded unavailable and surge capacity; separate cluster identity for incompatible changes |
+| Azure Container Apps | Explicit startup, readiness, and liveness probes plus container termination grace period | Replacement one-replica silo apps with new port pairs; isolated app set and cluster ID for incompatible changes |
+| Azure App Service | App Service Health check, startup and slot warm-up, application readiness, and bounded host shutdown | Staging-slot warm-up and swap for compatible changes; separate app and cluster ID for incompatible changes |
+| Service Fabric | Communication-listener lifecycle plus application-authored Service Fabric health reports and close timeout | Monitored rolling upgrade by update domain; separately named application and cluster ID for incompatible changes |
+
+## Qualify another platform
+
+The maintained target guides above provide complete platform-specific operations guidance. Use these supporting guides to qualify another hosting system:
+
+| Platform shape | Networking guidance | Qualification path |
+| --- | --- | --- |
+| Container orchestrator or service | [Run containers across multiple hosts](containers.md) | Prove direct per-container addressing or unique host-port mapping, then complete every [platform requirement](platform-guides.md) for the selected orchestrator. |
+| Virtual machines or bare-metal hosts | Stable private host addresses and unique silo and gateway ports | Complete the [platform requirements](platform-guides.md) with the infrastructure team's process supervision, failure-domain placement, patching, scaling, and replacement automation. |
+
+## Choose the networking model first
+
+Orleans membership identifies a specific silo endpoint. The selected platform therefore needs one of these models:
+
+- **Direct workload addressing** gives each pod, task, container, or process a private address which every silo can route to. Kubernetes with routable pod networking and Amazon ECS with `awsvpc` task networking use this model.
+- **Explicit endpoint mapping** gives each silo a private host or platform address plus unique published silo and gateway ports. Azure Container Apps, Azure App Service, and host-port container deployments use this model.
+- **Stable host addressing** gives each virtual machine or physical host a private address. Each silo on that host advertises a unique port pair.
+
+HTTP ingress, reverse proxies, and shared service virtual IPs route application traffic. Orleans transport connections continue to use the individual endpoints stored in membership. See [Topology, networking, and clustering](networking.md) for the runtime boundary.
+
+## Match client placement to the target
+
+An Orleans client discovers gateway endpoints from the clustering provider and connects to those endpoints directly.
+
+- In-cluster clients fit pod-overlay networks because they can route to every gateway pod IP.
+- Clients in connected virtual networks require a target whose advertised gateway addresses are routed to those networks.
+- Public callers use an authenticated application API. Keep silo and gateway ports on trusted private networks.
+- Cohosted clients use the local silo while application HTTP or gRPC ingress remains a separate platform path.
+
+Document the client networks and test every advertised gateway from each one before launch.
+
+## Match scaling to Orleans capacity
+
+The platform changes process or node count. Orleans membership incorporates new silos, placement uses the available silos, and activations recover after a silo leaves.
+
+Set scaling policy from measured application signals:
+
+- Keep a tested minimum silo count and enough capacity to lose one failure domain.
+- Scale out early enough for new silos to start, join membership, and absorb activations.
+- Scale in one bounded set of silos at a time after readiness is removed and graceful host shutdown begins.
+- Coordinate pod or process autoscaling with node, plan, or host capacity.
+- Load-test scale-out, scale-in, restart, provider degradation, and rolling replacement.
+
+See [Capacity planning and scaling](capacity-planning.md) and [Graceful shutdown and upgrades](upgrades.md).
+
+## Production coverage for every target
+
+Complete these outcomes in the selected target guide and record environment-specific values in the deployment runbook.
+
+| Concern | Required outcome |
+| --- | --- |
+| Topology and networking | Every silo has a unique advertised endpoint, every silo can reach every silo endpoint, and every client can reach every advertised gateway endpoint. |
+| Dependencies and data | Production clustering, grain storage, reminders, streams, and external dependencies have explicit availability, durability, quota, backup, and recovery decisions. |
+| Identity and secrets | Runtime and deployment identities have separate least-privilege permissions. Credentials and certificates use managed delivery, rotation, and expiry monitoring. |
+| Health and lifecycle | Startup, readiness, liveness, dependency health, graceful shutdown, and the platform termination deadline have distinct measured behavior. |
+| Scaling and resilience | Minimum capacity, autoscaling boundaries, failure-domain distribution, disruption policy, and recovery after one failure domain are load-tested. |
+| Upgrades and rollback | Compatible releases use bounded rolling replacement. Incompatible releases use isolated cluster IDs and an explicit state and traffic migration plan. |
+| Observability and incidents | Central logs, metrics, traces, deployment identity, membership evidence, alerts, dashboards, and incident commands support diagnosis under load. |
+| Infrastructure delivery | Infrastructure and workload configuration are versioned, reviewed, reproducible, and validated before production traffic. |
+
+Use the [production-readiness checklist](production-readiness.md) for the full review and [Troubleshoot deployments](troubleshooting-deployments.md) for incident evidence.

--- a/docs/site/src/content/docs/deployment/containers.md
+++ b/docs/site/src/content/docs/deployment/containers.md
@@ -76,6 +76,19 @@ On Amazon ECS, [`awsvpc` task networking](https://docs.aws.amazon.com/AmazonECS/
 
 For orchestrated and managed platforms, also review [Platform requirements](platform-guides.md), [Host Orleans on Kubernetes](kubernetes.md), and [Host Orleans on Azure Container Apps](deploy-to-azure-container-apps.md).
 
+## Complete platform qualification
+
+This page establishes the endpoint and routing model for a container platform. The selected orchestrator or managed service also needs to provide the remaining production mechanisms:
+
+- Workload identity or managed secret and certificate delivery.
+- Startup, readiness, liveness, dependency health, and a measured termination deadline.
+- Resource policy, a tested minimum silo count, scaling controls, and failure-domain placement.
+- Bounded rolling replacement or an isolated blue-green cluster with compatible state handling.
+- Central logs, metrics, traces, deployment identity, provider telemetry, and incident access.
+- Versioned infrastructure and workload configuration with repeatable validation.
+
+Use [Choose a deployment target](choose-deployment-target.md) for maintained target guides. For another orchestrator, complete the [platform requirements](platform-guides.md) and [production-readiness checklist](production-readiness.md) before production traffic.
+
 ## Diagnose forwarding loops and timeouts
 
 Start with the exact endpoints, not only the membership-provider health:

--- a/docs/site/src/content/docs/deployment/deploy-to-azure-app-service-linux.md
+++ b/docs/site/src/content/docs/deployment/deploy-to-azure-app-service-linux.md
@@ -8,7 +8,7 @@ ms.custom: devops
 
 # Deploy Orleans to Azure App Service on Linux
 
-This tutorial deploys the [Orleans shopping cart sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureAppService) to the [built-in .NET stack on Linux Azure App Service](https://learn.microsoft.com/azure/app-service/configure-language-dotnetcore). The application, storage, identity, networking, health, and OIDC design are shared with the [Windows guide](deploy-to-azure-app-service.md), but Linux plan, runtime, startup, and Easy Auth behavior require separate validation.
+This tutorial deploys the [Orleans shopping cart sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureAppService) to the [built-in .NET stack on Linux Azure App Service](https://learn.microsoft.com/azure/app-service/configure-language-dotnetcore). Start with the shared [Azure App Service target overview](azure-app-service.md). The application, storage, identity, networking, health, and OIDC design are shared with the [Windows guide](deploy-to-azure-app-service.md), while Linux plan, runtime, startup, and Easy Auth behavior receive separate validation.
 
 ## Understand the Linux topology
 
@@ -179,4 +179,17 @@ HTTPS terminates at the App Service front end. The sample's private Orleans silo
 
 App Service can replace workers without delivering the full shutdown interval. Size integration subnets for planned scale plus replacement capacity, preserve at least three workers, and validate failure recovery and rolling upgrades under load. Back up durable grain state independently from membership data.
 
-For shared operational guidance, see [Production-readiness checklist](production-readiness.md), [Topology, networking, and clustering](networking.md), [Health and observability](health-and-observability.md), and [Graceful shutdown and upgrades](upgrades.md).
+## Production checklist
+
+| Concern | Linux App Service outcome |
+| --- | --- |
+| Topology and networking | Every worker advertises its private instance address and allocated silo port, and every worker can connect to every active membership endpoint. |
+| Dependencies and data | Azure Table clustering and grain state use separate production data with tested backup and restore. Applications configure reminder and stream providers explicitly when used. |
+| Identity and secrets | Runtime storage access uses managed identity. App Service Authentication, routine deployment, and privileged bootstrap credentials remain separate and rotate before expiry. |
+| Health and lifecycle | Container startup, health check, slot warm-up, readiness removal, and bounded host shutdown reflect the application lifecycle. |
+| Scaling and resilience | The plan retains at least three workers and tested spare capacity. Scale-out, scale-in, worker replacement, dependency degradation, and abrupt loss are exercised under load. |
+| Upgrades and rollback | Compatible versions use a staging-slot swap with mixed-version validation. Incompatible versions use a separate app, cluster ID, state plan, and traffic cutover. |
+| Observability and incidents | Application Insights, Log Analytics, Orleans telemetry, worker identity, membership, provider signals, container events, and slot operations are correlated. |
+| Infrastructure delivery | Bicep and the protected GitHub OIDC workflow reproduce infrastructure and deploy immutable application artifacts through staging. |
+
+For shared operational guidance, see [Production-readiness checklist](production-readiness.md), [Topology, networking, and clustering](networking.md), [Health and observability](health-and-observability.md), [Graceful shutdown and upgrades](upgrades.md), and [Choose a deployment target](choose-deployment-target.md).

--- a/docs/site/src/content/docs/deployment/deploy-to-azure-app-service.md
+++ b/docs/site/src/content/docs/deployment/deploy-to-azure-app-service.md
@@ -8,7 +8,7 @@ ms.custom: devops
 
 # Deploy Orleans to Azure App Service on Windows
 
-This tutorial deploys the [Orleans shopping cart sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureAppService) as a multi-instance cluster on [Windows Azure App Service](https://learn.microsoft.com/azure/app-service/overview). For Linux plan, runtime, startup, and Easy Auth differences, see [Deploy Orleans to Azure App Service on Linux](deploy-to-azure-app-service-linux.md).
+This tutorial deploys the [Orleans shopping cart sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureAppService) as a multi-instance cluster on [Windows Azure App Service](https://learn.microsoft.com/azure/app-service/overview). Start with the shared [Azure App Service target overview](azure-app-service.md). For Linux plan, runtime, startup, and Easy Auth differences, see [Deploy Orleans to Azure App Service on Linux](deploy-to-azure-app-service-linux.md).
 
 The sample cohosts an ASP.NET Core Blazor app and an Orleans silo in each worker. It uses:
 
@@ -210,12 +210,19 @@ HTTPS protects the public web endpoint. The private Orleans silo connections are
 
 Application Insights receives request, dependency, exception, application, and Orleans logs. Monitor ready worker and silo counts, membership changes, latency, rejections, storage authorization/throttling, worker resources, restarts, and slot operations.
 
-## Production considerations
+## Production checklist
 
-- Keep at least three workers and spare capacity during upgrades.
-- Keep HTTP client affinity for the cohosted Blazor Server UI; Orleans doesn't require HTTP affinity.
-- Validate scale-out, scale-in, worker replacement, rollback, identity propagation, and private endpoint reachability under load.
-- Back up durable grain state independently from membership data.
-- Don't convert an existing App Service plan between Windows and Linux. Deploy a separate app and migrate traffic.
+| Concern | Windows App Service outcome |
+| --- | --- |
+| Topology and networking | Every worker advertises its private instance address and allocated silo port, and every worker can connect to every active membership endpoint. |
+| Dependencies and data | Azure Table clustering and grain state use separate production data with tested backup and restore. Applications configure reminder and stream providers explicitly when used. |
+| Identity and secrets | Runtime storage access uses managed identity. App Service Authentication, routine deployment, and privileged bootstrap credentials remain separate and rotate before expiry. |
+| Health and lifecycle | Health check, startup warm-up, slot warm-up, readiness removal, and bounded host shutdown reflect the application lifecycle. |
+| Scaling and resilience | The plan retains at least three workers and tested spare capacity. Scale-out, scale-in, worker replacement, dependency degradation, and abrupt loss are exercised under load. |
+| Upgrades and rollback | Compatible versions use a staging-slot swap with mixed-version validation. Incompatible versions use a separate app, cluster ID, state plan, and traffic cutover. |
+| Observability and incidents | Application Insights, Log Analytics, Orleans telemetry, worker identity, membership, provider signals, and slot operations are correlated. |
+| Infrastructure delivery | Bicep and the protected GitHub OIDC workflow reproduce infrastructure and deploy immutable application artifacts through staging. |
 
-For broader guidance, see [Production-readiness checklist](production-readiness.md), [Topology, networking, and clustering](networking.md), and [Graceful shutdown and upgrades](upgrades.md).
+Keep HTTP client affinity for the cohosted Blazor Server UI. Orleans transport uses the private silo endpoints independently from HTTP affinity. Migrate between Windows and Linux by deploying a separate app and moving traffic after validation.
+
+For broader guidance, see [Production-readiness checklist](production-readiness.md), [Topology, networking, and clustering](networking.md), [Graceful shutdown and upgrades](upgrades.md), and [Choose a deployment target](choose-deployment-target.md).

--- a/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
+++ b/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
@@ -7,9 +7,9 @@ ms.topic: concept-article
 
 # Host Orleans on Azure Container Apps
 
-Azure Container Apps can host Orleans, but the topology must preserve Orleans endpoint semantics. Orleans silos connect to the unique silo and gateway endpoint that each member advertises. Container Apps service discovery and TCP or HTTP ingress instead address a **container app or revision** and load-balance across its replicas. They don't provide a supported replica DNS name or replica IP address.
+Azure Container Apps hosts Orleans using a topology which preserves Orleans endpoint semantics. Orleans silos connect to the unique silo and gateway endpoint that each member advertises. Container Apps service discovery and TCP or HTTP ingress address a **container app or revision** and load-balance across its replicas. The maintained production topology therefore assigns each silo its own Container App and one replica.
 
-To build a cluster from documented Container Apps endpoints, use a virtual-network-integrated internal environment and its private static IP. Deploy each silo as a separate Container App with exactly one replica and assign each app a unique pair of TCP ingress ports on that private IP. Repeat that resource to add silos. You must still complete the production acceptance tests on this page. A single Container App scaled to multiple silo replicas can work in a particular environment, but direct replica addresses aren't part of the documented Container Apps networking contract.
+Use a virtual-network-integrated internal environment and its private static IP. Deploy each silo as a separate Container App with exactly one replica and assign each app a unique pair of TCP ingress ports on that private IP. Repeat that resource to add silos, then complete the production acceptance tests on this page. Multiple silo replicas in one Container App fall outside this maintained deployment shape because Container Apps publishes app and revision endpoints instead of a supported per-replica endpoint identity.
 
 Use the [Deploy and scale an Orleans app on Azure](../quickstarts/deploy-scale-orleans-on-azure.md) quickstart to learn the Azure Developer CLI deployment flow. The [Orleans cluster on Azure Container Apps sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps) is also useful for studying a multi-component topology and the external-scaler contract. Review the [sample limitations](#understand-the-sample) before adapting either resource for production.
 
@@ -20,7 +20,7 @@ If the application uses Aspire, the [Aspire deployment flow for Azure Container 
 | Topology | Endpoint behavior | Guidance |
 | --- | --- | --- |
 | One silo replica per Container App | A unique silo and gateway port pair on the environment's private static IP routes to one app and one silo. | Use this topology when Container Apps is required. Set both minimum and maximum replicas to one, and deploy multiple silo apps. |
-| Multiple silo replicas in one Container App | The app and revision host names route through the platform proxy to any eligible replica. Container Apps doesn't publish a supported address for selecting one replica. | Use only after environment-specific qualification. Don't treat observed container IP reachability as a platform guarantee. |
+| Multiple silo replicas in one Container App | The app and revision host names route through the platform proxy to any eligible replica. Container Apps publishes no supported address for selecting one replica. | Use the maintained one-replica-per-app topology or select a direct-address platform such as AKS. |
 | Silos on Kubernetes or another direct-address platform | The orchestrator publishes a routable address for each pod or process. | Prefer this topology when automatic replica scaling and conventional rolling replacement are requirements. |
 
 The one-replica-per-app topology is operationally heavier because infrastructure as code must create a bounded set of silo apps and allocate environment-unique ports. It also requires a deliberate replacement procedure during upgrades. In exchange, it doesn't depend on undocumented pod networking.
@@ -197,8 +197,6 @@ Complete these acceptance tests before production and after platform or network 
 1. Exercise the compatible rolling and isolated blue-green procedures, including rollback.
 1. Verify that silo and gateway ports aren't publicly reachable and that runtime and deployment identities have only the intended roles.
 
-For the multiple-replica-in-one-app topology, add a blocking test that matches every active Orleans membership endpoint to one Container Apps replica and tests every advertised address from every peer. A successful test establishes evidence for that environment, but it doesn't turn the observed replica IP into a documented Container Apps contract.
-
 ## Understand the sample
 
 The [in-repo sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps), imported from the [original Azure sample](https://github.com/Azure-Samples/Orleans-Cluster-on-Azure-Container-Apps), demonstrates:
@@ -217,3 +215,18 @@ The sample bounds public grain identities. Its hello grain uses an integer key, 
 The sample is still an architecture demonstration rather than a production deployment manifest. The registry and storage data endpoints remain public, although they require Microsoft Entra authentication. All runtime apps share one identity. The simple readiness endpoints don't implement application-specific draining, and the workflow updates existing apps in place, which can temporarily overlap revisions that advertise the same endpoint. For production upgrades, use the replacement-app procedure on this page. The one-replica apps don't prove cross-zone or independent failure-domain placement, and the external scaler doesn't make a capacity recommendation.
 
 Use the sample to understand component relationships, Orleans membership-based gateway discovery, managed identity, workload generation, and explicit endpoint mapping. Complete the networking, failure, upgrade, security, state-recovery, and readiness acceptance tests on this page before using the topology in production.
+
+## Production checklist
+
+| Concern | Azure Container Apps outcome |
+| --- | --- |
+| Topology and networking | Every one-replica silo app owns a unique private silo and gateway port pair, and every membership endpoint maps to exactly one app. |
+| Dependencies and data | Production clustering, grain storage, reminders, and streams have explicit providers, namespaces, durability, quotas, backup, and recovery procedures. |
+| Identity and secrets | Runtime, image-publishing, routine deployment, and privileged bootstrap identities have separate least-privilege roles. Secrets use managed delivery and rotation. |
+| Health and lifecycle | Startup, readiness, and liveness probes represent distinct application states, and the termination grace period exceeds measured host shutdown time. |
+| Scaling and resilience | Scale changes add or remove one-replica silo apps, preserve the tested capacity floor, and recover successfully from one app or host loss. |
+| Upgrades and rollback | Compatible versions use replacement apps with new port pairs. Incompatible versions use an isolated cluster ID, endpoint set, state plan, and application-traffic cutover. |
+| Observability and incidents | Orleans telemetry, Container App app/revision/replica identity, membership, provider signals, and deployment metadata are centrally correlated. |
+| Infrastructure delivery | Versioned Bicep and a protected GitHub OIDC workflow reproduce the bounded app topology and deploy immutable image digests. |
+
+Compare this target with [AKS, App Service, Kubernetes, Service Fabric, and multi-host containers](choose-deployment-target.md), then complete the shared [production-readiness checklist](production-readiness.md).

--- a/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
+++ b/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
@@ -7,7 +7,7 @@ ms.topic: concept-article
 
 # Host Orleans on Azure Container Apps
 
-Azure Container Apps hosts Orleans using a topology which preserves Orleans endpoint semantics. Orleans silos connect to the unique silo and gateway endpoint that each member advertises. Container Apps service discovery and TCP or HTTP ingress address a **container app or revision** and load-balance across its replicas. The maintained production topology therefore assigns each silo its own Container App and one replica.
+Azure Container Apps hosts Orleans using a topology that preserves Orleans endpoint semantics. Orleans silos connect to the unique silo and gateway endpoint that each member advertises. Container Apps service discovery and TCP or HTTP ingress address a **container app or revision** and load-balance across its replicas. The maintained production topology therefore assigns each silo its own Container App and one replica.
 
 Use a virtual-network-integrated internal environment and its private static IP. Deploy each silo as a separate Container App with exactly one replica and assign each app a unique pair of TCP ingress ports on that private IP. Repeat that resource to add silos, then complete the production acceptance tests on this page. Multiple silo replicas in one Container App fall outside this maintained deployment shape because Container Apps publishes app and revision endpoints instead of a supported per-replica endpoint identity.
 

--- a/docs/site/src/content/docs/deployment/index.md
+++ b/docs/site/src/content/docs/deployment/index.md
@@ -53,14 +53,18 @@ Use these articles together:
 
 ## Choose a platform
 
-- [Azure Container Apps deployment walkthrough and sample](../tutorials-and-samples/production-application.md)
-- [Containers across multiple hosts](containers.md)
-- [Kubernetes](kubernetes.md)
-- [Service Fabric](service-fabric.md)
-- [Azure App Service on Windows](deploy-to-azure-app-service.md)
-- [Azure App Service on Linux](deploy-to-azure-app-service-linux.md)
-- [Azure Container Apps](deploy-to-azure-container-apps.md)
-- Other orchestrators, virtual machines, or bare-metal hosts that satisfy the [platform requirements](platform-guides.md)
+Use [Choose a deployment target](choose-deployment-target.md) to compare maintained hosting topologies, endpoint identity, client reachability, scaling, failure-domain controls, operational ownership, and common provider choices.
+
+The target guides cover:
+
+- [Azure Kubernetes Service](azure-kubernetes-service.md) and [platform-neutral Kubernetes](kubernetes.md).
+- [Azure Container Apps](deploy-to-azure-container-apps.md), including its one-silo-per-app endpoint model.
+- [Azure App Service](azure-app-service.md) on [Windows](deploy-to-azure-app-service.md) or [Linux](deploy-to-azure-app-service-linux.md).
+- [Service Fabric](service-fabric.md).
+- [Containers across multiple hosts](containers.md).
+- Other orchestrators, virtual machines, or bare-metal hosts that satisfy the [platform requirements](platform-guides.md).
+
+For a guided deployment with a maintained application and infrastructure sample, use [Deploy an Orleans application to Azure Container Apps](../tutorials-and-samples/production-application.md).
 
 For application configuration, see [Server configuration](../host/configuration-guide/server-configuration.md), [Client configuration](../host/configuration-guide/client-configuration.md), and [Typical configurations](../host/configuration-guide/typical-configurations.md).
 

--- a/docs/site/src/content/docs/deployment/kubernetes.md
+++ b/docs/site/src/content/docs/deployment/kubernetes.md
@@ -10,6 +10,8 @@ ms.custom: devops
 
 Kubernetes can host Orleans when pods have direct network connectivity and the application uses a production clustering provider. Orleans doesn't require a Kubernetes-specific hosting package. The recommended approach is to configure each silo explicitly from the pod name and pod IP supplied by the Kubernetes [downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/).
 
+For Azure networking, workload identity, availability zones, node pools, autoscaling, managed upgrades, and Azure Monitor guidance, see [Host Orleans on Azure Kubernetes Service](azure-kubernetes-service.md).
+
 ## Configure the silo
 
 Reference `Microsoft.Orleans.Server` and a production clustering provider package. Configure the pod IP as the advertised address, listen on all pod interfaces, and use the pod name as the silo name:
@@ -218,4 +220,4 @@ For explicit endpoint configuration, compare `POD_NAME`, `POD_IP`, service ID, c
 
 If the optional hosting package reports missing `KUBERNETES_SERVICE_HOST` or `KUBERNETES_SERVICE_PORT`, verify that the process is running in a pod and that service environment links haven't been disabled. If the API returns `403 Forbidden`, check the pod's service account, role binding namespace, and required pod verbs.
 
-For broader triage, see [Troubleshoot deployments](troubleshooting-deployments.md).
+For broader triage, see [Troubleshoot deployments](troubleshooting-deployments.md). For target comparisons and the shared production-coverage matrix, see [Choose a deployment target](choose-deployment-target.md).

--- a/docs/site/src/content/docs/deployment/platform-guides.md
+++ b/docs/site/src/content/docs/deployment/platform-guides.md
@@ -16,7 +16,7 @@ A production platform must provide:
 - Stable per-instance addresses or explicit advertised endpoint mapping.
 - Direct bidirectional TCP connectivity from every silo to every silo endpoint.
 - Reachability from Orleans clients to advertised gateway endpoints.
-- Multiple concurrently running instances across failure domains.
+- Multiple concurrently running instances and a documented failure-domain model that meets the application's availability objective.
 - Graceful termination notification and a configurable termination deadline.
 - Startup, readiness, and liveness checks with separate semantics.
 - Secure access to a supported clustering provider and all state providers.
@@ -28,10 +28,12 @@ An HTTP-only platform isn't sufficient unless Orleans silos can also establish d
 
 ## Platform guidance
 
+- [Choose a deployment target](choose-deployment-target.md) compares maintained topologies, endpoint models, scaling controls, failure-domain placement, operational ownership, and common provider choices.
+- [Azure Kubernetes Service](azure-kubernetes-service.md) applies Azure CNI networking, workload identity, availability zones, node pools, autoscaling, upgrades, and Azure Monitor to the platform-neutral Kubernetes baseline.
 - [Multi-host container deployments](containers.md) require either direct per-container private addresses or unique, peer-reachable host-port mappings for every silo.
 - [Kubernetes](kubernetes.md) provides direct pod networking. Explicit endpoint configuration is recommended; the Orleans hosting package is optional and limited to simple one-`Deployment`-per-cluster topologies.
 - [Service Fabric](service-fabric.md) uses an application-authored stateless Reliable Service integration with runtime-allocated endpoints and an external Orleans clustering provider.
-- Azure App Service requires validation of private per-instance address and port mapping on [Windows](deploy-to-azure-app-service.md) and [Linux](deploy-to-azure-app-service-linux.md).
+- [Azure App Service](azure-app-service.md) uses private per-instance address and port mapping on [Windows](deploy-to-azure-app-service.md) and [Linux](deploy-to-azure-app-service-linux.md).
 - [Azure Container Apps](deploy-to-azure-container-apps.md) can map unique TCP port pairs on an internal environment's private IP to one replica per silo app; scaling multiple silos as replicas of one app relies on per-replica networking that the platform doesn't publish as a supported contract.
 
 For another platform, prove the required capabilities with at least three silos under rolling replacement, scale-in, host restart, and network interruption. Record the exact endpoint mapping and shutdown behavior in the deployment runbook.

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -186,6 +186,10 @@ items:
         href: tutorials-and-samples/custom-grain-storage.md
       - name: Deploy an Orleans application to Azure Container Apps
         href: tutorials-and-samples/production-application.md
+      - name: Deploy Orleans to Azure App Service on Windows
+        href: deployment/deploy-to-azure-app-service.md
+      - name: Deploy Orleans to Azure App Service on Linux
+        href: deployment/deploy-to-azure-app-service-linux.md
       - name: Test an Orleans application end to end
         href: tutorials-and-samples/testing-walkthrough.md
       - name: Build and recover a streaming application
@@ -305,10 +309,6 @@ items:
             href: deployment/deploy-to-azure-container-apps.md
           - name: Azure App Service
             href: deployment/azure-app-service.md
-          - name: Azure App Service on Windows
-            href: deployment/deploy-to-azure-app-service.md
-          - name: Azure App Service on Linux
-            href: deployment/deploy-to-azure-app-service-linux.md
           - name: Service Fabric
             href: deployment/service-fabric.md
       - name: Health and observability

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -283,6 +283,8 @@ items:
     items:
       - name: Overview
         href: deployment/index.md
+      - name: Choose a deployment target
+        href: deployment/choose-deployment-target.md
       - name: Production-readiness checklist
         href: deployment/production-readiness.md
       - name: Operate a production cluster
@@ -291,18 +293,24 @@ items:
         href: deployment/networking.md
       - name: Run containers across multiple hosts
         href: deployment/containers.md
-      - name: Platform requirements
-        href: deployment/platform-guides.md
-      - name: Host on Kubernetes
-        href: deployment/kubernetes.md
-      - name: Host on Service Fabric
-        href: deployment/service-fabric.md
-      - name: Deploy to Azure App Service on Windows
-        href: deployment/deploy-to-azure-app-service.md
-      - name: Deploy to Azure App Service on Linux
-        href: deployment/deploy-to-azure-app-service-linux.md
-      - name: Host on Azure Container Apps
-        href: deployment/deploy-to-azure-container-apps.md
+      - name: Deployment targets
+        items:
+          - name: Platform requirements
+            href: deployment/platform-guides.md
+          - name: Azure Kubernetes Service
+            href: deployment/azure-kubernetes-service.md
+          - name: Kubernetes
+            href: deployment/kubernetes.md
+          - name: Azure Container Apps
+            href: deployment/deploy-to-azure-container-apps.md
+          - name: Azure App Service
+            href: deployment/azure-app-service.md
+          - name: Azure App Service on Windows
+            href: deployment/deploy-to-azure-app-service.md
+          - name: Azure App Service on Linux
+            href: deployment/deploy-to-azure-app-service-linux.md
+          - name: Service Fabric
+            href: deployment/service-fabric.md
       - name: Health and observability
         href: deployment/health-and-observability.md
       - name: Capacity planning


### PR DESCRIPTION
## Problem

Orleans deployment guidance covered several platforms but did not provide a target-selection matrix, a dedicated AKS production path, or a consistent operational structure across the maintained Azure targets.

## Solution

- Add a deployment-target matrix covering topology, endpoint identity, scaling, failure domains, lifecycle, upgrades, ownership, and provider choices.
- Add a dedicated AKS guide for Azure CNI networking, workload identity, zones, node pools, autoscaling, upgrades, observability, and production validation.
- Add an Azure App Service target overview and align the Windows, Linux, and Azure Container Apps guides around the same production outcomes.
- Reorganize navigation and cross-link shared networking, health, capacity, upgrade, recovery, and troubleshooting guidance.

## Rationale

The structure keeps Orleans runtime invariants in shared pages while each target guide documents the platform mechanisms and supported deployment shape needed to satisfy them.

Fixes #10721
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10746)