### PR TITLE
fix(docs): remove recovered NuGet links from allowlist

### DIFF
--- a/docs/site/src/data/external-link-allowlist.json
+++ b/docs/site/src/data/external-link-allowlist.json
@@ -9,12 +9,6 @@
     "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html": "AWS serves this public CLI configuration page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/sdk-for-net/v4/developer-guide/creds-assign.html": "AWS serves this public SDK credential-resolution page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/streams/latest/dev/introduction.html": "AWS serves this public Kinesis overview to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Firestore": "The new Firestore clustering package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.Firestore": "The new Firestore grain-directory package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.Journaling.Redis": "The new Redis journaling package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.Persistence.Firestore": "The new Firestore persistence package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Firestore": "The new Firestore reminders package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
-    "https://www.nuget.org/packages/Microsoft.Orleans.Streaming.Kinesis": "The new Kinesis streaming package is documented but not yet published; remove this entry and its unpublished API-package entry after publication.",
     "https://en.wikipedia.org/wiki/Kalman_filter": "Wikipedia serves this public article to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://www.f5.com/company/blog/nginx/nginx-power-of-two-choices-load-balancing-algorithm": "The F5 site serves this canonical NGINX article to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403."
   }

--- a/docs/site/src/data/unpublished-api-packages.json
+++ b/docs/site/src/data/unpublished-api-packages.json
@@ -1,11 +1,4 @@
 {
   "description": "Generated API assemblies which are not currently published as standalone NuGet packages.",
-  "packages": {
-    "Microsoft.Orleans.Clustering.Firestore": "The new provider is awaiting its first NuGet publication.",
-    "Microsoft.Orleans.GrainDirectory.Firestore": "The new provider is awaiting its first NuGet publication.",
-    "Microsoft.Orleans.Journaling.Redis": "The new provider is awaiting its first NuGet publication.",
-    "Microsoft.Orleans.Persistence.Firestore": "The new provider is awaiting its first NuGet publication.",
-    "Microsoft.Orleans.Reminders.Firestore": "The new provider is awaiting its first NuGet publication.",
-    "Microsoft.Orleans.Streaming.Kinesis": "The new provider is awaiting its first NuGet publication."
-  }
+  "packages": {}
 }

--- a/docs/site/src/lib/api/packages.ts
+++ b/docs/site/src/lib/api/packages.ts
@@ -95,8 +95,11 @@ export function markdownCompanionPath(route: string): string {
   return `${route.replace(/\/$/, '')}.md`;
 }
 
-export function nugetHref(packageName: string): string | undefined {
-  if (Object.hasOwn(unpublishedApiPackages.packages, packageName)) {
+export function nugetHref(
+  packageName: string,
+  unpublishedPackages: Readonly<Record<string, string>> = unpublishedApiPackages.packages,
+): string | undefined {
+  if (Object.hasOwn(unpublishedPackages, packageName)) {
     return undefined;
   }
   return `https://www.nuget.org/packages/${encodeURIComponent(packageName)}`;

--- a/docs/site/tests/api-markdown.test.ts
+++ b/docs/site/tests/api-markdown.test.ts
@@ -14,9 +14,9 @@ import {
   buildTypeSignature,
   memberDisplayName,
   memberSlug,
+  nugetHref,
 } from '../src/lib/api/packages';
 import type { PackageApiDocument } from '../src/lib/api/types';
-import unpublishedApiPackages from '../src/data/unpublished-api-packages.json';
 
 const pkg = fixture as PackageApiDocument;
 const grain = pkg.types[0];
@@ -51,15 +51,14 @@ describe('native API Markdown companions', () => {
   });
 
   test('omits NuGet links only for explicitly unpublished API assemblies', () => {
-    const unpublished = structuredClone(pkg);
-    const unpublishedPackage = Object.keys(unpublishedApiPackages.packages).at(0);
-    if (!unpublishedPackage) throw new Error('Expected an unpublished API package fixture.');
-    unpublished.package.name = unpublishedPackage;
+    const unpublishedPackage = 'Microsoft.Orleans.UnpublishedFixture';
 
-    expect(renderPackageMarkdown(unpublished)).not.toContain(
-      `https://www.nuget.org/packages/${unpublishedPackage}`,
-    );
-    expect(renderTypeMarkdown(unpublished, unpublished.types[0])).not.toContain(
+    expect(
+      nugetHref(unpublishedPackage, {
+        [unpublishedPackage]: 'Test fixture.',
+      }),
+    ).toBeUndefined();
+    expect(nugetHref(unpublishedPackage, {})).toBe(
       `https://www.nuget.org/packages/${unpublishedPackage}`,
     );
   });


### PR DESCRIPTION
Fixes #10816

Six NuGet package pages are now published and return HTTP 200. Remove their temporary exact-URL exemptions so the documentation link audit treats them as ordinary reachable external links and no longer fails on stale allowlist entries.