### PR TITLE
fix(ci): retry transient coverage initialization failure

### DIFF
--- a/.github/actions/dotnet-test/action.yml
+++ b/.github/actions/dotnet-test/action.yml
@@ -37,11 +37,65 @@ runs:
   - name: Test with dynamic coverage
     if: github.event_name == 'pull_request' && runner.os != 'macOS' && inputs.static-instrumentation != 'true'
     shell: pwsh
-    run: dotnet-coverage collect --settings ./.github/coverage.config.xml --output "TestResults/${{ inputs.coverage-id }}.cobertura.xml" --output-format cobertura --nologo dotnet test --solution Orleans.slnx --framework "${{ inputs.framework }}" --filter-query "${{ inputs.filter-query }}" --minimum-expected-tests 1 --hangdump --hangdump-timeout 10m --crashdump --crashdump-type Full --hangdump-type Full --report-trx --report-trx-filename "test_results_${{ inputs.result-id }}_{asm}_{tfm}_{arch}.trx" --max-parallel-test-modules 1 -p:ContinuousIntegrationBuild=false
+    run: |
+      $command = @(
+        'dotnet'
+        'test'
+        '--solution'
+        'Orleans.slnx'
+        '--framework'
+        '${{ inputs.framework }}'
+        '--filter-query'
+        '${{ inputs.filter-query }}'
+        '--minimum-expected-tests'
+        '1'
+        '--hangdump'
+        '--hangdump-timeout'
+        '10m'
+        '--crashdump'
+        '--crashdump-type'
+        'Full'
+        '--hangdump-type'
+        'Full'
+        '--report-trx'
+        '--report-trx-filename'
+        'test_results_${{ inputs.result-id }}_{asm}_{tfm}_{arch}.trx'
+        '--max-parallel-test-modules'
+        '1'
+        '-p:ContinuousIntegrationBuild=false'
+      )
+      ./.github/scripts/invoke-coverage.ps1 -Settings ./.github/coverage.config.xml -Output "TestResults/${{ inputs.coverage-id }}.cobertura.xml" -RetryLogFile "logs/${{ inputs.coverage-id }}.retry.log" -Command $command
   - name: Test with static coverage
     if: github.event_name == 'pull_request' && (runner.os == 'macOS' || inputs.static-instrumentation == 'true')
     shell: pwsh
-    run: dotnet-coverage collect --settings ./.github/coverage.static.config.xml --output "TestResults/${{ inputs.coverage-id }}.cobertura.xml" --output-format cobertura --nologo "--include-files=${{ github.workspace }}/test/**/bin/Debug/${{ inputs.framework }}/*.dll" dotnet test --solution Orleans.slnx --framework "${{ inputs.framework }}" --filter-query "${{ inputs.filter-query }}" --minimum-expected-tests 1 --hangdump --hangdump-timeout 10m --crashdump --crashdump-type Full --hangdump-type Full --report-trx --report-trx-filename "test_results_${{ inputs.result-id }}_{asm}_{tfm}_{arch}.trx" --max-parallel-test-modules 1 --no-build
+    run: |
+      $command = @(
+        'dotnet'
+        'test'
+        '--solution'
+        'Orleans.slnx'
+        '--framework'
+        '${{ inputs.framework }}'
+        '--filter-query'
+        '${{ inputs.filter-query }}'
+        '--minimum-expected-tests'
+        '1'
+        '--hangdump'
+        '--hangdump-timeout'
+        '10m'
+        '--crashdump'
+        '--crashdump-type'
+        'Full'
+        '--hangdump-type'
+        'Full'
+        '--report-trx'
+        '--report-trx-filename'
+        'test_results_${{ inputs.result-id }}_{asm}_{tfm}_{arch}.trx'
+        '--max-parallel-test-modules'
+        '1'
+        '--no-build'
+      )
+      ./.github/scripts/invoke-coverage.ps1 -Settings ./.github/coverage.static.config.xml -Output "TestResults/${{ inputs.coverage-id }}.cobertura.xml" -RetryLogFile "logs/${{ inputs.coverage-id }}.retry.log" -IncludeFiles "${{ github.workspace }}/test/**/bin/Debug/${{ inputs.framework }}/*.dll" -Command $command
   - name: Validate coverage report
     if: github.event_name == 'pull_request'
     shell: pwsh

--- a/.github/scripts/invoke-coverage.ps1
+++ b/.github/scripts/invoke-coverage.ps1
@@ -33,9 +33,20 @@ function Assert-NotReparsePoint {
     }
 }
 
