### PR TITLE
fix(test): retain SQL Server setup ownership

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -67,6 +67,7 @@ namespace UnitTests.General
                 return;
             }
 
+            var setupSucceeded = false;
             try
             {
                 await ExecuteCommandAsync(
@@ -77,12 +78,21 @@ namespace UnitTests.General
                 {
                     await ExecuteCommandAsync(connection, scriptEnumerator.Current);
                 }
+
+                setupSucceeded = true;
             }
             finally
             {
-                await ExecuteCommandAsync(
-                    connection,
-                    $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;");
+                try
+                {
+                    await ExecuteCommandAsync(
+                        connection,
+                        $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;");
+                }
+                catch when (!setupSucceeded)
+                {
+                    // Preserve the setup failure instead of replacing it with a cleanup failure.
+                }
 
                 using var pooledConnection = new SqlConnection(CurrentConnectionString);
                 SqlConnection.ClearPool(pooledConnection);

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -61,30 +61,31 @@ namespace UnitTests.General
 
             using var commandBuilder = new SqlCommandBuilder();
             var quotedDatabaseName = commandBuilder.QuoteIdentifier(databaseName);
-            var hasExclusiveAccess = false;
+            using var scriptEnumerator = scripts.GetEnumerator();
+            if (!scriptEnumerator.MoveNext())
+            {
+                return;
+            }
+
             try
             {
                 await ExecuteCommandAsync(
                     connection,
-                    $"ALTER DATABASE {quotedDatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;");
-                hasExclusiveAccess = true;
+                    $"ALTER DATABASE {quotedDatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;\n{scriptEnumerator.Current}");
 
-                foreach (var script in scripts)
+                while (scriptEnumerator.MoveNext())
                 {
-                    await ExecuteCommandAsync(connection, script);
+                    await ExecuteCommandAsync(connection, scriptEnumerator.Current);
                 }
             }
             finally
             {
-                if (hasExclusiveAccess)
-                {
-                    await ExecuteCommandAsync(
-                        connection,
-                        $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;");
+                await ExecuteCommandAsync(
+                    connection,
+                    $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;");
 
-                    using var pooledConnection = new SqlConnection(CurrentConnectionString);
-                    SqlConnection.ClearPool(pooledConnection);
-                }
+                using var pooledConnection = new SqlConnection(CurrentConnectionString);
+                SqlConnection.ClearPool(pooledConnection);
             }
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -37,7 +37,9 @@ public class SqlServerStorageForTestingTests
         await using var competingConnection = new SqlConnection(storage.CurrentConnectionString);
         await competingConnection.OpenAsync();
         using var cancellation = new CancellationTokenSource();
-        var reconnectingClient = ReconnectUntilCanceledAsync(storage.CurrentConnectionString, cancellation.Token);
+        var reconnectingClients = Enumerable.Range(0, 4)
+            .Select(_ => ReconnectUntilCanceledAsync(storage.CurrentConnectionString, cancellation.Token))
+            .ToArray();
 
         try
         {
@@ -53,7 +55,7 @@ public class SqlServerStorageForTestingTests
         finally
         {
             await cancellation.CancelAsync();
-            await reconnectingClient;
+            await Task.WhenAll(reconnectingClients);
         }
 
         var databaseState = await storage.Storage.ReadAsync(


### PR DESCRIPTION
## Problem

SQL Server schema setup acquired SINGLE_USER access in one command and applied the first schema batch in a later command. A reconnecting pooled client could claim the database's sole user slot between those commands, causing unrelated provider fixtures to fail during setup.

## Solution

Execute the SINGLE_USER transition and the first schema batch in one command on the same non-pooled connection, then apply remaining batches before restoring MULTI_USER. Strengthen the regression with four continuously reconnecting clients to exercise the handoff.

## Rationale

Combining the transition with the first required database operation preserves ownership across the only vulnerable command boundary while retaining the existing cleanup and pool-reset behavior.

Fixes #10808
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10823)