### PR TITLE
test(streaming): cover first production during deactivation

### DIFF
--- a/test/Grains/TestGrainInterfaces/IStreamLifecycleTestGrains.cs
+++ b/test/Grains/TestGrainInterfaces/IStreamLifecycleTestGrains.cs
@@ -12,6 +12,7 @@ namespace UnitTests.GrainInterfaces
         Task BecomeConsumer(StreamId streamId, string providerName);
         Task TestBecomeConsumerSlim(StreamId streamId, string providerName);
         Task RemoveConsumer(StreamId streamId, string providerName, StreamSubscriptionHandle<int> consumerHandle);
+        Task ProduceOnDeactivate(StreamId streamId, string providerName);
         Task ClearGrain();
     }
 

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -150,6 +150,7 @@ namespace UnitTests.Grains
     [Orleans.Providers.StorageProvider(ProviderName = "MemoryStore")]
     internal class StreamLifecycleConsumerGrain : StreamLifecycleTestGrainBase, IStreamLifecycleConsumerGrain
     {
+        private IAsyncStream<int>? _deactivationStream;
         protected readonly InsideRuntimeClient runtimeClient;
         protected readonly IStreamProviderRuntime streamProviderRuntime;
 
@@ -194,6 +195,12 @@ namespace UnitTests.Grains
         public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("OnDeactivateAsync");
+
+            if (_deactivationStream is not null)
+            {
+                await _deactivationStream.OnNextAsync(1);
+            }
+
             await RecordDeactivate();
         }
 
@@ -253,6 +260,18 @@ namespace UnitTests.Grains
             Observers.Remove(subsHandle);
             State.ConsumerSubscriptionHandles.Remove(subsHandle);
             await WriteStateAsync();
