### PR TITLE
test(streaming): await subscription cursor drain

### DIFF
--- a/test/Orleans.Streaming.Tests/StreamingTests/MemorySubscriptionMultiplicityTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemorySubscriptionMultiplicityTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Configuration;
+using Orleans.Providers;
+using Orleans.TestingHost;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+[TestCategory("BVT"), TestCategory("Streaming")]
+public sealed class MemorySubscriptionMultiplicityTests : IClassFixture<MemorySubscriptionMultiplicityTests.Fixture>
+{
+    private const string StreamProviderName = "MemorySubscriptionMultiplicity";
+    private const string StreamNamespace = "MemorySubscriptionMultiplicityTests";
+    private readonly SubscriptionMultiplicityTestRunner _runner;
+
+    public MemorySubscriptionMultiplicityTests(Fixture fixture)
+    {
+        _runner = new SubscriptionMultiplicityTestRunner(StreamProviderName, fixture.HostedCluster);
+    }
+
+    [Fact]
+    public Task MemoryMultipleSubscriptionTest_AddRemove()
+        => _runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+
+    public sealed class Fixture : BaseTestClusterFixture
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.AddSiloBuilderConfigurator<Configurator>();
+            builder.AddClientBuilderConfigurator<Configurator>();
+        }
+
+        private sealed class Configurator : ISiloConfigurator, IClientBuilderConfigurator
+        {
+            public void Configure(ISiloBuilder siloBuilder)
+                => siloBuilder
+                    .AddMemoryGrainStorage("PubSubStore")
+                    .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName);
+
+            public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+                => clientBuilder.AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName);
+        }
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -184,12 +184,14 @@ public class SubscriptionMultiplicityTestRunner
         await WarmUpColdStreamAsync(
             producer,
             this.testCluster.Client!,
+            streamId,
             cts.Token,
             (consumer, firstSubscriptionHandle.HandleId),
             (consumer, secondSubscriptionHandle.HandleId));
         var produced = await ProduceUntilConsumedAsync(
             producer,
             this.testCluster.Client!,
+            streamId,
             cts.Token,
             EventCountPerPhase,
             (consumer, firstSubscriptionHandle.HandleId),
@@ -215,8 +217,8 @@ public class SubscriptionMultiplicityTestRunner
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId, async () => firstSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName), cts.Token);
-        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
-        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
+        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, streamId, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
+        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // clear counts
@@ -228,8 +230,8 @@ public class SubscriptionMultiplicityTestRunner
         // setup second subscription and send messages
         StreamSubscriptionHandle<int> secondSubscriptionHandle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId, async () => secondSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName), cts.Token);
-        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, cts.Token, (consumer, secondSubscriptionHandle.HandleId));
-        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, secondSubscriptionHandle.HandleId));
+        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, streamId, cts.Token, (consumer, secondSubscriptionHandle.HandleId));
+        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, (consumer, secondSubscriptionHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // remove second subscription
@@ -250,8 +252,8 @@ public class SubscriptionMultiplicityTestRunner
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId, async () => firstSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName), cts.Token);
-        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
-        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
+        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, streamId, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
+        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // clear counts
@@ -264,12 +266,14 @@ public class SubscriptionMultiplicityTestRunner
         await WarmUpColdStreamAsync(
             producer,
             this.testCluster.Client!,
+            streamId,
             cts.Token,
             (consumer, firstSubscriptionHandle.HandleId),
             (consumer, secondSubscriptionHandle.HandleId));
         produced = await ProduceUntilConsumedAsync(
             producer,
             this.testCluster.Client!,
+            streamId,
             cts.Token,
             EventCountPerPhase,
             (consumer, firstSubscriptionHandle.HandleId),
@@ -283,7 +287,7 @@ public class SubscriptionMultiplicityTestRunner
         // remove first subscription and send messages
         await WaitForSubscriptionDetachedAsync(streamId, async () => await consumer.StopConsuming(firstSubscriptionHandle), cts.Token);
 
-        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, secondSubscriptionHandle.HandleId));
+        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, (consumer, secondSubscriptionHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // remove second subscription
@@ -304,8 +308,8 @@ public class SubscriptionMultiplicityTestRunner
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId, async () => firstSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName), cts.Token);
-        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
-        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
+        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, streamId, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
+        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // Resume
@@ -314,7 +318,7 @@ public class SubscriptionMultiplicityTestRunner
 
         Assert.Equal(firstSubscriptionHandle, resumeHandle);
 
