### PR TITLE
fix(test): retry SQL Server setup login

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
@@ -198,8 +198,13 @@ namespace UnitTests.General
             var splitScripts = ConvertToExecutableBatches(setupScript, dataBaseName);
             foreach (var script in splitScripts)
             {
-                _ = await Storage.ExecuteAsync(script);
+                await ExecuteSetupScriptBatchAsync(script);
             }
+        }
+
+        protected virtual async Task ExecuteSetupScriptBatchAsync(string script)
+        {
+            _ = await Storage.ExecuteAsync(script);
         }
 
         /// <summary>

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -87,6 +87,26 @@ namespace UnitTests.General
             await readinessCommand.ExecuteNonQueryAsync();
         }
 
+        protected override async Task ExecuteSetupScriptBatchAsync(string script)
+        {
+            const int maxAttempts = 10;
+
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    await base.ExecuteSetupScriptBatchAsync(script);
+                    return;
+                }
+                catch (SqlException exception) when (exception.Number == 18456 && exception.State == 1 && attempt < maxAttempts)
+                {
+                    using var connection = new SqlConnection(CurrentConnectionString);
+                    SqlConnection.ClearPool(connection);
+                    await Task.Delay(TimeSpan.FromMilliseconds(500));
+                }
+            }
+        }
+
         public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }
 
         public override string CreateStreamTestTable { get { return "CREATE TABLE StreamingTest(Id INT NOT NULL, StreamData VARBINARY(MAX) NOT NULL);"; } }


### PR DESCRIPTION
Fixes #10766.

SQL Server 2025 can reject a pooled schema connection with error 18456/state 1 while the same test resets its database through `SINGLE_USER`. The existing readiness probe uses a non-pooled connection, so it can succeed while the following pooled schema batch still encounters the transient login transition.

Execute schema setup through a provider hook and retry only SQL Server 18456/state 1 failures at the individual batch boundary. Each retry clears the target connection pool before reconnecting. Since authentication fails before command execution, the retry cannot replay partially executed schema DDL, while unrelated SQL errors and the final failed attempt continue to surface directly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10774)