### PR TITLE
fix(test): follow latest reminder reconciliation

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -32,6 +32,7 @@ namespace Orleans.Runtime.ReminderService
         private readonly ReminderInstruments _reminderInstruments;
         private long localTableSequence;
         private long rangeChangeGeneration;
+        private TaskCompletionSource rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private Task rangeChangeTask = Task.CompletedTask;
         private uint initialReadCallCount = 0;
         private Task? runTask;
@@ -404,10 +405,11 @@ namespace Orleans.Runtime.ReminderService
                 LogIgnoringRangeChange(Status);
             }
 
+            var previousGenerationChanged = rangeChangeGenerationChanged;
+            rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
             rangeChangeGeneration++;
-            rangeChangeTask = rangeChangeTask.IsCompletedSuccessfully
-                ? task
-                : Task.WhenAll(rangeChangeTask, task);
+            rangeChangeTask = task;
+            previousGenerationChanged.TrySetResult();
             return task;
         }
 
@@ -415,18 +417,20 @@ namespace Orleans.Runtime.ReminderService
         {
             while (true)
             {
-                // Range-change turns can overlap after yielding to storage. Await every observed turn,
-                // then verify that no newer generation started while those reads were completing.
+                // A newer refresh supersedes older results through localTableSequence. Follow generation
+                // changes so a stalled obsolete read does not block the current reconciliation.
                 long observedGeneration = 0;
                 Task observedTask = Task.CompletedTask;
+                Task observedGenerationChanged = Task.CompletedTask;
                 await this.QueueTask(() =>
                 {
                     observedGeneration = rangeChangeGeneration;
                     observedTask = rangeChangeTask;
+                    observedGenerationChanged = rangeChangeGenerationChanged.Task;
                     return Task.CompletedTask;
                 }).WaitAsync(cancellationToken);
 
-                await observedTask.WaitAsync(cancellationToken);
+                await Task.WhenAny(observedTask, observedGenerationChanged).WaitAsync(cancellationToken);
 
                 var isCurrentGeneration = false;
                 await this.QueueTask(() =>
@@ -437,6 +441,7 @@ namespace Orleans.Runtime.ReminderService
 
                 if (isCurrentGeneration)
                 {
+                    await observedTask.WaitAsync(cancellationToken);
                     return;
                 }
             }

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -253,7 +253,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
-    public async Task RangeChangeBarrier_WaitsForReconciliation()
+    public async Task RangeChangeBarrier_FollowsLatestReconciliation()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
@@ -271,19 +271,20 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             var firstRangeChangeTask = reminderService.TestOnlyChangeRange(oldRange, intermediateRange, increased: false);
             await firstReadGate.WaitUntilBlockedAsync(cancellation.Token);
 
-            secondReadGate = reminderTable.BlockNextRangeRead();
-            var secondRangeChangeTask = reminderService.TestOnlyChangeRange(intermediateRange, newRange, increased: false);
-            await secondReadGate.WaitUntilBlockedAsync(cancellation.Token);
-
             var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
             Assert.False(reconciliationTask.IsCompleted);
 
-            secondReadGate.Release();
-            await secondRangeChangeTask.WaitAsync(cancellation.Token);
+            secondReadGate = reminderTable.BlockNextRangeRead();
+            var secondRangeChangeTask = reminderService.TestOnlyChangeRange(intermediateRange, newRange, increased: false);
+            await secondReadGate.WaitUntilBlockedAsync(cancellation.Token);
             Assert.False(reconciliationTask.IsCompleted);
 
+            secondReadGate.Release();
+            await Task.WhenAll(secondRangeChangeTask, reconciliationTask).WaitAsync(cancellation.Token);
+            Assert.False(firstRangeChangeTask.IsCompleted);
+
             firstReadGate.Release();
-            await Task.WhenAll(firstRangeChangeTask, reconciliationTask).WaitAsync(cancellation.Token);
+            await firstRangeChangeTask.WaitAsync(cancellation.Token);
         }
         finally
         {

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -165,8 +165,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         IReminderTestGrain2 g3 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
         using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
-        InProcessSiloHandle? additionalSilo = null;
+        Task<List<InProcessSiloHandle>>? startSilosTask = null;
         try
         {
             await Test_Reminders_MultiGrainMultiReminders(
@@ -175,10 +176,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                     await using (await PauseReminderTimeAsync(cancellationToken))
                     {
                         log.LogInformation("Starting another silo");
-                        additionalSilo = Assert.Single(await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
-                            1,
-                            cancellationToken,
-                            startAdditionalSiloOnNewPort: true));
+                        startSilosTask = StartAdditionalSilosAsync(1, startAdditionalSiloOnNewPort: true);
+                        var additionalSilos = await WaitForAdditionalSilosAndReminderServicesAsync(startSilosTask, cancellationToken);
+                        _ = Assert.Single(additionalSilos);
                     }
                 },
                 cts.Token,
@@ -190,12 +190,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            if (additionalSilo is not null)
-            {
-                using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
-                await StopSiloAsync(additionalSilo).WaitAsync(cleanupCts.Token);
-                await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
-            }
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
         }
     }
 
