### PR TITLE
fix(test): isolate stateless worker stream deliveries

### DIFF
--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -9,79 +9,101 @@ namespace UnitTests.Grains
 {
     public sealed class StatelessWorkerStreamConsumerState
     {
-        private readonly ConcurrentDictionary<Guid, int> _deliveryCounts = new();
-        private readonly ConcurrentDictionary<Guid, int> _observerCounts = new();
-        private readonly SemaphoreSlim _deliverySemaphore = new(0);
-        private TaskCompletionSource _deliveriesReleased = CreateCompletionSource();
-        private TaskCompletionSource _deliveryTargetReached = CreateCompletionSource();
-        private bool _blockDeliveries;
-        private int _deliveryCount;
-        private int _expectedDeliveries;
-        private int _waitingDeliveryCount;
+        private readonly ConcurrentDictionary<Guid, byte> _observerActivations = new();
+        private DeliveryRun? _currentRun;
 
-        public int DeliveryCount => Volatile.Read(ref _deliveryCount);
-
-        public int DeliveryActivationCount => _deliveryCounts.Count;
-
-        public int ObserverActivationCount => _observerCounts.Count;
-
-        public int WaitingDeliveryCount => Volatile.Read(ref _waitingDeliveryCount);
-
-        public void Reset(int expectedDeliveries, bool blockDeliveries = false)
+        public DeliveryRun StartRun(string deliveryId, int expectedDeliveries, bool blockDeliveries = false)
         {
-            if (WaitingDeliveryCount != 0)
-            {
-                throw new InvalidOperationException("All blocked stream deliveries must be released before resetting the test state.");
-            }
-
-            while (_deliverySemaphore.Wait(0))
-            {
-            }
-
-            _deliveryCounts.Clear();
-            _observerCounts.Clear();
-            Interlocked.Exchange(ref _deliveryCount, 0);
-            _expectedDeliveries = expectedDeliveries;
-            Volatile.Write(ref _blockDeliveries, blockDeliveries);
-            _deliveriesReleased = CreateCompletionSource();
-            _deliveryTargetReached = CreateCompletionSource();
+            var run = new DeliveryRun(deliveryId, expectedDeliveries, blockDeliveries);
+            Volatile.Write(ref _currentRun, run);
+            return run;
         }
 
-        public Task WaitForDeliveriesAsync(TimeSpan timeout) => _deliveryTargetReached.Task.WaitAsync(timeout);
+        internal void RecordObserver(Guid activationId) => _observerActivations.TryAdd(activationId, 0);
 
-        public Task WaitForReleasedDeliveriesAsync(TimeSpan timeout) => _deliveriesReleased.Task.WaitAsync(timeout);
-
-        public void ReleaseDeliveries() => _deliverySemaphore.Release(_expectedDeliveries);
-
-        internal void RecordObserver(Guid activationId) => _observerCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
-
-        internal async Task RecordDelivery(Guid activationId)
+        internal Task RecordDelivery(Guid activationId, string deliveryId)
         {
-            _deliveryCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
-            var deliveryCount = Interlocked.Increment(ref _deliveryCount);
-            if (!Volatile.Read(ref _blockDeliveries))
+            var run = Volatile.Read(ref _currentRun);
+            return run is not null && string.Equals(run.DeliveryId, deliveryId, StringComparison.Ordinal)
+                ? run.RecordDelivery(activationId, _observerActivations.ContainsKey(activationId))
+                : Task.CompletedTask;
+        }
+
+        public sealed class DeliveryRun
+        {
+            private readonly ConcurrentDictionary<Guid, int> _deliveryCounts = new();
+            private readonly ConcurrentDictionary<Guid, int> _observerCounts = new();
+            private readonly TaskCompletionSource _deliveriesReleased = CreateCompletionSource();
+            private readonly TaskCompletionSource _deliveryRelease = CreateCompletionSource();
+            private readonly TaskCompletionSource _deliveryTargetReached = CreateCompletionSource();
+            private readonly bool _blockDeliveries;
+            private readonly int _expectedDeliveries;
+            private int _deliveryCount;
+            private int _waitingDeliveryCount;
+
+            internal DeliveryRun(string deliveryId, int expectedDeliveries, bool blockDeliveries)
             {
-                if (deliveryCount >= _expectedDeliveries)
+                DeliveryId = deliveryId;
+                _expectedDeliveries = expectedDeliveries;
+                _blockDeliveries = blockDeliveries;
+            }
+
+            internal string DeliveryId { get; }
+
+            public int DeliveryCount => Volatile.Read(ref _deliveryCount);
+
+            public int DeliveryActivationCount => _deliveryCounts.Count;
+
+            public int ObserverActivationCount => _observerCounts.Count;
+
+            public int WaitingDeliveryCount => Volatile.Read(ref _waitingDeliveryCount);
+
+            public Task WaitForDeliveriesAsync(TimeSpan timeout) => _deliveryTargetReached.Task.WaitAsync(timeout);
+
+            public async Task ReleaseDeliveriesAsync(TimeSpan timeout)
+            {
+                _deliveryRelease.TrySetResult();
+                if (WaitingDeliveryCount == 0)
+                {
+                    _deliveriesReleased.TrySetResult();
+                }
+
+                await _deliveriesReleased.Task.WaitAsync(timeout);
+            }
+
+            internal async Task RecordDelivery(Guid activationId, bool observerAttached)
+            {
+                _deliveryCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
+                if (observerAttached)
+                {
+                    _observerCounts.AddOrUpdate(activationId, 1, static (_, count) => count + 1);
+                }
+
+                var deliveryCount = Interlocked.Increment(ref _deliveryCount);
+                if (!_blockDeliveries)
+                {
+                    if (deliveryCount >= _expectedDeliveries)
+                    {
+                        _deliveryTargetReached.TrySetResult();
+                    }
+                    return;
+                }
+
+                if (Interlocked.Increment(ref _waitingDeliveryCount) >= _expectedDeliveries)
                 {
                     _deliveryTargetReached.TrySetResult();
                 }
-                return;
-            }
 
-            if (Interlocked.Increment(ref _waitingDeliveryCount) >= _expectedDeliveries)
-            {
-                _deliveryTargetReached.TrySetResult();
-            }
-
-            try
-            {
-                await _deliverySemaphore.WaitAsync();
-            }
-            finally
-            {
-                if (Interlocked.Decrement(ref _waitingDeliveryCount) == 0)
+                try
                 {
-                    _deliveriesReleased.TrySetResult();
+                    await _deliveryRelease.Task;
+                }
+                finally
+                {
+                    if (Interlocked.Decrement(ref _waitingDeliveryCount) == 0)
+                    {
+                        _deliveriesReleased.TrySetResult();
+                    }
                 }
             }
         }
@@ -109,7 +131,7 @@ namespace UnitTests.Grains
 
         public Task OnErrorAsync(Exception ex) => Task.CompletedTask;
 
-        public Task OnNextAsync(string item, StreamSequenceToken? token = null) => _state.RecordDelivery(_activationId);
+        public Task OnNextAsync(string item, StreamSequenceToken? token = null) => _state.RecordDelivery(_activationId, item);
 
         public async Task BecomeConsumer(Guid[] streamIds, string providerToUse)
         {
@@ -166,7 +188,7 @@ namespace UnitTests.Grains
         {
             _state.RecordObserver(_activationId);
             await handleFactory.Create<string>().ResumeAsync(
-                (item, token) => _state.RecordDelivery(_activationId),
+                (item, token) => _state.RecordDelivery(_activationId, item),
                 static exception => Task.CompletedTask,
                 static () => Task.CompletedTask);
         }

--- a/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerStreamConsumerGrain.cs
@@ -14,6 +14,7 @@ namespace UnitTests.Grains
 
         public DeliveryRun StartRun(string deliveryId, int expectedDeliveries, bool blockDeliveries = false)
         {
+            _observerActivations.Clear();
             var run = new DeliveryRun(deliveryId, expectedDeliveries, blockDeliveries);
             Volatile.Write(ref _currentRun, run);
             return run;

--- a/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
@@ -41,6 +41,8 @@ namespace UnitTests.StreamingTests
                             streams => streams.ConfigurePartitioning(PartitionCount))
                         .AddMemoryGrainStorage("PubSubStore");
                     hostBuilder.Services.AddSingleton<StatelessWorkerStreamConsumerState>();
+                    hostBuilder.Services.AddSingleton<StreamingDiagnosticEventRecorder>();
+                    hostBuilder.AddStartupTask<StreamingDiagnosticEventRecorder>(ServiceLifecycleStage.RuntimeInitialize);
                 }
             }
 
@@ -67,16 +69,18 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional")]
         public async Task ExplicitSubscription_DeliversToStatelessWorker_AndCanBeRemovedAtGrainScope()
         {
+            await WaitForStreamingProviderReadyAsync();
             var state = GetConsumerState();
-            state.Reset(expectedDeliveries: 1);
+            var deliveryId = Guid.NewGuid().ToString();
+            var run = state.StartRun(deliveryId, expectedDeliveries: 1);
             var streamId = Guid.NewGuid();
             var consumer = fixture.GrainFactory.GetGrain<IStatelessWorkerStreamConsumerGrain>(0);
 
             await consumer.BecomeConsumer([streamId], StreamProvider);
-            await GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId).OnNextAsync("first");
-            await state.WaitForDeliveriesAsync(Timeout);
+            await GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId).OnNextAsync(deliveryId);
+            await run.WaitForDeliveriesAsync(Timeout);
 
