### PR TITLE
docs: document Orleans Journaling

### DIFF
--- a/docs/Docs.slnx
+++ b/docs/Docs.slnx
@@ -24,6 +24,9 @@
   </Folder>
   <Folder Name="/site/src/content/docs/grains/journaling/" />
   <Folder Name="/site/src/content/docs/grains/journaling/snippets/" />
+  <Folder Name="/site/src/content/docs/grains/journaling/snippets/journaling/">
+    <Project Path="site/src/content/docs/grains/journaling/snippets/journaling/Journaling.csproj" />
+  </Folder>
   <Folder Name="/site/src/content/docs/grains/journaling/snippets/redis-journaling/">
     <Project Path="site/src/content/docs/grains/journaling/snippets/redis-journaling/RedisJournaling.csproj" />
   </Folder>

--- a/docs/site/src/content/docs/grains/event-sourcing/index.md
+++ b/docs/site/src/content/docs/grains/event-sourcing/index.md
@@ -39,6 +39,6 @@ Log-consistency providers use optimistic concurrency and protocol notifications 
 `Microsoft.Orleans.EventSourcing` and `Microsoft.Orleans.Journaling` are separate packages and programming models.
 
 - Event Sourcing uses `JournaledGrain<TState, TEvent>` and log-consistency providers.
-- Journaling uses <xref:Orleans.Journaling.DurableGrain>, journaled state, and durable collections.
+- [Orleans Journaling](../journaling/index.md) uses <xref:Orleans.Journaling.DurableGrain>, journaled state, and durable collections.
 
-`Microsoft.Orleans.Journaling` is an alpha package whose APIs are marked experimental with diagnostic `ORLEANSEXP005`. It isn't a replacement for Event Sourcing. Evaluate it as an experimental feature and expect API or storage-format changes.
+`Microsoft.Orleans.Journaling` is an alpha package whose APIs are marked experimental with diagnostic `ORLEANSEXP005`. Its programming model serves applications evaluating operation-based persistence for mutable durable state. Event Sourcing serves applications which model domain changes as events and use log-consistency providers.

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -90,6 +90,7 @@ Most grains only need a contract, an implementation, a stable key, and regular r
 - [Response streaming with IAsyncEnumerable](response-streaming.md)
 - [Grain timers](timers.md)
 - [Reminders](reminders.md)
+- [Experimental Journaling](journaling/index.md)
 - [Observers](observers.md)
 - [Grain placement](grain-placement.md)
 - [Stateless worker grains](stateless-worker-grains.md)

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -80,7 +80,7 @@ See [Grain lifecycle](grain-lifecycle.md) for collection, lifecycle participatio
 
 ## Test grain behavior
 
