### PR TITLE
fix(test): await ReminderTestKit service startup

### DIFF
--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -48,11 +48,12 @@ public sealed class ReminderTestKitClusterIntegrationTests
     {
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
+        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var period = TimeSpan.FromMinutes(5);
@@ -93,11 +94,12 @@ public sealed class ReminderTestKitClusterIntegrationTests
     {
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
+        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
             await grain.RegisterReminderAsync("updated-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
@@ -125,11 +127,12 @@ public sealed class ReminderTestKitClusterIntegrationTests
     {
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
+        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
             oracle.SetAvailable(false);
@@ -174,7 +177,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -217,7 +220,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var timerLimit = TimeSpan.FromMilliseconds(0xfffffffe) + TimeSpan.FromMilliseconds(1);
@@ -267,7 +270,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = loadingWindow + TimeSpan.FromMinutes(1);
@@ -320,7 +323,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -374,7 +377,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await cluster.DeployAsync();
+            await DeployAndWaitForReminderServicesAsync(cluster, observer);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = TimeSpan.FromMinutes(10);
@@ -425,6 +428,18 @@ public sealed class ReminderTestKitClusterIntegrationTests
             await cluster.StopAllSilosAsync();
             await cluster.DisposeAsync();
         }
+    }
+
+    private static async Task DeployAndWaitForReminderServicesAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer)
+    {
+        await cluster.DeployAsync();
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var started = cluster.Silos.Select(silo =>
+            observer.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress));
+        await Task.WhenAll(started);
     }
 
     private static async Task AdvanceUntilAsync(


### PR DESCRIPTION
## Problem

The new ReminderTestKit cluster integration tests begin reminder operations immediately after `InProcessTestCluster.DeployAsync`. Deployment makes the silo available before `LocalReminderService` has necessarily completed its background initial range read. Under full BVT load, registration can therefore wait for service initialization until the client response timeout expires. This produced the same failure on Linux/net10.0 and Windows/net8.0.

## Solution

Wait for the existing `ReminderServiceStarted` diagnostic event from every silo before each cluster integration test performs reminder operations. A shared helper applies the readiness boundary consistently to the basic, fake-clock, stale-refresh, recovery, and multi-silo scenarios.

## Rationale

The tests depend on a started reminder service, and the runtime already emits an explicit readiness event for that invariant. Awaiting that event removes the startup race while preserving the exact stale-refresh interleaving and runtime behavior.

Fixes #10801
Fixes #10820
Fixes #10821
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10813)