-            Assert.Equal(1, state.DeliveryCount);
+            Assert.Equal(1, run.DeliveryCount);
             Assert.Equal(1, await consumer.StopConsuming(streamId, StreamProvider));
             Assert.Equal(0, await consumer.StopConsuming(streamId, StreamProvider));
         }
@@ -84,38 +88,81 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional")]
         public async Task ImplicitSubscription_AttachesObserverBeforeFirstDelivery()
         {
+            await WaitForStreamingProviderReadyAsync();
             var state = GetConsumerState();
-            state.Reset(expectedDeliveries: 1);
+            var deliveryId = Guid.NewGuid().ToString();
+            var run = state.StartRun(deliveryId, expectedDeliveries: 1);
             var streamId = Guid.NewGuid();
 
-            await GetStream(ImplicitStatelessWorkerStreamConsumerGrain.StreamNamespace, streamId).OnNextAsync("first");
-            await state.WaitForDeliveriesAsync(Timeout);
+            await GetStream(ImplicitStatelessWorkerStreamConsumerGrain.StreamNamespace, streamId).OnNextAsync(deliveryId);
+            await run.WaitForDeliveriesAsync(Timeout);
 
-            Assert.Equal(1, state.DeliveryCount);
-            Assert.Equal(1, state.ObserverActivationCount);
+            Assert.Equal(1, run.DeliveryCount);
+            Assert.Equal(1, run.ObserverActivationCount);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task ConcurrentQueueDeliveries_UseMultipleLocalWorkerActivations()
         {
+            await WaitForStreamingProviderReadyAsync();
             var state = GetConsumerState();
-            state.Reset(expectedDeliveries: PartitionCount, blockDeliveries: true);
+            var deliveryId = Guid.NewGuid().ToString();
+            var run = state.StartRun(deliveryId, expectedDeliveries: PartitionCount, blockDeliveries: true);
             var streamIds = CreateStreamIdsForDistinctQueues();
             var consumer = fixture.GrainFactory.GetGrain<IStatelessWorkerStreamConsumerGrain>(1);
             await consumer.BecomeConsumer(streamIds, StreamProvider);
 
-            await Task.WhenAll(streamIds.Select((streamId, index) =>
-                GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId)
-                    .OnNextAsync($"item-{index}")));
-            await state.WaitForDeliveriesAsync(Timeout);
+            try
+            {
+                await Task.WhenAll(streamIds.Select(streamId =>
+                    GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId)
+                        .OnNextAsync(deliveryId)));
+                await run.WaitForDeliveriesAsync(Timeout);
 
-            Assert.Equal(PartitionCount, state.WaitingDeliveryCount);
-            Assert.Equal(PartitionCount, state.DeliveryActivationCount);
-            Assert.Equal(PartitionCount, state.ObserverActivationCount);
+                Assert.Equal(PartitionCount, run.WaitingDeliveryCount);
+                Assert.Equal(PartitionCount, run.DeliveryActivationCount);
+                Assert.Equal(PartitionCount, run.ObserverActivationCount);
+            }
+            finally
+            {
+                await run.ReleaseDeliveriesAsync(Timeout);
+                await Task.WhenAll(streamIds.Select(streamId => consumer.StopConsuming(streamId, StreamProvider)));
+            }
 