+        }
+
+        public Task ProduceOnDeactivate(StreamId streamId, string providerName)
+        {
+            if (State.Stream is null)
+            {
+                throw new InvalidOperationException("Not a Consumer");
+            }
+
+            _deactivationStream = this.GetStreamProvider(providerName).GetStream<int>(streamId);
+            DeactivateOnIdle();
+            return Task.CompletedTask;
         }
 
         public async Task ClearGrain()

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -204,6 +204,7 @@ namespace UnitTests.Grains
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
+                    // Cancellation is expected when shutdown interrupts deactivation.
                 }
             }
 

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -196,9 +196,15 @@ namespace UnitTests.Grains
         {
             if (logger.IsEnabled(LogLevel.Debug)) logger.LogDebug("OnDeactivateAsync");
 
-            if (_deactivationStream is not null)
+            if (_deactivationStream is not null && !cancellationToken.IsCancellationRequested)
             {
-                await _deactivationStream.OnNextAsync(1).WaitAsync(cancellationToken);
+                try
+                {
+                    await _deactivationStream.OnNextAsync(1).WaitAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                }
             }
 
             await RecordDeactivate();

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -198,7 +198,7 @@ namespace UnitTests.Grains
 
             if (_deactivationStream is not null)
             {
-                await _deactivationStream.OnNextAsync(1);
+                await _deactivationStream.OnNextAsync(1).WaitAsync(cancellationToken);
             }
 
             await RecordDeactivate();

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -5,6 +5,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.Hosting;
 using Orleans.Storage;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using UnitTests.StorageTests;
@@ -107,6 +108,42 @@ namespace UnitTests.StreamingTests
 
             var exception = await Assert.ThrowsAsync<StorageProviderInjectedError>(() =>
                 Test_PubSub_Stream(StreamProviderName, StreamId));
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
+        public async Task Produce_First_Stream_Item_During_Deactivation()
+        {
+            var subscribedStreamId = Orleans.Runtime.StreamId.Create(StreamNamespace, Guid.NewGuid());
+            var producedStreamId = Orleans.Runtime.StreamId.Create(StreamNamespace, Guid.NewGuid());
+            var receivingConsumer = GrainFactory.GetGrain<IStreamLifecycleConsumerGrain>(Guid.NewGuid());
+            await receivingConsumer.BecomeConsumer(producedStreamId, StreamProviderName);
+
+            var deactivatingConsumer = GrainFactory.GetGrain<IStreamLifecycleConsumerGrain>(Guid.NewGuid());
+            await deactivatingConsumer.BecomeConsumer(subscribedStreamId, StreamProviderName);
+
+            using var observer = StreamingDiagnosticObserver.Create();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var deliveryTask = observer.WaitForItemDeliveryCountAsync(producedStreamId, 1, StreamProviderName, cts.Token);
+
+            await deactivatingConsumer.ProduceOnDeactivate(producedStreamId, StreamProviderName);
+            await deliveryTask;
+
+            Assert.Equal(1, await receivingConsumer.GetReceivedCount());
+
+            var managementGrain = GrainFactory.GetGrain<IManagementGrain>(0);
+            await TestingUtils.WaitUntilAsync(
+                async (lastTry, cancellationToken) =>
+                {
+                    var activationCount = await managementGrain.GetGrainActivationCount((GrainReference)deactivatingConsumer);
+                    if (lastTry)
+                    {
+                        Assert.Equal(0, activationCount);
+                    }
+
+                    return activationCount == 0;
+                },
+                TimeSpan.FromSeconds(30),
+                delayOnFail: TimeSpan.FromMilliseconds(100));
         }
 
         private async Task Test_PubSub_Stream(string streamProviderName, Guid streamId)

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -5,7 +5,6 @@ using Orleans.Runtime;
 using Orleans.Runtime.Hosting;
 using Orleans.Storage;
 using Orleans.TestingHost;
-using Orleans.TestingHost.Utils;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using UnitTests.StorageTests;
@@ -121,29 +120,18 @@ namespace UnitTests.StreamingTests
             var deactivatingConsumer = GrainFactory.GetGrain<IStreamLifecycleConsumerGrain>(Guid.NewGuid());
             await deactivatingConsumer.BecomeConsumer(subscribedStreamId, StreamProviderName);
 
-            using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            var deliveryTask = observer.WaitForItemDeliveryCountAsync(producedStreamId, 1, StreamProviderName, cts.Token);
+            var timeout = TimeSpan.FromSeconds(30);
+            using var streamObserver = StreamingDiagnosticObserver.Create();
+            using var grainObserver = GrainDiagnosticObserver.Create();
+            using var cts = new CancellationTokenSource(timeout);
+            var deliveryTask = streamObserver.WaitForItemDeliveryCountAsync(producedStreamId, 1, StreamProviderName, cts.Token);
+            var deactivationTask = grainObserver.WaitForDeactivatedAsync(deactivatingConsumer, timeout);
 
             await deactivatingConsumer.ProduceOnDeactivate(producedStreamId, StreamProviderName);
             await deliveryTask;
+            await deactivationTask;
 
             Assert.Equal(1, await receivingConsumer.GetReceivedCount());
-
-            var managementGrain = GrainFactory.GetGrain<IManagementGrain>(0);
-            await TestingUtils.WaitUntilAsync(
-                async (lastTry, cancellationToken) =>
-                {
-                    var activationCount = await managementGrain.GetGrainActivationCount((GrainReference)deactivatingConsumer);
-                    if (lastTry)
-                    {
-                        Assert.Equal(0, activationCount);
-                    }
-
-                    return activationCount == 0;
-                },
-                TimeSpan.FromSeconds(30),
-                delayOnFail: TimeSpan.FromMilliseconds(100));
         }
 
         private async Task Test_PubSub_Stream(string streamProviderName, Guid streamId)


### PR DESCRIPTION
## Summary

Add a focused regression covering an activation which subscribes to one stream, then produces to another stream for the first time from OnDeactivateAsync.

The test verifies that the item is delivered and that activation disposal completes, covering the producer initialization and stream-resource cleanup ordering raised in #1830.

Related to #1830.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10811)