@@ -230,28 +225,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            if (startSilosTask is not null)
-            {
-                try
-                {
-                    using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
-                    await startSilosTask.WaitAsync(startupCompletionCts.Token);
-                }
-                catch (Exception exception)
-                {
-                    log.LogInformation(exception, "Additional silo startup did not complete successfully before cleanup.");
-                }
-
-                var additionalSilos = HostedCluster.GetActiveSilos()
-                    .Where(silo => !initialSilos.Contains(silo))
-                    .ToArray();
-                if (additionalSilos.Length > 0)
-                {
-                    using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
-                    await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
-                    await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
-                }
-            }
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
         }
     }
 
@@ -328,6 +302,38 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
         await Task.WhenAll(rangeChangeReconciliations);
         return result;
+    }
+
+    private async Task CleanupAdditionalSilosAsync(
+        HashSet<InProcessSiloHandle> initialSilos,
+        Task<List<InProcessSiloHandle>>? startSilosTask)
+    {
+        if (startSilosTask is null)
+        {
+            return;
+        }
+
+        try
+        {
+            using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
+            await startSilosTask.WaitAsync(startupCompletionCts.Token);
+        }
+        catch (Exception exception)
+        {
+            log.LogInformation(exception, "Additional silo startup did not complete successfully before cleanup.");
+        }
+
+        var additionalSilos = HostedCluster.GetActiveSilos()
+            .Where(silo => !initialSilos.Contains(silo))
+            .ToArray();
+        if (additionalSilos.Length == 0)
+        {
+            return;
+        }
+
+        using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
+        await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
+        await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
     }
 
     protected async Task<InProcessSiloHandle> StopSiloAndStartAdditionalSiloAsync(


### PR DESCRIPTION
## Problem

#10794 made the reminder join barrier await every historical range-change read. A newer refresh already supersedes older results through `localTableSequence`, but a stalled obsolete provider or cluster request remained in the barrier's task chain and could consume the full churn deadline.

In the one-join in-memory scenario, a reconciliation timeout also occurred before the started silo handle was assigned. The additional silo remained active and contaminated the shared fixture, producing cascading setup and readiness failures.

## Solution

Track the current range-change reconciliation and signal generation changes. The barrier now follows a newer generation immediately, waits for the latest reconciliation to finish, and still propagates failures from the current generation.

Update the controlled interleaving test to keep an older range read blocked while a newer reconciliation completes, proving that obsolete work no longer prevents readiness.

Retain each join startup task and clean up every silo added after the initial topology, even when startup or reconciliation fails before the helper returns. The one- and two-join scenarios share the same cleanup path.

## Rationale

This aligns the test barrier with the reminder service's existing supersession invariant while preserving exact ownership and schedule synchronization. Topology restoration is now independent of where the join readiness sequence fails.

Fixes #10804
Fixes #10805
Fixes #10810