### PR TITLE
fix(ci): limit coverage to Orleans assemblies

### DIFF
--- a/.github/coverage.config.xml
+++ b/.github/coverage.config.xml
@@ -4,6 +4,11 @@
   <IncludeTestAssembly>False</IncludeTestAssembly>
   <ExcludeAssembliesWithoutSources>None</ExcludeAssembliesWithoutSources>
   <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*[\\/]Orleans\..*\.dll$</ModulePath>
+      </Include>
+    </ModulePaths>
     <Sources>
       <Include>
         <Source>.*[\\/]src[\\/].*</Source>

--- a/.github/coverage.config.xml
+++ b/.github/coverage.config.xml
@@ -6,7 +6,7 @@
   <CodeCoverage>
     <ModulePaths>
       <Include>
-        <ModulePath>.*[\\/]Orleans\..*\.dll$</ModulePath>
+        <ModulePath>.*[\\/]Orleans\.[^\\/]*\.dll$</ModulePath>
       </Include>
     </ModulePaths>
     <Sources>

--- a/.github/coverage.static.config.xml
+++ b/.github/coverage.static.config.xml
@@ -4,6 +4,11 @@
   <IncludeTestAssembly>False</IncludeTestAssembly>
   <ExcludeAssembliesWithoutSources>None</ExcludeAssembliesWithoutSources>
   <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*[\\/]Orleans\..*\.dll$</ModulePath>
+      </Include>
+    </ModulePaths>
     <Sources>
       <Include>
         <Source>.*[\\/]src[\\/].*</Source>

--- a/.github/coverage.static.config.xml
+++ b/.github/coverage.static.config.xml
@@ -6,7 +6,7 @@
   <CodeCoverage>
     <ModulePaths>
       <Include>
-        <ModulePath>.*[\\/]Orleans\..*\.dll$</ModulePath>
+        <ModulePath>.*[\\/]Orleans\.[^\\/]*\.dll$</ModulePath>
       </Include>
     </ModulePaths>
     <Sources>

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -293,6 +293,8 @@ try {
             ([regex]::Matches($dotnetTestAction, 'ContinuousIntegrationBuild=false')).Count `
             'GitHub coverage must preserve continuous integration build semantics.'
         foreach ($coverageConfig in $coverageConfigs) {
+            [xml] $coverageConfigXml = $coverageConfig
+            $modulePaths = @($coverageConfigXml.Configuration.CodeCoverage.ModulePaths.Include.ModulePath)
             Assert-Matches `
                 $coverageConfig `
                 '<DeterministicReport>True</DeterministicReport>' `
@@ -301,6 +303,14 @@ try {
                 $coverageConfig `
                 '<ExcludeAssembliesWithoutSources>None</ExcludeAssembliesWithoutSources>' `
                 'Coverage collection must retain symbol-bearing assemblies with deterministic sources.'
+            Assert-Matches `
+                $coverageConfig `
+                '<ModulePath>\.\*\[\\\\/\]Orleans\\\.\.\*\\\.dll\$</ModulePath>' `
+                'Coverage collection must include only Orleans product assemblies.'
+            Assert-Equal 1 $modulePaths.Count 'Coverage collection must define one product assembly filter.'
+            Assert-Equal $true ('C:\repo\src\Orleans.Runtime.dll' -match $modulePaths[0]) 'Coverage collection must include Orleans assemblies.'
+            Assert-Equal $false ('C:\packages\FSharp.Core.dll' -match $modulePaths[0]) 'Coverage collection must exclude FSharp.Core.'
+            Assert-Equal $false ('C:\packages\StackExchange.Redis.dll' -match $modulePaths[0]) 'Coverage collection must exclude StackExchange.Redis.'
         }
         Assert-Matches `
             $dotnetTestAction `

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -303,14 +303,13 @@ try {
                 $coverageConfig `
                 '<ExcludeAssembliesWithoutSources>None</ExcludeAssembliesWithoutSources>' `
                 'Coverage collection must retain symbol-bearing assemblies with deterministic sources.'
-            Assert-Matches `
-                $coverageConfig `
-                '<ModulePath>\.\*\[\\\\/\]Orleans\\\.\.\*\\\.dll\$</ModulePath>' `
-                'Coverage collection must include only Orleans product assemblies.'
             Assert-Equal 1 $modulePaths.Count 'Coverage collection must define one product assembly filter.'
+            Assert-Equal '.*[\\/]Orleans\.[^\\/]*\.dll$' $modulePaths[0] 'Coverage product assembly filter differs.'
             Assert-Equal $true ('C:\repo\src\Orleans.Runtime.dll' -match $modulePaths[0]) 'Coverage collection must include Orleans assemblies.'
             Assert-Equal $false ('C:\packages\FSharp.Core.dll' -match $modulePaths[0]) 'Coverage collection must exclude FSharp.Core.'
             Assert-Equal $false ('C:\packages\StackExchange.Redis.dll' -match $modulePaths[0]) 'Coverage collection must exclude StackExchange.Redis.'
+            Assert-Equal $false ('C:\repo\test\Orleans.Runtime.Tests\bin\Debug\net10.0\FSharp.Core.dll' -match $modulePaths[0]) 'Coverage collection must exclude dependencies under Orleans output directories.'
+            Assert-Equal $false ('C:\repo\test\Orleans.Runtime.Tests\bin\Debug\net10.0\StackExchange.Redis.dll' -match $modulePaths[0]) 'Coverage collection must exclude dependencies under Orleans output directories.'
         }
         Assert-Matches `
             $dotnetTestAction `


### PR DESCRIPTION
## Summary
- Restrict dynamic and static coverage collection to `Orleans.*.dll` modules.
- Prevent SourceLink paths from admitting `FSharp.Core` and `StackExchange.Redis`.
- Add regression checks.

## Testing
- `pwsh -NoProfile -File .github/scripts/test-summarize-coverage.ps1`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10843)