-        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, false, (consumer, resumeHandle.HandleId));
+        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, false, (consumer, resumeHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // remove subscription
@@ -336,8 +340,8 @@ public class SubscriptionMultiplicityTestRunner
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId, async () => firstSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName), cts.Token);
-        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
-        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
+        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, streamId, cts.Token, (consumer, firstSubscriptionHandle.HandleId));
+        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, (consumer, firstSubscriptionHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // Deactivate grain
@@ -353,7 +357,7 @@ public class SubscriptionMultiplicityTestRunner
 
         Assert.Equal(firstSubscriptionHandle, resumeHandle);
 
-        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, resumeHandle.HandleId));
+        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId, cts.Token, EventCountPerPhase, (consumer, resumeHandle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // remove subscription
@@ -425,8 +429,8 @@ public class SubscriptionMultiplicityTestRunner
 
         StreamSubscriptionHandle<int> handle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId1, async () => handle = await consumer.BecomeConsumer(streamGuid, streamNamespace1, streamProviderName), cts.Token);
-        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, cts.Token, (consumer, handle.HandleId));
-        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer, handle.HandleId));
+        await WarmUpColdStreamAsync(producer, this.testCluster.Client!, streamId1, cts.Token, (consumer, handle.HandleId));
+        var produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId1, cts.Token, EventCountPerPhase, (consumer, handle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         // send some events on second stream /////////////////////////////
@@ -438,12 +442,12 @@ public class SubscriptionMultiplicityTestRunner
 
         StreamSubscriptionHandle<int> handle2 = null!;
         await WaitForSubscriptionRegisteredAsync(streamId2, async () => handle2 = await consumer2.BecomeConsumer(streamGuid, streamNamespace2, streamProviderName), cts.Token);
-        await WarmUpColdStreamAsync(producer2, this.testCluster.Client!, cts.Token, (consumer2, handle2.HandleId));
-        var produced2 = await ProduceUntilConsumedAsync(producer2, this.testCluster.Client!, cts.Token, EventCountPerPhase, (consumer2, handle2.HandleId));
+        await WarmUpColdStreamAsync(producer2, this.testCluster.Client!, streamId2, cts.Token, (consumer2, handle2.HandleId));
+        var produced2 = await ProduceUntilConsumedAsync(producer2, this.testCluster.Client!, streamId2, cts.Token, EventCountPerPhase, (consumer2, handle2.HandleId));
         await AssertCountersAsync(producer2, consumer2, produced2, 1);
 
         // send some events on first stream again /////////////////////////////
-        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, cts.Token, EventCountPerPhase, false, (consumer, handle.HandleId));
+        produced = await ProduceUntilConsumedAsync(producer, this.testCluster.Client!, streamId1, cts.Token, EventCountPerPhase, false, (consumer, handle.HandleId));
         await AssertCountersAsync(producer, consumer, produced, 1);
 
         await consumer.StopConsuming(handle);
@@ -493,13 +497,14 @@ public class SubscriptionMultiplicityTestRunner
         }
     }
 
-    private static Task<int> ProduceUntilConsumedAsync(
+    private Task<int> ProduceUntilConsumedAsync(
         ISampleStreaming_ProducerGrain producer,
         IGrainFactory grainFactory,
+        StreamId streamId,
         CancellationToken cancellationToken,
         int target,
         params (IMultipleSubscriptionConsumerGrain Consumer, Guid HandleId)[] waits)
-        => ProduceUntilConsumedAsync(producer, grainFactory, cancellationToken, target, true, waits);
+        => ProduceUntilConsumedAsync(producer, grainFactory, streamId, cancellationToken, target, true, waits);
 
     private static async Task WaitForConsumerCountsAsync(
         IGrainFactory grainFactory,
@@ -549,9 +554,10 @@ public class SubscriptionMultiplicityTestRunner
         }
     }
 