-            state.ReleaseDeliveries();
-            await state.WaitForReleasedDeliveriesAsync(Timeout);
-            Assert.Equal(PartitionCount, state.DeliveryCount);
+            Assert.Equal(PartitionCount, run.DeliveryCount);
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task DeliveryRunCleanup_ReleasesBlockedDelivery_AndIsolatesNextRun()
+        {
+            await WaitForStreamingProviderReadyAsync();
+            var state = GetConsumerState();
+            var firstDeliveryId = Guid.NewGuid().ToString();
+            var firstRun = state.StartRun(firstDeliveryId, expectedDeliveries: 1, blockDeliveries: true);
+            var streamId = Guid.NewGuid();
+            var consumer = fixture.GrainFactory.GetGrain<IStatelessWorkerStreamConsumerGrain>(3);
+            await consumer.BecomeConsumer([streamId], StreamProvider);
+
+            try
+            {
+                var stream = GetStream(StatelessWorkerStreamConsumerGrain.ExplicitStreamNamespace, streamId);
+                await stream.OnNextAsync(firstDeliveryId);
+                await firstRun.WaitForDeliveriesAsync(Timeout);
+                await firstRun.ReleaseDeliveriesAsync(Timeout);
+
+                var nextDeliveryId = Guid.NewGuid().ToString();
+                var nextRun = state.StartRun(nextDeliveryId, expectedDeliveries: 1);
+                await stream.OnNextAsync(firstDeliveryId);
+                await stream.OnNextAsync(nextDeliveryId);
+                await nextRun.WaitForDeliveriesAsync(Timeout);
+
+                Assert.Equal(1, nextRun.DeliveryCount);
+            }
+            finally
+            {
+                await firstRun.ReleaseDeliveriesAsync(Timeout);
+                await consumer.StopConsuming(streamId, StreamProvider);
+            }
         }
 
         [Fact, TestCategory("Functional")]
