### PR TITLE
perf: optimize EventHub cache mapping

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventDataExtensions.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventDataExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Azure.Messaging.EventHubs;
 
 namespace Orleans.Streaming.EventHubs
@@ -42,8 +41,22 @@ namespace Orleans.Streaming.EventHubs
         /// </summary>
         public static byte[] SerializeProperties(this EventData eventData, Serialization.Serializer serializer)
         {
-            var result = serializer.SerializeToArray(eventData.Properties.Where(kvp => !string.Equals(kvp.Key, EventDataPropertyStreamNamespaceKey, StringComparison.Ordinal)).ToList());
-            return result;
+            if (eventData.Properties.Count == 0
+                || (eventData.Properties.Count == 1 && eventData.Properties.ContainsKey(EventDataPropertyStreamNamespaceKey)))
+            {
+                return [];
+            }
+
+            var properties = new List<KeyValuePair<string, object>>(eventData.Properties.Count);
+            foreach (var property in eventData.Properties)
+            {
+                if (!string.Equals(property.Key, EventDataPropertyStreamNamespaceKey, StringComparison.Ordinal))
+                {
+                    properties.Add(property);
+                }
+            }
+
+            return serializer.SerializeToArray(properties);
         }
 
         /// <summary>
@@ -51,8 +64,19 @@ namespace Orleans.Streaming.EventHubs
         /// </summary>
         public static IDictionary<string, object> DeserializeProperties(this ArraySegment<byte> bytes, Serialization.Serializer serializer)
         {
-            // Serialized EventData properties always contain a property list.
-            return serializer.Deserialize<List<KeyValuePair<string, object>>>(bytes.AsSpan())!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            if (bytes.Count == 0)
+            {
+                return new Dictionary<string, object>();
+            }
+
+            var properties = serializer.Deserialize<List<KeyValuePair<string, object>>>(bytes.AsSpan())!;
+            var result = new Dictionary<string, object>(properties.Count);
+            foreach (var property in properties)
+            {
+                result.Add(property.Key, property.Value);
+            }
+
+            return result;
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubDataAdapterTests.cs
@@ -1,4 +1,7 @@
+using Azure.Messaging.EventHubs;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Providers.Streams.Common;
+using Orleans.Serialization;
 using Orleans.Streaming.EventHubs;
 using TestExtensions;
 using Xunit;
@@ -7,6 +10,57 @@ namespace ServiceBus.Tests;
 
 public class EventHubDataAdapterTests
 {
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [TestArea("Streaming")]
+    [Theory, TestCategory("BVT"), TestCategory("Streaming")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SerializeProperties_ReturnsEmptyForNoApplicationProperties(bool includeStreamNamespace)
+    {
+        var eventData = new EventData();
+        if (includeStreamNamespace)
+        {
+            eventData.SetStreamNamespaceProperty("stream-namespace");
+        }
+
+        Assert.Empty(eventData.SerializeProperties(CreateSerializer()));
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [TestArea("Streaming")]
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void SerializeProperties_RoundTripsApplicationProperties()
+    {
+        var serializer = CreateSerializer();
+        var eventData = new EventData();
+        eventData.SetStreamNamespaceProperty("stream-namespace");
+        eventData.Properties["number"] = 42;
+        eventData.Properties["text"] = "value";
+
+        var bytes = eventData.SerializeProperties(serializer);
+        var properties = new ArraySegment<byte>(bytes).DeserializeProperties(serializer);
+
+        Assert.Equal(2, properties.Count);
+        Assert.Equal(42, properties["number"]);
+        Assert.Equal("value", properties["text"]);
+        Assert.DoesNotContain("StreamNamespace", properties);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [TestArea("Streaming")]
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public void DeserializeProperties_EmptyRepresentationReturnsMutableDictionary()
+    {
+        var properties = new ArraySegment<byte>([]).DeserializeProperties(CreateSerializer());
+
+        Assert.Empty(properties);
+        properties.Add("key", "value");
+        Assert.Equal("value", properties["key"]);
+    }
+
     [TestSuite("BVT")]
     [TestProvider("None")]
     [TestArea("Streaming")]
@@ -23,4 +77,9 @@ public class EventHubDataAdapterTests
         var exception = Assert.Throws<InvalidOperationException>(() => adapter.GetOffset(cachedMessage));
         Assert.Equal("Cached Event Hub message is missing its offset.", exception.Message);
     }
+
+    private static Serializer CreateSerializer() => new ServiceCollection()
+        .AddSerializer()
+        .BuildServiceProvider()
+        .GetRequiredService<Serializer>();
 }


### PR DESCRIPTION
## Problem

Issue #1742 identified unnecessary work when mapping Event Hubs `EventData` application properties into and out of the pooled stream cache. Orleans-produced messages normally contain only the internal `StreamNamespace` property, which is excluded from the cached application-property collection, but the adapter still serialized and deserialized an empty list for every message.

## Solution

Represent an empty application-property collection as a zero-length cache segment and construct the mutable empty dictionary directly when reading it. For messages with application properties, populate the serialized list and reconstructed dictionary with allocation-conscious loops instead of LINQ.

The representation is internal to each silo's in-memory cache, so it introduces no durable wire-format compatibility requirement. Application properties, duplicate-key errors, and the mutable `IDictionary` contract are preserved.

## Performance

BenchmarkDotNet on .NET 10 for the default no-application-properties path measured serialization improving from 117.6 ns / 128 B to 7.1 ns / 0 B, and deserialization improving from 74.6 ns / 112 B to 13.7 ns / 80 B. Messages with application properties retain equivalent throughput while the serialization-side temporary allocation drops from 280 B to 232 B for four properties.

Related to #1742.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10767)