### PR TITLE
test: remove delays from async executor tests

### DIFF
--- a/test/Orleans.Core.Tests/OrleansRuntime/AsyncSerialExecutorTests.cs
+++ b/test/Orleans.Core.Tests/OrleansRuntime/AsyncSerialExecutorTests.cs
@@ -73,14 +73,13 @@ namespace UnitTests.OrleansRuntime
         {
             if (operationsInProgress > 0) Assert.Fail($"1: Operation {opNumber} found {operationsInProgress} operationsInProgress.");
             operationsInProgress++;
-            var delay = RandomTimeSpan.Next(TimeSpan.FromSeconds(2));
 
             output.WriteLine("Task {0} Staring", opNumber);
-            await Task.Delay(delay);
+            await Task.Yield();
             if (operationsInProgress != 1) Assert.Fail($"2: Operation {opNumber} found {operationsInProgress} operationsInProgress.");
 
             output.WriteLine("Task {0} after first delay", opNumber);
-            await Task.Delay(delay);
+            await Task.Yield();
             if (operationsInProgress != 1) Assert.Fail($"3: Operation {opNumber} found {operationsInProgress} operationsInProgress.");
 
             operationsInProgress--;

--- a/test/Orleans.Core.Tests/OrleansRuntime/AsyncSerialExecutorTests.cs
+++ b/test/Orleans.Core.Tests/OrleansRuntime/AsyncSerialExecutorTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using Orleans;
-using Orleans.Internal;
 using Xunit;
 
 namespace UnitTests.OrleansRuntime
@@ -74,11 +73,11 @@ namespace UnitTests.OrleansRuntime
             if (operationsInProgress > 0) Assert.Fail($"1: Operation {opNumber} found {operationsInProgress} operationsInProgress.");
             operationsInProgress++;
 
-            output.WriteLine("Task {0} Staring", opNumber);
+            output.WriteLine("Task {0} starting", opNumber);
             await Task.Yield();
             if (operationsInProgress != 1) Assert.Fail($"2: Operation {opNumber} found {operationsInProgress} operationsInProgress.");
 
-            output.WriteLine("Task {0} after first delay", opNumber);
+            output.WriteLine("Task {0} after first yield", opNumber);
             await Task.Yield();
             if (operationsInProgress != 1) Assert.Fail($"3: Operation {opNumber} found {operationsInProgress} operationsInProgress.");
 


### PR DESCRIPTION
## Problem

`AsyncSerialExecutorTests_ParallelSubmit` averages 22.38 seconds across four recent CI samples because each serialized operation performs two random delays of up to two seconds.

Azure DevOps evidence:
- [Build 20260825.1](https://dev.azure.com/dnceng/internal/_build/results?buildId=3057217): 24.030s and 25.856s across net10.0/net8.0.
- [Build 20260825.3](https://dev.azure.com/dnceng/internal/_build/results?buildId=3057521): 22.506s and 17.130s across net10.0/net8.0.

## Solution

Replace both random delays with deterministic asynchronous yields. The operation still suspends twice, and the existing `operationsInProgress` assertions continue to detect concurrent execution without spending seconds waiting.

The complete three-test class passes on net8.0 and net10.0 in under two seconds per framework.

Fixes #10833
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10834)