@@ -142,6 +189,11 @@ namespace UnitTests.StreamingTests
 
         private StatelessWorkerStreamConsumerState GetConsumerState() =>
             fixture.HostedCluster.GetSiloServiceProvider().GetRequiredService<StatelessWorkerStreamConsumerState>();
+
+        private Task WaitForStreamingProviderReadyAsync() =>
+            fixture.HostedCluster.GetSiloServiceProvider()
+                .GetRequiredService<StreamingDiagnosticEventRecorder>()
+                .WaitForProviderReady(StreamProvider, Timeout);
 
         private IAsyncStream<string> GetStream(string streamNamespace, Guid streamId) =>
             fixture.Client.GetStreamProvider(StreamProvider).GetStream<string>(streamNamespace, streamId);


### PR DESCRIPTION
## Problem

`StatelessWorkersStreamTests.ConcurrentQueueDeliveries_UseMultipleLocalWorkerActivations` published to four memory-stream partitions before the pulling agents had initialized all assigned queue receivers. Under CI load, one or more deliveries could miss the 30-second observation window. Its blocked callbacks remained in singleton fixture state, so later tests failed during reset instead of running independently.

## Solution

- Wait for the existing streaming diagnostics readiness signal before publishing.
- Scope counters and release gates to a unique delivery run carried in each test payload.
- Always release blocked callbacks and unsubscribe the concurrency-test streams in `finally`.
- Cover cleanup by releasing a blocked run, sending a stale payload, and verifying the next run observes only its own delivery.

## Rationale

The workflow failed on attempts 1 and 2 and passed on attempt 3 without a streaming code change, while stateless-worker selection records queued work synchronously. This identifies a test lifecycle race rather than a runtime activation or delivery regression. Explicit readiness and run-scoped state preserve the runtime assertions while making failure cleanup deterministic.

Fixes #10778
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10793)