### PR TITLE
docs: remove redundant maintenance labels

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -13,7 +13,7 @@ These rules apply recursively to documentation, snippets, and samples under
   declare builders, configuration, services, and values used by the displayed
   region.
 - Compile every affected snippet project. Don't publish pseudo-code as if it were a copyable example.
-- Maintained documentation and snippet projects target `net10.0`.
+- Documentation and snippet projects target `net10.0`.
 - Every `Microsoft.Orleans.*` package reference must use the approved version `10.2.2`. Keep the Orleans package family aligned and centralize versions where the project structure supports it.
 - Use an older Orleans package only for a narrow migration example whose purpose
   requires that version. Keep it under `migration` and document the reason in
@@ -128,7 +128,7 @@ tutorial into a reference or burying architecture detail inside a how-to.
   and snippet project policy changes. It builds ordinary snippet projects and
   runs projects marked with `IsTestProject=true`, so executable testing examples
   are validated behaviorally.
-- Run `samples/Validate-Samples.ps1` when maintained samples change.
+- Run `samples/Validate-Samples.ps1` when samples change.
 - When `docs/Docs.slnx` is present after integration, build it as the aggregate documentation project.
 - From `docs/site`, run `npm run validate`, including redirect and rendered
   output auditing.

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,6 +1,6 @@
 # Orleans documentation site
 
-This Astro + Starlight site is the maintained home for Orleans documentation.
+This Astro + Starlight site hosts the Orleans documentation.
 The conceptual Markdown sources live under `src/content/docs`;
 `npm run prepare:docs` emits ignored `.mdx` siblings under `/docs/` so Starlight
 can render the imported Microsoft Learn syntax.
@@ -44,7 +44,7 @@ npm run validate
 The source audit reports a rule ID, file, line, and remediation. It enforces:
 
 - Orleans 10 guidance outside migration pages and explicitly versioned compatibility zones.
-- Exactly one `toc.yml` entry per maintained conceptual page, with `includes`,
+- Exactly one `toc.yml` entry per conceptual page, with `includes`,
   snippet support files, and compatibility routes marked `navigation: hidden`
   excluded; Architecture and internals and Event Sourcing remain first-class
   navigation sections.

--- a/docs/site/scripts/lib/project-policy.mjs
+++ b/docs/site/scripts/lib/project-policy.mjs
@@ -40,7 +40,7 @@ async function walkProjects(directory) {
   return projects;
 }
 