+$outputDirectory = Split-Path -Parent $Output
+
+function Assert-CoverageOutputPath {
+    if (-not [string]::IsNullOrWhiteSpace($outputDirectory)) {
+        Assert-NotReparsePoint $outputDirectory
+    }
+
+    Assert-NotReparsePoint $Output
+}
+
 function Invoke-Collector {
     param([switch] $EnableVerboseLog)
 
+    Assert-CoverageOutputPath
     $arguments = [Collections.Generic.List[string]]::new()
     $arguments.Add('collect')
     $arguments.Add('--settings')
@@ -95,6 +106,7 @@ function Test-IsUninitializedHandleFailure {
 $result = Invoke-Collector
 if ($result.ExitCode -ne 0 -and (Test-IsUninitializedHandleFailure $result.Messages)) {
     Write-Warning 'The coverage profiler failed with an uninitialized handle; retrying collection once.'
+    Assert-CoverageOutputPath
     Remove-Item -LiteralPath $Output -Force -ErrorAction SilentlyContinue
     $result = Invoke-Collector -EnableVerboseLog
 }

--- a/.github/scripts/invoke-coverage.ps1
+++ b/.github/scripts/invoke-coverage.ps1
@@ -1,0 +1,85 @@
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [Parameter(Mandatory)]
+    [string] $Settings,
+
+    [Parameter(Mandatory)]
+    [string] $Output,
+
+    [string] $IncludeFiles,
+
+    [string] $RetryLogFile,
+
+    [string] $CoverageCommand = 'dotnet-coverage',
+
+    [Parameter(Mandatory)]
+    [string[]] $Command
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Collector {
+    param([switch] $EnableVerboseLog)
+
+    $arguments = [Collections.Generic.List[string]]::new()
+    $arguments.Add('collect')
+    $arguments.Add('--settings')
+    $arguments.Add($Settings)
+    $arguments.Add('--output')
+    $arguments.Add($Output)
+    $arguments.Add('--output-format')
+    $arguments.Add('cobertura')
+    $arguments.Add('--nologo')
+
+    if (-not [string]::IsNullOrWhiteSpace($IncludeFiles)) {
+        $arguments.Add("--include-files=$IncludeFiles")
+    }
+
+    if ($EnableVerboseLog -and -not [string]::IsNullOrWhiteSpace($RetryLogFile)) {
+        $logDirectory = Split-Path -Parent $RetryLogFile
+        if (-not [string]::IsNullOrWhiteSpace($logDirectory)) {
+            [void] (New-Item -ItemType Directory -Force -Path $logDirectory)
+        }
+
+        Remove-Item -LiteralPath $RetryLogFile -Force -ErrorAction SilentlyContinue
+        $arguments.Add('--log-file')
+        $arguments.Add($RetryLogFile)
+        $arguments.Add('--log-level')
+        $arguments.Add('Verbose')
+    }
+
+    $arguments.AddRange($Command)
+    $messages = [Collections.Generic.List[string]]::new()
+    & $CoverageCommand @arguments 2>&1 | ForEach-Object {
+        $messages.Add($_.ToString())
+        $_ | Out-Host
+    }
+
+    return [pscustomobject] @{
+        ExitCode = $LASTEXITCODE
+        Messages = $messages.ToArray()
+    }
+}
+
+function Test-IsUninitializedHandleFailure {
+    param([string[]] $Messages)
+
+    $text = [string]::Join([Environment]::NewLine, $Messages)
+    return $text.Contains(
+        'One or more errors occurred. (Handle is not initialized.)',
+        [StringComparison]::Ordinal
+    ) -and $text.Contains(
+        'No code coverage data available. Profiler was not initialized.',
+        [StringComparison]::Ordinal
+    )
+}
+
+$result = Invoke-Collector
+if ($result.ExitCode -ne 0 -and (Test-IsUninitializedHandleFailure $result.Messages)) {
+    Write-Warning 'The coverage profiler failed with an uninitialized handle; retrying collection once.'
+    Remove-Item -LiteralPath $Output -Force -ErrorAction SilentlyContinue
+    $result = Invoke-Collector -EnableVerboseLog
+}
+
+exit $result.ExitCode

--- a/.github/scripts/invoke-coverage.ps1
+++ b/.github/scripts/invoke-coverage.ps1
@@ -19,6 +19,20 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+function Assert-NotReparsePoint {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+
+    $item = Get-Item -LiteralPath $Path -Force
+    $linkType = $item.PSObject.Properties['LinkType']
+    if (($linkType -and $linkType.Value) -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        throw "$Path must not be a symbolic link"
+    }
+}
+
 function Invoke-Collector {
     param([switch] $EnableVerboseLog)
 
@@ -39,9 +53,12 @@ function Invoke-Collector {
     if ($EnableVerboseLog -and -not [string]::IsNullOrWhiteSpace($RetryLogFile)) {
         $logDirectory = Split-Path -Parent $RetryLogFile
         if (-not [string]::IsNullOrWhiteSpace($logDirectory)) {
+            Assert-NotReparsePoint $logDirectory
             [void] (New-Item -ItemType Directory -Force -Path $logDirectory)
+            Assert-NotReparsePoint $logDirectory
         }
 
+        Assert-NotReparsePoint $RetryLogFile
         Remove-Item -LiteralPath $RetryLogFile -Force -ErrorAction SilentlyContinue
         $arguments.Add('--log-file')
         $arguments.Add($RetryLogFile)

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -316,6 +316,7 @@ try {
 
     Invoke-Test 'retries only the uninitialized coverage handle failure' {
         $testCase = New-TestCase
+        $invokeCoverageScript = Get-Content -Raw -LiteralPath $invokeCoverageScriptPath
         $attemptFile = Join-Path $testCase.Root 'attempt.txt'
         $fakeCollector = Join-Path $testCase.Root 'fake-collector.ps1'
         $collectorArguments = Join-Path $testCase.Root 'collector-arguments'
@@ -323,6 +324,9 @@ try {
         $coverageOutput = Join-Path $testCase.ReportDirectory 'coverage.cobertura.xml'
         $retryLog = Join-Path $testCase.Root 'logs/coverage.retry.log'
         [IO.File]::WriteAllText($settings, '<Configuration />', [Text.UTF8Encoding]::new($false))
+        Assert-Matches $invokeCoverageScript 'function Assert-NotReparsePoint' 'Coverage retry logging must reject linked paths.'
+        Assert-Equal 2 ([regex]::Matches($invokeCoverageScript, 'Assert-NotReparsePoint \$logDirectory')).Count 'Coverage retry log directory validation count differs.'
+        Assert-Equal 1 ([regex]::Matches($invokeCoverageScript, 'Assert-NotReparsePoint \$RetryLogFile')).Count 'Coverage retry log file validation count differs.'
         [IO.File]::WriteAllText(
             $fakeCollector,
             @'

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -471,6 +471,7 @@ exit 0
         Assert-Equal 2 ([regex]::Matches($setupCoverageScript, 'Assert-NotReparsePoint \$toolPath')).Count 'Coverage tool path validation count differs.'
     }
 
+    $global:LASTEXITCODE = 0
     Write-Output "$testsRun coverage tests passed."
 } finally {
     if (Test-Path $temporaryRoot) {

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -8,6 +8,7 @@ $scriptPath = Join-Path $PSScriptRoot 'summarize-coverage.ps1'
 $coverageReportScriptPath = Join-Path $PSScriptRoot 'coverage-report.ps1'
 $archiveTestResultsActionPath = Join-Path $PSScriptRoot '../actions/archive-test-results/action.yml'
 $dotnetTestActionPath = Join-Path $PSScriptRoot '../actions/dotnet-test/action.yml'
+$invokeCoverageScriptPath = Join-Path $PSScriptRoot 'invoke-coverage.ps1'
 $runTestsActionPath = Join-Path $PSScriptRoot '../actions/run-tests/action.yml'
 $setupCoverageScriptPath = Join-Path $PSScriptRoot 'setup-coverage.ps1'
 $workflowPath = Join-Path $PSScriptRoot '../workflows/ci.yml'
@@ -277,7 +278,7 @@ try {
         $coverageReportScript = Get-Content -Raw -LiteralPath $coverageReportScriptPath
         Assert-Matches `
             $dotnetTestAction `
-            'dotnet-coverage collect' `
+            'invoke-coverage\.ps1' `
             'Coverage must use the external collector with ContinuousIntegrationBuild.'
         Assert-Matches `
             $dotnetTestAction `
@@ -285,7 +286,7 @@ try {
             'Coverage builds must disable deterministic CI instrumentation.'
         Assert-Matches `
             $dotnetTestAction `
-            '--include-files=' `
+            '-IncludeFiles' `
             'macOS coverage must specify files for static instrumentation.'
         Assert-Matches `
             $dotnetTestAction `
@@ -311,6 +312,92 @@ try {
             $dotnetTestAction `
             'dotnet test --solution Orleans\.slnx' `
             'Test partitions must use native solution discovery.'
+    }
+
+    Invoke-Test 'retries only the uninitialized coverage handle failure' {
+        $testCase = New-TestCase
+        $attemptFile = Join-Path $testCase.Root 'attempt.txt'
+        $fakeCollector = Join-Path $testCase.Root 'fake-collector.ps1'
+        $collectorArguments = Join-Path $testCase.Root 'collector-arguments'
+        $settings = Join-Path $testCase.Root 'coverage.config.xml'
+        $coverageOutput = Join-Path $testCase.ReportDirectory 'coverage.cobertura.xml'
+        $retryLog = Join-Path $testCase.Root 'logs/coverage.retry.log'
+        [IO.File]::WriteAllText($settings, '<Configuration />', [Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllText(
+            $fakeCollector,
+            @'
+$attempt = if (Test-Path -LiteralPath $env:ORLEANS_COVERAGE_ATTEMPT_FILE) {
+    [int] (Get-Content -Raw -LiteralPath $env:ORLEANS_COVERAGE_ATTEMPT_FILE)
+} else {
+    0
+}
+
+$attempt++
+Set-Content -LiteralPath $env:ORLEANS_COVERAGE_ATTEMPT_FILE -Value $attempt
+Set-Content -LiteralPath "$env:ORLEANS_COVERAGE_ARGUMENTS.$attempt.txt" -Value $args
+if (($env:ORLEANS_COVERAGE_FAILURE -eq 'handle' -and $attempt -eq 1) -or
+    $env:ORLEANS_COVERAGE_FAILURE -eq 'handle-always') {
+    Write-Output 'Unhandled exception: One or more errors occurred. (Handle is not initialized.)'
+    Write-Output 'No code coverage data available. Profiler was not initialized.'
+    exit 1
+}
+
+if ($env:ORLEANS_COVERAGE_FAILURE -eq 'test') {
+    Write-Output 'A test failed.'
+    exit 1
+}
+
+exit 0
+'@,
+            [Text.UTF8Encoding]::new($false)
+        )
+
+        $previousAttemptFile = $env:ORLEANS_COVERAGE_ATTEMPT_FILE
+        $previousArguments = $env:ORLEANS_COVERAGE_ARGUMENTS
+        $previousFailure = $env:ORLEANS_COVERAGE_FAILURE
+        try {
+            $env:ORLEANS_COVERAGE_ATTEMPT_FILE = $attemptFile
+            $env:ORLEANS_COVERAGE_ARGUMENTS = $collectorArguments
+            $env:ORLEANS_COVERAGE_FAILURE = 'handle'
+            & $invokeCoverageScriptPath `
+                -Settings $settings `
+                -Output $coverageOutput `
+                -RetryLogFile $retryLog `
+                -CoverageCommand $fakeCollector `
+                -Command @('dotnet', 'test', '-p:ContinuousIntegrationBuild=false')
+            Assert-Equal 0 $LASTEXITCODE 'The retry should succeed.'
+            Assert-Equal 2 ([int] (Get-Content -Raw -LiteralPath $attemptFile)) 'The collector attempt count differs.'
+            $retryArguments = Get-Content -LiteralPath "$collectorArguments.2.txt"
+            Assert-Equal $true ($retryArguments -contains '-p:ContinuousIntegrationBuild=false') 'The inner MSBuild property must be forwarded.'
+            Assert-Equal $true ($retryArguments -contains '--log-file') 'The retry must capture a collector log.'
+            Assert-Equal $true ($retryArguments -contains 'Verbose') 'The retry collector log must be verbose.'
+
+            Remove-Item -LiteralPath $attemptFile
+            $env:ORLEANS_COVERAGE_FAILURE = 'test'
+            & $invokeCoverageScriptPath `
+                -Settings $settings `
+                -Output $coverageOutput `
+                -RetryLogFile $retryLog `
+                -CoverageCommand $fakeCollector `
+                -Command @('dotnet', 'test', '-p:ContinuousIntegrationBuild=false')
+            Assert-Equal 1 $LASTEXITCODE 'An unrelated test failure should be preserved.'
+            Assert-Equal 1 ([int] (Get-Content -Raw -LiteralPath $attemptFile)) 'An unrelated failure must not be retried.'
+
+            Remove-Item -LiteralPath $attemptFile
+            $env:ORLEANS_COVERAGE_FAILURE = 'handle-always'
+            & $invokeCoverageScriptPath `
+                -Settings $settings `
+                -Output $coverageOutput `
+                -RetryLogFile $retryLog `
+                -CoverageCommand $fakeCollector `
+                -Command @('dotnet', 'test', '-p:ContinuousIntegrationBuild=false')
+            Assert-Equal 1 $LASTEXITCODE 'A persistent collector failure should be preserved.'
+            Assert-Equal 2 ([int] (Get-Content -Raw -LiteralPath $attemptFile)) 'The collector must retry only once.'
+        } finally {
+            $env:ORLEANS_COVERAGE_ATTEMPT_FILE = $previousAttemptFile
+            $env:ORLEANS_COVERAGE_ARGUMENTS = $previousArguments
+            $env:ORLEANS_COVERAGE_FAILURE = $previousFailure
+        }
     }
 
     Invoke-Test 'downloads only coverage artifacts for merging' {
@@ -362,7 +449,9 @@ try {
         Assert-Equal 16 ([regex]::Matches($workflow, '(?m)^\s{8}provider: [A-Za-z]')).Count 'Provider-discovered test partition count differs.'
         Assert-Equal 2 ([regex]::Matches($runTestsAction, 'uses: \./\.github/actions/dotnet-test')).Count 'Native test action invocation count differs.'
         Assert-Equal 2 ([regex]::Matches($runTestsAction, "format\('/\[\(Provider=\{0\}\)")).Count 'Standard provider filter count differs.'
-        Assert-Equal 4 ([regex]::Matches($dotnetTestAction, 'dotnet test --solution Orleans\.slnx')).Count 'Native test command count differs.'
+        $directTestCommands = ([regex]::Matches($dotnetTestAction, 'dotnet test --solution Orleans\.slnx')).Count
+        $coveredTestCommands = ([regex]::Matches($dotnetTestAction, "(?s)'dotnet'\s*'test'\s*'--solution'\s*'Orleans\.slnx'")).Count
+        Assert-Equal 4 ($directTestCommands + $coveredTestCommands) 'Native test command count differs.'
         Assert-Matches $dotnetTestAction '--framework "\$\{\{ inputs\.framework \}\}".*?--list-tests' 'Static coverage builds must target and discover the selected framework.'
         Assert-Equal 1 ([regex]::Matches($workflow, "retry: 'true'")).Count 'Cosmos retry configuration count differs.'
         Assert-Matches $runTestsAction 'attempt1' 'The first retryable attempt must retain distinct test results.'

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -327,6 +327,11 @@ try {
         Assert-Matches $invokeCoverageScript 'function Assert-NotReparsePoint' 'Coverage retry logging must reject linked paths.'
         Assert-Equal 2 ([regex]::Matches($invokeCoverageScript, 'Assert-NotReparsePoint \$logDirectory')).Count 'Coverage retry log directory validation count differs.'
         Assert-Equal 1 ([regex]::Matches($invokeCoverageScript, 'Assert-NotReparsePoint \$RetryLogFile')).Count 'Coverage retry log file validation count differs.'
+        Assert-Matches `
+            $invokeCoverageScript `
+            '(?s)function Assert-CoverageOutputPath.*?Assert-NotReparsePoint \$outputDirectory.*?Assert-NotReparsePoint \$Output' `
+            'Coverage collection must reject linked output paths.'
+        Assert-Equal 2 ([regex]::Matches($invokeCoverageScript, '(?m)^ {4}Assert-CoverageOutputPath\r?$')).Count 'Coverage output validation count differs.'
         [IO.File]::WriteAllText(
             $fakeCollector,
             @'


### PR DESCRIPTION
## Problem

`dotnet-coverage` can intermittently exit before test execution with an uninitialized profiler handle, leaving no coverage or test-result artifact.

## Solution

Route dynamic and static coverage collection through a wrapper which retries once only when the collector emits both known initialization-failure messages. The retry captures a verbose collector log for diagnostics, while ordinary test and collector failures retain their original exit code without retrying.

Add workflow tests covering transient recovery, persistent collector failure, unrelated test failure, argument forwarding, and retry diagnostics.

## Rationale

No upstream package release identifies a fix for this signature. Both observed Orleans failures succeeded unchanged on rerun, so a signature-scoped retry remediates the transient without masking product failures.

Fixes #10824
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10839)