### PR TITLE
fix(test): await reminder range reconciliation

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -31,6 +31,8 @@ namespace Orleans.Runtime.ReminderService
         private readonly TimeProvider _timeProvider;
         private readonly ReminderInstruments _reminderInstruments;
         private long localTableSequence;
+        private long rangeChangeGeneration;
+        private Task rangeChangeTask = Task.CompletedTask;
         private uint initialReadCallCount = 0;
         private Task? runTask;
         private readonly object _deliveryLock = new();
@@ -394,11 +396,54 @@ namespace Orleans.Runtime.ReminderService
             CheckRuntimeContext();
 
             _ = base.OnRangeChange(oldRange, newRange, increased);
-            if (Status == GrainServiceStatus.Started)
-                return ReadAndUpdateReminders();
-            LogIgnoringRangeChange(Status);
-            return Task.CompletedTask;
+            var task = Status == GrainServiceStatus.Started
+                ? ReadAndUpdateReminders()
+                : Task.CompletedTask;
+            if (Status != GrainServiceStatus.Started)
+            {
+                LogIgnoringRangeChange(Status);
+            }
+
+            rangeChangeGeneration++;
+            rangeChangeTask = rangeChangeTask.IsCompletedSuccessfully
+                ? task
+                : Task.WhenAll(rangeChangeTask, task);
+            return task;
         }
+
+        internal async Task TestOnlyWaitForRangeChangeReconciliation()
+        {
+            while (true)
+            {
+                // Range-change turns can overlap after yielding to storage. Await every observed turn,
+                // then verify that no newer generation started while those reads were completing.
+                long observedGeneration = 0;
+                Task observedTask = Task.CompletedTask;
+                await this.QueueTask(() =>
+                {
+                    observedGeneration = rangeChangeGeneration;
+                    observedTask = rangeChangeTask;
+                    return Task.CompletedTask;
+                });
+
+                await observedTask;
+
+                var isCurrentGeneration = false;
+                await this.QueueTask(() =>
+                {
+                    isCurrentGeneration = observedGeneration == rangeChangeGeneration;
+                    return Task.CompletedTask;
+                });
+
+                if (isCurrentGeneration)
+                {
+                    return;
+                }
+            }
+        }
+
+        internal Task TestOnlyChangeRange(IRingRange oldRange, IRingRange newRange, bool increased)
+            => this.QueueTask(() => OnRangeChange(oldRange, newRange, increased));
 
         private async Task RunAsync()
         {

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -411,7 +411,7 @@ namespace Orleans.Runtime.ReminderService
             return task;
         }
 
-        internal async Task TestOnlyWaitForRangeChangeReconciliation()
+        internal async Task TestOnlyWaitForRangeChangeReconciliation(CancellationToken cancellationToken)
         {
             while (true)
             {
@@ -424,16 +424,16 @@ namespace Orleans.Runtime.ReminderService
                     observedGeneration = rangeChangeGeneration;
                     observedTask = rangeChangeTask;
                     return Task.CompletedTask;
-                });
+                }).WaitAsync(cancellationToken);
 
-                await observedTask;
+                await observedTask.WaitAsync(cancellationToken);
 
                 var isCurrentGeneration = false;
                 await this.QueueTask(() =>
                 {
                     isCurrentGeneration = observedGeneration == rangeChangeGeneration;
                     return Task.CompletedTask;
-                });
+                }).WaitAsync(cancellationToken);
 
                 if (isCurrentGeneration)
                 {

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -250,6 +250,48 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         Assert.True(reminderTable.RangeReadCount > 0);
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task RangeChangeBarrier_WaitsForReconciliation()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
+        var intermediateRange = RangeFactory.CreateRange(0, uint.MaxValue / 3);
+        var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
+        var firstReadGate = reminderTable.BlockNextRangeRead();
+        RangeReadGate? secondReadGate = null;
+        try
+        {
+            var firstRangeChangeTask = reminderService.TestOnlyChangeRange(oldRange, intermediateRange, increased: false);
+            await firstReadGate.WaitUntilBlockedAsync(cancellation.Token);
+
+            secondReadGate = reminderTable.BlockNextRangeRead();
+            var secondRangeChangeTask = reminderService.TestOnlyChangeRange(intermediateRange, newRange, increased: false);
+            await secondReadGate.WaitUntilBlockedAsync(cancellation.Token);
+
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation();
+            Assert.False(reconciliationTask.IsCompleted);
+
+            secondReadGate.Release();
+            await secondRangeChangeTask.WaitAsync(cancellation.Token);
+            Assert.False(reconciliationTask.IsCompleted);
+
+            firstReadGate.Release();
+            await Task.WhenAll(firstRangeChangeTask, reconciliationTask).WaitAsync(cancellation.Token);
+        }
+        finally
+        {
+            firstReadGate.Release();
+            secondReadGate?.Release();
+        }
+    }
+
     public sealed class Fixture : BaseInProcessTestClusterFixture
     {
         public ReminderDiagnosticObserver ReminderObserver { get; } = ReminderDiagnosticObserver.Create();
@@ -285,16 +327,34 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     private sealed class NullReturningReminderTable : IReminderTable
     {
         private int rangeReadCount;
+        private RangeReadGate? nextRangeRead;
 
         public int RangeReadCount => Volatile.Read(ref rangeReadCount);
 
+        public RangeReadGate BlockNextRangeRead()
+        {
+            var gate = new RangeReadGate();
+            if (Interlocked.CompareExchange(ref nextRangeRead, gate, null) is not null)
+            {
+                throw new InvalidOperationException("A range read is already blocked.");
+            }
+
+            return gate;
+        }
+
         public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
-        public Task<ReminderTableData> ReadRows(uint begin, uint end)
+        public async Task<ReminderTableData> ReadRows(uint begin, uint end)
         {
             Interlocked.Increment(ref rangeReadCount);
+            if (Interlocked.Exchange(ref nextRangeRead, null) is { } gate)
+            {
+                gate.MarkBlocked();
+                await gate.WaitForReleaseAsync();
+            }
+
             // Simulate a provider binary compiled before the return value was annotated as non-null.
-            return Task.FromResult<ReminderTableData>(null!);
+            return null!;
         }
 
         public Task<ReminderTableData> ReadRows(GrainId grainId) => throw new NotSupportedException();
@@ -306,5 +366,19 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         public Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag) => throw new NotSupportedException();
 
         public Task TestOnlyClearTable() => throw new NotSupportedException();
+    }
+
+    private sealed class RangeReadGate
+    {
+        private readonly TaskCompletionSource blocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void MarkBlocked() => blocked.TrySetResult();
+
+        public Task WaitUntilBlockedAsync(CancellationToken cancellationToken) => blocked.Task.WaitAsync(cancellationToken);
+
+        public Task WaitForReleaseAsync() => release.Task;
+
+        public void Release() => release.TrySetResult();
     }
 }

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -275,7 +275,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             var secondRangeChangeTask = reminderService.TestOnlyChangeRange(intermediateRange, newRange, increased: false);
             await secondReadGate.WaitUntilBlockedAsync(cancellation.Token);
 
