### PR TITLE
test(runtime): keep cancellation observers alive

### DIFF
--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -97,6 +97,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         finally
         {
             fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+            GC.KeepAlive(observer);
         }
     }
 
@@ -142,6 +143,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         finally
         {
             fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+            GC.KeepAlive(observer);
         }
     }
 
@@ -195,6 +197,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
             }
 
             fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+            GC.KeepAlive(observer);
         }
     }
 
@@ -476,6 +479,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         finally
         {
             fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+            GC.KeepAlive(observer);
         }
     }
 

--- a/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
@@ -184,6 +184,7 @@ namespace UnitTests.CancellationTests
             finally
             {
                 fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+                GC.KeepAlive(observer);
             }
         }
 


### PR DESCRIPTION
## Problem

The .NET 10 BVT run in [Azure DevOps build 3054773](https://dnceng.visualstudio.com/internal/_build/results?buildId=3054773&view=results) failed in `MultipleGrainsTaskCancellation(delay: 300)`. The downloaded client log shows that `LongRunningTaskObserver` was garbage-collected before its `OnCallStarted` messages arrived. Orleans stores local observer targets through weak references, so it deregistered the reference and cleanup later threw `Reference is not associated with a local object`.

## Solution

Keep each cancellation-test observer strongly reachable until after its Orleans object reference is deleted. Apply the same lifetime guarantee to every cancellation test using this observer pattern so delayed callbacks retain a valid target throughout the operation.

The full cancellation test classes pass with 112 tests, and the affected theory passes across 20 repeated runs totaling 180 test cases.

Fixes #10789
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10790)