### PR TITLE
test: fix ConfirmationWorker retry timer race

### DIFF
--- a/test/Transactions/Orleans.Transactions.Tests/ConfirmationWorkerTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConfirmationWorkerTests.cs
@@ -240,8 +240,6 @@ public class ConfirmationWorkerTests
 
         public Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default)
         {
-            this.DelayCallCount++;
-
             if (cancellationToken.IsCancellationRequested)
             {
                 return Task.FromResult(false);
@@ -253,6 +251,7 @@ public class ConfirmationWorkerTests
             lock (this.delays)
             {
                 this.delays.Enqueue(delay);
+                this.DelayCallCount++;
             }
 
             this.delayRequested.TrySetResult(null);
@@ -261,7 +260,7 @@ public class ConfirmationWorkerTests
 
         public Task WaitForDelayAsync()
         {
-            return this.DelayCallCount > 0 ? Task.CompletedTask : this.delayRequested.Task;
+            return this.delayRequested.Task;
         }
 
         public void ReleaseNextDelay(bool result = true)


### PR DESCRIPTION
Fixes #10747.

The ConfirmationWorker test timer published `DelayCallCount` before enqueueing the corresponding delay. `WaitForDelayAsync` could therefore complete while the queue was still empty, causing `ReleaseNextDelay` to throw intermittently.

Make the delay-request signal the readiness barrier and update the count while enqueueing. Once the barrier completes, the delay is guaranteed to be available for release.