-            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation();
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
             Assert.False(reconciliationTask.IsCompleted);
 
             secondReadGate.Release();

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -292,6 +292,41 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         }
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task RangeChangeBarrier_StopsWaitingWhenCanceled()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
+        var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
+        var readGate = reminderTable.BlockNextRangeRead();
+        try
+        {
+            var rangeChangeTask = reminderService.TestOnlyChangeRange(oldRange, newRange, increased: false);
+            await readGate.WaitUntilBlockedAsync(cancellation.Token);
+
+            using var barrierCancellation = new CancellationTokenSource();
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(barrierCancellation.Token);
+            Assert.False(reconciliationTask.IsCompleted);
+
+            barrierCancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => reconciliationTask);
+
+            readGate.Release();
+            await rangeChangeTask.WaitAsync(cancellation.Token);
+        }
+        finally
+        {
+            readGate.Release();
+        }
+    }
+
     public sealed class Fixture : BaseInProcessTestClusterFixture
     {
         public ReminderDiagnosticObserver ReminderObserver { get; } = ReminderDiagnosticObserver.Create();

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -323,6 +323,10 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         await Task.WhenAll(
             Task.WhenAll(reminderServicesStarted),
             WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
+        // Membership convergence does not await the reminder services' queued range-change reconciliation.
+        var rangeChangeReconciliations = HostedCluster.GetActiveSilos().Select(silo =>
+            silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyWaitForRangeChangeReconciliation());
+        await Task.WhenAll(rangeChangeReconciliations).WaitAsync(cancellationToken);
         return result;
     }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -325,8 +325,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
         // Membership convergence does not await the reminder services' queued range-change reconciliation.
         var rangeChangeReconciliations = HostedCluster.GetActiveSilos().Select(silo =>
-            silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyWaitForRangeChangeReconciliation());
-        await Task.WhenAll(rangeChangeReconciliations).WaitAsync(cancellationToken);
+            silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
+        await Task.WhenAll(rangeChangeReconciliations);
         return result;
     }
 


### PR DESCRIPTION
## Problem

The deterministic reminder join helper waits for membership, gateway, grain-directory, and reminder-service startup convergence, but that does not await the `LocalReminderService` range-change reconciliation queued by the topology change. The next forced refresh can therefore overlap the still-running range read on the same service scheduler and consume the shared churn deadline.

This gap remained after #10612 added explicit refresh barriers, #10665 serialized them, #10666 re-enabled the test, and #10709 restored fixture topology.

## Solution

Track every in-flight reminder range-change reconciliation and expose a test-only barrier which waits for all observed generations to complete. The join helper now awaits that barrier on every active silo while reminder time remains paused, before schedule synchronization or clock advancement resumes.

Add a controlled interleaving test which blocks two overlapping range reads, completes the newer one first, and verifies that the barrier continues waiting for the older reconciliation.

## Rationale

This establishes the missing topology boundary without increasing timeouts or weakening exact owner and tick assertions. Reconciliation failures continue to propagate instead of being hidden by a later forced refresh.

Fixes #10781
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10794)