-Use <xref:Orleans.TestingHost.InProcessTestCluster> for most grain tests so activation, scheduling, serialization, dependency injection, and messaging execute through the Orleans runtime. Use ordinary unit tests for extracted application logic. [Test Orleans applications](testing.md) explains these boundaries, including basic scenarios suited to [OrleansTestKit](https://github.com/OrleansContrib/OrleansTestKit), and provides maintained, executable examples. Follow [Test an Orleans application end to end](../tutorials-and-samples/testing-walkthrough.md) for a complete cluster-testing walkthrough.
+Use <xref:Orleans.TestingHost.InProcessTestCluster> for most grain tests so activation, scheduling, serialization, dependency injection, and messaging execute through the Orleans runtime. Use ordinary unit tests for extracted application logic. [Test Orleans applications](testing.md) explains these boundaries, including basic scenarios suited to [OrleansTestKit](https://github.com/OrleansContrib/OrleansTestKit), and provides executable examples. Follow [Test an Orleans application end to end](../tutorials-and-samples/testing-walkthrough.md) for a complete cluster-testing walkthrough.
 
 ## Choose basic or advanced features
 

--- a/docs/site/src/content/docs/grains/journaling/azure-storage.md
+++ b/docs/site/src/content/docs/grains/journaling/azure-storage.md
@@ -1,0 +1,66 @@
+---
+title: Azure Storage providers for Journaling
+description: Configure Azure Blob Storage or Azure Table Storage for experimental Orleans Journaling.
+ms.date: 08/21/2026
+ms.topic: how-to
+---
+
+# Azure Storage providers for Journaling
+
+The pre-release [`Microsoft.Orleans.Journaling.AzureStorage`](https://www.nuget.org/packages/Microsoft.Orleans.Journaling.AzureStorage) package provides Azure Blob Storage and Azure Table Storage implementations. Its APIs carry diagnostic `ORLEANSEXP005`.
+
+Use Microsoft Entra workload identity in hosted environments and grant the silo identity only the data-plane permissions required for the selected container or table.
+
+## Azure Blob Storage
+
+Configure <xref:Orleans.Journaling.AzureBlobStorageHostingExtensions.AddAzureBlobJournalStorage*> with an authenticated <xref:Azure.Storage.Blobs.BlobServiceClient>:
+
+:::code language="csharp" source="./snippets/journaling/JournalingConfiguration.cs" id="configure_azure_blob":::
+
+Each journal uses:
+
+- An append blob at `<journalId>/wal` by default.
+- Immutable checkpoint blobs at `<journalId>/chk.<snapshotId>`.
+- WAL metadata which identifies the current checkpoint, journal format, and optimistic-concurrency state.
+
+Recovery reads the published checkpoint followed by the WAL tail. A replacement uploads the new checkpoint and then atomically publishes it through WAL metadata. The provider performs best-effort cleanup of obsolete checkpoints after publication when <xref:Orleans.Journaling.AzureBlobJournalStorageOptions.DeleteOldCheckpoints> is `true`, which is the default.
+
+Customize <xref:Orleans.Journaling.AzureBlobJournalStorageOptions.GetWalBlobName> and <xref:Orleans.Journaling.AzureBlobJournalStorageOptions.GetCheckpointBlobName> to apply a tenant or application prefix. Keep the mapping stable or migrate every referenced blob and its metadata together.
+
+Azure append blobs limit append-block size and block count. The provider accepts an encoded append batch up to 100 MiB, requests compaction after 49,000 committed blocks, and reserves additional headroom before the 50,000-block service limit.
+
+The journal catalog discovers the default `/wal` naming shape. Preserve that suffix when custom names need catalog listing, or provide the application-specific discovery mechanism required by the caller.
+
+## Azure Table Storage
+
+Configure <xref:Orleans.Journaling.AzureTableStorageHostingExtensions.AddAzureTableJournalStorage*> with an authenticated <xref:Azure.Data.Tables.TableServiceClient>:
+
+:::code language="csharp" source="./snippets/journaling/JournalingConfiguration.cs" id="configure_azure_table":::
+
+Each journal occupies one table partition:
+
+- A header row stores the journal manifest, format, generation, and concurrency ETag.
+- Ordered data rows store the encoded journal bytes for the published generation.
+- Append operations commit new rows and the header update in one entity group transaction.
+- Replacement writes a new generation and atomically changes the header to publish it. The provider performs best-effort cleanup of the previous generation when <xref:Orleans.Journaling.AzureTableJournalStorageOptions.DeleteOldGenerations> is `true`.
+
+A single append batch is limited to 2 MiB by the provider's entity group transaction design. Snapshot replacements can exceed that size because rows are written before the header publishes the generation.
+
+Compaction is requested at either <xref:Orleans.Journaling.AzureTableJournalStorageOptions.CompactionRowCountThreshold> (10,000 rows by default) or <xref:Orleans.Journaling.AzureTableJournalStorageOptions.CompactionSizeThreshold> (32 MiB by default).
+
+Customize <xref:Orleans.Journaling.AzureTableJournalStorageOptions.GetPartitionKey> when a different partition layout is required. The mapping must remain unique per journal and satisfy Azure Table partition-key constraints.
+
+## Optimistic concurrency
+
+Both providers condition append, replace, and delete operations on the last observed ETag. Metadata-only conflicts receive a bounded in-place refresh and retry. A journal-content conflict raises <xref:Orleans.Storage.InconsistentStateException>, which causes the Journaling state manager to recover before later work.
+
+Configure the metadata-only retry cap and backoff with the corresponding `MaxMetadataOnlyConflictRetries`, `MetadataOnlyConflictInitialBackoff`, and `MetadataOnlyConflictMaxBackoff` options.
+
+## Backup and restore
+
+Capture a consistent provider-level backup:
+
+- For Blob Storage, preserve the WAL, the checkpoint named by WAL metadata, and all metadata required to interpret them.
+- For Table Storage, preserve the partition header and every row in its published generation.
+
+Restore the complete set before allowing silos to activate the grain. Validate representative journal replay and a subsequent compaction in an isolated environment.

--- a/docs/site/src/content/docs/grains/journaling/configuration.md
+++ b/docs/site/src/content/docs/grains/journaling/configuration.md
@@ -1,0 +1,64 @@
+---
+title: Configure Orleans Journaling
+description: Select an experimental Orleans Journaling storage provider and journal format.
+ms.date: 08/21/2026
+ms.topic: how-to
+---
+
+# Configure Orleans Journaling
+
+Configure one journal storage provider on every silo that can activate a <xref:Orleans.Journaling.DurableGrain>. Provider registration also adds the core Journaling services, durable-state keyed services, JSON format, and legacy Orleans binary reader.
+
+The Journaling packages are pre-release alpha packages and their APIs carry diagnostic `ORLEANSEXP005`.
+
+## Choose a storage provider
+
+| Provider | Package | Storage model | Compaction trigger |
+| --- | --- | --- | --- |
+| [Azure Blob Storage](azure-storage.md#azure-blob-storage) | `Microsoft.Orleans.Journaling.AzureStorage` | Append blob plus immutable checkpoint blobs | Append-blob block budget |
+| [Azure Table Storage](azure-storage.md#azure-table-storage) | `Microsoft.Orleans.Journaling.AzureStorage` | One partition per journal with header and ordered data rows | Row count or journal bytes |
+| [Redis](redis-journal-storage.md) | `Microsoft.Orleans.Journaling.Redis` | String journal plus hash metadata | Journal bytes |
+
+Select a provider based on atomic-write limits, replay latency, durability configuration, backup tooling, maximum hot-grain size, and operational familiarity.
+
+## Configure the JSON format
+
+JSON Lines is the default write format. Register source-generated metadata for every application type used as a durable key, value, collection item, persistent state, or durable task result:
+
+:::code language="csharp" source="./snippets/journaling/JournalingConfiguration.cs" id="configure_json_format":::
+
+The format emits UTF-8 JSON Lines with one complete journal entry per line and `application/jsonl` metadata where the provider supports content types.
+
+Serializer naming policies affect application payload values. Journal command names and record structure remain fixed by the format.
+
+## Migrate a journal format
+
+Providers persist a format key with journal metadata. Recovery selects the stored reader independently of the configured write format. When they differ, the next write creates a full snapshot using the configured format and updates the metadata.
+
+Use this deployment sequence:
+
+1. Back up the journal data and provider metadata as one recoverable unit.
+1. Deploy binaries that retain readers and command codecs for the stored format.
+1. Configure the new write format on every silo which can activate the grain type.
+1. Exercise representative grains and confirm migration compactions succeed.
+1. Retain the previous reader through the rollback window and until retired state streams are removed.
+
+The Orleans binary format key is `orleans-binary`. Configure it explicitly while maintaining an existing binary journal:
+
+:::code language="csharp" source="./snippets/journaling/JournalingConfiguration.cs" id="configure_binary_format":::
+
+An unknown stored format key or incompatible payload fails recovery and leaves the journal unchanged.
+
+## Configure state retirement
+
+Named states which disappear from a grain remain recoverable during a grace period:
+
+:::code language="csharp" source="./snippets/journaling/JournalingConfiguration.cs" id="configure_retirement":::
+
+The default minimum is seven days. Removal is persisted by a compaction after the period expires. Set the period to cover deployment rollout, observation, and rollback.
+
+## Development storage
+
+<xref:Orleans.Journaling.HostingExtensions.AddJournalStorage*> registers core services and resolves an <xref:Orleans.Journaling.IJournalStorageProvider>. Runtime tests and disposable development hosts can register <xref:Orleans.Journaling.VolatileJournalStorageProvider> directly; its contents live in process memory.
+
+Use the same durable provider category in staging that production uses so recovery, compaction, concurrency, and backup procedures receive realistic validation.

--- a/docs/site/src/content/docs/grains/journaling/durable-state.md
+++ b/docs/site/src/content/docs/grains/journaling/durable-state.md
@@ -1,0 +1,60 @@
+---
+title: Use durable state
+description: Build an experimental Orleans Journaling grain with durable values and collections.
+ms.date: 08/21/2026
+ms.topic: how-to
+---
+
+# Use durable state
+
+Install the pre-release [`Microsoft.Orleans.Journaling`](https://www.nuget.org/packages/Microsoft.Orleans.Journaling) package in the silo project. Install a [journal storage provider](configuration.md#choose-a-storage-provider) and configure it before activating a <xref:Orleans.Journaling.DurableGrain>.
+
+All Journaling APIs are experimental and carry diagnostic `ORLEANSEXP005`.
+
+## Define a durable grain
+
+Inject durable states with <xref:Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute>. The service key becomes the state's stable name in the grain journal:
+
+:::code language="csharp" source="./snippets/journaling/JournalingBasics.cs" id="durable_shopping_cart":::
+
+The dictionary mutation is immediately visible to the current activation. Awaiting <xref:Orleans.Journaling.DurableGrain.WriteStateAsync*> establishes the durability point for every pending durable-state mutation on that grain.
+
+## Select a state type
+
+| State type | In-memory API | Journaled operations |
+| --- | --- | --- |
+| <xref:Orleans.Journaling.IDurableValue`1> | One mutable value | Set |
+| <xref:Orleans.Journaling.IDurableDictionary`2> | <xref:System.Collections.Generic.IDictionary`2> | Set, remove, clear, snapshot |
+| <xref:Orleans.Journaling.IDurableList`1> | <xref:System.Collections.Generic.IList`1> plus `AddRange` | Add, insert, set, remove, clear, snapshot |
+| <xref:Orleans.Journaling.IDurableQueue`1> | Queue operations | Enqueue, dequeue, clear, snapshot |
+| <xref:Orleans.Journaling.IDurableSet`1> | <xref:System.Collections.Generic.ISet`1> | Add, remove, clear, snapshot |
+| <xref:Orleans.Journaling.IDurableTaskCompletionSource`1> | Durable task completion | Complete, fault, or cancel |
+| <xref:Orleans.Runtime.IPersistentState`1> | Record-style state | Set or clear a versioned state value |
+
+All named states in one grain share the grain's journal and participate in the same write. This makes a single <xref:Orleans.Journaling.DurableGrain.WriteStateAsync*> the atomic storage boundary for their pending changes. Coordination with another grain or an external service requires an application protocol such as idempotency, an inbox, or an outbox.
+
+An <xref:Orleans.Journaling.IDurableTaskCompletionSource`1> changes status in memory when `TrySetResult`, `TrySetException`, or `TrySetCanceled` succeeds. Its `Task` completes after a write acknowledges that status or recovery replays it, allowing waiters to observe a durable completion.
+
+## Keep state names and schemas stable
+
+The keyed service name identifies a durable state across activations and deployments. Apply these rules:
+
+- Keep each name unique within the grain.
+- Preserve names when changing constructors or refactoring fields.
+- Keep JSON key, value, and record schemas backward readable during rolling upgrades.
+- Register every JSON payload type in the configured source-generated serializer context when trimming or using Native AOT.
+- Retain removed state definitions through the [retirement grace period](runtime-behavior.md#retire-a-named-state) when a rollback can reintroduce them.
+
+Registering two states with the same name fails activation. Registering a state after activation setup also fails because recovery has already assigned journal stream identities.
+
+## Use journal-backed persistent state
+
+Journaling registers keyed <xref:Orleans.Runtime.IPersistentState`1> services. Its familiar `State`, `WriteStateAsync`, and `ClearStateAsync` members write through the same journal manager as the durable collections. `ReadStateAsync` completes from the already-recovered in-memory state because activation setup replayed the grain journal.
+
+Use a unique keyed service name exactly as you would for another durable state. The `ETag` is the journal-backed state's recovered version and `RecordExists` indicates whether a stored value is present.
+
+## Implement a custom journaled state
+
+Advanced integrations can implement <xref:Orleans.Journaling.IJournaledState> and register it with <xref:Orleans.Journaling.IJournaledStateManager>. The implementation owns its operation codec, snapshot representation, replay logic, deep-copy behavior, and volatile bookkeeping.
+
+An implementation runs on one logical grain thread. It applies mutations in memory, writes recoverable operations, and uses `OnWriteCompleted` for behavior that must follow storage acknowledgement. Its `Reset` and replay methods must rebuild all state after a failed write or activation recovery.

--- a/docs/site/src/content/docs/grains/journaling/index.md
+++ b/docs/site/src/content/docs/grains/journaling/index.md
@@ -1,0 +1,69 @@
+---
+title: Orleans Journaling overview
+description: Understand the experimental Orleans Journaling programming model for durable grain values and collections.
+ms.date: 08/21/2026
+ms.topic: overview
+---
+
+# Orleans Journaling overview
+
+Orleans Journaling is an experimental persistence model that records mutations to durable values and collections in an ordered per-grain journal. When a grain activates, Orleans replays that journal to reconstruct its in-memory state. A single write can persist changes from multiple durable states owned by the grain.
+
+> [!IMPORTANT]
+> `Microsoft.Orleans.Journaling` and its storage-provider packages are pre-release alpha packages. Their APIs carry diagnostic `ORLEANSEXP005`. Evaluate them with an explicit upgrade, rollback, backup, and recovery plan because APIs and storage formats can change before stabilization.
+
+## Programming model
+
+A journaling grain derives from <xref:Orleans.Journaling.DurableGrain> and receives named durable states through keyed dependency injection. Orleans currently provides:
+
+- <xref:Orleans.Journaling.IDurableValue`1>
+- <xref:Orleans.Journaling.IDurableDictionary`2>
+- <xref:Orleans.Journaling.IDurableList`1>
+- <xref:Orleans.Journaling.IDurableQueue`1>
+- <xref:Orleans.Journaling.IDurableSet`1>
+- <xref:Orleans.Journaling.IDurableTaskCompletionSource`1>
+- <xref:Orleans.Runtime.IPersistentState`1> backed by the grain's journal
+
+Mutations update the activation's in-memory state and add encoded operations to its pending journal buffer. Await <xref:Orleans.Journaling.DurableGrain.WriteStateAsync*> at the application durability point. The returned task completes after the storage provider acknowledges the append or snapshot replacement.
+
+Each named state has a stable stream identity within the grain journal. Keep those names stable across deployments so recovery can bind stored operations to the intended state.
+
+## Journal lifecycle
+
+1. During activation setup, Orleans reads the journal in order and replays each state stream.
+1. Grain code synchronously mutates durable values and collections during a grain turn.
+1. <xref:Orleans.Journaling.DurableGrain.WriteStateAsync*> gathers pending operations for the grain and submits one atomic journal append or replacement to storage.
+1. The storage provider can request compaction when its configured size or row threshold is reached. The next write creates a snapshot of the current durable states and atomically replaces the journal.
+1. A later activation replays the latest snapshot and subsequent operations to restore the same durable state.
+
+For the detailed guarantees, see [Runtime behavior and consistency](runtime-behavior.md).
+
+## Journal formats
+
+JSON Lines is the default write format. Each line contains a state stream identifier and one encoded operation. Configure source-generated <xref:System.Text.Json.Serialization.JsonSerializerContext> metadata for journaled key, value, and state types when using trimming or Native AOT.
+
+The earlier Orleans binary format remains registered so deployments can read existing data. Providers store the journal format key with the journal. When the configured write format differs from the stored format, recovery uses the stored reader and the next write snapshots the journal in the configured format.
+
+See [Configure Journaling](configuration.md) for format and migration guidance.
+
+## Journaling and Event Sourcing
+
+Orleans offers two separate journal-oriented programming models:
+
+| Model | Application state model | Persistence coordination |
+| --- | --- | --- |
+| Orleans Journaling | Mutable durable values and collections on <xref:Orleans.Journaling.DurableGrain> | One per-grain journal managed by `Microsoft.Orleans.Journaling` |
+| [Orleans Event Sourcing](../event-sourcing/index.md) | Application-defined events applied to `JournaledGrain<TState, TEvent>` | Log-consistency providers confirm, persist, and synchronize events |
+
+Choose Journaling when evaluating operation-based persistence for built-in mutable state structures. Choose Event Sourcing when domain events, event history, and the supported log-consistency programming model are application requirements.
+
+## Articles
+
+- [Use durable state](durable-state.md)
+- [Runtime behavior and consistency](runtime-behavior.md)
+- [Configure Journaling](configuration.md)
+- [Azure Storage providers](azure-storage.md)
+- [Redis journal storage](redis-journal-storage.md)
+- [Operate and troubleshoot Journaling](operations.md)
+- [Run the Journaling sample](samples.md)
+

--- a/docs/site/src/content/docs/grains/journaling/index.md
+++ b/docs/site/src/content/docs/grains/journaling/index.md
@@ -66,4 +66,3 @@ Choose Journaling when evaluating operation-based persistence for built-in mutab
 - [Redis journal storage](redis-journal-storage.md)
 - [Operate and troubleshoot Journaling](operations.md)
 - [Run the Journaling sample](samples.md)
-

--- a/docs/site/src/content/docs/grains/journaling/index.md
+++ b/docs/site/src/content/docs/grains/journaling/index.md
@@ -65,4 +65,4 @@ Choose Journaling when evaluating operation-based persistence for built-in mutab
 - [Azure Storage providers](azure-storage.md)
 - [Redis journal storage](redis-journal-storage.md)
 - [Operate and troubleshoot Journaling](operations.md)
-- [Run the Journaling sample](samples.md)
+- [Run Journaling samples](samples.md)

--- a/docs/site/src/content/docs/grains/journaling/operations.md
+++ b/docs/site/src/content/docs/grains/journaling/operations.md
@@ -1,0 +1,80 @@
+---
+title: Operate and troubleshoot Orleans Journaling
+description: Monitor capacity, compaction, recovery, upgrades, and failures for experimental Orleans Journaling.
+ms.date: 08/21/2026
+ms.topic: how-to
+---
+
+# Operate and troubleshoot Orleans Journaling
+
+Orleans Journaling is an experimental alpha feature. A production evaluation should define owners and tested procedures for package upgrades, storage-format migration, rollback, backup, restore, compaction, and provider outages.
+
+## Monitor writes and recovery
+
+Journaling emits metrics through the `Microsoft.Orleans` meter. Use the [metrics catalog](../../host/monitoring/metrics-catalog.md#journaling) for the full instrument list.
+
+At minimum, dashboard and alert on:
+
+- Storage operation errors and latency by `append`, `snapshot`, `replace`, `read`, and `delete`.
+- Recovery failures and recovery duration.
+- Storage-operation queue duration, which shows time waiting behind earlier work for the same journal.
+- Compaction triggers by `storage_requested`, `migration`, and `user_snapshot`.
+- Write coalescing, gathered state count, and operation byte distributions.
+- Azure Blob, Azure Table, or Redis provider operation errors and latency.
+
+Correlate these signals with grain identity, provider dependency health, deployment version, and storage throttling.
+
+## Plan capacity
+
+Journal replay cost grows with bytes and operations since the latest snapshot. Snapshot cost grows with the complete durable state of the grain.
+
+Capacity tests should include:
+
+- The largest expected durable collection and persistent-state payload.
+- Hot grain identities with frequent writes.
+- Activation after a long append sequence.
+- Provider-requested compaction during peak traffic.
+- Storage throttling, transient failures, and optimistic-concurrency recovery.
+- Backup and restore followed by activation and another write.
+
+Tune provider thresholds before replay time, storage growth, or backend transaction limits become operational risks. The [Azure Table provider](azure-storage.md#azure-table-storage) limits one append batch to 2 MiB. Redis requests compaction at 128 MiB by default. Azure Blob compacts before exhausting its append-block budget.
+
+## Upgrade and rollback
+
+Treat the package version, public API, journal format, application payload schema, and durable-state names as one compatibility contract.
+
+1. Back up journal bytes and metadata.
+1. Validate old data against the candidate binaries in an isolated environment.
+1. Keep all silos which can activate a journaling grain on a tested compatible version set.
+1. Deploy readers for old and new payload schemas before writers emit only the new schema.
+1. Observe recovery and migration-compaction metrics.
+1. Retain old readers, codecs, and state definitions through the rollback window.
+
+A provider key prefix, blob-name mapping, table partition mapping, journal format key, or durable-state name defines how the runtime finds and interprets existing data. Perform and verify the corresponding data migration before a new mapping serves traffic.
+
+## Backup and disaster recovery
+
+Provider metadata selects the published generation and journal format. Back up metadata and journal data consistently. Restore them as one unit and keep the same application `ServiceId`, grain identities, state names, format readers, and payload codecs.
+
+Exercise restore procedures regularly:
+
+1. Restore to an isolated provider namespace.
+1. Start a compatible silo.
+1. Activate representative grains and verify recovered state.
+1. Execute and acknowledge a new write.
+1. Trigger or await compaction and verify a second activation.
+
+## Diagnose common failures
+
+| Symptom | Runtime outcome | Operator response |
+| --- | --- | --- |
+| Activation fails with a journal format key | Recovery leaves storage unchanged | Deploy the required format and command codecs, or restore metadata which names the actual stored format |
+| Activation reports malformed or truncated journal data | Recovery stops before activation completes | Quarantine writes, restore a consistent backup, and preserve the failed data for diagnosis |
+| <xref:Orleans.Storage.InconsistentStateException> during a write | The write faults and the manager recovers before later work | Find stale or competing writers, confirm grain identity and cluster configuration, then retry the application command according to its idempotency contract |
+| Snapshot replacement fails after its pending append succeeds | The write faults while the mutation remains durable in the append history | Reconcile using the operation identifier and retry the command only through its idempotency protocol |
+| Write latency rises with storage queue duration | Writes for the journal are waiting behind earlier operations | Inspect provider latency and throttling, hot-grain traffic, write frequency, and snapshot size |
+| Recovery time and journal bytes grow | The current append history is large | Confirm compaction thresholds are enabled and that snapshot replacements succeed |
+| Format migration reports an unregistered state | A retired stream still requires its previous codec | Re-register the state for migration or retain the previous write format until retirement and compaction remove it |
+| Redis state is lost after a server failure | Recovery reflects the Redis durability configuration | Configure and test Redis persistence and replication for the required recovery point |
+
+Storage and codec exceptions are surfaced to the grain call. Preserve them in logs and traces rather than converting them into successful application responses.

--- a/docs/site/src/content/docs/grains/journaling/redis-journal-storage.md
+++ b/docs/site/src/content/docs/grains/journaling/redis-journal-storage.md
@@ -1,15 +1,15 @@
 ---
 title: Redis journal storage
-description: Configure Redis as a storage provider for Orleans Journaling durable state.
-ms.date: 08/10/2026
+description: Configure Redis as a storage provider for experimental Orleans Journaling durable state.
+ms.date: 08/21/2026
 ms.topic: how-to
 ---
 
 # Redis journal storage
 
-Orleans Journaling persists durable state changes as ordered journal data which is replayed to recover in-memory durable values and collections in <xref:Orleans.Journaling.DurableGrain> grains. It's a distinct mechanism from [Event Sourcing](../event-sourcing/index.md#event-sourcing-and-experimental-journaling), which uses `JournaledGrain<TState, TEvent>` and log-consistency providers.
+Orleans Journaling persists durable state changes as ordered journal data which is replayed to recover in-memory durable values and collections in <xref:Orleans.Journaling.DurableGrain> grains. See the [Journaling overview](index.md) for its programming model and the [Event Sourcing comparison](../event-sourcing/index.md#event-sourcing-and-experimental-journaling) for the boundary between the two features.
 
-The [`Microsoft.Orleans.Journaling.Redis`](https://www.nuget.org/packages/Microsoft.Orleans.Journaling.Redis) package stores that journal data in [Redis](https://redis.io/docs/latest/develop/data-types/). Orleans Journaling is experimental and its APIs are marked with diagnostic `ORLEANSEXP005`.
+The pre-release [`Microsoft.Orleans.Journaling.Redis`](https://www.nuget.org/packages/Microsoft.Orleans.Journaling.Redis) package stores journal data in [Redis](https://redis.io/docs/latest/develop/data-types/). Its APIs carry diagnostic `ORLEANSEXP005`.
 
 ## Configure Redis journal storage
 
@@ -17,9 +17,13 @@ Configure the provider with <xref:Orleans.Journaling.RedisJournalStorageHostingE
 
 :::code language="csharp" source="./snippets/redis-journaling/RedisJournalingConfiguration.cs" id="configure_redis_journaling":::
 
+The [runnable Redis Journaling sample](samples.md#run-the-redis-sample) uses the same provider with a <xref:Orleans.Journaling.DurableGrain>, acknowledges a durable value update, deactivates the grain, and verifies recovery on a new activation.
+
 ## Storage behavior
 
 The provider stores journal data in Redis strings and journal metadata in Redis hashes. Per-journal reads and mutations use atomic Lua scripts. Catalog operations discover journals by scanning metadata keys on each connected primary Redis server.
+
+Optimistic concurrency protects append, replace, and delete operations. A stale writer receives <xref:Orleans.Storage.InconsistentStateException>, and the Journaling state manager recovers the stored journal before processing later work. Concurrent reads observe either the journal before a replacement or the complete replacement.
 
 <xref:Orleans.Journaling.RedisJournalStorageOptions> supports:
 
@@ -30,10 +34,18 @@ The provider stores journal data in Redis strings and journal metadata in Redis 
 - <xref:Orleans.Journaling.RedisJournalStorageOptions.CompactionThresholdBytes> to select when the provider requests compaction.
 - <xref:Orleans.Journaling.RedisJournalStorageOptions.ReadChunkSize> to limit the size of recovery segments supplied to the journal consumer.
 
-Changing the key prefix or key-name function doesn't migrate existing journals. Retain the previous mapping or migrate the stored data before deploying the change.
+The key prefix and key-name function define the location of existing journals. Retain the previous mapping or migrate the stored data before deploying a new mapping.
+
+The default compaction threshold is 128 MiB and the default recovery chunk size is 1 MiB. Compaction replaces the append history with a snapshot of the grain's current durable states.
+
+Redis returns the journal string as one value. <xref:Orleans.Journaling.RedisJournalStorageOptions.ReadChunkSize> divides that value into replay segments after retrieval; capacity planning should account for the full journal value in the Redis client and silo process.
 
 ## Durability
 
 Redis journal durability depends on the Redis [persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/) and replication configuration. Configure persistence, such as append-only file (AOF) persistence with an appropriate `appendfsync` policy, according to the application's recovery-point requirements.
 
 Use a distinct <xref:Orleans.Journaling.RedisJournalStorageOptions.KeyPrefix> when multiple Orleans services share a Redis deployment.
+
+Back up each journal's string data and hash metadata consistently. Restore both under the same prefix and key mapping before allowing silos to activate the grain.
+
+For capacity, upgrade, backup, and troubleshooting guidance, see [Operate and troubleshoot Orleans Journaling](operations.md).

--- a/docs/site/src/content/docs/grains/journaling/runtime-behavior.md
+++ b/docs/site/src/content/docs/grains/journaling/runtime-behavior.md
@@ -1,0 +1,77 @@
+---
+title: Journaling runtime behavior and consistency
+description: Understand Orleans Journaling activation, write, recovery, compaction, concurrency, and failure semantics.
+ms.date: 08/21/2026
+ms.topic: conceptual
+---
+
+# Journaling runtime behavior and consistency
+
+Orleans Journaling assigns one <xref:Orleans.Journaling.JournalId> to each grain identity and one journal stream to each named durable state. The state manager serializes recovery and storage work for that journal.
+
+## Activation and recovery
+
+The <xref:Orleans.Journaling.DurableGrain> constructor attaches its state manager to the grain lifecycle. During the setup-state stage, the manager:
+
+1. Reads the journal as an ordered byte stream.
+1. Selects the reader named by the stored format metadata.
+1. Rebuilds the state-name directory.
+1. Resets and replays each registered durable state.
+1. Completes activation setup after replay finishes.
+
+Requests reach the grain after setup succeeds. A storage read, format, codec, or malformed-data failure fails activation and preserves the stored journal for diagnosis and recovery.
+
+Storage providers can split reads at arbitrary byte boundaries. The journal format buffers incomplete entries and only applies complete ordered records.
+
+## Mutation and write acknowledgement
+
+Durable collections encode their operation before applying it to the in-memory collection. A codec failure therefore leaves both the journal buffer and collection unchanged.
+
+<xref:Orleans.Journaling.DurableGrain.WriteStateAsync*> gathers pending entries from all named states and queues one storage operation:
+
+- **Append** adds the encoded operation batch atomically.
+- **Snapshot replacement** writes the current state of every registered stream and atomically publishes it as the new journal generation.
+
+Concurrent calls made while the same kind of write is queued can share that queued operation. Each caller observes its completion or failure. Calls made after a storage operation starts are processed by a later operation.
+
+> [!IMPORTANT]
+> In-memory mutation is visible before storage acknowledgement. Return success to a caller only after the required <xref:Orleans.Journaling.DurableGrain.WriteStateAsync*> completes. Recovery can rewind changes that were never acknowledged by storage.
+
+## Consistency and competing writers
+
+Orleans grain placement normally supplies a single active writer for a grain identity. Journal storage providers also use optimistic concurrency to protect the journal when a stale or competing writer reaches storage.
+
+An append, replacement, or delete with stale storage metadata throws <xref:Orleans.Storage.InconsistentStateException>. The state manager marks the journal for recovery, resets its in-memory durable states, and replays the current stored journal before processing later work. The failed write task remains faulted so the grain call reports an uncertain outcome.
+
+Design commands to tolerate retries at the application boundary. Use operation identifiers when a caller can repeat a command after an uncertain network outcome.
+
+## Storage failures
+
+A normal append failure leaves encoded pending entries available for a later write attempt.
+
+A compaction write has two storage stages: it first appends committed pending entries, then publishes a snapshot replacement. The append can succeed before the replacement fails. In that outcome, <xref:Orleans.Journaling.DurableGrain.WriteStateAsync*> faults even though the state mutation is durable in the append history. Treat every failed write as an uncertain application outcome and retry commands using an operation identifier or another idempotency mechanism.
+
+Recovery exceptions fault activation or queued work rather than replacing or truncating stored data. Restore the required format/codec registration or repair the backing data before retrying activation.
+
+## Compaction
+
+Each provider reports when its journal crosses a configured storage threshold. The next <xref:Orleans.Journaling.DurableGrain.WriteStateAsync*>:
+
+1. Persists any already-buffered append data.
+1. Builds a snapshot containing the state directory and every active durable state.
+1. Atomically replaces the published journal with the snapshot.
+1. Clears the compaction request after storage acknowledges the replacement.
+
+Compaction bounds replay work and storage growth according to provider thresholds. Snapshot size still scales with the complete durable state owned by the grain, so capacity tests must include hot and large grain identities.
+
+## Retire a named state
+
+Recovery preserves streams whose names are no longer registered by the current grain type. The manager starts a retirement grace period for each such state. The default minimum is seven days, configured with <xref:Orleans.Journaling.JournaledStateManagerOptions.RetirementGracePeriod>.
+
+Reintroducing the same state name during the grace period replays its preserved entries into the new state instance. After the grace period has elapsed, a later compaction removes the retired stream. Permanent removal can therefore occur later than the configured period.
+
+This behavior supports staged deployments and rollback. Keep the previous format codecs available while retired streams remain. A format migration pauses when an unregistered stream can't be decoded into a snapshot.
+
+## Deactivation and shutdown
+
+Grain deactivation stops the state manager's work loop. Completed writes are the durability barrier. Await every required write during the grain call which made the mutation, and size host shutdown grace periods for writes already in progress.

--- a/docs/site/src/content/docs/grains/journaling/samples.md
+++ b/docs/site/src/content/docs/grains/journaling/samples.md
@@ -37,7 +37,7 @@ The [compiled Redis Journaling sample](https://github.com/dotnet/orleans/tree/ma
 Start a local Redis server, then run the sample from the repository root:
 
 ```powershell
-dotnet run --project docs/site/src/content/docs/grains/journaling/snippets/redis-journaling -- "host:6379"
+dotnet run --project docs/site/src/content/docs/grains/journaling/snippets/redis-journaling -- "localhost:6379"
 ```
 
 Pass a StackExchange.Redis connection string as the first argument when Redis is available at another endpoint. The sample uses the isolated key prefix `journaling-docs-sample`. Configure Redis persistence and replication before evaluating server-restart recovery.

--- a/docs/site/src/content/docs/grains/journaling/samples.md
+++ b/docs/site/src/content/docs/grains/journaling/samples.md
@@ -1,13 +1,13 @@
 ---
 title: Run Orleans Journaling samples
-description: Run maintained Azure Blob and Redis examples for experimental Orleans Journaling.
+description: Run Azure Blob and Redis examples for experimental Orleans Journaling.
 ms.date: 08/21/2026
 ms.topic: tutorial
 ---
 
 # Run Orleans Journaling samples
 
-The maintained [Journaling with Azure Blob JSON](https://github.com/dotnet/orleans/tree/main/samples/JournalingAzureBlobJson) sample exercises the experimental Journaling programming model end to end. It uses .NET Aspire and the Azure Storage emulator and runs with local emulator credentials.
+The [Journaling with Azure Blob JSON](https://github.com/dotnet/orleans/tree/main/samples/JournalingAzureBlobJson) sample exercises the experimental Journaling programming model end to end. It uses .NET Aspire and the Azure Storage emulator and runs with local emulator credentials.
 
 The sample demonstrates:
 

--- a/docs/site/src/content/docs/grains/journaling/samples.md
+++ b/docs/site/src/content/docs/grains/journaling/samples.md
@@ -37,7 +37,7 @@ The [compiled Redis Journaling sample](https://github.com/dotnet/orleans/tree/ma
 Start a local Redis server, then run the sample from the repository root:
 
 ```powershell
-dotnet run --project docs/site/src/content/docs/grains/journaling/snippets/redis-journaling
+dotnet run --project docs/site/src/content/docs/grains/journaling/snippets/redis-journaling -- "host:6379"
 ```
 
 Pass a StackExchange.Redis connection string as the first argument when Redis is available at another endpoint. The sample uses the isolated key prefix `journaling-docs-sample`. Configure Redis persistence and replication before evaluating server-restart recovery.

--- a/docs/site/src/content/docs/grains/journaling/samples.md
+++ b/docs/site/src/content/docs/grains/journaling/samples.md
@@ -1,0 +1,43 @@
+---
+title: Run Orleans Journaling samples
+description: Run maintained Azure Blob and Redis examples for experimental Orleans Journaling.
+ms.date: 08/21/2026
+ms.topic: tutorial
+---
+
+# Run Orleans Journaling samples
+
+The maintained [Journaling with Azure Blob JSON](https://github.com/dotnet/orleans/tree/main/samples/JournalingAzureBlobJson) sample exercises the experimental Journaling programming model end to end. It uses .NET Aspire and the Azure Storage emulator and runs with local emulator credentials.
+
+The sample demonstrates:
+
+- <xref:Orleans.Journaling.IDurableDictionary`2>, <xref:Orleans.Journaling.IDurableList`1>, <xref:Orleans.Journaling.IDurableQueue`1>, and <xref:Orleans.Journaling.IDurableSet`1>.
+- <xref:Orleans.Journaling.IDurableValue`1>, journal-backed <xref:Orleans.Runtime.IPersistentState`1>, and <xref:Orleans.Journaling.IDurableTaskCompletionSource`1>.
+- JSON source-generation metadata for all journaled payload types.
+- Azure Blob WAL and checkpoint name customization.
+- An acknowledged write, grain deactivation, reactivation, and recovered-state verification.
+- Inspection of the raw JSON Lines journal.
+
+## Run with Aspire
+
+Install the .NET SDK, the [Aspire CLI](https://aspire.dev/get-started/install-cli/), and a Docker-compatible container runtime. From the sample directory, run:
+
+```powershell
+aspire run --project JournalingAzureBlobJson.AppHost
+```
+
+The app host starts the Azure Storage emulator and the sample service. The service writes every built-in durable state category, deactivates the grain, verifies the recovered values on a new activation, and prints the stored JSON Lines.
+
+## Run the Redis sample
+
+The [compiled Redis Journaling sample](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling) configures Redis, writes an <xref:Orleans.Journaling.IDurableValue`1>, deactivates the grain, and verifies recovery on a new activation:
+
+:::code language="csharp" source="./snippets/redis-journaling/Program.cs" id="redis_journal_counter":::
+
+Start a local Redis server, then run the sample from the repository root:
+
+```powershell
+dotnet run --project docs/site/src/content/docs/grains/journaling/snippets/redis-journaling
+```
+
+Pass a StackExchange.Redis connection string as the first argument when Redis is available at another endpoint. The sample uses the isolated key prefix `journaling-docs-sample`. Configure Redis persistence and replication before evaluating server-restart recovery.

--- a/docs/site/src/content/docs/grains/journaling/snippets/journaling/Journaling.csproj
+++ b/docs/site/src/content/docs/grains/journaling/snippets/journaling/Journaling.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RepositoryRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\..\..\..\..\..\'))</RepositoryRoot>
+    <NoWarn>$(NoWarn);ORLEANSEXP005</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.51.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepositoryRoot)src\Orleans.Server\Orleans.Server.csproj" />
+    <ProjectReference Include="$(RepositoryRoot)src\Orleans.Journaling\Orleans.Journaling.csproj" />
+    <ProjectReference Include="$(RepositoryRoot)src\Azure\Orleans.Journaling.AzureStorage\Orleans.Journaling.AzureStorage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingBasics.cs
+++ b/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingBasics.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Orleans;
 
 namespace Orleans.Docs.Snippets.Journaling;
 
@@ -26,4 +27,3 @@ public sealed class ShoppingCartGrain(
             new Dictionary<string, int>(items));
 }
 // </durable_shopping_cart>
-

--- a/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingBasics.cs
+++ b/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingBasics.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Orleans.Docs.Snippets.Journaling;
+
+public interface IShoppingCartGrain : IGrainWithStringKey
+{
+    ValueTask AddItem(string itemId, int quantity);
+
+    ValueTask<IReadOnlyDictionary<string, int>> GetItems();
+}
+
+// <durable_shopping_cart>
+public sealed class ShoppingCartGrain(
+    [FromKeyedServices("cart-items")]
+    Orleans.Journaling.IDurableDictionary<string, int> items)
+    : Orleans.Journaling.DurableGrain, IShoppingCartGrain
+{
+    public async ValueTask AddItem(string itemId, int quantity)
+    {
+        items[itemId] = quantity;
+        await WriteStateAsync();
+    }
+
+    public ValueTask<IReadOnlyDictionary<string, int>> GetItems() =>
+        ValueTask.FromResult<IReadOnlyDictionary<string, int>>(
+            new Dictionary<string, int>(items));
+}
+// </durable_shopping_cart>
+

--- a/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingConfiguration.cs
+++ b/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingConfiguration.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Serialization;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Journaling;
+using Orleans.Journaling.Json;
+
+namespace Orleans.Docs.Snippets.Journaling;
+
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(ulong))]
+internal partial class JournalJsonContext : JsonSerializerContext;
+
+public static class JournalingConfiguration
+{
+    public static IHost ConfigureJson()
+    {
+        // <configure_json_format>
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder
+                .AddAzureBlobJournalStorage(options =>
+                    options.ConfigureBlobServiceClient("UseDevelopmentStorage=true"))
+                .UseJsonJournalFormat(JournalJsonContext.Default);
+        });
+
+        var host = builder.Build();
+        // </configure_json_format>
+        return host;
+    }
+
+    public static IHost ConfigureBinary()
+    {
+        // <configure_binary_format>
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.AddAzureBlobJournalStorage(options =>
+                options.ConfigureBlobServiceClient("UseDevelopmentStorage=true"));
+            siloBuilder.Services.Configure<JournaledStateManagerOptions>(options =>
+                options.JournalFormatKey = "orleans-binary");
+        });
+
+        var host = builder.Build();
+        // </configure_binary_format>
+        return host;
+    }
+
+    public static IHost ConfigureRetirement()
+    {
+        // <configure_retirement>
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.AddAzureBlobJournalStorage(options =>
+                options.ConfigureBlobServiceClient("UseDevelopmentStorage=true"));
+            siloBuilder.Services.Configure<JournaledStateManagerOptions>(options =>
+                options.RetirementGracePeriod = TimeSpan.FromDays(14));
+        });
+
+        var host = builder.Build();
+        // </configure_retirement>
+        return host;
+    }
+
+    public static IHost ConfigureAzureBlob(BlobServiceClient blobServiceClient)
+    {
+        // <configure_azure_blob>
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.AddAzureBlobJournalStorage(options =>
+            {
+                options.BlobServiceClient = blobServiceClient;
+                options.ContainerName = "journals";
+                options.GetWalBlobName =
+                    journalId => $"orders/{journalId.Value}/wal";
+                options.GetCheckpointBlobName =
+                    (journalId, snapshotId) =>
+                        $"orders/{journalId.Value}/chk.{snapshotId}";
+            });
+        });
+
+        var host = builder.Build();
+        // </configure_azure_blob>
+        return host;
+    }
+
+    public static IHost ConfigureAzureTable(TableServiceClient tableServiceClient)
+    {
+        // <configure_azure_table>
+        var builder = Host.CreateApplicationBuilder();
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.AddAzureTableJournalStorage(options =>
+            {
+                options.TableServiceClient = tableServiceClient;
+                options.TableName = "journal";
+                options.CompactionRowCountThreshold = 10_000;
+                options.CompactionSizeThreshold = 32 * 1024 * 1024;
+            });
+        });
+
+        var host = builder.Build();
+        // </configure_azure_table>
+        return host;
+    }
+}

--- a/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingConfiguration.cs
+++ b/docs/site/src/content/docs/grains/journaling/snippets/journaling/JournalingConfiguration.cs
@@ -3,6 +3,7 @@ using Azure.Data.Tables;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
 using Orleans.Journaling;
 using Orleans.Journaling.Json;
 

--- a/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/GlobalUsings.cs
+++ b/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Orleans.Hosting;

--- a/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/Program.cs
+++ b/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/Program.cs
@@ -2,7 +2,6 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Orleans;
-using Orleans.Hosting;
 using Orleans.Journaling;
 using Orleans.Journaling.Json;
 using StackExchange.Redis;

--- a/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/Program.cs
+++ b/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/Program.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+using Orleans.Hosting;
+using Orleans.Journaling;
+using Orleans.Journaling.Json;
+using StackExchange.Redis;
+
+var redisConnection = args.FirstOrDefault() ?? "localhost:6379";
+var builder = Host.CreateApplicationBuilder(args);
+builder.UseOrleans(siloBuilder =>
+{
+    siloBuilder
+        .UseLocalhostClustering()
+        .AddRedisJournalStorage(options =>
+        {
+            options.ConfigurationOptions =
+                ConfigurationOptions.Parse(redisConnection);
+            options.KeyPrefix = "journaling-docs-sample";
+        })
+        .UseJsonJournalFormat(RedisJournalJsonContext.Default);
+});
+
+using var host = builder.Build();
+await host.StartAsync();
+
+var grain = host.Services.GetRequiredService<IGrainFactory>()
+    .GetGrain<IRedisJournalCounterGrain>("demo");
+var written = await grain.Increment();
+
+await grain.Deactivate();
+await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+var recovered = await grain.GetSnapshot();
+if (written.ActivationId == recovered.ActivationId ||
+    written.Count != recovered.Count)
+{
+    throw new InvalidOperationException("Redis journal recovery failed.");
+}
+
+Console.WriteLine($"Recovered count: {recovered.Count}");
+await host.StopAsync();
+
+public interface IRedisJournalCounterGrain : IGrainWithStringKey
+{
+    ValueTask<CounterSnapshot> Increment();
+
+    ValueTask<CounterSnapshot> GetSnapshot();
+
+    ValueTask Deactivate();
+}
+
+// <redis_journal_counter>
+public sealed class RedisJournalCounterGrain(
+    [FromKeyedServices("count")] IDurableValue<int> count)
+    : DurableGrain, IRedisJournalCounterGrain
+{
+    private readonly Guid _activationId = Guid.NewGuid();
+
+    public async ValueTask<CounterSnapshot> Increment()
+    {
+        count.Value++;
+        await WriteStateAsync();
+        return GetCurrentSnapshot();
+    }
+
+    public ValueTask<CounterSnapshot> GetSnapshot() =>
+        ValueTask.FromResult(GetCurrentSnapshot());
+
+    public ValueTask Deactivate()
+    {
+        DeactivateOnIdle();
+        return ValueTask.CompletedTask;
+    }
+
+    private CounterSnapshot GetCurrentSnapshot() =>
+        new(_activationId, count.Value);
+}
+// </redis_journal_counter>
+
+[GenerateSerializer]
+public sealed record CounterSnapshot(
+    [property: Id(0)] Guid ActivationId,
+    [property: Id(1)] int Count);
+
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(ulong))]
+internal partial class RedisJournalJsonContext : JsonSerializerContext;

--- a/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/RedisJournaling.csproj
+++ b/docs/site/src/content/docs/grains/journaling/snippets/redis-journaling/RedisJournaling.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
     <RepositoryRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\..\..\..\..\..\'))</RepositoryRoot>
     <NoWarn>$(NoWarn);ORLEANSEXP005</NoWarn>
   </PropertyGroup>

--- a/docs/site/src/content/docs/how-to/index.md
+++ b/docs/site/src/content/docs/how-to/index.md
@@ -36,6 +36,7 @@ If you are learning Orleans from an empty directory, start with the [tutorials a
 ## Use Orleans features
 
 - [Persist grain state](../grains/grain-persistence/index.md)
+- [Configure experimental Journaling](../grains/journaling/configuration.md)
 - [Schedule activation-scoped work with grain timers](../grains/timers.md)
 - [Schedule durable work with reminders](../grains/reminders.md)
 - [Configure Amazon DynamoDB reminders](../grains/reminders/dynamodb.md)
@@ -51,5 +52,6 @@ If you are learning Orleans from an empty directory, start with the [tutorials a
 - [Monitor silo and client error codes](../host/monitoring/silo-error-code-monitoring.md)
 - [Configure signals and alerting](../host/monitoring/signals.md)
 - [Handle failures and uncertain outcomes](../deployment/handling-failures.md)
+- [Troubleshoot experimental Orleans Journaling](../grains/journaling/operations.md)
 
 For public types, defaults, exceptions, and overloads, use the [C# API reference](https://dotnet.github.io/orleans/docs/api/csharp/). Reference entries provide the precise contract; the recipes above show how to apply it.

--- a/docs/site/src/content/docs/resources/nuget-packages.md
+++ b/docs/site/src/content/docs/resources/nuget-packages.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans NuGet packages
 description: Choose Orleans packages for hosts, providers, serialization, observability, and testing.
-ms.date: 08/02/2026
+ms.date: 08/21/2026
 ms.topic: reference
 ---
 
@@ -110,9 +110,9 @@ These packages don't replace the cluster membership provider.
 | Package | Purpose |
 | --- | --- |
 | [Microsoft.Orleans.EventSourcing](https://www.nuget.org/packages/Microsoft.Orleans.EventSourcing) | Event-sourced grain base types and log-consistency abstractions. |
-| [Microsoft.Orleans.Journaling](https://www.nuget.org/packages/Microsoft.Orleans.Journaling) | Experimental durable journaled collections and values (`ORLEANSEXP005`). |
-| [Microsoft.Orleans.Journaling.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.Journaling.AzureStorage) | Experimental Azure Blob Storage provider for Orleans Journaling. |
-| [Microsoft.Orleans.Journaling.Redis](https://www.nuget.org/packages/Microsoft.Orleans.Journaling.Redis) | Experimental Redis storage provider for Orleans Journaling. |
+| [Microsoft.Orleans.Journaling](https://www.nuget.org/packages/Microsoft.Orleans.Journaling) | Pre-release alpha durable journaled collections and values with experimental diagnostic `ORLEANSEXP005`; see the [Journaling overview](../grains/journaling/index.md). |
+| [Microsoft.Orleans.Journaling.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.Journaling.AzureStorage) | Pre-release alpha Azure Blob and Azure Table providers for Orleans Journaling. |
+| [Microsoft.Orleans.Journaling.Redis](https://www.nuget.org/packages/Microsoft.Orleans.Journaling.Redis) | Pre-release alpha Redis provider for Orleans Journaling. |
 | [Microsoft.Orleans.Transactions](https://www.nuget.org/packages/Microsoft.Orleans.Transactions) | Distributed transaction runtime. |
 | [Microsoft.Orleans.Transactions.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.Transactions.AzureStorage) | Azure Storage transaction state. |
 | [Microsoft.Orleans.Transactions.DynamoDB](https://www.nuget.org/packages/Microsoft.Orleans.Transactions.DynamoDB) | Amazon DynamoDB transaction state. |

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -94,7 +94,7 @@ items:
             href: grains/event-sourcing/log-consistency-providers.md
           - name: Replicated instances
             href: grains/event-sourcing/replicated-instances.md
-      - name: Orleans Journaling (experimental)
+      - name: Journaled state (experimental)
         items:
           - name: Overview
             href: grains/journaling/index.md

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -94,7 +94,7 @@ items:
             href: grains/event-sourcing/log-consistency-providers.md
           - name: Replicated instances
             href: grains/event-sourcing/replicated-instances.md
-      - name: Journaled state (experimental)
+      - name: Journaling (experimental)
         items:
           - name: Overview
             href: grains/journaling/index.md

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -94,8 +94,24 @@ items:
             href: grains/event-sourcing/log-consistency-providers.md
           - name: Replicated instances
             href: grains/event-sourcing/replicated-instances.md
-      - name: Redis journal storage
-        href: grains/journaling/redis-journal-storage.md
+      - name: Orleans Journaling (experimental)
+        items:
+          - name: Overview
+            href: grains/journaling/index.md
+          - name: Use durable state
+            href: grains/journaling/durable-state.md
+          - name: Runtime behavior and consistency
+            href: grains/journaling/runtime-behavior.md
+          - name: Configuration and formats
+            href: grains/journaling/configuration.md
+          - name: Azure Storage providers
+            href: grains/journaling/azure-storage.md
+          - name: Redis journal storage
+            href: grains/journaling/redis-journal-storage.md
+          - name: Operations and troubleshooting
+            href: grains/journaling/operations.md
+          - name: Sample
+            href: grains/journaling/samples.md
       - name: Transactions
         href: grains/transactions.md
   - name: Serialization and code generation

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -110,7 +110,7 @@ items:
             href: grains/journaling/redis-journal-storage.md
           - name: Operations and troubleshooting
             href: grains/journaling/operations.md
-          - name: Sample
+          - name: Samples
             href: grains/journaling/samples.md
       - name: Transactions
         href: grains/transactions.md

--- a/docs/site/src/content/docs/tutorials-and-samples/index.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/index.md
@@ -66,12 +66,12 @@ The [`samples` directory](https://github.com/dotnet/orleans/tree/main/samples) c
 | Sample | Demonstrates |
 | --- | --- |
 | [Bank Account](https://github.com/dotnet/orleans/tree/main/samples/BankAccount) | ACID transactions across stateful grains. |
-| [Journaled Todo List](https://github.com/dotnet/orleans/tree/main/samples/JournaledTodoList) | Experimental Journaling APIs, Aspire, and durable journaled grain state. |
+| [Journaled Todo List](https://github.com/dotnet/orleans/tree/main/samples/JournaledTodoList) | Event Sourcing with `JournaledGrain`, log-consistency providers, and Aspire. |
 | [Journaling with Azure Blob JSON](https://github.com/dotnet/orleans/tree/main/samples/JournalingAzureBlobJson) | Experimental Journaling APIs with Azure Blob Storage. |
 | [Chat Room](https://github.com/dotnet/orleans/tree/main/samples/ChatRoom) | A terminal chat application using Orleans Streams. |
 | [Stocks](https://github.com/dotnet/orleans/tree/main/samples/Stocks) | Grain timers, HTTP calls, and temporary caching. |
 
-The Journaling samples use the experimental `Microsoft.Orleans.Journaling` package. They are separate from the supported [Orleans Event Sourcing](../grains/event-sourcing/index.md) model.
+The Azure Blob JSON sample uses the experimental `Microsoft.Orleans.Journaling` package. The Journaled Todo List uses the supported [Orleans Event Sourcing](../grains/event-sourcing/index.md) model. See the [Journaling sample guide](../grains/journaling/samples.md) to run and inspect the durable-state sample.
 
 ### Deployment and operations
 

--- a/docs/site/src/content/docs/tutorials-and-samples/index.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/index.md
@@ -71,7 +71,7 @@ The [`samples` directory](https://github.com/dotnet/orleans/tree/main/samples) c
 | [Chat Room](https://github.com/dotnet/orleans/tree/main/samples/ChatRoom) | A terminal chat application using Orleans Streams. |
 | [Stocks](https://github.com/dotnet/orleans/tree/main/samples/Stocks) | Grain timers, HTTP calls, and temporary caching. |
 
-The Azure Blob JSON sample uses the experimental `Microsoft.Orleans.Journaling` package. The Journaled Todo List uses the supported [Orleans Event Sourcing](../grains/event-sourcing/index.md) model. See the [Journaling sample guide](../grains/journaling/samples.md) to run and inspect the durable-state sample.
+The Azure Blob JSON sample uses the experimental `Microsoft.Orleans.Journaling` package. The Journaled Todo List uses the supported [Orleans Event Sourcing](../grains/event-sourcing/index.md) model. See the [Journaling sample guide](../grains/journaling/samples.md) to run the Azure Blob and Redis durable-state samples.
 
 ### Deployment and operations
 

--- a/docs/site/src/content/docs/tutorials-and-samples/index.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/index.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans tutorials and samples
-description: Learn Orleans through maintained tutorials, explanations, and repository-backed samples.
+description: Learn Orleans through tutorials, explanations, and repository-backed samples.
 ms.date: 08/02/2026
 ms.topic: sample
 ---
@@ -12,7 +12,7 @@ Use this page to choose the right kind of learning material:
 - **Quickstarts** lead you through a focused task.
 - **Tutorials** teach a capability step by step.
 - **Explanations** describe how a complete application is modeled.
-- **Samples** are maintained, buildable applications which you can inspect and run.
+- **Samples** are buildable applications which you can inspect and run.
 
 ## Start here
 
@@ -38,7 +38,7 @@ For a more typical project structure, [Build your first Orleans app](../quicksta
 | [Why Orleans](../benefits.md) | The benefits and tradeoffs of the virtual actor model. |
 | [Orleans architecture design principles](../resources/orleans-architecture-principles-and-approach.md) | The design goals which shape Orleans APIs and runtime behavior. |
 
-## Maintained samples
+## Samples
 
 The [`samples` directory](https://github.com/dotnet/orleans/tree/main/samples) contains the official Orleans samples. Its [sample catalog](https://github.com/dotnet/orleans/blob/main/samples/README.md) is generated from the repository manifest and is validated together with the sample projects.
 


### PR DESCRIPTION
## Problem

Orleans Journaling was documented only through scattered package, sample, Event Sourcing comparison, metrics, and Redis references. Readers lacked a coherent explanation of the experimental programming model and its runtime and operational guarantees.

## Solution

Add a complete Journaling topic set covering durable state APIs, activation and recovery, write and compaction semantics, Azure Blob, Azure Table, and Redis providers, format migration, observability, capacity, backup, troubleshooting, and runnable Azure Blob and Redis examples. Register the pages in navigation and correct related package, sample, and Event Sourcing guidance.

## Rationale

The documentation derives behavior and limits from the current runtime, provider implementations, tests, public API surface, and repository samples. It presents the alpha status and `ORLEANSEXP005` contract prominently so evaluations include explicit compatibility and recovery planning.

Fixes #10720
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10749)