### PR TITLE
fix(deps): update Polly.Extensions to 8.6.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,7 +98,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
     <PackageVersion Include="Polly" Version="8.6.4" />
-    <PackageVersion Include="Polly.Extensions" Version="8.6.4" />
+    <PackageVersion Include="Polly.Extensions" Version="8.6.5" />
     <PackageVersion Include="protobuf-net" Version="3.2.56" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="SpanJson" Version="4.2.1" />


### PR DESCRIPTION
Aspire.Hosting.Testing 13.2.4 requires Polly.Extensions 8.6.5, while central package management pinned 8.6.4 and caused NU1109 during restore.

Update the central Polly.Extensions version to 8.6.5. Polly remains on 8.6.4 because the restored dependency graph satisfies all Polly requirements independently.

This keeps the dependency update minimal while restoring the Event Hubs Aspire project and solution build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10786)