### PR TITLE
fix(test): ignore superseded reminder reconciliations

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -405,9 +405,9 @@ namespace Orleans.Runtime.ReminderService
             }
 
             rangeChangeGeneration++;
-            rangeChangeTask = rangeChangeTask.IsCompletedSuccessfully
-                ? task
-                : Task.WhenAll(rangeChangeTask, task);
+            // A newer refresh advances localTableSequence before yielding, so older results cannot
+            // change local schedules after the latest reconciliation completes.
+            rangeChangeTask = task;
             return task;
         }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -253,7 +253,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
-    public async Task RangeChangeBarrier_WaitsForReconciliation()
+    public async Task RangeChangeBarrier_DoesNotWaitForSupersededReconciliation()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
@@ -279,11 +279,11 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             Assert.False(reconciliationTask.IsCompleted);
 
             secondReadGate.Release();
-            await secondRangeChangeTask.WaitAsync(cancellation.Token);
-            Assert.False(reconciliationTask.IsCompleted);
+            await Task.WhenAll(secondRangeChangeTask, reconciliationTask).WaitAsync(cancellation.Token);
+            Assert.False(firstRangeChangeTask.IsCompleted);
 
             firstReadGate.Release();
-            await Task.WhenAll(firstRangeChangeTask, reconciliationTask).WaitAsync(cancellation.Token);
+            await firstRangeChangeTask.WaitAsync(cancellation.Token);
         }
         finally
         {

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -165,8 +165,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         IReminderTestGrain2 g3 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
         using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
-        InProcessSiloHandle? additionalSilo = null;
+        Task<List<InProcessSiloHandle>>? startSilosTask = null;
         try
         {
             await Test_Reminders_MultiGrainMultiReminders(
@@ -175,10 +176,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                     await using (await PauseReminderTimeAsync(cancellationToken))
                     {
                         log.LogInformation("Starting another silo");
-                        additionalSilo = Assert.Single(await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
-                            1,
-                            cancellationToken,
-                            startAdditionalSiloOnNewPort: true));
+                        startSilosTask = StartAdditionalSilosAsync(1, startAdditionalSiloOnNewPort: true);
+                        var additionalSilos = await WaitForAdditionalSilosAndReminderServicesAsync(startSilosTask, cancellationToken);
+                        _ = Assert.Single(additionalSilos);
                     }
                 },
                 cts.Token,
@@ -190,12 +190,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            if (additionalSilo is not null)
-            {
-                using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
-                await StopSiloAsync(additionalSilo).WaitAsync(cleanupCts.Token);
-                await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
-            }
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
         }
     }
 
@@ -230,28 +225,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            if (startSilosTask is not null)
-            {
-                try
-                {
-                    using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
-                    await startSilosTask.WaitAsync(startupCompletionCts.Token);
-                }
-                catch (Exception exception)
-                {
-                    log.LogInformation(exception, "Additional silo startup did not complete successfully before cleanup.");
-                }
-
-                var additionalSilos = HostedCluster.GetActiveSilos()
-                    .Where(silo => !initialSilos.Contains(silo))
-                    .ToArray();
-                if (additionalSilos.Length > 0)
-                {
-                    using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
-                    await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
-                    await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
-                }
-            }
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
         }
     }
 
@@ -328,6 +302,38 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
         await Task.WhenAll(rangeChangeReconciliations);
         return result;
+    }
+
+    private async Task CleanupAdditionalSilosAsync(
+        HashSet<InProcessSiloHandle> initialSilos,
+        Task<List<InProcessSiloHandle>>? startSilosTask)
+    {
+        if (startSilosTask is null)
+        {
+            return;
+        }
+
+        try
+        {
+            using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
+            await startSilosTask.WaitAsync(startupCompletionCts.Token);
+        }
+        catch (Exception exception)
+        {
+            log.LogInformation(exception, "Additional silo startup did not complete successfully before cleanup.");
+        }
+
+        var additionalSilos = HostedCluster.GetActiveSilos()
+            .Where(silo => !initialSilos.Contains(silo))
+            .ToArray();
+        if (additionalSilos.Length == 0)
+        {
+            return;
+        }
+
+        using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
+        await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
+        await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
     }
 
     protected async Task<InProcessSiloHandle> StopSiloAndStartAdditionalSiloAsync(


### PR DESCRIPTION
## Problem

The range-change barrier introduced by #10794 retained every overlapping reconciliation task. A superseded storage read could therefore hold the join test until its five-minute churn deadline even after the latest reconciliation completed. If that wait failed, the one-join scenario also lost the started silo handle and left the shared fixture with an extra active silo.

## Solution

Track only the latest range-change reconciliation. Each newer refresh advances `localTableSequence` before yielding, so older results are discarded and cannot change schedules after the latest generation completes.

Update the controlled interleaving test to verify that the barrier completes when the latest reconciliation finishes while an older read remains blocked. Reuse topology-based cleanup for one- and two-join scenarios so every silo added by a failed startup/readiness attempt is stopped.

## Rationale

The readiness boundary now matches the runtime invariant: the latest completed reconciliation establishes current ownership, while superseded reads are non-authoritative. Cleanup restores the fixture topology independently of where startup or reconciliation fails.

Fixes #10810
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10814)