### PR TITLE
fix(ci): retry transient artifact uploads

### DIFF
--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -9,7 +9,8 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+  - id: archive-test-results
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     continue-on-error: true
     with:
       name: ${{ inputs.name }}
@@ -19,11 +20,43 @@ runs:
         **/TestResults/*
         !TestResults/*.cobertura.xml
         **/logs/*
+  - name: Wait before retrying test result upload
+    if: steps.archive-test-results.outcome == 'failure'
+    shell: pwsh
+    run: Start-Sleep -Seconds 30
+  - name: Retry test result upload
+    if: steps.archive-test-results.outcome == 'failure'
+    continue-on-error: true
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+    with:
+      name: ${{ inputs.name }}
+      if-no-files-found: warn
+      retention-days: 1
+      overwrite: true
+      path: |
+        **/TestResults/*
+        !TestResults/*.cobertura.xml
+        **/logs/*
   - name: Archive coverage
+    id: archive-coverage
     if: github.event_name == 'pull_request'
+    continue-on-error: true
     uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     with:
       name: coverage_${{ inputs.name }}
       if-no-files-found: error
       retention-days: 1
+      path: TestResults/${{ inputs.name }}.cobertura.xml
+  - name: Wait before retrying coverage upload
+    if: github.event_name == 'pull_request' && steps.archive-coverage.outcome == 'failure'
+    shell: pwsh
+    run: Start-Sleep -Seconds 30
+  - name: Retry coverage upload
+    if: github.event_name == 'pull_request' && steps.archive-coverage.outcome == 'failure'
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+    with:
+      name: coverage_${{ inputs.name }}
+      if-no-files-found: error
+      retention-days: 1
+      overwrite: true
       path: TestResults/${{ inputs.name }}.cobertura.xml

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -359,11 +359,11 @@ try {
         Assert-Equal 3 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only the final coverage upload attempt may gate the job.'
         Assert-Matches `
             $archiveTestResultsAction `
-            "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Retry test result upload\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n.*?      overwrite: true\r?$" `
+            "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Retry test result upload\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
             'Test result upload attempts must remain non-gating and retry with overwrite.'
         Assert-Matches `
             $archiveTestResultsAction `
-            "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: github\.event_name == 'pull_request'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n.*?^  - name: Retry coverage upload\r?\n    if: github\.event_name == 'pull_request' && steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n.*?      overwrite: true\r?$" `
+            "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: github\.event_name == 'pull_request'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n.*?^  - name: Retry coverage upload\r?\n    if: github\.event_name == 'pull_request' && steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
             'Coverage upload must retry with overwrite and keep the final attempt gating.'
     }
 

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -352,6 +352,19 @@ try {
             $archiveTestResultsAction `
             'path: TestResults/\$\{\{ inputs\.name \}\}\.cobertura\.xml' `
             'Each test job must publish its exact coverage report.'
+        Assert-Equal 4 ([regex]::Matches($archiveTestResultsAction, 'uses: actions/upload-artifact@')).Count 'Artifact upload attempt count differs.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'run: Start-Sleep -Seconds 30')).Count 'Artifact upload retry delay count differs.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact upload retries must replace partial artifacts.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Both coverage upload attempts must require the report.'
+        Assert-Equal 3 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only the final coverage upload attempt may gate the job.'
+        Assert-Matches `
+            $archiveTestResultsAction `
+            "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Retry test result upload\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n.*?      overwrite: true\r?$" `
+            'Test result upload attempts must remain non-gating and retry with overwrite.'
+        Assert-Matches `
+            $archiveTestResultsAction `
+            "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: github\.event_name == 'pull_request'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n.*?^  - name: Retry coverage upload\r?\n    if: github\.event_name == 'pull_request' && steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n.*?      overwrite: true\r?$" `
+            'Coverage upload must retry with overwrite and keep the final attempt gating.'
     }
 
     Invoke-Test 'collects coverage from every test job' {


### PR DESCRIPTION
Fixes #10831

`actions/upload-artifact` can exhaust its internal request retries during a transient DNS failure after tests and coverage generation have completed successfully.

Add one delayed outer retry in the shared test archival action. Diagnostic uploads remain advisory, while pull request coverage remains required after the retry. Retry attempts use `overwrite` so a partially created immutable artifact cannot block recovery.

Extend the coverage workflow contract checks to preserve those gating and retry guarantees.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10837)