### PR TITLE
perf(redis): avoid serializing addresses during unregister

### DIFF
--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -147,7 +147,6 @@ namespace Orleans.GrainDirectory.Redis
             {
                 ObjectDisposedException.ThrowIf(_disposed, _database);
 
-                var value = JsonSerializer.Serialize(address);
                 var result = (int)await _database.ScriptEvaluateAsync(
                     DeleteScript,
                     keys: new RedisKey[] { GetKey(address.GrainId) },


### PR DESCRIPTION
## Summary

Redis grain-directory unregister operations serialized the full `GrainAddress` even though the delete script only consumes its activation ID. This removes that unused serialization.

## Rationale

Unregister remains activation-aware and preserves conflict handling while avoiding a JSON string allocation and serialization work on every successful call.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10835)