### PR TITLE
fix(reminders): always start the first retry attempt

### DIFF
--- a/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
@@ -96,15 +96,16 @@ internal static class ReminderTableRetryPolicy
         while (true)
         {
             var remaining = timeout - stopwatch.Elapsed;
-            if (remaining <= TimeSpan.Zero)
+            if (attempts > 0 && remaining <= TimeSpan.Zero)
             {
                 ThrowTimeout();
             }
 
+            attempts++;
             try
             {
-                var value = await operation().WaitAsync(remaining);
-                attempts++;
+                var attempt = operation();
+                var value = await attempt.WaitAsync(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
                 lastException = null;
                 lastObservation = describe(value);
                 if (succeeded(value))
@@ -115,7 +116,6 @@ internal static class ReminderTableRetryPolicy
             }
             catch (Exception exception) when (exception is not ReminderConformanceException)
             {
-                attempts++;
                 lastException = exception;
             }
 

--- a/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
@@ -105,7 +105,14 @@ internal static class ReminderTableRetryPolicy
             try
             {
                 var attempt = operation();
-                var value = await attempt.WaitAsync(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
+                remaining = timeout - stopwatch.Elapsed;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    lastException = new TimeoutException("The retry timeout elapsed while starting the operation.");
+                    ThrowTimeout();
+                }
+
+                var value = await attempt.WaitAsync(remaining);
                 lastException = null;
                 lastObservation = describe(value);
                 if (succeeded(value))

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
@@ -147,6 +147,35 @@ public class ReminderTableRetryPolicyTests
         Assert.Contains("Last exception: System.TimeoutException", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task UniformPolicy_EnforcesDeadlineAfterStartingFirstAttempt()
+    {
+        var invocations = 0;
+
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(() =>
+            ReminderTableRetryPolicy.ExecuteUntilAsync(
+                () =>
+                {
+                    invocations++;
+                    Thread.Sleep(TimeSpan.FromMilliseconds(20));
+                    return Task.FromResult("late-success");
+                },
+                _ => true,
+                "DelayedStart",
+                "ReadGuarantee",
+                "ReadRow",
+                "a result within the deadline",
+                value => value,
+                "read convergence",
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(5)));
+
+        Assert.Equal(1, invocations);
+        Assert.Contains("attempts=1", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Last observation: <no completed attempt>", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Last exception: System.TimeoutException", exception.Message, StringComparison.Ordinal);
+    }
+
     private sealed class TestRunner(IReminderTable table, string providerName)
         : ReminderTableTestRunner(table, providerName);
 

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
@@ -123,10 +123,15 @@ public class ReminderTableRetryPolicyTests
     public async Task UniformPolicy_HardBoundsTheFirstAttempt()
     {
         var never = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var invocations = 0;
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(() =>
             ReminderTableRetryPolicy.ExecuteUntilAsync(
-                () => never.Task,
+                () =>
+                {
+                    invocations++;
+                    return never.Task;
+                },
                 _ => true,
                 "Blocked",
                 "ReadGuarantee",
@@ -134,9 +139,10 @@ public class ReminderTableRetryPolicyTests
                 "a completed read",
                 value => value,
                 "read convergence",
-                TimeSpan.FromMilliseconds(40),
+                TimeSpan.FromTicks(1),
                 TimeSpan.FromMilliseconds(5)));
 
+        Assert.Equal(1, invocations);
         Assert.Contains("attempts=1", exception.Message, StringComparison.Ordinal);
         Assert.Contains("Last exception: System.TimeoutException", exception.Message, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Problem

The reminder TestKit retry policy starts its timeout stopwatch before entering the retry loop. Under scheduler pressure, a short deadline can expire before the first operation is invoked, producing a timeout diagnostic with `attempts=0` even though the policy is intended to hard-bound the first attempt.

## Solution

Always start and count the first operation, then apply the remaining deadline to its completion. Subsequent attempts continue to start only while time remains. The regression test uses a one-tick timeout and verifies that the blocked operation is invoked exactly once and reported as `attempts=1`.

## Rationale

Attempt diagnostics now consistently describe operations which were started. The retry deadline remains hard-bounded, while scheduler delays before the first invocation can no longer skip the first attempt or make its diagnostic nondeterministic.

Fixes #10812
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10819)