### PR TITLE
fix(test): own SQL Server schema setup connection

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
@@ -193,7 +193,7 @@ namespace UnitTests.General
         /// <param name="setupScript">the script. usually CreateOrleansTables_xxxx.sql</param>
         /// <param name="dataBaseName">the target database to be populated</param>
         /// <returns></returns>
-        private async Task ExecuteSetupScript(string setupScript, string dataBaseName)
+        protected virtual async Task ExecuteSetupScript(string setupScript, string dataBaseName)
         {
             var splitScripts = ConvertToExecutableBatches(setupScript, dataBaseName);
             foreach (var script in splitScripts)

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -31,63 +31,64 @@ namespace UnitTests.General
 
         protected override async Task WaitForDatabaseReadyAsync()
         {
-            const int maxAttempts = 3;
             var databaseConnectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
             {
                 Pooling = false,
                 ConnectTimeout = 5
             };
 
-            for (var attempt = 1; ; attempt++)
-            {
-                try
-                {
-                    await using var connection = new SqlConnection(databaseConnectionStringBuilder.ConnectionString);
-                    await connection.OpenAsync();
-                    await using var command = connection.CreateCommand();
-                    command.CommandText = "SELECT 1";
-                    command.CommandTimeout = 5;
-                    _ = await command.ExecuteScalarAsync();
-                }
-                catch (SqlException exception) when (exception.Number == 18456 && exception.State == 1 && attempt < maxAttempts)
-                {
-                    await Task.Delay(TimeSpan.FromMilliseconds(250));
-                    continue;
-                }
+            await using var connection = new SqlConnection(databaseConnectionStringBuilder.ConnectionString);
+            await OpenConnectionAsync(connection);
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+            command.CommandTimeout = 5;
+            _ = await command.ExecuteScalarAsync();
+        }
 
-                break;
-            }
+        protected override Task ExecuteSetupScript(string setupScript, string dataBaseName) =>
+            ExecuteSetupScriptBatchesAsync(ConvertToExecutableBatches(setupScript, dataBaseName), dataBaseName);
 
-            // The first schema batch enables snapshot isolation and requires exclusive database access.
-            var administrativeConnectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
+        internal async Task ExecuteSetupScriptBatchesAsync(IEnumerable<string> scripts, string databaseName)
+        {
+            var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
             {
-                InitialCatalog = "master",
                 Pooling = false,
                 ConnectTimeout = 5
             };
 
-            await using var administrativeConnection = new SqlConnection(administrativeConnectionStringBuilder.ConnectionString);
-            await administrativeConnection.OpenAsync();
-            await using var readinessCommand = administrativeConnection.CreateCommand();
-            readinessCommand.CommandText = """
-                DECLARE @DatabaseId INT = DB_ID(@DatabaseName);
-                WHILE EXISTS
-                (
-                    SELECT 1
-                    FROM sys.dm_exec_sessions
-                    WHERE database_id = @DatabaseId
-                      AND session_id <> @@SPID
-                )
-                BEGIN
-                    WAITFOR DELAY '00:00:00.050';
-                END;
-                """;
-            readinessCommand.CommandTimeout = 30;
-            readinessCommand.Parameters.AddWithValue("DatabaseName", databaseConnectionStringBuilder.InitialCatalog);
-            await readinessCommand.ExecuteNonQueryAsync();
+            await using var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
+            await OpenConnectionAsync(connection);
+
+            using var commandBuilder = new SqlCommandBuilder();
+            var quotedDatabaseName = commandBuilder.QuoteIdentifier(databaseName);
+            var hasExclusiveAccess = false;
+            try
+            {
+                await ExecuteCommandAsync(
+                    connection,
+                    $"ALTER DATABASE {quotedDatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;");
+                hasExclusiveAccess = true;
+
+                foreach (var script in scripts)
+                {
+                    await ExecuteCommandAsync(connection, script);
+                }
+            }
+            finally
+            {
+                if (hasExclusiveAccess)
+                {
+                    await ExecuteCommandAsync(
+                        connection,
+                        $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;");
+
+                    using var pooledConnection = new SqlConnection(CurrentConnectionString);
+                    SqlConnection.ClearPool(pooledConnection);
+                }
+            }
         }
 
-        protected override async Task ExecuteSetupScriptBatchAsync(string script)
+        private static async Task OpenConnectionAsync(SqlConnection connection)
         {
             const int maxAttempts = 10;
 
@@ -95,16 +96,22 @@ namespace UnitTests.General
             {
                 try
                 {
-                    await base.ExecuteSetupScriptBatchAsync(script);
+                    await connection.OpenAsync();
                     return;
                 }
                 catch (SqlException exception) when (exception.Number == 18456 && exception.State == 1 && attempt < maxAttempts)
                 {
-                    using var connection = new SqlConnection(CurrentConnectionString);
                     SqlConnection.ClearPool(connection);
                     await Task.Delay(TimeSpan.FromMilliseconds(500));
                 }
             }
+        }
+
+        private static async Task ExecuteCommandAsync(SqlConnection connection, string script)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = script;
+            await command.ExecuteNonQueryAsync();
         }
 
         public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -79,12 +79,20 @@ public class SqlServerStorageForTestingTests
                 await using var command = connection.CreateCommand();
                 command.CommandText = "SELECT 1";
                 _ = await command.ExecuteScalarAsync(cancellationToken);
+                await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
             }
             catch (SqlException)
             {
                 if (!cancellationToken.IsCancellationRequested)
                 {
-                    await Task.Delay(TimeSpan.FromMilliseconds(10));
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -28,4 +28,68 @@ public class SqlServerStorageForTestingTests
             storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName);
         }
     }
