### PR TITLE
fix(reminders): decouple reconciliation barrier from scheduler

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -399,18 +399,18 @@ namespace Orleans.Runtime.ReminderService
             CheckRuntimeContext();
 
             _ = base.OnRangeChange(oldRange, newRange, increased);
-            Task task;
+            var status = Status;
+            var task = status == GrainServiceStatus.Started
+                ? ReadAndUpdateReminders()
+                : Task.CompletedTask;
+            if (status != GrainServiceStatus.Started)
+            {
+                LogIgnoringRangeChange(status);
+            }
+
             TaskCompletionSource previousGenerationChanged;
             lock (_rangeChangeLock)
             {
-                task = Status == GrainServiceStatus.Started
-                    ? ReadAndUpdateReminders()
-                    : Task.CompletedTask;
-                if (Status != GrainServiceStatus.Started)
-                {
-                    LogIgnoringRangeChange(Status);
-                }
-
                 previousGenerationChanged = rangeChangeGenerationChanged;
                 rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
                 rangeChangeGeneration++;

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -31,6 +31,8 @@ namespace Orleans.Runtime.ReminderService
         private readonly TimeProvider _timeProvider;
         private readonly ReminderInstruments _reminderInstruments;
         private long localTableSequence;
+        // The test barrier reads this state off-scheduler so it remains observable while the service is busy.
+        private readonly object _rangeChangeLock = new();
         private long rangeChangeGeneration;
         private TaskCompletionSource rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private Task rangeChangeTask = Task.CompletedTask;
@@ -397,18 +399,24 @@ namespace Orleans.Runtime.ReminderService
             CheckRuntimeContext();
 
             _ = base.OnRangeChange(oldRange, newRange, increased);
-            var task = Status == GrainServiceStatus.Started
-                ? ReadAndUpdateReminders()
-                : Task.CompletedTask;
-            if (Status != GrainServiceStatus.Started)
+            Task task;
+            TaskCompletionSource previousGenerationChanged;
+            lock (_rangeChangeLock)
             {
-                LogIgnoringRangeChange(Status);
+                task = Status == GrainServiceStatus.Started
+                    ? ReadAndUpdateReminders()
+                    : Task.CompletedTask;
+                if (Status != GrainServiceStatus.Started)
+                {
+                    LogIgnoringRangeChange(Status);
+                }
+
+                previousGenerationChanged = rangeChangeGenerationChanged;
+                rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                rangeChangeGeneration++;
+                rangeChangeTask = task;
             }
 
-            var previousGenerationChanged = rangeChangeGenerationChanged;
-            rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            rangeChangeGeneration++;
-            rangeChangeTask = task;
             previousGenerationChanged.TrySetResult();
             return task;
         }
@@ -419,30 +427,33 @@ namespace Orleans.Runtime.ReminderService
             {
                 // A newer refresh supersedes older results through localTableSequence. Follow generation
                 // changes so a stalled obsolete read does not block the current reconciliation.
-                long observedGeneration = 0;
-                Task observedTask = Task.CompletedTask;
-                Task observedGenerationChanged = Task.CompletedTask;
-                await this.QueueTask(() =>
+                long observedGeneration;
+                Task observedTask;
+                Task observedGenerationChanged;
+                lock (_rangeChangeLock)
                 {
                     observedGeneration = rangeChangeGeneration;
                     observedTask = rangeChangeTask;
                     observedGenerationChanged = rangeChangeGenerationChanged.Task;
-                    return Task.CompletedTask;
-                }).WaitAsync(cancellationToken);
+                }
 
                 await Task.WhenAny(observedTask, observedGenerationChanged).WaitAsync(cancellationToken);
 
-                var isCurrentGeneration = false;
-                await this.QueueTask(() =>
+                lock (_rangeChangeLock)
                 {
-                    isCurrentGeneration = observedGeneration == rangeChangeGeneration;
-                    return Task.CompletedTask;
-                }).WaitAsync(cancellationToken);
+                    if (observedGeneration != rangeChangeGeneration)
+                    {
+                        continue;
+                    }
+                }
 