-    private static async Task<int> ProduceUntilConsumedAsync(
+    private async Task<int> ProduceUntilConsumedAsync(
         ISampleStreaming_ProducerGrain producer,
         IGrainFactory grainFactory,
+        StreamId streamId,
         CancellationToken cancellationToken,
         int target,
         bool resetCounts = true,
@@ -567,6 +573,7 @@ public class SubscriptionMultiplicityTestRunner
             await producer.ClearNumberProduced();
         }
 
+        using var deliveryObserver = StreamingDiagnosticObserver.Create();
         await ProduceExactCountAsync(producer, target);
         var produced = await producer.GetNumberProduced();
 
@@ -581,6 +588,8 @@ public class SubscriptionMultiplicityTestRunner
                 $"Timed out waiting for consumers to reach produced count {produced}. Current produced={currentProduced}. {exception.Message}",
                 exception);
         }
+
+        await WaitForConsumerCursorsDrainedAsync(deliveryObserver, streamId, target, cancellationToken, waits);
 
         return produced;
     }
@@ -619,7 +628,7 @@ public class SubscriptionMultiplicityTestRunner
         return produced;
     }
 
-    private static async Task WaitForConsumersToCatchUpAsync(
+    private static async Task<int> WaitForConsumersToCatchUpAsync(
         ISampleStreaming_ProducerGrain producer,
         IGrainFactory grainFactory,
         CancellationToken cancellationToken,
@@ -633,7 +642,7 @@ public class SubscriptionMultiplicityTestRunner
             var confirmedProduced = await producer.GetNumberProduced();
             if (confirmedProduced == produced)
             {
-                return;
+                return produced;
             }
         }
     }
@@ -656,9 +665,10 @@ public class SubscriptionMultiplicityTestRunner
         }
     }
 
-    private static async Task WarmUpColdStreamAsync(
+    private async Task WarmUpColdStreamAsync(
         ISampleStreaming_ProducerGrain producer,
         IGrainFactory grainFactory,
+        StreamId streamId,
         CancellationToken cancellationToken,
         params (IMultipleSubscriptionConsumerGrain Consumer, Guid HandleId)[] waits)
     {
@@ -668,6 +678,7 @@ public class SubscriptionMultiplicityTestRunner
         }
 
         await producer.ClearNumberProduced();
+        using var deliveryObserver = StreamingDiagnosticObserver.Create();
         await producer.StartPeriodicProducing();
         try
         {
@@ -678,7 +689,8 @@ public class SubscriptionMultiplicityTestRunner
             await producer.StopPeriodicProducing().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
         }
 
-        await WaitForConsumersToCatchUpAsync(producer, grainFactory, cancellationToken, waits);
+        var produced = await WaitForConsumersToCatchUpAsync(producer, grainFactory, cancellationToken, waits);
+        await WaitForConsumerCursorsDrainedAsync(deliveryObserver, streamId, produced, cancellationToken, waits);
 
         foreach (var consumer in waits.Select(wait => wait.Consumer).Distinct())
         {
@@ -687,6 +699,19 @@ public class SubscriptionMultiplicityTestRunner
 
         await producer.ClearNumberProduced();
     }
+
+    private Task WaitForConsumerCursorsDrainedAsync(
+        StreamingDiagnosticObserver observer,
+        StreamId streamId,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        params (IMultipleSubscriptionConsumerGrain Consumer, Guid HandleId)[] waits)
+        => Task.WhenAll(waits.Select(wait => observer.WaitForItemDeliveryAndCursorDrainAsync(
+            streamId,
+            wait.HandleId,
+            expectedCount,
+            streamProviderName,
+            cancellationToken)));
 
     private static async Task WarmUpColdClientStreamAsync(
         ISampleStreaming_ProducerGrain producer,

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
@@ -226,7 +226,7 @@ public sealed class StreamingDiagnosticObserver : IDisposable
     }
 
     /// <summary>
-    /// Waits for a specific number of individual items to be delivered on a stream and then
+    /// Waits for messages containing a specific number of items to be delivered on a stream and then
     /// for that stream to report a cursor-drained transition afterward.
     /// </summary>
     public async Task WaitForItemDeliveryAndCursorDrainAsync(StreamId streamId, int expectedCount, string? streamProvider, CancellationToken cancellationToken)
@@ -234,13 +234,13 @@ public sealed class StreamingDiagnosticObserver : IDisposable
         await _events
             .Where(e => e switch
             {
-                StreamingEvents.ItemDelivered item => MatchesStream(item.StreamId, item.StreamProvider, streamId, streamProvider),
+                StreamingEvents.MessageDelivered message => MatchesStream(message.StreamId, message.StreamProvider, streamId, streamProvider),
                 StreamingEvents.ConsumerCursorDrained drained => MatchesStream(drained.StreamId, drained.StreamProvider, streamId, streamProvider),
                 _ => false,
             })
             .Scan((DeliveredCount: 0, Drained: false), (state, evt) => evt switch
             {
-                StreamingEvents.ItemDelivered => (state.DeliveredCount + 1, state.Drained),
+                StreamingEvents.MessageDelivered message => (state.DeliveredCount + message.Batch.GetEvents<object>().Count(), state.Drained),
                 StreamingEvents.ConsumerCursorDrained when state.DeliveredCount >= expectedCount => (state.DeliveredCount, true),
                 _ => state,
             })
@@ -250,7 +250,7 @@ public sealed class StreamingDiagnosticObserver : IDisposable
     }
 
     /// <summary>