+
+    [Fact]
+    public async Task SetupOwnsSingleUserSlotWhileApplyingSchema()
+    {
+        var storage = Assert.IsType<SqlServerStorageForTesting>(
+            await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName));
+        await using var competingConnection = new SqlConnection(storage.CurrentConnectionString);
+        await competingConnection.OpenAsync();
+        using var cancellation = new CancellationTokenSource();
+        var reconnectingClient = ReconnectUntilCanceledAsync(storage.CurrentConnectionString, cancellation.Token);
+
+        try
+        {
+            await storage.ExecuteSetupScriptBatchesAsync(
+                [
+                    $"""
+                    ALTER DATABASE [{TestDatabaseName}] SET READ_COMMITTED_SNAPSHOT OFF;
+                    ALTER DATABASE [{TestDatabaseName}] SET READ_COMMITTED_SNAPSHOT ON;
+                    """
+                ],
+                TestDatabaseName);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            await reconnectingClient;
+        }
+
+        var databaseState = await storage.Storage.ReadAsync(
+            """
+            SELECT user_access_desc, is_read_committed_snapshot_on
+            FROM sys.databases
+            WHERE name = @DatabaseName
+            """,
+            command => command.AddParameter("DatabaseName", TestDatabaseName),
+            (record, _, _) => Task.FromResult((record.GetString(0), record.GetBoolean(1))));
+
+        Assert.Equal(("MULTI_USER", true), Assert.Single(databaseState));
+    }
+
+    private static async Task ReconnectUntilCanceledAsync(string connectionString, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await using var connection = new SqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken);
+                await using var command = connection.CreateCommand();
+                command.CommandText = "SELECT 1";
+                _ = await command.ExecuteScalarAsync(cancellationToken);
+            }
+            catch (SqlException)
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(10));
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #10788.

SQL Server schema initialization first checked that the recreated database had no sessions, then opened a separate pooled connection for the schema script. A stale stream connection could re-enter in that gap and block the first batch while it enabled `READ_COMMITTED_SNAPSHOT`, producing the recurring 30-second setup timeout before the dropped-client test body ran.

Run SQL Server setup batches through one non-pooled target-database connection. That connection claims `SINGLE_USER` with rollback-immediate, remains the sole database user while every schema batch executes, restores `MULTI_USER` without leaving the database, and clears connections invalidated by the transition. The regression test keeps a competing client reconnecting while snapshot isolation is applied, proving setup owns the required exclusive-access boundary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10803)