-                if (isCurrentGeneration)
+                await observedTask.WaitAsync(cancellationToken);
+                lock (_rangeChangeLock)
                 {
-                    await observedTask.WaitAsync(cancellationToken);
-                    return;
+                    if (observedGeneration == rangeChangeGeneration)
+                    {
+                        return;
+                    }
                 }
             }
         }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -455,15 +455,11 @@ namespace Orleans.Runtime.ReminderService
                     {
                         continue;
                     }
-                }
 
-                await observedTask.WaitAsync(cancellationToken);
-                lock (_rangeChangeLock)
-                {
-                    if (observedGeneration == rangeChangeGeneration)
-                    {
-                        return;
-                    }
+                    // The generation-change task can only complete after the generation advances, so the
+                    // observed reconciliation is complete and its outcome can be read without blocking.
+                    observedTask.GetAwaiter().GetResult();
+                    return;
                 }
             }
         }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -399,26 +399,36 @@ namespace Orleans.Runtime.ReminderService
             CheckRuntimeContext();
 
             _ = base.OnRangeChange(oldRange, newRange, increased);
-            var status = Status;
-            var task = status == GrainServiceStatus.Started
-                ? ReadAndUpdateReminders()
-                : Task.CompletedTask;
-            if (status != GrainServiceStatus.Started)
-            {
-                LogIgnoringRangeChange(status);
-            }
-
+            var reconciliationTaskSource = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource previousGenerationChanged;
             lock (_rangeChangeLock)
             {
                 previousGenerationChanged = rangeChangeGenerationChanged;
                 rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
                 rangeChangeGeneration++;
-                rangeChangeTask = task;
+                rangeChangeTask = reconciliationTaskSource.Task.Unwrap();
             }
 
             previousGenerationChanged.TrySetResult();
-            return task;
+            try
+            {
+                var status = Status;
+                var task = status == GrainServiceStatus.Started
+                    ? ReadAndUpdateReminders()
+                    : Task.CompletedTask;
+                if (status != GrainServiceStatus.Started)
+                {
+                    LogIgnoringRangeChange(status);
+                }
+
+                reconciliationTaskSource.SetResult(task);
+                return task;
+            }
+            catch (Exception exception)
+            {
+                reconciliationTaskSource.SetException(exception);
+                throw;
+            }
         }
 
         internal async Task TestOnlyWaitForRangeChangeReconciliation(CancellationToken cancellationToken)

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -328,6 +328,40 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         }
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task RangeChangeBarrier_DoesNotDependOnServiceSchedulerAvailability()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
+
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        await reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+
+        var schedulerBlocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseScheduler = new ManualResetEventSlim();
+        var blockingTask = new Task(() =>
+        {
+            schedulerBlocked.TrySetResult();
+            releaseScheduler.Wait(cancellation.Token);
+        });
+        reminderService.Scheduler.QueueTask(blockingTask);
+        await schedulerBlocked.Task.WaitAsync(cancellation.Token);
+
+        try
+        {
+            using var barrierCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            await reminderService.TestOnlyWaitForRangeChangeReconciliation(barrierCancellation.Token);
+        }
+        finally
+        {
+            releaseScheduler.Set();
+            await blockingTask.WaitAsync(cancellation.Token);
+        }
+    }
+
     public sealed class Fixture : BaseInProcessTestClusterFixture
     {
         public ReminderDiagnosticObserver ReminderObserver { get; } = ReminderDiagnosticObserver.Create();


### PR DESCRIPTION
## Problem

The newest reminder-suite recurrence after #10815 timed out at the first queued state snapshot in LocalReminderService.TestOnlyWaitForRangeChangeReconciliation. The test barrier depended on the reminder-service scheduler being available while it was specifically waiting for that service to finish reconciliation, so scheduler or provider pressure could prevent the barrier from observing the task it needed to await.

## Solution

Publish range-change generation state under a lock and let the test barrier snapshot that state directly from the calling thread. The barrier continues to follow newer generations, awaits the current reconciliation, and propagates failures from the current generation.

Add a regression test which holds the reminder-service scheduler unavailable and verifies that the reconciliation barrier remains observable.

## Rationale

This removes the circular scheduler dependency from the test synchronization boundary while preserving the reminder service's reconciliation behavior and generation supersession guarantees.

Fixes #10499
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10838)