### PR TITLE
test: disable DiffEngine in automated runs

### DIFF
--- a/test/Orleans.Journaling.Tests/VerifyConfigurationTests.cs
+++ b/test/Orleans.Journaling.Tests/VerifyConfigurationTests.cs
@@ -1,0 +1,13 @@
+using DiffEngine;
+using Xunit;
+
+namespace Orleans.Journaling.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+public sealed class VerifyConfigurationTests
+{
+    [Fact]
+    public void SnapshotDiffToolsAreDisabled() => Assert.True(DiffRunner.Disabled);
+}

--- a/test/testconfig.json
+++ b/test/testconfig.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://xunit.net/schema/current/testconfig.schema.json",
+  "environmentVariables": {
+    "DiffEngine_Disabled": "true"
+  },
   "xUnit": {
     "diagnosticMessages": true,
     "longRunningTestSeconds": 120,


### PR DESCRIPTION
## Problem

Snapshot verification can initialize DiffEngine process cleanup. The resolved DiffEngine 16.2.1 package enumerates Windows processes through WMI, so a WMI quota violation prevents Verify from reaching the snapshot comparison.

## Solution

Set `DiffEngine_Disabled=true` through the repository's shared Microsoft.Testing.Platform configuration so every automated test process skips external diff-tool launch and cleanup. Add a focused assertion in `Orleans.Journaling.Tests` to preserve that test-process invariant.

## Rationale

Automated snapshot tests require deterministic file comparison and failure reporting. External interactive diff tooling is outside that boundary, and DiffEngine's documented process-level setting disables it before Verify initializes process cleanup.

Fixes #10760
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10769)