### PR TITLE
test(docs): isolate linear link scan regression

### DIFF
--- a/docs/site/scripts/lib/docfx.mjs
+++ b/docs/site/scripts/lib/docfx.mjs
@@ -1072,7 +1072,7 @@ function findMarkdownDestinationEnd(source, start) {
   return -1;
 }
 
-function collectMarkdownLinks(source) {
+export function collectMarkdownLinks(source) {
   const links = [];
   const labelStarts = [];
   let codeDelimiterLength = 0;

--- a/docs/site/tests/docfx.test.mjs
+++ b/docs/site/tests/docfx.test.mjs
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { performance } from 'node:perf_hooks';
 import { afterEach, describe, expect, test } from 'vitest';
 import {
   collectIncludeTargets,
@@ -1022,9 +1023,37 @@ describe('DocFX conversion', () => {
   });
 
   test('scans unmatched link destinations in linear time', () => {
-    const unmatchedDestinations = '[]('.repeat(100_000);
+    const shortInput = '[]('.repeat(12_500);
+    const longInput = '[]('.repeat(100_000);
+    const measure = (input, iterations) => {
+      const start = performance.now();
+      for (let iteration = 0; iteration < iterations; iteration += 1) {
+        collectMarkdownLinks(input);
+      }
+      return performance.now() - start;
+    };
 
-    expect(collectMarkdownLinks(unmatchedDestinations)).toEqual([]);
+    for (let iteration = 0; iteration < 10; iteration += 1) {
+      collectMarkdownLinks(shortInput);
+      collectMarkdownLinks(longInput);
+    }
+
+    const ratios = Array.from({ length: 9 }, (_value, index) => {
+      let shortDuration;
+      let longDuration;
+      if (index % 2 === 0) {
+        shortDuration = measure(shortInput, 160);
+        longDuration = measure(longInput, 20);
+      } else {
+        longDuration = measure(longInput, 20);
+        shortDuration = measure(shortInput, 160);
+      }
+      return longDuration / shortDuration;
+    }).sort((left, right) => left - right);
+
+    expect(collectMarkdownLinks(longInput)).toEqual([]);
+    // Equal total input should take comparable time; quadratic growth would approach an 8x ratio.
+    expect(ratios[4]).toBeLessThan(2.5);
   });
 
   test('converts links after code spans containing backslashes', async () => {

--- a/docs/site/tests/docfx.test.mjs
+++ b/docs/site/tests/docfx.test.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
 import {
   collectIncludeTargets,
+  collectMarkdownLinks,
   collectUidMap,
   convertDocfxMarkdown,
   convertHubYaml,
@@ -1020,22 +1021,11 @@ describe('DocFX conversion', () => {
     expect(converted).toContain(unmatchedLabels);
   });
 
-  test(
-    'scans unmatched link destinations in linear time',
-    async () => {
-      const directory = await temporaryDirectory();
-      const sourcePath = path.join(directory, 'guide.md');
-      const unmatchedDestinations = '[]('.repeat(100_000);
+  test('scans unmatched link destinations in linear time', () => {
+    const unmatchedDestinations = '[]('.repeat(100_000);
 
-      const converted = await convertDocfxMarkdown({
-        source: `---\ntitle: Links\n---\n${unmatchedDestinations}`,
-        sourcePath,
-      });
-
-      expect(converted).toContain(unmatchedDestinations);
-    },
-    10_000,
-  );
+    expect(collectMarkdownLinks(unmatchedDestinations)).toEqual([]);
+  });
 
   test('converts links after code spans containing backslashes', async () => {
     const directory = await temporaryDirectory();


### PR DESCRIPTION
Fixes #10757

The linear-time regression test passed a 300 KB adversarial link string through the entire DocFX conversion pipeline. PR #10658 subsequently added Markdown AST parsing to angle escaping, so the test began measuring parser and converter work unrelated to the link scanner. Under parallel test load, that unrelated work consumed most of the fixed 10-second budget and made the test sensitive to machine load.

Export the internal link scanner and exercise the adversarial input directly. This preserves the intended catastrophic-backtracking regression coverage while removing the arbitrary timeout and unrelated filesystem, frontmatter, conversion, and Markdown parsing work.

The original full-conversion test took 3.43–3.50 seconds in isolation and 3.96 seconds in the parallel docs suite on this machine; the focused scanner test takes 4–5 ms. Scanner measurements remain linear from 1.14 ms for 300 KB through 9.14 ms for 2.4 MB.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10836)