### PR TITLE
chore(test): align .NET 10 runtime package versions

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -33,7 +33,7 @@
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' and '$(IsOrleansTestApplication)' == 'true'">
     <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0" PrivateAssets="all" />
     <PackageReference Include="System.IO.Pipelines" VersionOverride="10.0.5" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" VersionOverride="10.0.5" PrivateAssets="all" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -23,21 +23,6 @@
     <OutputType Condition="'$(IsOrleansTestApplication)' == 'true'">Exe</OutputType>
     <UseMicrosoftTestingPlatformRunner Condition="'$(IsOrleansTestApplication)' == 'true'">true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformCommandLineArguments Condition="'$(IsOrleansTestApplication)' == 'true'">$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
-    <!-- Microsoft.Accordant currently requires System.Text.Json 10: https://github.com/microsoft/accordant/issues/38 -->
-    <UsesAccordantTestKit Condition="
-      '$(MSBuildProjectName)' == 'Benchmarks.AdoNet' or
-      '$(MSBuildProjectName)' == 'Orleans.AdoNet.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.AWS.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Azure.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Cosmos.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Journaling.Json.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Journaling.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Persistence.Firestore.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Persistence.TestKit.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Redis.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Streaming.EventHubs.Tests' or
-      '$(MSBuildProjectName)' == 'Orleans.Transactions.Azure.Test' or
-      '$(MSBuildProjectName)' == 'Orleans.Transactions.DynamoDB.Test'">true</UsesAccordantTestKit>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsOrleansTestApplication)' == 'true'">
@@ -48,10 +33,10 @@
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net8.0' and '$(UsesAccordantTestKit)' == 'true'" />
-    <PackageReference Include="System.IO.Pipelines" VersionOverride="10.0.5" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net8.0' and '$(UsesAccordantTestKit)' == 'true'" />
-    <PackageReference Include="System.Text.Json" VersionOverride="10.0.5" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net8.0' and '$(UsesAccordantTestKit)' == 'true'" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.IO.Pipelines" VersionOverride="10.0.5" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" VersionOverride="10.0.5" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
+++ b/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using System.IO;
+using System.IO.Pipelines;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -53,14 +55,20 @@ internal static class TestCompilationHelper
         var trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")
             ?? throw new InvalidOperationException("The test host must provide trusted platform assemblies.");
 
-        return GetFrameworkAssemblyPaths(trustedPlatformAssemblies, typeof(object).Assembly.Location)
+        return GetFrameworkAssemblyPaths(
+                trustedPlatformAssemblies,
+                typeof(object).Assembly.Location,
+                typeof(ImmutableArray<>).Assembly.Location,
+                typeof(Pipe).Assembly.Location,
+                typeof(JsonSerializer).Assembly.Location)
             .Select(static path => (MetadataReference)MetadataReference.CreateFromFile(path))
             .ToImmutableArray();
     }
 
     internal static ImmutableArray<string> GetFrameworkAssemblyPaths(
         string trustedPlatformAssemblies,
-        string frameworkAssemblyPath)
+        string frameworkAssemblyPath,
+        params string[] runtimeAssemblyPaths)
     {
         if (string.IsNullOrWhiteSpace(trustedPlatformAssemblies))
         {
@@ -85,6 +93,10 @@ internal static class TestCompilationHelper
                 $"The trusted platform assemblies must include references from '{frameworkDirectory}'.");
         }
 
-        return frameworkAssemblyPaths;
+        var runtimeAssemblies = runtimeAssemblyPaths.ToDictionary(static path => Path.GetFileName(path)!, PathComparer);
+        return frameworkAssemblyPaths
+            .Where(path => !runtimeAssemblies.ContainsKey(Path.GetFileName(path)!))
+            .Concat(runtimeAssemblies.Values)
+            .ToImmutableArray();
     }
 }

--- a/test/Orleans.CodeGenerator.Tests/TestCompilationHelperTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/TestCompilationHelperTests.cs
@@ -12,13 +12,15 @@ public class TestCompilationHelperTests
         var matchingDirectory = OperatingSystem.IsWindows() ? frameworkDirectory.ToUpperInvariant() : frameworkDirectory;
         var matchingAssemblyPath = Path.Combine(matchingDirectory, "System.Runtime.dll");
         var otherAssemblyPath = Path.Combine(Path.GetTempPath(), "Other", "System.Runtime.dll");
+        var runtimeAssemblyPath = Path.Combine(Path.GetTempPath(), "Packages", "System.Runtime.dll");
         var trustedPlatformAssemblies = $"{matchingAssemblyPath}{Path.PathSeparator}{otherAssemblyPath}";
 
         var result = TestCompilationHelper.GetFrameworkAssemblyPaths(
             trustedPlatformAssemblies,
-            frameworkAssemblyPath);
+            frameworkAssemblyPath,
+            runtimeAssemblyPath);
 
-        Assert.Equal(matchingAssemblyPath, Assert.Single(result));
+        Assert.Equal(runtimeAssemblyPath, Assert.Single(result));
     }
 
     [Theory]


### PR DESCRIPTION
The test tree should resolve the same .NET 10 runtime package versions consistently instead of limiting those overrides to projects selected by an Accordant-specific allowlist.

This removes `UsesAccordantTestKit` and applies the existing `System.Collections.Immutable`, `System.IO.Pipelines`, and `System.Text.Json` version overrides to every `net8.0` test application inheriting `test/Directory.Build.props`.

Two test harness boundaries remain version-coherent:

- Standalone fixture applications keep their native `net8.0` dependency graph, since they are separate processes rather than test applications.
- Code-generator test compilations replace framework metadata references with the package assemblies loaded by the test host, so Roslyn resolves the same runtime versions as the test process.

The `net10.0` targets continue using their centrally managed package versions.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10758)