-export async function discoverMaintainedProjects(repoRoot) {
+export async function discoverProjects(repoRoot) {
   const projects = [
     ...(await walkProjects(path.join(repoRoot, 'docs'))),
     ...(await walkProjects(path.join(repoRoot, 'samples'))),
@@ -106,7 +106,7 @@ export function validateSolutionCoverage({
       issues.push({
         rule: 'PROJECT001',
         project,
-        message: `Maintained project is missing from ${solutionName}.`,
+        message: `Project is missing from ${solutionName}.`,
         remediation: `Add the project to ${solutionName} with dotnet sln and preserve its directory hierarchy.`,
       });
     }
@@ -127,8 +127,8 @@ export function validateSolutionCoverage({
         rule: 'PROJECT003',
         project,
         message: project.startsWith('docs/') || project.startsWith('samples/')
-          ? 'Solution entry is stale or does not name a maintained project.'
-          : 'Solution entry is outside the maintained docs and samples trees.',
+          ? 'Solution entry is stale or does not name a discovered project.'
+          : 'Solution entry is outside the docs and samples trees.',
         remediation: 'Remove the stale entry; referenced source projects build transitively.',
       });
     }
@@ -196,7 +196,7 @@ export function validateProjectEvaluations({
         rule: 'PROJECT004',
         project,
         message: `Project evaluates to target framework(s) '${frameworks.join(';') || '(missing)'}'.`,
-        remediation: `Target exactly ${targetFramework}; maintained docs and samples do not multi-target.`,
+        remediation: `Target exactly ${targetFramework}; docs and samples use a single target framework.`,
       });
     }
 
@@ -319,7 +319,7 @@ export async function auditProjectPolicy({
   evaluate = evaluateProject,
   concurrency = 8,
 }) {
-  const discoveredProjects = await discoverMaintainedProjects(repoRoot);
+  const discoveredProjects = await discoverProjects(repoRoot);
   const inventories = solutionFiles ?? [
     {
       solutionFile,

--- a/docs/site/scripts/lib/source-quality.mjs
+++ b/docs/site/scripts/lib/source-quality.mjs
@@ -365,7 +365,7 @@ export function validateNavigation({
           'DOCS002',
           page,
           1,
-          'Maintained conceptual page is missing from toc.yml.',
+          'Conceptual page is missing from toc.yml.',
           'Add this page to toc.yml exactly once, or make it an explicit include/snippet support file.',
         ),
       );
@@ -376,7 +376,7 @@ export function validateNavigation({
           tocFile,
           hrefLine(tocSource, page),
           `Navigation target '${page}' appears ${count} times.`,
-          'Keep exactly one toc.yml entry for every maintained conceptual page.',
+          'Keep exactly one toc.yml entry for every conceptual page.',
         ),
       );
     }

--- a/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
+++ b/docs/site/src/content/docs/deployment/deploy-to-azure-container-apps.md
@@ -11,7 +11,7 @@ Azure Container Apps can host Orleans, but the topology must preserve Orleans en
 
 To build a cluster from documented Container Apps endpoints, use a virtual-network-integrated internal environment and its private static IP. Deploy each silo as a separate Container App with exactly one replica and assign each app a unique pair of TCP ingress ports on that private IP. Repeat that resource to add silos. You must still complete the production acceptance tests on this page. A single Container App scaled to multiple silo replicas can work in a particular environment, but direct replica addresses aren't part of the documented Container Apps networking contract.
 
-Use the [Deploy and scale an Orleans app on Azure](../quickstarts/deploy-scale-orleans-on-azure.md) quickstart to learn the Azure Developer CLI deployment flow. The maintained [Orleans cluster on Azure Container Apps sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps) is also useful for studying a multi-component topology and the external-scaler contract. Review the [sample limitations](#understand-the-maintained-sample) before adapting either resource for production.
+Use the [Deploy and scale an Orleans app on Azure](../quickstarts/deploy-scale-orleans-on-azure.md) quickstart to learn the Azure Developer CLI deployment flow. The [Orleans cluster on Azure Container Apps sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps) is also useful for studying a multi-component topology and the external-scaler contract. Review the [sample limitations](#understand-the-sample) before adapting either resource for production.
 
 If the application uses Aspire, the [Aspire deployment flow for Azure Container Apps](https://aspire.dev/deployment/azure/container-apps/) can provision and publish platform resources. It doesn't remove the Orleans endpoint requirements on this page: review the generated topology, keep one replica per advertised silo endpoint, configure external clustering and durable state, and add the required health, identity, upgrade, and capacity controls before production.
 
@@ -199,7 +199,7 @@ Complete these acceptance tests before production and after platform or network 
 
 For the multiple-replica-in-one-app topology, add a blocking test that matches every active Orleans membership endpoint to one Container Apps replica and tests every advertised address from every peer. A successful test establishes evidence for that environment, but it doesn't turn the observed replica IP into a documented Container Apps contract.
 
-## Understand the maintained sample
+## Understand the sample
 
 The [in-repo sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps), imported from the [original Azure sample](https://github.com/Azure-Samples/Orleans-Cluster-on-Azure-Container-Apps), demonstrates:
 
@@ -212,7 +212,7 @@ The [in-repo sample](https://github.com/dotnet/orleans/tree/main/samples/Deploym
 - Clients that discover individual gateways through Orleans membership rather than using HTTP ingress as an Orleans transport.
 - The external-scaler gRPC service as a study component. It isn't attached to a silo scaling rule because scaling one app to multiple silo replicas would reintroduce the unsupported endpoint assumption.
 
-The maintained sample bounds public grain identities. Its hello grain uses an integer key, the public route accepts only keys from 0 through 255 before calling Orleans, the provider endpoint returns numeric keys, and inactive hello grains have a two-minute collection age. Preserve that bounded-input pattern when adapting the API. A collection age alone doesn't make an unbounded key space safe.
+The sample bounds public grain identities. Its hello grain uses an integer key, the public route accepts only keys from 0 through 255 before calling Orleans, the provider endpoint returns numeric keys, and inactive hello grains have a two-minute collection age. Preserve that bounded-input pattern when adapting the API. A collection age alone doesn't make an unbounded key space safe.
 
 The sample is still an architecture demonstration rather than a production deployment manifest. The registry and storage data endpoints remain public, although they require Microsoft Entra authentication. All runtime apps share one identity. The simple readiness endpoints don't implement application-specific draining, and the workflow updates existing apps in place, which can temporarily overlap revisions that advertise the same endpoint. For production upgrades, use the replacement-app procedure on this page. The one-replica apps don't prove cross-zone or independent failure-domain placement, and the external scaler doesn't make a capacity recommendation.
 

--- a/docs/site/src/content/docs/grains/code-generation-customization.md
+++ b/docs/site/src/content/docs/grains/code-generation-customization.md
@@ -11,7 +11,7 @@ Orleans generates the proxy and request types which implement grain calls. Advan
 
 Use this extension point when a library needs a calling abstraction with explicit semantics beyond <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.ValueTask>, or <xref:System.Collections.Generic.IAsyncEnumerable`1>. The library owns the abstraction's completion, cancellation, failure, lifetime, allocation, and concurrency contract.
 
-For a complete application, see the custom grain-call return type entry in the [maintained samples catalog](https://github.com/dotnet/orleans/blob/main/samples/README.md).
+For a complete application, see the custom grain-call return type entry in the [samples catalog](https://github.com/dotnet/orleans/blob/main/samples/README.md).
 
 ## Define an awaitable return type
 

--- a/docs/site/src/content/docs/grains/grain-persistence/index.md
+++ b/docs/site/src/content/docs/grains/grain-persistence/index.md
@@ -13,7 +13,7 @@ Persistence is intentionally a record-oriented abstraction, not an object-relati
 
 ## Choose a provider
 
-Officially maintained providers are available from [NuGet](https://www.nuget.org/packages?q=Orleans+Persistence) and include:
+Official providers are available from [NuGet](https://www.nuget.org/packages?q=Orleans+Persistence) and include:
 
 | Provider | Package | Typical use |
 |---|---|---|

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -80,7 +80,7 @@ See [Grain lifecycle](grain-lifecycle.md) for collection, lifecycle participatio
 
 ## Test grain behavior
 
-Use <xref:Orleans.TestingHost.InProcessTestCluster> for most grain tests so activation, scheduling, serialization, dependency injection, and messaging execute through the Orleans runtime. Use ordinary unit tests for extracted application logic. [Test Orleans applications](testing.md) explains these boundaries, including basic scenarios suited to [OrleansTestKit](https://github.com/OrleansContrib/OrleansTestKit), and provides maintained, executable examples. Follow [Test an Orleans application end to end](../tutorials-and-samples/testing-walkthrough.md) for a complete cluster-testing walkthrough.
+Use <xref:Orleans.TestingHost.InProcessTestCluster> for most grain tests so activation, scheduling, serialization, dependency injection, and messaging execute through the Orleans runtime. Use ordinary unit tests for extracted application logic. [Test Orleans applications](testing.md) explains these boundaries, including basic scenarios suited to [OrleansTestKit](https://github.com/OrleansContrib/OrleansTestKit), and provides executable examples. Follow [Test an Orleans application end to end](../tutorials-and-samples/testing-walkthrough.md) for a complete cluster-testing walkthrough.
 
 ## Choose basic or advanced features
 

--- a/docs/site/src/content/docs/grains/testing.md
+++ b/docs/site/src/content/docs/grains/testing.md
@@ -93,7 +93,7 @@ Configure the production storage or reminder provider when the test covers its e
 
 ## Use OrleansTestKit for a basic single-activation test
 
-[OrleansTestKit](https://github.com/OrleansContrib/OrleansTestKit) is a community-maintained project in the OrleansContrib organization. It creates a fixture for one grain activation and supplies test implementations for activation identity, persistent state, grain references, timers, reminders, and streams. The test invokes grain code on its own execution context, so the test author controls sequencing and synchronization. This boundary suits basic arrange-act-assert tests of a single method whose result depends on injected values and recorded collaborator interactions. Match the OrleansTestKit major version to the Orleans major version used by the application.
+[OrleansTestKit](https://github.com/OrleansContrib/OrleansTestKit) is a community project in the OrleansContrib organization. It creates a fixture for one grain activation and supplies test implementations for activation identity, persistent state, grain references, timers, reminders, and streams. The test invokes grain code on its own execution context, so the test author controls sequencing and synchronization. This boundary suits basic arrange-act-assert tests of a single method whose result depends on injected values and recorded collaborator interactions. Match the OrleansTestKit major version to the Orleans major version used by the application.
 
 Install the package in the test project:
 

--- a/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
+++ b/docs/site/src/content/docs/quickstarts/build-your-first-orleans-app.md
@@ -141,4 +141,4 @@ Stop the silo by pressing <kbd>Ctrl</kbd>+<kbd>C</kbd> in its terminal.
 - [Choose between a co-hosted and external client](../host/client.md)
 - [Configure Orleans for production](../host/configuration-guide/index.md)
 - [Learn more about grain identity](../grains/grain-identity.md)
-- [Browse maintained samples](../tutorials-and-samples/index.md)
+- [Browse samples](../tutorials-and-samples/index.md)

--- a/docs/site/src/content/docs/quickstarts/deploy-scale-orleans-on-azure.md
+++ b/docs/site/src/content/docs/quickstarts/deploy-scale-orleans-on-azure.md
@@ -117,7 +117,7 @@ The original deployment only deployed the minimal services necessary to host the
 
 ## Install NuGet packages
 
-Before adding shared providers, align the template with the maintained snippets:
+Before adding shared providers, align the template with the snippets:
 
 1. Change the working directory to _./src/web/_.
 

--- a/docs/site/src/content/docs/resources/links.md
+++ b/docs/site/src/content/docs/resources/links.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans resources
-description: Find maintained Orleans documentation, source, samples, community, and research.
+description: Find Orleans documentation, source, samples, community, and research.
 ms.date: 08/02/2026
 ms.topic: reference
 ---
@@ -11,7 +11,7 @@ ms.topic: reference
 
 - [Orleans documentation](https://learn.microsoft.com/dotnet/orleans/)
 - [Orleans repository](https://github.com/dotnet/orleans)
-- [Maintained Orleans samples](https://github.com/dotnet/orleans/tree/main/samples)
+- [Orleans samples](https://github.com/dotnet/orleans/tree/main/samples)
 - [.NET API reference for Orleans](https://dotnet.github.io/orleans/docs/api/csharp/)
 - [Orleans NuGet packages](https://www.nuget.org/profiles/Orleans)
 - [Release notes](https://github.com/dotnet/orleans/releases)

--- a/docs/site/src/content/docs/resources/student-projects.md
+++ b/docs/site/src/content/docs/resources/student-projects.md
@@ -7,7 +7,7 @@ ms.topic: conceptual
 
 # Research and student projects
 
-The former project list described research ideas and Azure technologies from an earlier stage of Orleans. It is no longer maintained as a roadmap.
+The former project list describes research ideas and Azure technologies from an earlier stage of Orleans and serves as historical context.
 
 For project ideas:
 
@@ -16,4 +16,4 @@ For project ideas:
 - Read the [contributing guide](https://github.com/dotnet/orleans/blob/main/CONTRIBUTING.md) before proposing an implementation.
 - Explore the [Orleans research publications](https://www.microsoft.com/research/project/orleans-virtual-actors/publications/).
 
-Course projects can begin with a maintained [Orleans sample](https://github.com/dotnet/orleans/tree/main/samples) and evaluate a focused distributed-systems concern such as partitioning, consistency, failure recovery, observability, or load distribution.
+Course projects can begin with an [Orleans sample](https://github.com/dotnet/orleans/tree/main/samples) and evaluate a focused distributed-systems concern such as partitioning, consistency, failure recovery, observability, or load distribution.

--- a/docs/site/src/content/docs/scenarios.md
+++ b/docs/site/src/content/docs/scenarios.md
@@ -67,7 +67,7 @@ Players, game sessions, rooms, parties, matches, tournaments, and leaderboards h
 
 Use Orleans for authoritative game and social state, matchmaking coordination, presence, progression, and session lifecycle. Real-time simulation, rendering, and other CPU-intensive loops can run in specialized compute services while grains coordinate durable and interactive state.
 
-See the [Adventure game](tutorials-and-samples/adventure.md) explanation and the maintained [Presence Service sample](https://github.com/dotnet/orleans/tree/main/samples/Presence).
+See the [Adventure game](tutorials-and-samples/adventure.md) explanation and the [Presence Service sample](https://github.com/dotnet/orleans/tree/main/samples/Presence).
 
 ### Commerce, reservations, and customer services
 

--- a/docs/site/src/content/docs/streaming/external-streams.md
+++ b/docs/site/src/content/docs/streaming/external-streams.md
@@ -22,7 +22,7 @@ The built-in Azure Event Hubs provider supports a custom <xref:Orleans.Streaming
 
 Register the adapter with <xref:Orleans.Hosting.EventHubStreamConfiguratorExtensions.UseDataAdapter*>. Configure the same adapter for every silo and Orleans client that uses the provider. A silo needs it to read Event Hubs messages and to publish through Orleans streams; an Orleans client needs it when the client publishes.
 
-The maintained [custom data adapter sample](https://github.com/dotnet/orleans/tree/main/samples/Streaming/CustomDataAdapter) demonstrates an external Event Hubs producer that writes JSON and an Orleans grain that consumes the resulting stream.
+The [custom data adapter sample](https://github.com/dotnet/orleans/tree/main/samples/Streaming/CustomDataAdapter) demonstrates an external Event Hubs producer that writes JSON and an Orleans grain that consumes the resulting stream.
 
 ## Accept events from an external producer
 

--- a/docs/site/src/content/docs/tutorials-and-samples/hello-world.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/hello-world.md
@@ -68,4 +68,4 @@ Hello, Hi friend!
 
 - [Build your first Orleans app](../quickstarts/build-your-first-orleans-app.md) using a typical multi-project structure.
 - [Understand Orleans concepts](../overview.md).
-- [Browse maintained samples](index.md).
+- [Browse samples](index.md).

--- a/docs/site/src/content/docs/tutorials-and-samples/index.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/index.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans tutorials and samples
-description: Learn Orleans through maintained tutorials, explanations, and repository-backed samples.
+description: Learn Orleans through tutorials, explanations, and repository-backed samples.
 ms.date: 08/02/2026
 ms.topic: sample
 ---
@@ -12,7 +12,7 @@ Use this page to choose the right kind of learning material:
 - **Quickstarts** lead you through a focused task.
 - **Tutorials** teach a capability step by step.
 - **Explanations** describe how a complete application is modeled.
-- **Samples** are maintained, buildable applications which you can inspect and run.
+- **Samples** are buildable applications which you can inspect and run.
 
 ## Start here
 
@@ -38,7 +38,7 @@ For a more typical project structure, [Build your first Orleans app](../quicksta
 | [Why Orleans](../benefits.md) | The benefits and tradeoffs of the virtual actor model. |
 | [Orleans architecture design principles](../resources/orleans-architecture-principles-and-approach.md) | The design goals which shape Orleans APIs and runtime behavior. |
 
-## Maintained samples
+## Samples
 
 The [`samples` directory](https://github.com/dotnet/orleans/tree/main/samples) contains the official Orleans samples. Its [sample catalog](https://github.com/dotnet/orleans/blob/main/samples/README.md) is generated from the repository manifest and is validated together with the sample projects.
 

--- a/docs/site/src/content/docs/tutorials-and-samples/streaming-walkthrough.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/streaming-walkthrough.md
@@ -7,7 +7,7 @@ ms.topic: tutorial
 
 # Build and recover an Orleans streaming application
 
-This walkthrough uses the maintained [Simple Streaming sample](https://github.com/dotnet/orleans/tree/main/samples/Streaming/Simple) to follow an event from a producer grain to an implicit consumer. You first run with an in-memory provider, then switch to Azure Event Hubs and verify recovery.
+This walkthrough uses the [Simple Streaming sample](https://github.com/dotnet/orleans/tree/main/samples/Streaming/Simple) to follow an event from a producer grain to an implicit consumer. You first run with an in-memory provider, then switch to Azure Event Hubs and verify recovery.
 
 ## Run the local path
 

--- a/docs/site/src/content/docs/tutorials-and-samples/testing-walkthrough.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/testing-walkthrough.md
@@ -17,7 +17,7 @@ These boundaries preserve fast feedback and runtime fidelity.
 
 ## Run the first cluster test
 
-Clone the repository, then run the maintained test project:
+Clone the repository, then run the test project:
 
 ```powershell
 git clone https://github.com/dotnet/orleans.git

--- a/docs/site/src/site-pages/home.mdx
+++ b/docs/site/src/site-pages/home.mdx
@@ -128,7 +128,7 @@ var total = await counter.Add(1);`} lang="csharp" title="Program.cs" />
     icon="puzzle"
     href="/orleans/samples/"
     title="Browse samples"
-    description="Learn from complete applications and focused examples maintained in this repository."
+    description="Learn from complete applications and focused examples in this repository."
   />
   <LinkCard
     icon="github"

--- a/docs/site/tests/project-policy.test.mjs
+++ b/docs/site/tests/project-policy.test.mjs
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  discoverMaintainedProjects,
+  discoverProjects,
   normalizeProjectPath,
   readSolutionProjects,
   validateProjectEvaluations,
@@ -234,7 +234,7 @@ describe('documentation project policy', () => {
   });
 
   test('checked-in solution exactly covers a clean project discovery', async () => {
-    const discoveredProjects = await discoverMaintainedProjects(repoRoot);
+    const discoveredProjects = await discoverProjects(repoRoot);
     const docsSolutionProjects = await readSolutionProjects({
       repoRoot,
       solutionFile: path.join(repoRoot, 'docs', 'Docs.slnx'),

--- a/docs/site/tests/source-quality.test.mjs
+++ b/docs/site/tests/source-quality.test.mjs
@@ -973,7 +973,7 @@ describe('documentation source quality', () => {
     expect(issues.map((issue) => issue.message)).toEqual(
       expect.arrayContaining([
         "Navigation target 'gone.md' does not exist.",
-        'Maintained conceptual page is missing from toc.yml.',
+        'Conceptual page is missing from toc.yml.',
         "Navigation target 'overview.md' appears 2 times.",
       ]),
     );

--- a/samples/Deployment/AzureContainerApps/README.md
+++ b/samples/Deployment/AzureContainerApps/README.md
@@ -1,7 +1,7 @@
 # Deploy an Orleans cluster on Azure Container Apps
 
 > [!NOTE]
-> This sample is maintained in the [`dotnet/orleans` repository](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps). It was imported from [`Azure-Samples/Orleans-Cluster-on-Azure-Container-Apps`](https://github.com/Azure-Samples/Orleans-Cluster-on-Azure-Container-Apps), whose MIT license is preserved in this directory.
+> This sample lives in the [`dotnet/orleans` repository](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps). It was imported from [`Azure-Samples/Orleans-Cluster-on-Azure-Container-Apps`](https://github.com/Azure-Samples/Orleans-Cluster-on-Azure-Container-Apps), whose MIT license is preserved in this directory.
 
 This sample demonstrates a multi-component Orleans application on Azure Container Apps:
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,6 +1,6 @@
 # Orleans Samples
 
-This directory is the canonical maintained home of the official Orleans samples.
+This directory is the canonical home of the official Orleans samples.
 
 <!-- Generated from gallery.json by Update-Readme.ps1. -->
 

--- a/samples/ShoppingCart/README.md
+++ b/samples/ShoppingCart/README.md
@@ -13,7 +13,7 @@ description: "A canonical shopping cart sample application, built using Microsof
 # Orleans: Shopping Cart App sample
 
 > [!NOTE]
-> This sample is maintained in the [`dotnet/orleans` repository](https://github.com/dotnet/orleans/tree/main/samples/ShoppingCart). It was imported from [`dotnet/samples`](https://github.com/dotnet/samples/tree/main/orleans/ShoppingCart).
+> This sample lives in the [`dotnet/orleans` repository](https://github.com/dotnet/orleans/tree/main/samples/ShoppingCart). It was imported from [`dotnet/samples`](https://github.com/dotnet/samples/tree/main/orleans/ShoppingCart).
 
 A canonical shopping cart sample application, built using Microsoft Orleans. This app shows the following features:
 

--- a/samples/Update-Readme.ps1
+++ b/samples/Update-Readme.ps1
@@ -12,7 +12,7 @@ $lines = [System.Collections.Generic.List[string]]::new()
 
 $lines.Add('# Orleans Samples')
 $lines.Add('')
-$lines.Add('This directory is the canonical maintained home of the official Orleans samples.')
+$lines.Add('This directory is the canonical home of the official Orleans samples.')
 $lines.Add('')
 $lines.Add('<!-- Generated from gallery.json by Update-Readme.ps1. -->')
 $lines.Add('')

--- a/src/Orleans.Persistence.TestKit/README.md
+++ b/src/Orleans.Persistence.TestKit/README.md
@@ -273,7 +273,7 @@ public class MemoryStorageTests : GrainStorageTestRunner, IClassFixture<MemorySt
 
 ## Contributing
 
-This project is maintained in the [Orleans repository](https://github.com/dotnet/orleans).
+The source for this project is in the [Orleans repository](https://github.com/dotnet/orleans).
 
 ## License
 


### PR DESCRIPTION
Repository content repeatedly labels documentation, samples, and related Orleans projects as maintained. Since active maintenance is the expected default, those labels are redundant and can imply that other content is unmaintained.

Remove maintenance-status wording from documentation, samples, project descriptions, diagnostics, and policy helper names. Preserve uses of "maintained" which describe runtime behavior or invariants.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10753)