-    /// Waits for a specific number of individual items to be delivered to a particular subscription and then
+    /// Waits for messages containing a specific number of items to be delivered to a particular subscription and then
     /// for that subscription's cursor-drained transition to be reported.
     /// </summary>
     public async Task WaitForItemDeliveryAndCursorDrainAsync(StreamId streamId, Guid subscriptionId, int expectedCount, string? streamProvider, CancellationToken cancellationToken)
@@ -258,13 +258,13 @@ public sealed class StreamingDiagnosticObserver : IDisposable
         await _events
             .Where(e => e switch
             {
-                StreamingEvents.ItemDelivered item => MatchesSubscription(item.StreamId, item.SubscriptionId, item.StreamProvider, streamId, subscriptionId, streamProvider),
+                StreamingEvents.MessageDelivered message => MatchesSubscription(message.StreamId, message.SubscriptionId, message.StreamProvider, streamId, subscriptionId, streamProvider),
                 StreamingEvents.ConsumerCursorDrained drained => MatchesSubscription(drained.StreamId, drained.SubscriptionId, drained.StreamProvider, streamId, subscriptionId, streamProvider),
                 _ => false,
             })
             .Scan((DeliveredCount: 0, Drained: false), (state, evt) => evt switch
             {
-                StreamingEvents.ItemDelivered => (state.DeliveredCount + 1, state.Drained),
+                StreamingEvents.MessageDelivered message => (state.DeliveredCount + message.Batch.GetEvents<object>().Count(), state.Drained),
                 StreamingEvents.ConsumerCursorDrained when state.DeliveredCount >= expectedCount => (state.DeliveredCount, true),
                 _ => state,
             })


### PR DESCRIPTION
Fixes #10756.

The subscription multiplicity runner reset its counters as soon as consumers reached the producer count. Persistent stream delivery can still be draining the subscription cursor at that point, so a warm-up delivery can arrive after the reset and appear as an extra item in the next phase. The reported assertion occurs in the two-subscription phase, before the test removes either subscription.

Wait for each subscription's cursor-drained diagnostic transition after the expected deliveries before resetting counters or asserting phase totals. This preserves exact delivery assertions while synchronizing on the runtime's delivery boundary. Add an in-memory subscription multiplicity test so the add/remove scenario has a locally runnable regression path without Azure credentials.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10792)