### PR TITLE
fix(test): propagate xUnit cancellation

### DIFF
--- a/src/Orleans.Persistence.TestKit/GrainStorageModelBasedTestRunner.cs
+++ b/src/Orleans.Persistence.TestKit/GrainStorageModelBasedTestRunner.cs
@@ -79,9 +79,22 @@ public sealed class GrainStorageModelBasedTestRunner
     /// </summary>
     /// <returns>A task which represents the asynchronous test run.</returns>
     /// <exception cref="InvalidOperationException">One or more generated test cases failed.</exception>
-    public async Task RunGeneratedConformanceTests()
+    public Task RunGeneratedConformanceTests() =>
+        RunGeneratedConformanceTests(CancellationToken.None);
+
+    /// <summary>
+    /// Generates and executes storage operation sequences.
+    /// </summary>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    /// <returns>A task which represents the asynchronous test run.</returns>
+    /// <exception cref="InvalidOperationException">One or more generated test cases failed.</exception>
+    public async Task RunGeneratedConformanceTests(CancellationToken cancellationToken)
     {
-        var results = await GrainStorageModelBasedConformance.RunGeneratedTests(storage, options, output);
+        var results = await GrainStorageModelBasedConformance.RunGeneratedTests(
+            storage,
+            options,
+            output,
+            cancellationToken);
         var failures = results.Where(result => !result.Success).Select(GrainStorageModelBasedConformance.BuildFailureMessage).ToList();
         if (failures.Count > 0)
         {
@@ -92,21 +105,47 @@ public sealed class GrainStorageModelBasedTestRunner
 
 internal static class GrainStorageModelBasedConformance
 {
-    public static async Task<IList<TestCaseExecutionResult>> RunGeneratedTests(IGrainStorage storage, string storageName, Action<string>? output = null)
+    public static Task<IList<TestCaseExecutionResult>> RunGeneratedTests(
+        IGrainStorage storage,
+        string storageName,
+        Action<string>? output = null) =>
+        RunGeneratedTests(storage, storageName, output, CancellationToken.None);
+
+    public static async Task<IList<TestCaseExecutionResult>> RunGeneratedTests(
+        IGrainStorage storage,
+        string storageName,
+        Action<string>? output,
+        CancellationToken cancellationToken)
     {
         return await RunGeneratedTests(
             storage,
             new GrainStorageModelBasedConformanceOptions { ProviderName = storageName },
-            output);
+            output,
+            cancellationToken);
     }
 
-    public static async Task<IList<TestCaseExecutionResult>> RunGeneratedTests(IGrainStorage storage, GrainStorageModelBasedConformanceOptions options, Action<string>? output = null)
+    public static Task<IList<TestCaseExecutionResult>> RunGeneratedTests(
+        IGrainStorage storage,
+        GrainStorageModelBasedConformanceOptions options,
+        Action<string>? output = null) =>
+        RunGeneratedTests(storage, options, output, CancellationToken.None);
+
+    public static async Task<IList<TestCaseExecutionResult>> RunGeneratedTests(
+        IGrainStorage storage,
+        GrainStorageModelBasedConformanceOptions options,
+        Action<string>? output,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(storage);
         ArgumentNullException.ThrowIfNull(options);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var runId = options.KeyPrefix ?? $"{SanitizeStorageName(options.ProviderName)}-{Guid.NewGuid():N}";
-        var deleteStateOnClear = await DetectDeleteStateOnClear(storage, options.GrainType, $"{runId}-clear-behavior-{Guid.NewGuid():N}");
+        var deleteStateOnClear = await DetectDeleteStateOnClear(
+            storage,
+            options.GrainType,
+            $"{runId}-clear-behavior-{Guid.NewGuid():N}",
+            cancellationToken);
         var spec = new GrainStorageBehavioralSpec(deleteStateOnClear);
         var initialState = new GrainStorageBehavioralModelState();
         var inputSet = spec.CreateInputSet();
@@ -125,7 +164,7 @@ internal static class GrainStorageModelBasedConformance
         context.ResponsePrinter = response => response?.ToString() ?? "<null>";
 
         var testIndex = 0;
-        return await spec.RunTests(
+        var results = await spec.RunTests(
             context,
             initialState,
             testCases,
@@ -134,7 +173,12 @@ internal static class GrainStorageModelBasedConformance
                 StopOnFirstFailure = true,
                 BeforeEach = info =>
                 {
-                    info.Context.Register(new GrainStorageExecutionContext(storage, options.GrainType, $"{runId}-{testIndex++:D4}"));
+                    cancellationToken.ThrowIfCancellationRequested();
+                    info.Context.Register(new GrainStorageExecutionContext(
+                        storage,
+                        options.GrainType,
+                        $"{runId}-{testIndex++:D4}",
+                        cancellationToken));
                 },
                 AfterEach = info =>
                 {
@@ -144,13 +188,27 @@ internal static class GrainStorageModelBasedConformance
                     }
                 }
             });
+        cancellationToken.ThrowIfCancellationRequested();
+        return results;
     }
 
-    private static async Task<bool> DetectDeleteStateOnClear(IGrainStorage storage, string grainType, string key)
+    private static async Task<bool> DetectDeleteStateOnClear(
+        IGrainStorage storage,
+        string grainType,
+        string key,
+        CancellationToken cancellationToken)
     {
         var grainState = new GrainState<TestState1> { State = CreateState(StorageValue.One) };
-        await storage.WriteStateAsync(grainType, GrainId.Create(grainType, key), grainState);
-        await storage.ClearStateAsync(grainType, GrainId.Create(grainType, key), grainState);
+        await storage.WriteStateAsync(
+            grainType,
+            GrainId.Create(grainType, key),
+            grainState,
+            cancellationToken);
+        await storage.ClearStateAsync(
+            grainType,
+            GrainId.Create(grainType, key),
+            grainState,
+            cancellationToken);
         return grainState.ETag is null;
     }
 
@@ -349,12 +407,18 @@ internal static class GrainStorageModelBasedConformance
         private readonly IGrainStorage storage;
         private readonly string grainType;
         private readonly string keyPrefix;
+        private readonly CancellationToken cancellationToken;
 
-        public GrainStorageExecutionContext(IGrainStorage storage, string grainType, string keyPrefix)
+        public GrainStorageExecutionContext(
+            IGrainStorage storage,
+            string grainType,
+            string keyPrefix,
+            CancellationToken cancellationToken)
         {
             this.storage = storage;
             this.grainType = grainType;
             this.keyPrefix = keyPrefix;
+            this.cancellationToken = cancellationToken;
         }
 
         public async Task<StorageOperationResult> ReadAsync(StorageRequest request)
@@ -362,7 +426,11 @@ internal static class GrainStorageModelBasedConformance
             var grainState = new GrainState<TestState1> { State = new TestState1() };
             try
             {
-                await storage.ReadStateAsync(grainType, ToGrainId(request.Key), grainState);
+                await storage.ReadStateAsync(
+                    grainType,
+                    ToGrainId(request.Key),
+                    grainState,
+                    cancellationToken);
                 if (grainState.RecordExists)
                 {
                     records[request.Key] = new GrainStorageBehavioralRecord
@@ -386,6 +454,10 @@ internal static class GrainStorageModelBasedConformance
 
                 return StorageOperationResult.Success(grainState.ETag, grainState.RecordExists, ToStorageValue(grainState.State));
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception exception)
             {
                 return StorageOperationResult.Failure(exception, grainState.ETag, grainState.RecordExists, ToStorageValue(grainState.State));
@@ -404,7 +476,11 @@ internal static class GrainStorageModelBasedConformance
 
             try
             {
-                await storage.WriteStateAsync(grainType, ToGrainId(request.Key), grainState);
+                await storage.WriteStateAsync(
+                    grainType,
+                    ToGrainId(request.Key),
+                    grainState,
+                    cancellationToken);
                 records[request.Key] = new GrainStorageBehavioralRecord
                 {
                     Value = request.Value,
@@ -414,6 +490,10 @@ internal static class GrainStorageModelBasedConformance
                 };
 
                 return StorageOperationResult.Success(grainState.ETag, grainState.RecordExists, ToStorageValue(grainState.State));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exception)
             {
@@ -433,7 +513,11 @@ internal static class GrainStorageModelBasedConformance
             try
             {
                 var priorRecord = records.TryGetValue(request.Key, out var existing) ? existing : null;
-                await storage.ClearStateAsync(grainType, ToGrainId(request.Key), grainState);
+                await storage.ClearStateAsync(
+                    grainType,
+                    ToGrainId(request.Key),
+                    grainState,
+                    cancellationToken);
                 if (string.IsNullOrEmpty(grainState.ETag))
                 {
                     records.Remove(request.Key);
@@ -450,6 +534,10 @@ internal static class GrainStorageModelBasedConformance
                 }
 
                 return StorageOperationResult.Success(grainState.ETag, grainState.RecordExists, ToStorageValue(grainState.State));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exception)
             {

--- a/src/Orleans.Persistence.TestKit/GrainStorageTestRunner.cs
+++ b/src/Orleans.Persistence.TestKit/GrainStorageTestRunner.cs
@@ -62,11 +62,21 @@ public abstract class GrainStorageTestRunner
     /// <param name="grainTypeName">The type of the grain.</param>
     /// <param name="grainId">The grain ID.</param>
     /// <param name="grainState">The grain state to write.</param>
-    protected async Task Store_WriteRead<T>(string grainTypeName, GrainId grainId, GrainState<T> grainState) where T : new()
+    protected Task Store_WriteRead<T>(string grainTypeName, GrainId grainId, GrainState<T> grainState) where T : new() =>
+        Store_WriteRead(grainTypeName, grainId, grainState, CancellationToken.None);
+
+    /// <inheritdoc cref="Store_WriteRead{T}(string, GrainId, GrainState{T})"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    protected async Task Store_WriteRead<T>(
+        string grainTypeName,
+        GrainId grainId,
+        GrainState<T> grainState,
+        CancellationToken cancellationToken)
+        where T : new()
     {
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var storedGrainState = new GrainState<T> { State = new T() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, storedGrainState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, storedGrainState, cancellationToken).ConfigureAwait(false);
 
         Assert.Equal(grainState.ETag, storedGrainState.ETag);
         Assert.Equal(grainState.State, storedGrainState.State);
@@ -80,16 +90,26 @@ public abstract class GrainStorageTestRunner
     /// <param name="grainTypeName">The type of the grain.</param>
     /// <param name="grainId">The grain ID.</param>
     /// <param name="grainState">The grain state to write and clear.</param>
-    protected async Task Store_WriteClearRead<T>(string grainTypeName, GrainId grainId, GrainState<T> grainState) where T : new()
+    protected Task Store_WriteClearRead<T>(string grainTypeName, GrainId grainId, GrainState<T> grainState) where T : new() =>
+        Store_WriteClearRead(grainTypeName, grainId, grainState, CancellationToken.None);
+
+    /// <inheritdoc cref="Store_WriteClearRead{T}(string, GrainId, GrainState{T})"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    protected async Task Store_WriteClearRead<T>(
+        string grainTypeName,
+        GrainId grainId,
+        GrainState<T> grainState,
+        CancellationToken cancellationToken)
+        where T : new()
     {
         // A legal situation for clearing has to be arranged by writing a state to the storage before clearing it.
         // Writing and clearing both change the ETag, so they should differ.
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken);
         var writtenStateVersion = grainState.ETag;
         var recordExitsAfterWriting = grainState.RecordExists;
         Assert.True(recordExitsAfterWriting);
 
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var clearedStateVersion = grainState.ETag;
         Assert.NotEqual(writtenStateVersion, clearedStateVersion);
 
@@ -97,7 +117,7 @@ public abstract class GrainStorageTestRunner
         Assert.False(recordExitsAfterClearing);
 
         var storedGrainState = new GrainState<T> { State = new T(), ETag = clearedStateVersion };
-        await Storage.WriteStateAsync(grainTypeName, grainId, storedGrainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, storedGrainState, cancellationToken).ConfigureAwait(false);
         Assert.Equal(storedGrainState.State, Activator.CreateInstance<T>());
         Assert.True(storedGrainState.RecordExists);
     }
@@ -105,7 +125,12 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests basic read and write operations.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteReadIdCyrillic()
+    public virtual Task PersistenceStorage_WriteReadIdCyrillic() =>
+        PersistenceStorage_WriteReadIdCyrillicAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteReadIdCyrillic()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteReadIdCyrillicAsync(CancellationToken cancellationToken)
     {
         const string CyrillicValue = "\u041f\u0440\u0438\u0432\u0435\u0442, \u043c\u0438\u0440";
         var grainTypeName = "TestGrain";
@@ -113,9 +138,9 @@ public abstract class GrainStorageTestRunner
         var grainState = grainReference.GrainState;
         var state = Assert.IsType<TestState1>(grainState.State);
         state.A = CyrillicValue;
-        await Storage.WriteStateAsync(grainTypeName, grainReference.GrainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainReference.GrainId, grainState, cancellationToken).ConfigureAwait(false);
         var storedGrainState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainReference.GrainId, storedGrainState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainReference.GrainId, storedGrainState, cancellationToken).ConfigureAwait(false);
         var storedState = Assert.IsType<TestState1>(storedGrainState.State);
 
         Assert.Equal(grainState.ETag, storedGrainState.ETag);
@@ -126,16 +151,23 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Writes to storage and tries to re-write the same state with NULL as ETag, as if the grain was just created.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()
+    public virtual Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException() =>
+        PersistenceStorage_WriteDuplicateFailsWithInconsistentStateExceptionAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateExceptionAsync(
+        CancellationToken cancellationToken)
     {
         // A grain with a random ID will be arranged to the database. Then its state is set to null to simulate
         // the fact it is like a second activation after one that has succeeded to write.
         string grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
 
-        await Store_WriteRead(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Store_WriteRead(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         grainState.ETag = null;
-        var exception = await Record.ExceptionAsync(() => Store_WriteRead(grainTypeName, grainId, grainState)).ConfigureAwait(false);
+        var exception = await Record.ExceptionAsync(
+            () => Store_WriteRead(grainTypeName, grainId, grainState, cancellationToken)).ConfigureAwait(false);
 
         Assert.NotNull(exception);
         Assert.IsAssignableFrom<InconsistentStateException>(exception);
@@ -144,16 +176,22 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Writes a known inconsistent state to the storage and asserts an exception will be thrown.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException()
+    public virtual Task PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException() =>
+        PersistenceStorage_WriteInconsistentFailsWithInconsistentStateExceptionAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteInconsistentFailsWithInconsistentStateExceptionAsync(
+        CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
         grainState.State = new TestState1 { A = "initial", B = 1, C = 2 };
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var staleETag = grainState.ETag;
 
         grainState.State = new TestState1 { A = "latest", B = 3, C = 4 };
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         var staleState = new GrainState<TestState1>
         {
@@ -163,11 +201,11 @@ public abstract class GrainStorageTestRunner
         };
 
         var exception = await Record.ExceptionAsync(
-            () => Storage.WriteStateAsync(grainTypeName, grainId, staleState)).ConfigureAwait(false);
+            () => Storage.WriteStateAsync(grainTypeName, grainId, staleState, cancellationToken)).ConfigureAwait(false);
         Assert.IsAssignableFrom<InconsistentStateException>(exception);
 
         var readState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState, cancellationToken).ConfigureAwait(false);
         Assert.True(readState.RecordExists);
         Assert.Equal(grainState.State, readState.State);
         Assert.Equal(grainState.ETag, readState.ETag);
@@ -176,9 +214,15 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests parallel writes and reads to ensure the provider handles concurrency correctly.
     /// </summary>
-    public virtual Task PersistenceStorage_WriteReadWriteReadStatesInParallel()
+    public virtual Task PersistenceStorage_WriteReadWriteReadStatesInParallel() =>
+        PersistenceStorage_WriteReadWriteReadStatesInParallelAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteReadWriteReadStatesInParallel()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual Task PersistenceStorage_WriteReadWriteReadStatesInParallelAsync(
+        CancellationToken cancellationToken)
     {
-        return RunPersistenceStorage_WriteReadWriteReadStatesInParallel("Parallel", 100);
+        return RunPersistenceStorage_WriteReadWriteReadStatesInParallel("Parallel", 100, cancellationToken);
     }
 
     /// <summary>
@@ -186,7 +230,15 @@ public abstract class GrainStorageTestRunner
     /// </summary>
     /// <param name="prefix">Prefix for grain IDs.</param>
     /// <param name="countOfGrains">Number of grains to test with.</param>
-    protected async Task RunPersistenceStorage_WriteReadWriteReadStatesInParallel(string prefix, int countOfGrains)
+    protected Task RunPersistenceStorage_WriteReadWriteReadStatesInParallel(string prefix, int countOfGrains) =>
+        RunPersistenceStorage_WriteReadWriteReadStatesInParallel(prefix, countOfGrains, CancellationToken.None);
+
+    /// <inheritdoc cref="RunPersistenceStorage_WriteReadWriteReadStatesInParallel(string, int)"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    protected async Task RunPersistenceStorage_WriteReadWriteReadStatesInParallel(
+        string prefix,
+        int countOfGrains,
+        CancellationToken cancellationToken)
     {
         // As data is written and read the Version numbers (ETags) are checked for correctness (they change).
         // Additionally the Store_WriteRead tests do their validation.
@@ -208,20 +260,31 @@ public abstract class GrainStorageTestRunner
             var firstVersion = grainData.GrainState.ETag;
             Assert.Null(firstVersion);
 
-            await Store_WriteRead(grainTypeName, grainData.GrainId, grainData.GrainState).ConfigureAwait(false);
+            await Store_WriteRead(
+                grainTypeName,
+                grainData.GrainId,
+                grainData.GrainState,
+                cancellationToken).ConfigureAwait(false);
             var secondVersion = grainData.GrainState.ETag;
             Assert.NotEqual(firstVersion, secondVersion);
         }
 
         int MaxNumberOfThreads = Environment.ProcessorCount * 3;
 
-        await Parallel.ForEachAsync(grainStates, new ParallelOptions { MaxDegreeOfParallelism = MaxNumberOfThreads }, async (grainData, ct) =>
+        await Parallel.ForEachAsync(
+            grainStates,
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = MaxNumberOfThreads,
+                CancellationToken = cancellationToken,
+            },
+            async (grainData, ct) =>
         {
             // This loop writes the state consecutive times to the database to make sure its version is updated appropriately.
             for (int k = 0; k < 10; ++k)
             {
                 var versionBefore = grainData.GrainState.ETag;
-                await Store_WriteRead(grainTypeName, grainData.GrainId, grainData.GrainState);
+                await Store_WriteRead(grainTypeName, grainData.GrainId, grainData.GrainState, ct);
                 var versionAfter = grainData.GrainState.ETag;
                 Assert.NotEqual(versionBefore, versionAfter);
             }
@@ -231,14 +294,19 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests that reading a non-existent state returns RecordExists=false.
     /// </summary>
-    public virtual async Task PersistenceStorage_ReadNonExistentState()
+    public virtual Task PersistenceStorage_ReadNonExistentState() =>
+        PersistenceStorage_ReadNonExistentStateAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ReadNonExistentState()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ReadNonExistentStateAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
         grainState.State = new TestState1 { A = "stale", B = 1, C = 2 };
         grainState.RecordExists = true;
 
-        await Storage.ReadStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         Assert.False(grainState.RecordExists);
         Assert.Null(grainState.ETag);
@@ -248,7 +316,12 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests write, clear, and write cycle to ensure state can be re-written after clearing.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteClearWrite()
+    public virtual Task PersistenceStorage_WriteClearWrite() =>
+        PersistenceStorage_WriteClearWriteAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteClearWrite()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteClearWriteAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -256,24 +329,24 @@ public abstract class GrainStorageTestRunner
         state.A = "First";
         state.B = 1;
 
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var firstETag = grainState.ETag;
         Assert.NotNull(firstETag);
         Assert.True(grainState.RecordExists);
 
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var clearedETag = grainState.ETag;
         Assert.NotEqual(firstETag, clearedETag);
         Assert.False(grainState.RecordExists);
 
         grainState.State = new TestState1 { A = "Second", B = 2 };
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var secondETag = grainState.ETag;
         Assert.NotEqual(clearedETag, secondETag);
         Assert.True(grainState.RecordExists);
 
         var readState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState, cancellationToken).ConfigureAwait(false);
         var readStateValue = Assert.IsType<TestState1>(readState.State);
         Assert.Equal("Second", readStateValue.A);
         Assert.Equal(2, readStateValue.B);
@@ -283,7 +356,12 @@ public abstract class GrainStorageTestRunner
     /// Tests the full write-clear-read cycle including verification that state is properly initialized after clear.
     /// This test verifies that after clearing, a new write creates a fresh state that can be read back.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteClearRead()
+    public virtual Task PersistenceStorage_WriteClearRead() =>
+        PersistenceStorage_WriteClearReadAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteClearRead()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteClearReadAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -293,25 +371,25 @@ public abstract class GrainStorageTestRunner
         state.C = 100;
 
         // Write initial state
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken);
         var writtenStateVersion = grainState.ETag;
         Assert.True(grainState.RecordExists);
 
         // Clear the state
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var clearedStateVersion = grainState.ETag;
         Assert.NotEqual(writtenStateVersion, clearedStateVersion);
         Assert.False(grainState.RecordExists);
 
         // Write new state after clear
         var newState = new GrainState<TestState1> { State = new TestState1(), ETag = clearedStateVersion };
-        await Storage.WriteStateAsync(grainTypeName, grainId, newState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, newState, cancellationToken).ConfigureAwait(false);
         Assert.Equal(newState.State, Activator.CreateInstance<TestState1>());
         Assert.True(newState.RecordExists);
 
         // Read back and verify it's the default state
         var readBackState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readBackState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readBackState, cancellationToken).ConfigureAwait(false);
         Assert.True(readBackState.RecordExists);
         var readBackStateValue = Assert.IsType<TestState1>(readBackState.State);
         Assert.Null(readBackStateValue.A);
@@ -322,7 +400,12 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests storage operations with string-based grain keys.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteRead_StringKey()
+    public virtual Task PersistenceStorage_WriteRead_StringKey() =>
+        PersistenceStorage_WriteRead_StringKeyAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteRead_StringKey()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteRead_StringKeyAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var stringKey = $"StringKey-{Guid.NewGuid()}";
@@ -331,11 +414,11 @@ public abstract class GrainStorageTestRunner
         state.A = "TestString";
         state.B = 123;
 
-        await Store_WriteRead(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Store_WriteRead(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         // Verify we can read it back with the same key
         var readState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState, cancellationToken).ConfigureAwait(false);
         var readStateValue = Assert.IsType<TestState1>(readState.State);
         Assert.Equal("TestString", readStateValue.A);
         Assert.Equal(123, readStateValue.B);
@@ -345,7 +428,12 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests storage operations with integer-based grain keys.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteRead_IntegerKey()
+    public virtual Task PersistenceStorage_WriteRead_IntegerKey() =>
+        PersistenceStorage_WriteRead_IntegerKeyAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteRead_IntegerKey()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteRead_IntegerKeyAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var integerKey = Random.Shared.NextInt64();
@@ -355,11 +443,11 @@ public abstract class GrainStorageTestRunner
         state.B = 456;
         state.C = integerKey;
 
-        await Store_WriteRead(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Store_WriteRead(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         // Verify we can read it back with the same key
         var readState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState, cancellationToken).ConfigureAwait(false);
         var readStateValue = Assert.IsType<TestState1>(readState.State);
         Assert.Equal("TestInteger", readStateValue.A);
         Assert.Equal(456, readStateValue.B);
@@ -370,7 +458,12 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests that ETag updates properly on successive writes.
     /// </summary>
-    public virtual async Task PersistenceStorage_ETagChangesOnWrite()
+    public virtual Task PersistenceStorage_ETagChangesOnWrite() =>
+        PersistenceStorage_ETagChangesOnWriteAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ETagChangesOnWrite()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ETagChangesOnWriteAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -378,20 +471,20 @@ public abstract class GrainStorageTestRunner
 
         // First write
         state.A = "Version1";
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var etag1 = grainState.ETag;
         Assert.NotNull(etag1);
 
         // Second write
         state.A = "Version2";
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var etag2 = grainState.ETag;
         Assert.NotNull(etag2);
         Assert.NotEqual(etag1, etag2);
 
         // Third write
         state.A = "Version3";
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var etag3 = grainState.ETag;
         Assert.NotNull(etag3);
         Assert.NotEqual(etag2, etag3);
@@ -402,14 +495,19 @@ public abstract class GrainStorageTestRunner
     /// Tests that calling Clear before any write works correctly.
     /// Verifies that RecordExists is false and State is not null after clearing non-existent state.
     /// </summary>
-    public virtual async Task PersistenceStorage_ClearBeforeWrite()
+    public virtual Task PersistenceStorage_ClearBeforeWrite() =>
+        PersistenceStorage_ClearBeforeWriteAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ClearBeforeWrite()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ClearBeforeWriteAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
         grainState.State = new TestState1 { A = "stale", B = 1, C = 2 };
         grainState.RecordExists = true;
 
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         Assert.False(grainState.RecordExists);
         Assert.Equal(new TestState1(), grainState.State);
@@ -419,7 +517,13 @@ public abstract class GrainStorageTestRunner
     /// Tests that State property is never null after Clear operation.
     /// Verifies the State object remains initialized even after clearing.
     /// </summary>
-    public virtual async Task PersistenceStorage_ClearStateDoesNotNullifyState()
+    public virtual Task PersistenceStorage_ClearStateDoesNotNullifyState() =>
+        PersistenceStorage_ClearStateDoesNotNullifyStateAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ClearStateDoesNotNullifyState()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ClearStateDoesNotNullifyStateAsync(
+        CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -428,11 +532,11 @@ public abstract class GrainStorageTestRunner
         state.B = 100;
 
         // Write and then clear
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         Assert.True(grainState.RecordExists);
         Assert.NotNull(grainState.State);
 
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         // State object should not be null even after clear
         Assert.NotNull(grainState.State);
@@ -443,7 +547,12 @@ public abstract class GrainStorageTestRunner
     /// Tests that ETag changes after Clear operation.
     /// Some providers may set ETag to null on clear, others may update it - both are acceptable.
     /// </summary>
-    public virtual async Task PersistenceStorage_ClearUpdatesETag()
+    public virtual Task PersistenceStorage_ClearUpdatesETag() =>
+        PersistenceStorage_ClearUpdatesETagAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ClearUpdatesETag()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ClearUpdatesETagAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -451,12 +560,12 @@ public abstract class GrainStorageTestRunner
         state.A = "TestData";
 
         // Write state
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var writeETag = grainState.ETag;
         Assert.NotNull(writeETag);
 
         // Clear state
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var clearETag = grainState.ETag;
 
         // ETag should have changed (either to null or a new value)
@@ -468,7 +577,12 @@ public abstract class GrainStorageTestRunner
     /// Tests reading state after it has been cleared.
     /// Verifies that reading a cleared state returns RecordExists=false and State is not null.
     /// </summary>
-    public virtual async Task PersistenceStorage_ReadAfterClear()
+    public virtual Task PersistenceStorage_ReadAfterClear() =>
+        PersistenceStorage_ReadAfterClearAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ReadAfterClear()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ReadAfterClearAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -477,12 +591,12 @@ public abstract class GrainStorageTestRunner
         state.B = 42;
 
         // Write, clear, then read
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         // Read the cleared state
         var readState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState, cancellationToken).ConfigureAwait(false);
 
         // After reading a cleared state
         Assert.False(readState.RecordExists);
@@ -493,7 +607,12 @@ public abstract class GrainStorageTestRunner
     /// Tests multiple successive clear operations.
     /// Verifies that clearing an already-cleared state is idempotent.
     /// </summary>
-    public virtual async Task PersistenceStorage_MultipleClearOperations()
+    public virtual Task PersistenceStorage_MultipleClearOperations() =>
+        PersistenceStorage_MultipleClearOperationsAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_MultipleClearOperations()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_MultipleClearOperationsAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -501,16 +620,16 @@ public abstract class GrainStorageTestRunner
         state.A = "TestData";
 
         // Write state
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         Assert.True(grainState.RecordExists);
 
         // First clear
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var firstClearETag = grainState.ETag;
         Assert.False(grainState.RecordExists);
 
         // Second clear - should be idempotent
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         Assert.False(grainState.RecordExists);
         Assert.NotNull(grainState.State);
     }
@@ -518,13 +637,19 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests that State property remains initialized (not null) after reading non-existent state.
     /// </summary>
-    public virtual async Task PersistenceStorage_ReadNonExistentStateHasNonNullState()
+    public virtual Task PersistenceStorage_ReadNonExistentStateHasNonNullState() =>
+        PersistenceStorage_ReadNonExistentStateHasNonNullStateAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ReadNonExistentStateHasNonNullState()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ReadNonExistentStateHasNonNullStateAsync(
+        CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
 
         // Read state that was never written
-        await Storage.ReadStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         // State should be initialized even though nothing was written
         Assert.False(grainState.RecordExists);
@@ -535,19 +660,25 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests that state names identify independent records even when the grain ID is the same.
     /// </summary>
-    public virtual async Task PersistenceStorage_StateNamesUseIndependentRecords()
+    public virtual Task PersistenceStorage_StateNamesUseIndependentRecords() =>
+        PersistenceStorage_StateNamesUseIndependentRecordsAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_StateNamesUseIndependentRecords()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_StateNamesUseIndependentRecordsAsync(
+        CancellationToken cancellationToken)
     {
         var grainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N"));
         var first = new GrainState<TestState1> { State = new TestState1 { A = "first", B = 1, C = 2 } };
         var second = new GrainState<TestState1> { State = new TestState1 { A = "second", B = 3, C = 4 } };
 
-        await Storage.WriteStateAsync("first-state", grainId, first).ConfigureAwait(false);
-        await Storage.WriteStateAsync("second-state", grainId, second).ConfigureAwait(false);
+        await Storage.WriteStateAsync("first-state", grainId, first, cancellationToken).ConfigureAwait(false);
+        await Storage.WriteStateAsync("second-state", grainId, second, cancellationToken).ConfigureAwait(false);
 
         var firstRead = new GrainState<TestState1> { State = new TestState1() };
         var secondRead = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync("first-state", grainId, firstRead).ConfigureAwait(false);
-        await Storage.ReadStateAsync("second-state", grainId, secondRead).ConfigureAwait(false);
+        await Storage.ReadStateAsync("first-state", grainId, firstRead, cancellationToken).ConfigureAwait(false);
+        await Storage.ReadStateAsync("second-state", grainId, secondRead, cancellationToken).ConfigureAwait(false);
 
         Assert.Equal(first.State, firstRead.State);
         Assert.Equal(second.State, secondRead.State);
@@ -558,16 +689,22 @@ public abstract class GrainStorageTestRunner
     /// Tests that clearing state with a stale ETag throws <see cref="InconsistentStateException"/>
     /// and preserves the latest stored state.
     /// </summary>
-    public virtual async Task PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException()
+    public virtual Task PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException() =>
+        PersistenceStorage_ClearInconsistentFailsWithInconsistentStateExceptionAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_ClearInconsistentFailsWithInconsistentStateExceptionAsync(
+        CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
         grainState.State = new TestState1 { A = "initial", B = 1, C = 2 };
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var staleETag = grainState.ETag;
 
         grainState.State = new TestState1 { A = "latest", B = 3, C = 4 };
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
 
         var staleState = new GrainState<TestState1>
         {
@@ -577,11 +714,11 @@ public abstract class GrainStorageTestRunner
         };
 
         var exception = await Record.ExceptionAsync(
-            () => Storage.ClearStateAsync(grainTypeName, grainId, staleState)).ConfigureAwait(false);
+            () => Storage.ClearStateAsync(grainTypeName, grainId, staleState, cancellationToken)).ConfigureAwait(false);
         Assert.IsAssignableFrom<InconsistentStateException>(exception);
 
         var readState = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState, cancellationToken).ConfigureAwait(false);
         Assert.True(readState.RecordExists);
         Assert.Equal(grainState.State, readState.State);
         Assert.Equal(grainState.ETag, readState.ETag);
@@ -591,7 +728,12 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests write-read-clear-read cycle to verify state transitions.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteReadClearReadCycle()
+    public virtual Task PersistenceStorage_WriteReadClearReadCycle() =>
+        PersistenceStorage_WriteReadClearReadCycleAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteReadClearReadCycle()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteReadClearReadCycleAsync(CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -600,13 +742,13 @@ public abstract class GrainStorageTestRunner
         state.B = 99;
 
         // Write
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var writeETag = grainState.ETag;
         Assert.True(grainState.RecordExists);
 
         // Read back
         var readState1 = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState1).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState1, cancellationToken).ConfigureAwait(false);
         Assert.True(readState1.RecordExists);
         var readStateValue = Assert.IsType<TestState1>(readState1.State);
         Assert.Equal("InitialValue", readStateValue.A);
@@ -614,12 +756,12 @@ public abstract class GrainStorageTestRunner
         Assert.Equal(writeETag, readState1.ETag);
 
         // Clear
-        await Storage.ClearStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.ClearStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         Assert.False(grainState.RecordExists);
 
         // Read after clear
         var readState2 = new GrainState<TestState1> { State = new TestState1() };
-        await Storage.ReadStateAsync(grainTypeName, grainId, readState2).ConfigureAwait(false);
+        await Storage.ReadStateAsync(grainTypeName, grainId, readState2, cancellationToken).ConfigureAwait(false);
         Assert.False(readState2.RecordExists);
         Assert.NotNull(readState2.State);
     }
@@ -627,7 +769,13 @@ public abstract class GrainStorageTestRunner
     /// <summary>
     /// Tests that updating state with the same values still updates the ETag.
     /// </summary>
-    public virtual async Task PersistenceStorage_WriteWithSameValuesUpdatesETag()
+    public virtual Task PersistenceStorage_WriteWithSameValuesUpdatesETag() =>
+        PersistenceStorage_WriteWithSameValuesUpdatesETagAsync(CancellationToken.None);
+
+    /// <inheritdoc cref="PersistenceStorage_WriteWithSameValuesUpdatesETag()"/>
+    /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    public virtual async Task PersistenceStorage_WriteWithSameValuesUpdatesETagAsync(
+        CancellationToken cancellationToken)
     {
         var grainTypeName = "TestGrain";
         var (grainId, grainState) = GetTestReferenceAndState(Random.Shared.NextInt64(), null);
@@ -636,14 +784,14 @@ public abstract class GrainStorageTestRunner
         state.B = 123;
 
         // First write
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var etag1 = grainState.ETag;
         Assert.NotNull(etag1);
 
         // Write again with same values
         state.A = "SameValue";
         state.B = 123;
-        await Storage.WriteStateAsync(grainTypeName, grainId, grainState).ConfigureAwait(false);
+        await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var etag2 = grainState.ETag;
         Assert.NotNull(etag2);
 

--- a/src/Orleans.Reminders.TestKit/ReminderServiceTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceTestRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 
@@ -71,7 +72,15 @@ public abstract class ReminderServiceTestRunner
     /// Guarantee: registration is visible through lookup and enumeration, and unregister is explicitly observed by
     /// both the service and the table.
     /// </summary>
-    public virtual async Task ReminderService_RegisterLookupEnumerateAndUnregister()
+    public virtual Task ReminderService_RegisterLookupEnumerateAndUnregister()
+        => RunReminderService_RegisterLookupEnumerateAndUnregister(CancellationToken.None);
+
+    /// <summary>
+    /// Guarantee: registration is visible through lookup and enumeration, and unregister is explicitly observed by
+    /// both the service and the table.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderService_RegisterLookupEnumerateAndUnregister(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderService_RegisterLookupEnumerateAndUnregister);
         var grain = CreateGrain(Guarantee);
@@ -79,11 +88,11 @@ public abstract class ReminderServiceTestRunner
         const string Name = "service-lifecycle";
         var period = TimeSpan.FromMinutes(5);
 
-        var registeredName = await grain.RegisterOrUpdateAsync(Name, period, period);
+        var registeredName = await grain.RegisterOrUpdateAsync(Name, period, period).WaitAsync(cancellationToken);
         var registrationState = await ReminderTableRetryPolicy.ReadUntilAsync(
             async () => (
-                Persisted: await ReminderTable.ReadRow(grainId, Name),
-                Names: await grain.GetReminderNamesAsync()),
+                Persisted: await ReminderTable.ReadRow(grainId, Name).WaitAsync(cancellationToken),
+                Names: await grain.GetReminderNamesAsync().WaitAsync(cancellationToken)),
             state => state.Persisted is { } persisted
                 && persisted.GrainId == grainId
                 && persisted.ReminderName == Name
@@ -94,7 +103,8 @@ public abstract class ReminderServiceTestRunner
             Guarantee,
             "RegisterOrUpdateReminder/Read",
             $"one persisted row and one enumerated reminder named '{Name}'",
-            state => $"names=[{string.Join(", ", state.Names)}], row={Describe(state.Persisted)}");
+            state => $"names=[{string.Join(", ", state.Names)}], row={Describe(state.Persisted)}",
+            cancellationToken);
         var persisted = registrationState.Persisted;
         var names = registrationState.Names;
 
@@ -114,18 +124,19 @@ public abstract class ReminderServiceTestRunner
                 .Throw();
         }
 
-        var removed = await grain.UnregisterAsync(Name);
-        var removedAgain = await grain.UnregisterAsync(Name);
+        var removed = await grain.UnregisterAsync(Name).WaitAsync(cancellationToken);
+        var removedAgain = await grain.UnregisterAsync(Name).WaitAsync(cancellationToken);
         var removalState = await ReminderTableRetryPolicy.ReadUntilAsync(
             async () => (
-                Persisted: await ReminderTable.ReadRow(grainId, Name),
-                Names: await grain.GetReminderNamesAsync()),
+                Persisted: await ReminderTable.ReadRow(grainId, Name).WaitAsync(cancellationToken),
+                Names: await grain.GetReminderNamesAsync().WaitAsync(cancellationToken)),
             state => state.Persisted is null && state.Names.Length == 0,
             ProviderName,
             Guarantee,
             "UnregisterReminder/Read",
             "no persisted or enumerated reminder after unregister",
-            state => $"names=[{string.Join(", ", state.Names)}], row={Describe(state.Persisted)}");
+            state => $"names=[{string.Join(", ", state.Names)}], row={Describe(state.Persisted)}",
+            cancellationToken);
         var afterRemoval = removalState.Persisted;
         var namesAfterRemoval = removalState.Names;
         if (!removed || removedAgain || afterRemoval is not null || namesAfterRemoval.Length != 0)
@@ -143,7 +154,15 @@ public abstract class ReminderServiceTestRunner
     /// Guarantee: updating an existing service reminder replaces its schedule and ETag without duplicating its
     /// identity.
     /// </summary>
-    public virtual async Task ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate()
+    public virtual Task ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate()
+        => RunReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate(CancellationToken.None);
+
+    /// <summary>
+    /// Guarantee: updating an existing service reminder replaces its schedule and ETag without duplicating its
+    /// identity.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate);
         var grain = CreateGrain(Guarantee);
@@ -153,10 +172,10 @@ public abstract class ReminderServiceTestRunner
         var originalPeriod = TimeSpan.FromMinutes(7);
         var originalNotBefore = _reminderTimeProvider.GetUtcNow().UtcDateTime.Add(originalDueTime);
 
-        await grain.RegisterOrUpdateAsync(Name, originalDueTime, originalPeriod);
+        await grain.RegisterOrUpdateAsync(Name, originalDueTime, originalPeriod).WaitAsync(cancellationToken);
         var originalNotAfter = _reminderTimeProvider.GetUtcNow().UtcDateTime.Add(originalDueTime);
         var original = await ReminderTableRetryPolicy.ReadUntilAsync(
-            () => ReminderTable.ReadRow(grainId, Name),
+            () => ReminderTable.ReadRow(grainId, Name).WaitAsync(cancellationToken),
             entry => entry is not null
                 && !string.IsNullOrEmpty(entry.ETag)
                 && entry.Period == originalPeriod
@@ -165,17 +184,18 @@ public abstract class ReminderServiceTestRunner
             Guarantee,
             "RegisterOrUpdateReminder/ReadOriginal",
             $"the initially registered reminder with Period={originalPeriod} and StartAt within the requested due-time window",
-            Describe);
+            Describe,
+            cancellationToken);
         var originalEntry = original!;
         var updatedDueTime = TimeSpan.FromMinutes(9);
         var updatedPeriod = TimeSpan.FromMinutes(11);
         var updatedNotBefore = _reminderTimeProvider.GetUtcNow().UtcDateTime.Add(updatedDueTime);
-        await grain.RegisterOrUpdateAsync(Name, updatedDueTime, updatedPeriod);
+        await grain.RegisterOrUpdateAsync(Name, updatedDueTime, updatedPeriod).WaitAsync(cancellationToken);
         var updatedNotAfter = _reminderTimeProvider.GetUtcNow().UtcDateTime.Add(updatedDueTime);
         var updateState = await ReminderTableRetryPolicy.ReadUntilAsync(
             async () =>
             {
-                var updated = await ReminderTable.ReadRow(grainId, Name);
+                var updated = await ReminderTable.ReadRow(grainId, Name).WaitAsync(cancellationToken);
                 if (updated is not null
                     && updated.StartAt != originalEntry.StartAt
                     && updated.Period == updatedPeriod
@@ -191,7 +211,7 @@ public abstract class ReminderServiceTestRunner
 
                 return (
                     Updated: updated,
-                    Rows: await ReminderTable.ReadRows(grainId));
+                    Rows: await ReminderTable.ReadRows(grainId).WaitAsync(cancellationToken));
             },
             state => state.Updated is { } updated
                 && !string.IsNullOrEmpty(updated.ETag)
@@ -210,7 +230,8 @@ public abstract class ReminderServiceTestRunner
             Guarantee,
             "RegisterOrUpdateReminder/ReadUpdated",
             $"one exact updated row with StartAt within the requested due-time window, Period={updatedPeriod}, and a new ETag",
-            state => $"updated={Describe(state.Updated)}, rowCount={state.Rows.Reminders.Count}, enumerated={Describe(state.Rows.Reminders.Count == 1 ? state.Rows.Reminders[0] : null)}");
+            state => $"updated={Describe(state.Updated)}, rowCount={state.Rows.Reminders.Count}, enumerated={Describe(state.Rows.Reminders.Count == 1 ? state.Rows.Reminders[0] : null)}",
+            cancellationToken);
         var updated = updateState.Updated;
         var rows = updateState.Rows;
         var enumerated = rows.Reminders.Count == 1 ? rows.Reminders[0] : null;
@@ -241,7 +262,7 @@ public abstract class ReminderServiceTestRunner
                 .Throw();
         }
 
-        await grain.UnregisterAsync(Name);
+        await grain.UnregisterAsync(Name).WaitAsync(cancellationToken);
     }
 
     private IReminderServiceTestGrain CreateGrain(string label)

--- a/src/Orleans.Reminders.TestKit/ReminderTableIntrospection.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableIntrospection.cs
@@ -200,7 +200,7 @@ public sealed class ReminderTableOperationGate : IAsyncDisposable
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task which completes when the operation is blocked.</returns>
-    public Task WaitUntilBlockedAsync(CancellationToken cancellationToken = default) => _blocked.Task.WaitAsync(cancellationToken);
+    public Task WaitUntilBlockedAsync(CancellationToken cancellationToken) => _blocked.Task.WaitAsync(cancellationToken);
 
     /// <summary>
     /// Releases the blocked operation.

--- a/src/Orleans.Reminders.TestKit/ReminderTableIntrospection.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableIntrospection.cs
@@ -200,7 +200,7 @@ public sealed class ReminderTableOperationGate : IAsyncDisposable
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task which completes when the operation is blocked.</returns>
-    public Task WaitUntilBlockedAsync(CancellationToken cancellationToken) => _blocked.Task.WaitAsync(cancellationToken);
+    public Task WaitUntilBlockedAsync(CancellationToken cancellationToken = default) => _blocked.Task.WaitAsync(cancellationToken);
 
     /// <summary>
     /// Releases the blocked operation.

--- a/src/Orleans.Reminders.TestKit/ReminderTableModelBasedTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableModelBasedTestRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Accordant;
 using Orleans.Runtime;
@@ -92,9 +93,21 @@ public sealed class ReminderTableModelBasedTestRunner
     /// </summary>
     /// <returns>A task which represents the asynchronous test run.</returns>
     /// <exception cref="ReminderConformanceException">One or more generated test cases failed.</exception>
-    public async Task RunGeneratedConformanceTests()
+    public Task RunGeneratedConformanceTests() => RunGeneratedConformanceTests(CancellationToken.None);
+
+    /// <summary>
+    /// Generates and executes reminder table operation sequences.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task which represents the asynchronous test run.</returns>
+    /// <exception cref="ReminderConformanceException">One or more generated test cases failed.</exception>
+    public async Task RunGeneratedConformanceTests(CancellationToken cancellationToken)
     {
-        var results = await ReminderTableModelBasedConformance.RunGeneratedTests(_reminderTable, _options, _output);
+        var results = await ReminderTableModelBasedConformance.RunGeneratedTests(
+            _reminderTable,
+            _options,
+            cancellationToken,
+            _output);
         var failures = results
             .Where(result => !result.Success)
             .Select(result => ReminderTableModelBasedConformance.BuildFailureMessage(_options.ProviderName, _options.Seed, result))
@@ -113,6 +126,7 @@ internal static class ReminderTableModelBasedConformance
     public static async Task<IList<TestCaseExecutionResult>> RunGeneratedTests(
         IReminderTable reminderTable,
         ReminderTableModelBasedConformanceOptions options,
+        CancellationToken cancellationToken,
         Action<string>? output = null)
     {
         ArgumentNullException.ThrowIfNull(reminderTable);
@@ -137,67 +151,85 @@ internal static class ReminderTableModelBasedConformance
         context.ResponsePrinter = response => response?.ToString() ?? "<null>";
 
         var testIndex = 0;
-        var results = await spec.RunTests(
-            context,
-            initialState,
-            testCases,
-            new TestExecutionOptions
-            {
-                StopOnFirstFailure = true,
-                BeforeEach = info =>
-                {
-                    reminderTable.TestOnlyClearTable().GetAwaiter().GetResult();
-                    var prefix = $"{runId}-{testIndex++:D4}";
-                    info.Context.Register(new ReminderExecutionContext(
-                        reminderTable,
-                        options.ProviderName,
-                        options.GrainType,
-                        prefix,
-                        options.Seed));
-                },
-                AfterEach = info =>
-                {
-                    try
-                    {
-                        reminderTable.TestOnlyClearTable().GetAwaiter().GetResult();
-                    }
-                    catch when (!info.Success)
-                    {
-                        // Preserve the generated failure, which identifies the operation sequence and state mismatch.
-                    }
-
-                    if (!info.Success)
-                    {
-                        output?.Invoke(info.FailureMessage);
-                    }
-                }
-            });
-
+        IList<TestCaseExecutionResult>? results = null;
         try
         {
-            await reminderTable.TestOnlyClearTable();
-            var finalRows = await ReminderTableRetryPolicy.ReadUntilAsync(
-                () => reminderTable.ReadRows(0, 0),
-                rows => rows is not null && rows.Reminders.Count == 0,
-                options.ProviderName,
-                nameof(ReminderTableModelBasedTestRunner),
-                "FinalCleanup/ReadRows(0, 0)",
-                "an empty reminder table after final cleanup",
-                rows => rows is null
-                    ? "null"
-                    : $"{rows.Reminders.Count.ToString(CultureInfo.InvariantCulture)} rows");
-            if (finalRows is null || finalRows.Reminders.Count != 0)
+            var executionResults = await spec.RunTests(
+                context,
+                initialState,
+                testCases,
+                new TestExecutionOptions
+                {
+                    StopOnFirstFailure = true,
+                    BeforeEach = info =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        reminderTable.TestOnlyClearTable().WaitAsync(cancellationToken).GetAwaiter().GetResult();
+                        var prefix = $"{runId}-{testIndex++:D4}";
+                        info.Context.Register(new ReminderExecutionContext(
+                            reminderTable,
+                            options.ProviderName,
+                            options.GrainType,
+                            prefix,
+                            options.Seed,
+                            cancellationToken));
+                    },
+                    AfterEach = info =>
+                    {
+                        try
+                        {
+                            using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                            reminderTable.TestOnlyClearTable()
+                                .WaitAsync(cleanupCancellation.Token)
+                                .GetAwaiter()
+                                .GetResult();
+                        }
+                        catch when (!info.Success || cancellationToken.IsCancellationRequested)
+                        {
+                            // Preserve the generated failure or test cancellation.
+                        }
+
+                        if (!info.Success)
+                        {
+                            output?.Invoke(info.FailureMessage);
+                        }
+                    }
+                }).WaitAsync(cancellationToken);
+            results = executionResults;
+
+            return executionResults;
+        }
+        finally
+        {
+            try
             {
-                throw new ReminderConformanceException(
-                    $"Final reminder table cleanup left {finalRows?.Reminders.Count.ToString(CultureInfo.InvariantCulture) ?? "null"} rows; expected an empty table.");
+                using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await reminderTable.TestOnlyClearTable().WaitAsync(cleanupCancellation.Token);
+                var finalRows = await ReminderTableRetryPolicy.ReadUntilAsync(
+                    () => reminderTable.ReadRows(0, 0),
+                    rows => rows is not null && rows.Reminders.Count == 0,
+                    options.ProviderName,
+                    nameof(ReminderTableModelBasedTestRunner),
+                    "FinalCleanup/ReadRows(0, 0)",
+                    "an empty reminder table after final cleanup",
+                    rows => rows is null
+                        ? "null"
+                        : $"{rows.Reminders.Count.ToString(CultureInfo.InvariantCulture)} rows",
+                    cleanupCancellation.Token);
+                if (finalRows is null || finalRows.Reminders.Count != 0)
+                {
+                    throw new ReminderConformanceException(
+                        $"Final reminder table cleanup left {finalRows?.Reminders.Count.ToString(CultureInfo.InvariantCulture) ?? "null"} rows; expected an empty table.");
+                }
+            }
+            catch when (
+                results is null
+                || cancellationToken.IsCancellationRequested
+                || results.Any(result => !result.Success))
+            {
+                // Preserve the generated failure, test cancellation, or execution exception.
             }
         }
-        catch when (results.Any(result => !result.Success))
-        {
-            // Preserve the generated failure, which contains the operation sequence and observed state.
-        }
-
-        return results;
     }
 
     public static string BuildFailureMessage(string providerName, int seed, TestCaseExecutionResult result)
@@ -662,6 +694,7 @@ internal static class ReminderTableModelBasedConformance
 
         private readonly IReminderTable _reminderTable;
         private readonly string _providerName;
+        private readonly CancellationToken _cancellationToken;
         private readonly Dictionary<string, (GrainId GrainId, string ReminderName)> _identities;
         private readonly Dictionary<string, string?> _currentETags = new(StringComparer.Ordinal);
         private readonly Dictionary<string, string?> _previousETags = new(StringComparer.Ordinal);
@@ -673,10 +706,12 @@ internal static class ReminderTableModelBasedConformance
             string providerName,
             string grainType,
             string prefix,
-            int seed)
+            int seed,
+            CancellationToken cancellationToken)
         {
             _reminderTable = reminderTable;
             _providerName = providerName;
+            _cancellationToken = cancellationToken;
             var grainType1 = GrainType.Create(grainType);
             var primaryKey = $"{prefix}/{ReminderKey.PrimaryGrainName}";
             var primary = GrainId.Create(grainType1, GrainIdKeyExtensions.CreateGuidKey(ReminderTestData.CreateGuid(seed, primaryKey), primaryKey));
@@ -713,7 +748,8 @@ internal static class ReminderTableModelBasedConformance
                     nameof(ReminderTableModelBasedTestRunner),
                     "UpsertRow",
                     $"a non-empty ETag for '{request.Key}'",
-                    value => value ?? "<null>");
+                    value => value ?? "<null>",
+                    _cancellationToken);
                 _previousETags[request.Key] = previous;
                 _currentETags[request.Key] = etag;
                 if (!string.IsNullOrEmpty(etag))
@@ -735,7 +771,7 @@ internal static class ReminderTableModelBasedConformance
                     removed: false,
                     entries: ToObservedEntries(readBack is null ? [] : [readBack]));
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!_cancellationToken.IsCancellationRequested)
             {
                 return ReminderOperationResult.Failure(exception);
             }
@@ -759,7 +795,7 @@ internal static class ReminderTableModelBasedConformance
                     removed: false,
                     entries: ToObservedEntries(entry is null ? [] : [entry]));
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!_cancellationToken.IsCancellationRequested)
             {
                 return ReminderOperationResult.Failure(exception);
             }
@@ -781,7 +817,7 @@ internal static class ReminderTableModelBasedConformance
                     $"{expected.Count} current rows for grain '{request.Key}'");
                 return ReminderOperationResult.Success(null, false, ToObservedEntries(rows?.Reminders ?? []));
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!_cancellationToken.IsCancellationRequested)
             {
                 return ReminderOperationResult.Failure(exception);
             }
@@ -809,7 +845,7 @@ internal static class ReminderTableModelBasedConformance
                     $"{expected.Count} current rows in ({begin}, {end}]");
                 return ReminderOperationResult.Success(null, false, ToObservedEntries(rows?.Reminders ?? []));
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!_cancellationToken.IsCancellationRequested)
             {
                 return ReminderOperationResult.Failure(exception);
             }
@@ -827,7 +863,7 @@ internal static class ReminderTableModelBasedConformance
 
             try
             {
-                var removed = await _reminderTable.RemoveRow(grainId, reminderName, etag);
+                var removed = await _reminderTable.RemoveRow(grainId, reminderName, etag).WaitAsync(_cancellationToken);
                 if (removed)
                 {
                     _previousETags[request.Key] = null;
@@ -856,7 +892,7 @@ internal static class ReminderTableModelBasedConformance
                     false,
                     ToObservedEntries(readBack is null ? [] : [readBack]));
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!_cancellationToken.IsCancellationRequested)
             {
                 return ReminderOperationResult.Failure(exception);
             }
@@ -867,7 +903,7 @@ internal static class ReminderTableModelBasedConformance
             _ = request;
             try
             {
-                await _reminderTable.TestOnlyClearTable();
+                await _reminderTable.TestOnlyClearTable().WaitAsync(_cancellationToken);
                 _currentETags.Clear();
                 _previousETags.Clear();
                 _currentEntries.Clear();
@@ -879,7 +915,7 @@ internal static class ReminderTableModelBasedConformance
                     "an empty reminder table");
                 return ReminderOperationResult.Success(null, false, ToObservedEntries(rows?.Reminders ?? []));
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!_cancellationToken.IsCancellationRequested)
             {
                 return ReminderOperationResult.Failure(exception);
             }
@@ -914,7 +950,8 @@ internal static class ReminderTableModelBasedConformance
                     ReminderEntry entry => ReminderTableEntrySnapshot.Observe(entry, supportsSubSecondPrecision: true).ToString(),
                     ReminderTableData rows => $"{rows.Reminders.Count} rows: [{string.Join(", ", rows.Reminders.Select(entry => ReminderTableEntrySnapshot.Observe(entry, supportsSubSecondPrecision: true)))}]",
                     _ => value.ToString() ?? "<null>"
-                });
+                },
+                _cancellationToken);
 
         private bool Matches(ReminderTableEntrySnapshot expected, ReminderEntry actual)
             => ReminderTableEntrySnapshotComparer.CompareExact(

--- a/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
@@ -31,6 +31,25 @@ internal static class ReminderTableRetryPolicy
         string operation,
         string expected,
         Func<T, string> describe)
+        => ReadUntilAsync(
+            read,
+            hasConverged,
+            providerName,
+            guarantee,
+            operation,
+            expected,
+            describe,
+            CancellationToken.None);
+
+    public static Task<T> ReadUntilAsync<T>(
+        Func<Task<T>> read,
+        Func<T, bool> hasConverged,
+        string providerName,
+        string guarantee,
+        string operation,
+        string expected,
+        Func<T, string> describe,
+        CancellationToken cancellationToken)
         => ExecuteUntilAsync(
             read,
             hasConverged,
@@ -41,7 +60,8 @@ internal static class ReminderTableRetryPolicy
             describe,
             "read convergence",
             Timeout,
-            Delay);
+            Delay,
+            cancellationToken);
 
     public static Task<T> MutateUntilAsync<T>(
         Func<Task<T>> mutation,
@@ -51,6 +71,25 @@ internal static class ReminderTableRetryPolicy
         string operation,
         string expected,
         Func<T, string> describe)
+        => MutateUntilAsync(
+            mutation,
+            succeeded,
+            providerName,
+            guarantee,
+            operation,
+            expected,
+            describe,
+            CancellationToken.None);
+
+    public static Task<T> MutateUntilAsync<T>(
+        Func<Task<T>> mutation,
+        Func<T, bool> succeeded,
+        string providerName,
+        string guarantee,
+        string operation,
+        string expected,
+        Func<T, string> describe,
+        CancellationToken cancellationToken)
         => ExecuteUntilAsync(
             mutation,
             succeeded,
@@ -61,7 +100,8 @@ internal static class ReminderTableRetryPolicy
             describe,
             "mutation retry",
             Timeout,
-            Delay);
+            Delay,
+            cancellationToken);
 
     internal static async Task<T> ExecuteUntilAsync<T>(
         Func<Task<T>> operation,
@@ -73,7 +113,8 @@ internal static class ReminderTableRetryPolicy
         Func<T, string> describe,
         string policyName,
         TimeSpan timeout,
-        TimeSpan delay)
+        TimeSpan delay,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(operation);
         ArgumentNullException.ThrowIfNull(succeeded);
@@ -95,6 +136,7 @@ internal static class ReminderTableRetryPolicy
 
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var remaining = timeout - stopwatch.Elapsed;
             if (attempts > 0 && remaining <= TimeSpan.Zero)
             {
@@ -112,7 +154,7 @@ internal static class ReminderTableRetryPolicy
                     ThrowTimeout();
                 }
 
-                var value = await attempt.WaitAsync(remaining);
+                var value = await attempt.WaitAsync(remaining, cancellationToken);
                 lastException = null;
                 lastObservation = describe(value);
                 if (succeeded(value))
@@ -121,7 +163,9 @@ internal static class ReminderTableRetryPolicy
                 }
 
             }
-            catch (Exception exception) when (exception is not ReminderConformanceException)
+            catch (Exception exception) when (
+                exception is not ReminderConformanceException
+                && !cancellationToken.IsCancellationRequested)
             {
                 lastException = exception;
             }
@@ -132,7 +176,7 @@ internal static class ReminderTableRetryPolicy
                 ThrowTimeout();
             }
 
-            await Task.Delay(remaining < delay ? remaining : delay);
+            await Task.Delay(remaining < delay ? remaining : delay, cancellationToken);
         }
 
         void ThrowTimeout()

--- a/src/Orleans.Reminders.TestKit/ReminderTableTestFixture.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableTestFixture.cs
@@ -108,7 +108,7 @@ public abstract class ReminderTableTestFixture
         var cluster = builder.Build();
         try
         {
-            await cluster.DeployAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+            await cluster.DeployAsync(cancellationToken).ConfigureAwait(false);
             var reminderTable = ResolveReminderTable(cluster.Silos[0].ServiceProvider);
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cancellation.CancelAfter(TimeSpan.FromMinutes(1));
@@ -144,7 +144,7 @@ public abstract class ReminderTableTestFixture
 
         try
         {
-            await cluster.StopAllSilosAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+            await cluster.StopAllSilosAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Orleans.Reminders.TestKit/ReminderTableTestFixture.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableTestFixture.cs
@@ -14,10 +14,11 @@ namespace Orleans.Reminders.TestKit;
 /// <remarks>
 /// The fixture deploys an <see cref="InProcessTestCluster"/>, configures the provider under test through
 /// <see cref="ConfigureSilo"/>, and resolves the reminder table from the first silo. Connect
-/// <see cref="InitializeAsync"/> and <see cref="DisposeAsync"/> to the lifecycle hooks of your test framework.
+/// <see cref="InitializeAsync()"/> and <see cref="DisposeAsync()"/> to the lifecycle hooks of your test framework.
 /// </remarks>
 public abstract class ReminderTableTestFixture
 {
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromMinutes(1);
     private ExceptionDispatchInfo? _preconditionException;
     private InProcessTestCluster? _cluster;
     private IReminderTable? _reminderTable;
@@ -81,7 +82,14 @@ public abstract class ReminderTableTestFixture
     /// Deploys the cluster and resolves the reminder table.
     /// </summary>
     /// <returns>A task which represents the asynchronous initialization.</returns>
-    public virtual async ValueTask InitializeAsync()
+    public virtual ValueTask InitializeAsync() => InitializeAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Deploys the cluster and resolves the reminder table.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task which represents the asynchronous initialization.</returns>
+    public virtual async ValueTask InitializeAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -100,16 +108,18 @@ public abstract class ReminderTableTestFixture
         var cluster = builder.Build();
         try
         {
-            await cluster.DeployAsync().ConfigureAwait(false);
+            await cluster.DeployAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
             var reminderTable = ResolveReminderTable(cluster.Silos[0].ServiceProvider);
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromMinutes(1));
             await reminderTable.StartAsync(cancellation.Token).ConfigureAwait(false);
             _cluster = cluster;
             _reminderTable = reminderTable;
         }
         catch
         {
-            await cluster.DisposeAsync().ConfigureAwait(false);
+            using var cleanupCancellation = new CancellationTokenSource(CleanupTimeout);
+            await cluster.DisposeAsync().AsTask().WaitAsync(cleanupCancellation.Token).ConfigureAwait(false);
             throw;
         }
     }
@@ -118,7 +128,14 @@ public abstract class ReminderTableTestFixture
     /// Stops and disposes the cluster.
     /// </summary>
     /// <returns>A task which represents the asynchronous disposal.</returns>
-    public virtual async ValueTask DisposeAsync()
+    public virtual ValueTask DisposeAsync() => DisposeAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Stops and disposes the cluster.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task which represents the asynchronous disposal.</returns>
+    public virtual async ValueTask DisposeAsync(CancellationToken cancellationToken)
     {
         if (_cluster is not { } cluster)
         {
@@ -127,11 +144,12 @@ public abstract class ReminderTableTestFixture
 
         try
         {
-            await cluster.StopAllSilosAsync().ConfigureAwait(false);
+            await cluster.StopAllSilosAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            await cluster.DisposeAsync().ConfigureAwait(false);
+            using var cleanupCancellation = new CancellationTokenSource(CleanupTimeout);
+            await cluster.DisposeAsync().AsTask().WaitAsync(cleanupCancellation.Token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Orleans.Reminders.TestKit/ReminderTableTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableTestRunner.cs
@@ -19,6 +19,7 @@ namespace Orleans.Reminders.TestKit;
 /// </remarks>
 public abstract class ReminderTableTestRunner
 {
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromMinutes(1);
     private int _grainCounter;
 
     /// <summary>
@@ -64,33 +65,45 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: <see cref="IReminderTable.StartAsync"/> is idempotent and leaves the table usable.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_StartAsync_IsIdempotent()
+    public virtual Task ReminderTable_StartAsync_IsIdempotent()
+        => RunReminderTable_StartAsync_IsIdempotent(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_StartAsync_IsIdempotent()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_StartAsync_IsIdempotent(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_StartAsync_IsIdempotent);
 
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellation.CancelAfter(TimeSpan.FromMinutes(1));
         await ReminderTable.StartAsync(cancellation.Token);
         await ReminderTable.StartAsync(cancellation.Token);
 
         var grainId = NewGrainId("start-idempotent");
         var entry = NewEntry(grainId, "start-idempotent");
-        var etag = await UpsertAsync(entry, Guarantee);
+        var etag = await UpsertAsync(entry, Guarantee, cancellationToken);
 
-        await RemoveAsync(grainId, entry.ReminderName, etag);
+        await RemoveAsync(grainId, entry.ReminderName, etag, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: after <see cref="IReminderTable.StopAsync"/> the table can be restarted and resumes serving reads.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_StopAsync_ThenRestart_ResumesService()
+    public virtual Task ReminderTable_StopAsync_ThenRestart_ResumesService()
+        => RunReminderTable_StopAsync_ThenRestart_ResumesService(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_StopAsync_ThenRestart_ResumesService()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_StopAsync_ThenRestart_ResumesService(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_StopAsync_ThenRestart_ResumesService);
         var grainId = NewGrainId("restart");
         var entry = NewEntry(grainId, "restart");
-        var etag = await UpsertAsync(entry, Guarantee);
+        var etag = await UpsertAsync(entry, Guarantee, cancellationToken);
 
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellation.CancelAfter(TimeSpan.FromMinutes(1));
         await ReminderTable.StopAsync(cancellation.Token);
         await ReminderTable.StartAsync(cancellation.Token);
 
@@ -99,7 +112,8 @@ public abstract class ReminderTableTestRunner
             value => value is not null && EntryMatches(entry, etag, value),
             Guarantee,
             "ReadRow",
-            $"the restarted table to return {Describe(entry)} with ETag {FormatETag(etag)}");
+            $"the restarted table to return {Describe(entry)} with ETag {FormatETag(etag)}",
+            cancellationToken);
         if (reread is null)
         {
             Report(Guarantee, "ReadRow")
@@ -112,7 +126,7 @@ public abstract class ReminderTableTestRunner
         }
 
         AssertEntry(Guarantee, "ReadRow", entry, etag, reread!);
-        await RemoveAsync(grainId, entry.ReminderName, reread!.ETag!);
+        await RemoveAsync(grainId, entry.ReminderName, reread!.ETag!, cancellationToken);
     }
 
     // ---------------------------------------------------------------------------------------------------------
@@ -123,45 +137,64 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: a successful upsert returns a non-empty ETag.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_UpsertRow_ReturnsNewNonEmptyETag()
+    public virtual Task ReminderTable_UpsertRow_ReturnsNewNonEmptyETag()
+        => RunReminderTable_UpsertRow_ReturnsNewNonEmptyETag(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_UpsertRow_ReturnsNewNonEmptyETag()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_UpsertRow_ReturnsNewNonEmptyETag(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_UpsertRow_ReturnsNewNonEmptyETag);
 
         var grainId = NewGrainId("upsert-etag");
-        var first = await UpsertAsync(NewEntry(grainId, "upsert-etag"), Guarantee);
-        var second = await UpsertAsync(NewEntry(grainId, "upsert-etag", BaseTime.AddMinutes(5)), Guarantee, first);
+        var first = await UpsertAsync(NewEntry(grainId, "upsert-etag"), Guarantee, cancellationToken);
+        var second = await UpsertAsync(
+            NewEntry(grainId, "upsert-etag", BaseTime.AddMinutes(5)),
+            Guarantee,
+            cancellationToken,
+            first);
 
-        await RemoveAsync(grainId, "upsert-etag", second);
+        await RemoveAsync(grainId, "upsert-etag", second, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: a point read returns the persisted identity, schedule and ETag of an upserted reminder.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_UpsertRow_PersistsScheduleForPointRead()
+    public virtual Task ReminderTable_UpsertRow_PersistsScheduleForPointRead()
+        => RunReminderTable_UpsertRow_PersistsScheduleForPointRead(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_UpsertRow_PersistsScheduleForPointRead()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_UpsertRow_PersistsScheduleForPointRead(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_UpsertRow_PersistsScheduleForPointRead);
 
         var grainId = NewGrainId("point-read");
         var entry = NewEntry(grainId, "foo/bar\\#b_a_z?", BaseTime.AddMinutes(7), TimeSpan.FromMinutes(3));
-        var etag = await UpsertAsync(entry, Guarantee);
+        var etag = await UpsertAsync(entry, Guarantee, cancellationToken);
 
-        var read = await ReadRequiredAsync(grainId, entry.ReminderName, Guarantee, entry, etag);
+        var read = await ReadRequiredAsync(grainId, entry.ReminderName, Guarantee, cancellationToken, entry, etag);
         AssertEntry(Guarantee, "ReadRow", entry, etag, read);
 
-        await RemoveAsync(grainId, entry.ReminderName, etag);
+        await RemoveAsync(grainId, entry.ReminderName, etag, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: a point read of an unknown reminder returns <see langword="null"/> rather than a default entry.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRow_MissingReminder_ReturnsNull()
+    public virtual Task ReminderTable_ReadRow_MissingReminder_ReturnsNull()
+        => RunReminderTable_ReadRow_MissingReminder_ReturnsNull(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRow_MissingReminder_ReturnsNull()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRow_MissingReminder_ReturnsNull(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRow_MissingReminder_ReturnsNull);
 
         var grainId = NewGrainId("missing-point-read");
-        var read = await ReminderTable.ReadRow(grainId, "never-registered");
+        var read = await ReminderTable.ReadRow(grainId, "never-registered").WaitAsync(cancellationToken);
         if (read is not null)
         {
             Report(Guarantee, "ReadRow")
@@ -178,7 +211,12 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: the grain-scoped read returns every reminder of the requested grain and no reminder of any other grain.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders()
+    public virtual Task ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders()
+        => RunReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders);
 
@@ -188,16 +226,17 @@ public abstract class ReminderTableTestRunner
         var first = NewEntry(target, "alpha", BaseTime, TimeSpan.FromMinutes(1));
         var second = NewEntry(target, "beta", BaseTime.AddMinutes(1), TimeSpan.FromMinutes(2));
         var otherEntry = NewEntry(other, "alpha", BaseTime, TimeSpan.FromMinutes(1));
-        var firstETag = await UpsertAsync(first, Guarantee);
-        var secondETag = await UpsertAsync(second, Guarantee);
-        var otherETag = await UpsertAsync(otherEntry, Guarantee);
+        var firstETag = await UpsertAsync(first, Guarantee, cancellationToken);
+        var secondETag = await UpsertAsync(second, Guarantee, cancellationToken);
+        var otherETag = await UpsertAsync(otherEntry, Guarantee, cancellationToken);
 
         var rows = await ReadUntilAsync(
             () => ReminderTable.ReadRows(target),
             value => value is not null && value.Reminders.Count == 2,
             Guarantee,
             "ReadRows(GrainId)",
-            "both reminders written for the target grain");
+            "both reminders written for the target grain",
+            cancellationToken);
         var requiredRows = RequireRows(Guarantee, "ReadRows(GrainId)", rows);
         AssertExactEntries(
             Guarantee,
@@ -221,16 +260,21 @@ public abstract class ReminderTableTestRunner
             }
         }
 
-        await RemoveAsync(target, "alpha", firstETag);
-        await RemoveAsync(target, "beta", secondETag);
-        await RemoveAsync(other, "alpha", otherETag);
+        await RemoveAsync(target, "alpha", firstETag, cancellationToken);
+        await RemoveAsync(target, "beta", secondETag, cancellationToken);
+        await RemoveAsync(other, "alpha", otherETag, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: the grain-scoped read of a grain with no reminders returns an empty, non-null result.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty()
+    public virtual Task ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty()
+        => RunReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty);
 
@@ -239,7 +283,8 @@ public abstract class ReminderTableTestRunner
             () => ReminderTable.ReadRows(grainId),
             [],
             Guarantee,
-            "ReadRows(GrainId)");
+            "ReadRows(GrainId)",
+            cancellationToken);
         if (rows.Reminders.Count != 0)
         {
             Report(Guarantee, "ReadRows(GrainId)")
@@ -254,7 +299,12 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: reminder identity is the pair (<see cref="ReminderEntry.GrainId"/>, <see cref="ReminderEntry.ReminderName"/>).
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_Identity_IsGrainIdAndReminderName()
+    public virtual Task ReminderTable_Identity_IsGrainIdAndReminderName()
+        => RunReminderTable_Identity_IsGrainIdAndReminderName(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_Identity_IsGrainIdAndReminderName()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_Identity_IsGrainIdAndReminderName(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_Identity_IsGrainIdAndReminderName);
 
@@ -265,16 +315,16 @@ public abstract class ReminderTableTestRunner
         var aSecond = NewEntry(grainA, "other-name", BaseTime.AddMinutes(2), TimeSpan.FromMinutes(2));
         var bFirst = NewEntry(grainB, "shared-name", BaseTime.AddMinutes(4), TimeSpan.FromMinutes(3));
 
-        var aFirstETag = await UpsertAsync(aFirst, Guarantee);
-        var aSecondETag = await UpsertAsync(aSecond, Guarantee);
-        var bFirstETag = await UpsertAsync(bFirst, Guarantee);
+        var aFirstETag = await UpsertAsync(aFirst, Guarantee, cancellationToken);
+        var aSecondETag = await UpsertAsync(aSecond, Guarantee, cancellationToken);
+        var bFirstETag = await UpsertAsync(bFirst, Guarantee, cancellationToken);
 
-        AssertEntry(Guarantee, "ReadRow", aFirst, aFirstETag, await ReadRequiredAsync(grainA, "shared-name", Guarantee, aFirst, aFirstETag));
-        AssertEntry(Guarantee, "ReadRow", aSecond, aSecondETag, await ReadRequiredAsync(grainA, "other-name", Guarantee, aSecond, aSecondETag));
-        AssertEntry(Guarantee, "ReadRow", bFirst, bFirstETag, await ReadRequiredAsync(grainB, "shared-name", Guarantee, bFirst, bFirstETag));
+        AssertEntry(Guarantee, "ReadRow", aFirst, aFirstETag, await ReadRequiredAsync(grainA, "shared-name", Guarantee, cancellationToken, aFirst, aFirstETag));
+        AssertEntry(Guarantee, "ReadRow", aSecond, aSecondETag, await ReadRequiredAsync(grainA, "other-name", Guarantee, cancellationToken, aSecond, aSecondETag));
+        AssertEntry(Guarantee, "ReadRow", bFirst, bFirstETag, await ReadRequiredAsync(grainB, "shared-name", Guarantee, cancellationToken, bFirst, bFirstETag));
 
         // Removing one identity must not affect the two identities which share one component with it.
-        if (!await ReminderTable.RemoveRow(grainA, "shared-name", aFirstETag))
+        if (!await ReminderTable.RemoveRow(grainA, "shared-name", aFirstETag).WaitAsync(cancellationToken))
         {
             Report(Guarantee, "RemoveRow")
                 .WithIdentity(grainA, "shared-name")
@@ -284,27 +334,32 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        AssertEntry(Guarantee, "ReadRow", aSecond, aSecondETag, await ReadRequiredAsync(grainA, "other-name", Guarantee, aSecond, aSecondETag));
-        AssertEntry(Guarantee, "ReadRow", bFirst, bFirstETag, await ReadRequiredAsync(grainB, "shared-name", Guarantee, bFirst, bFirstETag));
+        AssertEntry(Guarantee, "ReadRow", aSecond, aSecondETag, await ReadRequiredAsync(grainA, "other-name", Guarantee, cancellationToken, aSecond, aSecondETag));
+        AssertEntry(Guarantee, "ReadRow", bFirst, bFirstETag, await ReadRequiredAsync(grainB, "shared-name", Guarantee, cancellationToken, bFirst, bFirstETag));
 
-        await RemoveAsync(grainA, "other-name", aSecondETag);
-        await RemoveAsync(grainB, "shared-name", bFirstETag);
+        await RemoveAsync(grainA, "other-name", aSecondETag, cancellationToken);
+        await RemoveAsync(grainB, "shared-name", bFirstETag, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: reminder names containing path, escape, fragment, and query characters round-trip unchanged.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_Identity_WithSpecialCharacters_RoundTrips()
+    public virtual Task ReminderTable_Identity_WithSpecialCharacters_RoundTrips()
+        => RunReminderTable_Identity_WithSpecialCharacters_RoundTrips(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_Identity_WithSpecialCharacters_RoundTrips()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_Identity_WithSpecialCharacters_RoundTrips(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_Identity_WithSpecialCharacters_RoundTrips);
         const string ReminderName = "foo/bar\\#b_a_z?";
         var grainId = NewGrainId("special-characters");
         var expected = NewEntry(grainId, ReminderName);
-        var etag = await UpsertAsync(expected, Guarantee);
+        var etag = await UpsertAsync(expected, Guarantee, cancellationToken);
 
-        AssertEntry(Guarantee, "ReadRow", expected, etag, await ReadRequiredAsync(grainId, ReminderName, Guarantee, expected, etag));
-        await RemoveAsync(grainId, ReminderName, etag);
+        AssertEntry(Guarantee, "ReadRow", expected, etag, await ReadRequiredAsync(grainId, ReminderName, Guarantee, cancellationToken, expected, etag));
+        await RemoveAsync(grainId, ReminderName, etag, cancellationToken);
     }
 
     // ---------------------------------------------------------------------------------------------------------
@@ -315,7 +370,12 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: every successful upsert replaces the ETag, and the point read observes the newest ETag.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_UpsertRow_ReplacesETagOnEachWrite()
+    public virtual Task ReminderTable_UpsertRow_ReplacesETagOnEachWrite()
+        => RunReminderTable_UpsertRow_ReplacesETagOnEachWrite(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_UpsertRow_ReplacesETagOnEachWrite()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_UpsertRow_ReplacesETagOnEachWrite(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_UpsertRow_ReplacesETagOnEachWrite);
         var grainId = NewGrainId("etag-replace");
@@ -325,7 +385,7 @@ public abstract class ReminderTableTestRunner
         for (var i = 0; i < 3; i++)
         {
             var entry = NewEntry(grainId, "etag-replace", BaseTime.AddMinutes(i), TimeSpan.FromMinutes(1 + i));
-            var etag = await UpsertAsync(entry, Guarantee, previous);
+            var etag = await UpsertAsync(entry, Guarantee, cancellationToken, previous);
             if (previous is not null && string.Equals(previous, etag, StringComparison.Ordinal))
             {
                 Report(Guarantee, "UpsertRow")
@@ -340,7 +400,7 @@ public abstract class ReminderTableTestRunner
             observed.Add(etag);
             previous = etag;
 
-            var read = await ReadRequiredAsync(grainId, "etag-replace", Guarantee, entry, etag);
+            var read = await ReadRequiredAsync(grainId, "etag-replace", Guarantee, cancellationToken, entry, etag);
             if (!string.Equals(read.ETag, etag, StringComparison.Ordinal))
             {
                 Report(Guarantee, "ReadRow")
@@ -362,22 +422,27 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        await RemoveAsync(grainId, "etag-replace", observed[^1]);
+        await RemoveAsync(grainId, "etag-replace", observed[^1], cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: conditional removal with the current ETag removes the row.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_RemoveRow_WithCurrentETag_RemovesRow()
+    public virtual Task ReminderTable_RemoveRow_WithCurrentETag_RemovesRow()
+        => RunReminderTable_RemoveRow_WithCurrentETag_RemovesRow(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_RemoveRow_WithCurrentETag_RemovesRow()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_RemoveRow_WithCurrentETag_RemovesRow(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_RemoveRow_WithCurrentETag_RemovesRow);
 
         var grainId = NewGrainId("remove-current");
         var entry = NewEntry(grainId, "remove-current");
-        var etag = await UpsertAsync(entry, Guarantee);
+        var etag = await UpsertAsync(entry, Guarantee, cancellationToken);
 
-        var removed = await ReminderTable.RemoveRow(grainId, entry.ReminderName, etag);
+        var removed = await ReminderTable.RemoveRow(grainId, entry.ReminderName, etag).WaitAsync(cancellationToken);
         if (!removed)
         {
             Report(Guarantee, "RemoveRow")
@@ -394,7 +459,8 @@ public abstract class ReminderTableTestRunner
             static value => value is null,
             Guarantee,
             "ReadRow",
-            "null after successful removal");
+            "null after successful removal",
+            cancellationToken);
         if (read is not null)
         {
             Report(Guarantee, "ReadRow")
@@ -410,15 +476,23 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: conditional removal with a stale ETag fails and leaves the current row untouched.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow()
+    public virtual Task ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow()
+        => RunReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow);
         var grainId = NewGrainId("remove-stale");
-        var staleETag = await UpsertAsync(NewEntry(grainId, "remove-stale", BaseTime, TimeSpan.FromMinutes(1)), Guarantee);
+        var staleETag = await UpsertAsync(
+            NewEntry(grainId, "remove-stale", BaseTime, TimeSpan.FromMinutes(1)),
+            Guarantee,
+            cancellationToken);
         var updated = NewEntry(grainId, "remove-stale", BaseTime.AddMinutes(9), TimeSpan.FromMinutes(4));
-        var currentETag = await UpsertAsync(updated, Guarantee, staleETag);
+        var currentETag = await UpsertAsync(updated, Guarantee, cancellationToken, staleETag);
 
-        var removed = await ReminderTable.RemoveRow(grainId, "remove-stale", staleETag);
+        var removed = await ReminderTable.RemoveRow(grainId, "remove-stale", staleETag).WaitAsync(cancellationToken);
         if (removed)
         {
             Report(Guarantee, "RemoveRow")
@@ -430,25 +504,30 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        var read = await ReadRequiredAsync(grainId, "remove-stale", Guarantee, updated, currentETag);
+        var read = await ReadRequiredAsync(grainId, "remove-stale", Guarantee, cancellationToken, updated, currentETag);
         AssertEntry(Guarantee, "ReadRow", updated, currentETag, read);
 
-        await RemoveAsync(grainId, "remove-stale", currentETag);
+        await RemoveAsync(grainId, "remove-stale", currentETag, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: removal targeting an unknown reminder name returns <see langword="false"/> and removes nothing.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse()
+    public virtual Task ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse()
+        => RunReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse);
 
         var grainId = NewGrainId("remove-unknown");
         var entry = NewEntry(grainId, "present");
-        var etag = await UpsertAsync(entry, Guarantee);
+        var etag = await UpsertAsync(entry, Guarantee, cancellationToken);
 
-        var removed = await ReminderTable.RemoveRow(grainId, "absent", etag);
+        var removed = await ReminderTable.RemoveRow(grainId, "absent", etag).WaitAsync(cancellationToken);
         if (removed)
         {
             Report(Guarantee, "RemoveRow")
@@ -459,24 +538,29 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        AssertEntry(Guarantee, "ReadRow", entry, etag, await ReadRequiredAsync(grainId, "present", Guarantee, entry, etag));
-        await RemoveAsync(grainId, "present", etag);
+        AssertEntry(Guarantee, "ReadRow", entry, etag, await ReadRequiredAsync(grainId, "present", Guarantee, cancellationToken, entry, etag));
+        await RemoveAsync(grainId, "present", etag, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: a repeated removal of an already removed reminder returns <see langword="false"/>.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess()
+    public virtual Task ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess()
+        => RunReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess);
 
         var grainId = NewGrainId("remove-twice");
         var entry = NewEntry(grainId, "remove-twice");
-        var etag = await UpsertAsync(entry, Guarantee);
+        var etag = await UpsertAsync(entry, Guarantee, cancellationToken);
 
-        var first = await ReminderTable.RemoveRow(grainId, entry.ReminderName, etag);
-        var second = await ReminderTable.RemoveRow(grainId, entry.ReminderName, etag);
+        var first = await ReminderTable.RemoveRow(grainId, entry.ReminderName, etag).WaitAsync(cancellationToken);
+        var second = await ReminderTable.RemoveRow(grainId, entry.ReminderName, etag).WaitAsync(cancellationToken);
 
         if (!first || second)
         {
@@ -498,23 +582,32 @@ public abstract class ReminderTableTestRunner
     /// <see cref="ReminderEntry.Period"/> in place rather than creating a second row.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_UpsertRow_UpdatesStartAtAndPeriod()
+    public virtual Task ReminderTable_UpsertRow_UpdatesStartAtAndPeriod()
+        => RunReminderTable_UpsertRow_UpdatesStartAtAndPeriod(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_UpsertRow_UpdatesStartAtAndPeriod()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_UpsertRow_UpdatesStartAtAndPeriod(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_UpsertRow_UpdatesStartAtAndPeriod);
 
         var grainId = NewGrainId("schedule-update");
-        var originalETag = await UpsertAsync(NewEntry(grainId, "schedule-update", BaseTime, TimeSpan.FromMinutes(1)), Guarantee);
+        var originalETag = await UpsertAsync(
+            NewEntry(grainId, "schedule-update", BaseTime, TimeSpan.FromMinutes(1)),
+            Guarantee,
+            cancellationToken);
 
         var updated = NewEntry(grainId, "schedule-update", BaseTime.AddHours(2), TimeSpan.FromMinutes(17));
-        var updatedETag = await UpsertAsync(updated, Guarantee, originalETag);
+        var updatedETag = await UpsertAsync(updated, Guarantee, cancellationToken, originalETag);
 
-        AssertEntry(Guarantee, "ReadRow", updated, updatedETag, await ReadRequiredAsync(grainId, "schedule-update", Guarantee, updated, updatedETag));
+        AssertEntry(Guarantee, "ReadRow", updated, updatedETag, await ReadRequiredAsync(grainId, "schedule-update", Guarantee, cancellationToken, updated, updatedETag));
 
         var rows = await ReadRowsUntilExactAsync(
             () => ReminderTable.ReadRows(grainId),
             [ReminderTableEntrySnapshot.Create(updated, updatedETag, supportsSubSecondPrecision: false)],
             Guarantee,
-            "ReadRows(GrainId)");
+            "ReadRows(GrainId)",
+            cancellationToken);
         if (rows.Reminders.Count != 1)
         {
             Report(Guarantee, "ReadRows(GrainId)")
@@ -525,7 +618,7 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        await RemoveAsync(grainId, "schedule-update", updatedETag);
+        await RemoveAsync(grainId, "schedule-update", updatedETag, cancellationToken);
     }
 
     /// <summary>
@@ -533,7 +626,12 @@ public abstract class ReminderTableTestRunner
     /// point read and the grain-scoped read, and the previous schedule is no longer visible.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows()
+    public virtual Task ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows()
+        => RunReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows);
 
@@ -541,7 +639,7 @@ public abstract class ReminderTableTestRunner
         var grainId = NewGrainId("window-move");
 
         var inside = NewEntry(grainId, "window-move", BaseTime.AddMinutes(2), TimeSpan.FromMinutes(30));
-        var insideETag = await UpsertAsync(inside, Guarantee);
+        var insideETag = await UpsertAsync(inside, Guarantee, cancellationToken);
         if (!IsWithinWindow(inside.StartAt, BaseTime, window))
         {
             Report(Guarantee, "UpsertRow")
@@ -554,9 +652,9 @@ public abstract class ReminderTableTestRunner
         }
 
         var outside = NewEntry(grainId, "window-move", BaseTime.AddHours(3), TimeSpan.FromMinutes(30));
-        var outsideETag = await UpsertAsync(outside, Guarantee, insideETag);
+        var outsideETag = await UpsertAsync(outside, Guarantee, cancellationToken, insideETag);
 
-        var read = await ReadRequiredAsync(grainId, "window-move", Guarantee, outside, outsideETag);
+        var read = await ReadRequiredAsync(grainId, "window-move", Guarantee, cancellationToken, outside, outsideETag);
         AssertEntry(Guarantee, "ReadRow", outside, outsideETag, read);
 
         var expectedRows = new[]
@@ -567,7 +665,8 @@ public abstract class ReminderTableTestRunner
             () => ReminderTable.ReadRows(0, 0),
             expectedRows,
             Guarantee,
-            "ReadRows(0, 0)");
+            "ReadRows(0, 0)",
+            cancellationToken);
         AssertExactEntries(Guarantee, "ReadRows(0, 0)", expectedRows, rows.Reminders);
 
         var enumerated = rows.Reminders[0];
@@ -583,7 +682,7 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        await RemoveAsync(grainId, "window-move", outsideETag);
+        await RemoveAsync(grainId, "window-move", outsideETag, cancellationToken);
     }
 
     // ---------------------------------------------------------------------------------------------------------
@@ -594,18 +693,24 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: the degenerate range <c>(0, 0]</c> enumerates every reminder in the table.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_FullRange_ReturnsAllReminders()
+    public virtual Task ReminderTable_ReadRows_FullRange_ReturnsAllReminders()
+        => RunReminderTable_ReadRows_FullRange_ReturnsAllReminders(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_FullRange_ReturnsAllReminders()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_FullRange_ReturnsAllReminders(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_FullRange_ReturnsAllReminders);
 
-        var fixtureState = await CreateRangeFixtureAsync(Guarantee);
+        var fixtureState = await CreateRangeFixtureAsync(Guarantee, cancellationToken);
         try
         {
             var full = await ReadRangeUntilExactAsync(
                 () => ReminderTable.ReadRows(0, 0),
                 fixtureState.All,
                 Guarantee,
-                "ReadRows(0, 0)");
+                "ReadRows(0, 0)",
+                cancellationToken);
             AssertRange(Guarantee, "ReadRows(0, 0)", 0, 0, fixtureState, full, fixtureState.All, []);
 
         }
@@ -619,10 +724,15 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: the unsigned upper ring boundary <c>(0, uint.MaxValue]</c> excludes only hash zero.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering()
+    public virtual Task ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering()
+        => RunReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering);
-        var fixtureState = await CreateRangeFixtureAsync(Guarantee);
+        var fixtureState = await CreateRangeFixtureAsync(Guarantee, cancellationToken);
         try
         {
             var expected = fixtureState.All.Where(item => item.Hash != 0).ToList();
@@ -631,7 +741,8 @@ public abstract class ReminderTableTestRunner
                 () => ReminderTable.ReadRows(0, uint.MaxValue),
                 expected,
                 Guarantee,
-                "ReadRows(0, uint.MaxValue)");
+                "ReadRows(0, uint.MaxValue)",
+                cancellationToken);
             AssertRange(Guarantee, "ReadRows(0, uint.MaxValue)", 0, uint.MaxValue, fixtureState, bounded, expected, excluded);
         }
         finally
@@ -645,7 +756,14 @@ public abstract class ReminderTableTestRunner
     /// </summary>
     /// <param name="reminderCount">The exact positive number of reminders to create and enumerate.</param>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(int reminderCount)
+    public virtual Task ReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(int reminderCount)
+        => RunReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(reminderCount, CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(int)"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(
+        int reminderCount,
+        CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality);
 
@@ -664,7 +782,7 @@ public abstract class ReminderTableTestRunner
                     $"requested-cardinality-{index}",
                     BaseTime.AddMinutes(index),
                     TimeSpan.FromMinutes((index % 17) + 1));
-                created.Add((entry, await UpsertAsync(entry, Guarantee)));
+                created.Add((entry, await UpsertAsync(entry, Guarantee, cancellationToken)));
             }
 
             var expected = created.Select(item => ReminderTableEntrySnapshot.Create(
@@ -675,14 +793,20 @@ public abstract class ReminderTableTestRunner
                 () => ReminderTable.ReadRows(0, 0),
                 expected,
                 Guarantee,
-                "ReadRows(0, 0)");
+                "ReadRows(0, 0)",
+                cancellationToken);
             AssertExactEntries(Guarantee, "ReadRows(0, 0)", expected, rows.Reminders);
         }
         finally
         {
+            using var cleanupCancellation = new CancellationTokenSource(CleanupTimeout);
             foreach (var item in created)
             {
-                await RemoveAsync(item.Entry.GrainId, item.Entry.ReminderName, item.ETag);
+                await RemoveAsync(
+                    item.Entry.GrainId,
+                    item.Entry.ReminderName,
+                    item.ETag,
+                    cleanupCancellation.Token);
             }
         }
     }
@@ -691,10 +815,15 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: a non-wrapping range is exclusive of <c>begin</c> and inclusive of <c>end</c>.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd()
+    public virtual Task ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd()
+        => RunReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd);
-        var fixtureState = await CreateRangeFixtureAsync(Guarantee);
+        var fixtureState = await CreateRangeFixtureAsync(Guarantee, cancellationToken);
         try
         {
             var low = fixtureState.All[0];
@@ -705,14 +834,16 @@ public abstract class ReminderTableTestRunner
                 () => ReminderTable.ReadRows(low.Hash, middle.Hash),
                 [middle],
                 Guarantee,
-                "ReadRows(low, middle)");
+                "ReadRows(low, middle)",
+                cancellationToken);
             AssertRange(Guarantee, "ReadRows(low, middle)", low.Hash, middle.Hash, fixtureState, rows, [middle], [low, high]);
 
             var upper = await ReadRangeUntilExactAsync(
                 () => ReminderTable.ReadRows(middle.Hash, high.Hash),
                 [high],
                 Guarantee,
-                "ReadRows(middle, high)");
+                "ReadRows(middle, high)",
+                cancellationToken);
             AssertRange(Guarantee, "ReadRows(middle, high)", middle.Hash, high.Hash, fixtureState, upper, [high], [low, middle]);
         }
         finally
@@ -725,10 +856,15 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: a wrap-around range where <c>begin &gt;= end</c> returns the union of both ring segments.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment()
+    public virtual Task ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment()
+        => RunReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment);
-        var fixtureState = await CreateRangeFixtureAsync(Guarantee);
+        var fixtureState = await CreateRangeFixtureAsync(Guarantee, cancellationToken);
         try
         {
             var low = fixtureState.All[0];
@@ -740,7 +876,8 @@ public abstract class ReminderTableTestRunner
                 () => ReminderTable.ReadRows(high.Hash, low.Hash),
                 [low],
                 Guarantee,
-                "ReadRows(high, low)");
+                "ReadRows(high, low)",
+                cancellationToken);
             AssertRange(Guarantee, "ReadRows(high, low)", high.Hash, low.Hash, fixtureState, wrapped, [low], [middle, high]);
 
             // (middle, low] wraps as well and contains 'high' (above begin) and 'low' (at or below end).
@@ -748,7 +885,8 @@ public abstract class ReminderTableTestRunner
                 () => ReminderTable.ReadRows(middle.Hash, low.Hash),
                 [low, high],
                 Guarantee,
-                "ReadRows(middle, low)");
+                "ReadRows(middle, low)",
+                cancellationToken);
             AssertRange(Guarantee, "ReadRows(middle, low)", middle.Hash, low.Hash, fixtureState, wrappedUnion, [low, high], [middle]);
         }
         finally
@@ -761,16 +899,24 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: absence from a hash-range read does not remove or otherwise modify the durable reminder.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder()
+    public virtual Task ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder()
+        => RunReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder);
         var grainId = NewGrainId("outside-range");
         var expected = NewEntry(grainId, "outside-range");
-        var etag = await UpsertAsync(expected, Guarantee);
+        var etag = await UpsertAsync(expected, Guarantee, cancellationToken);
         var hash = grainId.GetUniformHashCode();
         var end = unchecked(hash + 1);
 
-        var rows = RequireRows(Guarantee, "ReadRows(hash, hash + 1)", await ReminderTable.ReadRows(hash, end));
+        var rows = RequireRows(
+            Guarantee,
+            "ReadRows(hash, hash + 1)",
+            await ReminderTable.ReadRows(hash, end).WaitAsync(cancellationToken));
         if (rows.Reminders.Any(reminder => reminder.GrainId.Equals(grainId) && string.Equals(reminder.ReminderName, expected.ReminderName, StringComparison.Ordinal)))
         {
             Report(Guarantee, "ReadRows(hash, hash + 1)")
@@ -781,23 +927,28 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        AssertEntry(Guarantee, "ReadRow", expected, etag, await ReadRequiredAsync(grainId, expected.ReminderName, Guarantee, expected, etag));
-        await RemoveAsync(grainId, expected.ReminderName, etag);
+        AssertEntry(Guarantee, "ReadRow", expected, etag, await ReadRequiredAsync(grainId, expected.ReminderName, Guarantee, cancellationToken, expected, etag));
+        await RemoveAsync(grainId, expected.ReminderName, etag, cancellationToken);
     }
 
     /// <summary>
     /// Guarantee: a removed reminder disappears from range enumeration while its siblings remain.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder()
+    public virtual Task ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder()
+        => RunReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder);
 
-        var fixtureState = await CreateRangeFixtureAsync(Guarantee);
+        var fixtureState = await CreateRangeFixtureAsync(Guarantee, cancellationToken);
         try
         {
             var removed = fixtureState.All[1];
-            if (!await ReminderTable.RemoveRow(removed.GrainId, removed.ReminderName, removed.ETag))
+            if (!await ReminderTable.RemoveRow(removed.GrainId, removed.ReminderName, removed.ETag).WaitAsync(cancellationToken))
             {
                 Report(Guarantee, "RemoveRow")
                     .WithIdentity(removed.GrainId, removed.ReminderName)
@@ -814,7 +965,8 @@ public abstract class ReminderTableTestRunner
                 () => ReminderTable.ReadRows(0, 0),
                 remaining,
                 Guarantee,
-                "ReadRows(0, 0)");
+                "ReadRows(0, 0)",
+                cancellationToken);
             AssertRange(Guarantee, "ReadRows(0, 0)", 0, 0, fixtureState, rows, remaining, [removed]);
         }
         finally
@@ -828,19 +980,27 @@ public abstract class ReminderTableTestRunner
     /// range or due-time enumeration alone must never be treated as durable deletion.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ReadRow_AfterRemoval_ReturnsNull()
+    public virtual Task ReminderTable_ReadRow_AfterRemoval_ReturnsNull()
+        => RunReminderTable_ReadRow_AfterRemoval_ReturnsNull(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ReadRow_AfterRemoval_ReturnsNull()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ReadRow_AfterRemoval_ReturnsNull(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ReadRow_AfterRemoval_ReturnsNull);
 
         var grainId = NewGrainId("deletion-observation");
         var entry = NewEntry(grainId, "deletion-observation", BaseTime.AddMinutes(11), TimeSpan.FromMinutes(6));
-        var etag = await UpsertAsync(entry, Guarantee);
+        var etag = await UpsertAsync(entry, Guarantee, cancellationToken);
         var hash = grainId.GetUniformHashCode();
 
         // A range which cannot contain this reminder proves absence from a page is not deletion.
         var disjointBegin = unchecked(hash + 1);
         var disjointEnd = unchecked(hash + 2);
-        var disjoint = RequireRows(Guarantee, "ReadRows(disjoint)", await ReminderTable.ReadRows(disjointBegin, disjointEnd));
+        var disjoint = RequireRows(
+            Guarantee,
+            "ReadRows(disjoint)",
+            await ReminderTable.ReadRows(disjointBegin, disjointEnd).WaitAsync(cancellationToken));
         if (disjoint.Reminders.Any(reminder => reminder.GrainId.Equals(grainId) && string.Equals(reminder.ReminderName, entry.ReminderName, StringComparison.Ordinal)))
         {
             Report(Guarantee, "ReadRows(begin, end)")
@@ -857,7 +1017,8 @@ public abstract class ReminderTableTestRunner
             value => value is not null && EntryMatches(entry, etag, value),
             Guarantee,
             "ReadRow",
-            "the row to remain durably present after an excluding range read");
+            "the row to remain durably present after an excluding range read",
+            cancellationToken);
         if (stillPresent is null)
         {
             Report(Guarantee, "ReadRow")
@@ -870,14 +1031,15 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        await RemoveAsync(grainId, entry.ReminderName, etag);
+        await RemoveAsync(grainId, entry.ReminderName, etag, cancellationToken);
 
         var afterRemoval = await ReadUntilAsync(
             () => ReminderTable.ReadRow(grainId, entry.ReminderName),
             static value => value is null,
             Guarantee,
             "ReadRow",
-            "null after successful removal");
+            "null after successful removal",
+            cancellationToken);
         if (afterRemoval is not null)
         {
             Report(Guarantee, "ReadRow")
@@ -897,7 +1059,12 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: concurrent upserts of one identity all succeed and each returns a distinct ETag.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ConcurrentUpserts_ProduceDistinctETags()
+    public virtual Task ReminderTable_ConcurrentUpserts_ProduceDistinctETags()
+        => RunReminderTable_ConcurrentUpserts_ProduceDistinctETags(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ConcurrentUpserts_ProduceDistinctETags()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ConcurrentUpserts_ProduceDistinctETags(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ConcurrentUpserts_ProduceDistinctETags);
         const int Count = 5;
@@ -913,9 +1080,10 @@ public abstract class ReminderTableTestRunner
                 Guarantee,
                 "UpsertRow",
                 $"a non-empty ETag for ({grainId}, '{entry.ReminderName}')",
-                FormatETag);
+                FormatETag,
+                cancellationToken);
             return (Entry: entry, ETag: etag);
-        }));
+        })).WaitAsync(cancellationToken);
 
         var etags = writes.Select(write => write.ETag).ToArray();
         var distinct = etags.Where(etag => !string.IsNullOrEmpty(etag)).Distinct(StringComparer.Ordinal).Count();
@@ -933,7 +1101,8 @@ public abstract class ReminderTableTestRunner
             value => value is not null && writes.Any(write => EntryMatches(write.Entry, write.ETag, value)),
             Guarantee,
             "ReadRow",
-            $"one complete entry matching its returned ETag from [{string.Join(", ", writes.Select(write => $"{Describe(write.Entry)} => {FormatETag(write.ETag)}"))}]");
+            $"one complete entry matching its returned ETag from [{string.Join(", ", writes.Select(write => $"{Describe(write.Entry)} => {FormatETag(write.ETag)}"))}]",
+            cancellationToken);
         if (read is null)
         {
             Report(Guarantee, "ReadRow")
@@ -951,7 +1120,8 @@ public abstract class ReminderTableTestRunner
                 value => value is not null && value.Reminders.Count == 1,
                 Guarantee,
                 "ReadRows(GrainId)",
-                "exactly one durable row for one reminder identity"));
+                "exactly one durable row for one reminder identity",
+                cancellationToken));
         if (rows.Reminders.Count != 1)
         {
             Report(Guarantee, "ReadRows(GrainId)")
@@ -961,7 +1131,7 @@ public abstract class ReminderTableTestRunner
                 .Throw();
         }
 
-        await RemoveAsync(grainId, "concurrent-upsert", read!.ETag!);
+        await RemoveAsync(grainId, "concurrent-upsert", read!.ETag!, cancellationToken);
     }
 
     /// <summary>
@@ -969,7 +1139,12 @@ public abstract class ReminderTableTestRunner
     /// exactly one row from its own ETag stream.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated()
+    public virtual Task ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated()
+        => RunReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated);
         const int GrainCount = 5;
@@ -979,7 +1154,10 @@ public abstract class ReminderTableTestRunner
         // Seed serially so this guarantee isolates parallel replacement streams from same-identity insert contention.
         foreach (var grainId in grains)
         {
-            await UpsertAsync(NewEntry(grainId, "parallel", BaseTime, TimeSpan.FromMinutes(1)), Guarantee);
+            await UpsertAsync(
+                NewEntry(grainId, "parallel", BaseTime, TimeSpan.FromMinutes(1)),
+                Guarantee,
+                cancellationToken);
         }
 
         var results = await Task.WhenAll(grains.Select(async grainId =>
@@ -999,11 +1177,12 @@ public abstract class ReminderTableTestRunner
                     Guarantee,
                     "UpsertRow",
                     $"a non-empty ETag within the replacement stream for grain {grainId}",
-                    FormatETag);
+                    FormatETag,
+                    cancellationToken);
             }
 
             return (GrainId: grainId, Entries: entries, ETags: etags);
-        }));
+        })).WaitAsync(cancellationToken);
 
         foreach (var (grainId, entries, etags) in results)
         {
@@ -1023,7 +1202,8 @@ public abstract class ReminderTableTestRunner
                     && etags.Contains(value.Reminders[0].ETag, StringComparer.Ordinal),
                 Guarantee,
                 "ReadRows(GrainId)",
-                $"one durable replacement for grain {grainId} with an ETag from its own stream");
+                $"one durable replacement for grain {grainId} with an ETag from its own stream",
+                cancellationToken);
             var row = RequireRows(Guarantee, "ReadRows(GrainId)", rows).Reminders.Single();
             var expectedIndex = Array.FindIndex(etags, etag => string.Equals(etag, row.ETag, StringComparison.Ordinal));
             if (expectedIndex < 0 || !row.GrainId.Equals(grainId))
@@ -1037,7 +1217,7 @@ public abstract class ReminderTableTestRunner
             }
 
             AssertEntry(Guarantee, "ReadRows(GrainId)", entries[expectedIndex], etags[expectedIndex]!, row);
-            await ReminderTable.RemoveRow(grainId, row.ReminderName, row.ETag!);
+            await ReminderTable.RemoveRow(grainId, row.ReminderName, row.ETag!).WaitAsync(cancellationToken);
         }
     }
 
@@ -1049,15 +1229,20 @@ public abstract class ReminderTableTestRunner
     /// Guarantee: <see cref="IReminderTable.TestOnlyClearTable"/> removes every reminder.
     /// </summary>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    public virtual async Task ReminderTable_TestOnlyClearTable_RemovesAllReminders()
+    public virtual Task ReminderTable_TestOnlyClearTable_RemovesAllReminders()
+        => RunReminderTable_TestOnlyClearTable_RemovesAllReminders(CancellationToken.None);
+
+    /// <inheritdoc cref="ReminderTable_TestOnlyClearTable_RemovesAllReminders()"/>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    public virtual async Task RunReminderTable_TestOnlyClearTable_RemovesAllReminders(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderTable_TestOnlyClearTable_RemovesAllReminders);
         var first = NewGrainId("clear-a");
         var second = NewGrainId("clear-b");
-        await UpsertAsync(NewEntry(first, "clear-a"), Guarantee);
-        await UpsertAsync(NewEntry(second, "clear-b"), Guarantee);
+        await UpsertAsync(NewEntry(first, "clear-a"), Guarantee, cancellationToken);
+        await UpsertAsync(NewEntry(second, "clear-b"), Guarantee, cancellationToken);
 
-        await ReminderTable.TestOnlyClearTable();
+        await ReminderTable.TestOnlyClearTable().WaitAsync(cancellationToken);
 
         var rows = RequireRows(
             Guarantee,
@@ -1067,7 +1252,8 @@ public abstract class ReminderTableTestRunner
                 value => value is not null && value.Reminders.Count == 0,
                 Guarantee,
                 "ReadRows(0, 0)",
-                "an empty table after TestOnlyClearTable"));
+                "an empty table after TestOnlyClearTable",
+                cancellationToken));
         if (rows.Reminders.Count != 0)
         {
             Report(Guarantee, "TestOnlyClearTable")
@@ -1083,7 +1269,8 @@ public abstract class ReminderTableTestRunner
                 static value => value is null,
                 Guarantee,
                 "ReadRow",
-                $"null for ({grainId}, '{name}') after TestOnlyClearTable");
+                $"null for ({grainId}, '{name}') after TestOnlyClearTable",
+                cancellationToken);
             if (read is not null)
             {
                 Report(Guarantee, "ReadRow")
@@ -1159,7 +1346,22 @@ public abstract class ReminderTableTestRunner
     /// <param name="guarantee">The guarantee being verified.</param>
     /// <param name="previousETag">The ETag which a replacement must rotate, or <see langword="null"/> for a new row.</param>
     /// <returns>The new ETag.</returns>
-    protected async Task<string> UpsertAsync(ReminderEntry entry, string guarantee, string? previousETag = null)
+    protected Task<string> UpsertAsync(ReminderEntry entry, string guarantee, string? previousETag = null)
+        => UpsertAsync(entry, guarantee, CancellationToken.None, previousETag);
+
+    /// <summary>
+    /// Upserts an entry and asserts that a non-empty ETag was returned.
+    /// </summary>
+    /// <param name="entry">The entry to upsert.</param>
+    /// <param name="guarantee">The guarantee being verified.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <param name="previousETag">The ETag which a replacement must rotate, or <see langword="null"/> for a new row.</param>
+    /// <returns>The new ETag.</returns>
+    protected async Task<string> UpsertAsync(
+        ReminderEntry entry,
+        string guarantee,
+        CancellationToken cancellationToken,
+        string? previousETag = null)
     {
         var etag = (await ReminderTableRetryPolicy.MutateUntilAsync(
             () => ReminderTable.UpsertRow(entry),
@@ -1168,7 +1370,8 @@ public abstract class ReminderTableTestRunner
             guarantee,
             "UpsertRow",
             "a non-empty provider-issued ETag",
-            FormatETag))!;
+            FormatETag,
+            cancellationToken))!;
 
         if (previousETag is not null && string.Equals(previousETag, etag, StringComparison.Ordinal))
         {
@@ -1197,6 +1400,31 @@ public abstract class ReminderTableTestRunner
         string guarantee,
         ReminderEntry? expected = null,
         string? expectedETag = null)
+        => await ReadRequiredAsync(
+            grainId,
+            reminderName,
+            guarantee,
+            CancellationToken.None,
+            expected,
+            expectedETag);
+
+    /// <summary>
+    /// Reads a reminder which the guarantee requires to be present.
+    /// </summary>
+    /// <param name="grainId">The grain identifier.</param>
+    /// <param name="reminderName">The reminder name.</param>
+    /// <param name="guarantee">The guarantee being verified.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <param name="expected">The expected entry.</param>
+    /// <param name="expectedETag">The expected ETag.</param>
+    /// <returns>The reminder entry.</returns>
+    protected async Task<ReminderEntry> ReadRequiredAsync(
+        GrainId grainId,
+        string reminderName,
+        string guarantee,
+        CancellationToken cancellationToken,
+        ReminderEntry? expected = null,
+        string? expectedETag = null)
     {
         var read = await ReadUntilAsync(
             () => ReminderTable.ReadRow(grainId, reminderName),
@@ -1205,7 +1433,8 @@ public abstract class ReminderTableTestRunner
             "ReadRow",
             expected is null
                 ? "the previously upserted reminder to be readable"
-                : $"{Describe(expected)} with ETag {FormatETag(expectedETag)}");
+                : $"{Describe(expected)} with ETag {FormatETag(expectedETag)}",
+            cancellationToken);
         if (read is null)
         {
             Report(guarantee, "ReadRow")
@@ -1223,7 +1452,8 @@ public abstract class ReminderTableTestRunner
         Func<T, bool> hasConverged,
         string guarantee,
         string operation,
-        string expected)
+        string expected,
+        CancellationToken cancellationToken)
         => ReminderTableRetryPolicy.ReadUntilAsync(
             read,
             hasConverged,
@@ -1237,7 +1467,8 @@ public abstract class ReminderTableTestRunner
                 ReminderEntry entry => Describe(entry),
                 ReminderTableData rows => $"{rows.Reminders.Count} rows: [{string.Join(", ", rows.Reminders.Select(Describe))}]",
                 _ => value.ToString() ?? "<null>"
-            });
+            },
+            cancellationToken);
 
     private bool EntryMatches(ReminderEntry expected, string? expectedETag, ReminderEntry actual)
         => actual.GrainId.Equals(expected.GrainId)
@@ -1253,9 +1484,24 @@ public abstract class ReminderTableTestRunner
     /// <param name="reminderName">The reminder name.</param>
     /// <param name="etag">The current ETag.</param>
     /// <returns>A task which represents the asynchronous operation.</returns>
-    protected async Task RemoveAsync(GrainId grainId, string reminderName, string etag)
+    protected Task RemoveAsync(GrainId grainId, string reminderName, string etag)
+        => RemoveAsync(grainId, reminderName, etag, CancellationToken.None);
+
+    /// <summary>
+    /// Removes a reminder during test cleanup.
+    /// </summary>
+    /// <param name="grainId">The grain identifier.</param>
+    /// <param name="reminderName">The reminder name.</param>
+    /// <param name="etag">The current ETag.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
+    protected async Task RemoveAsync(
+        GrainId grainId,
+        string reminderName,
+        string etag,
+        CancellationToken cancellationToken)
     {
-        await ReminderTable.RemoveRow(grainId, reminderName, etag);
+        await ReminderTable.RemoveRow(grainId, reminderName, etag).WaitAsync(cancellationToken);
     }
 
     /// <summary>
@@ -1282,7 +1528,8 @@ public abstract class ReminderTableTestRunner
         Func<Task<ReminderTableData>> read,
         IReadOnlyList<ReminderTableEntrySnapshot> expected,
         string guarantee,
-        string operation)
+        string operation,
+        CancellationToken cancellationToken)
     {
         var rows = await ReminderTableRetryPolicy.ReadUntilAsync(
             read,
@@ -1308,7 +1555,8 @@ public abstract class ReminderTableTestRunner
                 return difference is null
                     ? $"[{string.Join(", ", actual)}]"
                     : $"differingField: '{difference.Field}'. {difference}. Expected=[{string.Join(", ", expected)}], Actual=[{string.Join(", ", actual)}]";
-            });
+            },
+            cancellationToken);
         return RequireRows(guarantee, operation, rows);
     }
 
@@ -1316,7 +1564,8 @@ public abstract class ReminderTableTestRunner
         Func<Task<ReminderTableData>> read,
         IReadOnlyList<RangeItem> expected,
         string guarantee,
-        string operation)
+        string operation,
+        CancellationToken cancellationToken)
         => ReadRowsUntilExactAsync(
             read,
             expected.Select(item => ReminderTableEntrySnapshot.Create(
@@ -1324,7 +1573,8 @@ public abstract class ReminderTableTestRunner
                 item.ETag,
                 supportsSubSecondPrecision: false)).ToList(),
             guarantee,
-            operation);
+            operation,
+            cancellationToken);
 
     /// <summary>
     /// Asserts that a read observed the expected identity, schedule and ETag.
@@ -1407,7 +1657,9 @@ public abstract class ReminderTableTestRunner
     /// <returns>The rendered ETag.</returns>
     protected static string FormatETag(string? etag) => etag is null ? "<null>" : etag.Length == 0 ? "<empty>" : $"'{etag}'";
 
-    private async Task<RangeFixture> CreateRangeFixtureAsync(string guarantee)
+    private async Task<RangeFixture> CreateRangeFixtureAsync(
+        string guarantee,
+        CancellationToken cancellationToken)
     {
         var items = new List<RangeItem>();
         var seen = new HashSet<uint>();
@@ -1423,7 +1675,7 @@ public abstract class ReminderTableTestRunner
 
             var name = $"range-{items.Count}";
             var entry = NewEntry(grainId, name, BaseTime.AddMinutes(items.Count), TimeSpan.FromMinutes(items.Count + 1));
-            var etag = await UpsertAsync(entry, guarantee);
+            var etag = await UpsertAsync(entry, guarantee, cancellationToken);
             items.Add(new RangeItem(entry, hash, etag));
         }
 
@@ -1563,7 +1815,9 @@ public abstract class ReminderTableTestRunner
         public bool Removed { get; set; }
     }
 
-    private sealed class RangeFixture(ReminderTableTestRunner runner, List<RangeItem> items)
+    private sealed class RangeFixture(
+        ReminderTableTestRunner runner,
+        List<RangeItem> items)
     {
         public IReadOnlyList<RangeItem> All { get; } = items;
 
@@ -1571,11 +1825,16 @@ public abstract class ReminderTableTestRunner
 
         public async Task CleanupAsync()
         {
+            using var cleanupCancellation = new CancellationTokenSource(CleanupTimeout);
             foreach (var item in All)
             {
                 if (!item.Removed)
                 {
-                    await runner.RemoveAsync(item.GrainId, item.ReminderName, item.ETag);
+                    await runner.RemoveAsync(
+                        item.GrainId,
+                        item.ReminderName,
+                        item.ETag,
+                        cleanupCancellation.Token);
                 }
             }
         }

--- a/src/Orleans.Runtime/Persistence/FileStorage/FileGrainStorage.cs
+++ b/src/Orleans.Runtime/Persistence/FileStorage/FileGrainStorage.cs
@@ -27,16 +27,32 @@ public sealed class FileGrainStorage(
     private readonly string _rootDirectory = Path.GetFullPath(options.RootDirectory);
 
     /// <inheritdoc />
-    public async Task ClearStateAsync<T>(
+    public Task ClearStateAsync<T>(
         string stateName,
         GrainId grainId,
-        IGrainState<T> grainState)
+        IGrainState<T> grainState) =>
+        ClearStateAsync(stateName, grainId, grainState, CancellationToken.None);
+
+    Task IGrainStorage.ClearStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState,
+        CancellationToken cancellationToken) =>
+        ClearStateAsync(stateName, grainId, grainState, cancellationToken);
+
+    private async Task ClearStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var path = GetRecordPath(stateName, grainId);
-        var record = await TryReadRecordAsync(path).ConfigureAwait(false);
+        var record = await TryReadRecordAsync(path, cancellationToken).ConfigureAwait(false);
         if (record is not null)
         {
             ValidateETag<T>("ClearState", grainId, grainState.ETag, record.Value.ETag);
+            cancellationToken.ThrowIfCancellationRequested();
             File.Delete(path);
         }
 
@@ -44,31 +60,64 @@ public sealed class FileGrainStorage(
     }
 
     /// <inheritdoc />
-    public async Task ReadStateAsync<T>(
+    public Task ReadStateAsync<T>(
         string stateName,
         GrainId grainId,
-        IGrainState<T> grainState)
+        IGrainState<T> grainState) =>
+        ReadStateAsync(stateName, grainId, grainState, CancellationToken.None);
+
+    Task IGrainStorage.ReadStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState,
+        CancellationToken cancellationToken) =>
+        ReadStateAsync(stateName, grainId, grainState, cancellationToken);
+
+    private async Task ReadStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState,
+        CancellationToken cancellationToken)
     {
-        var record = await TryReadRecordAsync(GetRecordPath(stateName, grainId)).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        var record = await TryReadRecordAsync(
+            GetRecordPath(stateName, grainId),
+            cancellationToken).ConfigureAwait(false);
         if (record is null)
         {
             ResetState(grainState);
             return;
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         grainState.State = options.GrainStorageSerializer.Deserialize<T>(new BinaryData(record.Value.Payload));
         grainState.ETag = record.Value.ETag;
         grainState.RecordExists = true;
     }
 
     /// <inheritdoc />
-    public async Task WriteStateAsync<T>(
+    public Task WriteStateAsync<T>(
         string stateName,
         GrainId grainId,
-        IGrainState<T> grainState)
+        IGrainState<T> grainState) =>
+        WriteStateAsync(stateName, grainId, grainState, CancellationToken.None);
+
+    Task IGrainStorage.WriteStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState,
+        CancellationToken cancellationToken) =>
+        WriteStateAsync(stateName, grainId, grainState, cancellationToken);
+
+    private async Task WriteStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var path = GetRecordPath(stateName, grainId);
-        var existingRecord = await TryReadRecordAsync(path).ConfigureAwait(false);
+        var existingRecord = await TryReadRecordAsync(path, cancellationToken).ConfigureAwait(false);
         if (existingRecord is not null)
         {
             ValidateETag<T>("WriteState", grainId, grainState.ETag, existingRecord.Value.ETag);
@@ -79,8 +128,12 @@ public sealed class FileGrainStorage(
         }
 
         var etag = Guid.NewGuid().ToString("N");
+        cancellationToken.ThrowIfCancellationRequested();
         var payload = options.GrainStorageSerializer.Serialize(grainState.State).ToArray();
-        await File.WriteAllBytesAsync(path, CreateRecord(etag, payload)).ConfigureAwait(false);
+        await File.WriteAllBytesAsync(
+            path,
+            CreateRecord(etag, payload),
+            cancellationToken).ConfigureAwait(false);
 
         grainState.ETag = etag;
         grainState.RecordExists = true;
@@ -106,11 +159,13 @@ public sealed class FileGrainStorage(
         return result;
     }
 
-    private static async Task<StoredRecord?> TryReadRecordAsync(string path)
+    private static async Task<StoredRecord?> TryReadRecordAsync(
+        string path,
+        CancellationToken cancellationToken)
     {
         try
         {
-            var bytes = await File.ReadAllBytesAsync(path).ConfigureAwait(false);
+            var bytes = await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false);
             if (bytes.Length < RecordHeaderLength ||
                 !bytes.AsSpan(0, RecordMagic.Length).SequenceEqual(RecordMagic))
             {

--- a/src/Orleans.Runtime/Persistence/FileStorage/FileGrainStorage.cs
+++ b/src/Orleans.Runtime/Persistence/FileStorage/FileGrainStorage.cs
@@ -130,10 +130,12 @@ public sealed class FileGrainStorage(
         var etag = Guid.NewGuid().ToString("N");
         cancellationToken.ThrowIfCancellationRequested();
         var payload = options.GrainStorageSerializer.Serialize(grainState.State).ToArray();
+        cancellationToken.ThrowIfCancellationRequested();
+        // Once the write begins, complete it so cancellation cannot leave a partial record.
         await File.WriteAllBytesAsync(
             path,
             CreateRecord(etag, payload),
-            cancellationToken).ConfigureAwait(false);
+            CancellationToken.None).ConfigureAwait(false);
 
         grainState.ETag = etag;
         grainState.RecordExists = true;

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -230,8 +230,15 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// <summary>
     /// Deploys the cluster using the specified configuration and starts the client in-process.
     /// </summary>
-    public async Task DeployAsync()
+    public Task DeployAsync() => DeployAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Deploys the cluster using the specified configuration and starts the client in-process.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel deployment.</param>
+    public async Task DeployAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (_silos.Count > 0) throw new InvalidOperationException("Cluster host already deployed.");
 
         AppDomain.CurrentDomain.UnhandledException += ReportUnobservedException;
@@ -240,11 +247,11 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         {
             string startMsg = "----------------------------- STARTING NEW UNIT TEST SILO HOST: " + GetType().FullName + " -------------------------------------";
             WriteLog(startMsg);
-            await InitializeAsync();
+            await InitializeAsync(cancellationToken);
 
             if (Options.InitializeClientOnDeploy)
             {
-                await WaitForInitialStabilization();
+                await WaitForInitialStabilization(cancellationToken);
             }
         }
         catch (TimeoutException te)
@@ -254,7 +261,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            await StopAllSilosAsync();
+            await StopAllSilosAsync(CancellationToken.None);
 
             Exception baseExc = ex.GetBaseException();
             FlushLogToConsole();
@@ -279,7 +286,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         }
     }
 
-    private async Task WaitForInitialStabilization()
+    private async Task WaitForInitialStabilization(CancellationToken cancellationToken)
     {
         // Poll each silo to check that it knows the expected number of active silos.
         // If any silo does not have the expected number of active silos in its cluster membership oracle, try again.
@@ -294,7 +301,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
             foreach (var silo in silos)
             {
                 var hooks = InternalClient!.GetTestHooks(silo); // Membership stabilization requires a deployed client.
-                var statuses = await hooks.GetApproximateSiloStatuses();
+                var statuses = await hooks.GetApproximateSiloStatuses().WaitAsync(cancellationToken);
                 var activeCount = statuses.Count(s => s.Value == SiloStatus.Active);
                 if (activeCount != expectedCount) break;
                 remainingSilos--;
@@ -307,7 +314,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
             }
 
             WriteLog($"{remainingSilos} silos do not have a consistent cluster view, waiting until stabilization.");
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
 
             if (totalWait.Elapsed < TimeSpan.FromSeconds(60))
             {
@@ -481,13 +488,31 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="silosToStart">Number of silos to start.</param>
     /// <returns>List of SiloHandles for the newly started silos.</returns>
-    public async Task<List<InProcessSiloHandle>> StartSilosAsync(int silosToStart)
+    public Task<List<InProcessSiloHandle>> StartSilosAsync(int silosToStart)
+        => StartSilosAsync(silosToStart, CancellationToken.None);
+
+    /// <summary>
+    /// Start a number of additional silos, so that they join the existing cluster.
+    /// </summary>
+    /// <param name="silosToStart">Number of silos to start.</param>
+    /// <param name="cancellationToken">The token used to cancel silo startup.</param>
+    /// <returns>List of silo handles for the newly started silos.</returns>
+    public async Task<List<InProcessSiloHandle>> StartSilosAsync(
+        int silosToStart,
+        CancellationToken cancellationToken)
     {
         var instances = new List<InProcessSiloHandle>();
         if (silosToStart > 0)
         {
-            var siloStartTasks = Enumerable.Range(_startedInstances, silosToStart)
-                .Select(instanceNumber => Task.Run(() => StartSiloAsync((short)instanceNumber, Options))).ToArray();
+            var silos = Silos;
+            var firstInstanceNumber = silos.Count == 0
+                ? 0
+                : silos.Max(static silo => silo.InstanceNumber) + 1;
+            var siloStartTasks = Enumerable.Range(firstInstanceNumber, silosToStart)
+                .Select(instanceNumber => Task.Run(
+                    () => StartSiloAsync((short)instanceNumber, Options, cancellationToken),
+                    cancellationToken))
+                .ToArray();
 
             try
             {
@@ -497,7 +522,10 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
             {
                 lock (_silos)
                 {
-                    _silos.AddRange(siloStartTasks.Where(t => t.Exception == null).Select(t => t.Result));
+                    _silos.AddRange(
+                        siloStartTasks
+                            .Where(static task => task.Status == TaskStatus.RanToCompletion)
+                            .Select(static task => task.Result));
                 }
 
                 throw;
@@ -516,11 +544,17 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// <summary>
     /// Stop all silos.
     /// </summary>
-    public async Task StopSilosAsync()
+    public Task StopSilosAsync() => StopSilosAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Stop all silos.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+    public async Task StopSilosAsync(CancellationToken cancellationToken)
     {
         foreach (var instance in _silos.ToList())
         {
-            await StopSiloAsync(instance);
+            await StopSiloAsync(instance, cancellationToken);
         }
     }
 
@@ -528,19 +562,30 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// Stop cluster client as an asynchronous operation.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task StopClusterClientAsync()
+    public Task StopClusterClientAsync() => StopClusterClientAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Stop cluster client as an asynchronous operation.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task StopClusterClientAsync(CancellationToken cancellationToken)
     {
         var client = ClientHost;
         try
         {
             if (client is not null)
             {
-                await client.StopAsync().ConfigureAwait(false);
+                await client.StopAsync(cancellationToken).ConfigureAwait(false);
             }
         }
         catch (Exception exc)
         {
             WriteLog("Exception stopping client: {0}", exc);
+            if (exc is OperationCanceledException && cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
         }
         finally
         {
@@ -560,25 +605,50 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// <summary>
     /// Stop all current silos.
     /// </summary>
-    public async Task StopAllSilosAsync()
+    public Task StopAllSilosAsync() => StopAllSilosAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Stop all current silos.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+    public async Task StopAllSilosAsync(CancellationToken cancellationToken)
     {
-        await StopClusterClientAsync();
-        await StopSilosAsync();
-        AppDomain.CurrentDomain.UnhandledException -= ReportUnobservedException;
+        try
+        {
+            await StopClusterClientAsync(cancellationToken);
+            await StopSilosAsync(cancellationToken);
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.UnhandledException -= ReportUnobservedException;
+        }
     }
 
     /// <summary>
     /// Do a semi-graceful Stop of the specified silo.
     /// </summary>
     /// <param name="instance">Silo to be stopped.</param>
-    public async Task StopSiloAsync(InProcessSiloHandle instance)
+    public Task StopSiloAsync(InProcessSiloHandle instance) => StopSiloAsync(instance, CancellationToken.None);
+
+    /// <summary>
+    /// Do a semi-graceful Stop of the specified silo.
+    /// </summary>
+    /// <param name="instance">Silo to be stopped.</param>
+    /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+    public async Task StopSiloAsync(InProcessSiloHandle instance, CancellationToken cancellationToken)
     {
         if (instance != null)
         {
-            await StopSiloAsync(instance, true);
-            lock (_silos)
+            try
             {
-                _silos.Remove(instance);
+                await StopSiloAsync(instance, true, cancellationToken);
+            }
+            finally
+            {
+                lock (_silos)
+                {
+                    _silos.Remove(instance);
+                }
             }
         }
     }
@@ -587,15 +657,29 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// Do an immediate Kill of the specified silo.
     /// </summary>
     /// <param name="instance">Silo to be killed.</param>
-    public async Task KillSiloAsync(InProcessSiloHandle instance)
+    public Task KillSiloAsync(InProcessSiloHandle instance) => KillSiloAsync(instance, CancellationToken.None);
+
+    /// <summary>
+    /// Do an immediate Kill of the specified silo.
+    /// </summary>
+    /// <param name="instance">Silo to be killed.</param>
+    /// <param name="cancellationToken">The token used to cancel the operation.</param>
+    public async Task KillSiloAsync(InProcessSiloHandle instance, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (instance != null)
         {
-            // do NOT stop, just kill directly, to simulate crash.
-            await StopSiloAsync(instance, false);
-            lock (_silos)
+            try
             {
-                _silos.Remove(instance);
+                // do NOT stop, just kill directly, to simulate crash.
+                await StopSiloAsync(instance, false, cancellationToken);
+            }
+            finally
+            {
+                lock (_silos)
+                {
+                    _silos.Remove(instance);
+                }
             }
         }
     }
@@ -661,15 +745,21 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Initialize the grain client. This should be already done by <see cref="DeployAsync"/>
+    /// Initialize the grain client. This should be already done by <see cref="DeployAsync()"/>
     /// </summary>
-    public async Task InitializeClientAsync()
+    public Task InitializeClientAsync() => InitializeClientAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Initialize the grain client.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel initialization.</param>
+    public async Task InitializeClientAsync(CancellationToken cancellationToken)
     {
         WriteLog("Initializing Cluster Client");
 
         if (ClientHost is not null)
         {
-            await StopClusterClientAsync();
+            await StopClusterClientAsync(cancellationToken);
         }
 
         var hostBuilder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
@@ -705,7 +795,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         var clientHost = hostBuilder.Build();
         try
         {
-            await clientHost.StartAsync();
+            await clientHost.StartAsync(cancellationToken);
             ClientHost = clientHost;
         }
         catch
@@ -715,24 +805,35 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         }
     }
 
-    private async Task InitializeAsync()
+    private async Task InitializeAsync(CancellationToken cancellationToken)
     {
         var silosToStart = Options.InitialSilosCount;
 
         if (silosToStart > 0)
         {
-            await StartSilosAsync(silosToStart);
+            await StartSilosAsync(silosToStart, cancellationToken);
         }
 
         WriteLog("Done initializing cluster");
 
         if (Options.InitializeClientOnDeploy)
         {
-            await InitializeClientAsync();
+            await InitializeClientAsync(cancellationToken);
         }
     }
 
-    public async Task<InProcessSiloHandle> CreateSiloAsync(InProcessTestSiloSpecificOptions siloOptions)
+    public Task<InProcessSiloHandle> CreateSiloAsync(InProcessTestSiloSpecificOptions siloOptions)
+        => CreateSiloAsync(siloOptions, CancellationToken.None);
+
+    /// <summary>
+    /// Creates and starts an in-process silo.
+    /// </summary>
+    /// <param name="siloOptions">The silo options.</param>
+    /// <param name="cancellationToken">The token used to cancel silo startup.</param>
+    /// <returns>A handle to the started silo.</returns>
+    public async Task<InProcessSiloHandle> CreateSiloAsync(
+        InProcessTestSiloSpecificOptions siloOptions,
+        CancellationToken cancellationToken)
     {
         var host = await Task.Run(async () =>
         {
@@ -814,9 +915,17 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
             var host = appBuilder.Build();
             TestClusterFatalErrorHandler.Attach(host);
             InitializeTestHooksSystemTarget(host);
-            await host.StartAsync();
-            return host;
-        });
+            try
+            {
+                await host.StartAsync(cancellationToken);
+                return host;
+            }
+            catch
+            {
+                await DisposeAsync(host);
+                throw;
+            }
+        }, cancellationToken);
 
         return new InProcessSiloHandle
         {
@@ -862,10 +971,23 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// <param name="instanceNumber">The instance number to deploy</param>
     /// <param name="clusterOptions">The options to use.</param>
     /// <returns>A handle to the deployed silo.</returns>
-    public async Task<InProcessSiloHandle> StartSiloAsync(int instanceNumber, InProcessTestClusterOptions clusterOptions)
+    public Task<InProcessSiloHandle> StartSiloAsync(int instanceNumber, InProcessTestClusterOptions clusterOptions)
+        => StartSiloAsync(instanceNumber, clusterOptions, CancellationToken.None);
+
+    /// <summary>
+    /// Starts a new silo.
+    /// </summary>
+    /// <param name="instanceNumber">The instance number to deploy.</param>
+    /// <param name="clusterOptions">The options to use.</param>
+    /// <param name="cancellationToken">The token used to cancel silo startup.</param>
+    /// <returns>A handle to the deployed silo.</returns>
+    public async Task<InProcessSiloHandle> StartSiloAsync(
+        int instanceNumber,
+        InProcessTestClusterOptions clusterOptions,
+        CancellationToken cancellationToken)
     {
         var siloOptions = InProcessTestSiloSpecificOptions.Create(this, clusterOptions, instanceNumber, assignNewPort: true);
-        var handle = await CreateSiloAsync(siloOptions);
+        var handle = await CreateSiloAsync(siloOptions, cancellationToken);
         handle.InstanceNumber = (short)instanceNumber;
         Interlocked.Increment(ref _startedInstances);
         return handle;
@@ -885,11 +1007,14 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         return await StartSiloAsync(instanceNumber, clusterOptions);
     }
 
-    private async Task StopSiloAsync(InProcessSiloHandle instance, bool stopGracefully)
+    private async Task StopSiloAsync(
+        InProcessSiloHandle instance,
+        bool stopGracefully,
+        CancellationToken cancellationToken)
     {
         try
         {
-            await instance.StopSiloAsync(stopGracefully).ConfigureAwait(false);
+            await instance.StopSiloAsync(stopGracefully, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -934,6 +1059,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
 
         await Task.Run(async () =>
         {
+            AppDomain.CurrentDomain.UnhandledException -= ReportUnobservedException;
             foreach (var handle in Silos)
             {
                 await DisposeAsync(handle).ConfigureAwait(false);

--- a/src/Orleans.TestingHost/InProcessSiloHandle.cs
+++ b/src/Orleans.TestingHost/InProcessSiloHandle.cs
@@ -38,13 +38,44 @@ namespace Orleans.TestingHost
             string siloName,
             IConfiguration configuration,
             Action<IHostBuilder>? postConfigureHostBuilder = null)
+            => await CreateAsync(siloName, configuration, postConfigureHostBuilder, CancellationToken.None);
+
+        /// <summary>
+        /// Create a silo handle.
+        /// </summary>
+        /// <param name="siloName">Name of the silo.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="postConfigureHostBuilder">An optional delegate which is invoked just prior to building the host builder.</param>
+        /// <param name="cancellationToken">The token used to cancel silo startup.</param>
+        /// <returns>The silo handle.</returns>
+        public static async Task<InProcessSiloHandle> CreateAsync(
+            string siloName,
+            IConfiguration configuration,
+            Action<IHostBuilder>? postConfigureHostBuilder,
+            CancellationToken cancellationToken)
         {
             var host = await Task.Run(async () =>
             {
                 var result = TestClusterHostFactory.CreateSiloHost(siloName, configuration, postConfigureHostBuilder);
-                await result.StartAsync();
-                return result;
-            });
+                try
+                {
+                    await result.StartAsync(cancellationToken);
+                    return result;
+                }
+                catch
+                {
+                    if (result is IAsyncDisposable asyncDisposable)
+                    {
+                        await asyncDisposable.DisposeAsync();
+                    }
+                    else
+                    {
+                        result.Dispose();
+                    }
+
+                    throw;
+                }
+            }, cancellationToken);
 
             var retValue = new InProcessSiloHandle
             {

--- a/src/Orleans.TestingHost/SiloHandle.cs
+++ b/src/Orleans.TestingHost/SiloHandle.cs
@@ -32,6 +32,12 @@ namespace Orleans.TestingHost
         /// <param name="stopGracefully">Specifies whether the silo should be stopped gracefully or abruptly.</param>
         public abstract Task StopSiloAsync(bool stopGracefully);
 
+        /// <summary>Stop the remote silo.</summary>
+        /// <param name="stopGracefully">Specifies whether the silo should be stopped gracefully or abruptly.</param>
+        /// <param name="cancellationToken">Specifies the cancellation token to use for the shutdown sequence.</param>
+        public virtual Task StopSiloAsync(bool stopGracefully, CancellationToken cancellationToken)
+            => StopSiloAsync(stopGracefully ? cancellationToken : new CancellationToken(canceled: true));
+
         /// <summary>Stop the remote silo. This method cannot be use with AppDomain</summary>
         /// <param name="ct">Specifies the cancellation token to use for the shutdown sequence</param>
         public abstract Task StopSiloAsync(CancellationToken ct);

--- a/src/Orleans.TestingHost/SiloHandle.cs
+++ b/src/Orleans.TestingHost/SiloHandle.cs
@@ -34,9 +34,13 @@ namespace Orleans.TestingHost
 
         /// <summary>Stop the remote silo.</summary>
         /// <param name="stopGracefully">Specifies whether the silo should be stopped gracefully or abruptly.</param>
-        /// <param name="cancellationToken">Specifies the cancellation token to use for the shutdown sequence.</param>
+        /// <param name="cancellationToken">
+        /// Specifies the cancellation token for graceful shutdown or for canceling the wait for abrupt shutdown.
+        /// </param>
         public virtual Task StopSiloAsync(bool stopGracefully, CancellationToken cancellationToken)
-            => StopSiloAsync(stopGracefully ? cancellationToken : new CancellationToken(canceled: true));
+            => stopGracefully
+                ? StopSiloAsync(cancellationToken)
+                : StopSiloAsync(stopGracefully).WaitAsync(cancellationToken);
 
         /// <summary>Stop the remote silo. This method cannot be use with AppDomain</summary>
         /// <param name="ct">Specifies the cancellation token to use for the shutdown sequence</param>

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -41,6 +41,8 @@ namespace Orleans.TestingHost
         private readonly StringBuilder log = new StringBuilder();
         private readonly InMemoryTransportConnectionHub _transportHub = new();
         private readonly GrainDirectoryObserver _grainDirectoryObserver = new();
+        private Func<string, IConfiguration, Task<SiloHandle>> _createSiloAsync;
+        private Func<string, IConfiguration, CancellationToken, Task<SiloHandle>> _createSiloAsyncWithCancellation;
         private bool _disposed;
         private int startedInstances;
 
@@ -130,7 +132,28 @@ namespace Orleans.TestingHost
         /// <summary>
         /// Delegate used to create and start an individual silo.
         /// </summary>
-        public Func<string, IConfiguration, Task<SiloHandle>> CreateSiloAsync { private get; set; }
+        public Func<string, IConfiguration, Task<SiloHandle>> CreateSiloAsync
+        {
+            private get => _createSiloAsync;
+            set
+            {
+                _createSiloAsync = value;
+                _createSiloAsyncWithCancellation = (name, configuration, _) => value(name, configuration);
+            }
+        }
+
+        /// <summary>
+        /// Delegate used to create and start an individual silo with cancellation.
+        /// </summary>
+        public Func<string, IConfiguration, CancellationToken, Task<SiloHandle>> CreateSiloAsyncWithCancellation
+        {
+            private get => _createSiloAsyncWithCancellation;
+            set
+            {
+                _createSiloAsyncWithCancellation = value;
+                _createSiloAsync = (name, configuration) => value(name, configuration, CancellationToken.None);
+            }
+        }
 
         /// <summary>
         /// The port allocator.
@@ -148,7 +171,8 @@ namespace Orleans.TestingHost
             this.options = options;
             this.ConfigurationSources = configurationSources.ToArray();
             this.PortAllocator = portAllocator;
-            this.CreateSiloAsync = DefaultCreateSiloAsync;
+            _createSiloAsync = DefaultCreateSiloAsync;
+            _createSiloAsyncWithCancellation = DefaultCreateSiloAsync;
         }
 
         /// <summary>
@@ -288,8 +312,15 @@ namespace Orleans.TestingHost
         /// <summary>
         /// Deploys the cluster using the specified configuration and starts the client in-process.
         /// </summary>
-        public async Task DeployAsync()
+        public Task DeployAsync() => DeployAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Deploys the cluster using the specified configuration and starts the client in-process.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel deployment.</param>
+        public async Task DeployAsync(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (this.Primary != null || this.additionalSilos.Count > 0) throw new InvalidOperationException("Cluster host already deployed.");
 
             AppDomain.CurrentDomain.UnhandledException += ReportUnobservedException;
@@ -298,11 +329,11 @@ namespace Orleans.TestingHost
             {
                 string startMsg = "----------------------------- STARTING NEW UNIT TEST SILO HOST: " + GetType().FullName + " -------------------------------------";
                 WriteLog(startMsg);
-                await InitializeAsync();
+                await InitializeAsync(cancellationToken);
 
                 if (this.options.InitializeClientOnDeploy)
                 {
-                    await WaitForInitialStabilization();
+                    await WaitForInitialStabilization(cancellationToken);
                 }
             }
             catch (TimeoutException te)
@@ -312,7 +343,7 @@ namespace Orleans.TestingHost
             }
             catch (Exception ex)
             {
-                await StopAllSilosAsync();
+                await StopAllSilosAsync(CancellationToken.None);
 
                 Exception baseExc = ex.GetBaseException();
                 FlushLogToConsole();
@@ -337,7 +368,7 @@ namespace Orleans.TestingHost
             }
         }
 
-        private async Task WaitForInitialStabilization()
+        private async Task WaitForInitialStabilization(CancellationToken cancellationToken)
         {
             // Poll each silo to check that it knows the expected number of active silos.
             // If any silo does not have the expected number of active silos in its cluster membership oracle, try again.
@@ -352,7 +383,7 @@ namespace Orleans.TestingHost
                 foreach (var silo in silos)
                 {
                     var hooks = this.InternalClient!.GetTestHooks(silo); // Membership stabilization requires an initialized client.
-                    var statuses = await hooks.GetApproximateSiloStatuses();
+                    var statuses = await hooks.GetApproximateSiloStatuses().WaitAsync(cancellationToken);
                     var activeCount = statuses.Count(s => s.Value == SiloStatus.Active);
                     if (activeCount != expectedCount) break;
                     remainingSilos--;
@@ -365,7 +396,7 @@ namespace Orleans.TestingHost
                 }
 
                 WriteLog($"{remainingSilos} silos do not have a consistent cluster view, waiting until stabilization.");
-                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
 
                 if (totalWait.Elapsed < TimeSpan.FromSeconds(60))
                 {
@@ -523,12 +554,40 @@ namespace Orleans.TestingHost
         /// <param name="startAdditionalSiloOnNewPort"></param>
         /// <returns>List of SiloHandles for the newly started silos.</returns>
         public async Task<List<SiloHandle>> StartAdditionalSilosAsync(int silosToStart, bool startAdditionalSiloOnNewPort = false)
+            => await StartAdditionalSilosAsync(
+                silosToStart,
+                startAdditionalSiloOnNewPort,
+                CancellationToken.None);
+
+        /// <summary>
+        /// Start a number of additional silos, so that they join the existing cluster.
+        /// </summary>
+        /// <param name="silosToStart">Number of silos to start.</param>
+        /// <param name="startAdditionalSiloOnNewPort">Whether to start each silo on a new port.</param>
+        /// <param name="cancellationToken">The token used to cancel silo startup.</param>
+        /// <returns>List of silo handles for the newly started silos.</returns>
+        public async Task<List<SiloHandle>> StartAdditionalSilosAsync(
+            int silosToStart,
+            bool startAdditionalSiloOnNewPort,
+            CancellationToken cancellationToken)
         {
             var instances = new List<SiloHandle>();
             if (silosToStart > 0)
             {
-                var siloStartTasks = Enumerable.Range(this.startedInstances, silosToStart)
-                    .Select(instanceNumber => Task.Run(() => StartSiloAsync((short)instanceNumber, this.options, startSiloOnNewPort: startAdditionalSiloOnNewPort))).ToArray();
+                var silos = Silos;
+                var firstInstanceNumber = silos.Count == 0
+                    ? 0
+                    : silos.Max(static silo => silo.InstanceNumber) + 1;
+                var siloStartTasks = Enumerable.Range(firstInstanceNumber, silosToStart)
+                    .Select(instanceNumber => Task.Run(
+                        () => StartSiloAsync(
+                            (short)instanceNumber,
+                            this.options,
+                            configurationOverrides: null,
+                            startAdditionalSiloOnNewPort,
+                            cancellationToken),
+                        cancellationToken))
+                    .ToArray();
 
                 try
                 {
@@ -538,7 +597,10 @@ namespace Orleans.TestingHost
                 {
                     lock (additionalSilos)
                     {
-                        this.additionalSilos.AddRange(siloStartTasks.Where(t => t.Exception == null).Select(t => t.Result));
+                        this.additionalSilos.AddRange(
+                            siloStartTasks
+                                .Where(static task => task.Status == TaskStatus.RanToCompletion)
+                                .Select(static task => task.Result));
                     }
 
                     throw;
@@ -557,41 +619,64 @@ namespace Orleans.TestingHost
         /// <summary>
         /// Stop any additional silos, not including the default Primary silo.
         /// </summary>
-        public async Task StopSecondarySilosAsync()
+        public Task StopSecondarySilosAsync() => StopSecondarySilosAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Stop any additional silos, not including the default Primary silo.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+        public async Task StopSecondarySilosAsync(CancellationToken cancellationToken)
         {
             foreach (var instance in this.additionalSilos.ToList())
             {
-                await StopSiloAsync(instance);
+                await StopSiloAsync(instance, cancellationToken);
             }
         }
 
         /// <summary>
         /// Stops the default Primary silo.
         /// </summary>
-        public async Task StopPrimarySiloAsync()
+        public Task StopPrimarySiloAsync() => StopPrimarySiloAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Stops the default Primary silo.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+        public async Task StopPrimarySiloAsync(CancellationToken cancellationToken)
         {
             if (Primary == null) throw new InvalidOperationException("There is no primary silo");
-            await StopClusterClientAsync();
-            await StopSiloAsync(Primary);
+            await StopClusterClientAsync(cancellationToken);
+            await StopSiloAsync(Primary, cancellationToken);
         }
 
         /// <summary>
         /// Stop cluster client as an asynchronous operation.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task StopClusterClientAsync()
+        public Task StopClusterClientAsync() => StopClusterClientAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Stop cluster client as an asynchronous operation.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task StopClusterClientAsync(CancellationToken cancellationToken)
         {
             var client = this.ClientHost;
             try
             {
                 if (client is not null)
                 {
-                    await client.StopAsync().ConfigureAwait(false);
+                    await client.StopAsync(cancellationToken).ConfigureAwait(false);
                 }                
             }
             catch (Exception exc)
             {
                 WriteLog("Exception stopping client: {0}", exc);
+                if (exc is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
             }
             finally
             {
@@ -611,35 +696,60 @@ namespace Orleans.TestingHost
         /// <summary>
         /// Stop all current silos.
         /// </summary>
-        public async Task StopAllSilosAsync()
+        public Task StopAllSilosAsync() => StopAllSilosAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Stop all current silos.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+        public async Task StopAllSilosAsync(CancellationToken cancellationToken)
         {
-            await StopClusterClientAsync();
-            await StopSecondarySilosAsync();
-            if (Primary != null)
+            try
             {
-                await StopPrimarySiloAsync();
+                await StopClusterClientAsync(cancellationToken);
+                await StopSecondarySilosAsync(cancellationToken);
+                if (Primary != null)
+                {
+                    await StopPrimarySiloAsync(cancellationToken);
+                }
             }
-            AppDomain.CurrentDomain.UnhandledException -= ReportUnobservedException;
+            finally
+            {
+                AppDomain.CurrentDomain.UnhandledException -= ReportUnobservedException;
+            }
         }
 
         /// <summary>
         /// Do a semi-graceful Stop of the specified silo.
         /// </summary>
         /// <param name="instance">Silo to be stopped.</param>
-        public async Task StopSiloAsync(SiloHandle instance)
+        public Task StopSiloAsync(SiloHandle instance) => StopSiloAsync(instance, CancellationToken.None);
+
+        /// <summary>
+        /// Do a semi-graceful Stop of the specified silo.
+        /// </summary>
+        /// <param name="instance">Silo to be stopped.</param>
+        /// <param name="cancellationToken">The token used to cancel shutdown.</param>
+        public async Task StopSiloAsync(SiloHandle instance, CancellationToken cancellationToken)
         {
             if (instance != null)
             {
-                await StopSiloAsync(instance, true);
-                if (Primary == instance)
+                try
                 {
-                    Primary = null;
+                    await StopSiloAsync(instance, true, cancellationToken);
                 }
-                else
+                finally
                 {
-                    lock (additionalSilos)
+                    if (Primary == instance)
                     {
-                        additionalSilos.Remove(instance);
+                        Primary = null;
+                    }
+                    else
+                    {
+                        lock (additionalSilos)
+                        {
+                            additionalSilos.Remove(instance);
+                        }
                     }
                 }
             }
@@ -649,21 +759,35 @@ namespace Orleans.TestingHost
         /// Do an immediate Kill of the specified silo.
         /// </summary>
         /// <param name="instance">Silo to be killed.</param>
-        public async Task KillSiloAsync(SiloHandle instance)
+        public Task KillSiloAsync(SiloHandle instance) => KillSiloAsync(instance, CancellationToken.None);
+
+        /// <summary>
+        /// Do an immediate Kill of the specified silo.
+        /// </summary>
+        /// <param name="instance">Silo to be killed.</param>
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
+        public async Task KillSiloAsync(SiloHandle instance, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (instance != null)
             {
-                // do NOT stop, just kill directly, to simulate crash.
-                await StopSiloAsync(instance, false);
-                if (Primary == instance)
+                try
                 {
-                    Primary = null;
+                    // do NOT stop, just kill directly, to simulate crash.
+                    await StopSiloAsync(instance, false, cancellationToken);
                 }
-                else
+                finally
                 {
-                    lock (additionalSilos)
+                    if (Primary == instance)
                     {
-                        additionalSilos.Remove(instance);
+                        Primary = null;
+                    }
+                    else
+                    {
+                        lock (additionalSilos)
+                        {
+                            additionalSilos.Remove(instance);
+                        }
                     }
                 }
             }
@@ -739,15 +863,21 @@ namespace Orleans.TestingHost
         }
 
         /// <summary>
-        /// Initialize the grain client. This should be already done by <see cref="Deploy()"/> or <see cref="DeployAsync"/>
+        /// Initialize the grain client. This should be already done by <see cref="Deploy()"/> or <see cref="DeployAsync()"/>
         /// </summary>
-        public async Task InitializeClientAsync()
+        public Task InitializeClientAsync() => InitializeClientAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Initialize the grain client.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel initialization.</param>
+        public async Task InitializeClientAsync(CancellationToken cancellationToken)
         {
             WriteLog("Initializing Cluster Client");
 
             if (ClientHost is not null)
             {
-                await StopClusterClientAsync();
+                await StopClusterClientAsync(cancellationToken);
             }
 
             var configurationBuilder = new ConfigurationBuilder();
@@ -813,7 +943,7 @@ namespace Orleans.TestingHost
                 });
             try
             {
-                await clientHost.StartAsync();
+                await clientHost.StartAsync(cancellationToken);
                 this.ClientHost = clientHost;
             }
             catch
@@ -829,26 +959,34 @@ namespace Orleans.TestingHost
         /// <value>The configuration sources.</value>
         public IReadOnlyList<IConfigurationSource> ConfigurationSources { get; }
 
-        private async Task InitializeAsync()
+        private async Task InitializeAsync(CancellationToken cancellationToken)
         {
             short silosToStart = this.options.InitialSilosCount;
 
             if (this.options.UseTestClusterMembership)
             {
-                this.Primary = await StartSiloAsync(this.startedInstances, this.options);
+                this.Primary = await StartSiloAsync(
+                    this.startedInstances,
+                    this.options,
+                    configurationOverrides: null,
+                    startSiloOnNewPort: false,
+                    cancellationToken);
                 silosToStart--;
             }
 
             if (silosToStart > 0)
             {
-                await this.StartAdditionalSilosAsync(silosToStart);
+                await this.StartAdditionalSilosAsync(
+                    silosToStart,
+                    startAdditionalSiloOnNewPort: false,
+                    cancellationToken);
             }
 
             WriteLog("Done initializing cluster");
 
             if (this.options.InitializeClientOnDeploy)
             {
-                await InitializeClientAsync();
+                await InitializeClientAsync(cancellationToken);
             }
         }
 
@@ -859,6 +997,19 @@ namespace Orleans.TestingHost
         /// <param name="configuration">The configuration.</param>
         /// <returns>The silo handle.</returns>
         public async Task<SiloHandle> DefaultCreateSiloAsync(string siloName, IConfiguration configuration)
+            => await DefaultCreateSiloAsync(siloName, configuration, CancellationToken.None);
+
+        /// <summary>
+        /// Creates a new silo handle.
+        /// </summary>
+        /// <param name="siloName">Name of the silo.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="cancellationToken">The token used to cancel silo startup.</param>
+        /// <returns>The silo handle.</returns>
+        public async Task<SiloHandle> DefaultCreateSiloAsync(
+            string siloName,
+            IConfiguration configuration,
+            CancellationToken cancellationToken)
         {
             return await InProcessSiloHandle.CreateAsync(siloName, configuration, hostBuilder =>
             {
@@ -889,7 +1040,7 @@ namespace Orleans.TestingHost
                         }
                     }
                 });
-            });
+            }, cancellationToken);
         }
 
         /// <summary>
@@ -922,6 +1073,28 @@ namespace Orleans.TestingHost
         /// <param name="startSiloOnNewPort">Whether we start this silo on a new port, instead of the default one</param>
         /// <returns>A handle to the deployed silo.</returns>
         public async Task<SiloHandle> StartSiloAsync(int instanceNumber, TestClusterOptions clusterOptions, IReadOnlyList<IConfigurationSource>? configurationOverrides = null, bool startSiloOnNewPort = false)
+            => await StartSiloAsync(
+                instanceNumber,
+                clusterOptions,
+                configurationOverrides,
+                startSiloOnNewPort,
+                CancellationToken.None);
+
+        /// <summary>
+        /// Starts a new silo.
+        /// </summary>
+        /// <param name="instanceNumber">The instance number to deploy.</param>
+        /// <param name="clusterOptions">The options to use.</param>
+        /// <param name="configurationOverrides">Configuration overrides.</param>
+        /// <param name="startSiloOnNewPort">Whether to start this silo on a new port.</param>
+        /// <param name="cancellationToken">The token used to cancel silo startup.</param>
+        /// <returns>A handle to the deployed silo.</returns>
+        public async Task<SiloHandle> StartSiloAsync(
+            int instanceNumber,
+            TestClusterOptions clusterOptions,
+            IReadOnlyList<IConfigurationSource>? configurationOverrides,
+            bool startSiloOnNewPort,
+            CancellationToken cancellationToken)
         {
             var configurationSources = this.ConfigurationSources.ToList();
 
@@ -939,17 +1112,20 @@ namespace Orleans.TestingHost
                 configurationBuilder.Add(source);
             }
             var configuration = configurationBuilder.Build();
-            var handle = await this.CreateSiloAsync(siloSpecificOptions.SiloName, configuration);
+            var handle = await _createSiloAsyncWithCancellation(
+                siloSpecificOptions.SiloName,
+                configuration,
+                cancellationToken);
             handle.InstanceNumber = (short)instanceNumber;
             Interlocked.Increment(ref this.startedInstances);
             return handle;
         }
 
-        private async Task StopSiloAsync(SiloHandle instance, bool stopGracefully)
+        private async Task StopSiloAsync(SiloHandle instance, bool stopGracefully, CancellationToken cancellationToken)
         {
             try
             {
-                await instance.StopSiloAsync(stopGracefully).ConfigureAwait(false);
+                await instance.StopSiloAsync(stopGracefully, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -994,6 +1170,7 @@ namespace Orleans.TestingHost
 
             await Task.Run(async () =>
             {
+                AppDomain.CurrentDomain.UnhandledException -= ReportUnobservedException;
                 await DisposeAsync(ClientHost).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
                 foreach (var handle in SecondarySilos)

--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -18,6 +18,7 @@ namespace Orleans.TestingHost
         private readonly List<Action<IConfigurationBuilder>> configureHostConfigActions = new List<Action<IConfigurationBuilder>>();
         private readonly List<Action> configureBuilderActions = new List<Action>();
         private Func<string, IConfiguration, Task<SiloHandle>>? _createSiloAsync;
+        private Func<string, IConfiguration, CancellationToken, Task<SiloHandle>>? _createSiloAsyncWithCancellation;
 
         /// <summary>
         /// Initializes a new instance of <see cref="TestClusterBuilder"/> using the default options.
@@ -74,6 +75,21 @@ namespace Orleans.TestingHost
             set
             {
                 _createSiloAsync = value;
+
+                // The custom builder does not have access to the in-memory transport.
+                Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the cancellation-aware delegate used to create and start an individual silo.
+        /// </summary>
+        public Func<string, IConfiguration, CancellationToken, Task<SiloHandle>> CreateSiloAsyncWithCancellation
+        {
+            private get => _createSiloAsyncWithCancellation!;
+            set
+            {
+                _createSiloAsyncWithCancellation = value;
 
                 // The custom builder does not have access to the in-memory transport.
                 Options.ConnectionTransport = ConnectionTransportType.TcpSocket;
@@ -166,7 +182,15 @@ namespace Orleans.TestingHost
 
             var configSources = new ReadOnlyCollection<IConfigurationSource>(configBuilder.Sources);
             var testCluster = new TestCluster(finalOptions, configSources, portAllocator);
-            if (CreateSiloAsync != null) testCluster.CreateSiloAsync = CreateSiloAsync;
+            if (_createSiloAsyncWithCancellation is not null)
+            {
+                testCluster.CreateSiloAsyncWithCancellation = CreateSiloAsyncWithCancellation;
+            }
+            else if (_createSiloAsync is not null)
+            {
+                testCluster.CreateSiloAsync = CreateSiloAsync;
+            }
+
             return testCluster;
         }
 

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
@@ -604,11 +604,16 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
 
         internal void Release() => this.release.TrySetResult();
 
-        internal async Task<RecoveryTransition> WaitAsync(long deadline)
+        internal Task<RecoveryTransition> WaitAsync(long deadline) =>
+            WaitAsync(deadline, CancellationToken.None);
+
+        internal async Task<RecoveryTransition> WaitAsync(
+            long deadline,
+            CancellationToken cancellationToken)
         {
             if (this.reached.Task.IsCompleted)
             {
-                return await this.reached.Task;
+                return await this.reached.Task.WaitAsync(cancellationToken);
             }
 
             var now = Stopwatch.GetTimestamp();
@@ -619,7 +624,9 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
 
             try
             {
-                return await this.reached.Task.WaitAsync(Stopwatch.GetElapsedTime(now, deadline));
+                return await this.reached.Task.WaitAsync(
+                    Stopwatch.GetElapsedTime(now, deadline),
+                    cancellationToken);
             }
             catch (TimeoutException)
             {

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryFailureObservation.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryFailureObservation.cs
@@ -62,17 +62,21 @@ internal static class TransactionRecoveryFailureObservation
         Task<TFailure> firstFailure,
         CancellationTokenSource stopProducing,
         TimeSpan observationWindow,
-        TimeSpan producerDrainTimeout)
+        TimeSpan producerDrainTimeout,
+        CancellationToken cancellationToken)
         where TFailure : class
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(observationWindow, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThan(producerDrainTimeout, TimeSpan.Zero);
 
+        using var cancellationRegistration = cancellationToken.Register(
+            static state => ((CancellationTokenSource)state!).Cancel(),
+            stopProducing);
         var startedAt = Stopwatch.GetTimestamp();
         var responseDeadline = GetDeadline(startedAt, observationWindow);
         var drainDeadline = GetDeadline(responseDeadline, producerDrainTimeout);
 
-        await WaitUntilAsync(firstFailure, producer, responseDeadline);
+        await WaitUntilAsync(firstFailure, producer, responseDeadline, cancellationToken);
         if (firstFailure.IsCompleted)
         {
             return await CompleteFailureAsync(
@@ -80,7 +84,8 @@ internal static class TransactionRecoveryFailureObservation
                 firstFailure,
                 stopProducing,
                 startedAt,
-                drainDeadline);
+                drainDeadline,
+                cancellationToken);
         }
 
         if (producer.IsCompleted)
@@ -93,7 +98,8 @@ internal static class TransactionRecoveryFailureObservation
                     firstFailure,
                     stopProducing,
                     startedAt,
-                    drainDeadline);
+                    drainDeadline,
+                    cancellationToken);
             }
 
             return new(
@@ -107,7 +113,7 @@ internal static class TransactionRecoveryFailureObservation
 
         stopProducing.Cancel();
         var drainStartedAt = Stopwatch.GetTimestamp();
-        await WaitUntilAsync(firstFailure, producer, drainDeadline);
+        await WaitUntilAsync(firstFailure, producer, drainDeadline, cancellationToken);
 
         if (firstFailure.IsCompleted)
         {
@@ -117,6 +123,7 @@ internal static class TransactionRecoveryFailureObservation
                 stopProducing,
                 startedAt,
                 drainDeadline,
+                cancellationToken,
                 drainStartedAt);
         }
 
@@ -131,6 +138,7 @@ internal static class TransactionRecoveryFailureObservation
                     stopProducing,
                     startedAt,
                     drainDeadline,
+                    cancellationToken,
                     drainStartedAt);
             }
 
@@ -159,6 +167,7 @@ internal static class TransactionRecoveryFailureObservation
         CancellationTokenSource stopProducing,
         long startedAt,
         long drainDeadline,
+        CancellationToken cancellationToken,
         long? drainStartedAt = null)
         where TFailure : class
     {
@@ -167,7 +176,7 @@ internal static class TransactionRecoveryFailureObservation
         var drainStarted = drainStartedAt ?? Stopwatch.GetTimestamp();
         if (!producer.IsCompleted)
         {
-            await WaitUntilAsync(producer, drainDeadline);
+            await WaitUntilAsync(producer, drainDeadline, cancellationToken);
         }
 
         if (producer.IsCompleted)
@@ -191,31 +200,45 @@ internal static class TransactionRecoveryFailureObservation
             Stopwatch.GetElapsedTime(drainStarted));
     }
 
-    private static async Task WaitUntilAsync(Task first, long deadline)
+    private static async Task WaitUntilAsync(
+        Task first,
+        long deadline,
+        CancellationToken cancellationToken)
     {
         while (!first.IsCompleted)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var now = Stopwatch.GetTimestamp();
             if (now >= deadline)
             {
                 return;
             }
 
-            await Task.WhenAny(first, Task.Delay(Stopwatch.GetElapsedTime(now, deadline))).ConfigureAwait(false);
+            await Task.WhenAny(
+                first,
+                Task.Delay(Stopwatch.GetElapsedTime(now, deadline), cancellationToken)).ConfigureAwait(false);
         }
     }
 
-    private static async Task WaitUntilAsync(Task first, Task second, long deadline)
+    private static async Task WaitUntilAsync(
+        Task first,
+        Task second,
+        long deadline,
+        CancellationToken cancellationToken)
     {
         while (!first.IsCompleted && !second.IsCompleted)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var now = Stopwatch.GetTimestamp();
             if (now >= deadline)
             {
                 return;
             }
 
-            await Task.WhenAny(first, second, Task.Delay(Stopwatch.GetElapsedTime(now, deadline))).ConfigureAwait(false);
+            await Task.WhenAny(
+                first,
+                second,
+                Task.Delay(Stopwatch.GetElapsedTime(now, deadline), cancellationToken)).ConfigureAwait(false);
         }
     }
 

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
@@ -363,7 +363,8 @@ namespace Orleans.Transactions.TestKit
                 firstFailure.Task,
                 stopProducing,
                 failureObservationTimeout.ObservationWindow,
-                failureObservationTimeout.ProducerDrainTimeout);
+                failureObservationTimeout.ProducerDrainTimeout,
+                CancellationToken.None);
             this.Log(
                 $"Recovery phase=failure-watchdog completed, timestamp={DateTime.UtcNow:O}. "
                 + $"Outcome={failureDetection.Kind}, elapsed={failureDetection.Elapsed}, "

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
@@ -63,6 +63,29 @@ namespace Orleans.Transactions.TestKit
 
         private sealed record InFlightBatch(int Index, int PendingCount);
 
+        private sealed class ProducerCancellationScope(
+            CancellationTokenSource stopProducing,
+            Task producer) : IDisposable
+        {
+            public void Dispose()
+            {
+                stopProducing.Cancel();
+                producer.Ignore();
+                if (producer.IsCompleted)
+                {
+                    stopProducing.Dispose();
+                    return;
+                }
+
+                _ = producer.ContinueWith(
+                    static (_, state) => ((CancellationTokenSource)state!).Dispose(),
+                    stopProducing,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+        }
+
         private sealed record RecoveryResult(
             bool Succeeded,
             bool LastProbeSucceeded,
@@ -89,13 +112,51 @@ namespace Orleans.Transactions.TestKit
         }
 
         public virtual Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(string transactionTestGrainClassName, int concurrent)
+            => TransactionWillRecoverAfterRandomSiloFailure(
+                transactionTestGrainClassName,
+                concurrent,
+                gracefulShutdown: true);
+
+        /// <summary>
+        /// Verifies transaction recovery after gracefully stopping a randomly selected silo.
+        /// </summary>
+        /// <param name="transactionTestGrainClassName">The transaction test grain class name.</param>
+        /// <param name="concurrent">The number of concurrent transaction groups.</param>
+        /// <param name="cancellationToken">A token which cancels the recovery test.</param>
+        public virtual Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(
+            string transactionTestGrainClassName,
+            int concurrent,
+            CancellationToken cancellationToken)
         {
-            return TransactionWillRecoverAfterRandomSiloFailure(transactionTestGrainClassName, concurrent, true);
+            return TransactionWillRecoverAfterRandomSiloFailure(
+                transactionTestGrainClassName,
+                concurrent,
+                gracefulShutdown: true,
+                cancellationToken);
         }
 
         public virtual Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(string transactionTestGrainClassName, int concurrent)
+            => TransactionWillRecoverAfterRandomSiloFailure(
+                transactionTestGrainClassName,
+                concurrent,
+                gracefulShutdown: false);
+
+        /// <summary>
+        /// Verifies transaction recovery after abruptly stopping a randomly selected silo.
+        /// </summary>
+        /// <param name="transactionTestGrainClassName">The transaction test grain class name.</param>
+        /// <param name="concurrent">The number of concurrent transaction groups.</param>
+        /// <param name="cancellationToken">A token which cancels the recovery test.</param>
+        public virtual Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(
+            string transactionTestGrainClassName,
+            int concurrent,
+            CancellationToken cancellationToken)
         {
-            return TransactionWillRecoverAfterRandomSiloFailure(transactionTestGrainClassName, concurrent, false);
+            return TransactionWillRecoverAfterRandomSiloFailure(
+                transactionTestGrainClassName,
+                concurrent,
+                gracefulShutdown: false,
+                cancellationToken);
         }
 
         /// <summary>
@@ -282,7 +343,28 @@ namespace Orleans.Transactions.TestKit
         private static long GetDeadline(TimeSpan timeout)
             => Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
 
-        protected virtual async Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName, int concurrent, bool gracefulShutdown)
+        protected virtual Task TransactionWillRecoverAfterRandomSiloFailure(
+            string transactionTestGrainClassName,
+            int concurrent,
+            bool gracefulShutdown)
+            => TransactionWillRecoverAfterRandomSiloFailure(
+                transactionTestGrainClassName,
+                concurrent,
+                gracefulShutdown,
+                CancellationToken.None);
+
+        /// <summary>
+        /// Verifies transaction recovery after stopping a randomly selected silo.
+        /// </summary>
+        /// <param name="transactionTestGrainClassName">The transaction test grain class name.</param>
+        /// <param name="concurrent">The number of concurrent transaction groups.</param>
+        /// <param name="gracefulShutdown">Whether to stop the silo gracefully.</param>
+        /// <param name="cancellationToken">A token which cancels the recovery test.</param>
+        protected virtual async Task TransactionWillRecoverAfterRandomSiloFailure(
+            string transactionTestGrainClassName,
+            int concurrent,
+            bool gracefulShutdown,
+            CancellationToken cancellationToken)
         {
             var index = 0;
             int getIndex() => Interlocked.Increment(ref index) - 1;
@@ -291,19 +373,19 @@ namespace Orleans.Transactions.TestKit
                 .Select(grainId => new ExpectedGrainActivity(grainId, TestGrain<ITransactionalBitArrayGrain>(transactionTestGrainClassName, grainId)))
                 .ToList();
             //ping all grains to activate them
-            await WakeupGrains(txGrains.Select(g=>g.Grain).ToList());
+            await WakeupGrains(txGrains.Select(g=>g.Grain).ToList()).WaitAsync(cancellationToken);
             List<ExpectedGrainActivity>[] transactionGroups = txGrains
                 .Select((txGrain, i) => new { index = i, value = txGrain })
                 .GroupBy(v => v.index / 2)
                 .Select(g => g.Select(i => i.value).ToList())
                 .ToArray();
             using var recoveryEvents = new TransactionRecoveryEventObserver(txGrains.Select(grain => grain.RuntimeGrainId));
-            var txSucceedBeforeInterruption = await AllTxSucceed(transactionGroups, getIndex());
+            var txSucceedBeforeInterruption = await AllTxSucceed(transactionGroups, getIndex()).WaitAsync(cancellationToken);
             txSucceedBeforeInterruption.Should().BeTrue();
-            await ValidateResults(txGrains, transactionGroups);
+            await ValidateResults(txGrains, transactionGroups).WaitAsync(cancellationToken);
 
             // have transactions in flight when silo goes down
-            using var stopProducing = new CancellationTokenSource();
+            var stopProducing = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var firstFailure = new TaskCompletionSource<TransactionFailure>(TaskCreationOptions.RunContinuationsAsynchronously);
             var firstInFlightBatch = new TaskCompletionSource<InFlightBatch>(TaskCreationOptions.RunContinuationsAsynchronously);
             Task<List<ExpectedGrainActivity>[]?> producer = RunWhileSucceeding(
@@ -312,13 +394,14 @@ namespace Orleans.Transactions.TestKit
                 stopProducing,
                 firstFailure,
                 firstInFlightBatch);
-            var inFlightBatch = await firstInFlightBatch.Task.WaitAsync(this.failureDetectionTimeout);
+            using var producerCancellationScope = new ProducerCancellationScope(stopProducing, producer);
+            var inFlightBatch = await firstInFlightBatch.Task.WaitAsync(this.failureDetectionTimeout, cancellationToken);
 
             if (firstFailure.Task.IsCompleted)
             {
                 stopProducing.Cancel();
                 producer.Ignore();
-                var prematureFailure = await firstFailure.Task;
+                var prematureFailure = await firstFailure.Task.WaitAsync(cancellationToken);
                 throw new InvalidOperationException(
                     $"A transaction failed before the silo was terminated. Index: {prematureFailure.Index}. "
                     + $"Groups: {string.Join(":", prematureFailure.GrainIds)}. Exception: {prematureFailure.Exception.GetType().Name}.");
@@ -338,9 +421,9 @@ namespace Orleans.Transactions.TestKit
 
             var shutdownStartedAt = Stopwatch.GetTimestamp();
             if (gracefulShutdown)
-                await this.testCluster.StopSiloAsync(siloToTerminate);
+                await this.testCluster.StopSiloAsync(siloToTerminate, cancellationToken);
             else
-                await this.testCluster.KillSiloAsync(siloToTerminate);
+                await this.testCluster.KillSiloAsync(siloToTerminate, cancellationToken);
             var shutdownElapsed = Stopwatch.GetElapsedTime(shutdownStartedAt);
             this.Log(
                 $"Recovery phase=silo-shutdown completed, timestamp={DateTime.UtcNow:O}. Silo={siloToTerminate.SiloAddress}, "
@@ -364,7 +447,7 @@ namespace Orleans.Transactions.TestKit
                 stopProducing,
                 failureObservationTimeout.ObservationWindow,
                 failureObservationTimeout.ProducerDrainTimeout,
-                CancellationToken.None);
+                cancellationToken);
             this.Log(
                 $"Recovery phase=failure-watchdog completed, timestamp={DateTime.UtcNow:O}. "
                 + $"Outcome={failureDetection.Kind}, elapsed={failureDetection.Elapsed}, "
@@ -446,7 +529,8 @@ namespace Orleans.Transactions.TestKit
             this.Log(
                 $"Recovery phase=membership-directory-convergence started, timestamp={DateTime.UtcNow:O}, "
                 + $"groups={FormatGroups(groupsToRecover)}.");
-            await this.testCluster.WaitForLivenessToStabilizeAsync(didKill: !gracefulShutdown);
+            await this.testCluster.WaitForLivenessToStabilizeAsync(didKill: !gracefulShutdown)
+                .WaitAsync(cancellationToken);
             var convergenceElapsed = Stopwatch.GetElapsedTime(convergenceStartedAt);
             this.Log(
                 $"Recovery phase=membership-directory-convergence completed, timestamp={DateTime.UtcNow:O}, "
@@ -462,7 +546,8 @@ namespace Orleans.Transactions.TestKit
                 getIndex,
                 this.recoveryTimeout,
                 this.failureDetectionTimeout,
-                recoveryEvents);
+                recoveryEvents,
+                cancellationToken);
             this.Log(
                 $"Recovery phase=transaction-path-probe completed, timestamp={DateTime.UtcNow:O}. Succeeded={recovery.Succeeded}, "
                 + $"lastProbeSucceeded={recovery.LastProbeSucceeded}, "
@@ -478,7 +563,7 @@ namespace Orleans.Transactions.TestKit
                 $"Recovery phase=final-validation started, timestamp={DateTime.UtcNow:O}. "
                 + $"Performed {Volatile.Read(ref index)} transactions on each group.");
             var validationStartedAt = Stopwatch.GetTimestamp();
-            await ValidateResults(txGrains, transactionGroups);
+            await ValidateResults(txGrains, transactionGroups).WaitAsync(cancellationToken);
             this.Log(
                 $"Recovery phase=final-validation completed, timestamp={DateTime.UtcNow:O}, "
                 + $"elapsed={Stopwatch.GetElapsedTime(validationStartedAt)}. Transaction results validated.");
@@ -537,7 +622,8 @@ namespace Orleans.Transactions.TestKit
             Func<int> getIndex,
             TimeSpan timeout,
             TimeSpan cleanupTimeout,
-            TransactionRecoveryEventObserver recoveryEvents)
+            TransactionRecoveryEventObserver recoveryEvents,
+            CancellationToken cancellationToken = default)
         {
             var startedAt = Stopwatch.GetTimestamp();
             var deadline = startedAt + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
@@ -550,9 +636,13 @@ namespace Orleans.Transactions.TestKit
 
             while (Stopwatch.GetTimestamp() < deadline)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (probeRequiresTransition)
                 {
-                    var transition = await recoveryEvents.WaitForNextTransitionAsync(waitForTransitionAfter, deadline);
+                    var transition = await recoveryEvents.WaitForNextTransitionAsync(
+                        waitForTransitionAfter,
+                        deadline,
+                        cancellationToken);
                     waitForTransitionAfter = transition.Sequence;
                     if (transition.Sequence > timelineLogCursor)
                     {
@@ -581,11 +671,14 @@ namespace Orleans.Transactions.TestKit
                 try
                 {
                     var now = Stopwatch.GetTimestamp();
-                    failedGroups = await probeTask.WaitAsync(Stopwatch.GetElapsedTime(now, deadline));
+                    failedGroups = await probeTask.WaitAsync(
+                        Stopwatch.GetElapsedTime(now, deadline),
+                        cancellationToken);
                 }
                 catch (TimeoutException)
                 {
-                    var cleanup = await Task.WhenAny(probeTask, Task.Delay(cleanupTimeout));
+                    var cleanup = await Task.WhenAny(probeTask, Task.Delay(cleanupTimeout, cancellationToken));
+                    cancellationToken.ThrowIfCancellationRequested();
                     var cleanupSettled = ReferenceEquals(cleanup, probeTask);
                     if (cleanupSettled)
                     {

--- a/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs
@@ -26,5 +26,18 @@ namespace Orleans.Transactions.TestKit.xUnit
         {
             return base.TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(transactionTestGrainClassName, concurrent);
         }
+
+        /// <inheritdoc />
+        protected override Task TransactionWillRecoverAfterRandomSiloFailure(
+            string transactionTestGrainClassName,
+            int concurrent,
+            bool gracefulShutdown)
+        {
+            return base.TransactionWillRecoverAfterRandomSiloFailure(
+                transactionTestGrainClassName,
+                concurrent,
+                gracefulShutdown,
+                TestContext.Current.CancellationToken);
+        }
     }
 }

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -67,6 +67,8 @@ namespace Orleans.TestingHost
 
         public Microsoft.Extensions.Hosting.IHost SiloHost { get { throw null; } init { } }
 
+        public static System.Threading.Tasks.Task<InProcessSiloHandle> CreateAsync(string siloName, Microsoft.Extensions.Configuration.IConfiguration configuration, System.Action<Microsoft.Extensions.Hosting.IHostBuilder>? postConfigureHostBuilder, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public static System.Threading.Tasks.Task<InProcessSiloHandle> CreateAsync(string siloName, Microsoft.Extensions.Configuration.IConfiguration configuration, System.Action<Microsoft.Extensions.Hosting.IHostBuilder>? postConfigureHostBuilder = null) { throw null; }
 
         protected override void Dispose(bool disposing) { }
@@ -90,6 +92,8 @@ namespace Orleans.TestingHost
 
         public System.Collections.ObjectModel.ReadOnlyCollection<InProcessSiloHandle> Silos { get { throw null; } }
 
+        public System.Threading.Tasks.Task<InProcessSiloHandle> CreateSiloAsync(InProcessTestSiloSpecificOptions siloOptions, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task<InProcessSiloHandle> CreateSiloAsync(InProcessTestSiloSpecificOptions siloOptions) { throw null; }
 
         public System.Threading.Tasks.Task DeactivateAsync(Runtime.GrainId grainId) { throw null; }
@@ -97,6 +101,8 @@ namespace Orleans.TestingHost
         public System.Threading.Tasks.Task DeactivateAsync(Runtime.IAddressable grain) { throw null; }
 
         public System.Threading.Tasks.Task DeployAsync() { throw null; }
+
+        public System.Threading.Tasks.Task DeployAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public void Dispose() { }
 
@@ -114,7 +120,11 @@ namespace Orleans.TestingHost
 
         public System.Threading.Tasks.Task InitializeClientAsync() { throw null; }
 
+        public System.Threading.Tasks.Task InitializeClientAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task KillClientAsync() { throw null; }
+
+        public System.Threading.Tasks.Task KillSiloAsync(InProcessSiloHandle instance, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task KillSiloAsync(InProcessSiloHandle instance) { throw null; }
 
@@ -143,10 +153,14 @@ namespace Orleans.TestingHost
         [System.Obsolete("Use the overload which does not have a 'startSiloOnNewPort' parameter.")]
         public System.Threading.Tasks.Task<InProcessSiloHandle> StartSiloAsync(int instanceNumber, InProcessTestClusterOptions clusterOptions, System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Configuration.IConfigurationSource> configurationOverrides, bool startSiloOnNewPort) { throw null; }
 
+        public System.Threading.Tasks.Task<InProcessSiloHandle> StartSiloAsync(int instanceNumber, InProcessTestClusterOptions clusterOptions, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task<InProcessSiloHandle> StartSiloAsync(int instanceNumber, InProcessTestClusterOptions clusterOptions) { throw null; }
 
         [System.Obsolete("Use overload which does not have a 'startAdditionalSiloOnNewPort' parameter.")]
         public System.Threading.Tasks.Task<System.Collections.Generic.List<InProcessSiloHandle>> StartSilosAsync(int silosToStart, bool startAdditionalSiloOnNewPort) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<InProcessSiloHandle>> StartSilosAsync(int silosToStart, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task<System.Collections.Generic.List<InProcessSiloHandle>> StartSilosAsync(int silosToStart) { throw null; }
 
@@ -154,11 +168,19 @@ namespace Orleans.TestingHost
 
         public System.Threading.Tasks.Task StopAllSilosAsync() { throw null; }
 
+        public System.Threading.Tasks.Task StopAllSilosAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task StopClusterClientAsync() { throw null; }
+
+        public System.Threading.Tasks.Task StopClusterClientAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task StopSiloAsync(InProcessSiloHandle instance, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task StopSiloAsync(InProcessSiloHandle instance) { throw null; }
 
         public System.Threading.Tasks.Task StopSilosAsync() { throw null; }
+
+        public System.Threading.Tasks.Task StopSilosAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public bool TryGetGrainContext(Runtime.GrainId grainId, out Runtime.IGrainContext? grainContext) { throw null; }
 
@@ -292,6 +314,8 @@ namespace Orleans.TestingHost
         ~SiloHandle() {
         }
 
+        public virtual System.Threading.Tasks.Task StopSiloAsync(bool stopGracefully, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public abstract System.Threading.Tasks.Task StopSiloAsync(bool stopGracefully);
         public abstract System.Threading.Tasks.Task StopSiloAsync(System.Threading.CancellationToken ct);
         public override string ToString() { throw null; }
@@ -355,6 +379,8 @@ namespace Orleans.TestingHost
 
         public System.Func<string, Microsoft.Extensions.Configuration.IConfiguration, System.Threading.Tasks.Task<SiloHandle>> CreateSiloAsync { set { } }
 
+        public System.Func<string, Microsoft.Extensions.Configuration.IConfiguration, System.Threading.CancellationToken, System.Threading.Tasks.Task<SiloHandle>> CreateSiloAsyncWithCancellation { set { } }
+
         public IGrainFactory GrainFactory { get { throw null; } }
 
         public TestClusterOptions Options { get { throw null; } }
@@ -373,11 +399,15 @@ namespace Orleans.TestingHost
 
         public System.Threading.Tasks.Task DeactivateAsync(Runtime.IAddressable grain) { throw null; }
 
+        public System.Threading.Tasks.Task<SiloHandle> DefaultCreateSiloAsync(string siloName, Microsoft.Extensions.Configuration.IConfiguration configuration, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task<SiloHandle> DefaultCreateSiloAsync(string siloName, Microsoft.Extensions.Configuration.IConfiguration configuration) { throw null; }
 
         public void Deploy() { }
 
         public System.Threading.Tasks.Task DeployAsync() { throw null; }
+
+        public System.Threading.Tasks.Task DeployAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public void Dispose() { }
 
@@ -395,7 +425,11 @@ namespace Orleans.TestingHost
 
         public System.Threading.Tasks.Task InitializeClientAsync() { throw null; }
 
+        public System.Threading.Tasks.Task InitializeClientAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task KillClientAsync() { throw null; }
+
+        public System.Threading.Tasks.Task KillSiloAsync(SiloHandle instance, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task KillSiloAsync(SiloHandle instance) { throw null; }
 
@@ -411,9 +445,13 @@ namespace Orleans.TestingHost
 
         public System.Threading.Tasks.Task<SiloHandle> StartAdditionalSiloAsync(bool startAdditionalSiloOnNewPort = false) { throw null; }
 
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<SiloHandle>> StartAdditionalSilosAsync(int silosToStart, bool startAdditionalSiloOnNewPort, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task<System.Collections.Generic.List<SiloHandle>> StartAdditionalSilosAsync(int silosToStart, bool startAdditionalSiloOnNewPort = false) { throw null; }
 
         public static System.Threading.Tasks.Task<SiloHandle> StartSiloAsync(TestCluster cluster, int instanceNumber, TestClusterOptions clusterOptions, System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Configuration.IConfigurationSource>? configurationOverrides = null, bool startSiloOnNewPort = false) { throw null; }
+
+        public System.Threading.Tasks.Task<SiloHandle> StartSiloAsync(int instanceNumber, TestClusterOptions clusterOptions, System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Configuration.IConfigurationSource>? configurationOverrides, bool startSiloOnNewPort, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task<SiloHandle> StartSiloAsync(int instanceNumber, TestClusterOptions clusterOptions, System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Configuration.IConfigurationSource>? configurationOverrides = null, bool startSiloOnNewPort = false) { throw null; }
 
@@ -421,11 +459,21 @@ namespace Orleans.TestingHost
 
         public System.Threading.Tasks.Task StopAllSilosAsync() { throw null; }
 
+        public System.Threading.Tasks.Task StopAllSilosAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task StopClusterClientAsync() { throw null; }
+
+        public System.Threading.Tasks.Task StopClusterClientAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task StopPrimarySiloAsync() { throw null; }
 
+        public System.Threading.Tasks.Task StopPrimarySiloAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public System.Threading.Tasks.Task StopSecondarySilosAsync() { throw null; }
+
+        public System.Threading.Tasks.Task StopSecondarySilosAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task StopSiloAsync(SiloHandle instance, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task StopSiloAsync(SiloHandle instance) { throw null; }
 
@@ -447,6 +495,8 @@ namespace Orleans.TestingHost
         public TestClusterBuilder(short initialSilosCount) { }
 
         public System.Func<string, Microsoft.Extensions.Configuration.IConfiguration, System.Threading.Tasks.Task<SiloHandle>> CreateSiloAsync { set { } }
+
+        public System.Func<string, Microsoft.Extensions.Configuration.IConfiguration, System.Threading.CancellationToken, System.Threading.Tasks.Task<SiloHandle>> CreateSiloAsyncWithCancellation { set { } }
 
         public TestClusterOptions Options { get { throw null; } }
 

--- a/src/api/Orleans.Transactions.TestKit.Base/Orleans.Transactions.TestKit.Base.cs
+++ b/src/api/Orleans.Transactions.TestKit.Base/Orleans.Transactions.TestKit.Base.cs
@@ -810,9 +810,15 @@ namespace Orleans.Transactions.TestKit
 
         public System.Threading.Tasks.Task TransactionWillRecoverAfterManagerWait(string transactionTestGrainClassName) { throw null; }
 
+        protected virtual System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName, int concurrent, bool gracefulShutdown, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         protected virtual System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName, int concurrent, bool gracefulShutdown) { throw null; }
 
+        public virtual System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(string transactionTestGrainClassName, int concurrent, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public virtual System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(string transactionTestGrainClassName, int concurrent) { throw null; }
+
+        public virtual System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(string transactionTestGrainClassName, int concurrent, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public virtual System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(string transactionTestGrainClassName, int concurrent) { throw null; }
 

--- a/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
+++ b/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
@@ -16,7 +16,7 @@ namespace Orleans.Transactions.TestKit.xUnit
 
         protected override bool StorageErrorInjectionActive { get { throw null; } }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ConsistencyTransactionTestRunner.cs", 17)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ConsistencyTransactionTestRunner.cs", 17)]
         [Xunit.InlineData(new[] { 2, 2, true, true, Consistency.ReadWriteDetermination.PerGrain })]
         [Xunit.InlineData(new[] { 2, 3, true, true, Consistency.ReadWriteDetermination.PerGrain })]
         [Xunit.InlineData(new[] { 2, 4, true, true, Consistency.ReadWriteDetermination.PerGrain })]
@@ -105,7 +105,7 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public ControlledFaultInjectionTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs", 24)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ControlledFaultInjectionTransactionTestRunner.cs", 24)]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterPrepare, FaultInjectionType.Deactivation })]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterConfirm, FaultInjectionType.Deactivation })]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterPrepared, FaultInjectionType.Deactivation })]
@@ -118,10 +118,10 @@ namespace Orleans.Transactions.TestKit.xUnit
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.BeforePrepareAndCommit, FaultInjectionType.ExceptionBeforeStore })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransaction_FaultInjection(TransactionFaultInjectPhase injectionPhase, FaultInjectionType injectionType) { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs", 12)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ControlledFaultInjectionTransactionTestRunner.cs", 12)]
         public override System.Threading.Tasks.Task SingleGrainReadTransaction() { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs", 18)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ControlledFaultInjectionTransactionTestRunner.cs", 18)]
         public override System.Threading.Tasks.Task SingleGrainWriteTransaction() { throw null; }
     }
 
@@ -129,11 +129,11 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected DisabledTransactionsTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/DisabledTransactionsTestRunner.cs", 17)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\DisabledTransactionsTestRunner.cs", 17)]
         [Xunit.InlineData(new[] { "NoStateTransactionalGrain" })]
         public override void MultiTransactionGrainsThrowWhenTransactions(string transactionTestGrainClassName) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/DisabledTransactionsTestRunner.cs", 10)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\DisabledTransactionsTestRunner.cs", 10)]
         [Xunit.InlineData(new[] { "NoStateTransactionalGrain" })]
         public override void TransactionGrainsThrowWhenTransactions(string transactionTestGrainClassName) { }
     }
@@ -142,11 +142,11 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected ExclusiveLockTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs", 19)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ExclusiveLockTransactionTestRunner.cs", 19)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task ConcurrentReadThenWriteWithExclusiveLock_NoLockException(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs", 12)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ExclusiveLockTransactionTestRunner.cs", 12)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task ConcurrentReadThenWriteWithoutExclusiveLock_ThrowsLockException(string grainStates) { throw null; }
     }
@@ -155,49 +155,49 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected GoldenPathTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 38)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 38)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainReadWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 29)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 29)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 56)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 56)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task MultiWriteToSingleGrainTransaction(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 47)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 47)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task RepeatGrainReadWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 65)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 65)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task RWRWTest(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 11)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 11)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleGrainReadTransaction(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 20)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 20)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleGrainWriteTransaction(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 74)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 74)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
@@ -208,31 +208,31 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public GrainFaultTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 39)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 39)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionExceptionInnerExceptionOnlyContainsOneRootCauseException(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 12)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 12)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionOnExceptions(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 48)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 48)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionOnOrphanCalls(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 21)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 21)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionOnReadOnlyViolatedException(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 30)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 30)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
@@ -243,25 +243,25 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected ScopedTransactionsTestRunnerxUnit(IGrainFactory grainFactory, ITransactionClient transactionFrame, Xunit.ITestOutputHelper output) : base(default!, default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 39)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 39)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task CreateNestedTransactionScopeAndSetValueAndInnerFailAndAssert(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 12)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 12)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task CreateTransactionScopeAndSetValue(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 30)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 30)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task CreateTransactionScopeAndSetValueAndAssert(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 21)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 21)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
@@ -272,13 +272,13 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected TocFaultTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs", 20)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TocFaultTransactionTestRunner.cs", 20)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransactionWithCommitException(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TocFaultTransactionTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
@@ -289,7 +289,7 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected TocGoldenPathTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TOCGoldenPathTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TOCGoldenPathTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransaction(string grainStates, int grainCount) { throw null; }
@@ -299,16 +299,16 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public TransactionalStateStorageTestRunnerxUnit(System.Func<System.Threading.Tasks.Task<Abstractions.ITransactionalStateStorage<TState>>> stateStorageFactory, System.Func<int, TState> stateFactory, IGrainFactory grainFactory, Xunit.ITestOutputHelper testOutput, System.Func<AwesomeAssertions.Equivalency.EquivalencyOptions<TState>, AwesomeAssertions.Equivalency.EquivalencyOptions<TState>>? assertConfig = null) : base(default!, default!, default!, default!, default) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 110)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 110)]
         [Xunit.InlineData(new[] { 99 })]
         [Xunit.InlineData(new[] { 100 })]
         [Xunit.InlineData(new[] { 200 })]
         public override System.Threading.Tasks.Task CancelMany(int count) { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 56)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 56)]
         public override System.Threading.Tasks.Task CancelOne() { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 98)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 98)]
         [Xunit.InlineData(new[] { 99, true })]
         [Xunit.InlineData(new[] { 99, false })]
         [Xunit.InlineData(new[] { 100, true })]
@@ -317,45 +317,45 @@ namespace Orleans.Transactions.TestKit.xUnit
         [Xunit.InlineData(new[] { 200, false })]
         public override System.Threading.Tasks.Task ConfirmMany(int count, bool useTwoSteps) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 48)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 48)]
         [Xunit.InlineData(new[] { true })]
         [Xunit.InlineData(new[] { false })]
         public override System.Threading.Tasks.Task ConfirmOne(bool useTwoSteps) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 68)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 68)]
         [Xunit.InlineData(new[] { false, false })]
         [Xunit.InlineData(new[] { true, true })]
         [Xunit.InlineData(new[] { true, false })]
         public override System.Threading.Tasks.Task ConfirmOneAndCancelOne(bool useTwoSteps, bool reverseOrder) { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 30)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 30)]
         public override System.Threading.Tasks.Task FirstTime_Load_ShouldReturnEmptyLoadResponse() { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 77)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 77)]
         public override System.Threading.Tasks.Task GrowingBatch() { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 89)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 89)]
         [Xunit.InlineData(new[] { 99 })]
         [Xunit.InlineData(new[] { 100 })]
         [Xunit.InlineData(new[] { 200 })]
         public override System.Threading.Tasks.Task PrepareMany(int count) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 119)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 119)]
         [Xunit.InlineData(new[] { 99 })]
         [Xunit.InlineData(new[] { 100 })]
         [Xunit.InlineData(new[] { 200 })]
         public override System.Threading.Tasks.Task ReplaceMany(int count) { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 62)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 62)]
         public override System.Threading.Tasks.Task ReplaceOne() { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 83)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 83)]
         public override System.Threading.Tasks.Task ShrinkingBatch() { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 36)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 36)]
         public override System.Threading.Tasks.Task StoreWithoutChanges() { throw null; }
 
-        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 42)]
+        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 42)]
         public override System.Threading.Tasks.Task WrongEtags() { throw null; }
     }
 
@@ -363,19 +363,19 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected TransactionConcurrencyTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs", 16)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionConcurrencyTestRunner.cs", 16)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleSharedGrainTest(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs", 30)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionConcurrencyTestRunner.cs", 30)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task TransactionChainTest(string grainStates) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs", 44)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionConcurrencyTestRunner.cs", 44)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
@@ -386,12 +386,14 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public TransactionRecoveryTestsRunnerxUnit(TestingHost.TestCluster cluster, Xunit.ITestOutputHelper testOutput) : base(default!, default!) { }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs", 14)]
+        protected override System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName, int concurrent, bool gracefulShutdown) { throw null; }
+
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionRecoveryTestsRunner.cs", 14)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 30 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 20 })]
         public override System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(string transactionTestGrainClassName, int concurrent) { throw null; }
 
-        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs", 22)]
+        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionRecoveryTestsRunner.cs", 22)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 30 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 20 })]
         public override System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(string transactionTestGrainClassName, int concurrent) { throw null; }

--- a/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
+++ b/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
@@ -16,7 +16,7 @@ namespace Orleans.Transactions.TestKit.xUnit
 
         protected override bool StorageErrorInjectionActive { get { throw null; } }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ConsistencyTransactionTestRunner.cs", 17)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ConsistencyTransactionTestRunner.cs", 17)]
         [Xunit.InlineData(new[] { 2, 2, true, true, Consistency.ReadWriteDetermination.PerGrain })]
         [Xunit.InlineData(new[] { 2, 3, true, true, Consistency.ReadWriteDetermination.PerGrain })]
         [Xunit.InlineData(new[] { 2, 4, true, true, Consistency.ReadWriteDetermination.PerGrain })]
@@ -105,7 +105,7 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public ControlledFaultInjectionTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ControlledFaultInjectionTransactionTestRunner.cs", 24)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs", 24)]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterPrepare, FaultInjectionType.Deactivation })]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterConfirm, FaultInjectionType.Deactivation })]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterPrepared, FaultInjectionType.Deactivation })]
@@ -118,10 +118,10 @@ namespace Orleans.Transactions.TestKit.xUnit
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.BeforePrepareAndCommit, FaultInjectionType.ExceptionBeforeStore })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransaction_FaultInjection(TransactionFaultInjectPhase injectionPhase, FaultInjectionType injectionType) { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ControlledFaultInjectionTransactionTestRunner.cs", 12)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs", 12)]
         public override System.Threading.Tasks.Task SingleGrainReadTransaction() { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ControlledFaultInjectionTransactionTestRunner.cs", 18)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs", 18)]
         public override System.Threading.Tasks.Task SingleGrainWriteTransaction() { throw null; }
     }
 
@@ -129,11 +129,11 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected DisabledTransactionsTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\DisabledTransactionsTestRunner.cs", 17)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/DisabledTransactionsTestRunner.cs", 17)]
         [Xunit.InlineData(new[] { "NoStateTransactionalGrain" })]
         public override void MultiTransactionGrainsThrowWhenTransactions(string transactionTestGrainClassName) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\DisabledTransactionsTestRunner.cs", 10)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/DisabledTransactionsTestRunner.cs", 10)]
         [Xunit.InlineData(new[] { "NoStateTransactionalGrain" })]
         public override void TransactionGrainsThrowWhenTransactions(string transactionTestGrainClassName) { }
     }
@@ -142,11 +142,11 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected ExclusiveLockTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ExclusiveLockTransactionTestRunner.cs", 19)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs", 19)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task ConcurrentReadThenWriteWithExclusiveLock_NoLockException(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ExclusiveLockTransactionTestRunner.cs", 12)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs", 12)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task ConcurrentReadThenWriteWithoutExclusiveLock_ThrowsLockException(string grainStates) { throw null; }
     }
@@ -155,49 +155,49 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected GoldenPathTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 38)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 38)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainReadWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 29)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 29)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 56)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 56)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task MultiWriteToSingleGrainTransaction(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 47)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 47)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task RepeatGrainReadWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 65)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 65)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task RWRWTest(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 11)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 11)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleGrainReadTransaction(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 20)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 20)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleGrainWriteTransaction(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GoldenPathTransactionTestRunner.cs", 74)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs", 74)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
@@ -208,31 +208,31 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public GrainFaultTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 39)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 39)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionExceptionInnerExceptionOnlyContainsOneRootCauseException(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 12)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 12)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionOnExceptions(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 48)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 48)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionOnOrphanCalls(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 21)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 21)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task AbortTransactionOnReadOnlyViolatedException(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\GrainFaultTransactionTestRunner.cs", 30)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs", 30)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
@@ -243,25 +243,25 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected ScopedTransactionsTestRunnerxUnit(IGrainFactory grainFactory, ITransactionClient transactionFrame, Xunit.ITestOutputHelper output) : base(default!, default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 39)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 39)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task CreateNestedTransactionScopeAndSetValueAndInnerFailAndAssert(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 12)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 12)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task CreateTransactionScopeAndSetValue(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 30)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 30)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task CreateTransactionScopeAndSetValueAndAssert(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\ScopedTransactionsTestRunnerxUnit.cs", 21)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs", 21)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
@@ -272,13 +272,13 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected TocFaultTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TocFaultTransactionTestRunner.cs", 20)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs", 20)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransactionWithCommitException(string grainStates, int grainCount) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TocFaultTransactionTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
@@ -289,7 +289,7 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected TocGoldenPathTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TOCGoldenPathTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TOCGoldenPathTestRunner.cs", 11, Skip = "https://github.com/dotnet/orleans/issues/9556")]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransaction(string grainStates, int grainCount) { throw null; }
@@ -299,16 +299,16 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public TransactionalStateStorageTestRunnerxUnit(System.Func<System.Threading.Tasks.Task<Abstractions.ITransactionalStateStorage<TState>>> stateStorageFactory, System.Func<int, TState> stateFactory, IGrainFactory grainFactory, Xunit.ITestOutputHelper testOutput, System.Func<AwesomeAssertions.Equivalency.EquivalencyOptions<TState>, AwesomeAssertions.Equivalency.EquivalencyOptions<TState>>? assertConfig = null) : base(default!, default!, default!, default!, default) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 110)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 110)]
         [Xunit.InlineData(new[] { 99 })]
         [Xunit.InlineData(new[] { 100 })]
         [Xunit.InlineData(new[] { 200 })]
         public override System.Threading.Tasks.Task CancelMany(int count) { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 56)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 56)]
         public override System.Threading.Tasks.Task CancelOne() { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 98)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 98)]
         [Xunit.InlineData(new[] { 99, true })]
         [Xunit.InlineData(new[] { 99, false })]
         [Xunit.InlineData(new[] { 100, true })]
@@ -317,45 +317,45 @@ namespace Orleans.Transactions.TestKit.xUnit
         [Xunit.InlineData(new[] { 200, false })]
         public override System.Threading.Tasks.Task ConfirmMany(int count, bool useTwoSteps) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 48)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 48)]
         [Xunit.InlineData(new[] { true })]
         [Xunit.InlineData(new[] { false })]
         public override System.Threading.Tasks.Task ConfirmOne(bool useTwoSteps) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 68)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 68)]
         [Xunit.InlineData(new[] { false, false })]
         [Xunit.InlineData(new[] { true, true })]
         [Xunit.InlineData(new[] { true, false })]
         public override System.Threading.Tasks.Task ConfirmOneAndCancelOne(bool useTwoSteps, bool reverseOrder) { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 30)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 30)]
         public override System.Threading.Tasks.Task FirstTime_Load_ShouldReturnEmptyLoadResponse() { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 77)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 77)]
         public override System.Threading.Tasks.Task GrowingBatch() { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 89)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 89)]
         [Xunit.InlineData(new[] { 99 })]
         [Xunit.InlineData(new[] { 100 })]
         [Xunit.InlineData(new[] { 200 })]
         public override System.Threading.Tasks.Task PrepareMany(int count) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 119)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 119)]
         [Xunit.InlineData(new[] { 99 })]
         [Xunit.InlineData(new[] { 100 })]
         [Xunit.InlineData(new[] { 200 })]
         public override System.Threading.Tasks.Task ReplaceMany(int count) { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 62)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 62)]
         public override System.Threading.Tasks.Task ReplaceOne() { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 83)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 83)]
         public override System.Threading.Tasks.Task ShrinkingBatch() { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 36)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 36)]
         public override System.Threading.Tasks.Task StoreWithoutChanges() { throw null; }
 
-        [Xunit.Fact("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionalStateStorageTestRunner.cs", 42)]
+        [Xunit.Fact("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs", 42)]
         public override System.Threading.Tasks.Task WrongEtags() { throw null; }
     }
 
@@ -363,19 +363,19 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected TransactionConcurrencyTestRunnerxUnit(IGrainFactory grainFactory, Xunit.ITestOutputHelper output) : base(default!, default!) { }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionConcurrencyTestRunner.cs", 16)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs", 16)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleSharedGrainTest(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionConcurrencyTestRunner.cs", 30)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs", 30)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task TransactionChainTest(string grainStates) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionConcurrencyTestRunner.cs", 44)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs", 44)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
@@ -388,12 +388,12 @@ namespace Orleans.Transactions.TestKit.xUnit
 
         protected override System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloFailure(string transactionTestGrainClassName, int concurrent, bool gracefulShutdown) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionRecoveryTestsRunner.cs", 14)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs", 14)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 30 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 20 })]
         public override System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(string transactionTestGrainClassName, int concurrent) { throw null; }
 
-        [Xunit.Theory("C:\\dev\\copilot-worktrees\\orleans\\rb-ideal-train\\src\\Orleans.Transactions.TestKit.xUnit\\TransactionRecoveryTestsRunner.cs", 22)]
+        [Xunit.Theory("/_/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs", 22)]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 30 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 20 })]
         public override System.Threading.Tasks.Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(string transactionTestGrainClassName, int concurrent) { throw null; }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -10,7 +10,7 @@
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);FS2003;1591;xUnit1051</NoWarn>
+    <NoWarn>$(NoWarn);FS2003;1591</NoWarn>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/test/DistributedTests/DistributedTests.Client/Commands/ChaosAgentCommand.cs
+++ b/test/DistributedTests/DistributedTests.Client/Commands/ChaosAgentCommand.cs
@@ -37,16 +37,19 @@ namespace DistributedTests.Client.Commands
             AddOption(OptionHelper.CreateOption<bool>("--graceful", defaultValue: false));
             AddOption(OptionHelper.CreateOption<bool>("--restart", defaultValue: false));
 
-            Handler = CommandHandler.Create<Parameters>(RunAsync);
+            Handler = CommandHandler.Create<Parameters, CancellationToken>(RunAsync);
             _logger = logger;
         }
 
-        private async Task RunAsync(Parameters parameters)
+        private async Task RunAsync(Parameters parameters, CancellationToken cancellationToken)
         {
-            var channel = await Channels.CreateSendChannel(parameters.ClusterId, parameters.AzureQueueUri);
+            var channel = await Channels.CreateSendChannel(
+                parameters.ClusterId,
+                parameters.AzureQueueUri,
+                cancellationToken);
 
             _logger.LogInformation("Waiting {WaitSeconds} seconds before starting...", parameters.Wait);
-            await Task.Delay(TimeSpan.FromSeconds(parameters.Wait));
+            await Task.Delay(TimeSpan.FromSeconds(parameters.Wait), cancellationToken);
 
             for (var i=0; i<parameters.Rounds; i++)
             {
@@ -56,15 +59,15 @@ namespace DistributedTests.Client.Commands
                     parameters.ServersPerRound,
                     parameters.Restart,
                     parameters.Graceful);
-                var responses = await channel.SendMessages(
-                    GetMessages(),
-                    new CancellationTokenSource(TimeSpan.FromSeconds(parameters.RoundDelay)).Token);
+                using var roundCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                roundCancellation.CancelAfter(TimeSpan.FromSeconds(parameters.RoundDelay));
+                var responses = await channel.SendMessages(GetMessages(), roundCancellation.Token);
                 _logger.LogInformation(
                     "Round #{Round}: silos {Silos} acked",
                     i + 1,
                     string.Join(",", responses.Select(r => r.ServerName)));
                 _logger.LogInformation("Round #{Round}: waiting {RoundDelay}", i + 1, parameters.RoundDelay);
-                await Task.Delay(TimeSpan.FromSeconds(parameters.RoundDelay));
+                await Task.Delay(TimeSpan.FromSeconds(parameters.RoundDelay), cancellationToken);
             }
 
             List<ServerMessage> GetMessages()

--- a/test/DistributedTests/DistributedTests.Client/Commands/CounterCaptureCommand.cs
+++ b/test/DistributedTests/DistributedTests.Client/Commands/CounterCaptureCommand.cs
@@ -34,11 +34,11 @@ namespace DistributedTests.Client.Commands
             AddOption(OptionHelper.CreateOption("--counterKey", defaultValue: StreamingConstants.DefaultCounterGrain));
             AddArgument(new Argument<List<string>>("Counters") { Arity = ArgumentArity.OneOrMore });
 
-            Handler = CommandHandler.Create<Parameters>(RunAsync);
+            Handler = CommandHandler.Create<Parameters, CancellationToken>(RunAsync);
             _logger = logger;
         }
 
-        private async Task RunAsync(Parameters parameters)
+        private async Task RunAsync(Parameters parameters, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Connecting to cluster...");
             var hostBuilder = new HostBuilder()
@@ -48,26 +48,26 @@ namespace DistributedTests.Client.Commands
                         .UseAzureStorageClustering(options => options.TableServiceClient = parameters.AzureTableUri.CreateTableServiceClient());
                 });
             using var host = hostBuilder.Build();
-            await host.StartAsync();
+            await host.StartAsync(cancellationToken);
 
             // The Orleans client is always registered by UseOrleansClient above.
             var client = host.Services.GetService<IClusterClient>()!;
 
             var counterGrain = client.GetGrain<ICounterGrain>(parameters.CounterKey);
 
-            var duration = await counterGrain.GetRunDuration();
+            var duration = await counterGrain.GetRunDuration(cancellationToken);
             BenchmarksEventSource.Register("duration", Operations.First, Operations.Last, "duration", "duration", "n0");
             BenchmarksEventSource.Measure("duration", duration.TotalSeconds);
 
-            var initialWait = await counterGrain.WaitTimeForReport();
+            var initialWait = await counterGrain.WaitTimeForReport(cancellationToken);
 
             _logger.LogInformation("Counters should be ready in {InitialWait}", initialWait);
-            await Task.Delay(initialWait);
+            await Task.Delay(initialWait, cancellationToken);
 
             _logger.LogInformation("Counters ready");
             foreach (var counter in parameters.Counters)
             {
-                var value = await counterGrain.GetTotalCounterValue(counter);
+                var value = await counterGrain.GetTotalCounterValue(counter, cancellationToken);
                 _logger.LogInformation("{Counter}: {Value}", counter, value);
                 BenchmarksEventSource.Register(counter, Operations.First, Operations.Sum, counter, counter, "n0");
                 BenchmarksEventSource.Measure(counter, value);
@@ -79,7 +79,7 @@ namespace DistributedTests.Client.Commands
                 }
             }
 
-            await host.StopAsync();
+            await host.StopAsync(cancellationToken);
         }
     }
 }

--- a/test/DistributedTests/DistributedTests.Client/Commands/ScenarioCommand.cs
+++ b/test/DistributedTests/DistributedTests.Client/Commands/ScenarioCommand.cs
@@ -27,7 +27,7 @@ namespace DistributedTests.Client.Commands
             AddOption(OptionHelper.CreateOption<int>("--requestsPerBlock", defaultValue: 500, validator: OptionHelper.OnlyStrictlyPositive));
             AddOption(OptionHelper.CreateOption<int>("--duration", defaultValue: 0, validator: OptionHelper.OnlyPositiveOrZero));
 
-            Handler = CommandHandler.Create<ClientParameters, LoadGeneratorParameters>(_runner.Run);
+            Handler = CommandHandler.Create<ClientParameters, LoadGeneratorParameters, CancellationToken>(_runner.Run);
         }
     }
 

--- a/test/DistributedTests/DistributedTests.Client/LoadGeneratorScenario/ConcurrentLoadGenerator.cs
+++ b/test/DistributedTests/DistributedTests.Client/LoadGeneratorScenario/ConcurrentLoadGenerator.cs
@@ -17,7 +17,7 @@ namespace DistributedTests.Client
 
         public int BlocksCompleted { get; set; }
 
-        public readonly long RatePerSecond => (long)(Completed / TotalDuration);
+        public readonly long RatePerSecond => TotalDuration > 0 ? (long)(Completed / TotalDuration) : 0;
 
         public override readonly string ToString()
         {
@@ -42,7 +42,7 @@ namespace DistributedTests.Client
         }
 
         private Channel<WorkBlock> _completedBlocks = null!;
-        private readonly Func<TState, ValueTask> _issueRequest;
+        private readonly Func<TState, CancellationToken, ValueTask> _issueRequest;
         private readonly Func<int, TState> _getStateForWorker;
         private readonly ILogger _logger;
         private readonly bool _logIntermediateResults;
@@ -56,7 +56,7 @@ namespace DistributedTests.Client
             int numWorkers,
             int blocksPerWorker,
             int requestsPerBlock,
-            Func<TState, ValueTask> issueRequest,
+            Func<TState, CancellationToken, ValueTask> issueRequest,
             Func<int, TState> getStateForWorker,
             ILogger logger,
             bool logIntermediateResults = false)
@@ -72,7 +72,7 @@ namespace DistributedTests.Client
             this._states = new TState[numWorkers];
         }
 
-        public async Task Warmup()
+        public async Task Warmup(CancellationToken cancellationToken)
         {
             this.ResetBetweenRuns();
             var completedBlockReader = this._completedBlocks.Reader;
@@ -80,11 +80,15 @@ namespace DistributedTests.Client
             for (var ree = 0; ree < this._numWorkers; ree++)
             {
                 this._states[ree] = _getStateForWorker(ree);
-                this._tasks[ree] = this.RunWorker(this._states[ree], this._requestsPerBlock, 3, default);
+                this._tasks[ree] = this.RunWorker(
+                    this._states[ree],
+                    this._requestsPerBlock,
+                    3,
+                    cancellationToken);
             }
 
             // Wait for warmup to complete.
-            await Task.WhenAll(this._tasks);
+            await Task.WhenAll(this._tasks).WaitAsync(cancellationToken);
 
             // Ignore warmup blocks.
             while (completedBlockReader.TryRead(out _)) ;
@@ -104,7 +108,9 @@ namespace DistributedTests.Client
                 });
         }
 
-        public async Task<LoadGeneratorReport> Run(CancellationToken ct)
+        public async Task<LoadGeneratorReport> Run(
+            CancellationToken runCancellationToken,
+            CancellationToken cancellationToken)
         {
             this.ResetBetweenRuns();
             var completedBlockReader = this._completedBlocks.Reader;
@@ -112,18 +118,22 @@ namespace DistributedTests.Client
             // Start the run.
             for (var i = 0; i < this._numWorkers; i++)
             {
-                this._tasks[i] = this.RunWorker(this._states[i], this._requestsPerBlock, this._blocksPerWorker, ct);
+                this._tasks[i] = this.RunWorker(
+                    this._states[i],
+                    this._requestsPerBlock,
+                    this._blocksPerWorker,
+                    runCancellationToken);
             }
 
             var completion = Task.WhenAll(this._tasks);
-            _ = Task.Run(async () => { try { await completion; } catch { } finally { this._completedBlocks.Writer.Complete(); } });
+            _ = CompleteWriterAsync(completion);
             // Do not allocated a list with a too high capacity
             var blocks = new List<WorkBlock>(this._numWorkers * Math.Min(100, this._blocksPerWorker));
             var blocksPerReport = this._numWorkers * Math.Min(100, this._blocksPerWorker) / 5;
             var nextReportBlockCount = blocksPerReport;
             while (!completion.IsCompleted)
             {
-                var more = await completedBlockReader.WaitToReadAsync();
+                var more = await completedBlockReader.WaitToReadAsync(cancellationToken);
                 if (!more) break;
                 while (completedBlockReader.TryRead(out var block))
                 {
@@ -189,12 +199,16 @@ namespace DistributedTests.Client
             {
                 var workBlock = new WorkBlock();
                 workBlock.StartTimestamp = Stopwatch.GetTimestamp();
-                while (workBlock.Completed < requestsPerBlock)
+                while (workBlock.Completed < requestsPerBlock && !ct.IsCancellationRequested)
                 {
                     try
                     {
-                        await this._issueRequest(state).ConfigureAwait(false);
+                        await this._issueRequest(state, ct).ConfigureAwait(false);
                         ++workBlock.Successes;
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        break;
                     }
                     catch
                     {
@@ -203,8 +217,25 @@ namespace DistributedTests.Client
                 }
 
                 workBlock.EndTimestamp = Stopwatch.GetTimestamp();
-                await completedBlockWriter.WriteAsync(workBlock);
+                if (workBlock.Completed > 0 && !completedBlockWriter.TryWrite(workBlock))
+                {
+                    break;
+                }
+
                 --numBlocks;
+            }
+        }
+
+        private async Task CompleteWriterAsync(Task completion)
+        {
+            try
+            {
+                await completion;
+                this._completedBlocks.Writer.TryComplete();
+            }
+            catch (Exception exception)
+            {
+                this._completedBlocks.Writer.TryComplete(exception);
             }
         }
     }

--- a/test/DistributedTests/DistributedTests.Client/LoadGeneratorScenario/LoadGeneratorScenarioRunner.cs
+++ b/test/DistributedTests/DistributedTests.Client/LoadGeneratorScenario/LoadGeneratorScenarioRunner.cs
@@ -36,7 +36,10 @@ namespace DistributedTests.Client.LoadGeneratorScenario
             _logger = loggerFactory.CreateLogger(scenario.Name);
         }
 
-        public async Task Run(ClientParameters clientParams, LoadGeneratorParameters loadParams)
+        public async Task Run(
+            ClientParameters clientParams,
+            LoadGeneratorParameters loadParams,
+            CancellationToken cancellationToken)
         {
             Console.WriteLine($"AzureTableUri: {clientParams.AzureTableUri}");
 
@@ -52,7 +55,7 @@ namespace DistributedTests.Client.LoadGeneratorScenario
             using var host = hostBuilder.Build();
 
             _logger.LogInformation("Connecting to cluster...");
-            await host.StartAsync();
+            await host.StartAsync(cancellationToken);
             // The Orleans client is always registered by UseOrleansClient above.
             var client = host.Services.GetService<IClusterClient>()!;
 
@@ -66,19 +69,24 @@ namespace DistributedTests.Client.LoadGeneratorScenario
                 logIntermediateResults: true);
 
             _logger.LogInformation("Warming-up...");
-            await generator.Warmup();
+            await generator.Warmup(cancellationToken);
 
-            var cts = loadParams.Duration != 0
-                ? new CancellationTokenSource(TimeSpan.FromSeconds(loadParams.Duration))
-                : new CancellationTokenSource();
+            using var durationCancellation = new CancellationTokenSource();
+            if (loadParams.Duration != 0)
+            {
+                durationCancellation.CancelAfter(TimeSpan.FromSeconds(loadParams.Duration));
+            }
 
+            using var runCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                durationCancellation.Token);
             _logger.LogInformation("Running");
-            var report = await generator.Run(cts.Token);
+            var report = await generator.Run(runCancellation.Token, cancellationToken);
 
             BenchmarksEventSource.Register("overall-rps", Operations.Last, Operations.Last, "Overall RPS", "RPS", "n0");
             BenchmarksEventSource.Measure("overall-rps", report.RatePerSecond);
 
-            await host.StopAsync();
+            await host.StopAsync(cancellationToken);
         }
     }
 }

--- a/test/DistributedTests/DistributedTests.Client/LoadGeneratorScenario/LoadGeneratorScenarios.cs
+++ b/test/DistributedTests/DistributedTests.Client/LoadGeneratorScenario/LoadGeneratorScenarios.cs
@@ -8,7 +8,7 @@ namespace DistributedTests.Client.LoadGeneratorScenario
 
         TState GetStateForWorker(IClusterClient client, int workerId);
 
-        ValueTask IssueRequest(TState state);
+        ValueTask IssueRequest(TState state, CancellationToken cancellationToken);
     }
 
     public class PingScenario : ILoadGeneratorScenario<IPingGrain>
@@ -17,7 +17,8 @@ namespace DistributedTests.Client.LoadGeneratorScenario
 
         public IPingGrain GetStateForWorker(IClusterClient client, int workerId) => client.GetGrain<IPingGrain>(Guid.NewGuid());
 
-        public ValueTask IssueRequest(IPingGrain state) => state.Ping();
+        public ValueTask IssueRequest(IPingGrain state, CancellationToken cancellationToken) =>
+            state.Ping(cancellationToken);
     }
 
     public class FanOutScenario : ILoadGeneratorScenario<ITreeGrain>
@@ -26,6 +27,7 @@ namespace DistributedTests.Client.LoadGeneratorScenario
 
         public ITreeGrain GetStateForWorker(IClusterClient client, int workerId) => client.GetGrain<ITreeGrain>(primaryKey: 0, keyExtension: workerId.ToString());
 
-        public ValueTask IssueRequest(ITreeGrain root) => root.Ping();
+        public ValueTask IssueRequest(ITreeGrain root, CancellationToken cancellationToken) =>
+            root.Ping(cancellationToken);
     }
 }

--- a/test/DistributedTests/DistributedTests.Common/GrainInterfaces/IPingGrain.cs
+++ b/test/DistributedTests/DistributedTests.Common/GrainInterfaces/IPingGrain.cs
@@ -2,6 +2,5 @@ namespace DistributedTests.GrainInterfaces;
 
 public interface IPingGrain : IGrainWithGuidKey
 {
-    ValueTask Ping();
+    ValueTask Ping(CancellationToken cancellationToken);
 }
-

--- a/test/DistributedTests/DistributedTests.Common/GrainInterfaces/IStreamingGrains.cs
+++ b/test/DistributedTests/DistributedTests.Common/GrainInterfaces/IStreamingGrains.cs
@@ -17,7 +17,7 @@ namespace DistributedTests.GrainInterfaces
 
     public interface IGrainWithCounter : IGrainWithGuidKey
     {
-        Task<int> GetCounterValue(string counterName);
+        Task<int> GetCounterValue(string counterName, CancellationToken cancellationToken);
     }
 
     public interface IImplicitSubscriberGrain : IGrainWithCounter
@@ -28,10 +28,10 @@ namespace DistributedTests.GrainInterfaces
     {
         Task Track(IGrainWithCounter grain);
 
-        Task<TimeSpan> GetRunDuration();
+        Task<TimeSpan> GetRunDuration(CancellationToken cancellationToken);
 
-        Task<TimeSpan> WaitTimeForReport();
+        Task<TimeSpan> WaitTimeForReport(CancellationToken cancellationToken);
 
-        Task<int> GetTotalCounterValue(string counterName);
+        Task<int> GetTotalCounterValue(string counterName, CancellationToken cancellationToken);
     }
 }

--- a/test/DistributedTests/DistributedTests.Common/GrainInterfaces/ITreeGrain.cs
+++ b/test/DistributedTests/DistributedTests.Common/GrainInterfaces/ITreeGrain.cs
@@ -2,6 +2,5 @@
 
 public interface ITreeGrain : IGrainWithIntegerCompoundKey
 {
-    public ValueTask Ping();
+    public ValueTask Ping(CancellationToken cancellationToken);
 }
-

--- a/test/DistributedTests/DistributedTests.Common/MessageChannel/Channels.cs
+++ b/test/DistributedTests/DistributedTests.Common/MessageChannel/Channels.cs
@@ -14,7 +14,7 @@ namespace DistributedTests.Common.MessageChannel
     {
         Task<ServerMessage> WaitForMessage(CancellationToken cancellationToken);
 
-        Task SendAck(ServerMessage message);
+        Task SendAck(ServerMessage message, CancellationToken cancellationToken);
     }
 
     public class SendChannel : ISendChannel
@@ -59,10 +59,10 @@ namespace DistributedTests.Common.MessageChannel
 
         public async Task<ServerMessage> WaitForMessage(CancellationToken cancellationToken) => await _readQueue.WaitForMessage<ServerMessage>(cancellationToken);
 
-        public async Task SendAck(ServerMessage message)
+        public async Task SendAck(ServerMessage message, CancellationToken cancellationToken)
         {
             var ack = AckMessage.CreateAckMessage(message, _serverName);
-            await _writeQueue.SendMessageAsync(JsonSerializer.Serialize(ack));
+            await _writeQueue.SendMessageAsync(JsonSerializer.Serialize(ack), cancellationToken);
         }
     }
 
@@ -71,52 +71,72 @@ namespace DistributedTests.Common.MessageChannel
         private static readonly string CLIENT_TO_SERVER_QUEUE = "servers-{0}";
         private static readonly string SILO_TO_CLIENT_QUEUE = "client-{0}";
 
-        public static Task<ISendChannel> CreateSendChannel(string clusterId, Uri azureQueueUri)
-            => CreateSendChannel(clusterId, azureQueueUri.CreateQueueServiceClient());
+        public static Task<ISendChannel> CreateSendChannel(
+            string clusterId,
+            Uri azureQueueUri,
+            CancellationToken cancellationToken)
+            => CreateSendChannel(clusterId, azureQueueUri.CreateQueueServiceClient(), cancellationToken);
 
-        public static async Task<ISendChannel> CreateSendChannel(string clusterId, QueueServiceClient queueServiceClient)
+        public static async Task<ISendChannel> CreateSendChannel(
+            string clusterId,
+            QueueServiceClient queueServiceClient,
+            CancellationToken cancellationToken)
         {
             var writeQueue = queueServiceClient.GetQueueClient(string.Format(CLIENT_TO_SERVER_QUEUE, clusterId));
             var readQueue = queueServiceClient.GetQueueClient(string.Format(SILO_TO_CLIENT_QUEUE, clusterId));
 
-            await writeQueue.CreateIfNotExistsAsync();
-            await readQueue.CreateIfNotExistsAsync();
+            await writeQueue.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            await readQueue.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
 
             return new SendChannel(writeQueue, readQueue);
         }
 
-        public static Task<IReceiveChannel> CreateReceiveChannel(string serverName, string clusterId, Uri azureQueueUri)
-            => CreateReceiveChannel(serverName, clusterId, azureQueueUri.CreateQueueServiceClient());
+        public static Task<IReceiveChannel> CreateReceiveChannel(
+            string serverName,
+            string clusterId,
+            Uri azureQueueUri,
+            CancellationToken cancellationToken)
+            => CreateReceiveChannel(serverName, clusterId, azureQueueUri.CreateQueueServiceClient(), cancellationToken);
 
-        public static async Task<IReceiveChannel> CreateReceiveChannel(string serverName, string clusterId, QueueServiceClient queueServiceClient)
+        public static async Task<IReceiveChannel> CreateReceiveChannel(
+            string serverName,
+            string clusterId,
+            QueueServiceClient queueServiceClient,
+            CancellationToken cancellationToken)
         {
             var writeQueue = queueServiceClient.GetQueueClient(string.Format(SILO_TO_CLIENT_QUEUE, clusterId));
             var readQueue = queueServiceClient.GetQueueClient(string.Format(CLIENT_TO_SERVER_QUEUE, clusterId));
 
-            await writeQueue.CreateIfNotExistsAsync();
-            await readQueue.CreateIfNotExistsAsync();
+            await writeQueue.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            await readQueue.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
 
             return new ReceiveChannel(writeQueue, readQueue, serverName);
         }
 
-        internal static async Task<T> WaitForMessage<T>(this QueueClient queueClient, CancellationToken ct)
+        internal static async Task<T> WaitForMessage<T>(
+            this QueueClient queueClient,
+            CancellationToken cancellationToken)
         {
-            while (!ct.IsCancellationRequested)
+            while (true)
             {
-                var result = await queueClient.ReceiveMessagesAsync(maxMessages: 1, cancellationToken: ct);
+                cancellationToken.ThrowIfCancellationRequested();
+                var result = await queueClient.ReceiveMessagesAsync(
+                    maxMessages: 1,
+                    cancellationToken: cancellationToken);
                 var msg = result.Value?.FirstOrDefault();
 
                 if (msg != null)
                 {
-                    await queueClient.DeleteMessageAsync(msg.MessageId, msg.PopReceipt);
+                    await queueClient.DeleteMessageAsync(
+                        msg.MessageId,
+                        msg.PopReceipt,
+                        cancellationToken);
                     // A message that was just dequeued is expected to deserialize to a valid T.
                     return JsonSerializer.Deserialize<T>(msg.MessageText)!;
                 }
 
-                await Task.Delay(1000, ct);
+                await Task.Delay(1000, cancellationToken);
             }
-            ct.ThrowIfCancellationRequested();
-            throw new Exception("No message");
         }
     }
 }

--- a/test/DistributedTests/DistributedTests.Grains/CounterReportingGrain.cs
+++ b/test/DistributedTests/DistributedTests.Grains/CounterReportingGrain.cs
@@ -13,14 +13,20 @@ namespace DistributedTests.Grains
             _options = options.Value;
         }
 
-        public Task<TimeSpan> GetRunDuration() => Task.FromResult(TimeSpan.FromSeconds(_options.Duration));
+        public Task<TimeSpan> GetRunDuration(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(TimeSpan.FromSeconds(_options.Duration));
+        }
 
-        public async Task<int> GetTotalCounterValue(string counterName)
+        public async Task<int> GetTotalCounterValue(
+            string counterName,
+            CancellationToken cancellationToken)
         {
             var counter = 0;
             foreach (var grain in _trackedGrains)
             {
-                counter += await grain.GetCounterValue(counterName);
+                counter += await grain.GetCounterValue(counterName, cancellationToken);
             }
             return counter;
         }
@@ -31,8 +37,9 @@ namespace DistributedTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task<TimeSpan> WaitTimeForReport()
+        public Task<TimeSpan> WaitTimeForReport(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var ts = _options.ReportAt - DateTime.UtcNow;
             return ts < TimeSpan.Zero
                 ? Task.FromResult(TimeSpan.Zero)

--- a/test/DistributedTests/DistributedTests.Grains/ImplicitSubscriberGrain.cs
+++ b/test/DistributedTests/DistributedTests.Grains/ImplicitSubscriberGrain.cs
@@ -17,8 +17,9 @@ namespace DistributedTests.Grains
             _logger = logger;
         }
 
-        public Task<int> GetCounterValue(string counterName)
+        public Task<int> GetCounterValue(string counterName, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return counterName switch
             {
                 "requests" => Task.FromResult(_requestCounter),

--- a/test/DistributedTests/DistributedTests.Grains/PingGrain.cs
+++ b/test/DistributedTests/DistributedTests.Grains/PingGrain.cs
@@ -4,5 +4,9 @@ namespace DistributedTests.Grains;
 
 public class PingGrain : Grain, IPingGrain
 {
-    public ValueTask Ping() => default;
+    public ValueTask Ping(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return default;
+    }
 }

--- a/test/DistributedTests/DistributedTests.Grains/TreeGrain.cs
+++ b/test/DistributedTests/DistributedTests.Grains/TreeGrain.cs
@@ -25,12 +25,13 @@ public class TreeGrain : Grain, ITreeGrain
         }
     }
 
-    public async ValueTask Ping()
+    public async ValueTask Ping(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var tasks = new List<ValueTask>(_children.Count);
         foreach (var child in _children)
         {
-            tasks.Add(child.Ping());
+            tasks.Add(child.Ping(cancellationToken));
         }
 
         // Wait for the tasks to complete.

--- a/test/DistributedTests/DistributedTests.Server/ServerCommand.cs
+++ b/test/DistributedTests/DistributedTests.Server/ServerCommand.cs
@@ -27,7 +27,7 @@ namespace DistributedTests.Server
                 AddOption(opt);
             }
 
-            Handler = CommandHandler.Create<CommonParameters, T>(_siloRunner.Run);
+            Handler = CommandHandler.Create<CommonParameters, T, CancellationToken>(_siloRunner.Run);
         }
     }
 

--- a/test/DistributedTests/DistributedTests.Server/ServerRunner.cs
+++ b/test/DistributedTests/DistributedTests.Server/ServerRunner.cs
@@ -21,6 +21,8 @@ namespace DistributedTests.Server
 
     public class ServerRunner<T>
     {
+        private static readonly TimeSpan AbruptShutdownTimeout = TimeSpan.FromSeconds(5);
+
         private readonly ISiloConfigurator<T> _siloConfigurator;
         private readonly string _siloName;
 
@@ -65,13 +67,25 @@ namespace DistributedTests.Server
 
                 msg = await channel.WaitForMessage(cancellationToken);
 
-                using var stopCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                if (!msg.IsGraceful)
+                if (msg.IsGraceful)
                 {
-                    stopCancellation.Cancel();
+                    await host.StopAsync(cancellationToken);
                 }
-
-                await host.StopAsync(stopCancellation.Token);
+                else
+                {
+                    using var stopCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    stopCancellation.CancelAfter(AbruptShutdownTimeout);
+                    try
+                    {
+                        await host.StopAsync(stopCancellation.Token);
+                    }
+                    catch (OperationCanceledException) when (
+                        stopCancellation.IsCancellationRequested
+                        && !cancellationToken.IsCancellationRequested)
+                    {
+                        // Host disposal completes the abrupt shutdown after the bounded stop attempt.
+                    }
+                }
 
                 if (!msg.Restart)
                 {

--- a/test/DistributedTests/DistributedTests.Server/ServerRunner.cs
+++ b/test/DistributedTests/DistributedTests.Server/ServerRunner.cs
@@ -30,15 +30,22 @@ namespace DistributedTests.Server
             _siloName = $"{Environment.MachineName}-{Guid.NewGuid().ToString("N")[..5]}";
         }
 
-        public async Task Run(CommonParameters commonParameters, T configuratorParameters)
+        public async Task Run(
+            CommonParameters commonParameters,
+            T configuratorParameters,
+            CancellationToken cancellationToken)
         {
-            var channel = await Channels.CreateReceiveChannel(_siloName, commonParameters.ClusterId, commonParameters.AzureQueueUri);
+            var channel = await Channels.CreateReceiveChannel(
+                _siloName,
+                commonParameters.ClusterId,
+                commonParameters.AzureQueueUri,
+                cancellationToken);
 
             ServerMessage? msg = null;
 
             while (true)
             {
-                var host = Host
+                using var host = Host
                     .CreateDefaultBuilder()
                     .ConfigureLogging(logging =>
                     {
@@ -47,22 +54,28 @@ namespace DistributedTests.Server
                     .UseOrleans((ctx, siloBuilder) => ConfigureOrleans(siloBuilder, commonParameters, configuratorParameters))
                     .Build();
 
-                var hostTask = host.RunAsync();
+                await host.StartAsync(cancellationToken);
 
                 if (msg != null)
                 {
                     // we did restart the silo
-                    await channel.SendAck(msg);
+                    await channel.SendAck(msg, cancellationToken);
                     msg = null;
                 }
 
-                msg = await channel.WaitForMessage(CancellationToken.None);
+                msg = await channel.WaitForMessage(cancellationToken);
 
-                await host.StopAsync(new CancellationToken(!msg.IsGraceful));
+                using var stopCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                if (!msg.IsGraceful)
+                {
+                    stopCancellation.Cancel();
+                }
+
+                await host.StopAsync(stopCancellation.Token);
 
                 if (!msg.Restart)
                 {
-                    await channel.SendAck(msg);
+                    await channel.SendAck(msg, cancellationToken);
                     break;
                 }
             }

--- a/test/Extensions/Google/GoogleEmulatorHost.cs
+++ b/test/Extensions/Google/GoogleEmulatorHost.cs
@@ -65,7 +65,7 @@ public static class GoogleEmulatorHost
         try
         {
             client.ConnectAsync(IPAddress.Loopback, port)
-                .WaitAsync(TimeSpan.FromSeconds(1))
+                .WaitAsync(TimeSpan.FromSeconds(1), Xunit.TestContext.Current.CancellationToken)
                 .GetAwaiter()
                 .GetResult();
         }

--- a/test/Extensions/Orleans.AWS.Tests/StorageTests/AWSTestConstants.cs
+++ b/test/Extensions/Orleans.AWS.Tests/StorageTests/AWSTestConstants.cs
@@ -10,43 +10,51 @@ namespace AWSUtils.Tests.StorageTests
 {
     public class AWSTestConstants
     {
-        private static readonly Lazy<bool> _isDynamoDbAvailable = new Lazy<bool>(() =>
-        {
-            if (string.IsNullOrEmpty(DynamoDbService))
+        private static readonly Lazy<bool> _isDynamoDbAvailable = new(
+            () =>
             {
-                return false;
-            }
+                if (string.IsNullOrEmpty(DynamoDbService))
+                {
+                    return false;
+                }
 
-            try
-            {
-                DynamoDBStorage storage;
                 try
                 {
-                    storage = new DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), DynamoDbService);
+                    DynamoDBStorage storage;
+                    try
+                    {
+                        storage = new DynamoDBStorage(NullLoggerFactory.Instance.CreateLogger("DynamoDBStorage"), DynamoDbService);
+                    }
+                    catch (AmazonServiceException)
+                    {
+                        return false;
+                    }
+                    storage.InitializeTable(
+                        "TestTable",
+                        new List<KeySchemaElement> {
+                            new KeySchemaElement { AttributeName = "PartitionKey", KeyType = KeyType.HASH }
+                        },
+                        new List<AttributeDefinition> {
+                            new AttributeDefinition { AttributeName = "PartitionKey", AttributeType = ScalarAttributeType.S }
+                        })
+                    .WaitAsync(TimeSpan.FromSeconds(2), Xunit.TestContext.Current.CancellationToken)
+                    .GetAwaiter()
+                    .GetResult();
+                    return true;
                 }
-                catch (AmazonServiceException)
+                catch (TimeoutException)
                 {
                     return false;
                 }
-                storage.InitializeTable(
-                    "TestTable",
-                    new List<KeySchemaElement> {
-                        new KeySchemaElement { AttributeName = "PartitionKey", KeyType = KeyType.HASH }
-                    },
-                    new List<AttributeDefinition> {
-                        new AttributeDefinition { AttributeName = "PartitionKey", AttributeType = ScalarAttributeType.S }
-                    })
-                .WaitAsync(TimeSpan.FromSeconds(2)).Wait();
-                return true;
-            }
-            catch (Exception exc)
-            {
-                if (exc.InnerException is TimeoutException)
-                    return false;
+                catch (Exception exc)
+                {
+                    if (exc.InnerException is TimeoutException)
+                        return false;
 
-                throw;
-            }
-        });
+                    throw;
+                }
+            },
+            LazyThreadSafetyMode.PublicationOnly);
 
         public static string DynamoDbAccessKey { get; set; } = TestDefaultConfiguration.DynamoDbAccessKey!;
         public static string DynamoDbSecretKey { get; set; } = TestDefaultConfiguration.DynamoDbSecretKey!;

--- a/test/Extensions/Orleans.AWS.Tests/StorageTests/DynamoDBStorageProviderTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/StorageTests/DynamoDBStorageProviderTests.cs
@@ -180,7 +180,7 @@ namespace AWSUtils.Tests.StorageTests
             var storage = await InitDynamoDBGrainStorage();
             var runner = new GrainStorageModelBasedTestRunner(storage, "DynamoDB", output.WriteLine);
 
-            await runner.RunGeneratedConformanceTests();
+            await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("ModelBased")]
@@ -194,7 +194,7 @@ namespace AWSUtils.Tests.StorageTests
             var storage = await InitDynamoDBGrainStorage(deleteStateOnClear: true);
             var runner = new GrainStorageModelBasedTestRunner(storage, "DynamoDBDeleteStateOnClear", output.WriteLine);
 
-            await runner.RunGeneratedConformanceTests();
+            await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
         }
 
         private async Task<DynamoDBGrainStorage> InitDynamoDBGrainStorage(DynamoDBStorageOptions options)

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSAdapterTests.cs
@@ -71,12 +71,14 @@ namespace AWSUtils.Tests.Streaming
             var dataAdapter = new SQSDataAdapter(fixture.Serializer);
             var adapterFactory = new SQSAdapterFactory(SQS_STREAM_PROVIDER_NAME, options, new HashRingStreamQueueMapperOptions(), new SimpleQueueCacheOptions(), Options.Create(clusterOptions), dataAdapter, NullLoggerFactory.Instance);
             adapterFactory.Init();
-            await SendAndReceiveFromQueueAdapter(adapterFactory);
+            await SendAndReceiveFromQueueAdapter(adapterFactory, TestContext.Current.CancellationToken);
         }
 
-        private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
+        private async Task SendAndReceiveFromQueueAdapter(
+            IQueueAdapterFactory adapterFactory,
+            CancellationToken cancellationToken)
         {
-            IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
+            IQueueAdapter adapter = await adapterFactory.CreateAdapter(cancellationToken);
             IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
             // Create receiver per queue
@@ -106,10 +108,10 @@ namespace AWSUtils.Tests.Streaming
                     {
                         var messages = (await receiver.GetQueueMessagesAsync(
                             SQSStorage.MAX_NUMBER_OF_MESSAGE_TO_PEEK,
-                            CancellationToken.None)).ToArray();
+                            cancellationToken)).ToArray();
                         if (!messages.Any())
                         {
-                            await Task.Delay(QueuePollRate);
+                            await Task.Delay(QueuePollRate, cancellationToken);
                             continue;
                         }
                         foreach (var message in messages.Cast<SQSBatchContainer>())
@@ -128,7 +130,7 @@ namespace AWSUtils.Tests.Streaming
                         Interlocked.Add(ref receivedBatches, messages.Length);
                         qCache.AddToCache(messages);
                     }
-                });
+                }, cancellationToken);
                 work.Add(task);
             }
 
@@ -138,17 +140,19 @@ namespace AWSUtils.Tests.Streaming
             {
                 foreach (var streamId in Enumerable.Range(0, NumBatches).Select(i => i % 2 == 0 ? streamId1 : streamId2))
                 {
-                    await adapter.QueueMessageBatchAsync(
-                        StreamId.Create(streamId.ToString(), streamId),
-                        events.Take(NumMessagesPerBatch).ToArray(),
-                        null,
-                        RequestContextExtensions.Export(this.fixture.DeepCopier));
+                    await AwaitWithCancellation(
+                        adapter.QueueMessageBatchAsync(
+                            StreamId.Create(streamId.ToString(), streamId),
+                            events.Take(NumMessagesPerBatch).ToArray(),
+                            null,
+                            RequestContextExtensions.Export(this.fixture.DeepCopier)),
+                        cancellationToken);
                 }
-            }));
+            }, cancellationToken));
             await Task.WhenAll(work);
 
             // Wait for everything to be consumed.
-            await Task.Delay(QueuePollRate * 2);
+            await Task.Delay(QueuePollRate * 2, cancellationToken);
 
             // Make sure we got back everything we sent
             Assert.Equal(NumBatches, receivedBatches);
@@ -196,6 +200,27 @@ namespace AWSUtils.Tests.Streaming
                     const int expected = NumBatches / 2 - 10 + 1; // all except the first 10, including the 10th (10 + 1)
                     Assert.Equal(expected, messageCount);
                 }
+            }
+        }
+
+        private static async Task AwaitWithCancellation(Task task, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await task.WaitAsync(cancellationToken);
+            }
+            catch
+            {
+                if (!task.IsCompleted)
+                {
+                    _ = task.ContinueWith(
+                        static completed => _ = completed.Exception,
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+
+                throw;
             }
         }
 

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSClientStreamTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSClientStreamTests.cs
@@ -98,7 +98,10 @@ namespace AWSUtils.Tests.Streaming
         public async Task SQSStreamProducerOnDroppedClientTest()
         {
             logger.LogInformation("************************ AQStreamProducerOnDroppedClientTest *********************************");
-            await runner.StreamProducerOnDroppedClientTest(SQSStreamProviderName, StreamNamespace);
+            await runner.StreamProducerOnDroppedClientTest(
+                SQSStreamProviderName,
+                StreamNamespace,
+                TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSDataAdapterTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSDataAdapterTests.cs
@@ -72,12 +72,14 @@ public class SQSDataAdapterTests : IAsyncLifetime
         var dataAdapter = new StringOrIntSqsDataAdapter(fixture.Serializer);
         var adapterFactory = new SQSAdapterFactory(SQS_STREAM_PROVIDER_NAME, options, new HashRingStreamQueueMapperOptions(), new SimpleQueueCacheOptions(), Options.Create(clusterOptions), dataAdapter, NullLoggerFactory.Instance);
         adapterFactory.Init();
-        await SendAndReceiveFromQueueAdapter(adapterFactory);
+        await SendAndReceiveFromQueueAdapter(adapterFactory, TestContext.Current.CancellationToken);
     }
 
-    private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
+    private async Task SendAndReceiveFromQueueAdapter(
+        IQueueAdapterFactory adapterFactory,
+        CancellationToken cancellationToken)
     {
-        IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
+        IQueueAdapter adapter = await adapterFactory.CreateAdapter(cancellationToken);
         IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
         // Create receiver per queue
@@ -107,10 +109,10 @@ public class SQSDataAdapterTests : IAsyncLifetime
                 {
                     var messages = (await receiver.GetQueueMessagesAsync(
                         SQSStorage.MAX_NUMBER_OF_MESSAGE_TO_PEEK,
-                        CancellationToken.None)).ToArray();
+                        cancellationToken)).ToArray();
                     if (!messages.Any())
                     {
-                        await Task.Delay(QueuePollRate);
+                        await Task.Delay(QueuePollRate, cancellationToken);
                         continue;
                     }
                     foreach (var message in messages.Cast<SQSBatchContainer>())
@@ -129,7 +131,7 @@ public class SQSDataAdapterTests : IAsyncLifetime
                     Interlocked.Add(ref receivedBatches, messages.Length);
                     qCache.AddToCache(messages);
                 }
-            });
+            }, cancellationToken);
             work.Add(task);
         }
 
@@ -139,17 +141,19 @@ public class SQSDataAdapterTests : IAsyncLifetime
         {
             foreach (var streamId in Enumerable.Range(0, NumBatches).Select(i => i % 2 == 0 ? streamId1 : streamId2))
             {
-                await adapter.QueueMessageBatchAsync(
-                    StreamId.Create(streamId.ToString(), streamId),
-                    events.Take(NumMessagesPerBatch).ToArray(),
-                    null,
-                    RequestContextExtensions.Export(this.fixture.DeepCopier));
+                await AwaitWithCancellation(
+                    adapter.QueueMessageBatchAsync(
+                        StreamId.Create(streamId.ToString(), streamId),
+                        events.Take(NumMessagesPerBatch).ToArray(),
+                        null,
+                        RequestContextExtensions.Export(this.fixture.DeepCopier)),
+                    cancellationToken);
             }
-        }));
+        }, cancellationToken));
         await Task.WhenAll(work);
 
         // Wait for everything to be consumed.
-        await Task.Delay(QueuePollRate * 2);
+        await Task.Delay(QueuePollRate * 2, cancellationToken);
 
         // Make sure we got back everything we sent
         Assert.Equal(NumBatches, receivedBatches);
@@ -197,6 +201,27 @@ public class SQSDataAdapterTests : IAsyncLifetime
                 const int expected = NumBatches / 2 - 10 + 1; // all except the first 10, including the 10th (10 + 1)
                 Assert.Equal(expected, messageCount);
             }
+        }
+    }
+
+    private static async Task AwaitWithCancellation(Task task, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await task.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            if (!task.IsCompleted)
+            {
+                _ = task.ContinueWith(
+                    static completed => _ = completed.Exception,
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+
+            throw;
         }
     }
 

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSFIFOStreamTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSFIFOStreamTests.cs
@@ -157,25 +157,25 @@ public class SQSFIFOStreamTests : TestClusterPerTest
     [Fact]
     public async Task SQS_01_OneProducerGrainOneConsumerGrain()
     {
-        await runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+        await runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_02_OneProducerGrainOneConsumerClient()
     {
-        await runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+        await runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_03_OneProducerClientOneConsumerGrain()
     {
-        await runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+        await runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_04_OneProducerClientOneConsumerClient()
     {
-        await runner.StreamTest_04_OneProducerClientOneConsumerClient();
+        await runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
     }
 
     //------------------------ MANY to Many different grains ----------------------//
@@ -183,50 +183,50 @@ public class SQSFIFOStreamTests : TestClusterPerTest
     [Fact]
     public async Task SQS_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
-        await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+        await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
     {
-        await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+        await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
     {
-        await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+        await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
     {
-        await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+        await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
     }
 
     //------------------------ MANY to Many Same grains ----------------------//
     [Fact]
     public async Task SQS_09_ManySame_ManyProducerGrainsManyConsumerGrains()
     {
-        await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+        await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_10_ManySame_ManyConsumerGrainsManyProducerGrains()
     {
-        await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+        await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_11_ManySame_ManyProducerGrainsManyConsumerClients()
     {
-        await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+        await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_12_ManySame_ManyProducerClientsManyConsumerGrains()
     {
-        await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+        await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     //------------------------ MANY to Many producer consumer same grain ----------------------//
@@ -234,13 +234,13 @@ public class SQSFIFOStreamTests : TestClusterPerTest
     [Fact]
     public async Task SQS_13_SameGrain_ConsumerFirstProducerLater()
     {
-        await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+        await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_14_SameGrain_ProducerFirstConsumerLater()
     {
-        await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+        await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
     }
 
     //----------------------------------------------//
@@ -248,14 +248,15 @@ public class SQSFIFOStreamTests : TestClusterPerTest
     [Fact]
     public async Task SQS_15_ConsumeAtProducersRequest()
     {
-        await runner.StreamTest_15_ConsumeAtProducersRequest();
+        await runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task SQS_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
         var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 16, false);
-        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -263,6 +264,7 @@ public class SQSFIFOStreamTests : TestClusterPerTest
     {
         var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 17, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
-            () => HostedCluster.StartAdditionalSilo());
+            () => HostedCluster.StartAdditionalSilo(),
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 }

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSStreamTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSStreamTests.cs
@@ -126,25 +126,25 @@ namespace AWSUtils.Tests.Streaming
         [Fact]
         public async Task SQS_01_OneProducerGrainOneConsumerGrain()
         {
-            await runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+            await runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_02_OneProducerGrainOneConsumerClient()
         {
-            await runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+            await runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_03_OneProducerClientOneConsumerGrain()
         {
-            await runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+            await runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_04_OneProducerClientOneConsumerClient()
         {
-            await runner.StreamTest_04_OneProducerClientOneConsumerClient();
+            await runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many different grains ----------------------//
@@ -152,50 +152,50 @@ namespace AWSUtils.Tests.Streaming
         [Fact]
         public async Task SQS_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+            await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
         {
-            await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+            await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
         {
-            await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+            await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
         {
-            await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+            await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many Same grains ----------------------//
         [Fact]
         public async Task SQS_09_ManySame_ManyProducerGrainsManyConsumerGrains()
         {
-            await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+            await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_10_ManySame_ManyConsumerGrainsManyProducerGrains()
         {
-            await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+            await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_11_ManySame_ManyProducerGrainsManyConsumerClients()
         {
-            await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+            await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_12_ManySame_ManyProducerClientsManyConsumerGrains()
         {
-            await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+            await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many producer consumer same grain ----------------------//
@@ -203,13 +203,13 @@ namespace AWSUtils.Tests.Streaming
         [Fact]
         public async Task SQS_13_SameGrain_ConsumerFirstProducerLater()
         {
-            await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+            await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_14_SameGrain_ProducerFirstConsumerLater()
         {
-            await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+            await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
         }
 
         //----------------------------------------------//
@@ -217,14 +217,15 @@ namespace AWSUtils.Tests.Streaming
         [Fact]
         public async Task SQS_15_ConsumeAtProducersRequest()
         {
-            await runner.StreamTest_15_ConsumeAtProducersRequest();
+            await runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task SQS_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
             var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 16, false);
-            await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+            await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -232,7 +233,8 @@ namespace AWSUtils.Tests.Streaming
         {
             var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 17, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
-                () => HostedCluster.StartAdditionalSilo());
+                () => HostedCluster.StartAdditionalSilo(),
+                cancellationToken: TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSSubscriptionMultiplicityTests.cs
@@ -89,56 +89,56 @@ namespace AWSUtils.Tests.Streaming
         public async Task SQSMultipleParallelSubscriptionTest()
         {
             logger.LogInformation("************************ SQSMultipleParallelSubscriptionTest *********************************");
-            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("AWS")]
         public async Task SQSMultipleLinearSubscriptionTest()
         {
             logger.LogInformation("************************ SQSMultipleLinearSubscriptionTest *********************************");
-            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("AWS")]
         public async Task SQSMultipleSubscriptionTest_AddRemove()
         {
             logger.LogInformation("************************ SQSMultipleSubscriptionTest_AddRemove *********************************");
-            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("AWS")]
         public async Task SQSResubscriptionTest()
         {
             logger.LogInformation("************************ SQSResubscriptionTest *********************************");
-            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("AWS")]
         public async Task SQSResubscriptionAfterDeactivationTest()
         {
             logger.LogInformation("************************ ResubscriptionAfterDeactivationTest *********************************");
-            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("AWS")]
         public async Task SQSActiveSubscriptionTest()
         {
             logger.LogInformation("************************ SQSActiveSubscriptionTest *********************************");
-            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("AWS")]
         public async Task SQSTwoIntermittentStreamTest()
         {
             logger.LogInformation("************************ SQSTwoIntermittentStreamTest *********************************");
-            await runner.TwoIntermittentStreamTest(Guid.NewGuid());
+            await runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("AWS")]
         public async Task SQSSubscribeFromClientTest()
         {
             logger.LogInformation("************************ SQSSubscribeFromClientTest *********************************");
-            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
+            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryClusterTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryClusterTests.cs
@@ -68,7 +68,10 @@ public abstract class AdoNetGrainDirectoryClusterTests : MultipleGrainDirectorie
     public override async ValueTask InitializeAsync()
     {
         // set up the adonet environment before the base initializes
-        _testing = await RelationalStorageForTesting.SetupInstance(_invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            _invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryTests.cs
@@ -67,7 +67,10 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
 
     public async ValueTask InitializeAsync()
     {
-        _testing = await RelationalStorageForTesting.SetupInstance(invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
@@ -96,7 +99,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         var lifetime = new FakeHostApplicationLifetime();
         var directory = new AdoNetGrainDirectory("MyProviderId", options, logger, clusterOptions, lifetime);
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         // act
         var address = new GrainAddress
@@ -113,7 +116,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         Assert.Equal(address.SiloAddress, result.SiloAddress);
         Assert.Equal(address.ActivationId, result.ActivationId);
 
-        var saved = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory");
+        var saved = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
         var entry = Assert.Single(saved);
         Assert.Equal("MyClusterId", entry.ClusterId);
         Assert.Equal("MyProviderId", entry.ProviderId);
@@ -142,7 +145,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         var lifetime = new FakeHostApplicationLifetime();
         var directory = new AdoNetGrainDirectory("MyProviderId", options, logger, clusterOptions, lifetime);
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         var address = new GrainAddress
         {
@@ -156,7 +159,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         await directory.Unregister(address);
 
         // assert
-        var saved = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory");
+        var saved = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
         Assert.Empty(saved);
     }
 
@@ -180,7 +183,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         var lifetime = new FakeHostApplicationLifetime();
         var directory = new AdoNetGrainDirectory("MyProviderId", options, logger, clusterOptions, lifetime);
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         var grainId = GrainId.Create("MyGrainType", "MyGrainKey");
         var siloAddress = SiloAddress.New(IPEndPoint.Parse("127.0.0.1:11111"), 123456);
@@ -223,7 +226,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         var lifetime = new FakeHostApplicationLifetime();
         var directory = new AdoNetGrainDirectory("MyProviderId", options, logger, clusterOptions, lifetime);
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         var grainIds = Enumerable.Range(0, 5).Select(i => GrainId.Create("MyGrainType", $"MyGrainKey{i}")).ToArray();
         var siloAddresses = Enumerable.Range(0, 5).Select(i => SiloAddress.New(IPEndPoint.Parse($"127.0.0.{i}:11111"), 123456)).ToArray();
@@ -244,7 +247,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         await directory.UnregisterSilos([siloAddresses[0], siloAddresses[2], siloAddresses[4]]);
 
         // assert
-        var results = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory ORDER BY GrainId");
+        var results = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory ORDER BY GrainId", TestContext.Current.CancellationToken);
         var resultAddresses = results.Select(entry => entry.ToGrainAddress()).ToArray();
         Assert.Equal([addresses[1], addresses[3]], resultAddresses);
     }
@@ -271,10 +274,14 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         var lifetime = new FakeHostApplicationLifetime();
         var directory = new AdoNetGrainDirectory("MyProviderId", options, logger, clusterOptions, lifetime);
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         // act
-        await Parallel.ForAsync(0, 10000, new ParallelOptions { MaxDegreeOfParallelism = concurrency }, async (i, ct) =>
+        await Parallel.ForAsync(0, 10000, new ParallelOptions
+        {
+            MaxDegreeOfParallelism = concurrency,
+            CancellationToken = TestContext.Current.CancellationToken
+        }, async (i, ct) =>
         {
             var grainId = GrainId.Create("MyGrainType", $"MyGrainKey{Random.Shared.Next(10)}");
             var siloAddress = SiloAddress.New(IPEndPoint.Parse($"127.0.0.{Random.Shared.Next(10)}:11111"), 123456);
@@ -302,7 +309,7 @@ public abstract class AdoNetGrainDirectoryTests(string invariant, int concurrenc
         });
 
         // assert
-        var remaining = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory");
+        var remaining = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
         Assert.Empty(remaining);
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/RelationalOrleansQueriesTests.cs
@@ -60,7 +60,10 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
 
     public async ValueTask InitializeAsync()
     {
-        var testing = await RelationalStorageForTesting.SetupInstance(invariant, TestDatabaseName);
+        var testing = await RelationalStorageForTesting.SetupInstance(
+            invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
         Assert.SkipWhen(IsNullOrEmpty(testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
         _storage = RelationalStorage.CreateInstance(invariant, testing.CurrentConnectionString);
@@ -93,7 +96,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var siloAddress = RandomSiloAddress();
         var activationId = RandomActivationId();
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         // act
         var entry = await _queries.RegisterGrainActivationAsync(clusterId, providerId, grainId, siloAddress, activationId);
@@ -106,7 +109,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(siloAddress, entry.SiloAddress);
         Assert.Equal(activationId, entry.ActivationId);
 
-        var results = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory");
+        var results = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
         var result = Assert.Single(results);
         Assert.Equal(clusterId, result.ClusterId);
         Assert.Equal(providerId, result.ProviderId);
@@ -128,7 +131,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var siloAddress = RandomSiloAddress();
         var activationId = RandomActivationId();
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         // act
         var entry = await _queries.RegisterGrainActivationAsync(clusterId, providerId, grainId, siloAddress, activationId);
@@ -138,7 +141,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.NotNull(entry);
         Assert.Equal(1, count);
 
-        var results = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory");
+        var results = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
         Assert.Empty(results);
     }
 
@@ -155,7 +158,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var siloAddress = RandomSiloAddress();
         var activationId = RandomActivationId();
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         // act
         var entry = await _queries.RegisterGrainActivationAsync(clusterId, providerId, grainId, siloAddress, activationId);
@@ -183,7 +186,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var grainId = RandomGrainId();
         var activationId = RandomActivationId();
 
-        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory");
+        await _storage.ExecuteAsync("DELETE FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
 
         await _queries.RegisterGrainActivationAsync(clusterId, providerId, "G1", "A", "A1");
         await _queries.RegisterGrainActivationAsync(clusterId, providerId, "G2", "B", "A2");
@@ -197,7 +200,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         // assert
         Assert.Equal(3, count);
 
-        var remaining = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory");
+        var remaining = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
         Assert.Collection(remaining.OrderBy(x => x.GrainId),
             entry => Assert.Equal("G2", entry.GrainId),
             entry => Assert.Equal("G4", entry.GrainId));
@@ -220,7 +223,11 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var providerId = RandomProviderId();
 
         // act
-        await Parallel.ForAsync(0, 10000, new ParallelOptions { MaxDegreeOfParallelism = concurrency }, async (x, ct) =>
+        await Parallel.ForAsync(0, 10000, new ParallelOptions
+        {
+            MaxDegreeOfParallelism = concurrency,
+            CancellationToken = TestContext.Current.CancellationToken
+        }, async (x, ct) =>
         {
             var grainId = RandomGrainId();
             var siloAddress = RandomSiloAddress();
@@ -237,7 +244,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         });
 
         // assert
-        var remaining = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory");
+        var remaining = await _storage.ReadAsync<AdoNetGrainDirectoryEntry>("SELECT * FROM OrleansGrainDirectory", TestContext.Current.CancellationToken);
         Assert.Empty(remaining);
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/LivenessTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/LivenessTests.cs
@@ -28,7 +28,10 @@ namespace UnitTests.MembershipTests
 
         public override async ValueTask InitializeAsync()
         {
-            var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+            var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                AdoNetInvariantName,
+                TestDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             _connectionString = relationalStorage.CurrentConnectionString;
             await base.InitializeAsync();
             if (!PreconditionsMet)
@@ -113,7 +116,10 @@ namespace UnitTests.MembershipTests
 
         public override async ValueTask InitializeAsync()
         {
-            var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+            var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                AdoNetInvariantName,
+                TestDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             _connectionString = relationalStorage.CurrentConnectionString;
             await base.InitializeAsync();
             if (!PreconditionsMet)
@@ -198,7 +204,10 @@ namespace UnitTests.MembershipTests
 
         public override async ValueTask InitializeAsync()
         {
-            var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+            var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                AdoNetInvariantName,
+                TestDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             _connectionString = relationalStorage.CurrentConnectionString;
             await base.InitializeAsync();
             if (!PreconditionsMet)

--- a/test/Extensions/Orleans.AdoNet.Tests/MySqlMembershipTableTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/MySqlMembershipTableTests.cs
@@ -55,7 +55,10 @@ namespace UnitTests.MembershipTests
 
         protected override async Task<string> GetConnectionString()
         {
-            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            var instance = await RelationalStorageForTesting.SetupInstance(
+                GetAdoInvariant(),
+                testDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             return instance.CurrentConnectionString;
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql.cs
@@ -41,7 +41,10 @@ namespace Tester.AdoNet.Persistence
                     return;
                 }
 
-                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                    AdoInvariant,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
                 _connectionString = relationalStorage.CurrentConnectionString;
                 await base.InitializeAsync();
                 if (!PreconditionsMet)

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_MySql_DeleteStateOnClear.cs
@@ -42,7 +42,10 @@ namespace Tester.AdoNet.Persistence
                     return;
                 }
 
-                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                    AdoInvariant,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
                 _connectionString = relationalStorage.CurrentConnectionString;
                 await base.InitializeAsync();
                 if (!PreconditionsMet)

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres.cs
@@ -41,7 +41,10 @@ namespace Tester.AdoNet.Persistence
                     return;
                 }
 
-                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                    AdoInvariant,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
                 _connectionString = relationalStorage.CurrentConnectionString;
                 await base.InitializeAsync();
                 if (!PreconditionsMet)

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_Postgres_DeleteStateOnClear.cs
@@ -42,7 +42,10 @@ namespace Tester.AdoNet.Persistence
                     return;
                 }
 
-                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                    AdoInvariant,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
                 _connectionString = relationalStorage.CurrentConnectionString;
                 await base.InitializeAsync();
                 if (!PreconditionsMet)

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer.cs
@@ -40,7 +40,10 @@ namespace Tester.AdoNet.Persistence
                     return;
                 }
 
-                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                    AdoInvariant,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
                 _connectionString = relationalStorage.CurrentConnectionString;
                 await base.InitializeAsync();
                 if (!PreconditionsMet)

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/PersistenceGrainTests_SqlServer_DeleteStateOnClear.cs
@@ -42,7 +42,10 @@ namespace Tester.AdoNet.Persistence
                     return;
                 }
 
-                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                    AdoInvariant,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
                 _connectionString = relationalStorage.CurrentConnectionString;
                 await base.InitializeAsync();
                 if (!PreconditionsMet)

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageFixture.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageFixture.cs
@@ -41,19 +41,28 @@ namespace Tester.AdoNet.Persistence
 
         public async ValueTask InitializeAsync()
         {
-            await this.InitializeSchemaAsync();
-            this.Storage = await this.CreateGrainStorageAsync();
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await this.InitializeSchemaAsync(cancellationToken);
+            this.Storage = await this.CreateGrainStorageAsync(cancellationToken);
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-        public async Task InitializeSchemaAsync()
+        public async Task InitializeSchemaAsync(CancellationToken cancellationToken)
         {
-            await this.DatabaseStorage.ExecuteAsync(await LoadScriptAsync("Sqlite-Main.sql"), command => { }).ConfigureAwait(false);
-            await this.DatabaseStorage.ExecuteAsync(await LoadScriptAsync("Sqlite-Persistence.sql"), command => { }).ConfigureAwait(false);
+            await this.DatabaseStorage.ExecuteAsync(
+                await LoadScriptAsync("Sqlite-Main.sql", cancellationToken),
+                command => { },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            await this.DatabaseStorage.ExecuteAsync(
+                await LoadScriptAsync("Sqlite-Persistence.sql", cancellationToken),
+                command => { },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<AdoNetGrainStorage> CreateGrainStorageAsync(string storageName = "SqliteGrainStorageForTest")
+        public async Task<AdoNetGrainStorage> CreateGrainStorageAsync(
+            CancellationToken cancellationToken,
+            string storageName = "SqliteGrainStorageForTest")
         {
             var providerRuntime = new ClientProviderRuntime(
                 this.InternalGrainFactory,
@@ -76,11 +85,11 @@ namespace Tester.AdoNet.Persistence
 
             ISiloLifecycleSubject siloLifeCycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
             storageProvider.Participate(siloLifeCycle);
-            await siloLifeCycle.OnStart(CancellationToken.None).ConfigureAwait(false);
+            await siloLifeCycle.OnStart(cancellationToken).ConfigureAwait(false);
             return storageProvider;
         }
 
-        private static async Task<string> LoadScriptAsync(string fileName)
+        private static async Task<string> LoadScriptAsync(string fileName, CancellationToken cancellationToken)
         {
             var scriptPath = Path.Combine(AppContext.BaseDirectory, fileName);
             if (!File.Exists(scriptPath))
@@ -93,11 +102,12 @@ namespace Tester.AdoNet.Persistence
                 throw new FileNotFoundException($"Unable to locate SQL script '{fileName}'.", fileName);
             }
 
-            return await File.ReadAllTextAsync(scriptPath).ConfigureAwait(false);
+            return await File.ReadAllTextAsync(scriptPath, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<AdoNetGrainStorage> CreateGrainStorageAsync(
             System.Data.Common.DbDataSource dataSource,
+            CancellationToken cancellationToken,
             string storageName = "SqliteDataSourceGrainStorageForTest")
         {
             var providerRuntime = new ClientProviderRuntime(
@@ -121,7 +131,7 @@ namespace Tester.AdoNet.Persistence
 
             ISiloLifecycleSubject siloLifeCycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
             storageProvider.Participate(siloLifeCycle);
-            await siloLifeCycle.OnStart(CancellationToken.None).ConfigureAwait(false);
+            await siloLifeCycle.OnStart(cancellationToken).ConfigureAwait(false);
             return storageProvider;
         }
     }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageTests.cs
@@ -65,7 +65,9 @@ namespace Tester.AdoNet.Persistence
         [Fact]
         public async Task ClearInconsistentFailsWithInconsistentStateException()
         {
-            var storage = await this.fixture.CreateGrainStorageAsync($"SqliteClearInconsistent-{Guid.NewGuid():N}");
+            var storage = await this.fixture.CreateGrainStorageAsync(
+                TestContext.Current.CancellationToken,
+                $"SqliteClearInconsistent-{Guid.NewGuid():N}");
             const string grainType = "sqlite-clear-inconsistent-grain";
             var grainId = GrainId.Create(GrainType.Create(grainType), GrainIdKeyExtensions.CreateIntegerKey(Random.Shared.NextInt64()));
 
@@ -90,7 +92,9 @@ namespace Tester.AdoNet.Persistence
         [Fact]
         public async Task HashCollisionWriteReadWriteRead()
         {
-            var storage = await this.fixture.CreateGrainStorageAsync($"SqliteHashCollision-{Guid.NewGuid():N}");
+            var storage = await this.fixture.CreateGrainStorageAsync(
+                TestContext.Current.CancellationToken,
+                $"SqliteHashCollision-{Guid.NewGuid():N}");
             storage.HashPicker = new StorageHasherPicker(new[] { new ConstantHasher() });
             var storageTests = new CommonStorageTests(storage);
             await storageTests.PersistenceStorage_WriteReadWriteReadStatesInParallel(nameof(HashCollisionWriteReadWriteRead), 2);
@@ -99,7 +103,9 @@ namespace Tester.AdoNet.Persistence
         [Fact]
         public async Task ExtensionStringIdentityMatching()
         {
-            var storage = await this.fixture.CreateGrainStorageAsync($"SqliteExtension-{Guid.NewGuid():N}");
+            var storage = await this.fixture.CreateGrainStorageAsync(
+                TestContext.Current.CancellationToken,
+                $"SqliteExtension-{Guid.NewGuid():N}");
             storage.HashPicker = new StorageHasherPicker(new[] { new ConstantHasher() });
 
             const string grainType = "sqlite-extension-string-sensitive-grain";
@@ -125,7 +131,10 @@ namespace Tester.AdoNet.Persistence
         [Fact]
         public async Task ConcurrentFirstWriteRaceUsesOptimisticConcurrency()
         {
-            var storage = await this.fixture.CreateGrainStorageAsync($"SqliteConcurrentFirstWrite-{Guid.NewGuid():N}");
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var storage = await this.fixture.CreateGrainStorageAsync(
+                cancellationToken,
+                $"SqliteConcurrentFirstWrite-{Guid.NewGuid():N}");
             const string grainType = "sqlite-concurrent-first-write-grain";
             var inconsistentStateExceptionCount = 0;
 
@@ -136,17 +145,17 @@ namespace Tester.AdoNet.Persistence
 
                 var firstWrite = Task.Run(async () =>
                 {
-                    await startGate.Task;
+                    await startGate.Task.WaitAsync(cancellationToken);
                     var state = new GrainState<TestState1> { State = new TestState1 { A = "first", B = i, C = i } };
                     return await Record.ExceptionAsync(() => storage.WriteStateAsync(grainType, grainId, state));
-                });
+                }, cancellationToken);
 
                 var secondWrite = Task.Run(async () =>
                 {
-                    await startGate.Task;
+                    await startGate.Task.WaitAsync(cancellationToken);
                     var state = new GrainState<TestState1> { State = new TestState1 { A = "second", B = i + 1000, C = i + 1000 } };
                     return await Record.ExceptionAsync(() => storage.WriteStateAsync(grainType, grainId, state));
-                });
+                }, cancellationToken);
 
                 startGate.SetResult();
                 var exceptions = await Task.WhenAll(firstWrite, secondWrite);
@@ -191,7 +200,10 @@ namespace Tester.AdoNet.Persistence
         public async Task DataSource_WriteReadClear_LeavesCallerOwnedDataSourceUsable()
         {
             using var dataSource = new TrackingSqliteDataSource(this.fixture.ConnectionString);
-            var storage = await this.fixture.CreateGrainStorageAsync(dataSource, $"SqliteDataSource-{Guid.NewGuid():N}");
+            var storage = await this.fixture.CreateGrainStorageAsync(
+                dataSource,
+                TestContext.Current.CancellationToken,
+                $"SqliteDataSource-{Guid.NewGuid():N}");
             const string grainType = "sqlite-data-source-grain";
             var grainId = GrainId.Create(GrainType.Create(grainType), GrainIdKeyExtensions.CreateIntegerKey(Random.Shared.NextInt64()));
             var written = new GrainState<TestState1> { State = new TestState1 { A = "from-data-source", B = 17, C = 29 } };
@@ -211,11 +223,11 @@ namespace Tester.AdoNet.Persistence
             Assert.NotEqual(etagBeforeClear, read.ETag);
             Assert.False(dataSource.IsDisposed);
 
-            await using (var connection = await dataSource.OpenConnectionAsync())
+            await using (var connection = await dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken))
             await using (var command = connection.CreateCommand())
             {
                 command.CommandText = "SELECT 43;";
-                Assert.Equal(43L, await command.ExecuteScalarAsync());
+                Assert.Equal(43L, await command.ExecuteScalarAsync(TestContext.Current.CancellationToken));
             }
 
             Assert.True(dataSource.OpenConnectionAsyncCallCount >= 5);

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageTests.cs
@@ -59,7 +59,7 @@ namespace Tester.AdoNet.Persistence
         {
             var runner = new GrainStorageModelBasedTestRunner(this.fixture.Storage, "Sqlite");
 
-            await runner.RunGeneratedConformanceTests();
+            await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
         }
 
         [Fact]

--- a/test/Extensions/Orleans.AdoNet.Tests/PostgreSqlMembershipTableTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/PostgreSqlMembershipTableTests.cs
@@ -58,7 +58,10 @@ namespace UnitTests.MembershipTests
 
         protected override async Task<string> GetConnectionString()
         {
-            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            var instance = await RelationalStorageForTesting.SetupInstance(
+                GetAdoInvariant(),
+                testDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             return instance.CurrentConnectionString;
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
@@ -101,7 +101,11 @@ namespace UnitTests.General
             Assert.SkipWhen(string.IsNullOrEmpty(connectionString), "Connection string not provided.");
         }
 
-        public static async Task<RelationalStorageForTesting> SetupInstance(string invariantName, string testDatabaseName, string? connectionString = null)
+        public static async Task<RelationalStorageForTesting> SetupInstance(
+            string invariantName,
+            string testDatabaseName,
+            string? connectionString = null,
+            CancellationToken cancellationToken = default)
         {
             CheckPreconditionsOrThrow(invariantName, connectionString);
             if (string.IsNullOrWhiteSpace(invariantName))
@@ -128,16 +132,16 @@ namespace UnitTests.General
             Console.WriteLine("Dropping and recreating database '{0}' with ConnectionString '{1}'", testDatabaseName, testStorage.CurrentConnectionString);
             testStorage.PrepareForDatabaseReset(testDatabaseName);
 
-            if (await testStorage.ExistsDatabaseAsync(testDatabaseName))
+            if (await testStorage.ExistsDatabaseAsync(testDatabaseName, cancellationToken))
             {
-                await testStorage.DropDatabaseAsync(testDatabaseName);
+                await testStorage.DropDatabaseAsync(testDatabaseName, cancellationToken);
             }
 
-            await testStorage.CreateDatabaseAsync(testDatabaseName);
+            await testStorage.CreateDatabaseAsync(testDatabaseName, cancellationToken);
 
             //The old storage instance has the previous connection string, time have a new handle with a new connection string...
             testStorage = testStorage.CopyInstance(testDatabaseName);
-            await testStorage.WaitForDatabaseReadyAsync();
+            await testStorage.WaitForDatabaseReadyAsync(cancellationToken);
 
             Console.WriteLine("Creating database tables...");
 
@@ -146,13 +150,13 @@ namespace UnitTests.General
             // Concatenate scripts
             foreach (var fileName in testStorage.SetupSqlScriptFileNames)
             {
-                setupScript += File.ReadAllText(fileName);
+                setupScript += await File.ReadAllTextAsync(fileName, cancellationToken);
 
                 // Just in case add a CRLF between files, but they should end in a new line.
                 setupScript += "\r\n";
             }
 
-            await testStorage.ExecuteSetupScript(setupScript, testDatabaseName);
+            await testStorage.ExecuteSetupScript(setupScript, testDatabaseName, cancellationToken);
 
             Console.WriteLine("Initializing relational databases done.");
 
@@ -185,7 +189,7 @@ namespace UnitTests.General
         {
         }
 
-        protected virtual Task WaitForDatabaseReadyAsync() => Task.CompletedTask;
+        protected virtual Task WaitForDatabaseReadyAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         /// <summary>
         /// Executes the given script in a test context.
@@ -193,18 +197,21 @@ namespace UnitTests.General
         /// <param name="setupScript">the script. usually CreateOrleansTables_xxxx.sql</param>
         /// <param name="dataBaseName">the target database to be populated</param>
         /// <returns></returns>
-        protected virtual async Task ExecuteSetupScript(string setupScript, string dataBaseName)
+        protected virtual async Task ExecuteSetupScript(
+            string setupScript,
+            string dataBaseName,
+            CancellationToken cancellationToken)
         {
             var splitScripts = ConvertToExecutableBatches(setupScript, dataBaseName);
             foreach (var script in splitScripts)
             {
-                await ExecuteSetupScriptBatchAsync(script);
+                await ExecuteSetupScriptBatchAsync(script, cancellationToken);
             }
         }
 
-        protected virtual async Task ExecuteSetupScriptBatchAsync(string script)
+        protected virtual async Task ExecuteSetupScriptBatchAsync(string script, CancellationToken cancellationToken)
         {
-            _ = await Storage.ExecuteAsync(script);
+            _ = await Storage.ExecuteAsync(script, cancellationToken);
         }
 
         /// <summary>
@@ -212,10 +219,10 @@ namespace UnitTests.General
         /// </summary>
         /// <param name="databaseName">The name of the database existence of which to check.</param>
         /// <returns><em>TRUE</em> if the given database exists. <em>FALSE</em> otherwise.</returns>
-        private async Task<bool> ExistsDatabaseAsync(string databaseName)
+        private async Task<bool> ExistsDatabaseAsync(string databaseName, CancellationToken cancellationToken)
         {
             var ret = await Storage.ReadAsync(string.Format(ExistsDatabaseTemplate, databaseName), command =>
-            { }, (selector, resultSetCount, cancellationToken) => { return Task.FromResult(selector.GetBoolean(0)); }).ConfigureAwait(continueOnCapturedContext: false);
+            { }, (selector, resultSetCount, _) => { return Task.FromResult(selector.GetBoolean(0)); }, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
 
             return ret.First();
         }
@@ -225,9 +232,12 @@ namespace UnitTests.General
         /// </summary>
         /// <param name="databaseName">The name of the database to create.</param>
         /// <returns>The call will be successful if the DDL query is successful. Otherwise an exception will be thrown.</returns>
-        private async Task CreateDatabaseAsync(string databaseName)
+        private async Task CreateDatabaseAsync(string databaseName, CancellationToken cancellationToken)
         {
-            await Storage.ExecuteAsync(string.Format(CreateDatabaseTemplate, databaseName), command => { }).ConfigureAwait(continueOnCapturedContext: false);
+            await Storage.ExecuteAsync(
+                string.Format(CreateDatabaseTemplate, databaseName),
+                command => { },
+                cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         /// <summary>
@@ -235,9 +245,12 @@ namespace UnitTests.General
         /// </summary>
         /// <param name="databaseName">The name of the database to drop.</param>
         /// <returns>The call will be successful if the DDL query is successful. Otherwise an exception will be thrown.</returns>
-        protected virtual async Task DropDatabaseAsync(string databaseName)
+        protected virtual async Task DropDatabaseAsync(string databaseName, CancellationToken cancellationToken)
         {
-            await Storage.ExecuteAsync(string.Format(DropDatabaseTemplate, databaseName), command => { });
+            await Storage.ExecuteAsync(
+                string.Format(DropDatabaseTemplate, databaseName),
+                command => { },
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -29,7 +29,7 @@ namespace UnitTests.General
             SqlConnection.ClearPool(databaseConnection);
         }
 
-        protected override async Task WaitForDatabaseReadyAsync()
+        protected override async Task WaitForDatabaseReadyAsync(CancellationToken cancellationToken)
         {
             var databaseConnectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
             {
@@ -38,17 +38,26 @@ namespace UnitTests.General
             };
 
             await using var connection = new SqlConnection(databaseConnectionStringBuilder.ConnectionString);
-            await OpenConnectionAsync(connection);
+            await OpenConnectionAsync(connection, cancellationToken);
             await using var command = connection.CreateCommand();
             command.CommandText = "SELECT 1";
             command.CommandTimeout = 5;
-            _ = await command.ExecuteScalarAsync();
+            _ = await command.ExecuteScalarAsync(cancellationToken);
         }
 
-        protected override Task ExecuteSetupScript(string setupScript, string dataBaseName) =>
-            ExecuteSetupScriptBatchesAsync(ConvertToExecutableBatches(setupScript, dataBaseName), dataBaseName);
+        protected override Task ExecuteSetupScript(
+            string setupScript,
+            string dataBaseName,
+            CancellationToken cancellationToken) =>
+            ExecuteSetupScriptBatchesAsync(
+                ConvertToExecutableBatches(setupScript, dataBaseName),
+                dataBaseName,
+                cancellationToken);
 
-        internal async Task ExecuteSetupScriptBatchesAsync(IEnumerable<string> scripts, string databaseName)
+        internal async Task ExecuteSetupScriptBatchesAsync(
+            IEnumerable<string> scripts,
+            string databaseName,
+            CancellationToken cancellationToken)
         {
             var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
             {
@@ -57,7 +66,7 @@ namespace UnitTests.General
             };
 
             await using var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
-            await OpenConnectionAsync(connection);
+            await OpenConnectionAsync(connection, cancellationToken);
 
             using var commandBuilder = new SqlCommandBuilder();
             var quotedDatabaseName = commandBuilder.QuoteIdentifier(databaseName);
@@ -72,22 +81,25 @@ namespace UnitTests.General
             {
                 await ExecuteCommandAsync(
                     connection,
-                    $"ALTER DATABASE {quotedDatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;\n{scriptEnumerator.Current}");
+                    $"ALTER DATABASE {quotedDatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;\n{scriptEnumerator.Current}",
+                    cancellationToken);
 
                 while (scriptEnumerator.MoveNext())
                 {
-                    await ExecuteCommandAsync(connection, scriptEnumerator.Current);
+                    await ExecuteCommandAsync(connection, scriptEnumerator.Current, cancellationToken);
                 }
 
                 setupSucceeded = true;
             }
             finally
             {
+                using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 try
                 {
                     await ExecuteCommandAsync(
                         connection,
-                        $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;");
+                        $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;",
+                        cleanupCancellation.Token);
                 }
                 catch when (!setupSucceeded)
                 {
@@ -99,7 +111,7 @@ namespace UnitTests.General
             }
         }
 
-        private static async Task OpenConnectionAsync(SqlConnection connection)
+        private static async Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
         {
             const int maxAttempts = 10;
 
@@ -107,22 +119,25 @@ namespace UnitTests.General
             {
                 try
                 {
-                    await connection.OpenAsync();
+                    await connection.OpenAsync(cancellationToken);
                     return;
                 }
                 catch (SqlException exception) when (exception.Number == 18456 && exception.State == 1 && attempt < maxAttempts)
                 {
                     SqlConnection.ClearPool(connection);
-                    await Task.Delay(TimeSpan.FromMilliseconds(500));
+                    await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
                 }
             }
         }
 
-        private static async Task ExecuteCommandAsync(SqlConnection connection, string script)
+        private static async Task ExecuteCommandAsync(
+            SqlConnection connection,
+            string script,
+            CancellationToken cancellationToken)
         {
             await using var command = connection.CreateCommand();
             command.CommandText = script;
-            await command.ExecuteNonQueryAsync();
+            await command.ExecuteNonQueryAsync(cancellationToken);
         }
 
         public override string CancellationTestQuery { get { return "WAITFOR DELAY '00:00:010'; SELECT 1; "; } }
@@ -154,7 +169,7 @@ namespace UnitTests.General
             }
         }
 
-        protected override async Task DropDatabaseAsync(string databaseName)
+        protected override async Task DropDatabaseAsync(string databaseName, CancellationToken cancellationToken)
         {
             const int maxAttempts = 3;
 
@@ -162,7 +177,7 @@ namespace UnitTests.General
             {
                 try
                 {
-                    await base.DropDatabaseAsync(databaseName);
+                    await base.DropDatabaseAsync(databaseName, cancellationToken);
                     return;
                 }
                 catch (SqlException exception) when (exception.Number == 3702 && attempt < maxAttempts)

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -14,29 +14,40 @@ public class SqlServerStorageForTestingTests
     [Fact]
     public async Task RecreatesDatabaseWithActivePooledConnection()
     {
-        var storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName);
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var storage = await RelationalStorageForTesting.SetupInstance(
+            AdoNetInvariants.InvariantNameSqlServer,
+            TestDatabaseName,
+            cancellationToken: cancellationToken);
 
         for (var iteration = 0; iteration < 3; iteration++)
         {
             await using var connection = new SqlConnection(storage.CurrentConnectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
             await using var command = connection.CreateCommand();
             command.CommandText = "SELECT 1";
 
-            Assert.Equal(1, await command.ExecuteScalarAsync());
+            Assert.Equal(1, await command.ExecuteScalarAsync(cancellationToken));
 
-            storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName);
+            storage = await RelationalStorageForTesting.SetupInstance(
+                AdoNetInvariants.InvariantNameSqlServer,
+                TestDatabaseName,
+                cancellationToken: cancellationToken);
         }
     }
 
     [Fact]
     public async Task SetupOwnsSingleUserSlotWhileApplyingSchema()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storage = Assert.IsType<SqlServerStorageForTesting>(
-            await RelationalStorageForTesting.SetupInstance(AdoNetInvariants.InvariantNameSqlServer, TestDatabaseName));
+            await RelationalStorageForTesting.SetupInstance(
+                AdoNetInvariants.InvariantNameSqlServer,
+                TestDatabaseName,
+                cancellationToken: cancellationToken));
         await using var competingConnection = new SqlConnection(storage.CurrentConnectionString);
-        await competingConnection.OpenAsync();
-        using var cancellation = new CancellationTokenSource();
+        await competingConnection.OpenAsync(cancellationToken);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var reconnectingClients = Enumerable.Range(0, 4)
             .Select(_ => ReconnectUntilCanceledAsync(storage.CurrentConnectionString, cancellation.Token))
             .ToArray();
@@ -50,7 +61,8 @@ public class SqlServerStorageForTestingTests
                     ALTER DATABASE [{TestDatabaseName}] SET READ_COMMITTED_SNAPSHOT ON;
                     """
                 ],
-                TestDatabaseName);
+                TestDatabaseName,
+                cancellationToken);
         }
         finally
         {
@@ -65,7 +77,8 @@ public class SqlServerStorageForTestingTests
             WHERE name = @DatabaseName
             """,
             command => command.AddParameter("DatabaseName", TestDatabaseName),
-            (record, _, _) => Task.FromResult((record.GetString(0), record.GetBoolean(1))));
+            (record, _, _) => Task.FromResult((record.GetString(0), record.GetBoolean(1))),
+            cancellationToken: cancellationToken);
 
         Assert.Equal(("MULTI_USER", true), Assert.Single(databaseState));
     }

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/MySqlRemindersTableTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/MySqlRemindersTableTests.cs
@@ -49,7 +49,10 @@ namespace UnitTests.RemindersTest
 
         protected override async Task<string> GetConnectionString()
         {
-            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            var instance = await RelationalStorageForTesting.SetupInstance(
+                GetAdoInvariant(),
+                testDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             return instance.CurrentConnectionString;
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/PostgreSqlRemindersTableTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/PostgreSqlRemindersTableTests.cs
@@ -47,7 +47,10 @@ namespace UnitTests.RemindersTest
 
         protected override async Task<string> GetConnectionString()
         {
-            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            var instance = await RelationalStorageForTesting.SetupInstance(
+                GetAdoInvariant(),
+                testDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             return instance.CurrentConnectionString;
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
@@ -54,7 +54,10 @@ namespace Tester.AdoNet.Reminders
                     return;
                 }
 
-                var relationalStorage = await RelationalStorageForTesting.SetupInstance(AdoInvariant, TestDatabaseName);
+                var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+                    AdoInvariant,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
                 _connectionString = relationalStorage.CurrentConnectionString;
                 await base.InitializeAsync();
                 if (!PreconditionsMet)
@@ -98,7 +101,7 @@ namespace Tester.AdoNet.Reminders
             // ReminderTable.Clear() cannot be called from a non-Orleans thread,
             // so we must proxy the call through a grain.
             var controlProxy = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            await controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout);
+            await controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken);
         }
 
         ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
@@ -114,7 +117,7 @@ namespace Tester.AdoNet.Reminders
         [Fact]
         public async Task Rem_Sql_UpdateReminder_DoesNotRestartLocalReminder()
         {
-            await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder();
+            await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder(TestContext.Current.CancellationToken);
         }
 
         [Fact]

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
@@ -111,7 +111,7 @@ namespace Tester.AdoNet.Reminders
         [Fact]
         public async Task Rem_Sql_Basic_StopByRef()
         {
-            await Test_Reminders_Basic_StopByRef();
+            await Test_Reminders_Basic_StopByRef(TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Tester.AdoNet.Reminders
         [Fact]
         public async Task Rem_Sql_Basic_ListOps()
         {
-            await Test_Reminders_Basic_ListOps();
+            await Test_Reminders_Basic_ListOps(TestContext.Current.CancellationToken);
         }
 
         // Single join tests ... multi grain, multi reminders
@@ -131,13 +131,13 @@ namespace Tester.AdoNet.Reminders
         [Fact]
         public async Task Rem_Sql_1J_MultiGrainMultiReminders()
         {
-            await Test_Reminders_1J_MultiGrainMultiReminders();
+            await Test_Reminders_1J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Rem_Sql_ReminderNotFound()
         {
-            await Test_Reminders_ReminderNotFound();
+            await Test_Reminders_ReminderNotFound(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/SqlServerRemindersTableTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/SqlServerRemindersTableTests.cs
@@ -48,7 +48,10 @@ namespace UnitTests.RemindersTest
 
         protected override async Task<string> GetConnectionString()
         {
-            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            var instance = await RelationalStorageForTesting.SetupInstance(
+                GetAdoInvariant(),
+                testDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             return instance.CurrentConnectionString;
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/SqlServerMembershipTableTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/SqlServerMembershipTableTests.cs
@@ -56,7 +56,10 @@ namespace UnitTests.MembershipTests
 
         protected override async Task<string> GetConnectionString()
         {
-            var instance = await RelationalStorageForTesting.SetupInstance(GetAdoInvariant(), testDatabaseName);
+            var instance = await RelationalStorageForTesting.SetupInstance(
+                GetAdoInvariant(),
+                testDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
             return instance.CurrentConnectionString;
         }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
@@ -27,7 +27,10 @@ namespace UnitTests.StorageTests.AdoNet
 
             public async ValueTask InitializeAsync()
             {
-                Storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+                Storage = await RelationalStorageForTesting.SetupInstance(
+                    AdoNetInvariantName,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
             }
 
             public ValueTask DisposeAsync() => ValueTask.CompletedTask;
@@ -41,8 +44,9 @@ namespace UnitTests.StorageTests.AdoNet
         [Fact, TestCategory("Functional")]
         public async Task Streaming_MySql_Test()
         {
-            using(var tokenSource = new CancellationTokenSource(StreamCancellationTimeoutLimit))
+            using(var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken))
             {             
+                tokenSource.CancelAfter(StreamCancellationTimeoutLimit);
                 var isMatch = await Task.WhenAll(InsertAndReadStreamsAndCheckMatch(_storage, StreamSizeToBeInsertedInBytes, NumberOfParallelStreams, tokenSource.Token));
                 Assert.True(isMatch.All(i => i), "All inserted streams should be equal to read streams.");
             }
@@ -51,7 +55,7 @@ namespace UnitTests.StorageTests.AdoNet
         [Fact, TestCategory("Functional")]
         public async Task CancellationToken_MySql_Test()
         {
-            await CancellationTokenTest(_storage, CancellationTestTimeoutLimit);
+            await CancellationTokenTest(_storage, CancellationTestTimeoutLimit, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -65,7 +69,8 @@ namespace UnitTests.StorageTests.AdoNet
             var values = await storage.ReadAsync(
                 "SELECT 47;",
                 parameterProvider: null,
-                (record, _, _) => Task.FromResult(record.GetInt32(0)));
+                (record, _, _) => Task.FromResult(record.GetInt32(0)),
+                cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.Equal([47], values);
         }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
@@ -24,7 +24,10 @@ namespace UnitTests.StorageTests.AdoNet
 
             public async ValueTask InitializeAsync()
             {
-                Storage = await RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName);
+                Storage = await RelationalStorageForTesting.SetupInstance(
+                    AdoNetInvariantName,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken);
             }
 
             public ValueTask DisposeAsync() => ValueTask.CompletedTask;
@@ -38,8 +41,9 @@ namespace UnitTests.StorageTests.AdoNet
         [Fact, TestCategory("Functional")]
         public async Task Streaming_PostgreSql_Test()
         {
-            using(var tokenSource = new CancellationTokenSource(StreamCancellationTimeoutLimit))
+            using(var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken))
             {             
+                tokenSource.CancelAfter(StreamCancellationTimeoutLimit);
                 var isMatch = await Task.WhenAll(InsertAndReadStreamsAndCheckMatch(_storage, StreamSizeToBeInsertedInBytes, NumberOfParallelStreams, tokenSource.Token));
                 Assert.True(isMatch.All(i => i), "All inserted streams should be equal to read streams.");
             }
@@ -48,7 +52,7 @@ namespace UnitTests.StorageTests.AdoNet
         [Fact, TestCategory("Functional")]
         public async Task CancellationToken_PostgreSql_Test()
         {
-            await CancellationTokenTest(_storage, CancellationTestTimeoutLimit);
+            await CancellationTokenTest(_storage, CancellationTestTimeoutLimit, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -61,7 +65,8 @@ namespace UnitTests.StorageTests.AdoNet
             var values = await storage.ReadAsync(
                 "SELECT 47;",
                 parameterProvider: null,
-                (record, _, _) => Task.FromResult(record.GetInt32(0)));
+                (record, _, _) => Task.FromResult(record.GetInt32(0)),
+                cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.Equal([47], values);
         }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/CommonFixture.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/CommonFixture.cs
@@ -65,9 +65,11 @@ namespace UnitTests.StorageTests.Relational
         /// </summary>
         /// <remarks>If the environment invariants have failed to hold upon creation of the storage provider,
         /// a <em>null</em> value will be provided.</remarks>
-        public async Task<IGrainStorage?> GetStorageProvider(string storageInvariant)
+        public async Task<IGrainStorage?> GetStorageProvider(
+            string storageInvariant,
+            CancellationToken cancellationToken)
         {
-            return await GetStorageProvider(storageInvariant, deleteStateOnClear: false);
+            return await GetStorageProvider(storageInvariant, deleteStateOnClear: false, cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +79,10 @@ namespace UnitTests.StorageTests.Relational
         /// <param name="deleteStateOnClear">If <see langword="true"/>, the provider will delete the row from the database when clearing state.</param>
         /// <remarks>If the environment invariants have failed to hold upon creation of the storage provider,
         /// a <em>null</em> value will be provided.</remarks>
-        public async Task<IGrainStorage?> GetStorageProvider(string storageInvariant, bool deleteStateOnClear)
+        public async Task<IGrainStorage?> GetStorageProvider(
+            string storageInvariant,
+            bool deleteStateOnClear,
+            CancellationToken cancellationToken)
         {
             //Make sure the environment invariants hold before trying to give a functioning SUT instantiation.
             //This is done instead of the constructor to have more granularity on how the environment should be initialized.
@@ -98,7 +103,10 @@ namespace UnitTests.StorageTests.Relational
                         {
                             // Each storage mode has its own class fixture, so it must not recreate a database used by the other mode.
                             var storageName = deleteStateOnClear ? "OrleansStorageTestsDeleteOnClear" : "OrleansStorageTests";
-                            Storage = await Invariants.EnsureStorageForTestingAsync(connectionString, storageName);
+                            Storage = await Invariants.EnsureStorageForTestingAsync(
+                                connectionString,
+                                storageName,
+                                cancellationToken);
 
                             var options = new AdoNetGrainStorageOptions()
                             {
@@ -119,7 +127,7 @@ namespace UnitTests.StorageTests.Relational
                                 storageInvariant + "_StorageProvider");
                             ISiloLifecycleSubject siloLifeCycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
                             storageProvider.Participate(siloLifeCycle);
-                            await siloLifeCycle.OnStart(CancellationToken.None);
+                            await siloLifeCycle.OnStart(cancellationToken);
 
                             StorageProviders[cacheKey] = storageProvider;
                         }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
@@ -18,7 +18,7 @@ public sealed class RelationalStorageDataSourceTests
     {
         using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
         var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlLite, dataSource);
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         var values = await storage.ReadAsync(
             "SELECT 42;",

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageTests.cs
@@ -46,7 +46,10 @@ namespace UnitTests.StorageTests.Relational
 
         public async ValueTask InitializeAsync()
         {
-            var persistenceStorage = await Fixture.GetStorageProvider(_adoNetInvariant, _deleteStateOnClear);
+            var persistenceStorage = await Fixture.GetStorageProvider(
+                _adoNetInvariant,
+                _deleteStateOnClear,
+                TestContext.Current.CancellationToken);
             Assert.SkipWhen(persistenceStorage is null, $"Persistence storage not available for {_adoNetInvariant}.");
             PersistenceStorageTests = new CommonStorageTests(persistenceStorage);
         }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/TestEnvironmentInvariant.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/TestEnvironmentInvariant.cs
@@ -93,7 +93,10 @@ namespace UnitTests.StorageTests.Relational
         /// <param name="connection">The connection with which to ensure the storage is functional.</param>
         /// <param name="storageName">Storage name. This is optional.</param>
         /// <returns></returns>
-        public async Task<RelationalStorageForTesting?> EnsureStorageForTestingAsync(StorageConnection connection, string? storageName = null)
+        public async Task<RelationalStorageForTesting?> EnsureStorageForTestingAsync(
+            StorageConnection connection,
+            string? storageName,
+            CancellationToken cancellationToken)
         {
             if (AdoNetInvariants.Invariants.Contains(connection.StorageInvariant))
             {
@@ -101,7 +104,8 @@ namespace UnitTests.StorageTests.Relational
                 return await RelationalStorageForTesting.SetupInstance(
                     connection.StorageInvariant,
                     storageName ?? RelationalStorageTestDb,
-                    connection.ConnectionString);
+                    connectionString: connection.ConnectionString,
+                    cancellationToken: cancellationToken);
             }
 
             return null;
@@ -148,7 +152,9 @@ namespace UnitTests.StorageTests.Relational
         /// </summary>
         /// <param name="connection">The connection to check.</param>
         /// <returns></returns>
-        private static async Task<bool> CanConnectToStorage(StorageConnection connection)
+        private static async Task<bool> CanConnectToStorage(
+            StorageConnection connection,
+            CancellationToken cancellationToken)
         {
             //How detect if a database can be connected is surprisingly tricky. Some information at
             //http://stackoverflow.com/questions/3668506/efficient-sql-test-query-or-validation-query-that-will-work-across-all-or-most.
@@ -156,7 +162,7 @@ namespace UnitTests.StorageTests.Relational
             var query = connection.ConnectionString != AdoNetInvariants.InvariantNameOracleDatabase ? "SELECT 1;" : "SELECT 1 FROM DUAL;";
             try
             {
-                await storage.ExecuteAsync(query);
+                await storage.ExecuteAsync(query, cancellationToken);
             }
             catch
             {

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/RelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/RelationalStoreTests.cs
@@ -49,7 +49,7 @@ namespace UnitTests.StorageTests.AdoNet
                     await InsertIntoDatabaseUsingStream(sut, streamId, rb, cancellationToken);
                     var dataStreamFromTheDb = await ReadFromDatabaseUsingAsyncStream(sut, streamId, cancellationToken);
                     return dataStreamFromTheDb.StreamData.SequenceEqual(rb);
-                });
+                }, cancellationToken);
             }
 
             return streamChecks;
@@ -92,15 +92,15 @@ namespace UnitTests.StorageTests.AdoNet
                 p.ParameterName = "streamId";
                 p.Value = streamId;
                 command.Parameters.Add(p);
-            }, async (selector, resultSetCount, canellationToken) =>
+            }, async (selector, resultSetCount, cancellationToken) =>
             {
                 var streamSelector = (DbDataReader)selector;
-                var id = await streamSelector.GetValueAsync<int>("Id");
+                var id = await streamSelector.GetValueAsync<int>("Id", cancellationToken);
                 using (var ms = new MemoryStream())
                 {
                     using (var downloadStream = streamSelector.GetStream(1, sut.Storage))
                     {
-                        await downloadStream.CopyToAsync(ms);
+                        await downloadStream.CopyToAsync(ms, cancellationToken);
 
                         return new StreamingTest { Id = id, StreamData = ms.ToArray() };
                     }
@@ -108,11 +108,15 @@ namespace UnitTests.StorageTests.AdoNet
             }, CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false)).Single();
         }
 
-        protected static Task CancellationTokenTest(RelationalStorageForTesting sut, TimeSpan timeoutLimit)
+        protected static Task CancellationTokenTest(
+            RelationalStorageForTesting sut,
+            TimeSpan timeoutLimit,
+            CancellationToken testCancellationToken)
         {
             Assert.SkipWhen(string.IsNullOrEmpty(sut.CurrentConnectionString), "Database was not initialized correctly");
-            using (var tokenSource = new CancellationTokenSource(timeoutLimit))
+            using (var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken))
             {
+                tokenSource.CancelAfter(timeoutLimit);
                 try
                 {
                     //Here one second is added to the task timeout limit in order to account for the delays.
@@ -125,6 +129,8 @@ namespace UnitTests.StorageTests.AdoNet
                 }
                 catch(Exception ex)
                 {
+                    testCancellationToken.ThrowIfCancellationRequested();
+
                     //There can be a DbException due to the operation being forcefully cancelled...
                     //... Unless this is a test for a provider which does not support for cancellation.
                     //The exception is wrapped into an AggregrateException due to the test arrangement of hard synchronous

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
@@ -24,7 +24,10 @@ namespace UnitTests.StorageTests.AdoNet
             private readonly Func<Task<RelationalStorageForTesting>> _storageFactory;
 
             public Fixture() : this(
-                () => RelationalStorageForTesting.SetupInstance(AdoNetInvariantName, TestDatabaseName))
+                () => RelationalStorageForTesting.SetupInstance(
+                    AdoNetInvariantName,
+                    TestDatabaseName,
+                    cancellationToken: TestContext.Current.CancellationToken))
             {
             }
 
@@ -52,8 +55,9 @@ namespace UnitTests.StorageTests.AdoNet
         [Fact, TestCategory("Functional")]
         public async Task Streaming_SqlServer_Test()
         {
-            using(var tokenSource = new CancellationTokenSource(StreamCancellationTimeoutLimit))
+            using(var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken))
             {                
+                tokenSource.CancelAfter(StreamCancellationTimeoutLimit);
                 var isMatch = await Task.WhenAll(InsertAndReadStreamsAndCheckMatch(_storage, StreamSizeToBeInsertedInBytes, NumberOfParallelStreams, tokenSource.Token));
                 Assert.True(isMatch.All(i => i), "All inserted streams should be equal to read streams.");
             }
@@ -62,7 +66,7 @@ namespace UnitTests.StorageTests.AdoNet
         [Fact, TestCategory("Functional")]
         public async Task CancellationToken_SqlServer_Test()
         {
-            await CancellationTokenTest(_storage, CancellationTestTimeoutLimit);
+            await CancellationTokenTest(_storage, CancellationTestTimeoutLimit, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -77,7 +81,8 @@ namespace UnitTests.StorageTests.AdoNet
             var values = await storage.ReadAsync(
                 "SELECT 47;",
                 parameterProvider: null,
-                (record, _, _) => Task.FromResult(record.GetInt32(0)));
+                (record, _, _) => Task.FromResult(record.GetInt32(0)),
+                cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.Equal([47], values);
         }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetClientStreamTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetClientStreamTests.cs
@@ -72,7 +72,10 @@ public abstract class AdoNetClientStreamTests : TestClusterPerTest
     public override async ValueTask InitializeAsync()
     {
         // set up the adonet environment before the base initializes
-        _testing = await RelationalStorageForTesting.SetupInstance(_invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            _invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
@@ -127,6 +130,7 @@ public abstract class AdoNetClientStreamTests : TestClusterPerTest
     [Fact, TestCategory("Functional")]
     public virtual Task AdoNetStreamConsumerOnDroppedClientTest()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         return _runner.StreamConsumerOnDroppedClientTest(
             AdoNetStreamProviderName,
             StreamNamespace,
@@ -134,7 +138,8 @@ public abstract class AdoNetClientStreamTests : TestClusterPerTest
             async () => (await _testing.Storage.ReadAsync(
                 "SELECT COUNT(*) FROM OrleansStreamDeadLetter",
                 _ => { },
-                (record, i, ct) => Task.FromResult(record.GetInt32(0))))
+                (record, i, ct) => Task.FromResult(record.GetInt32(0)),
+                cancellationToken: cancellationToken))
                 .Single());
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetClientStreamTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetClientStreamTests.cs
@@ -125,7 +125,10 @@ public abstract class AdoNetClientStreamTests : TestClusterPerTest
     }
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetStreamProducerOnDroppedClientTest() => _runner.StreamProducerOnDroppedClientTest(AdoNetStreamProviderName, StreamNamespace);
+    public Task AdoNetStreamProducerOnDroppedClientTest() => _runner.StreamProducerOnDroppedClientTest(
+        AdoNetStreamProviderName,
+        StreamNamespace,
+        TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
     public virtual Task AdoNetStreamConsumerOnDroppedClientTest()
@@ -140,6 +143,7 @@ public abstract class AdoNetClientStreamTests : TestClusterPerTest
                 _ => { },
                 (record, i, ct) => Task.FromResult(record.GetInt32(0)),
                 cancellationToken: cancellationToken))
-                .Single());
+                .Single(),
+            cancellationToken: cancellationToken);
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterFactoryTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterFactoryTests.cs
@@ -63,7 +63,10 @@ public abstract class AdoNetQueueAdapterFactoryTests(string invariant, TestEnvir
 
     public async ValueTask InitializeAsync()
     {
-        _testing = await RelationalStorageForTesting.SetupInstance(invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
@@ -28,6 +28,7 @@ public class AdoNetQueueAdapterReceiverLifecycleTests(TestEnvironmentFixture fix
     [Fact]
     public async Task AdoNetQueueAdapterReceiver_Shutdown_WaitsForDequeueBookkeepingBeforeRelease()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var serviceId = $"Service-{Guid.NewGuid()}";
         var providerId = $"Provider-{Guid.NewGuid()}";
         var queueId = $"Queue-{Guid.NewGuid()}";
@@ -45,18 +46,18 @@ public class AdoNetQueueAdapterReceiverLifecycleTests(TestEnvironmentFixture fix
         var message = new AdoNetStreamMessage(serviceId, providerId, queueId, 42, 1, now.AddMinutes(5), now.AddHours(1), now, now, payload);
         var dequeueStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var continueDequeue = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var queries = new BlockingStreamMessageQueries(message, dequeueStarted, continueDequeue);
+        var queries = new BlockingStreamMessageQueries(message, dequeueStarted, continueDequeue, cancellationToken);
 
         var receiver = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, queries, serializer, logger);
         var getTask = receiver.GetQueueMessagesAsync(1);
-        await dequeueStarted.Task;
+        await dequeueStarted.Task.WaitAsync(cancellationToken);
 
         var shutdownTask = receiver.Shutdown(TimeSpan.FromSeconds(10));
         Assert.False(shutdownTask.IsCompleted);
 
         continueDequeue.SetResult();
-        var dequeued = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await getTask));
-        await shutdownTask;
+        var dequeued = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await getTask.WaitAsync(cancellationToken)));
+        await shutdownTask.WaitAsync(cancellationToken);
 
         Assert.Equal(message.MessageId, dequeued.SequenceToken.SequenceNumber);
         var released = Assert.Single(queries.Released);
@@ -72,7 +73,8 @@ public class AdoNetQueueAdapterReceiverLifecycleTests(TestEnvironmentFixture fix
     private sealed class BlockingStreamMessageQueries(
         AdoNetStreamMessage message,
         TaskCompletionSource dequeueStarted,
-        TaskCompletionSource continueDequeue) : IStreamMessageQueries
+        TaskCompletionSource continueDequeue,
+        CancellationToken cancellationToken) : IStreamMessageQueries
     {
         public IList<AdoNetStreamConfirmation> Released { get; private set; } = [];
 
@@ -88,7 +90,7 @@ public class AdoNetQueueAdapterReceiverLifecycleTests(TestEnvironmentFixture fix
             int evictionBatchSize)
         {
             dequeueStarted.SetResult();
-            await continueDequeue.Task;
+            await continueDequeue.Task.WaitAsync(cancellationToken);
             return [message];
         }
 
@@ -164,7 +166,10 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
 
     public async ValueTask InitializeAsync()
     {
-        _testing = await RelationalStorageForTesting.SetupInstance(invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
         _storage = _testing.Storage;
@@ -217,11 +222,15 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
         // act - dequeue messages via receiver
         var dequeued = await receiver.GetQueueMessagesAsync(maxCount);
         Assert.NotNull(dequeued);
-        var storedDequeued = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage")).ToDictionary(x => x.MessageId);
+        var storedDequeued = (await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken)).ToDictionary(x => x.MessageId);
 
         // act - confirm messages via receiver
         await receiver.MessagesDeliveredAsync(dequeued);
-        var storedConfirmed = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage")).ToDictionary(x => x.MessageId);
+        var storedConfirmed = (await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken)).ToDictionary(x => x.MessageId);
 
         // assert - dequeued messages are as expected
         var single = Assert.IsType<AdoNetBatchContainer>(Assert.Single(dequeued));
@@ -255,6 +264,7 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
     [Fact]
     public async Task AdoNetQueueAdapterReceiver_Shutdown_ReleasesUnconfirmedMessages()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var serviceId = $"Service-{Guid.NewGuid()}";
         var providerId = $"Provider-{Guid.NewGuid()}";
         var queueId = $"Queue-{Guid.NewGuid()}";
@@ -274,17 +284,19 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
         var ack = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, 100);
 
         var receiver = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, _queries, serializer, logger);
-        var first = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await receiver.GetQueueMessagesAsync(1)));
+        var first = Assert.IsType<AdoNetBatchContainer>(
+            Assert.Single(await receiver.GetQueueMessagesAsync(1).WaitAsync(cancellationToken)));
         Assert.Equal(1, first.Dequeued);
 
-        await receiver.Shutdown(TimeSpan.FromSeconds(10));
+        await receiver.Shutdown(TimeSpan.FromSeconds(10)).WaitAsync(cancellationToken);
 
         var replacement = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, _queries, serializer, logger);
-        var redelivered = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await replacement.GetQueueMessagesAsync(1)));
+        var redelivered = Assert.IsType<AdoNetBatchContainer>(
+            Assert.Single(await replacement.GetQueueMessagesAsync(1).WaitAsync(cancellationToken)));
         Assert.Equal(ack.MessageId, redelivered.SequenceToken.SequenceNumber);
         Assert.Equal(2, redelivered.Dequeued);
-        await replacement.MessagesDeliveredAsync([redelivered]);
-        await replacement.Shutdown(TimeSpan.FromSeconds(10));
+        await replacement.MessagesDeliveredAsync([redelivered]).WaitAsync(cancellationToken);
+        await replacement.Shutdown(TimeSpan.FromSeconds(10)).WaitAsync(cancellationToken);
     }
 
     /// <summary>
@@ -293,6 +305,7 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
     [Fact]
     public async Task AdoNetQueueAdapterReceiver_Shutdown_WaitsForOutstandingTask()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var serviceId = $"Service-{Guid.NewGuid()}";
         var providerId = $"Provider-{Guid.NewGuid()}";
         var queueId = $"Queue-{Guid.NewGuid()}";
@@ -312,18 +325,19 @@ public abstract class AdoNetQueueAdapterReceiverTests(string invariant, TestEnvi
         var ack = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, 100);
 
         var getTask = receiver.GetQueueMessagesAsync(1);
-        await receiver.Shutdown(TimeSpan.FromSeconds(10));
+        await receiver.Shutdown(TimeSpan.FromSeconds(10)).WaitAsync(cancellationToken);
 
         Assert.True(getTask.IsCompleted);
-        var first = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await getTask));
+        var first = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await getTask.WaitAsync(cancellationToken)));
         Assert.Equal(1, first.Dequeued);
 
         var replacement = new AdoNetQueueAdapterReceiver(providerId, queueId, streamOptions, clusterOptions, cacheOptions, _queries, serializer, logger);
-        var redelivered = Assert.IsType<AdoNetBatchContainer>(Assert.Single(await replacement.GetQueueMessagesAsync(1)));
+        var redelivered = Assert.IsType<AdoNetBatchContainer>(
+            Assert.Single(await replacement.GetQueueMessagesAsync(1).WaitAsync(cancellationToken)));
         Assert.Equal(ack.MessageId, redelivered.SequenceToken.SequenceNumber);
         Assert.Equal(2, redelivered.Dequeued);
-        await replacement.MessagesDeliveredAsync([redelivered]);
-        await replacement.Shutdown(TimeSpan.FromSeconds(10));
+        await replacement.MessagesDeliveredAsync([redelivered]).WaitAsync(cancellationToken);
+        await replacement.Shutdown(TimeSpan.FromSeconds(10)).WaitAsync(cancellationToken);
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
@@ -63,7 +63,10 @@ public abstract class AdoNetQueueAdapterTests(string invariant, TestEnvironmentF
 
     public async ValueTask InitializeAsync()
     {
-        _testing = await RelationalStorageForTesting.SetupInstance(invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
@@ -141,7 +144,9 @@ public abstract class AdoNetQueueAdapterTests(string invariant, TestEnvironmentF
         var afterEnqueued = DateTime.UtcNow.AddSeconds(1);
 
         // assert - stored messages are as expected
-        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage")).ToList();
+        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken)).ToList();
         for (var i = 0; i < stored.Count; i++)
         {
             var item = stored[i];
@@ -210,7 +215,7 @@ public abstract class AdoNetQueueAdapterTests(string invariant, TestEnvironmentF
         var receiver = adapter.CreateReceiver(queueId);
         await receiver.Initialize(TimeSpan.FromSeconds(10));
         var beforeDequeued = DateTime.UtcNow.AddSeconds(-1);
-        var messages = await receiver.GetQueueMessagesAsync(10, CancellationToken.None);
+        var messages = await receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken);
         var afterDequeued = DateTime.UtcNow.AddSeconds(1);
 
         // assert - dequeued messages are as expected
@@ -227,7 +232,9 @@ public abstract class AdoNetQueueAdapterTests(string invariant, TestEnvironmentF
         }
 
         // assert - stored messages are as expected
-        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage")).ToList();
+        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken)).ToList();
         for (var i = 0; i < stored.Count; i++)
         {
             var item = stored[i];

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
@@ -61,7 +61,10 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
 
     public async ValueTask InitializeAsync()
     {
-        _testing = await RelationalStorageForTesting.SetupInstance(invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
@@ -142,13 +145,17 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
             streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling(),
             streamOptions.EvictionInterval.TotalSecondsCeiling(),
             streamOptions.EvictionBatchSize);
-        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
+        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>(
+            "SELECT * FROM OrleansStreamDeadLetter",
+            TestContext.Current.CancellationToken));
 
         // act - clean up with max attempts of one so the message above is flagged
         await handler.OnDeliveryFailure(GuidId.GetNewGuidId(), providerId, streamId, new EventSequenceTokenV2(ack.MessageId));
 
         // assert
-        var dead = Assert.Single(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
+        var dead = Assert.Single(await _storage.ReadAsync<AdoNetStreamDeadLetter>(
+            "SELECT * FROM OrleansStreamDeadLetter",
+            TestContext.Current.CancellationToken));
         Assert.Equal(clusterOptions.ServiceId, dead.ServiceId);
         Assert.Equal(providerId, dead.ProviderId);
         Assert.Equal(queueId, dead.QueueId);
@@ -206,7 +213,9 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
         await handler.OnDeliveryFailure(GuidId.GetNewGuidId(), providerId, streamId, new EventSequenceTokenV2(ack.MessageId));
 
         // assert
-        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
+        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>(
+            "SELECT * FROM OrleansStreamDeadLetter",
+            TestContext.Current.CancellationToken));
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFilteringTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFilteringTests.cs
@@ -80,7 +80,10 @@ public abstract class AdoNetStreamFilteringTests : StreamFilteringTestsBase, IAs
         public override async ValueTask InitializeAsync()
         {
             // set up the adonet environment before the base initializes
-            _testing = await RelationalStorageForTesting.SetupInstance(_invariant, TestDatabaseName);
+            _testing = await RelationalStorageForTesting.SetupInstance(
+                _invariant,
+                TestDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
@@ -74,7 +74,11 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
     public override async ValueTask InitializeAsync()
     {
         // set up the adonet environment before the base initializes
-        _testing = await RelationalStorageForTesting.SetupInstance(_invariant, TestDatabaseName);
+        var cancellationToken = TestContext.Current.CancellationToken;
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            _invariant,
+            TestDatabaseName,
+            cancellationToken: cancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
@@ -84,7 +88,7 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
         {
             return;
         }
-        await WaitForStreamingProviderReadyAsync();
+        await WaitForStreamingProviderReadyAsync(cancellationToken);
 
         // the runner must only be created after base initialization
         _runner = new SingleStreamTestRunner(InternalClient, AdoNetStreamProviderName);
@@ -128,7 +132,7 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
         }
     }
 
-    private async Task WaitForStreamingProviderReadyAsync()
+    private async Task WaitForStreamingProviderReadyAsync(CancellationToken cancellationToken)
     {
         var activeSilos = HostedCluster.GetActiveSilos().Select(static silo => silo.SiloAddress).ToArray();
         var grainFactory = (IInternalGrainFactory)GrainFactory;
@@ -139,7 +143,7 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
             .WaitForProviderReady(AdoNetStreamProviderName, StreamingDiagnosticTimeout))
             .ToArray();
 
-        await Task.WhenAll(waits);
+        await Task.WhenAll(waits).WaitAsync(cancellationToken);
     }
 
     //------------------------ One to One -----------------------------------------------------//

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
@@ -149,64 +149,65 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
     //------------------------ One to One -----------------------------------------------------//
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_01_OneProducerGrainOneConsumerGrain() => _runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+    public Task AdoNet_01_OneProducerGrainOneConsumerGrain() => _runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_02_OneProducerGrainOneConsumerClient() => _runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+    public Task AdoNet_02_OneProducerGrainOneConsumerClient() => _runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_03_OneProducerClientOneConsumerGrain() => _runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+    public Task AdoNet_03_OneProducerClientOneConsumerGrain() => _runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_04_OneProducerClientOneConsumerClient() => _runner.StreamTest_04_OneProducerClientOneConsumerClient();
+    public Task AdoNet_04_OneProducerClientOneConsumerClient() => _runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
 
     //------------------------ MANY to Many different grains ----------------------------------//
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains() => _runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+    public Task AdoNet_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains() => _runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_06_ManyDifferent_ManyProducerGrainManyConsumerClients() => _runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+    public Task AdoNet_06_ManyDifferent_ManyProducerGrainManyConsumerClients() => _runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_07_ManyDifferent_ManyProducerClientsManyConsumerGrains() => _runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+    public Task AdoNet_07_ManyDifferent_ManyProducerClientsManyConsumerGrains() => _runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_08_ManyDifferent_ManyProducerClientsManyConsumerClients() => _runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+    public Task AdoNet_08_ManyDifferent_ManyProducerClientsManyConsumerClients() => _runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
 
     //------------------------ MANY to Many Same grains ---------------------------------------//
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_09_ManySame_ManyProducerGrainsManyConsumerGrains() => _runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+    public Task AdoNet_09_ManySame_ManyProducerGrainsManyConsumerGrains() => _runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_10_ManySame_ManyConsumerGrainsManyProducerGrains() => _runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+    public Task AdoNet_10_ManySame_ManyConsumerGrainsManyProducerGrains() => _runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_11_ManySame_ManyProducerGrainsManyConsumerClients() => _runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+    public Task AdoNet_11_ManySame_ManyProducerGrainsManyConsumerClients() => _runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_12_ManySame_ManyProducerClientsManyConsumerGrains() => _runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+    public Task AdoNet_12_ManySame_ManyProducerClientsManyConsumerGrains() => _runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     //------------------------ MANY to Many producer consumer same grain ----------------------//
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_13_SameGrain_ConsumerFirstProducerLater() => _runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+    public Task AdoNet_13_SameGrain_ConsumerFirstProducerLater() => _runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_14_SameGrain_ProducerFirstConsumerLater() => _runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+    public Task AdoNet_14_SameGrain_ProducerFirstConsumerLater() => _runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
 
     //-----------------------------------------------------------------------------------------//
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNet_15_ConsumeAtProducersRequest() => _runner.StreamTest_15_ConsumeAtProducersRequest();
+    public Task AdoNet_15_ConsumeAtProducersRequest() => _runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
     public async Task AdoNet_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
         var multiRunner = new MultipleStreamsTestRunner(InternalClient, AdoNetStreamProviderName, 16, false);
 
-        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("Functional")]
@@ -214,6 +215,8 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
     {
         var multiRunner = new MultipleStreamsTestRunner(InternalClient, AdoNetStreamProviderName, 17, false);
 
-        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(() => HostedCluster.StartAdditionalSilo());
+        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+            () => HostedCluster.StartAdditionalSilo(),
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamsBatchingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamsBatchingTests.cs
@@ -80,7 +80,10 @@ public abstract class AdoNetStreamsBatchingTests : StreamBatchingTestRunner, IAs
         public override async ValueTask InitializeAsync()
         {
             // set up the adonet environment before the base initializes
-            _testing = await RelationalStorageForTesting.SetupInstance(_invariant, TestDatabaseName);
+            _testing = await RelationalStorageForTesting.SetupInstance(
+                _invariant,
+                TestDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionMultiplicityTests.cs
@@ -121,26 +121,26 @@ public abstract class AdoNetSubscriptionMultiplicityTests : TestClusterPerTest
     }
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetMultipleParallelSubscriptionTest() => _runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public Task AdoNetMultipleParallelSubscriptionTest() => _runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetMultipleLinearSubscriptionTest() => _runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public Task AdoNetMultipleLinearSubscriptionTest() => _runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetMultipleSubscriptionTest_AddRemove() => _runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+    public Task AdoNetMultipleSubscriptionTest_AddRemove() => _runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetResubscriptionTest() => _runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public Task AdoNetResubscriptionTest() => _runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetResubscriptionAfterDeactivationTest() => _runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+    public Task AdoNetResubscriptionAfterDeactivationTest() => _runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetActiveSubscriptionTest() => _runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public Task AdoNetActiveSubscriptionTest() => _runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetTwoIntermittentStreamTest() => _runner.TwoIntermittentStreamTest(Guid.NewGuid());
+    public Task AdoNetTwoIntermittentStreamTest() => _runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("Functional")]
-    public Task AdoNetSubscribeFromClientTest() => _runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
+    public Task AdoNetSubscribeFromClientTest() => _runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionMultiplicityTests.cs
@@ -69,7 +69,10 @@ public abstract class AdoNetSubscriptionMultiplicityTests : TestClusterPerTest
     public override async ValueTask InitializeAsync()
     {
         // set up the adonet environment before the base initializes
-        _testing = await RelationalStorageForTesting.SetupInstance(_invariant, TestDatabaseName);
+        _testing = await RelationalStorageForTesting.SetupInstance(
+            _invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionObserverWithImplicitSubscribingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionObserverWithImplicitSubscribingTests.cs
@@ -79,7 +79,10 @@ public abstract class AdoNetSubscriptionObserverWithImplicitSubscribingTests(Ado
         public override async ValueTask InitializeAsync()
         {
             // set up the adonet environment before the base initializes
-            _testing = await RelationalStorageForTesting.SetupInstance(_invariant, TestDatabaseName);
+            _testing = await RelationalStorageForTesting.SetupInstance(
+                _invariant,
+                TestDatabaseName,
+                cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.SkipWhen(IsNullOrEmpty(_testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -20,7 +20,8 @@ namespace Tester.AdoNet.Streaming;
 public class SqlServerRelationalOrleansQueriesTests() : RelationalOrleansQueriesTests(AdoNetInvariants.InvariantNameSqlServer, 90)
 {
     [Fact]
-    public Task RelationalOrleansQueries_SerializesQueueMessageCommits() => VerifySqlServerQueueMessageCommitsAreSerialized();
+    public Task RelationalOrleansQueries_SerializesQueueMessageCommits() =>
+        VerifySqlServerQueueMessageCommitsAreSerialized(TestContext.Current.CancellationToken);
 }
 
 /// <summary>
@@ -37,7 +38,8 @@ public class MySqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
     }
 
     [Fact]
-    public Task RelationalOrleansQueries_OrdersProviderResults() => VerifyProviderResultsAreOrdered();
+    public Task RelationalOrleansQueries_OrdersProviderResults() =>
+        VerifyProviderResultsAreOrdered(TestContext.Current.CancellationToken);
 }
 
 /// <summary>
@@ -69,7 +71,10 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
 
     public async ValueTask InitializeAsync()
     {
-        var testing = await RelationalStorageForTesting.SetupInstance(invariant, TestDatabaseName);
+        var testing = await RelationalStorageForTesting.SetupInstance(
+            invariant,
+            TestDatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
         Assert.SkipWhen(IsNullOrEmpty(testing.CurrentConnectionString), $"Database '{TestDatabaseName}' not initialized");
 
         _storage = RelationalStorage.CreateInstance(invariant, testing.CurrentConnectionString);
@@ -98,26 +103,68 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         string queueId,
         byte[] payload,
         int expiryTimeout,
-        int count)
+        int count,
+        CancellationToken cancellationToken)
     {
         using var semaphore = new SemaphoreSlim(concurrency);
         return await Task.WhenAll(Enumerable.Range(0, count).Select(async _ =>
         {
-            await semaphore.WaitAsync();
-            try
-            {
-                return await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout);
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            return await ExecuteProviderOperationAsync(
+                semaphore,
+                () => _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout),
+                cancellationToken);
         }));
+    }
+
+    private static async Task<T> ExecuteProviderOperationAsync<T>(
+        SemaphoreSlim semaphore,
+        Func<Task<T>> operationFactory,
+        CancellationToken cancellationToken)
+    {
+        await semaphore.WaitAsync(cancellationToken);
+        Task<T>? operation = null;
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            operation = operationFactory();
+            return await operation.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (operation is not null)
+            {
+                if (operation.IsCompleted)
+                {
+                    await ObserveLateCompletionAsync(operation);
+                }
+                else
+                {
+                    _ = ObserveLateCompletionAsync(operation);
+                }
+            }
+
+            throw;
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+
+    private static async Task ObserveLateCompletionAsync(Task operation)
+    {
+        try
+        {
+            await operation;
+        }
+        catch
+        {
+        }
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    protected async Task VerifyProviderResultsAreOrdered()
+    protected async Task VerifyProviderResultsAreOrdered(CancellationToken cancellationToken)
     {
         const string reverseQuery = """
             SELECT ServiceId, ProviderId, QueueId, MessageId, Dequeued, VisibleOn, ExpiresOn, CreatedOn, ModifiedOn, Payload
@@ -132,7 +179,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var queueId = RandomQueueId();
         var payload = new byte[] { 0xFF };
 
-        await QueueMessagesAsync(serviceId, providerId, queueId, payload, 100, 100);
+        await QueueMessagesAsync(serviceId, providerId, queueId, payload, 100, 100, cancellationToken);
 
         await _storage.ExecuteAsync(
             "UPDATE OrleansQuery SET QueryText = @QueryText WHERE QueryKey = 'GetStreamMessagesKey'",
@@ -142,7 +189,8 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
                 parameter.ParameterName = "QueryText";
                 parameter.Value = reverseQuery;
                 command.Parameters.Add(parameter);
-            });
+            },
+            cancellationToken: cancellationToken);
 
         var queries = await RelationalOrleansQueries.CreateInstance(invariant, _storage.ConnectionString);
         var messages = await queries.GetStreamMessagesAsync(serviceId, providerId, queueId, 100, 3, 10, 100, 10, 1000);
@@ -150,7 +198,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(messages.OrderBy(message => message.MessageId), messages);
     }
 
-    protected async Task VerifySqlServerQueueMessageCommitsAreSerialized()
+    protected async Task VerifySqlServerQueueMessageCommitsAreSerialized(CancellationToken cancellationToken)
     {
         var serviceId = RandomServiceId();
         var providerId = RandomProviderId();
@@ -159,23 +207,23 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         const int expiryTimeout = 100;
 
         await using var firstConnection = new SqlConnection(_storage.ConnectionString);
-        await firstConnection.OpenAsync();
-        await using var firstTransaction = (SqlTransaction)await firstConnection.BeginTransactionAsync();
+        await firstConnection.OpenAsync(cancellationToken);
+        await using var firstTransaction = (SqlTransaction)await firstConnection.BeginTransactionAsync(cancellationToken);
         await using var firstCommand = CreateQueueCommand(firstConnection, firstTransaction, serviceId, providerId, queueId, payload, expiryTimeout);
-        var firstMessageId = await ReadMessageId(firstCommand);
+        var firstMessageId = await ReadMessageId(firstCommand, cancellationToken);
 
         await using (var secondConnection = new SqlConnection(_storage.ConnectionString))
         {
-            await secondConnection.OpenAsync();
+            await secondConnection.OpenAsync(cancellationToken);
             await using var secondCommand = CreateQueueCommand(secondConnection, transaction: null, serviceId, providerId, queueId, payload, expiryTimeout);
             secondCommand.CommandType = CommandType.Text;
             secondCommand.CommandText = "SET LOCK_TIMEOUT 0; EXECUTE QueueStreamMessage @ServiceId, @ProviderId, @QueueId, @Payload, @ExpiryTimeout;";
 
-            var exception = await Assert.ThrowsAsync<SqlException>(() => secondCommand.ExecuteReaderAsync());
+            var exception = await Assert.ThrowsAsync<SqlException>(() => secondCommand.ExecuteReaderAsync(cancellationToken));
             Assert.Equal(51000, exception.Number);
         }
 
-        await firstTransaction.CommitAsync();
+        await firstTransaction.CommitAsync(cancellationToken);
 
         var secondAck = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout);
         var messages = await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, 2, 3, 10, 100, 10, 1000);
@@ -204,10 +252,10 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         return command;
     }
 
-    private static async Task<long> ReadMessageId(SqlCommand command)
+    private static async Task<long> ReadMessageId(SqlCommand command, CancellationToken cancellationToken)
     {
-        await using var reader = await command.ExecuteReaderAsync();
-        Assert.True(await reader.ReadAsync());
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        Assert.True(await reader.ReadAsync(cancellationToken));
         return reader.GetInt64(reader.GetOrdinal(nameof(AdoNetStreamMessage.MessageId)));
     }
 
@@ -237,7 +285,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(1, ack.MessageId);
 
         // assert - storage
-        var messages = await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage");
+        var messages = await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken);
         var message = Assert.Single(messages);
         Assert.Equal(serviceId, message.ServiceId);
         Assert.Equal(providerId, message.ProviderId);
@@ -261,6 +311,8 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
     [Fact]
     public async Task RelationalOrleansQueries_QueuesManyMessagesInParallel()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         // arrange
         var serviceId = RandomServiceId();
         var providerId = RandomProviderId();
@@ -278,16 +330,11 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
             .Range(0, count)
             .Select(i => Task.Run(async () =>
             {
-                await semaphore.WaitAsync();
-                try
-                {
-                    return await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-            }))
+                return await ExecuteProviderOperationAsync(
+                    semaphore,
+                    () => _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, expiryTimeout),
+                    cancellationToken);
+            }, cancellationToken))
             .ToList());
         var after = DateTime.UtcNow.AddSeconds(1);
 
@@ -308,7 +355,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         }
 
         // assert - messages were stored as expected
-        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"))
+        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            cancellationToken))
             .OrderBy(x => x.ServiceId)
             .ThenBy(x => x.ProviderId)
             .ThenBy(x => x.QueueId)
@@ -339,6 +388,8 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
     [Fact]
     public async Task RelationalOrleansQueries_QueuesManyMessagesInParallelOnManyQueues()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         // arrange - create up to 27 random partition keys with around 1000 random messages per partition in random order
         var expiryTimeout = RandomExpiryTimeout();
         var count = 3 * 3 * 3 * 1000;
@@ -361,17 +412,12 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         var results = await Task.WhenAll(partitions
             .Select(p => Task.Run(async () =>
             {
-                await semaphore.WaitAsync();
-                try
-                {
-                    var ack = await _queries.QueueStreamMessageAsync(p.ServiceId, p.ProviderId, p.QueueId, p.Payload, expiryTimeout);
-                    return (Partition: p, Ack: ack);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-            }))
+                var ack = await ExecuteProviderOperationAsync(
+                    semaphore,
+                    () => _queries.QueueStreamMessageAsync(p.ServiceId, p.ProviderId, p.QueueId, p.Payload, expiryTimeout),
+                    cancellationToken);
+                return (Partition: p, Ack: ack);
+            }, cancellationToken))
             .ToList());
         var after = DateTime.UtcNow.AddSeconds(1);
 
@@ -391,7 +437,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(messageIds.Count, messageIds.Max);
 
         // assert - messages were stored as expected
-        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"))
+        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            cancellationToken))
             .ToDictionary(x => (x.ServiceId, x.ProviderId, x.QueueId, x.MessageId));
 
         foreach (var (partition, ack) in results)
@@ -418,7 +466,7 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
     public async Task RelationalOrleansQueries_DequeuesSingleMessage()
     {
         // arrange
-        await _storage.ExecuteAsync("DELETE FROM OrleansStreamMessage");
+        await _storage.ExecuteAsync("DELETE FROM OrleansStreamMessage", TestContext.Current.CancellationToken);
         var serviceId = RandomServiceId();
         var providerId = RandomProviderId();
         var queueId = RandomQueueId();
@@ -467,7 +515,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(payload, message.Payload);
 
         // assert - the stored message changed
-        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
+        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken));
         Assert.Equal(message.ServiceId, stored.ServiceId);
         Assert.Equal(message.ProviderId, stored.ProviderId);
         Assert.Equal(message.QueueId, stored.QueueId);
@@ -502,7 +552,14 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
 
         // arrange - enqueue messages concurrently
         var beforeQueueing = DateTime.UtcNow.AddSeconds(-1);
-        var acks = await QueueMessagesAsync(serviceId, providerId, queueId, payload, expiryTimeout, total);
+        var acks = await QueueMessagesAsync(
+            serviceId,
+            providerId,
+            queueId,
+            payload,
+            expiryTimeout,
+            total,
+            TestContext.Current.CancellationToken);
         var afterQueueing = DateTime.UtcNow.AddSeconds(1);
 
         // act - dequeue all messages
@@ -545,7 +602,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
 
         // assert - stored messages are consistent with dequeued messages
         var messageLookup = messages.ToDictionary(x => (x.ServiceId, x.ProviderId, x.QueueId, x.MessageId));
-        var stored = await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage");
+        var stored = await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken);
         foreach (var item in stored)
         {
             Assert.True(messageLookup.TryGetValue((item.ServiceId, item.ProviderId, item.QueueId, item.MessageId), out var message), "Message not found");
@@ -621,7 +680,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Empty(results[maxAttempts]);
 
         // assert - final stored message is consistent with final dequeued message
-        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
+        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken));
         var final = Assert.Single(results[maxAttempts - 1]);
         Assert.Equal(final.ServiceId, stored.ServiceId);
         Assert.Equal(final.ProviderId, stored.ProviderId);
@@ -668,7 +729,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(ack.MessageId, first.MessageId);
 
         // assert - stored message is consistent with first message
-        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
+        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken));
         Assert.Equal(first.ServiceId, stored.ServiceId);
         Assert.Equal(first.ProviderId, stored.ProviderId);
         Assert.Equal(first.QueueId, stored.QueueId);
@@ -752,7 +815,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Empty(messages);
 
         // assert - stored message are as expected
-        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
+        var stored = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken));
         Assert.Equal(ack.ServiceId, stored.ServiceId);
         Assert.Equal(ack.ProviderId, stored.ProviderId);
         Assert.Equal(ack.QueueId, stored.QueueId);
@@ -813,7 +878,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         }
 
         // assert - no data remains in storage
-        var stored = await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage");
+        var stored = await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken);
         Assert.Empty(stored);
     }
 
@@ -855,7 +922,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Empty(results);
 
         // assert - data remains in storage
-        var stored = await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage");
+        var stored = await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken);
         Assert.Equal(maxCount, stored.Count());
     }
 
@@ -899,7 +968,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
 
         // assert - confirmed messages are as expected
         var lookup = acks.ToDictionary(x => (x.ServiceId, x.ProviderId, x.QueueId, x.MessageId));
-        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"))
+        var stored = (await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken))
             .ToDictionary(x => (x.ServiceId, x.ProviderId, x.QueueId, x.MessageId));
         foreach (var item in confirmed)
         {
@@ -928,6 +999,8 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
     [Fact]
     public async Task RelationalOrleansQueries_ChaosTest()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         // arrange - generate test data
         var total = 10000;
         var serviceIds = Enumerable.Range(0, 3).Select(x => $"ServiceId{x}").ToList();
@@ -961,19 +1034,13 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
                     var providerId = providerIds[Random.Shared.Next(providerIds.Count)];
                     var queueId = queueIds[Random.Shared.Next(queueIds.Count)];
 
-                    AdoNetStreamMessageAck ack;
-                    await semaphore.WaitAsync();
-                    try
-                    {
-                        ack = await _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, visibilityTimeout);
-                    }
-                    finally
-                    {
-                        semaphore.Release();
-                    }
+                    var ack = await ExecuteProviderOperationAsync(
+                        semaphore,
+                        () => _queries.QueueStreamMessageAsync(serviceId, providerId, queueId, payload, visibilityTimeout),
+                        cancellationToken);
 
                     acks.Add(ack);
-                });
+                }, cancellationToken);
 
                 // spin up a random dequeuing task that does not confirm
                 var dequeue = Task.Run(async () =>
@@ -982,22 +1049,16 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
                     var providerId = providerIds[Random.Shared.Next(providerIds.Count)];
                     var queueId = queueIds[Random.Shared.Next(queueIds.Count)];
 
-                    IEnumerable<AdoNetStreamMessage> messages;
-                    await semaphore.WaitAsync();
-                    try
-                    {
-                        messages = await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize);
-                    }
-                    finally
-                    {
-                        semaphore.Release();
-                    }
+                    var messages = await ExecuteProviderOperationAsync(
+                        semaphore,
+                        () => _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize),
+                        cancellationToken);
 
                     foreach (var item in messages)
                     {
                         dequeued1.Add(item);
                     }
-                });
+                }, cancellationToken);
 
                 // spin a random dequeuing task that also confirms
                 var confirm = Task.Run(async () =>
@@ -1006,38 +1067,30 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
                     var providerId = providerIds[Random.Shared.Next(providerIds.Count)];
                     var queueId = queueIds[Random.Shared.Next(queueIds.Count)];
 
-                    IEnumerable<AdoNetStreamMessage> messages;
-                    await semaphore.WaitAsync();
-                    try
-                    {
-                        messages = await _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize);
-                    }
-                    finally
-                    {
-                        semaphore.Release();
-                    }
+                    var messages = await ExecuteProviderOperationAsync(
+                        semaphore,
+                        () => _queries.GetStreamMessagesAsync(serviceId, providerId, queueId, maxCount, maxAttempts, visibilityTimeout, removalTimeout, evictionInterval, evictionBatchSize),
+                        cancellationToken);
 
                     foreach (var item in messages)
                     {
                         dequeued2.Add(item);
                     }
 
-                    IEnumerable<AdoNetStreamConfirmationAck> confirmation;
-                    await semaphore.WaitAsync();
-                    try
-                    {
-                        confirmation = await _queries.ConfirmStreamMessagesAsync(serviceId, providerId, queueId, messages.Select(x => new AdoNetStreamConfirmation(x.MessageId, x.Dequeued)).ToList());
-                    }
-                    finally
-                    {
-                        semaphore.Release();
-                    }
+                    var confirmation = await ExecuteProviderOperationAsync(
+                        semaphore,
+                        () => _queries.ConfirmStreamMessagesAsync(
+                            serviceId,
+                            providerId,
+                            queueId,
+                            messages.Select(x => new AdoNetStreamConfirmation(x.MessageId, x.Dequeued)).ToList()),
+                        cancellationToken);
 
                     foreach (var item in confirmation)
                     {
                         confirmed.Add(item);
                     }
-                });
+                }, cancellationToken);
 
                 // wait for all to complete
                 await Task.WhenAll(enqueue, dequeue, confirm);
@@ -1055,7 +1108,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.NotEmpty(confirmed);
 
         // assert - some messages were left behind (rng dependant, remove assert if flaky)
-        var stored = await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage");
+        var stored = await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            cancellationToken);
         Assert.NotEmpty(stored);
 
         // assert - confirmed messages were not left behind
@@ -1085,16 +1140,22 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
 
         // arrange - dequeue the message and make immediately available
         await _queries.GetStreamMessagesAsync(ack.ServiceId, ack.ProviderId, ack.QueueId, cacheOptions.CacheSize, streamOptions.MaxAttempts, 0, streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling(), streamOptions.EvictionInterval.TotalSecondsCeiling(), streamOptions.EvictionBatchSize);
-        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
+        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>(
+            "SELECT * FROM OrleansStreamDeadLetter",
+            TestContext.Current.CancellationToken));
 
         // act - clean up with max attempts of one so the message above is flagged
         await _queries.FailStreamMessageAsync(ack.ServiceId, ack.ProviderId, ack.QueueId, ack.MessageId, 1, streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling());
 
         // assert - message no longer in the message table
-        Assert.Empty(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
+        Assert.Empty(await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken));
 
         // assert - message was moved
-        var dead = Assert.Single(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
+        var dead = Assert.Single(await _storage.ReadAsync<AdoNetStreamDeadLetter>(
+            "SELECT * FROM OrleansStreamDeadLetter",
+            TestContext.Current.CancellationToken));
         Assert.Equal(serviceId, dead.ServiceId);
         Assert.Equal(providerId, dead.ProviderId);
         Assert.Equal(queueId, dead.QueueId);
@@ -1130,7 +1191,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         await _queries.FailStreamMessageAsync(ack.ServiceId, ack.ProviderId, ack.QueueId, ack.MessageId, streamOptions.MaxAttempts, streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling());
 
         // assert - the message is still in the table and was made visible again
-        var saved = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage"));
+        var saved = Assert.Single(await _storage.ReadAsync<AdoNetStreamMessage>(
+            "SELECT * FROM OrleansStreamMessage",
+            TestContext.Current.CancellationToken));
         Assert.Equal(ack.ServiceId, saved.ServiceId);
         Assert.Equal(ack.ProviderId, saved.ProviderId);
         Assert.Equal(ack.QueueId, saved.QueueId);
@@ -1139,7 +1202,9 @@ public abstract class RelationalOrleansQueriesTests(string invariant, int concur
         Assert.Equal(saved.ModifiedOn, saved.VisibleOn);
 
         // assert - no message arrived at dead letters
-        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
+        Assert.Empty(await _storage.ReadAsync<AdoNetStreamDeadLetter>(
+            "SELECT * FROM OrleansStreamDeadLetter",
+            TestContext.Current.CancellationToken));
     }
 
     private static List<T> Randomize<T>(IEnumerable<T> source)

--- a/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
@@ -22,7 +22,7 @@ public class AzureMembershipPaginationTests
         var storage = new ScriptedMembershipTableReadStorage();
         storage.AddQuery(Query(false, Version(1, "v1"), Silo("silo-1", "s1")));
 
-        var result = await CreateManager(storage).FindAllSiloEntries();
+        var result = await CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, result.Count);
         Assert.Equal(1, storage.QueryCount);
@@ -34,7 +34,7 @@ public class AzureMembershipPaginationTests
         var storage = new ScriptedMembershipTableReadStorage();
         storage.AddQuery(FencedQuery(1, Silo("silo-1", "s1")));
 
-        var result = await CreateManager(storage).FindAllSiloEntries();
+        var result = await CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken);
 
         Assert.Equal(["silo-1", SiloInstanceTableEntry.TABLE_VERSION_ROW], result.Select(entry => entry.Entity.RowKey));
         Assert.Equal(1, storage.QueryCount);
@@ -52,7 +52,7 @@ public class AzureMembershipPaginationTests
             BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, 2, "after-2")));
         storage.AddQuery(FencedQuery(2, Silo("silo-2", "s2")));
 
-        var result = await CreateManager(storage).FindAllSiloEntries();
+        var result = await CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken);
 
         Assert.Equal(["silo-2", SiloInstanceTableEntry.TABLE_VERSION_ROW], result.Select(entry => entry.Entity.RowKey));
         Assert.Equal(2, storage.QueryCount);
@@ -69,7 +69,7 @@ public class AzureMembershipPaginationTests
             Version(11, "legacy-11"),
             BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, 10, "after-10")));
 
-        var result = await CreateManager(storage).FindAllSiloEntries();
+        var result = await CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken);
 
         Assert.Equal("stale", result.Single(entry => entry.Entity.RowKey == "silo-1").ETag);
         Assert.Equal(1, storage.QueryCount);
@@ -87,7 +87,7 @@ public class AzureMembershipPaginationTests
             BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, 3, "after-3")));
         storage.AddQuery(FencedQuery(3, Silo("silo-1", "current")));
 
-        var result = await CreateManager(storage).FindAllSiloEntries();
+        var result = await CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken);
 
         Assert.Equal("current", result.Single(entry => entry.Entity.RowKey == "silo-1").ETag);
         Assert.Equal(2, storage.QueryCount);
@@ -108,7 +108,7 @@ public class AzureMembershipPaginationTests
         }
 
         var exception = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => CreateManager(storage).FindAllSiloEntries());
+            () => CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken));
 
         Assert.Equal((OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts - 1).ToString(), exception.StoredEtag);
         Assert.Equal(OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts.ToString(), exception.CurrentEtag);
@@ -121,7 +121,7 @@ public class AzureMembershipPaginationTests
         var storage = new ScriptedMembershipTableReadStorage();
         storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
 
-        var result = await CreateManager(storage).FindAllSiloEntries();
+        var result = await CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken);
 
         Assert.Equal("v1", result.Single(entry => entry.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW).ETag);
         Assert.Equal(1, storage.QueryCount);
@@ -133,7 +133,7 @@ public class AzureMembershipPaginationTests
         var storage = new ScriptedMembershipTableReadStorage();
         storage.AddQuery(FencedQuery(1, Silo("silo-1", "heartbeat-2")));
 
-        var result = await CreateManager(storage).FindAllSiloEntries();
+        var result = await CreateManager(storage).FindAllSiloEntries(TestContext.Current.CancellationToken);
 
         Assert.Equal("heartbeat-2", result.Single(entry => entry.Entity.RowKey == "silo-1").ETag);
         Assert.Equal(1, storage.QueryCount);
@@ -142,7 +142,8 @@ public class AzureMembershipPaginationTests
     [Fact]
     public async Task CancellationTokenFlowsThroughPaginatedRead()
     {
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
         var storage = new ScriptedMembershipTableReadStorage();
         storage.AddQuery(FencedQuery(1, Silo("silo-1", "s1")));
 

--- a/test/Extensions/Orleans.Azure.Tests/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureQueueDataManagerTests.cs
@@ -98,7 +98,7 @@ namespace Tester.AzureUtils
             {
                 promises.Add(manager.AddQueueMessage(i.ToString()));
             }
-            await Task.WhenAll(promises).WaitAsync(TestContext.Current.CancellationToken);
+            await Task.WhenAll(promises);
             Assert.Equal(numMsgs, await manager.GetApproximateMessageCount());
 
             var receivedMessages = await manager.GetQueueMessages(numMsgs);

--- a/test/Extensions/Orleans.Azure.Tests/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureQueueDataManagerTests.cs
@@ -98,7 +98,7 @@ namespace Tester.AzureUtils
             {
                 promises.Add(manager.AddQueueMessage(i.ToString()));
             }
-            await Task.WhenAll(promises);
+            await Task.WhenAll(promises).WaitAsync(TestContext.Current.CancellationToken);
             Assert.Equal(numMsgs, await manager.GetApproximateMessageCount());
 
             var receivedMessages = await manager.GetQueueMessages(numMsgs);
@@ -112,7 +112,7 @@ namespace Tester.AzureUtils
             {
                 promises.Add(manager.DeleteQueueMessage(msg));
             }
-            await Task.WhenAll(promises);
+            await Task.WhenAll(promises).WaitAsync(TestContext.Current.CancellationToken);
             Assert.Equal(0, await manager.GetApproximateMessageCount());
         }
 
@@ -126,13 +126,15 @@ namespace Tester.AzureUtils
 
             for (int i = 0; i < NumThreads; i++)
             {
-                promises[i] = Task.Run(async () =>
-                {
-                    AzureQueueDataManager manager = await GetTableManager(queueName);
-                    return true;
-                });
+                promises[i] = Task.Run(
+                    async () =>
+                    {
+                        AzureQueueDataManager manager = await GetTableManager(queueName);
+                        return true;
+                    },
+                    TestContext.Current.CancellationToken);
             }
-            await Task.WhenAll(promises);
+            await Task.WhenAll(promises).WaitAsync(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -173,7 +175,8 @@ namespace Tester.AzureUtils
                     return false;
                 },
                 TimeSpan.FromSeconds(30),
-                TimeSpan.FromMilliseconds(100));
+                TimeSpan.FromMilliseconds(100),
+                TestContext.Current.CancellationToken);
 
             var outMessage2 = await manager.GetQueueMessage();
             Assert.NotNull(outMessage2);

--- a/test/Extensions/Orleans.Azure.Tests/AzureTableDataManagerStressTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureTableDataManagerStressTests.cs
@@ -25,7 +25,7 @@ namespace Tester.AzureUtils
             this.output = output;
 
             // Pre-create table, if required
-            manager = new UnitTestAzureTableDataManager();
+            manager = new UnitTestAzureTableDataManager(TestContext.Current.CancellationToken);
 
             PartitionKey = "AzureTableDataManagerStressTests-" + Guid.NewGuid();
         }
@@ -39,7 +39,12 @@ namespace Tester.AzureUtils
             const int numPartitions = 1;
 
             // Write some data
-            await WriteAlot_Async(testName, numPartitions, iterations, batchSize);
+            await WriteAlot_Async(
+                testName,
+                numPartitions,
+                iterations,
+                batchSize,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -51,7 +56,12 @@ namespace Tester.AzureUtils
             const int numPartitions = 100;
 
             // Write some data
-            await WriteAlot_Async(testName, numPartitions, iterations, batchSize);
+            await WriteAlot_Async(
+                testName,
+                numPartitions,
+                iterations,
+                batchSize,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -61,12 +71,21 @@ namespace Tester.AzureUtils
             const int iterations = 1000;
 
             // Write some data
-            await WriteAlot_Async(testName, 1, iterations, iterations);
+            await WriteAlot_Async(
+                testName,
+                1,
+                iterations,
+                iterations,
+                TestContext.Current.CancellationToken);
 
             Stopwatch sw = Stopwatch.StartNew();
 
-            var data = (await manager.ReadAllTableEntriesForPartitionAsync(PartitionKey)
-                .WaitAsync(new AzureStoragePolicyOptions().CreationTimeout)).Select(tuple => tuple.Entity);
+            var data = (await manager.ReadAllTableEntriesForPartitionAsync(
+                    PartitionKey,
+                    TestContext.Current.CancellationToken)
+                .WaitAsync(
+                    new AzureStoragePolicyOptions().CreationTimeout,
+                    TestContext.Current.CancellationToken)).Select(tuple => tuple.Entity);
 
             sw.Stop();
             int count = data.Count();
@@ -82,11 +101,18 @@ namespace Tester.AzureUtils
             const int iterations = 2000;
 
             // Write some data
-            await WriteAlot_Async(testName, 3, iterations, iterations);
+            await WriteAlot_Async(
+                testName,
+                3,
+                iterations,
+                iterations,
+                TestContext.Current.CancellationToken);
 
             Stopwatch sw = Stopwatch.StartNew();
 
-            var data = (await manager.ReadAllTableEntriesAsync().WaitAsync(new AzureStoragePolicyOptions().CreationTimeout))
+            var data = (await manager.ReadAllTableEntriesAsync(TestContext.Current.CancellationToken).WaitAsync(
+                    new AzureStoragePolicyOptions().CreationTimeout,
+                    TestContext.Current.CancellationToken))
                 .Select(tuple => tuple.Entity);
 
             sw.Stop();
@@ -96,12 +122,19 @@ namespace Tester.AzureUtils
             Assert.True(count >= iterations, $"ReadAllshould return some data: Found={count}");
 
             sw = Stopwatch.StartNew();
-            await manager.ClearTableAsync().WaitAsync(new AzureStoragePolicyOptions().CreationTimeout);
+            await manager.ClearTableAsync().WaitAsync(
+                new AzureStoragePolicyOptions().CreationTimeout,
+                TestContext.Current.CancellationToken);
             sw.Stop();
             output.WriteLine("AzureTable_ReadAllTableEntities clear. Cleared table of {0} entries in {1} at {2} RPS", count, sw.Elapsed, count / sw.Elapsed.TotalSeconds);
         }
 
-        private async Task WriteAlot_Async(string testName, int numPartitions, int iterations, int batchSize)
+        private async Task WriteAlot_Async(
+            string testName,
+            int numPartitions,
+            int iterations,
+            int batchSize,
+            CancellationToken cancellationToken)
         {
             output.WriteLine("Iterations={0}, Batch={1}, Partitions={2}", iterations, batchSize, numPartitions);
             List<Task> promises = new List<Task>();
@@ -120,13 +153,17 @@ namespace Tester.AzureUtils
                 promises.Add(promise);
                 if ((i % batchSize) == 0 && i > 0)
                 {
-                    await Task.WhenAll(promises).WaitAsync(new AzureStoragePolicyOptions().CreationTimeout);
+                    await Task.WhenAll(promises).WaitAsync(
+                        new AzureStoragePolicyOptions().CreationTimeout,
+                        cancellationToken);
                     promises.Clear();
                     output.WriteLine("{0} has written {1} rows in {2} at {3} RPS",
                         testName, i, sw.Elapsed, i / sw.Elapsed.TotalSeconds);
                 }
             }
-            await Task.WhenAll(promises).WaitAsync(new AzureStoragePolicyOptions().CreationTimeout);
+            await Task.WhenAll(promises).WaitAsync(
+                new AzureStoragePolicyOptions().CreationTimeout,
+                cancellationToken);
             sw.Stop();
             output.WriteLine("{0} completed. Wrote {1} entries to {2} partition(s) in {3} at {4} RPS",
                 testName, iterations, numPartitions, sw.Elapsed, iterations / sw.Elapsed.TotalSeconds);

--- a/test/Extensions/Orleans.Azure.Tests/AzureTableDataManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureTableDataManagerTests.cs
@@ -27,7 +27,7 @@ namespace Tester.AzureUtils
         public AzureTableDataManagerTests()
         {
             // Pre-create table, if required
-            manager = new UnitTestAzureTableDataManager();
+            manager = new UnitTestAzureTableDataManager(TestContext.Current.CancellationToken);
             PartitionKey = "PK-AzureTableDataManagerTests-" + Guid.NewGuid();
         }
 
@@ -52,7 +52,10 @@ namespace Tester.AzureUtils
                 Assert.Equal(HttpStatusCode.Conflict, httpStatusCode);
                 Assert.Equal("EntityAlreadyExists", restStatus);
             }
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(
+                data.PartitionKey,
+                data.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.NotNull(tuple.Entity);
             Assert.Equal(data.StringData, tuple.Entity.StringData);
         }
@@ -62,14 +65,20 @@ namespace Tester.AzureUtils
         {
             var data = GenerateNewData();
             await manager.UpsertTableEntryAsync(data);
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(
+                data.PartitionKey,
+                data.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.NotNull(tuple.Entity);
             Assert.Equal(data.StringData, tuple.Entity.StringData);
 
             var data2 = data.Clone();
             data2.StringData = "NewData";
             await manager.UpsertTableEntryAsync(data2);
-            tuple = await manager.ReadSingleTableEntryAsync(data2.PartitionKey, data2.RowKey);
+            tuple = await manager.ReadSingleTableEntryAsync(
+                data2.PartitionKey,
+                data2.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.NotNull(tuple.Entity);
             Assert.Equal(data2.StringData, tuple.Entity.StringData);
         }
@@ -95,21 +104,30 @@ namespace Tester.AzureUtils
             }
 
             await manager.UpsertTableEntryAsync(data);
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(
+                data.PartitionKey,
+                data.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.NotNull(tuple.Entity);
             Assert.Equal(data.StringData, tuple.Entity.StringData);
 
             var data2 = data.Clone();
             data2.StringData = "NewData";
             string eTag1 = await manager.UpdateTableEntryAsync(data2, AzureTableUtils.ANY_ETAG);
-            tuple = await manager.ReadSingleTableEntryAsync(data2.PartitionKey, data2.RowKey);
+            tuple = await manager.ReadSingleTableEntryAsync(
+                data2.PartitionKey,
+                data2.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.NotNull(tuple.Entity);
             Assert.Equal(data2.StringData, tuple.Entity.StringData);
 
             var data3 = data.Clone();
             data3.StringData = "EvenNewerData";
             _ = await manager.UpdateTableEntryAsync(data3, eTag1);
-            tuple = await manager.ReadSingleTableEntryAsync(data3.PartitionKey, data3.RowKey);
+            tuple = await manager.ReadSingleTableEntryAsync(
+                data3.PartitionKey,
+                data3.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.NotNull(tuple.Entity);
             Assert.Equal(data3.StringData, tuple.Entity.StringData);
 
@@ -162,7 +180,10 @@ namespace Tester.AzureUtils
                 Assert.Equal(HttpStatusCode.NotFound, httpStatusCode);
             }
 
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(
+                data.PartitionKey,
+                data.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.Null(tuple.Entity);
         }
 
@@ -206,7 +227,10 @@ namespace Tester.AzureUtils
                 Assert.True(restStatus == TableErrorCode.UpdateConditionNotSatisfied.ToString());
             }
 
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(
+                data.PartitionKey,
+                data.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.NotNull(tuple.Entity);
             Assert.Equal("NewData", tuple.Entity.StringData);
         }
@@ -215,7 +239,10 @@ namespace Tester.AzureUtils
         public async Task AzureTableDataManager_ReadSingleTableEntryAsync()
         {
             var data = GenerateNewData();
-            var tuple = await manager.ReadSingleTableEntryAsync(data.PartitionKey, data.RowKey);
+            var tuple = await manager.ReadSingleTableEntryAsync(
+                data.PartitionKey,
+                data.RowKey,
+                TestContext.Current.CancellationToken);
             Assert.Null(tuple.Entity);
         }
 

--- a/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
@@ -65,16 +65,32 @@ namespace Tester.AzureUtils.Lease
         {
             var mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
             //6 queue and 4 silo, then each agent manager should own queues/agents in range of [1, 2]
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(1, 2, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                1,
+                2,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
             //stop one silo, 6 queues, 3 silo, then each agent manager should own 2 queues 
             await this.HostedCluster.StopSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                2,
+                2,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
             //stop another silo, 6 queues, 2 silo, then each agent manager should own 3 queues
             await this.HostedCluster.StopSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(3, 3, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                3,
+                3,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
             //start one silo, 6 queues, 3 silo, then each agent manager should own 2 queues
             this.HostedCluster.StartAdditionalSilo(true);
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                2,
+                2,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -82,19 +98,39 @@ namespace Tester.AzureUtils.Lease
         {
             var mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
             //6 queue and 4 silo, then each agent manager should own queues/agents in range of [1, 2]
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(1, 2, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                1,
+                2,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
             //stop one silo, 6 queues, 3 silo, then each agent manager should own 2 queues 
             await this.HostedCluster.KillSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                2,
+                2,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
             //stop another silo, 6 queues, 2 silo, then each agent manager should own 3 queues
             await this.HostedCluster.KillSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(3, 3, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                3,
+                3,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
             //start one silo, 6 queues, 3 silo, then each agent manager should own 2 queues
             this.HostedCluster.StartAdditionalSilo(true);
-            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+                2,
+                2,
+                mgmtGrain,
+                TestContext.Current.CancellationToken);
         }
 
-        private static async Task WaitUntilAgentManagersOwnCorrectAmountOfAgents(int expectedAgentCountMin, int expectedAgentCountMax, IManagementGrain mgmtGrain)
+        private static async Task WaitUntilAgentManagersOwnCorrectAmountOfAgents(
+            int expectedAgentCountMin,
+            int expectedAgentCountMax,
+            IManagementGrain mgmtGrain,
+            CancellationToken cancellationToken)
         {
             int[]? lastObservedCounts = null;
             Exception? lastException = null;
@@ -103,6 +139,7 @@ namespace Tester.AzureUtils.Lease
 
             while (stopwatch.Elapsed < TimeOut)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var observedVersion = queueChanges.Version;
                 try
                 {
@@ -113,18 +150,27 @@ namespace Tester.AzureUtils.Lease
                         return;
                     }
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception exception)
                 {
                     lastException = exception;
                 }
 
                 var remaining = TimeOut - stopwatch.Elapsed;
-                if (remaining <= TimeSpan.Zero || !await queueChanges.WaitForNextChangeAsync(observedVersion, remaining))
+                if (remaining <= TimeSpan.Zero
+                    || !await queueChanges.WaitForNextChangeAsync(
+                        observedVersion,
+                        remaining,
+                        cancellationToken))
                 {
                     break;
                 }
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
                 lastObservedCounts = await GetRunningAgentCounts(mgmtGrain);
@@ -191,7 +237,10 @@ namespace Tester.AzureUtils.Lease
                 }
             }
 
-            public async Task<bool> WaitForNextChangeAsync(long observedVersion, TimeSpan timeout)
+            public async Task<bool> WaitForNextChangeAsync(
+                long observedVersion,
+                TimeSpan timeout,
+                CancellationToken cancellationToken)
             {
                 Task task;
                 lock (lockObj)
@@ -206,7 +255,7 @@ namespace Tester.AzureUtils.Lease
 
                 try
                 {
-                    await task.WaitAsync(timeout);
+                    await task.WaitAsync(timeout, cancellationToken);
                     return true;
                 }
                 catch (TimeoutException)

--- a/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
@@ -71,14 +71,18 @@ namespace Tester.AzureUtils.Lease
                 mgmtGrain,
                 TestContext.Current.CancellationToken);
             //stop one silo, 6 queues, 3 silo, then each agent manager should own 2 queues 
-            await this.HostedCluster.StopSiloAsync(this.HostedCluster.SecondarySilos[0]);
+            await this.HostedCluster.StopSiloAsync(
+                this.HostedCluster.SecondarySilos[0],
+                TestContext.Current.CancellationToken);
             await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
                 2,
                 2,
                 mgmtGrain,
                 TestContext.Current.CancellationToken);
             //stop another silo, 6 queues, 2 silo, then each agent manager should own 3 queues
-            await this.HostedCluster.StopSiloAsync(this.HostedCluster.SecondarySilos[0]);
+            await this.HostedCluster.StopSiloAsync(
+                this.HostedCluster.SecondarySilos[0],
+                TestContext.Current.CancellationToken);
             await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
                 3,
                 3,
@@ -104,14 +108,18 @@ namespace Tester.AzureUtils.Lease
                 mgmtGrain,
                 TestContext.Current.CancellationToken);
             //stop one silo, 6 queues, 3 silo, then each agent manager should own 2 queues 
-            await this.HostedCluster.KillSiloAsync(this.HostedCluster.SecondarySilos[0]);
+            await this.HostedCluster.KillSiloAsync(
+                this.HostedCluster.SecondarySilos[0],
+                TestContext.Current.CancellationToken);
             await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
                 2,
                 2,
                 mgmtGrain,
                 TestContext.Current.CancellationToken);
             //stop another silo, 6 queues, 2 silo, then each agent manager should own 3 queues
-            await this.HostedCluster.KillSiloAsync(this.HostedCluster.SecondarySilos[0]);
+            await this.HostedCluster.KillSiloAsync(
+                this.HostedCluster.SecondarySilos[0],
+                TestContext.Current.CancellationToken);
             await WaitUntilAgentManagersOwnCorrectAmountOfAgents(
                 3,
                 3,

--- a/test/Extensions/Orleans.Azure.Tests/Persistence/AzureBlobGrainStorageTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Persistence/AzureBlobGrainStorageTests.cs
@@ -26,6 +26,7 @@ namespace Tester.AzureUtils.Persistence;
 [TestArea("Persistence")]
 public sealed class AzureBlobGrainStorageTests : AzureStorageBasicTests, IAsyncDisposable
 {
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(30);
     private const string GrainType = "test-grain";
     private readonly BlobContainerClient _container;
     private readonly string _containerName = $"test-grainstate-{Guid.NewGuid():N}";
@@ -50,20 +51,32 @@ public sealed class AzureBlobGrainStorageTests : AzureStorageBasicTests, IAsyncD
 
     public async ValueTask DisposeAsync()
     {
-        await _container.DeleteIfExistsAsync();
-        _services.Dispose();
+        using var cleanupCancellation = new CancellationTokenSource(CleanupTimeout);
+        try
+        {
+            await _container.DeleteIfExistsAsync(
+                cancellationToken: cleanupCancellation.Token);
+        }
+        finally
+        {
+            _services.Dispose();
+        }
     }
 
     [Fact, TestCategory("Functional")]
     public async Task AzureBlobStorage_ReadState_StreamDeserializationFailure_DoesNotMutateGrainState()
     {
-        await AssertFailedReadDoesNotMutateStateAsync(new ThrowingStreamDeserializeSerializer(CreateSetupSerializer()));
+        await AssertFailedReadDoesNotMutateStateAsync(
+            new ThrowingStreamDeserializeSerializer(CreateSetupSerializer()),
+            TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("Functional")]
     public async Task AzureBlobStorage_ReadState_PooledBinaryDeserializationFailure_DoesNotMutateGrainState()
     {
-        await AssertFailedReadDoesNotMutateStateAsync(new ThrowingBinaryDeserializeSerializer(CreateSetupSerializer()));
+        await AssertFailedReadDoesNotMutateStateAsync(
+            new ThrowingBinaryDeserializeSerializer(CreateSetupSerializer()),
+            TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("Functional"), TestCategory("ModelBased")]
@@ -84,13 +97,19 @@ public sealed class AzureBlobGrainStorageTests : AzureStorageBasicTests, IAsyncD
         await runner.RunGeneratedConformanceTests();
     }
 
-    private async Task AssertFailedReadDoesNotMutateStateAsync(IGrainStorageSerializer serializer)
+    private async Task AssertFailedReadDoesNotMutateStateAsync(
+        IGrainStorageSerializer serializer,
+        CancellationToken cancellationToken)
     {
         var storage = await CreateStorageAsync(serializer);
         var blob = _container.GetBlobClient(GetBlobName());
-        await blob.UploadAsync(CreateSetupSerializer().Serialize(new TestState { Value = 7 }), overwrite: true);
+        await blob.UploadAsync(
+            CreateSetupSerializer().Serialize(new TestState { Value = 7 }),
+            overwrite: true,
+            cancellationToken: cancellationToken);
 
-        var actualEtag = (await blob.GetPropertiesAsync()).Value.ETag.ToString();
+        var actualEtag = (await blob.GetPropertiesAsync(
+            cancellationToken: cancellationToken)).Value.ETag.ToString();
         const string initialEtag = "\"initial-etag\"";
         Assert.NotEqual(initialEtag, actualEtag);
 

--- a/test/Extensions/Orleans.Azure.Tests/Persistence/AzureBlobGrainStorageTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Persistence/AzureBlobGrainStorageTests.cs
@@ -85,7 +85,7 @@ public sealed class AzureBlobGrainStorageTests : AzureStorageBasicTests, IAsyncD
         var storage = await CreateStorageAsync(CreateSetupSerializer());
         var runner = new GrainStorageModelBasedTestRunner(storage, "AzureBlob", _output.WriteLine);
 
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("Functional"), TestCategory("ModelBased")]
@@ -94,7 +94,7 @@ public sealed class AzureBlobGrainStorageTests : AzureStorageBasicTests, IAsyncD
         var storage = await CreateStorageAsync(CreateSetupSerializer(), deleteStateOnClear: false);
         var runner = new GrainStorageModelBasedTestRunner(storage, "AzureBlobClearWritesTombstone", _output.WriteLine);
 
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     private async Task AssertFailedReadDoesNotMutateStateAsync(

--- a/test/Extensions/Orleans.Azure.Tests/Persistence/AzureTableGrainStorageTestKitTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Persistence/AzureTableGrainStorageTestKitTests.cs
@@ -57,7 +57,10 @@ public class AzureTableGrainStorageTestKitTests : GrainStorageTestRunner, IClass
     [Fact]
     public override Task PersistenceStorage_WriteReadWriteReadStatesInParallel()
     {
-        return RunPersistenceStorage_WriteReadWriteReadStatesInParallel("AzureTableTest", 50);
+        return RunPersistenceStorage_WriteReadWriteReadStatesInParallel(
+            "AzureTableTest",
+            50,
+            TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/test/Extensions/Orleans.Azure.Tests/Persistence/PersistenceProviderTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Persistence/PersistenceProviderTests.cs
@@ -92,7 +92,7 @@ namespace Tester.AzureUtils.Persistence
             var storage = await InitAzureTableGrainStorage(deleteStateOnClear: false);
             var runner = new GrainStorageModelBasedTestRunner(storage, "AzureTable", output.WriteLine);
 
-            await runner.RunGeneratedConformanceTests();
+            await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("AzureStorage"), TestCategory("ModelBased")]
@@ -105,7 +105,7 @@ namespace Tester.AzureUtils.Persistence
             var storage = await InitAzureTableGrainStorage(deleteStateOnClear: true);
             var runner = new GrainStorageModelBasedTestRunner(storage, "AzureTableDeleteStateOnClear", output.WriteLine);
 
-            await runner.RunGeneratedConformanceTests();
+            await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
         }
 
         [Theory, TestCategory("Functional"), TestCategory("AzureStorage")]

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -67,7 +67,9 @@ namespace Tester.AzureUtils.TimerTests
 
                 var silos = HostedCluster.Silos.ToArray();
                 _initialSilos = silos.Select(silo => silo.SiloAddress).ToArray();
-                using var cancellation = new CancellationTokenSource(ReminderServiceStartupTimeout);
+                using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                    TestContext.Current.CancellationToken);
+                cancellation.CancelAfter(ReminderServiceStartupTimeout);
                 var startedTasks = silos
                     .Select(silo => _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress))
                     .ToArray();
@@ -78,7 +80,9 @@ namespace Tester.AzureUtils.TimerTests
                         .Select(started => started.SiloAddress!)
                         .ToArray();
                 }
-                catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+                catch (OperationCanceledException) when (
+                    cancellation.IsCancellationRequested
+                    && !TestContext.Current.CancellationToken.IsCancellationRequested)
                 {
                     var missing = silos
                         .Where((_, index) => !startedTasks[index].IsCompletedSuccessfully)
@@ -125,7 +129,8 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_UpdateReminder_DoesNotRestartLocalReminder()
         {
-            await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder();
+            await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder(
+                TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -151,7 +156,9 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_Basic()
         {
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
             var grain = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var period = await grain.GetReminderPeriod(DR);
 
@@ -171,7 +178,9 @@ namespace Tester.AzureUtils.TimerTests
         {
             IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             TimeSpan period = await grain.GetReminderPeriod(DR);
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
 
             await grain.StartReminder(DR);
             await AdvanceRemindersByTicksAsync(2, cts.Token, (grain, DR));
@@ -192,7 +201,7 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Rem_Azure_MultipleReminders()
         {
             IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            await PerGrainMultiReminderTest(grain);
+            await PerGrainMultiReminderTest(grain, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -209,7 +218,9 @@ namespace Tester.AzureUtils.TimerTests
             IReminderTestGrain2 g3 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
 
             await Test_Reminders_MultiGrainMultiReminders(
                 afterFirstTick: null,
@@ -225,7 +236,9 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Rem_Azure_1F_Basic()
         {
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
 
             await PrepareForGrainFailureAsync(cts.Token, g1);
 
@@ -244,7 +257,9 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_2F_MultiGrain()
         {
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
             _ = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
                 2,
                 cts.Token,
@@ -276,7 +291,9 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_1F1J_MultiGrain()
         {
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
             _ = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -310,7 +327,9 @@ namespace Tester.AzureUtils.TimerTests
             Task<IGrainReminder> promise1 = grain.StartReminder(DR);
             Task<IGrainReminder> promise2 = grain.StartReminder(DR);
             Task<IGrainReminder>[] tasks = { promise1, promise2 };
-            await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(15));
+            await Task.WhenAll(tasks).WaitAsync(
+                TimeSpan.FromSeconds(15),
+                TestContext.Current.CancellationToken);
             //Assert.NotEqual(promise1.Result, promise2.Result);
             // TODO: write tests where period of a reminder is changed
         }
@@ -320,7 +339,9 @@ namespace Tester.AzureUtils.TimerTests
         {
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestCopyGrain g2 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
 
             await g1.StartReminder(DR);
             await AdvanceRemindersByTicksAsync(2, cts.Token, (g1, DR));
@@ -340,7 +361,9 @@ namespace Tester.AzureUtils.TimerTests
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/4319"), TestCategory("Functional")]
         public async Task Rem_Azure_GT_1F1J_MultiGrain()
         {
-            using var cts = new CancellationTokenSource(ENDWAIT);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cts.CancelAfter(ENDWAIT);
             _ = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -123,7 +123,7 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_Basic_StopByRef()
         {
-            await Test_Reminders_Basic_StopByRef();
+            await Test_Reminders_Basic_StopByRef(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -136,7 +136,7 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_Basic_ListOps()
         {
-            await Test_Reminders_Basic_ListOps();
+            await Test_Reminders_Basic_ListOps(TestContext.Current.CancellationToken);
         }
 
         // Single join tests ... multi grain, multi reminders
@@ -144,13 +144,13 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_1J_MultiGrainMultiReminders()
         {
-            await Test_Reminders_1J_MultiGrainMultiReminders();
+            await Test_Reminders_1J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_ReminderNotFound()
         {
-            await Test_Reminders_ReminderNotFound();
+            await Test_Reminders_ReminderNotFound(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -207,7 +207,7 @@ namespace Tester.AzureUtils.TimerTests
         [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_2J_MultiGrainMultiReminders()
         {
-            await Test_Reminders_2J_MultiGrainMultiReminders();
+            await Test_Reminders_2J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_Azure_Standalone.cs
@@ -48,10 +48,10 @@ namespace Tester.AzureUtils.TimerTests
             storageOptions.Value.ConfigureTestDefaults();
 
             IReminderTable table = new AzureBasedReminderTable(this.loggerFactory, clusterOptions, storageOptions);
-            await table.StartAsync();
+            await table.StartAsync(TestContext.Current.CancellationToken);
 
-            await TestTableInsertRate(table, 10);
-            await TestTableInsertRate(table, 500);
+            await TestTableInsertRate(table, 10, TestContext.Current.CancellationToken);
+            await TestTableInsertRate(table, 500, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Reminders"), TestCategory("Functional")]
@@ -62,7 +62,7 @@ namespace Tester.AzureUtils.TimerTests
             var storageOptions = Options.Create(new AzureTableReminderStorageOptions());
             storageOptions.Value.ConfigureTestDefaults();
             IReminderTable table = new AzureBasedReminderTable(this.loggerFactory, clusterOptions, storageOptions);
-            await table.StartAsync();
+            await table.StartAsync(TestContext.Current.CancellationToken);
 
             ReminderEntry[] rows = (await GetAllRows(table)).ToArray();
             Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, clusterId);
@@ -81,7 +81,10 @@ namespace Tester.AzureUtils.TimerTests
             Assert.False(string.IsNullOrWhiteSpace(actual.ETag), $"The newly inserted reminder table (sid={this.serviceId}, did={clusterId}) row contains an invalid etag.");
         }
 
-        private async Task TestTableInsertRate(IReminderTable reminderTable, double numOfInserts)
+        private async Task TestTableInsertRate(
+            IReminderTable reminderTable,
+            double numOfInserts,
+            CancellationToken cancellationToken)
         {
             DateTime startedAt = DateTime.UtcNow;
 
@@ -101,17 +104,19 @@ namespace Tester.AzureUtils.TimerTests
                 };
 
                 int capture = i;
-                Task<bool> promise = Task.Run(async () =>
-                {
-                    await reminderTable.UpsertRow(e);
-                    this.output.WriteLine("Done " + capture);
-                    return true;
-                });
+                Task<bool> promise = Task.Run(
+                    async () =>
+                    {
+                        await reminderTable.UpsertRow(e);
+                        this.output.WriteLine("Done " + capture);
+                        return true;
+                    },
+                    cancellationToken);
                 promises.Add(promise);
                 this.log.LogInformation("Started {Capture}", capture);
             }
             this.log.LogInformation("Started all, now waiting...");
-            await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500));
+            await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500), cancellationToken);
 
             TimeSpan dur = DateTime.UtcNow - startedAt;
             this.log.LogInformation(

--- a/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
@@ -54,7 +54,11 @@ namespace Tester.AzureUtils
                 this.clusterId,
                 fixture.LoggerFactory,
                 new AzureStorageClusteringOptions { TableName = new AzureStorageClusteringOptions().TableName }.ConfigureTestDefaults())
-                .WaitAsync(SiloInstanceTableTestConstants.Timeout).Result;
+                .WaitAsync(
+                    SiloInstanceTableTestConstants.Timeout,
+                    TestContext.Current.CancellationToken)
+                .GetAwaiter()
+                .GetResult();
         }
 
         // Use TestCleanup to run code after each test has run
@@ -66,10 +70,24 @@ namespace Tester.AzureUtils
 
                 output.WriteLine("TestCleanup Timeout={0}", timeout);
 
-                manager.DeleteTableEntries(this.clusterId).WaitAsync(timeout).Wait();
+                using var cleanupCancellation = new CancellationTokenSource(timeout);
+                try
+                {
+                    manager.DeleteTableEntries(this.clusterId)
+                        .WaitAsync(cleanupCancellation.Token)
+                        .GetAwaiter()
+                        .GetResult();
 
-                output.WriteLine("TestCleanup -  Finished");
-                manager = null!;
+                    output.WriteLine("TestCleanup -  Finished");
+                }
+                catch (OperationCanceledException) when (cleanupCancellation.IsCancellationRequested)
+                {
+                    throw new TimeoutException($"Test cleanup timed out after {timeout}.");
+                }
+                finally
+                {
+                    manager = null!;
+                }
             }
         }
 
@@ -114,11 +132,11 @@ namespace Tester.AzureUtils
                 await manager.ActivateSiloInstance(instance);
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(3));
+            await Task.Delay(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
 
             await manager.CleanupDefunctSiloEntries(DateTime.Now - TimeSpan.FromSeconds(1));
 
-            var entries = await manager.FindAllSiloEntries();
+            var entries = await manager.FindAllSiloEntries(TestContext.Current.CancellationToken);
             Assert.Equal(5, entries.Count);
             Assert.All(entries, e => Assert.NotEqual(SiloInstanceTableTestConstants.INSTANCE_STATUS_DEAD, e.Item1.Status));
             var before = await manager.ReadSingleTableEntryAsync(
@@ -136,7 +154,9 @@ namespace Tester.AzureUtils
         public async Task SiloInstanceTable_Op_CreateSiloEntryConditionally()
         {
             bool didInsert = await manager.TryCreateTableVersionEntryAsync()
-                .WaitAsync(new AzureStoragePolicyOptions().OperationTimeout);
+                .WaitAsync(
+                    new AzureStoragePolicyOptions().OperationTimeout,
+                    TestContext.Current.CancellationToken);
 
             Assert.True(didInsert, "Did insert");
             var before = await manager.ReadSingleTableEntryAsync(

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQClientStreamTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQClientStreamTests.cs
@@ -102,7 +102,10 @@ namespace Tester.AzureUtils.Streaming
         public async Task AQStreamProducerOnDroppedClientTest()
         {
             logger.LogInformation("************************ AQStreamProducerOnDroppedClientTest *********************************");
-            await runner.StreamProducerOnDroppedClientTest(AQStreamProviderName, StreamNamespace);
+            await runner.StreamProducerOnDroppedClientTest(
+                AQStreamProviderName,
+                StreamNamespace,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact(Skip = "AzureQueue has unpredictable event delivery counts - re-enable when we figure out how to handle this."), TestCategory("Functional"), TestCategory("AzureStorage"), TestCategory("Storage"), TestCategory("Streaming")]
@@ -110,7 +113,8 @@ namespace Tester.AzureUtils.Streaming
         {
             logger.LogInformation("************************ AQStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(AQStreamProviderName, StreamNamespace, output,
-                    () => TestAzureTableStorageStreamFailureHandler.GetDeliveryFailureCount(AQStreamProviderName));
+                    () => TestAzureTableStorageStreamFailureHandler.GetDeliveryFailureCount(AQStreamProviderName),
+                    cancellationToken: TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamingTests.cs
@@ -141,25 +141,25 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_01_OneProducerGrainOneConsumerGrain()
         {
-            await fixture.Runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+            await fixture.Runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_02_OneProducerGrainOneConsumerClient()
         {
-            await fixture.Runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+            await fixture.Runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_03_OneProducerClientOneConsumerGrain()
         {
-            await fixture.Runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+            await fixture.Runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_04_OneProducerClientOneConsumerClient()
         {
-            await fixture.Runner.StreamTest_04_OneProducerClientOneConsumerClient();
+            await fixture.Runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many different grains ----------------------//
@@ -167,50 +167,50 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+            await fixture.Runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
         {
-            await fixture.Runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+            await fixture.Runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/5648"), TestCategory("Functional")]
         public async Task AQ_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+            await fixture.Runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
         {
-            await fixture.Runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+            await fixture.Runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many Same grains ----------------------//
         [Fact, TestCategory("Functional")]
         public async Task AQ_09_ManySame_ManyProducerGrainsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+            await fixture.Runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_10_ManySame_ManyConsumerGrainsManyProducerGrains()
         {
-            await fixture.Runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+            await fixture.Runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_11_ManySame_ManyProducerGrainsManyConsumerClients()
         {
-            await fixture.Runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+            await fixture.Runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_12_ManySame_ManyProducerClientsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+            await fixture.Runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many producer consumer same grain ----------------------//
@@ -218,13 +218,13 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_13_SameGrain_ConsumerFirstProducerLater()
         {
-            await fixture.Runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+            await fixture.Runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_14_SameGrain_ProducerFirstConsumerLater()
         {
-            await fixture.Runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+            await fixture.Runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
         }
 
         //----------------------------------------------//
@@ -232,14 +232,15 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_15_ConsumeAtProducersRequest()
         {
-            await fixture.Runner.StreamTest_15_ConsumeAtProducersRequest();
+            await fixture.Runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
             var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!.InternalClient!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 16, false); // The fixture deploys the client.
-            await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+            await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -247,7 +248,8 @@ namespace Tester.AzureUtils.Streaming
         {
             var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!.InternalClient!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 17, false); // The fixture deploys the client.
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
-                fixture.Cluster!.StartAdditionalSilo);
+                fixture.Cluster!.StartAdditionalSilo,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         //[Fact, TestCategory("BVT")]
@@ -263,21 +265,21 @@ namespace Tester.AzureUtils.Streaming
         public async Task AQ_19_ConsumerImplicitlySubscribedToProducerClient()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await fixture.Runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient();
+            await fixture.Runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task AQ_20_ConsumerImplicitlySubscribedToProducerGrain()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await fixture.Runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain();
+            await fixture.Runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact(Skip = "Ignored"), TestCategory("Failures")]
         public async Task AQ_21_GenericConsumerImplicitlySubscribedToProducerGrain()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await fixture.Runner.StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain();
+            await fixture.Runner.StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQSubscriptionMultiplicityTests.cs
@@ -86,56 +86,56 @@ namespace Tester.AzureUtils.Streaming
         public async Task AQMultipleParallelSubscriptionTest()
         {
             logger.LogInformation("************************ AQMultipleParallelSubscriptionTest *********************************");
-            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQMultipleLinearSubscriptionTest()
         {
             logger.LogInformation("************************ AQMultipleLinearSubscriptionTest *********************************");
-            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQMultipleSubscriptionTest_AddRemove()
         {
             logger.LogInformation("************************ AQMultipleSubscriptionTest_AddRemove *********************************");
-            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQResubscriptionTest()
         {
             logger.LogInformation("************************ AQResubscriptionTest *********************************");
-            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQResubscriptionAfterDeactivationTest()
         {
             logger.LogInformation("************************ ResubscriptionAfterDeactivationTest *********************************");
-            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQActiveSubscriptionTest()
         {
             logger.LogInformation("************************ AQActiveSubscriptionTest *********************************");
-            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQTwoIntermittentStreamTest()
         {
             logger.LogInformation("************************ AQTwoIntermittentStreamTest *********************************");
-            await runner.TwoIntermittentStreamTest(Guid.NewGuid());
+            await runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQSubscribeFromClientTest()
         {
             logger.LogInformation("************************ AQSubscribeFromClientTest *********************************");
-            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
+            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
@@ -66,12 +66,16 @@ namespace Tester.AzureUtils.Streaming
                 queueDataAdapter,
                 loggerFactory);
             adapterFactory.Init();
-            await SendAndReceiveFromQueueAdapter(adapterFactory);
+            await SendAndReceiveFromQueueAdapter(
+                adapterFactory,
+                TestContext.Current.CancellationToken);
         }
 
-        private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
+        private async Task SendAndReceiveFromQueueAdapter(
+            IQueueAdapterFactory adapterFactory,
+            CancellationToken cancellationToken)
         {
-            IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
+            IQueueAdapter adapter = await adapterFactory.CreateAdapter(cancellationToken);
             IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
             // Create receiver per queue
@@ -79,7 +83,8 @@ namespace Tester.AzureUtils.Streaming
             Dictionary<QueueId, IQueueAdapterReceiver> receivers = mapper.GetAllQueues().ToDictionary(queueId => queueId, adapter.CreateReceiver);
             Dictionary<QueueId, IQueueCache> caches = mapper.GetAllQueues().ToDictionary(queueId => queueId, cache.CreateQueueCache);
 
-            await Task.WhenAll(receivers.Values.Select(receiver => receiver.Initialize(TimeSpan.FromSeconds(5))));
+            await Task.WhenAll(receivers.Values.Select(receiver =>
+                receiver.Initialize(TimeSpan.FromSeconds(5)))).WaitAsync(cancellationToken);
 
             // test using 2 streams
             Guid streamId1 = Guid.NewGuid();
@@ -95,49 +100,60 @@ namespace Tester.AzureUtils.Streaming
                 QueueId queueId = receiverKvp.Key;
                 var receiver = receiverKvp.Value;
                 var qCache = caches[queueId];
-                Task task = Task.Factory.StartNew(() =>
-                {
-                    while (receivedBatches < NumBatches)
+                Task task = Task.Run(
+                    async () =>
                     {
-                        var receivedMessages = receiver.GetQueueMessagesAsync(
+                        while (Volatile.Read(ref receivedBatches) < NumBatches)
+                        {
+                            var receivedMessages = await receiver.GetQueueMessagesAsync(
                             QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG,
-                            CancellationToken.None).Result;
-                        Assert.NotNull(receivedMessages);
-                        var messages = receivedMessages.ToArray();
-                        if (!messages.Any())
-                        {
-                            continue;
+                               cancellationToken);
+                            Assert.NotNull(receivedMessages);
+                            var messages = receivedMessages.ToArray();
+                            if (!messages.Any())
+                            {
+                               continue;
+                            }
+                            foreach (IBatchContainer message in messages)
+                            {
+                               streamsPerQueue.AddOrUpdate(queueId,
+                                   id => new HashSet<StreamId> { message.StreamId },
+                                   (id, set) =>
+                                   {
+                                       set.Add(message.StreamId);
+                                       return set;
+                                   });
+                               this.output.WriteLine("Queue {0} received message on stream {1}", queueId,
+                                   message.StreamId);
+                               Assert.Equal(NumMessagesPerBatch / 2, message.GetEvents<int>().Count());  // "Half the events were ints"
+                               Assert.Equal(NumMessagesPerBatch / 2, message.GetEvents<string>().Count());  // "Half the events were strings"
+                            }
+                            Interlocked.Add(ref receivedBatches, messages.Length);
+                            qCache.AddToCache(messages);
                         }
-                        foreach (IBatchContainer message in messages)
-                        {
-                            streamsPerQueue.AddOrUpdate(queueId,
-                                id => new HashSet<StreamId> { message.StreamId },
-                                (id, set) =>
-                                {
-                                    set.Add(message.StreamId);
-                                    return set;
-                                });
-                            this.output.WriteLine("Queue {0} received message on stream {1}", queueId,
-                                message.StreamId);
-                            Assert.Equal(NumMessagesPerBatch / 2, message.GetEvents<int>().Count());  // "Half the events were ints"
-                            Assert.Equal(NumMessagesPerBatch / 2, message.GetEvents<string>().Count());  // "Half the events were strings"
-                        }
-                        Interlocked.Add(ref receivedBatches, messages.Length);
-                        qCache.AddToCache(messages);
-                    }
-                });
+                    },
+                    cancellationToken);
                 work.Add(task);
             }
 
             // send events
             List<object> events = CreateEvents(NumMessagesPerBatch);
-            work.Add(Task.Factory.StartNew(() => Enumerable.Range(0, NumBatches)
-                .Select(i => i % 2 == 0 ? streamId1 : streamId2)
-                .ToList()
-                .ForEach(streamId =>
-                    adapter.QueueMessageBatchAsync(StreamId.Create(streamId.ToString(), streamId),
-                        events.Take(NumMessagesPerBatch).ToArray(), null!, RequestContextExtensions.Export(this.fixture.DeepCopier)!).Wait())));
-            await Task.WhenAll(work);
+            work.Add(Task.Run(
+                async () =>
+                {
+                    foreach (var streamId in Enumerable.Range(0, NumBatches)
+                        .Select(i => i % 2 == 0 ? streamId1 : streamId2))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await adapter.QueueMessageBatchAsync(
+                            StreamId.Create(streamId.ToString(), streamId),
+                            events.Take(NumMessagesPerBatch).ToArray(),
+                            null!,
+                            RequestContextExtensions.Export(this.fixture.DeepCopier)!);
+                    }
+                },
+                cancellationToken));
+            await Task.WhenAll(work).WaitAsync(cancellationToken);
 
             // Make sure we got back everything we sent
             Assert.Equal(NumBatches, receivedBatches);

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
@@ -132,7 +132,10 @@ namespace Tester.AzureUtils.Streaming
                 includeHistory: true);
 
             var existingSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
-            var addedSilos = await this.HostedCluster.StartAdditionalSilosAsync(2, true);
+            var addedSilos = await this.HostedCluster.StartAdditionalSilosAsync(
+                2,
+                true,
+                TestContext.Current.CancellationToken);
             var addedSiloAddresses = addedSilos.Select(silo => silo.SiloAddress).ToArray();
             var activeSiloAddresses = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
 

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
@@ -113,32 +113,59 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_1()
         {
-            await WaitForAgentsState(2, "1", includeHistory: true);
+            await WaitForAgentsState(
+                2,
+                "1",
+                TestContext.Current.CancellationToken,
+                includeHistory: true);
 
-            await WaitForAgentsState(4, "2");
+            await WaitForAgentsState(4, "2", TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_2()
         {
-            await WaitForAgentsState(2, "1", includeHistory: true);
+            await WaitForAgentsState(
+                2,
+                "1",
+                TestContext.Current.CancellationToken,
+                includeHistory: true);
 
             var existingSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
             var addedSilos = await this.HostedCluster.StartAdditionalSilosAsync(2, true);
             var addedSiloAddresses = addedSilos.Select(silo => silo.SiloAddress).ToArray();
             var activeSiloAddresses = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
 
-            await WaitForAgentsState(2, "2");
+            await WaitForAgentsState(2, "2", TestContext.Current.CancellationToken);
 
-            await diagnosticObserver.WaitForLocalMaturityAsync(activeSiloAddresses, AGENT_STATE_TIMEOUT, "3");
-            await diagnosticObserver.WaitForRemoteMaturityAsync(existingSilos, addedSiloAddresses, AGENT_STATE_TIMEOUT, "3");
-            await WaitForAgentsState(2, "3");
+            await diagnosticObserver.WaitForLocalMaturityAsync(
+                activeSiloAddresses,
+                AGENT_STATE_TIMEOUT,
+                "3",
+                TestContext.Current.CancellationToken);
+            await diagnosticObserver.WaitForRemoteMaturityAsync(
+                existingSilos,
+                addedSiloAddresses,
+                AGENT_STATE_TIMEOUT,
+                "3",
+                TestContext.Current.CancellationToken);
+            await WaitForAgentsState(2, "3", TestContext.Current.CancellationToken);
         }
 
-        private Task WaitForAgentsState(int numExpectedAgentsPerSilo, string callContext, bool includeHistory = false)
+        private Task WaitForAgentsState(
+            int numExpectedAgentsPerSilo,
+            string callContext,
+            CancellationToken cancellationToken,
+            bool includeHistory = false)
         {
             var activeSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
-            return diagnosticObserver.WaitForAgentsStateAsync(activeSilos, numExpectedAgentsPerSilo, includeHistory, AGENT_STATE_TIMEOUT, callContext);
+            return diagnosticObserver.WaitForAgentsStateAsync(
+                activeSilos,
+                numExpectedAgentsPerSilo,
+                includeHistory,
+                AGENT_STATE_TIMEOUT,
+                callContext,
+                cancellationToken);
         }
 
         private sealed class StreamQueueDiagnosticObserver : IDisposable, IObserver<StreamingEvents.StreamingEvent>
@@ -163,23 +190,40 @@ namespace Tester.AzureUtils.Streaming
                 return new StreamQueueDiagnosticObserver(streamProvider);
             }
 
-            public Task WaitForAgentsStateAsync(SiloAddress[] expectedSilos, int expectedAgentsPerSilo, bool includeHistory, TimeSpan timeout, string callContext)
+            public Task WaitForAgentsStateAsync(
+                SiloAddress[] expectedSilos,
+                int expectedAgentsPerSilo,
+                bool includeHistory,
+                TimeSpan timeout,
+                string callContext,
+                CancellationToken cancellationToken)
             {
                 return WaitUntilAsync(
                     () => HasAgentState(expectedSilos, expectedAgentsPerSilo, includeHistory),
                     timeout,
-                    () => $"Call {callContext}: expected silos {Utils.EnumerableToString(expectedSilos)} to have {expectedAgentsPerSilo} agents each, got {FormatAgentStates(expectedSilos)}.");
+                    () => $"Call {callContext}: expected silos {Utils.EnumerableToString(expectedSilos)} to have {expectedAgentsPerSilo} agents each, got {FormatAgentStates(expectedSilos)}.",
+                    cancellationToken);
             }
 
-            public Task WaitForLocalMaturityAsync(SiloAddress[] siloAddresses, TimeSpan timeout, string callContext)
+            public Task WaitForLocalMaturityAsync(
+                SiloAddress[] siloAddresses,
+                TimeSpan timeout,
+                string callContext,
+                CancellationToken cancellationToken)
             {
                 return WaitUntilAsync(
                     () => siloAddresses.All(locallyMaturedSilos.Contains),
                     timeout,
-                    () => $"Call {callContext}: timed out waiting for local queue balancer maturity on silos {Utils.EnumerableToString(siloAddresses)}. Matured silos: {Utils.EnumerableToString(locallyMaturedSilos)}.");
+                    () => $"Call {callContext}: timed out waiting for local queue balancer maturity on silos {Utils.EnumerableToString(siloAddresses)}. Matured silos: {Utils.EnumerableToString(locallyMaturedSilos)}.",
+                    cancellationToken);
             }
 
-            public Task WaitForRemoteMaturityAsync(SiloAddress[] localSilos, SiloAddress[] maturedSilos, TimeSpan timeout, string callContext)
+            public Task WaitForRemoteMaturityAsync(
+                SiloAddress[] localSilos,
+                SiloAddress[] maturedSilos,
+                TimeSpan timeout,
+                string callContext,
+                CancellationToken cancellationToken)
             {
                 var expectedMaturities =
                     (from localSilo in localSilos
@@ -189,7 +233,8 @@ namespace Tester.AzureUtils.Streaming
                 return WaitUntilAsync(
                     () => expectedMaturities.All(remotelyMaturedSilos.Contains),
                     timeout,
-                    () => $"Call {callContext}: timed out waiting for remote queue balancer maturity. Expected: {FormatMaturities(expectedMaturities)}. Completed: {FormatMaturities(remotelyMaturedSilos)}.");
+                    () => $"Call {callContext}: timed out waiting for remote queue balancer maturity. Expected: {FormatMaturities(expectedMaturities)}. Completed: {FormatMaturities(remotelyMaturedSilos)}.",
+                    cancellationToken);
             }
 
             public void OnNext(StreamingEvents.StreamingEvent value)
@@ -244,7 +289,11 @@ namespace Tester.AzureUtils.Streaming
                         : agentStates.TryGetValue(silo, out var state) && state.RunningAgents == expectedAgentsPerSilo);
             }
 
-            private Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout, Func<string> timeoutMessage)
+            private Task WaitUntilAsync(
+                Func<bool> predicate,
+                TimeSpan timeout,
+                Func<string> timeoutMessage,
+                CancellationToken cancellationToken)
             {
                 lock (lockObj)
                 {
@@ -255,15 +304,23 @@ namespace Tester.AzureUtils.Streaming
 
                     var waiter = new ConditionWaiter(predicate);
                     waiters.Add(waiter);
-                    return WaitWithTimeoutAsync(waiter, timeout, timeoutMessage);
+                    return WaitWithTimeoutAsync(
+                        waiter,
+                        timeout,
+                        timeoutMessage,
+                        cancellationToken);
                 }
             }
 
-            private async Task WaitWithTimeoutAsync(ConditionWaiter waiter, TimeSpan timeout, Func<string> timeoutMessage)
+            private async Task WaitWithTimeoutAsync(
+                ConditionWaiter waiter,
+                TimeSpan timeout,
+                Func<string> timeoutMessage,
+                CancellationToken cancellationToken)
             {
                 try
                 {
-                    await waiter.Task.WaitAsync(timeout);
+                    await waiter.Task.WaitAsync(timeout, cancellationToken);
                 }
                 catch (TimeoutException)
                 {
@@ -275,6 +332,15 @@ namespace Tester.AzureUtils.Streaming
                     }
 
                     throw new TimeoutException(message);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    lock (lockObj)
+                    {
+                        waiters.Remove(waiter);
+                    }
+
+                    throw;
                 }
             }
 

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
@@ -110,8 +110,14 @@ namespace UnitTests.HaloTests.Streaming
             _streamProvider = AzureQueueStreamProviderName;
             Guid consumerGuid = Guid.NewGuid();
             Guid producerGuid = Guid.NewGuid();
-            await ConsumerProducerTest(consumerGuid, producerGuid);
-            await ConsumerProducerTest(consumerGuid, producerGuid);
+            await ConsumerProducerTest(
+                consumerGuid,
+                producerGuid,
+                TestContext.Current.CancellationToken);
+            await ConsumerProducerTest(
+                consumerGuid,
+                producerGuid,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -122,11 +128,20 @@ namespace UnitTests.HaloTests.Streaming
             _streamProvider = AzureQueueStreamProviderName;
             Guid producerGuid = Guid.NewGuid();
             Guid consumerGuid = Guid.NewGuid();
-            await ProducerConsumerTest(producerGuid, consumerGuid);
-            await ProducerConsumerTest(producerGuid, consumerGuid);
+            await ProducerConsumerTest(
+                producerGuid,
+                consumerGuid,
+                TestContext.Current.CancellationToken);
+            await ProducerConsumerTest(
+                producerGuid,
+                consumerGuid,
+                TestContext.Current.CancellationToken);
         }
 
-        private async Task ConsumerProducerTest(Guid consumerGuid, Guid producerGuid)
+        private async Task ConsumerProducerTest(
+            Guid consumerGuid,
+            Guid producerGuid,
+            CancellationToken cancellationToken)
         {
             // consumer joins first, producer later
             IConsumerEventCountingGrain consumer = this.fixture.GrainFactory.GetGrain<IConsumerEventCountingGrain>(consumerGuid);
@@ -136,19 +151,26 @@ namespace UnitTests.HaloTests.Streaming
             await producer.BecomeProducer(_streamId, _streamProvider);
 
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(Timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(Timeout);
 
             await producer.SendEvent();
 
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync((_, cancellationToken) => CheckCounters(producer, consumer, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync(
+                (_, token) => CheckCounters(producer, consumer, token),
+                Timeout,
+                cancellationToken: cts.Token);
 
             await consumer.StopConsuming();
         }
 
-        private async Task ProducerConsumerTest(Guid producerGuid, Guid consumerGuid)
+        private async Task ProducerConsumerTest(
+            Guid producerGuid,
+            Guid consumerGuid,
+            CancellationToken cancellationToken)
         {
             // producer joins first, consumer later
             IProducerEventCountingGrain producer = this.fixture.GrainFactory.GetGrain<IProducerEventCountingGrain>(producerGuid);
@@ -158,14 +180,18 @@ namespace UnitTests.HaloTests.Streaming
             await consumer.BecomeConsumer(_streamId, _streamProvider);
 
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(Timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(Timeout);
 
             await producer.SendEvent();
 
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync((_, cancellationToken) => CheckCounters(producer, consumer, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync(
+                (_, token) => CheckCounters(producer, consumer, token),
+                Timeout,
+                cancellationToken: cts.Token);
 
             await consumer.StopConsuming();
         }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/SampleAzureQueueStreamingTests.cs
@@ -58,7 +58,7 @@ namespace Tester.AzureUtils.Streaming
         {
             logger.LogInformation("************************ SampleStreamingTests_4 *********************************");
             var runner = new SampleStreamingTests(StreamProvider, this.logger, this.HostedCluster);
-            await runner.StreamingTests_Consumer_Producer(Guid.NewGuid());
+            await runner.StreamingTests_Consumer_Producer(Guid.NewGuid(), TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
@@ -66,7 +66,7 @@ namespace Tester.AzureUtils.Streaming
         {
             logger.LogInformation("************************ SampleStreamingTests_5 *********************************");
             var runner = new SampleStreamingTests(StreamProvider, this.logger, this.HostedCluster);
-            await runner.StreamingTests_Producer_Consumer(Guid.NewGuid());
+            await runner.StreamingTests_Producer_Consumer(Guid.NewGuid(), TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/StreamReliabilityTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/StreamReliabilityTests.cs
@@ -703,7 +703,12 @@ namespace UnitTests.Streaming.Reliability
 
             string when = "After restart all silos";
             CheckSilosRunning(when, _numExpectedSilos);
-            await WaitForGrainsReachableAsync(when, false, producerGrainId, consumerGrainId);
+            await WaitForGrainsReachableAsync(
+                when,
+                false,
+                TestContext.Current.CancellationToken,
+                producerGrainId,
+                consumerGrainId);
 
             when = "SendItem";
             var producerGrain = GetGrain(producerGrainId);
@@ -739,7 +744,12 @@ namespace UnitTests.Streaming.Reliability
 
             when = "After restart all silos";
             CheckSilosRunning(when, _numExpectedSilos);
-            await WaitForGrainsReachableAsync(when, false, producerGrainId, consumerGrainId);
+            await WaitForGrainsReachableAsync(
+                when,
+                false,
+                TestContext.Current.CancellationToken,
+                producerGrainId,
+                consumerGrainId);
             // Note: It is not guaranteed that the list of producers will not get modified / cleaned up during silo shutdown, so can't assume count will be 1 here.
             // Expected == -1 means don't care.
             await StreamTestUtils.CheckPubSubCounts(this.InternalClient, _output, when, -1, 1, _streamId, _streamProviderName, StreamTestsConstants.StreamReliabilityNamespace);
@@ -786,7 +796,12 @@ namespace UnitTests.Streaming.Reliability
 
             when = "After kill one silo";
             CheckSilosRunning(when, _numExpectedSilos - 1);
-            await WaitForGrainsReachableAsync(when, true, producerGrainId, consumerGrainId);
+            await WaitForGrainsReachableAsync(
+                when,
+                true,
+                TestContext.Current.CancellationToken,
+                producerGrainId,
+                consumerGrainId);
 
             when = "SendItem";
             await SendItemAndWaitForDeliveryAsync(when, producerGrain, _subscriptionId, 1);
@@ -825,7 +840,12 @@ namespace UnitTests.Streaming.Reliability
 
             when = "After kill one silo";
             CheckSilosRunning(when, _numExpectedSilos - 1);
-            await WaitForGrainsReachableAsync(when, true, producerGrainId, consumerGrainId);
+            await WaitForGrainsReachableAsync(
+                when,
+                true,
+                TestContext.Current.CancellationToken,
+                producerGrainId,
+                consumerGrainId);
 
             when = "SendItem";
             await SendItemAndWaitForDeliveryAsync(when, producerGrain, _subscriptionId, 1);
@@ -864,7 +884,12 @@ namespace UnitTests.Streaming.Reliability
 
             when = "After restart one silo";
             CheckSilosRunning(when, _numExpectedSilos);
-            await WaitForGrainsReachableAsync(when, true, producerGrainId, consumerGrainId);
+            await WaitForGrainsReachableAsync(
+                when,
+                true,
+                TestContext.Current.CancellationToken,
+                producerGrainId,
+                consumerGrainId);
 
             when = "SendItem";
             await SendItemAndWaitForDeliveryAsync(when, producerGrain, _subscriptionId, 1);
@@ -903,7 +928,12 @@ namespace UnitTests.Streaming.Reliability
 
             when = "After restart one silo";
             CheckSilosRunning(when, _numExpectedSilos);
-            await WaitForGrainsReachableAsync(when, true, producerGrainId, consumerGrainId);
+            await WaitForGrainsReachableAsync(
+                when,
+                true,
+                TestContext.Current.CancellationToken,
+                producerGrainId,
+                consumerGrainId);
 
             when = "SendItem";
             await SendItemAndWaitForDeliveryAsync(when, producerGrain, _subscriptionId, 1);
@@ -1363,6 +1393,7 @@ namespace UnitTests.Streaming.Reliability
         {
             foreach (var task in tasks)
             {
+                // Fault observation must run even after the test is canceled.
                 _ = task.ContinueWith(
                     static completed => _ = completed.Exception,
                     CancellationToken.None,
@@ -1394,7 +1425,11 @@ namespace UnitTests.Streaming.Reliability
         private readonly record struct ConsumerSubscription(IStreamReliabilityTestGrain Grain, Guid SubscriptionId);
 #endif
 
-        private async Task WaitForGrainsReachableAsync(string when, bool didKill, params long[] grainIds)
+        private async Task WaitForGrainsReachableAsync(
+            string when,
+            bool didKill,
+            CancellationToken cancellationToken,
+            params long[] grainIds)
         {
             var stopwatch = Stopwatch.StartNew();
             Exception? lastException = null;
@@ -1425,7 +1460,10 @@ namespace UnitTests.Streaming.Reliability
 
                 try
                 {
-                    await WaitForLifecycleAndStreamingReadinessAsync($"{when} after transient grain reachability failure", didKill).WaitAsync(remaining);
+                    await WaitForLifecycleAndStreamingReadinessAsync(
+                            $"{when} after transient grain reachability failure",
+                            didKill)
+                        .WaitAsync(remaining, cancellationToken);
                 }
                 catch (Exception exception) when (exception is TimeoutException || IsTransientLifecycleException(exception))
                 {

--- a/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
+++ b/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
@@ -54,11 +54,14 @@ namespace Tester.AzureUtils
     {
         protected const string INSTANCE_TABLE_NAME = "UnitTestAzureData";
 
-        public UnitTestAzureTableDataManager()
+        public UnitTestAzureTableDataManager(CancellationToken cancellationToken)
             : base(new AzureStorageOperationOptions { TableName = INSTANCE_TABLE_NAME }.ConfigureTestDefaults(),
                   NullLoggerFactory.Instance.CreateLogger<UnitTestAzureTableDataManager>())
         {
-            InitTableAsync().WaitAsync(new AzureStoragePolicyOptions().CreationTimeout).Wait();
+            InitTableAsync()
+                .WaitAsync(new AzureStoragePolicyOptions().CreationTimeout, cancellationToken)
+                .GetAwaiter()
+                .GetResult();
         }
     }
 }

--- a/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraClusteringTableTests.cs
+++ b/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraClusteringTableTests.cs
@@ -35,7 +35,8 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_GetGateways()
     {
-        var (membershipTable, gatewayListProvider) = await CreateNewMembershipTableAsync();
+        var (membershipTable, gatewayListProvider) = await CreateNewMembershipTableAsync(
+            TestContext.Current.CancellationToken);
 
         var membershipEntries = Enumerable.Range(0, 10).Select(_ => CreateMembershipEntryForTest()).ToArray();
 
@@ -71,7 +72,8 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_ReadAll_EmptyTable()
     {
-        var (membershipTable, _) = await CreateNewMembershipTableAsync();
+        var (membershipTable, _) = await CreateNewMembershipTableAsync(
+            TestContext.Current.CancellationToken);
 
         var data = await membershipTable.ReadAll();
         Assert.NotNull(data);
@@ -86,7 +88,8 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_InsertRow()
     {
-        var (membershipTable, _) = await CreateNewMembershipTableAsync();
+        var (membershipTable, _) = await CreateNewMembershipTableAsync(
+            TestContext.Current.CancellationToken);
 
         var membershipEntry = CreateMembershipEntryForTest();
 
@@ -109,7 +112,10 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_ReadRow_Insert_Read()
     {
-        var (membershipTable, gatewayProvider) = await CreateNewMembershipTableAsync("Phalanx", "blu");
+        var (membershipTable, gatewayProvider) = await CreateNewMembershipTableAsync(
+            "Phalanx",
+            "blu",
+            TestContext.Current.CancellationToken);
 
         MembershipTableData data = await membershipTable.ReadAll();
 
@@ -163,7 +169,8 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_ReadAll_Insert_ReadAll()
     {
-        var (membershipTable, _) = await CreateNewMembershipTableAsync();
+        var (membershipTable, _) = await CreateNewMembershipTableAsync(
+            TestContext.Current.CancellationToken);
 
         var data = await membershipTable.ReadAll();
         _testOutputHelper.WriteLine("Membership.ReadAll returned TableVersion={0} Data={1}", data.Version, data);
@@ -196,7 +203,8 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_UpdateRow()
     {
-        var (membershipTable, _) = await CreateNewMembershipTableAsync();
+        var (membershipTable, _) = await CreateNewMembershipTableAsync(
+            TestContext.Current.CancellationToken);
 
         var tableData = await membershipTable.ReadAll();
         Assert.NotNull(tableData.Version);
@@ -294,11 +302,14 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
         var tasks = new List<Task>();
         for (var i = 0; i < 50; i++)
         {
-            tasks.Add(Task.Run(async () =>
-            {
-                await Task.Yield();
-                var (membershipTable, _) = await CreateNewMembershipTableAsync();
-            }));
+            tasks.Add(Task.Run(
+                async () =>
+                {
+                    await Task.Yield();
+                    var (membershipTable, _) = await CreateNewMembershipTableAsync(
+                        TestContext.Current.CancellationToken);
+                },
+                TestContext.Current.CancellationToken));
         }
         await Task.WhenAll(tasks);
     }
@@ -306,7 +317,8 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_UpdateRowInParallel()
     {
-        var (membershipTable, _) = await CreateNewMembershipTableAsync();
+        var (membershipTable, _) = await CreateNewMembershipTableAsync(
+            TestContext.Current.CancellationToken);
 
         var tableData = await membershipTable.ReadAll();
 
@@ -326,7 +338,7 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
                 var updatedTableData = await membershipTable.ReadAll();
                 var updatedRow = updatedTableData.TryGet(data.SiloAddress);
 
-                await Task.Delay(10);
+                await Task.Delay(10, TestContext.Current.CancellationToken);
                 if (updatedRow is null) continue;
 
                 var tableVersion = updatedTableData.Version.Next();
@@ -339,7 +351,7 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
                     done = false;
                 }
             } while (!done);
-        })).WithTimeout(TimeSpan.FromSeconds(30));
+        })).WithTimeout(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
 
         tableData = await membershipTable.ReadAll();
@@ -355,11 +367,15 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [InlineData(false)]
     public async Task MembershipTable_UpdateIAmAlive(bool cassandraTtl)
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
+
         // Drop the membership table before starting because the TTL behavior depends on the table creation
-        ISession ttlSession = await CreateSession();
+        ISession ttlSession = await CreateSession(testCancellationToken);
         await ttlSession.ExecuteAsync(new SimpleStatement("DROP TABLE IF EXISTS membership;"));
 
-        var (membershipTable, _) = await CreateNewMembershipTableAsync(cassandraTtl:cassandraTtl);
+        var (membershipTable, _) = await CreateNewMembershipTableAsync(
+            testCancellationToken,
+            cassandraTtl: cassandraTtl);
 
         var tableData = await membershipTable.ReadAll();
 
@@ -413,14 +429,17 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
 
         // Validate data automatically expires when using Cassandra TTL, and is still present if not
         // The Cassandra TTL is set to 20 seconds for this testing
-        using var cts = new CancellationTokenSource(delay:TimeSpan.FromSeconds(30));
+        using var timeoutCts = new CancellationTokenSource(delay: TimeSpan.FromSeconds(30));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutCts.Token,
+            testCancellationToken);
         if (cassandraTtl)
         {
-            await ValidateDataIsDeleted(cts.Token);
+            await ValidateDataIsDeleted(cts.Token, timeoutCts.Token);
         }
         else
         {
-            await ValidateDataIsNotDeleted(cts.Token);
+            await ValidateDataIsNotDeleted(cts.Token, timeoutCts.Token);
         }
 
         return;
@@ -430,7 +449,7 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
             if (cassandraTtl && initial)
             {
                 // When actually using the TTL, wait 5 seconds so the TTL values will be less than 20
-                await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken.None);
+                await Task.Delay(TimeSpan.FromSeconds(5), testCancellationToken);
             }
 
             // Cassandra columns that are part of the primary key are not available with the TTL command
@@ -515,11 +534,14 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
             }
         }
 
-        async Task ValidateDataIsDeleted(CancellationToken ct)
+        async Task ValidateDataIsDeleted(
+            CancellationToken cancellationToken,
+            CancellationToken timeoutToken)
         {
             while (true)
             {
-                if (ct.IsCancellationRequested)
+                testCancellationToken.ThrowIfCancellationRequested();
+                if (timeoutToken.IsCancellationRequested)
                 {
                     throw new TimeoutException("Did not validate Cassandra data deletion within timeout");
                 }
@@ -531,21 +553,47 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
                     return;
                 }
 
-                await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+                }
+                catch (OperationCanceledException) when (
+                    timeoutToken.IsCancellationRequested
+                    && !testCancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException("Did not validate Cassandra data deletion within timeout");
+                }
             }
         }
 
-        async Task ValidateDataIsNotDeleted(CancellationToken ct)
+        async Task ValidateDataIsNotDeleted(
+            CancellationToken cancellationToken,
+            CancellationToken timeoutToken)
         {
-            while (!ct.IsCancellationRequested)
+            while (true)
             {
+                testCancellationToken.ThrowIfCancellationRequested();
+                if (timeoutToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 tableData = await membershipTable.ReadAll();
                 if (tableData.Members.Count == 0)
                 {
                     throw new Exception("Cassandra data was unexpectedly deleted when not using a TTL");
                 }
 
-                await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+                }
+                catch (OperationCanceledException) when (
+                    timeoutToken.IsCancellationRequested
+                    && !testCancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
             }
         }
     }
@@ -553,7 +601,8 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     [Fact]
     public async Task MembershipTable_CleanupDefunctSiloEntries()
     {
-        var (membershipTable, _) = await CreateNewMembershipTableAsync();
+        var (membershipTable, _) = await CreateNewMembershipTableAsync(
+            TestContext.Current.CancellationToken);
 
         var data = await membershipTable.ReadAll();
         _testOutputHelper.WriteLine("Membership.ReadAll returned TableVersion={0} Data={1}", data.Version, data);
@@ -650,6 +699,7 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
     private async Task<(IMembershipTable, IGatewayListProvider)> CreateNewMembershipTableAsync(
         string serviceId,
         string clusterId,
+        CancellationToken cancellationToken,
         bool cassandraTtl = false)
     {
         var services = new ServiceCollection()
@@ -658,7 +708,7 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
             .Configure<ClusterOptions>(o => { o.ServiceId = serviceId; o.ClusterId = clusterId; })
             .Configure<CassandraClusteringOptions>(o =>
             {
-                o.ConfigureClient(async _ => await CreateSession());
+                o.ConfigureClient(async _ => await CreateSession(cancellationToken));
                 o.UseCassandraTtl = cassandraTtl;
             })
             .Configure<ClusterMembershipOptions>(o =>
@@ -680,19 +730,25 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
         return (membershipTable, gatewayProvider);
     }
 
-    private async Task<ISession> CreateSession()
+    private async Task<ISession> CreateSession(CancellationToken cancellationToken)
     {
-        var container = await _cassandraContainer.RunImage();
+        var container = await _cassandraContainer.RunImage(cancellationToken);
 
         return container.session;
     }
 
-    private Task<(IMembershipTable, IGatewayListProvider)> CreateNewMembershipTableAsync(bool cassandraTtl = false)
+    private Task<(IMembershipTable, IGatewayListProvider)> CreateNewMembershipTableAsync(
+        CancellationToken cancellationToken,
+        bool cassandraTtl = false)
     {
         var serviceId = $"Service_{Guid.NewGuid()}";
         var clusterId = $"Cluster_{Guid.NewGuid()}";
 
-        return CreateNewMembershipTableAsync(serviceId, clusterId, cassandraTtl);
+        return CreateNewMembershipTableAsync(
+            serviceId,
+            clusterId,
+            cancellationToken,
+            cassandraTtl);
     }
 
     [Fact]
@@ -702,9 +758,15 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
         var clusterId = $"Cluster_{Guid.NewGuid()}";
         var clusterOptions = new ClusterOptions { ServiceId = serviceId, ClusterId = clusterId + "_1" };
         var clusterIdentifier = clusterOptions.ServiceId + "-" + clusterOptions.ClusterId;
-        var (membershipTable, gatewayProvider) = await CreateNewMembershipTableAsync(serviceId, clusterId + "_1");
+        var (membershipTable, gatewayProvider) = await CreateNewMembershipTableAsync(
+            serviceId,
+            clusterId + "_1",
+            TestContext.Current.CancellationToken);
 
-        var (otherMembershipTable, _) = await CreateNewMembershipTableAsync(serviceId, clusterId + "_2");
+        var (otherMembershipTable, _) = await CreateNewMembershipTableAsync(
+            serviceId,
+            clusterId + "_2",
+            TestContext.Current.CancellationToken);
 
         var tableData = await membershipTable.ReadAll();
 

--- a/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraContainer.cs
+++ b/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraContainer.cs
@@ -7,19 +7,58 @@ namespace Tester.Cassandra.Clustering;
 
 public class CassandraContainer
 {
-    public Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> RunImage() => _innerRunImage.Value;
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(30);
+    private readonly object _lock = new();
+    private Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)>? _runImage;
 
-    private readonly Lazy<Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)>> _innerRunImage =
-        new(async () =>
+    public async Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> RunImage(
+        CancellationToken cancellationToken)
+    {
+        Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> task;
+        lock (_lock)
         {
-            var containerPort = 9042;
+            if (_runImage is { IsCanceled: true } or { IsFaulted: true })
+            {
+                _runImage = null;
+            }
 
-            var container = new ContainerBuilder("cassandra:" + Environment.GetEnvironmentVariable("CASSANDRAVERSION"))
-                    .WithPortBinding(containerPort, true)
-                    .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(containerPort))
-                    .Build();
+            task = _runImage ??= RunImageCore(cancellationToken);
+        }
 
-            await container.StartAsync();
+        try
+        {
+            return await task.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            lock (_lock)
+            {
+                if (ReferenceEquals(_runImage, task)
+                    && task.IsCompleted
+                    && !task.IsCompletedSuccessfully)
+                {
+                    _runImage = null;
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> RunImageCore(
+        CancellationToken cancellationToken)
+    {
+        var containerPort = 9042;
+        IContainer? container = null;
+
+        try
+        {
+            container = new ContainerBuilder("cassandra:" + Environment.GetEnvironmentVariable("CASSANDRAVERSION"))
+                .WithPortBinding(containerPort, true)
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(containerPort))
+                .Build();
+
+            await container.StartAsync(cancellationToken);
 
             var exposedPort = container.GetMappedPublicPort(containerPort);
 
@@ -34,7 +73,25 @@ public class CassandraContainer
                     .CreateSimpleStrategyReplicationProperty(1));
 
             return (container, exposedPort, cluster, session);
-        });
+        }
+        catch
+        {
+            if (container is not null)
+            {
+                try
+                {
+                    using var cleanupCancellation = new CancellationTokenSource(CleanupTimeout);
+                    await container.DisposeAsync().AsTask().WaitAsync(cleanupCancellation.Token);
+                }
+                catch
+                {
+                    // Preserve the startup failure.
+                }
+            }
+
+            throw;
+        }
+    }
 
     public string Name { get; set; } = string.Empty;
 }

--- a/test/Extensions/Orleans.Clustering.Cassandra.Tests/Utility/TestExtensions.cs
+++ b/test/Extensions/Orleans.Clustering.Cassandra.Tests/Utility/TestExtensions.cs
@@ -2,46 +2,61 @@ namespace Tester.Cassandra.Utility
 {
     public static class TestExtensions
     {
-        public static async Task WithTimeout(this Task taskToComplete, TimeSpan timeout)
+        public static async Task WithTimeout(
+            this Task taskToComplete,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
         {
-            if (taskToComplete.IsCompleted)
+            using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);
+            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                timeoutCancellationTokenSource.Token,
+                cancellationToken);
+
+            try
             {
-                await taskToComplete;
-                return;
+                await taskToComplete.WaitAsync(linkedCancellationTokenSource.Token);
             }
-
-            using var timeoutCancellationTokenSource = new CancellationTokenSource();
-            var completedTask = await Task.WhenAny(taskToComplete, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
-
-            if (taskToComplete == completedTask)
+            catch (OperationCanceledException) when (
+                timeoutCancellationTokenSource.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested)
             {
-                timeoutCancellationTokenSource.Cancel();
-                await taskToComplete;
-                return;
-            }
+                if (taskToComplete.IsCompleted)
+                {
+                    await taskToComplete;
+                    return;
+                }
 
-            taskToComplete.Ignore();
-            throw new TimeoutException(string.Format("WithTimeout has timed out after {0}.", timeout));
+                taskToComplete.Ignore();
+                throw new TimeoutException(string.Format("WithTimeout has timed out after {0}.", timeout));
+            }
         }
 
-        public static async Task<T> WithTimeout<T>(this Task<T> taskToComplete, TimeSpan timeout)
+        public static async Task<T> WithTimeout<T>(
+            this Task<T> taskToComplete,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
         {
-            if (taskToComplete.IsCompleted)
+            using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);
+            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                timeoutCancellationTokenSource.Token,
+                cancellationToken);
+
+            try
             {
-                return await taskToComplete;
+                return await taskToComplete.WaitAsync(linkedCancellationTokenSource.Token);
             }
-
-            using var timeoutCancellationTokenSource = new CancellationTokenSource();
-            var completedTask = await Task.WhenAny(taskToComplete, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
-
-            if (taskToComplete == completedTask)
+            catch (OperationCanceledException) when (
+                timeoutCancellationTokenSource.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested)
             {
-                timeoutCancellationTokenSource.Cancel();
-                return await taskToComplete;
-            }
+                if (taskToComplete.IsCompleted)
+                {
+                    return await taskToComplete;
+                }
 
-            taskToComplete.Ignore();
-            throw new TimeoutException(string.Format("WithTimeout has timed out after {0}.", timeout));
+                taskToComplete.Ignore();
+                throw new TimeoutException(string.Format("WithTimeout has timed out after {0}.", timeout));
+            }
         }
     }
 }

--- a/test/Extensions/Orleans.Clustering.Consul.Tests/ConsulMembershipTableTest.cs
+++ b/test/Extensions/Orleans.Clustering.Consul.Tests/ConsulMembershipTableTest.cs
@@ -77,7 +77,9 @@ namespace Consul.Tests
 
         protected override async Task<string> GetConnectionString()
         {
-            return await ConsulTestUtils.EnsureConsulAsync() ? ConsulTestUtils.ConsulConnectionString : null!;
+            return await ConsulTestUtils.EnsureConsulAsync(TestContext.Current.CancellationToken)
+                ? ConsulTestUtils.ConsulConnectionString
+                : null!;
         }
 
         /// <summary>

--- a/test/Extensions/Orleans.Clustering.Consul.Tests/ConsulTestUtils.cs
+++ b/test/Extensions/Orleans.Clustering.Consul.Tests/ConsulTestUtils.cs
@@ -14,9 +14,13 @@ namespace Consul.Tests
 
         private const string WindowsDockerModeSkipReason = "Docker is running in Windows container mode (OSType=windows), so Consul tests are skipped.";
 
-        private static readonly Lazy<string?> DockerDaemonOsTypeLazy = new(GetDockerDaemonOsType);
+        private static readonly Lazy<string?> DockerDaemonOsTypeLazy = new(
+            GetDockerDaemonOsType,
+            LazyThreadSafetyMode.PublicationOnly);
 
-        private static readonly Lazy<string?> EnsureConsulSkipReasonLazy = new(() => EnsureConsulAndGetSkipReasonAsync().GetAwaiter().GetResult());
+        private static readonly Lazy<string?> EnsureConsulSkipReasonLazy = new(
+            () => EnsureConsulAndGetSkipReasonAsync().GetAwaiter().GetResult(),
+            LazyThreadSafetyMode.PublicationOnly);
 
         private static readonly ConsulContainer _container = new ConsulBuilder("public.ecr.aws/hashicorp/consul:1.19")
             .WithCreateParameterModifier(parameters =>
@@ -44,8 +48,9 @@ namespace Consul.Tests
                 throw Xunit.Sdk.SkipException.ForSkip(skipReason);
         }
 
-        public static Task<bool> EnsureConsulAsync()
+        public static Task<bool> EnsureConsulAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(EnsureConsulSkipReasonLazy.Value is null);
         }
 
@@ -59,14 +64,14 @@ namespace Consul.Tests
 
             try
             {
-                await _container.StartAsync();
+                await _container.StartAsync(TestContext.Current.CancellationToken);
                 return null;
             }
             catch (HttpRequestException)
             {
                 return DockerUnavailableSkipReason;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!TestContext.Current.CancellationToken.IsCancellationRequested)
             {
                 return DockerUnavailableSkipReason;
             }
@@ -104,14 +109,17 @@ namespace Consul.Tests
                 using var dockerClient = TestcontainersSettings.OS.DockerEndpointAuthConfig
                     .GetDockerClientConfiguration(Guid.NewGuid())
                     .CreateClient();
-                var dockerInfo = dockerClient.System.GetSystemInfoAsync().GetAwaiter().GetResult();
+                var dockerInfo = dockerClient.System
+                    .GetSystemInfoAsync(TestContext.Current.CancellationToken)
+                    .GetAwaiter()
+                    .GetResult();
                 return dockerInfo.OSType;
             }
             catch (HttpRequestException)
             {
                 return null;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!TestContext.Current.CancellationToken.IsCancellationRequested)
             {
                 return null;
             }

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreClusteringTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreClusteringTests.cs
@@ -27,14 +27,14 @@ public class FirestoreClusteringTests : IAsyncLifetime
     public async Task CleanDeadSiloInstance()
     {
         this._generation = 0;
-        await WriteSiloInstance(SiloStatus.Dead);
+        await WriteSiloInstance(SiloStatus.Dead, TestContext.Current.CancellationToken);
 
         // Create new active entries
         for (int i = 1; i < 5; i++)
         {
             this._generation = i;
             this._siloAddress = SiloAddressUtils.NewLocalSiloAddress(this._generation);
-            await WriteSiloInstance(SiloStatus.Active);
+            await WriteSiloInstance(SiloStatus.Active, TestContext.Current.CancellationToken);
         }
 
         await this._membershipTable.CleanupDefunctSiloEntries(TestStartTime.AddTicks(1));
@@ -64,7 +64,9 @@ public class FirestoreClusteringTests : IAsyncLifetime
 
         foreach (var chunk in entries.Chunk(50))
         {
-            await Task.WhenAll(chunk.Select(entity => this._storage.UpsertEntity(entity)));
+            await Task.WhenAll(chunk.Select(entity => this._storage.UpsertEntity(
+                entity,
+                TestContext.Current.CancellationToken)));
         }
 
         await this._membershipTable.CleanupDefunctSiloEntries(TestStartTime.AddTicks(1));
@@ -76,13 +78,13 @@ public class FirestoreClusteringTests : IAsyncLifetime
     [Fact]
     public async Task FindAllGatewayProxyEndpoints()
     {
-        await WriteSiloInstance(SiloStatus.Created);
+        await WriteSiloInstance(SiloStatus.Created, TestContext.Current.CancellationToken);
 
         var gateways = await this._gatewayProvider.GetGateways();
         Assert.Empty(gateways);  // "Number of gateways before Silo.Activate"
 
         this._entity.Status = (int)SiloStatus.Active;
-        await this._storage.UpsertEntity(this._entity);
+        await this._storage.UpsertEntity(this._entity, TestContext.Current.CancellationToken);
 
         gateways = await this._gatewayProvider.GetGateways();
         Assert.Single(gateways);  // "Number of gateways after Silo.Activate"
@@ -96,7 +98,7 @@ public class FirestoreClusteringTests : IAsyncLifetime
     public async Task UpdateIAmAliveDoesNotOverwriteNewerHeartbeat()
     {
         var current = TestStartTime.AddMinutes(2);
-        await WriteSiloInstance(SiloStatus.Active, current);
+        await WriteSiloInstance(SiloStatus.Active, TestContext.Current.CancellationToken, current);
 
         var entry = this._entity.ToMembershipEntry();
         entry.IAmAliveTime = current.AddMinutes(-1).UtcDateTime;
@@ -147,7 +149,10 @@ public class FirestoreClusteringTests : IAsyncLifetime
         Assert.NotEqual(insertedEtag, Assert.Single(updated.Members).Item2);
     }
 
-    private async Task WriteSiloInstance(SiloStatus status, DateTimeOffset? iAmAliveTime = null)
+    private async Task WriteSiloInstance(
+        SiloStatus status,
+        CancellationToken cancellationToken,
+        DateTimeOffset? iAmAliveTime = null)
     {
         IPEndPoint myEndpoint = this._siloAddress.Endpoint;
 
@@ -168,7 +173,7 @@ public class FirestoreClusteringTests : IAsyncLifetime
             IAmAliveTime = iAmAliveTime ?? TestStartTime,
         };
 
-        var etag = await this._storage.UpsertEntity(this._entity);
+        var etag = await this._storage.UpsertEntity(this._entity, cancellationToken);
         this._entity.ETag = Clustering.Firestore.Utils.ParseTimestamp(etag);
     }
 

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreDataManagerStressTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreDataManagerStressTests.cs
@@ -12,6 +12,7 @@ namespace Orleans.Clustering.Firestore.Tests;
 [TestCategory("Stress"), TestCategory("Firestore"), TestCategory("GoogleCloud")]
 public class FirestoreDataManagerStressTests : IAsyncLifetime
 {
+    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromMinutes(1);
     private readonly ITestOutputHelper _output = default!;
     private readonly List<FirestoreDataManager> _managers = [];
     private FirestoreOptions _options = default!;
@@ -29,7 +30,12 @@ public class FirestoreDataManagerStressTests : IAsyncLifetime
         const int batchSize = 1000;
         const int numPartitions = 1;
 
-        return WriteMany(testName, numPartitions, iterations, batchSize);
+        return WriteMany(
+            testName,
+            numPartitions,
+            iterations,
+            batchSize,
+            TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -40,10 +46,20 @@ public class FirestoreDataManagerStressTests : IAsyncLifetime
         const int batchSize = 1000;
         const int numPartitions = 100;
 
-        return WriteMany(testName, numPartitions, iterations, batchSize);
+        return WriteMany(
+            testName,
+            numPartitions,
+            iterations,
+            batchSize,
+            TestContext.Current.CancellationToken);
     }
 
-    private async Task WriteMany(string testName, int numPartitions, int iterations, int batchSize)
+    private async Task WriteMany(
+        string testName,
+        int numPartitions,
+        int iterations,
+        int batchSize,
+        CancellationToken cancellationToken)
     {
         _output.WriteLine("Iterations={0}, Batch={1}, Partitions={2}", iterations, batchSize, numPartitions);
         var managers = Enumerable.Range(0, numPartitions)
@@ -54,7 +70,7 @@ public class FirestoreDataManagerStressTests : IAsyncLifetime
                 NullLoggerFactory.Instance.CreateLogger<FirestoreDataManagerStressTests>()))
             .ToArray();
         _managers.AddRange(managers);
-        await Task.WhenAll(managers.Select(manager => manager.Initialize()));
+        await Task.WhenAll(managers.Select(manager => manager.Initialize(cancellationToken)));
 
         var promises = new List<Task>();
         var sw = Stopwatch.StartNew();
@@ -66,22 +82,22 @@ public class FirestoreDataManagerStressTests : IAsyncLifetime
                 StringData = "This is a test string",
                 BinaryData = new byte[128]
             };
-            var promise = managers[i % managers.Length].UpsertEntity(dataObject);
+            var promise = managers[i % managers.Length].UpsertEntity(dataObject, cancellationToken);
             promises.Add(promise);
             if (promises.Count == batchSize)
             {
-                await Task.WhenAll(promises);
+                await Task.WhenAll(promises).WaitAsync(cancellationToken);
                 promises.Clear();
                 _output.WriteLine("{0} has written {1} rows in {2} at {3} RPS",
                     testName, i + 1, sw.Elapsed, (i + 1) / sw.Elapsed.TotalSeconds);
             }
         }
 
-        await Task.WhenAll(promises);
+        await Task.WhenAll(promises).WaitAsync(cancellationToken);
         sw.Stop();
 
         var counts = await Task.WhenAll(managers.Select(async manager =>
-            (await manager.ReadAllEntities<DummyLoadEntity>()).Length));
+            (await manager.ReadAllEntities<DummyLoadEntity>(cancellationToken)).Length));
         Assert.Equal(iterations, counts.Sum());
 
         _output.WriteLine("{0} completed. Wrote {1} entries to {2} partition(s) in {3} at {4} RPS",
@@ -90,7 +106,16 @@ public class FirestoreDataManagerStressTests : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        await Task.WhenAll(_managers.Select(manager => manager.ClearCollection()));
+        using var cleanupCancellation = new CancellationTokenSource(CleanupTimeout);
+        try
+        {
+            await Task.WhenAll(_managers.Select(manager =>
+                manager.ClearCollection(cleanupCancellation.Token)));
+        }
+        finally
+        {
+            _managers.Clear();
+        }
     }
 
     public ValueTask InitializeAsync()

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreDataManagerTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreDataManagerTests.cs
@@ -20,14 +20,17 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     public async Task CreateEntry()
     {
         var data = GetDummyEntity();
-        var eTag = await this._manager.CreateEntity(data);
+        var eTag = await this._manager.CreateEntity(data, TestContext.Current.CancellationToken);
 
         var data2 = data.Clone();
         data2.Age = 99;
-        var exception = await Assert.ThrowsAsync<RpcException>(() => this._manager.CreateEntity(data2));
+        var exception = await Assert.ThrowsAsync<RpcException>(
+            () => this._manager.CreateEntity(data2, TestContext.Current.CancellationToken));
         Assert.Equal(StatusCode.AlreadyExists, exception.StatusCode);
 
-        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id);
+        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken);
         Assert.NotNull(returned);
         Assert.Equal(data.Id, returned.Id);
         Assert.Equal(data.Name, returned.Name);
@@ -41,21 +44,24 @@ public class FirestoreDataManagerTests : IAsyncLifetime
         var data = GetDummyEntity();
         data.Id = " ";
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => this._manager.CreateEntity(data));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._manager.CreateEntity(data, TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task UpsertEntry()
     {
         var data = GetDummyEntity();
-        var etag1 = await this._manager.UpsertEntity(data);
+        var etag1 = await this._manager.UpsertEntity(data, TestContext.Current.CancellationToken);
 
         var data2 = data.Clone();
         data2.Age = 99;
 
-        var eTag2 = await this._manager.UpsertEntity(data2);
+        var eTag2 = await this._manager.UpsertEntity(data2, TestContext.Current.CancellationToken);
 
-        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id);
+        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken);
         Assert.NotNull(returned);
         Assert.Equal(data.Id, returned.Id);
         Assert.Equal(data2.Name, returned.Name);
@@ -68,10 +74,12 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     {
         var data = GetDummyEntity();
         data.Id = default!;
-        await Assert.ThrowsAsync<InvalidOperationException>(() => this._manager.Update(data));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._manager.Update(data, TestContext.Current.CancellationToken));
 
         data.Id = Guid.NewGuid().ToString();
-        await Assert.ThrowsAsync<InvalidOperationException>(() => this._manager.Update(data));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._manager.Update(data, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -80,10 +88,13 @@ public class FirestoreDataManagerTests : IAsyncLifetime
         var data = GetDummyEntity();
         data.ETag = Timestamp.FromDateTimeOffset(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var found = await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id);
+        var found = await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken);
         Assert.Null(found);
 
-        var exception = await Assert.ThrowsAsync<RpcException>(() => this._manager.Update(data));
+        var exception = await Assert.ThrowsAsync<RpcException>(
+            () => this._manager.Update(data, TestContext.Current.CancellationToken));
         Assert.Equal(StatusCode.FailedPrecondition, exception.StatusCode);
     }
 
@@ -91,16 +102,19 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     public async Task UpdateWithStaleEtagFails()
     {
         var data = GetDummyEntity();
-        var eTag = await this._manager.CreateEntity(data);
+        var eTag = await this._manager.CreateEntity(data, TestContext.Current.CancellationToken);
 
         var data2 = data.Clone();
         data2.Age = 99;
         data2.ETag = Timestamp.FromDateTimeOffset(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var exception = await Assert.ThrowsAsync<RpcException>(() => this._manager.Update(data2));
+        var exception = await Assert.ThrowsAsync<RpcException>(
+            () => this._manager.Update(data2, TestContext.Current.CancellationToken));
         Assert.Equal(StatusCode.FailedPrecondition, exception.StatusCode);
 
-        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id);
+        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken);
         Assert.NotNull(returned);
         Assert.Equal(data.Age, returned.Age);
         Assert.Equal(Utils.ParseTimestamp(eTag), returned.ETag);
@@ -110,15 +124,17 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     public async Task UpdateEntry()
     {
         var data = GetDummyEntity();
-        var eTag = await this._manager.CreateEntity(data);
+        var eTag = await this._manager.CreateEntity(data, TestContext.Current.CancellationToken);
 
         var data2 = data.Clone();
         data2.Age = 99;
         data2.ETag = Utils.ParseTimestamp(eTag);
 
-        var eTag2 = await this._manager.Update(data2);
+        var eTag2 = await this._manager.Update(data2, TestContext.Current.CancellationToken);
 
-        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id);
+        var returned = await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken);
         Assert.NotNull(returned);
         Assert.Equal(data.Id, returned.Id);
         Assert.Equal(data2.Name, returned.Name);
@@ -131,24 +147,38 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     {
         var data = GetDummyEntity();
 
-        var result = await this._manager.DeleteEntity(data.Id);
+        var result = await this._manager.DeleteEntity(
+            data.Id,
+            cancellationToken: TestContext.Current.CancellationToken);
         Assert.False(result, "A missing entry should not be deleted.");
 
-        await this._manager.CreateEntity(data);
+        await this._manager.CreateEntity(data, TestContext.Current.CancellationToken);
 
-        var found = await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id);
+        var found = await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken);
         Assert.NotNull(found);
 
-        result = await this._manager.DeleteEntity(data.Id, Utils.FormatTimestamp(Timestamp.FromDateTimeOffset(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero))));
+        result = await this._manager.DeleteEntity(
+            data.Id,
+            Utils.FormatTimestamp(Timestamp.FromDateTimeOffset(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero))),
+            TestContext.Current.CancellationToken);
         Assert.False(result, "An entry with a stale ETag should not be deleted.");
 
-        result = await this._manager.DeleteEntity(data.Id, Utils.FormatTimestamp(found.ETag!.Value));
+        result = await this._manager.DeleteEntity(
+            data.Id,
+            Utils.FormatTimestamp(found.ETag!.Value),
+            TestContext.Current.CancellationToken);
         Assert.True(result, "An entry with the current ETag should be deleted.");
 
-        found = await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id);
+        found = await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken);
         Assert.Null(found);
 
-        result = await this._manager.DeleteEntity(data.Id);
+        result = await this._manager.DeleteEntity(
+            data.Id,
+            cancellationToken: TestContext.Current.CancellationToken);
         Assert.False(result, "A previously deleted entry should not be deleted again.");
     }
 
@@ -156,15 +186,16 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     public async Task ReadAllEntries()
     {
         var data = GetDummyEntity();
-        var eTag = await this._manager.CreateEntity(data);
+        var eTag = await this._manager.CreateEntity(data, TestContext.Current.CancellationToken);
 
         var data2 = GetDummyEntity();
-        var eTag2 = await this._manager.CreateEntity(data2);
+        var eTag2 = await this._manager.CreateEntity(data2, TestContext.Current.CancellationToken);
 
         var data3 = GetDummyEntity();
-        var eTag3 = await this._manager.CreateEntity(data3);
+        var eTag3 = await this._manager.CreateEntity(data3, TestContext.Current.CancellationToken);
 
-        var all = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        var all = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
         Assert.NotNull(all);
         Assert.Equal(3, all.Length);
 
@@ -189,10 +220,11 @@ public class FirestoreDataManagerTests : IAsyncLifetime
         Assert.Equal(data3.Age, found.Age);
         Assert.Equal(Utils.ParseTimestamp(eTag3), found.ETag);
 
-        await this._manager.DeleteEntity(data.Id, eTag);
-        await this._manager.DeleteEntity(data2.Id, eTag2);
+        await this._manager.DeleteEntity(data.Id, eTag, TestContext.Current.CancellationToken);
+        await this._manager.DeleteEntity(data2.Id, eTag2, TestContext.Current.CancellationToken);
 
-        all = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        all = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(all);
         Assert.Single(all);
@@ -204,9 +236,10 @@ public class FirestoreDataManagerTests : IAsyncLifetime
         Assert.Equal(data3.Age, found.Age);
         Assert.Equal(Utils.ParseTimestamp(eTag3), found.ETag);
 
-        await this._manager.DeleteEntity(data3.Id, eTag3);
+        await this._manager.DeleteEntity(data3.Id, eTag3, TestContext.Current.CancellationToken);
 
-        all = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        all = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
         Assert.NotNull(all);
         Assert.Empty(all);
     }
@@ -217,15 +250,17 @@ public class FirestoreDataManagerTests : IAsyncLifetime
         var tasks = Enumerable.Range(0, FirestoreDataManager.MaxBatchSize + 1).Select(x =>
         {
             var entity = GetDummyEntity();
-            return this._manager.CreateEntity(entity);
+            return this._manager.CreateEntity(entity, TestContext.Current.CancellationToken);
         });
 
         await Task.WhenAll(tasks);
 
-        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
         Assert.Equal(FirestoreDataManager.MaxBatchSize + 1, entities.Length);
 
-        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => this._manager.DeleteEntities(entities));
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => this._manager.DeleteEntities(entities, TestContext.Current.CancellationToken));
         Assert.Equal("entities", exception.ParamName);
     }
 
@@ -233,43 +268,57 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     public async Task DeleteEntitiesRejectsStaleEtag()
     {
         await Task.WhenAll(Enumerable.Range(0, 2)
-            .Select(_ => this._manager.CreateEntity(GetDummyEntity())));
+            .Select(_ => this._manager.CreateEntity(
+                GetDummyEntity(),
+                TestContext.Current.CancellationToken)));
 
-        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
         entities[0].ETag = Timestamp.FromDateTimeOffset(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var exception = await Assert.ThrowsAsync<RpcException>(() => this._manager.DeleteEntities(entities));
+        var exception = await Assert.ThrowsAsync<RpcException>(
+            () => this._manager.DeleteEntities(entities, TestContext.Current.CancellationToken));
         Assert.Equal(StatusCode.FailedPrecondition, exception.StatusCode);
-        Assert.Equal(2, (await this._manager.ReadAllEntities<DummyFirestoreEntity>()).Length);
+        Assert.Equal(
+            2,
+            (await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+                TestContext.Current.CancellationToken)).Length);
     }
 
     [Fact]
     public async Task DeleteEntitiesRejectsInvalidEntity()
     {
         var data = GetDummyEntity();
-        await this._manager.CreateEntity(data);
+        await this._manager.CreateEntity(data, TestContext.Current.CancellationToken);
 
-        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
         entities[0].ETag = Timestamp.FromDateTimeOffset(DateTimeOffset.MinValue);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => this._manager.DeleteEntities(entities));
-        Assert.Single(await this._manager.ReadAllEntities<DummyFirestoreEntity>());
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this._manager.DeleteEntities(entities, TestContext.Current.CancellationToken));
+        Assert.Single(await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task DeleteEntities()
     {
         await Task.WhenAll(Enumerable.Range(0, 3)
-            .Select(_ => this._manager.CreateEntity(GetDummyEntity())));
+            .Select(_ => this._manager.CreateEntity(
+                GetDummyEntity(),
+                TestContext.Current.CancellationToken)));
 
-        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        var entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
         Assert.Equal(3, entities.Length);
-        await this._manager.DeleteEntities(entities);
+        await this._manager.DeleteEntities(entities, TestContext.Current.CancellationToken);
 
-        entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>();
+        entities = await this._manager.ReadAllEntities<DummyFirestoreEntity>(
+            TestContext.Current.CancellationToken);
         Assert.Empty(entities);
 
-        await this._manager.DeleteEntities(entities);
+        await this._manager.DeleteEntities(entities, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -277,20 +326,28 @@ public class FirestoreDataManagerTests : IAsyncLifetime
     {
         var data = GetDummyEntity();
         data.Age = 21;
-        await this._manager.CreateEntity(data);
-        data = (await this._manager.ReadEntity<DummyFirestoreEntity>(data.Id))!;
+        await this._manager.CreateEntity(data, TestContext.Current.CancellationToken);
+        data = (await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data.Id,
+            TestContext.Current.CancellationToken))!;
 
         var data2 = GetDummyEntity();
         data2.Age = 60;
-        await this._manager.CreateEntity(data2);
-        data2 = (await this._manager.ReadEntity<DummyFirestoreEntity>(data2.Id))!;
+        await this._manager.CreateEntity(data2, TestContext.Current.CancellationToken);
+        data2 = (await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data2.Id,
+            TestContext.Current.CancellationToken))!;
 
         var data3 = GetDummyEntity();
         data3.Age = 10;
-        await this._manager.CreateEntity(data3);
-        data3 = (await this._manager.ReadEntity<DummyFirestoreEntity>(data3.Id))!;
+        await this._manager.CreateEntity(data3, TestContext.Current.CancellationToken);
+        data3 = (await this._manager.ReadEntity<DummyFirestoreEntity>(
+            data3.Id,
+            TestContext.Current.CancellationToken))!;
 
-        var entities = await this._manager.QueryEntities<DummyFirestoreEntity>(x => x.WhereGreaterThanOrEqualTo("Age", 18));
+        var entities = await this._manager.QueryEntities<DummyFirestoreEntity>(
+            x => x.WhereGreaterThanOrEqualTo("Age", 18),
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(entities);
         Assert.Equal(2, entities.Length);
@@ -302,7 +359,9 @@ public class FirestoreDataManagerTests : IAsyncLifetime
         Assert.Equal(data.Age, found.Age);
         Assert.Equal(data.ETag, found.ETag);
 
-        entities = await this._manager.QueryEntities<DummyFirestoreEntity>(x => x.WhereLessThan("Age", 18));
+        entities = await this._manager.QueryEntities<DummyFirestoreEntity>(
+            x => x.WhereLessThan("Age", 18),
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(entities);
         Assert.Single(entities);
@@ -314,7 +373,9 @@ public class FirestoreDataManagerTests : IAsyncLifetime
         Assert.Equal(data3.Age, found.Age);
         Assert.Equal(data3.ETag, found.ETag);
 
-        entities = await this._manager.QueryEntities<DummyFirestoreEntity>(x => x.WhereGreaterThan("Age", 60));
+        entities = await this._manager.QueryEntities<DummyFirestoreEntity>(
+            x => x.WhereGreaterThan("Age", 60),
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(entities);
         Assert.Empty(entities);
@@ -345,7 +406,7 @@ public class FirestoreDataManagerTests : IAsyncLifetime
             opt,
             NullLoggerFactory.Instance.CreateLogger<FirestoreDataManager>());
 
-        await this._manager.Initialize();
+        await this._manager.Initialize(TestContext.Current.CancellationToken);
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreEmulatorTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreEmulatorTests.cs
@@ -22,8 +22,10 @@ public class FirestoreEmulatorTests
         }.Build();
 
         var collection = db.Collection("users");
-        var document = await collection.AddAsync(new { Name = new { First = "Ada", Last = "Lovelace" }, Born = 1815 });
-        var snapshot = await document.GetSnapshotAsync();
+        var document = await collection.AddAsync(
+            new { Name = new { First = "Ada", Last = "Lovelace" }, Born = 1815 },
+            TestContext.Current.CancellationToken);
+        var snapshot = await document.GetSnapshotAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal("Ada", snapshot.GetValue<string>("Name.First"));
         Assert.Equal("Lovelace", snapshot.GetValue<string>("Name.Last"));

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreMembershipTableTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreMembershipTableTests.cs
@@ -121,7 +121,9 @@ public class FirestoreMembershipTableTests : MembershipTableTestsBase, IClassFix
                         proxyPort: 30_000),
                     membershipVersion: 0))
                 .ToArray();
-            await Task.WhenAll(fillers.Select(filler => storage.UpsertEntity(filler)));
+            await Task.WhenAll(fillers.Select(filler => storage.UpsertEntity(
+                filler,
+                TestContext.Current.CancellationToken)));
 
             var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var writer = WriteUpdates();
@@ -129,17 +131,21 @@ public class FirestoreMembershipTableTests : MembershipTableTestsBase, IClassFix
             var readRow = ReadSnapshots(() => table.ReadRow(address));
             start.SetResult();
 
-            await Task.WhenAll(writer, readAll, readRow).WaitAsync(TimeSpan.FromMinutes(2));
+            await Task.WhenAll(writer, readAll, readRow).WaitAsync(
+                TimeSpan.FromMinutes(2),
+                TestContext.Current.CancellationToken);
 
             async Task WriteUpdates()
             {
-                await start.Task;
+                await start.Task.WaitAsync(TestContext.Current.CancellationToken);
                 for (var i = 0; i < updateCount; i++)
                 {
                     var updated = false;
                     while (!updated)
                     {
-                        var snapshot = await ReadWithRetries(() => table.ReadRow(address));
+                        var snapshot = await ReadWithRetries(
+                            () => table.ReadRow(address),
+                            TestContext.Current.CancellationToken);
                         var row = Assert.Single(snapshot.Members);
                         var nextVersion = snapshot.Version.Next();
                         row.Item1.ProxyPort = nextVersion.Version;
@@ -151,11 +157,13 @@ public class FirestoreMembershipTableTests : MembershipTableTestsBase, IClassFix
 
             async Task ReadSnapshots(Func<Task<MembershipTableData>> read)
             {
-                await start.Task;
+                await start.Task.WaitAsync(TestContext.Current.CancellationToken);
                 var previousVersion = -1;
                 for (var i = 0; i < readsPerReader; i++)
                 {
-                    var snapshot = await ReadWithRetries(read);
+                    var snapshot = await ReadWithRetries(
+                        read,
+                        TestContext.Current.CancellationToken);
                     Assert.True(snapshot.Version.Version >= previousVersion);
                     var row = Assert.Single(
                         snapshot.Members,
@@ -165,7 +173,9 @@ public class FirestoreMembershipTableTests : MembershipTableTestsBase, IClassFix
                 }
             }
 
-            static async Task<MembershipTableData> ReadWithRetries(Func<Task<MembershipTableData>> read)
+            static async Task<MembershipTableData> ReadWithRetries(
+                Func<Task<MembershipTableData>> read,
+                CancellationToken cancellationToken)
             {
                 for (var attempt = 0; ; attempt++)
                 {
@@ -176,7 +186,7 @@ public class FirestoreMembershipTableTests : MembershipTableTestsBase, IClassFix
                     catch (RpcException exception) when (
                         exception.StatusCode == StatusCode.Aborted && attempt < 9)
                     {
-                        await Task.Delay(10);
+                        await Task.Delay(10, cancellationToken);
                     }
                 }
             }

--- a/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZookeeperMembershipTableTests.cs
+++ b/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZookeeperMembershipTableTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests.MembershipTests
 
         protected override async Task<string> GetConnectionString()
         {
-            bool isReachable = await ZookeeperTestUtils.EnsureZooKeeperAsync();
+            bool isReachable = await ZookeeperTestUtils.EnsureZooKeeperAsync(TestContext.Current.CancellationToken);
             return isReachable ? TestDefaultConfiguration.ZooKeeperConnectionString! : null!;
         }
 

--- a/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZookeeperTestUtils.cs
+++ b/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZookeeperTestUtils.cs
@@ -6,7 +6,9 @@ namespace Tester.ZooKeeperUtils
 {
     public static class ZookeeperTestUtils
     {
-        private static readonly Lazy<bool> EnsureZooKeeperLazy = new Lazy<bool>(() => EnsureZooKeeperAsync().Result);
+        private static readonly Lazy<bool> EnsureZooKeeperLazy = new(
+            () => EnsureZooKeeperAsync(TestContext.Current.CancellationToken).GetAwaiter().GetResult(),
+            LazyThreadSafetyMode.PublicationOnly);
 
         public static void EnsureZooKeeper()
         {
@@ -14,7 +16,7 @@ namespace Tester.ZooKeeperUtils
                 throw Xunit.Sdk.SkipException.ForSkip("ZooKeeper isn't running");
         }
 
-        public static async Task<bool> EnsureZooKeeperAsync()
+        public static async Task<bool> EnsureZooKeeperAsync(CancellationToken cancellationToken = default)
         {
             var connectionString = TestDefaultConfiguration.ZooKeeperConnectionString;
             if (string.IsNullOrWhiteSpace(connectionString))
@@ -22,18 +24,20 @@ namespace Tester.ZooKeeperUtils
                 return false;
             }
 
-            return await ZooKeeper.Using(connectionString, 2000, new ZooKeeperWatcher(), async zk =>
-            {
-                try
+            return await ZooKeeper
+                .Using(connectionString, 2000, new ZooKeeperWatcher(), async zk =>
                 {
-                    await zk.existsAsync("/test", false);
-                    return true;
-                }
-                catch (KeeperException.ConnectionLossException)
-                {
-                    return false;
-                }
-            });
+                    try
+                    {
+                        await zk.existsAsync("/test", false);
+                        return true;
+                    }
+                    catch (KeeperException.ConnectionLossException)
+                    {
+                        return false;
+                    }
+                })
+                .WaitAsync(cancellationToken);
         }
 
         private class ZooKeeperWatcher : Watcher

--- a/test/Extensions/Orleans.Cosmos.Tests/FeedIteratorExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/FeedIteratorExtensionsTests.cs
@@ -37,7 +37,7 @@ public class FeedIteratorExtensionsTests
             Array.Empty<int>(),
             new[] { 4, 5 });
 
-        var drained = await iterator.ToListAsync();
+        var drained = await iterator.ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new[] { 1, 2, 3, 4, 5 }, drained);
     }
@@ -51,7 +51,7 @@ public class FeedIteratorExtensionsTests
             Array.Empty<int>(),
             new[] { 1, 2, 3 });
 
-        var drained = await iterator.ToListAsync();
+        var drained = await iterator.ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new[] { 1, 2, 3 }, drained);
     }
@@ -64,7 +64,7 @@ public class FeedIteratorExtensionsTests
             Array.Empty<int>(),
             Array.Empty<int>());
 
-        var drained = await iterator.ToListAsync();
+        var drained = await iterator.ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Empty(drained);
     }
@@ -74,7 +74,7 @@ public class FeedIteratorExtensionsTests
     {
         var iterator = new FakeFeedIterator<int>(new[] { 1, 2, 3, 4, 5 });
 
-        var drained = await iterator.ToListAsync();
+        var drained = await iterator.ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new[] { 1, 2, 3, 4, 5 }, drained);
     }
@@ -86,7 +86,7 @@ public class FeedIteratorExtensionsTests
             new[] { 1, 2 },
             Array.Empty<int>());
 
-        var drained = await iterator.ToListAsync();
+        var drained = await iterator.ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new[] { 1, 2 }, drained);
     }

--- a/test/Extensions/Orleans.Cosmos.Tests/PersistenceProviderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/PersistenceProviderTests_Cosmos.cs
@@ -71,7 +71,7 @@ public class PersistenceProviderTests_Cosmos
         var storage = await InitializeStorage(deleteStateOnClear: false);
         var runner = new GrainStorageModelBasedTestRunner(storage, "Cosmos", output.WriteLine);
 
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("Functional"), TestCategory("ModelBased")]
@@ -80,7 +80,7 @@ public class PersistenceProviderTests_Cosmos
         var storage = await InitializeStorage(deleteStateOnClear: true);
         var runner = new GrainStorageModelBasedTestRunner(storage, "CosmosDeleteStateOnClear", output.WriteLine);
 
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("Functional")]

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -69,7 +69,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_Basic_StopByRef()
     {
-        await Test_Reminders_Basic_StopByRef();
+        await Test_Reminders_Basic_StopByRef(TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]
@@ -83,7 +83,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_Basic_ListOps()
     {
-        await Test_Reminders_Basic_ListOps();
+        await Test_Reminders_Basic_ListOps(TestContext.Current.CancellationToken);
     }
 
     // Single join tests ... multi grain, multi reminders
@@ -92,14 +92,14 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_1J_MultiGrainMultiReminders()
     {
-        await Test_Reminders_1J_MultiGrainMultiReminders();
+        await Test_Reminders_1J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]
     [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_ReminderNotFound()
     {
-        await Test_Reminders_ReminderNotFound();
+        await Test_Reminders_ReminderNotFound(TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]
@@ -157,7 +157,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_2J_MultiGrainMultiReminders()
     {
-        await Test_Reminders_2J_MultiGrainMultiReminders();
+        await Test_Reminders_2J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -76,7 +76,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact, TestCategory("Functional")]
     public async Task Rem_Cosmos_UpdateReminder_DoesNotRestartLocalReminder()
     {
-        await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder();
+        await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder(TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]
@@ -111,11 +111,11 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         TimeSpan period = await grain.GetReminderPeriod(DR);
         // start up the 'DR' reminder and wait for two ticks to pass.
         await grain.StartReminder(DR);
-        long last = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2);
+        long last = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2, TestContext.Current.CancellationToken);
         Assert.Equal(2, last);
         // stop the timer and wait for a whole period.
-        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder);
-        await AdvanceReminderTimeAsync(period);
+        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, TestContext.Current.CancellationToken);
+        await AdvanceReminderTimeAsync(period, TestContext.Current.CancellationToken);
         long curr = await grain.GetCounter(DR);
         Assert.Equal(last, curr);
     }
@@ -127,12 +127,12 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IReminderTestGrain2 grain = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         TimeSpan period = await grain.GetReminderPeriod(DR);
         await grain.StartReminder(DR);
-        long last = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2);
+        long last = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2, TestContext.Current.CancellationToken);
         Assert.Equal(2, last);
 
-        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder);
+        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, TestContext.Current.CancellationToken);
         TimeSpan sleepFor = period;
-        await AdvanceReminderTimeAsync(sleepFor);
+        await AdvanceReminderTimeAsync(sleepFor, TestContext.Current.CancellationToken);
         long curr = await grain.GetCounter(DR);
         Assert.Equal(last, curr);
         AssertIsInRange(curr, last, last + 1, grain, DR, sleepFor);
@@ -140,9 +140,9 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         // start the same reminder again
         await grain.StartReminder(DR);
         sleepFor = period.Multiply(2);
-        curr = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2);
+        curr = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2, TestContext.Current.CancellationToken);
         AssertIsInRange(curr, 2, 3, grain, DR, sleepFor);
-        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder); // cleanup
+        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, TestContext.Current.CancellationToken); // cleanup
     }
 
     [TestSuite("Functional")]
@@ -150,7 +150,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     public async Task Rem_Azure_MultipleReminders()
     {
         IReminderTestGrain2 grain = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        await PerGrainMultiReminderTest(grain);
+        await PerGrainMultiReminderTest(grain, TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]
@@ -169,7 +169,8 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IReminderTestGrain2 g3 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g4 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource(ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(ENDWAIT);
 
         await Test_Reminders_MultiGrainMultiReminders(
             afterFirstTick: null,
@@ -186,7 +187,8 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     public async Task Rem_Azure_1F_Basic()
     {
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource(ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(ENDWAIT);
 
         await PrepareForGrainFailureAsync(cts.Token, g1);
 
@@ -206,7 +208,8 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_2F_MultiGrain()
     {
-        using var cts = new CancellationTokenSource(ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(ENDWAIT);
         _ = await StartAdditionalSilosAndWaitForReminderServicesAsync(
             2,
             cts.Token,
@@ -239,7 +242,8 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_1F1J_MultiGrain()
     {
-        using var cts = new CancellationTokenSource(ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(ENDWAIT);
         _ = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -274,7 +278,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         Task<IGrainReminder> promise1 = grain.StartReminder(DR);
         Task<IGrainReminder> promise2 = grain.StartReminder(DR);
         Task<IGrainReminder>[] tasks = { promise1, promise2 };
-        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(15));
+        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
         //Assert.NotEqual(promise1.Result, promise2.Result);
         // TODO: write tests where period of a reminder is changed
     }
@@ -286,7 +290,8 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestCopyGrain g2 = GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
         TimeSpan period = await g1.GetReminderPeriod(DR); // using same period
-        using var cts = new CancellationTokenSource(ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(ENDWAIT);
 
         var reminder1 = await g1.StartReminder(DR);
         Assert.Equal(DR, reminder1.ReminderName);
@@ -314,7 +319,8 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [Fact(Skip = "https://github.com/dotnet/orleans/issues/4319"), TestCategory("Functional")]
     public async Task Rem_Azure_GT_1F1J_MultiGrain()
     {
-        using var cts = new CancellationTokenSource(ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(ENDWAIT);
         _ = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
@@ -41,35 +41,39 @@ public class ReminderTests_Cosmos_Standalone
     [Fact, TestCategory("Reminders"), TestCategory("Performance")]
     public async Task Reminders_AzureTable_InsertRate()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "TMSLocalTesting", ServiceId = _serviceId });
         var storageOptions = Options.Create(new CosmosReminderTableOptions());
         storageOptions.Value.ConfigureTestDefaults();
 
         IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
-        using var cancellation = new CancellationTokenSource(new ReminderOptions().InitializationTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(new ReminderOptions().InitializationTimeout);
         await table.StartAsync(cancellation.Token);
 
-        await TestTableInsertRate(table, 10);
-        await TestTableInsertRate(table, 500);
+        await TestTableInsertRate(table, 10, testCancellationToken);
+        await TestTableInsertRate(table, 500, testCancellationToken);
     }
 
     [Fact, TestCategory("Reminders"), TestCategory("Functional")]
     public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         string clusterId = NewClusterId();
         var clusterOptions = Options.Create(new ClusterOptions { ClusterId = clusterId, ServiceId = _serviceId });
         var storageOptions = Options.Create(new CosmosReminderTableOptions());
         storageOptions.Value.ConfigureTestDefaults();
         IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
-        using var cancellation = new CancellationTokenSource(new ReminderOptions().InitializationTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(new ReminderOptions().InitializationTimeout);
         await table.StartAsync(cancellation.Token);
 
-        ReminderEntry[] rows = (await GetAllRows(table)).ToArray();
+        ReminderEntry[] rows = (await GetAllRows(table, testCancellationToken)).ToArray();
         Assert.Empty(rows); // "The reminder table (sid={0}, did={1}) was not empty.", ServiceId, clusterId);
 
         ReminderEntry expected = NewReminderEntry();
-        await table.UpsertRow(expected);
-        rows = (await GetAllRows(table)).ToArray();
+        await table.UpsertRow(expected).WaitAsync(testCancellationToken);
+        rows = (await GetAllRows(table, testCancellationToken)).ToArray();
 
         Assert.Single(rows); // "The reminder table (sid={0}, did={1}) did not contain the correct number of rows (1).", ServiceId, clusterId);
         ReminderEntry actual = rows[0];
@@ -81,7 +85,10 @@ public class ReminderTests_Cosmos_Standalone
         Assert.False(string.IsNullOrWhiteSpace(actual.ETag), $"The newly inserted reminder table (sid={_serviceId}, did={clusterId}) row contains an invalid etag.");
     }
 
-    private async Task TestTableInsertRate(IReminderTable reminderTable, double numOfInserts)
+    private async Task TestTableInsertRate(
+        IReminderTable reminderTable,
+        double numOfInserts,
+        CancellationToken cancellationToken)
     {
         DateTime startedAt = DateTime.UtcNow;
 
@@ -103,15 +110,15 @@ public class ReminderTests_Cosmos_Standalone
             int capture = i;
             Task<bool> promise = Task.Run(async () =>
             {
-                await reminderTable.UpsertRow(e);
+                await reminderTable.UpsertRow(e).WaitAsync(cancellationToken);
                 _output.WriteLine("Done " + capture);
                 return true;
-            });
+            }, cancellationToken);
             promises.Add(promise);
             _log.LogInformation("Started {Capture}", capture);
         }
         _log.LogInformation("Started all, now waiting...");
-        await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500));
+        await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500), cancellationToken);
 
         TimeSpan dur = DateTime.UtcNow - startedAt;
         _log.LogInformation(
@@ -138,9 +145,11 @@ public class ReminderTests_Cosmos_Standalone
         return string.Format("ReminderTest.{0}", Guid.NewGuid());
     }
 
-    private static async Task<IEnumerable<ReminderEntry>> GetAllRows(IReminderTable table)
+    private static async Task<IEnumerable<ReminderEntry>> GetAllRows(
+        IReminderTable table,
+        CancellationToken cancellationToken)
     {
-        ReminderTableData data = await table.ReadRows(0, 0xffffffff);
+        ReminderTableData data = await table.ReadRows(0, 0xffffffff).WaitAsync(cancellationToken);
         Assert.NotNull(data);
         return data.Reminders;
     }

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureBlobJournaledJobShardManagerTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureBlobJournaledJobShardManagerTests.cs
@@ -44,7 +44,8 @@ public sealed class AzureBlobJournaledJobShardManagerTestFixture : IJobShardMana
         var storageProvider = serviceProvider.GetRequiredService<IJournalStorageProvider>();
         Assert.IsAssignableFrom<ILifecycleParticipant<ISiloLifecycle>>(storageProvider).Participate(lifecycle);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(60));
         await lifecycle.OnStart(cts.Token);
         return new AzureBlobJournaledJobShardManagerTestScope(serviceProvider, lifecycle, CreateContainerClient(containerName));
     }
@@ -64,9 +65,24 @@ public sealed class AzureBlobJournaledJobShardManagerTestFixture : IJobShardMana
         public override async ValueTask DisposeAsync()
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-            await lifecycle.OnStop(cts.Token);
+            try
+            {
+                await lifecycle.OnStop(cts.Token);
+            }
+            catch (OperationCanceledException) when (TestContext.Current.CancellationToken.IsCancellationRequested)
+            {
+                // Preserve the original test cancellation after bounded cleanup.
+            }
+
             await base.DisposeAsync();
-            await container.DeleteIfExistsAsync(cancellationToken: cts.Token);
+            try
+            {
+                await container.DeleteIfExistsAsync(cancellationToken: cts.Token);
+            }
+            catch (OperationCanceledException) when (TestContext.Current.CancellationToken.IsCancellationRequested)
+            {
+                // Preserve the original test cancellation after bounded cleanup.
+            }
         }
     }
 }

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureBlobJournaledJobShardManagerTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureBlobJournaledJobShardManagerTests.cs
@@ -22,7 +22,7 @@ public sealed class AzureBlobJournaledJobShardManagerTests(AzureBlobJournaledJob
 
 public sealed class AzureBlobJournaledJobShardManagerTestFixture : IJobShardManagerTestFixture
 {
-    public async Task<IJobShardManagerTestScope> CreateScopeAsync()
+    public async Task<IJobShardManagerTestScope> CreateScopeAsync(CancellationToken cancellationToken)
     {
         TestUtils.CheckForAzureStorage();
 
@@ -44,7 +44,7 @@ public sealed class AzureBlobJournaledJobShardManagerTestFixture : IJobShardMana
         var storageProvider = serviceProvider.GetRequiredService<IJournalStorageProvider>();
         Assert.IsAssignableFrom<ILifecycleParticipant<ISiloLifecycle>>(storageProvider).Participate(lifecycle);
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromSeconds(60));
         await lifecycle.OnStart(cts.Token);
         return new AzureBlobJournaledJobShardManagerTestScope(serviceProvider, lifecycle, CreateContainerClient(containerName));

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageBlobDurableJobsTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageBlobDurableJobsTests.cs
@@ -49,7 +49,14 @@ public class AzureStorageBlobDurableJobsTests : TestClusterPerTest
             if (_containerName is not null)
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                await CreateContainerClient(_containerName).DeleteIfExistsAsync(cancellationToken: cts.Token);
+                try
+                {
+                    await CreateContainerClient(_containerName).DeleteIfExistsAsync(cancellationToken: cts.Token);
+                }
+                catch (OperationCanceledException) when (TestContext.Current.CancellationToken.IsCancellationRequested)
+                {
+                    // Preserve the original test cancellation after bounded cleanup.
+                }
             }
         }
     }
@@ -81,92 +88,99 @@ public class AzureStorageBlobDurableJobsTests : TestClusterPerTest
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task DurableJobGrain()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.DurableJobGrain(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task JobExecutionOrder()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.JobExecutionOrder(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task PastDueTime()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.PastDueTime(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task JobWithMetadata()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.JobWithMetadata(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task MultipleGrains()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.MultipleGrains(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task DuplicateJobNames()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.DuplicateJobNames(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task CancelNonExistentJob()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.CancelNonExistentJob(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task CancelAlreadyExecutedJob()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.CancelAlreadyExecutedJob(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task ConcurrentScheduling()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.ConcurrentScheduling(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task JobPropertiesVerification()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.JobPropertiesVerification(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task DequeueCount()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.DequeueCount(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task ScheduleJobOnAnotherGrain()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.ScheduleJobOnAnotherGrain(cts.Token);
     }
 
     [Fact, TestCategory("Azure"), TestCategory("DurableJobs")]
     public async Task JobRetry()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        using var cts = CreateTestCancellationTokenSource();
         await _runner.JobRetry(cts.Token);
+    }
+
+    private static CancellationTokenSource CreateTestCancellationTokenSource()
+    {
+        var result = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        result.CancelAfter(TimeSpan.FromMinutes(2));
+        return result;
     }
 }
 

--- a/test/Extensions/Orleans.Persistence.Firestore.Tests/FirestoreStorageProviderTests.cs
+++ b/test/Extensions/Orleans.Persistence.Firestore.Tests/FirestoreStorageProviderTests.cs
@@ -289,7 +289,7 @@ public class FirestoreStorageProviderTests : IClassFixture<TestEnvironmentFixtur
         var storage = await CreateStorage(deleteStateOnClear: true);
         var runner = new GrainStorageModelBasedTestRunner(storage, "Firestore", _output.WriteLine);
 
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("Functional"), TestCategory("ModelBased")]
@@ -297,7 +297,7 @@ public class FirestoreStorageProviderTests : IClassFixture<TestEnvironmentFixtur
     {
         var storage = await CreateStorage(deleteStateOnClear: false);
         var runner = new GrainStorageModelBasedTestRunner(storage, "FirestoreClearWritesTombstone", _output.WriteLine);
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]

--- a/test/Extensions/Orleans.Redis.Tests/Journaling/RedisJournalStorageTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Journaling/RedisJournalStorageTests.cs
@@ -39,21 +39,23 @@ public sealed class RedisJournalStorageTests
     public async Task AppendAndRead_RoundTripsBytesAndMetadata()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var provider = context.Provider;
         var storage = provider.CreateStorage(JournalId.Create("redis", "append"));
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "test" }));
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "test" },
+            TestContext.Current.CancellationToken));
 
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1, 2]), CancellationToken.None);
-        await storage.AppendAsync(CreateSequence([3, 4], [5]), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1, 2]), TestContext.Current.CancellationToken);
+        await storage.AppendAsync(CreateSequence([3, 4], [5]), TestContext.Current.CancellationToken);
 
-        var metadata = await storage.GetMetadataAsync();
+        var metadata = await storage.GetMetadataAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(metadata);
         Assert.Equal("test", metadata.Properties["owner"]);
         Assert.Equal(new JournaledStateManagerOptions().JournalFormatKey, metadata.Format);
 
         var consumer = new CapturingJournalStorageConsumer();
-        await provider.CreateStorage(JournalId.Create("redis", "append")).ReadAsync(consumer, CancellationToken.None);
+        await provider.CreateStorage(JournalId.Create("redis", "append")).ReadAsync(consumer, TestContext.Current.CancellationToken);
 
         Assert.True(consumer.IsCompleted);
         Assert.Equal([1, 2, 3, 4, 5], consumer.Bytes.ToArray());
@@ -64,24 +66,28 @@ public sealed class RedisJournalStorageTests
     public async Task ReplaceListAndDelete_UseJournalIds()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var provider = context.Provider;
         var idA = JournalId.Create("redis", "list", "a");
         var idB = JournalId.Create("redis", "list", "b");
         var child = JournalId.Create("redis", "list", "a", "child");
         var other = JournalId.Create("redis", "other");
 
-        await provider.CreateStorage(idA).ReplaceAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        await provider.CreateStorage(idB).CreateIfNotExistsAsync();
-        await provider.CreateStorage(child).AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
-        await provider.CreateStorage(other).CreateIfNotExistsAsync();
+        await provider.CreateStorage(idA).ReplaceAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
+        await provider.CreateStorage(idB).CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await provider.CreateStorage(child).AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken);
+        await provider.CreateStorage(other).CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        var listed = await ToListAsync(provider.ListAsync(JournalId.Create("redis", "list")));
+        var listed = await ToListAsync(
+            provider.ListAsync(JournalId.Create("redis", "list"), TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
         Assert.Equal([idA, child, idB], listed);
 
-        await provider.CreateStorage(idA).DeleteAsync(CancellationToken.None);
+        await provider.CreateStorage(idA).DeleteAsync(TestContext.Current.CancellationToken);
 
-        listed = await ToListAsync(provider.ListAsync(JournalId.Create("redis", "list")));
+        listed = await ToListAsync(
+            provider.ListAsync(JournalId.Create("redis", "list"), TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
         Assert.Equal([child, idB], listed);
     }
 
@@ -89,20 +95,23 @@ public sealed class RedisJournalStorageTests
     public async Task UpdateMetadata_UsesETagCasAndPreservesNoChangeETag()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var provider = context.Provider;
         var storage = provider.CreateStorage(JournalId.Create("redis", "metadata"));
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string>
-        {
-            ["keep"] = "1",
-            ["remove"] = "2",
-        }));
-        var original = (await storage.GetMetadataAsync())!;
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string>
+            {
+                ["keep"] = "1",
+                ["remove"] = "2",
+            },
+            TestContext.Current.CancellationToken));
+        var original = (await storage.GetMetadataAsync(TestContext.Current.CancellationToken))!;
 
         var updated = await storage.UpdateMetadataAsync(
             new Dictionary<string, string> { ["keep"] = "3", ["add"] = "4" },
             ["remove"],
-            original.ETag);
+            original.ETag,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(updated);
         Assert.NotEqual(original.ETag, updated.ETag);
@@ -113,13 +122,15 @@ public sealed class RedisJournalStorageTests
         var stale = await storage.UpdateMetadataAsync(
             new Dictionary<string, string> { ["keep"] = "5" },
             remove: null,
-            original.ETag);
+            original.ETag,
+            TestContext.Current.CancellationToken);
         Assert.Null(stale);
 
         var noChange = await storage.UpdateMetadataAsync(
             new Dictionary<string, string> { ["keep"] = "3" },
             remove: null,
-            updated.ETag);
+            updated.ETag,
+            TestContext.Current.CancellationToken);
         Assert.NotNull(noChange);
         Assert.Equal(updated.ETag, noChange.ETag);
     }
@@ -128,33 +139,33 @@ public sealed class RedisJournalStorageTests
     public async Task StaleAppend_ThrowsInconsistentStateException()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var provider = context.Provider;
         var id = JournalId.Create("redis", "stale");
         var first = provider.CreateStorage(id);
         var second = provider.CreateStorage(id);
 
-        await first.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await first.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
         var consumer = new CapturingJournalStorageConsumer();
-        await second.ReadAsync(consumer, CancellationToken.None);
-        await first.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+        await second.ReadAsync(consumer, TestContext.Current.CancellationToken);
+        await first.AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAsync<InconsistentStateException>(
-            () => second.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
+            () => second.AppendAsync(new ReadOnlySequence<byte>([3]), TestContext.Current.CancellationToken).AsTask());
     }
 
     [Fact]
     public async Task ColdAppendToExistingJournal_AppendsCurrentVersion()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var id = JournalId.Create("redis", "cold-append");
-        await context.Provider.CreateStorage(id).AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await context.Provider.CreateStorage(id).AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
 
-        await context.Provider.CreateStorage(id).AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+        await context.Provider.CreateStorage(id).AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken);
 
         var consumer = new CapturingJournalStorageConsumer();
-        await context.Provider.CreateStorage(id).ReadAsync(consumer, CancellationToken.None);
+        await context.Provider.CreateStorage(id).ReadAsync(consumer, TestContext.Current.CancellationToken);
         Assert.Equal([1, 2], consumer.Bytes);
     }
 
@@ -162,27 +173,33 @@ public sealed class RedisJournalStorageTests
     public async Task StaleAppendAfterDelete_DoesNotRecreateJournal()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var id = JournalId.Create("redis", "stale-after-delete");
         var stale = context.Provider.CreateStorage(id);
-        await stale.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        await context.Provider.CreateStorage(id).DeleteAsync(CancellationToken.None);
+        await stale.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
+        await context.Provider.CreateStorage(id).DeleteAsync(TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAsync<InconsistentStateException>(
-            () => stale.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
-        Assert.Null(await context.Provider.CreateStorage(id).GetMetadataAsync());
+            () => stale.AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken).AsTask());
+        Assert.Null(await context.Provider.CreateStorage(id).GetMetadataAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task Read_PreservesIncompleteRecordsAcrossSegments()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync(options => options.ReadChunkSize = 2);
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(
+            TestContext.Current.CancellationToken,
+            options => options.ReadChunkSize = 2);
         var storage = context.Provider.CreateStorage(JournalId.Create("redis", "segmented-read"));
-        await storage.ReplaceAsync(new ReadOnlySequence<byte>(Enumerable.Range(0, 10).Select(static value => (byte)value).ToArray()), CancellationToken.None);
+        await storage.ReplaceAsync(
+            new ReadOnlySequence<byte>(Enumerable.Range(0, 10).Select(static value => (byte)value).ToArray()),
+            TestContext.Current.CancellationToken);
 
         var consumer = new FixedRecordJournalStorageConsumer(recordSize: 5);
-        await context.Provider.CreateStorage(JournalId.Create("redis", "segmented-read")).ReadAsync(consumer, CancellationToken.None);
+        await context.Provider.CreateStorage(JournalId.Create("redis", "segmented-read")).ReadAsync(
+            consumer,
+            TestContext.Current.CancellationToken);
 
         Assert.True(consumer.IsCompleted);
         Assert.Equal(2, consumer.Records.Count);
@@ -194,12 +211,14 @@ public sealed class RedisJournalStorageTests
     public async Task Read_ObservesCancellationBetweenSegments()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync(options => options.ReadChunkSize = 2);
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(
+            TestContext.Current.CancellationToken,
+            options => options.ReadChunkSize = 2);
         var id = JournalId.Create("redis", "cancelled-read");
         await context.Provider.CreateStorage(id).ReplaceAsync(
             new ReadOnlySequence<byte>(Enumerable.Range(0, 10).Select(static value => (byte)value).ToArray()),
-            CancellationToken.None);
-        using var cancellation = new CancellationTokenSource();
+            TestContext.Current.CancellationToken);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var consumer = new CancellingJournalStorageConsumer(cancellation);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -212,21 +231,22 @@ public sealed class RedisJournalStorageTests
     public async Task MetadataOnlyUpdate_DoesNotInvalidateContentWriter()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var id = JournalId.Create("redis", "metadata-content-etag");
         var writer = context.Provider.CreateStorage(id);
         var metadataWriter = context.Provider.CreateStorage(id);
-        await writer.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        var metadata = await metadataWriter.GetMetadataAsync();
+        await writer.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
+        var metadata = await metadataWriter.GetMetadataAsync(TestContext.Current.CancellationToken);
 
         var updated = await metadataWriter.UpdateMetadataAsync(
             new Dictionary<string, string> { ["owner"] = "metadata-writer" },
-            expectedETag: metadata!.ETag);
-        await writer.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+            expectedETag: metadata!.ETag,
+            cancellationToken: TestContext.Current.CancellationToken);
+        await writer.AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken);
 
         Assert.NotNull(updated);
         var consumer = new CapturingJournalStorageConsumer();
-        await context.Provider.CreateStorage(id).ReadAsync(consumer, CancellationToken.None);
+        await context.Provider.CreateStorage(id).ReadAsync(consumer, TestContext.Current.CancellationToken);
         Assert.Equal([1, 2], consumer.Bytes);
     }
 
@@ -234,27 +254,30 @@ public sealed class RedisJournalStorageTests
     public async Task ConcurrentReadAndReplace_ReturnsAtomicSnapshot()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync(options => options.ReadChunkSize = 8);
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(
+            cancellationToken,
+            options => options.ReadChunkSize = 8);
         var id = JournalId.Create("redis", "atomic-read");
         var writer = context.Provider.CreateStorage(id);
         var first = Enumerable.Repeat((byte)0x11, 512).ToArray();
         var second = Enumerable.Repeat((byte)0x22, 512).ToArray();
-        await writer.ReplaceAsync(new ReadOnlySequence<byte>(first), CancellationToken.None);
+        await writer.ReplaceAsync(new ReadOnlySequence<byte>(first), cancellationToken);
 
         var replaceTask = Task.Run(async () =>
         {
             for (var i = 0; i < 100; i++)
             {
                 var value = i % 2 == 0 ? second : first;
-                await writer.ReplaceAsync(new ReadOnlySequence<byte>(value), CancellationToken.None);
+                await writer.ReplaceAsync(new ReadOnlySequence<byte>(value), cancellationToken);
             }
-        });
+        }, cancellationToken);
         var readTasks = Enumerable.Range(0, 8).Select(async _ =>
         {
             for (var i = 0; i < 25; i++)
             {
                 var consumer = new CapturingJournalStorageConsumer();
-                await context.Provider.CreateStorage(id).ReadAsync(consumer, CancellationToken.None);
+                await context.Provider.CreateStorage(id).ReadAsync(consumer, cancellationToken);
                 var bytes = consumer.Bytes.ToArray();
                 Assert.True(bytes.SequenceEqual(first) || bytes.SequenceEqual(second));
             }
@@ -267,22 +290,22 @@ public sealed class RedisJournalStorageTests
     public async Task ConcurrentDeleteAndCreate_NeverLeavesMetadataWithoutData()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
 
         for (var i = 0; i < 64; i++)
         {
             var id = JournalId.Create("redis", "delete-create", i.ToString());
             var deleting = context.Provider.CreateStorage(id);
             var creating = context.Provider.CreateStorage(id);
-            var deleteTask = deleting.DeleteAsync(CancellationToken.None).AsTask();
-            var appendTask = TryAppendAsync(creating, [1, 2, 3]);
+            var deleteTask = deleting.DeleteAsync(TestContext.Current.CancellationToken).AsTask();
+            var appendTask = TryAppendAsync(creating, [1, 2, 3], TestContext.Current.CancellationToken);
             await Task.WhenAll(deleteTask, appendTask);
 
-            var metadata = await context.Provider.CreateStorage(id).GetMetadataAsync();
+            var metadata = await context.Provider.CreateStorage(id).GetMetadataAsync(TestContext.Current.CancellationToken);
             if (metadata is not null)
             {
                 var consumer = new CapturingJournalStorageConsumer();
-                await context.Provider.CreateStorage(id).ReadAsync(consumer, CancellationToken.None);
+                await context.Provider.CreateStorage(id).ReadAsync(consumer, TestContext.Current.CancellationToken);
                 Assert.Equal([1, 2, 3], consumer.Bytes);
             }
         }
@@ -293,24 +316,32 @@ public sealed class RedisJournalStorageTests
     {
         TestUtils.CheckForRedis();
         var keyPrefix = $"orleans-tests/journaling/literal*?[x]\\{Guid.NewGuid():N}";
-        await using var context = await RedisJournalStorageTestContext.CreateAsync(options => options.KeyPrefix = keyPrefix);
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(
+            TestContext.Current.CancellationToken,
+            options => options.KeyPrefix = keyPrefix);
         var id = JournalId.Create("redis", "pattern-prefix");
-        await context.Provider.CreateStorage(id).CreateIfNotExistsAsync();
+        await context.Provider.CreateStorage(id).CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Assert.Equal([id], await ToListAsync(context.Provider.ListAsync()));
+        Assert.Equal(
+            [id],
+            await ToListAsync(
+                context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+                TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async Task MappedKeyCollision_IsRejected()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync(options => options.GetKeyName = _ => "shared");
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(
+            TestContext.Current.CancellationToken,
+            options => options.GetKeyName = _ => "shared");
         var first = context.Provider.CreateStorage(JournalId.Create("redis", "collision", "first"));
         var second = context.Provider.CreateStorage(JournalId.Create("redis", "collision", "second"));
-        Assert.True(await first.CreateIfNotExistsAsync());
+        Assert.True(await first.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken));
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => second.CreateIfNotExistsAsync().AsTask());
+            () => second.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken).AsTask());
         Assert.Contains("key mapping collision", exception.Message);
     }
 
@@ -318,14 +349,16 @@ public sealed class RedisJournalStorageTests
     public async Task Replace_ResetsCompactionAccounting()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync(options => options.CompactionThresholdBytes = 3);
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(
+            TestContext.Current.CancellationToken,
+            options => options.CompactionThresholdBytes = 3);
         var storage = context.Provider.CreateStorage(JournalId.Create("redis", "compaction"));
 
-        await storage.ReplaceAsync(new ReadOnlySequence<byte>([1, 2, 3, 4]), CancellationToken.None);
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([1, 2, 3, 4]), TestContext.Current.CancellationToken);
         Assert.False(storage.IsCompactionRequested);
-        await storage.AppendAsync(new ReadOnlySequence<byte>([5, 6]), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>([5, 6]), TestContext.Current.CancellationToken);
         Assert.False(storage.IsCompactionRequested);
-        await storage.AppendAsync(new ReadOnlySequence<byte>([7]), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>([7]), TestContext.Current.CancellationToken);
         Assert.True(storage.IsCompactionRequested);
     }
 
@@ -335,37 +368,38 @@ public sealed class RedisJournalStorageTests
     public async Task InvalidAppendLength_BlocksMutations(string invalidAppendLength)
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var id = JournalId.Create("redis", "invalid-append-length", invalidAppendLength);
         var storage = context.Provider.CreateStorage(id);
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        var metadata = await storage.GetMetadataAsync();
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
+        var metadata = await storage.GetMetadataAsync(TestContext.Current.CancellationToken);
         var metadataKey = context.GetMetadataKey(id);
         await context.Database.HashSetAsync(metadataKey, RedisJournalStorage.AppendLengthMetadataKey, invalidAppendLength);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
+            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => storage.UpdateMetadataAsync(
                 new Dictionary<string, string> { ["owner"] = "invalid" },
-                expectedETag: metadata!.ETag).AsTask());
+                expectedETag: metadata!.ETag,
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
 
         await context.Database.HashSetAsync(metadataKey, RedisJournalStorage.AppendLengthMetadataKey, "1");
         var consumer = new CapturingJournalStorageConsumer();
-        await context.Provider.CreateStorage(id).ReadAsync(consumer, CancellationToken.None);
+        await context.Provider.CreateStorage(id).ReadAsync(consumer, TestContext.Current.CancellationToken);
         Assert.Equal([1], consumer.Bytes);
-        Assert.False((await storage.GetMetadataAsync())!.Properties.ContainsKey("owner"));
+        Assert.False((await storage.GetMetadataAsync(TestContext.Current.CancellationToken))!.Properties.ContainsKey("owner"));
     }
 
     [Fact]
     public async Task CurrentSchemaVersion_IsStored()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var id = JournalId.Create("redis", "schema-version");
-        await context.Provider.CreateStorage(id).AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await context.Provider.CreateStorage(id).AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
 
         var schemaVersion = await context.Database.HashGetAsync(
             context.GetMetadataKey(id),
@@ -380,11 +414,11 @@ public sealed class RedisJournalStorageTests
     public async Task MissingOrUnsupportedSchemaVersion_BlocksAccessAndMutations(string? schemaVersion)
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var id = JournalId.Create("redis", "unsupported-schema", schemaVersion ?? "missing");
         var storage = context.Provider.CreateStorage(id);
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        var metadata = await storage.GetMetadataAsync();
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
+        var metadata = await storage.GetMetadataAsync(TestContext.Current.CancellationToken);
         var metadataKey = context.GetMetadataKey(id);
         if (schemaVersion is null)
         {
@@ -396,39 +430,44 @@ public sealed class RedisJournalStorageTests
         }
 
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => context.Provider.CreateStorage(id).GetMetadataAsync().AsTask());
+            () => context.Provider.CreateStorage(id).GetMetadataAsync(TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => context.Provider.CreateStorage(id).ReadAsync(new CapturingJournalStorageConsumer(), CancellationToken.None).AsTask());
+            () => context.Provider.CreateStorage(id).ReadAsync(
+                new CapturingJournalStorageConsumer(),
+                TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
+            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<NotSupportedException>(
             () => storage.UpdateMetadataAsync(
                 new Dictionary<string, string> { ["owner"] = "unsupported" },
-                expectedETag: metadata!.ETag).AsTask());
+                expectedETag: metadata!.ETag,
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => storage.DeleteAsync(CancellationToken.None).AsTask());
+            () => storage.DeleteAsync(TestContext.Current.CancellationToken).AsTask());
 
         await context.Database.HashSetAsync(
             metadataKey,
             RedisJournalStorage.SchemaVersionMetadataKey,
             RedisJournalStorage.CurrentSchemaVersion);
         var consumer = new CapturingJournalStorageConsumer();
-        await context.Provider.CreateStorage(id).ReadAsync(consumer, CancellationToken.None);
+        await context.Provider.CreateStorage(id).ReadAsync(consumer, TestContext.Current.CancellationToken);
         Assert.Equal([1], consumer.Bytes);
-        Assert.False((await storage.GetMetadataAsync())!.Properties.ContainsKey("owner"));
+        Assert.False((await storage.GetMetadataAsync(TestContext.Current.CancellationToken))!.Properties.ContainsKey("owner"));
     }
 
     [Fact]
     public async Task CallerMayUseFormatMetadata()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var storage = context.Provider.CreateStorage(JournalId.Create("redis", "caller-format"));
-        await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["format"] = "caller" });
+        await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["format"] = "caller" },
+            TestContext.Current.CancellationToken);
 
-        var metadata = await storage.GetMetadataAsync();
+        var metadata = await storage.GetMetadataAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(new JournaledStateManagerOptions().JournalFormatKey, metadata!.Format);
         Assert.Equal("caller", metadata.Properties["format"]);
@@ -438,22 +477,29 @@ public sealed class RedisJournalStorageTests
     public async Task CallerCannotSetProviderOwnedProperties()
     {
         TestUtils.CheckForRedis();
-        await using var context = await RedisJournalStorageTestContext.CreateAsync();
+        await using var context = await RedisJournalStorageTestContext.CreateAsync(TestContext.Current.CancellationToken);
         var provider = context.Provider;
         var storage = provider.CreateStorage(JournalId.Create("redis", "reserved"));
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["$owner"] = "provider" }).AsTask());
+            () => storage.CreateIfNotExistsAsync(
+                new Dictionary<string, string> { ["$owner"] = "provider" },
+                TestContext.Current.CancellationToken).AsTask());
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.UpdateMetadataAsync(new Dictionary<string, string> { ["$format"] = "provider" }).AsTask());
+            () => storage.UpdateMetadataAsync(
+                new Dictionary<string, string> { ["$format"] = "provider" },
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
     }
 
-    private static async Task<bool> TryAppendAsync(IJournalStorage storage, byte[] value)
+    private static async Task<bool> TryAppendAsync(
+        IJournalStorage storage,
+        byte[] value,
+        CancellationToken cancellationToken)
     {
         try
         {
-            await storage.AppendAsync(new ReadOnlySequence<byte>(value), CancellationToken.None);
+            await storage.AppendAsync(new ReadOnlySequence<byte>(value), cancellationToken);
             return true;
         }
         catch (InconsistentStateException)
@@ -469,10 +515,12 @@ public sealed class RedisJournalStorageTests
         return new(firstSegment, 0, lastSegment, lastSegment.Memory.Length);
     }
 
-    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    private static async Task<List<T>> ToListAsync<T>(
+        IAsyncEnumerable<T> source,
+        CancellationToken cancellationToken)
     {
         var result = new List<T>();
-        await foreach (var item in source)
+        await foreach (var item in source.WithCancellation(cancellationToken))
         {
             result.Add(item);
         }
@@ -502,12 +550,39 @@ public sealed class RedisJournalStorageTests
         public RedisKey GetMetadataKey(JournalId journalId)
             => RedisJournalStorage.GetMetadataKey(_keyPrefix, journalId.Value);
 
-        public static async Task<RedisJournalStorageTestContext> CreateAsync(Action<RedisJournalStorageOptions>? configure = null)
+        public static async Task<RedisJournalStorageTestContext> CreateAsync(
+            CancellationToken cancellationToken,
+            Action<RedisJournalStorageOptions>? configure = null)
         {
             var keyPrefix = $"orleans-tests/journaling/{Guid.NewGuid():N}";
             var connectionString = TestDefaultConfiguration.RedisConnectionString
                 ?? throw new InvalidOperationException("Redis connection string is not configured.");
-            var multiplexer = await ConnectionMultiplexer.ConnectAsync(connectionString);
+            var connectTask = ConnectionMultiplexer.ConnectAsync(connectionString);
+            ConnectionMultiplexer multiplexer;
+            try
+            {
+                multiplexer = await connectTask.WaitAsync(cancellationToken);
+            }
+            catch
+            {
+                _ = connectTask.ContinueWith(
+                    static task =>
+                    {
+                        if (task.IsCompletedSuccessfully)
+                        {
+                            task.Result.Dispose();
+                        }
+                        else
+                        {
+                            _ = task.Exception;
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+                throw;
+            }
+
             var options = new RedisJournalStorageOptions
             {
                 ConfigurationOptions = ConfigurationOptions.Parse(connectionString),
@@ -525,8 +600,16 @@ public sealed class RedisJournalStorageTests
 
             var lifecycle = new SiloLifecycleSubject(Microsoft.Extensions.Logging.Abstractions.NullLogger<SiloLifecycleSubject>.Instance);
             provider.Participate(lifecycle);
-            await lifecycle.OnStart(CancellationToken.None);
-            return new(provider, keyPrefix, multiplexer);
+            try
+            {
+                await lifecycle.OnStart(cancellationToken);
+                return new(provider, keyPrefix, multiplexer);
+            }
+            catch
+            {
+                multiplexer.Dispose();
+                throw;
+            }
         }
 
         public async ValueTask DisposeAsync()

--- a/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests.cs
@@ -145,7 +145,7 @@ namespace Tester.Redis.Persistence
         public async Task GrainStorage_ModelBasedGeneratedConformance()
         {
             var runner = new GrainStorageModelBasedTestRunner(storageProvider, "Redis", output.WriteLine);
-            await runner.RunGeneratedConformanceTests();
+            await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests.cs
@@ -27,7 +27,9 @@ namespace Tester.Redis.Persistence
             TestUtils.CheckForRedis();
             this.fixture = commonFixture;
             this.output = output;
-            this.storageProvider = commonFixture.CreateRedisGrainStorage(false).GetAwaiter().GetResult();
+            this.storageProvider = commonFixture.CreateRedisGrainStorage(
+                false,
+                cancellationToken: TestContext.Current.CancellationToken).GetAwaiter().GetResult();
             this.commonStorageTests = new CommonStorageTests(storageProvider);
         }
 

--- a/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests_DeleteStateOnClear.cs
@@ -95,7 +95,7 @@ namespace Tester.Redis.Persistence
         {
             var runner = new GrainStorageModelBasedTestRunner(storageProvider, "RedisDeleteStateOnClear", output.WriteLine);
 
-            await runner.RunGeneratedConformanceTests();
+            await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
         }
     }
 

--- a/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests_DeleteStateOnClear.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests_DeleteStateOnClear.cs
@@ -27,7 +27,10 @@ namespace Tester.Redis.Persistence
             TestUtils.CheckForRedis();
             this.fixture = commonFixture;
             this.output = output;
-            this.storageProvider = commonFixture.CreateRedisGrainStorage(useOrleansSerializer: false, deleteStateOnClear: true).GetAwaiter().GetResult();
+            this.storageProvider = commonFixture.CreateRedisGrainStorage(
+                useOrleansSerializer: false,
+                deleteStateOnClear: true,
+                cancellationToken: TestContext.Current.CancellationToken).GetAwaiter().GetResult();
             this.commonStorageTests = new CommonStorageTests(storageProvider);
         }
 

--- a/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests_OrleansSerializer.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageTests_OrleansSerializer.cs
@@ -22,7 +22,9 @@ namespace Tester.Redis.Persistence
         {
             TestUtils.CheckForRedis();
             this.fixture = commonFixture;
-            var storageProvider = fixture.CreateRedisGrainStorage(true).Result;
+            var storageProvider = fixture.CreateRedisGrainStorage(
+                true,
+                cancellationToken: TestContext.Current.CancellationToken).Result;
             this.commonStorageTests = new CommonStorageTests(storageProvider);
         }
 

--- a/test/Extensions/Orleans.Redis.Tests/RedisMultiplexerOwnershipTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/RedisMultiplexerOwnershipTests.cs
@@ -266,7 +266,7 @@ public sealed class RedisMultiplexerOwnershipTests
         {
             ISiloLifecycleSubject lifecycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
             storage.Participate(lifecycle);
-            await lifecycle.OnStart(CancellationToken.None);
+            await lifecycle.OnStart(TestContext.Current.CancellationToken);
         });
     }
 

--- a/test/Extensions/Orleans.Redis.Tests/Streaming/RedisClientStreamTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Streaming/RedisClientStreamTests.cs
@@ -25,10 +25,17 @@ public sealed class RedisClientStreamTests : TestClusterPerTest
     }
 
     [Fact]
-    public async Task Redis_StreamProducerOnDroppedClientTest() => await _runner.StreamProducerOnDroppedClientTest(StreamProviderName, StreamNamespace);
+    public async Task Redis_StreamProducerOnDroppedClientTest() => await _runner.StreamProducerOnDroppedClientTest(
+        StreamProviderName,
+        StreamNamespace,
+        TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_StreamConsumerOnDroppedClientTest() => await _runner.StreamConsumerOnDroppedClientTest(StreamProviderName, StreamNamespace, _output);
+    public async Task Redis_StreamConsumerOnDroppedClientTest() => await _runner.StreamConsumerOnDroppedClientTest(
+        StreamProviderName,
+        StreamNamespace,
+        _output,
+        cancellationToken: TestContext.Current.CancellationToken);
 
     public override async ValueTask InitializeAsync()
     {

--- a/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamTests.cs
@@ -77,7 +77,9 @@ public sealed class RedisStreamTests : TestClusterPerTest
     }
 
     [Fact]
-    public async Task Redis_18_Deactivation_OneProducerGrainOneConsumerGrain() => await _runner.StreamTest_16_Deactivation_OneProducerGrainOneConsumerGrain();
+    public async Task Redis_18_Deactivation_OneProducerGrainOneConsumerGrain() =>
+        await _runner.StreamTest_16_Deactivation_OneProducerGrainOneConsumerGrain(
+            cancellationToken: TestContext.Current.CancellationToken);
 
     [Fact]
     public async Task Redis_19_ConsumerImplicitlySubscribedToProducerClient() => await _runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient();

--- a/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamTests.cs
@@ -18,62 +18,65 @@ public sealed class RedisStreamTests : TestClusterPerTest
     private SingleStreamTestRunner _runner = null!;
 
     [Fact]
-    public async Task Redis_01_OneProducerGrainOneConsumerGrain() => await _runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+    public async Task Redis_01_OneProducerGrainOneConsumerGrain() => await _runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_02_OneProducerGrainOneConsumerClient() => await _runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+    public async Task Redis_02_OneProducerGrainOneConsumerClient() => await _runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_03_OneProducerClientOneConsumerGrain() => await _runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+    public async Task Redis_03_OneProducerClientOneConsumerGrain() => await _runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_04_OneProducerClientOneConsumerClient() => await _runner.StreamTest_04_OneProducerClientOneConsumerClient();
+    public async Task Redis_04_OneProducerClientOneConsumerClient() => await _runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains() => await _runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+    public async Task Redis_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains() => await _runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_06_ManyDifferent_ManyProducerGrainManyConsumerClients() => await _runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+    public async Task Redis_06_ManyDifferent_ManyProducerGrainManyConsumerClients() => await _runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_07_ManyDifferent_ManyProducerClientsManyConsumerGrains() => await _runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+    public async Task Redis_07_ManyDifferent_ManyProducerClientsManyConsumerGrains() => await _runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_08_ManyDifferent_ManyProducerClientsManyConsumerClients() => await _runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+    public async Task Redis_08_ManyDifferent_ManyProducerClientsManyConsumerClients() => await _runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_09_ManySame_ManyProducerGrainsManyConsumerGrains() => await _runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+    public async Task Redis_09_ManySame_ManyProducerGrainsManyConsumerGrains() => await _runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_10_ManySame_ManyConsumerGrainsManyProducerGrains() => await _runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+    public async Task Redis_10_ManySame_ManyConsumerGrainsManyProducerGrains() => await _runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_11_ManySame_ManyProducerGrainsManyConsumerClients() => await _runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+    public async Task Redis_11_ManySame_ManyProducerGrainsManyConsumerClients() => await _runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_12_ManySame_ManyProducerClientsManyConsumerGrains() => await _runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+    public async Task Redis_12_ManySame_ManyProducerClientsManyConsumerGrains() => await _runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_13_SameGrain_ConsumerFirstProducerLater() => await _runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+    public async Task Redis_13_SameGrain_ConsumerFirstProducerLater() => await _runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_14_SameGrain_ProducerFirstConsumerLater() => await _runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+    public async Task Redis_14_SameGrain_ProducerFirstConsumerLater() => await _runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_15_ConsumeAtProducersRequest() => await _runner.StreamTest_15_ConsumeAtProducersRequest();
+    public async Task Redis_15_ConsumeAtProducersRequest() => await _runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
 
     [Fact]
     public async Task Redis_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
         var multiRunner = new MultipleStreamsTestRunner(InternalClient, StreamProviderName, 16, false);
-        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Redis_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
     {
         var multiRunner = new MultipleStreamsTestRunner(InternalClient, StreamProviderName, 17, false);
-        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(() => HostedCluster.StartAdditionalSilo());
+        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+            () => HostedCluster.StartAdditionalSilo(),
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -82,10 +85,10 @@ public sealed class RedisStreamTests : TestClusterPerTest
             cancellationToken: TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_19_ConsumerImplicitlySubscribedToProducerClient() => await _runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient();
+    public async Task Redis_19_ConsumerImplicitlySubscribedToProducerClient() => await _runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient(TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_20_ConsumerImplicitlySubscribedToProducerGrain() => await _runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain();
+    public async Task Redis_20_ConsumerImplicitlySubscribedToProducerGrain() => await _runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain(TestContext.Current.CancellationToken);
 
     public override async ValueTask InitializeAsync()
     {

--- a/test/Extensions/Orleans.Redis.Tests/Streaming/RedisSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Streaming/RedisSubscriptionMultiplicityTests.cs
@@ -18,28 +18,28 @@ public sealed class RedisSubscriptionMultiplicityTests : TestClusterPerTest
     private SubscriptionMultiplicityTestRunner _runner = null!;
 
     [Fact]
-    public async Task Redis_MultipleParallelSubscriptionTest() => await _runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public async Task Redis_MultipleParallelSubscriptionTest() => await _runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_MultipleLinearSubscriptionTest() => await _runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public async Task Redis_MultipleLinearSubscriptionTest() => await _runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_MultipleSubscriptionTest_AddRemove() => await _runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+    public async Task Redis_MultipleSubscriptionTest_AddRemove() => await _runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_ResubscriptionTest() => await _runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public async Task Redis_ResubscriptionTest() => await _runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_ResubscriptionAfterDeactivationTest() => await _runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+    public async Task Redis_ResubscriptionAfterDeactivationTest() => await _runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_ActiveSubscriptionTest() => await _runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+    public async Task Redis_ActiveSubscriptionTest() => await _runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_TwoIntermittentStreamTest() => await _runner.TwoIntermittentStreamTest(Guid.NewGuid());
+    public async Task Redis_TwoIntermittentStreamTest() => await _runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
 
     [Fact]
-    public async Task Redis_SubscribeFromClientTest() => await _runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
+    public async Task Redis_SubscribeFromClientTest() => await _runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
 
     public override async ValueTask InitializeAsync()
     {

--- a/test/Extensions/Orleans.Redis.Tests/Utility/CommonFixture.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Utility/CommonFixture.cs
@@ -12,6 +12,7 @@ using Orleans.Storage;
 using StackExchange.Redis;
 using Tester;
 using TestExtensions;
+using Xunit;
 
 public class CommonFixture : TestEnvironmentFixture
 {
@@ -37,17 +38,49 @@ public class CommonFixture : TestEnvironmentFixture
     /// </summary>
     /// <remarks>If the environment invariants have failed to hold upon creation of the storage provider,
     /// a <em>null</em> value will be provided.</remarks>
-    public async Task<IGrainStorage> CreateRedisGrainStorage(bool useOrleansSerializer = false, bool deleteStateOnClear = false)
+    public async Task<IGrainStorage> CreateRedisGrainStorage(
+        bool useOrleansSerializer = false,
+        bool deleteStateOnClear = false,
+        CancellationToken cancellationToken = default)
     {
         TestUtils.CheckForRedis();
         IGrainStorageSerializer grainStorageSerializer = useOrleansSerializer ? new OrleansGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<Serializer>()!)
                                                                               : new JsonGrainStorageSerializer(this.DefaultProviderRuntime.ServiceProvider.GetService<OrleansJsonSerializer>()!);
-        var options = new RedisStorageOptions()
+        var options = new RedisStorageOptions
         {
             ConfigurationOptions = ConfigurationOptions.Parse(TestDefaultConfiguration.RedisConnectionString!),
             GrainStorageSerializer = grainStorageSerializer,
             DeleteStateOnClear = deleteStateOnClear,
         };
+        var connectTask = ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+        ConnectionMultiplexer connection;
+        try
+        {
+            connection = await connectTask.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            _ = connectTask.ContinueWith(
+                static task =>
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        task.Result.Dispose();
+                    }
+                    else
+                    {
+                        _ = task.Exception;
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            throw;
+        }
+
+        options.CreateMultiplexer = _ => Task.FromResult((
+            Multiplexer: (IConnectionMultiplexer)connection,
+            IsShared: false));
 
         var clusterOptions = new ClusterOptions()
         {
@@ -64,7 +97,15 @@ public class CommonFixture : TestEnvironmentFixture
             serviceProvider.GetRequiredService<ILogger<RedisGrainStorage>>());
         ISiloLifecycleSubject siloLifeCycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
         storageProvider.Participate(siloLifeCycle);
-        await siloLifeCycle.OnStart(CancellationToken.None);
-        return storageProvider;
+        try
+        {
+            await siloLifeCycle.OnStart(cancellationToken);
+            return storageProvider;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -110,7 +110,7 @@ public class EventHubCheckpointerTests
         {
             if (PurgeOffsetToReport is not null)
             {
-                checkpointer?.Update(PurgeOffsetToReport, DateTime.UtcNow, CancellationToken.None);
+                checkpointer?.Update(PurgeOffsetToReport, DateTime.UtcNow, TestContext.Current.CancellationToken);
             }
         }
 
@@ -273,7 +273,7 @@ public class EventHubCheckpointerTests
         var eventHubReceiver = new NullReturningEventHubReceiver();
         var receiver = await CreateReceiver(new TestCheckpointer(), cache, eventHubReceiver);
 
-        var messages = await receiver.GetQueueMessagesAsync(10, CancellationToken.None);
+        var messages = await receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken);
 
         Assert.Empty(messages);
         Assert.Equal(1, eventHubReceiver.ReceiveCount);
@@ -288,10 +288,12 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(
             new TestCheckpointer(),
             eventHubReceiver: eventHubReceiver);
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         var operation = receiver.GetQueueMessagesAsync(10, cancellation.Token);
-        Assert.Equal(cancellation.Token, await eventHubReceiver.ReceiveStarted.Task);
+        Assert.Equal(
+            cancellation.Token,
+            await eventHubReceiver.ReceiveStarted.Task.WaitAsync(TestContext.Current.CancellationToken));
         cancellation.Cancel();
 
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
@@ -303,7 +305,7 @@ public class EventHubCheckpointerTests
     public async Task CancellationOverloads_FallBackToLegacyReceiver()
     {
         IEventHubReceiver receiver = new TestEventHubReceiver();
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.Cancel();
 
         Assert.Empty(await receiver.ReceiveAsync(10, TimeSpan.Zero, cancellation.Token));
@@ -353,7 +355,9 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer, cache, eventHubReceiver);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => receiver.Shutdown(TimeSpan.FromMilliseconds(50)).WaitAsync(TimeSpan.FromSeconds(5)));
+            () => receiver.Shutdown(TimeSpan.FromMilliseconds(50)).WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken));
 
         Assert.Equal(1, checkpointer.FlushCount);
         Assert.Equal(1, cache.DisposeCount);
@@ -366,7 +370,7 @@ public class EventHubCheckpointerTests
     {
         var checkpointer = CreateUninitializedCheckpointer();
 
-        await checkpointer.FlushAsync(CancellationToken.None);
+        await checkpointer.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.False(checkpointer.CheckpointExists);
         Assert.Equal(string.Empty, GetLatestOffset(checkpointer));
@@ -383,7 +387,7 @@ public class EventHubCheckpointerTests
         SetPersistedOffset(checkpointer, "20");
 
         checkpointer.Update(candidate, new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc));
-        await checkpointer.FlushAsync(CancellationToken.None);
+        await checkpointer.FlushAsync(TestContext.Current.CancellationToken);
 
         Assert.True(checkpointer.CheckpointExists);
         Assert.Equal("20", GetLatestOffset(checkpointer));
@@ -471,7 +475,7 @@ public class EventHubCheckpointerTests
         Assert.NotNull(constructor);
         var checkpointer = (EventHubCheckpointer)constructor.Invoke([inner]);
 
-        Assert.Equal(expected, await checkpointer.Load(CancellationToken.None));
+        Assert.Equal(expected, await checkpointer.Load(TestContext.Current.CancellationToken));
     }
 
     [TestSuite("BVT")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CollectionFixtures.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CollectionFixtures.cs
@@ -48,7 +48,8 @@ namespace ServiceBus.Tests
                 .Select(silo => HostedCluster.GetSiloServiceProvider(silo.SiloAddress).GetRequiredService<IMeterFactory>())
                 .Select(meterFactory => new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-streams-queue-read-duration"))
                 .ToArray();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
             try
             {
                 // Wait for 10 queue reads across the cluster.

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubsAspireIntegrationTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubsAspireIntegrationTests.cs
@@ -59,7 +59,7 @@ public sealed class EventHubsAspireIntegrationTests
             .Single(endpoint => endpoint.Name == "emulator");
         emulatorEndpoint.AllocatedEndpoint = new AllocatedEndpoint(emulatorEndpoint, "localhost", 5672);
 
-        await using var app = await builder.BuildAsync();
+        await using var app = await builder.BuildAsync(TestContext.Current.CancellationToken);
         var environment = await GetEnvironmentVariablesAsync(silo.Resource, app.Services);
 
         Assert.Equal(expectedProviderType, environment[$"Orleans:Streaming:{providerName}:ProviderType"]);

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -75,7 +75,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             //add items into cache, make sure will allocate multiple buffers from the pool
             int itemAddToCache = 100;
             foreach(var cache in this.cacheList)
-                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache, TestContext.Current.CancellationToken));
             await Task.WhenAll(tasks);
 
             //set cachePressureMonitor to be underPressure
@@ -98,7 +98,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             //add items into cache
             int itemAddToCache = 100;
             foreach (var cache in this.cacheList)
-                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache, TestContext.Current.CancellationToken));
             await Task.WhenAll(tasks);
 
             //set cachePressureMonitor to be underPressure
@@ -123,7 +123,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             //add items into cache
             int itemAddToCache = 100;
             foreach (var cache in this.cacheList)
-                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache, TestContext.Current.CancellationToken));
             await Task.WhenAll(tasks);
 
             //set cachePressureMonitor to be underPressure
@@ -149,7 +149,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             //add items into cache
             int itemAddToCache = 100;
             foreach (var cache in this.cacheList)
-                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache, TestContext.Current.CancellationToken));
             await Task.WhenAll(tasks);
 
             //set up condition so that purge will be performed
@@ -185,7 +185,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             //add items into cache again
             itemAddToCache = 100;
             foreach (var cache in this.cacheList)
-                tasks.Add(AddDataIntoCache(cache, itemAddToCache));
+                tasks.Add(AddDataIntoCache(cache, itemAddToCache, TestContext.Current.CancellationToken));
             await Task.WhenAll(tasks);
             //block pool should have purged buffers returned by now, and used those to allocate buffer for new item
             var newBufferAllocated = new List<FixedSizeBuffer>();
@@ -227,9 +227,12 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             return itemCount;
         }
 
-        private static async Task AddDataIntoCache(EventHubQueueCacheForTesting cache, int count)
+        private static async Task AddDataIntoCache(
+            EventHubQueueCacheForTesting cache,
+            int count,
+            CancellationToken cancellationToken)
         {
-            await Task.Delay(10);
+            await Task.Delay(10, cancellationToken);
             List<EventData> messages = Enumerable.Range(0, count)
                 .Select(i => MakeEventData(i))
                 .ToList();

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/PluggableQueueBalancerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/PluggableQueueBalancerTests.cs
@@ -62,7 +62,12 @@ namespace ServiceBus.Tests
         [Fact, TestCategory("BVT")]
         public Task PluggableQueueBalancerTest_ShouldUseInjectedQueueBalancerAndBalanceCorrectly()
         {
-            return base.ShouldUseInjectedQueueBalancerAndBalanceCorrectly(this.fixture, StreamProviderName, SiloCount, TotalQueueCount);
+            return base.ShouldUseInjectedQueueBalancerAndBalanceCorrectly(
+                this.fixture,
+                StreamProviderName,
+                SiloCount,
+                TotalQueueCount,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -92,7 +92,8 @@ namespace ServiceBus.Tests.SlowConsumingTests
                     streamGuid,
                     StreamNamespace,
                     StreamProviderName,
-                    healthyConsumerCount);
+                    healthyConsumerCount,
+                    testCancellationToken);
 
                 //configure data generator for stream and start producing
                 var randomStreamPlacementArg = new EventDataGeneratorAdapterFactory.StreamRandomPlacementArg(streamId, this.seed.Next(100));
@@ -123,7 +124,9 @@ namespace ServiceBus.Tests.SlowConsumingTests
                 {
                     await CleanupAsync(() => slowConsumer.StopConsuming(), testCancellationToken);
                 }
-                await CleanupAsync(() => StopHealthyConsumerGrainComing(healthyConsumers), testCancellationToken);
+                await CleanupAsync(
+                    cancellationToken => StopHealthyConsumerGrainComing(healthyConsumers, cancellationToken),
+                    testCancellationToken);
                 if (productionStarted)
                 {
                     await CleanupAsync(
@@ -133,6 +136,19 @@ namespace ServiceBus.Tests.SlowConsumingTests
                             streamId),
                         testCancellationToken);
                 }
+            }
+        }
+
+        private static async Task CleanupAsync(Func<CancellationToken, Task> cleanup, CancellationToken testCancellationToken)
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            try
+            {
+                await cleanup(cancellation.Token);
+            }
+            catch (OperationCanceledException) when (testCancellationToken.IsCancellationRequested)
+            {
+                // Preserve the original test cancellation after bounded cleanup.
             }
         }
 
@@ -149,7 +165,13 @@ namespace ServiceBus.Tests.SlowConsumingTests
             }
         }
 
-        public static async Task<List<ISampleStreaming_ConsumerGrain>> SetUpHealthyConsumerGrain(IGrainFactory GrainFactory, Guid streamId, string streamNameSpace, string streamProvider, int grainCount)
+        public static async Task<List<ISampleStreaming_ConsumerGrain>> SetUpHealthyConsumerGrain(
+            IGrainFactory GrainFactory,
+            Guid streamId,
+            string streamNameSpace,
+            string streamProvider,
+            int grainCount,
+            CancellationToken cancellationToken)
         {
             List<ISampleStreaming_ConsumerGrain> grains = new List<ISampleStreaming_ConsumerGrain>();
             List<Task> tasks = new List<Task>();
@@ -157,19 +179,21 @@ namespace ServiceBus.Tests.SlowConsumingTests
             {
                 var consumer = GrainFactory.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid());
                 grains.Add(consumer);
-                tasks.Add(consumer.BecomeConsumer(streamId, streamNameSpace, streamProvider));
+                tasks.Add(consumer.BecomeConsumer(streamId, streamNameSpace, streamProvider, cancellationToken));
                 grainCount--;
             }
             await Task.WhenAll(tasks);
             return grains;
         }
 
-        private static async Task StopHealthyConsumerGrainComing(List<ISampleStreaming_ConsumerGrain> grains)
+        private static async Task StopHealthyConsumerGrainComing(
+            List<ISampleStreaming_ConsumerGrain> grains,
+            CancellationToken cancellationToken)
         {
             List<Task> tasks = new List<Task>();
             foreach (var grain in grains)
             {
-                tasks.Add(grain.StopConsuming());
+                tasks.Add(grain.StopConsuming(cancellationToken));
             }
             await Task.WhenAll(tasks);
         }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -72,35 +72,81 @@ namespace ServiceBus.Tests.SlowConsumingTests
         [Fact, TestCategory("Functional")]
         public async Task EHSlowConsuming_ShouldFavorSlowConsumer()
         {
+            var testCancellationToken = TestContext.Current.CancellationToken;
             var streamGuid = Guid.NewGuid();
             var streamId = StreamId.Create(StreamNamespace, streamGuid);
-            //set up one slow consumer grain
             var slowConsumer = this.fixture.GrainFactory.GetGrain<ISlowConsumingGrain>(Guid.NewGuid());
-            await slowConsumer.BecomeConsumer(streamGuid, StreamNamespace, StreamProviderName);
-
-            //set up 30 healthy consumer grain to show how much we favor slow consumer 
-            int healthyConsumerCount = 30;
-            var healthyConsumers = await SetUpHealthyConsumerGrain(this.fixture.GrainFactory, streamGuid, StreamNamespace, StreamProviderName, healthyConsumerCount);
-
-            //configure data generator for stream and start producing
             var mgmtGrain = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);
-            var randomStreamPlacementArg = new EventDataGeneratorAdapterFactory.StreamRandomPlacementArg(streamId, this.seed.Next(100));
-            await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
-                (int)EventDataGeneratorAdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
-            //since there's an extreme slow consumer, so the back pressure algorithm should be triggered
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => AssertCacheBackPressureTriggered(true, lastTry, cancellationToken), timeout);
+            List<ISampleStreaming_ConsumerGrain> healthyConsumers = [];
+            var productionStarted = false;
+            var slowConsumerStopped = false;
+            try
+            {
+                //set up one slow consumer grain
+                await slowConsumer.BecomeConsumer(streamGuid, StreamNamespace, StreamProviderName);
 
-            //make slow consumer stop consuming
-            await slowConsumer.StopConsuming();
+                //set up 30 healthy consumer grain to show how much we favor slow consumer
+                int healthyConsumerCount = 30;
+                healthyConsumers = await SetUpHealthyConsumerGrain(
+                    this.fixture.GrainFactory,
+                    streamGuid,
+                    StreamNamespace,
+                    StreamProviderName,
+                    healthyConsumerCount);
 
-            //slowConsumer stopped consuming, back pressure algorithm should be cleared in next check period.
-            await Task.Delay(monitorPressureWindowSize);
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => AssertCacheBackPressureTriggered(false, lastTry, cancellationToken), timeout);
+                //configure data generator for stream and start producing
+                var randomStreamPlacementArg = new EventDataGeneratorAdapterFactory.StreamRandomPlacementArg(streamId, this.seed.Next(100));
+                await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
+                    (int)EventDataGeneratorAdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
+                productionStarted = true;
 
-            //clean up test
-            await StopHealthyConsumerGrainComing(healthyConsumers);
-            await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
-                (int)EventDataGeneratorAdapterFactory.Commands.Stop_Producing_On_Stream, streamId);
+                //since there's an extreme slow consumer, so the back pressure algorithm should be triggered
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, cancellationToken) => AssertCacheBackPressureTriggered(true, lastTry, cancellationToken),
+                    timeout,
+                    cancellationToken: testCancellationToken);
+
+                //make slow consumer stop consuming
+                await slowConsumer.StopConsuming();
+                slowConsumerStopped = true;
+
+                //slowConsumer stopped consuming, back pressure algorithm should be cleared in next check period.
+                await Task.Delay(monitorPressureWindowSize, testCancellationToken);
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, cancellationToken) => AssertCacheBackPressureTriggered(false, lastTry, cancellationToken),
+                    timeout,
+                    cancellationToken: testCancellationToken);
+            }
+            finally
+            {
+                if (!slowConsumerStopped)
+                {
+                    await CleanupAsync(() => slowConsumer.StopConsuming(), testCancellationToken);
+                }
+                await CleanupAsync(() => StopHealthyConsumerGrainComing(healthyConsumers), testCancellationToken);
+                if (productionStarted)
+                {
+                    await CleanupAsync(
+                        () => mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(
+                            StreamProviderName,
+                            (int)EventDataGeneratorAdapterFactory.Commands.Stop_Producing_On_Stream,
+                            streamId),
+                        testCancellationToken);
+                }
+            }
+        }
+
+        private static async Task CleanupAsync(Func<Task> cleanup, CancellationToken testCancellationToken)
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            try
+            {
+                await cleanup().WaitAsync(cancellation.Token);
+            }
+            catch (OperationCanceledException) when (testCancellationToken.IsCancellationRequested)
+            {
+                // Preserve the original test cancellation after bounded cleanup.
+            }
         }
 
         public static async Task<List<ISampleStreaming_ConsumerGrain>> SetUpHealthyConsumerGrain(IGrainFactory GrainFactory, Guid streamId, string streamNameSpace, string streamProvider, int grainCount)

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -80,7 +80,13 @@ namespace ServiceBus.Tests.MonitorTests
             var streamId = new FullStreamIdentity(Guid.NewGuid(), StreamNamespace, StreamProviderName);
             //set up 30 healthy consumer grain to show how much we favor slow consumer 
             int healthyConsumerCount = 30;
-            _ = await EHSlowConsumingTests.SetUpHealthyConsumerGrain(this.fixture.GrainFactory, streamId.Guid, StreamNamespace, StreamProviderName, healthyConsumerCount);
+            _ = await EHSlowConsumingTests.SetUpHealthyConsumerGrain(
+                this.fixture.GrainFactory,
+                streamId.Guid,
+                StreamNamespace,
+                StreamProviderName,
+                healthyConsumerCount,
+                TestContext.Current.CancellationToken);
 
             //configure data generator for stream and start producing
             var mgmtGrain = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -86,19 +86,22 @@ namespace ServiceBus.Tests.MonitorTests
             var mgmtGrain = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);
             await TestingUtils.WaitUntilAsync(
                 (lastTry, cancellationToken) => CheckReceiversInitialized(mgmtGrain, lastTry, cancellationToken),
-                timeout);
+                timeout,
+                cancellationToken: TestContext.Current.CancellationToken);
             var randomStreamPlacementArg = new EHStreamProviderForMonitorTestsAdapterFactory.StreamRandomPlacementArg(streamId, this.seed.Next(100));
             await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
                 (int)EHStreamProviderForMonitorTestsAdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
             await TestingUtils.WaitUntilAsync(
                 (lastTry, cancellationToken) => CheckMonitorCounters(mgmtGrain, requireCachePressure: false, lastTry, cancellationToken),
-                timeout);
+                timeout,
+                cancellationToken: TestContext.Current.CancellationToken);
 
             await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
                 (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.ChangeCachePressure, null);
             await TestingUtils.WaitUntilAsync(
                 (lastTry, cancellationToken) => CheckMonitorCounters(mgmtGrain, requireCachePressure: true, lastTry, cancellationToken),
-                timeout);
+                timeout,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         private static async Task<bool> CheckReceiversInitialized(IManagementGrain mgmtGrain, bool lastTry, CancellationToken cancellationToken)

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
@@ -68,49 +68,49 @@ namespace ServiceBus.Tests.StreamingTests
         public async Task EHBatchedMultipleParallelSubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHBatchedMultipleParallelSubscriptionTest *********************************");
-            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedMultipleLinearSubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHBatchedMultipleLinearSubscriptionTest *********************************");
-            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedMultipleSubscriptionTest_AddRemove()
         {
             this.fixture.Logger.LogInformation("************************ EHBatchedMultipleSubscriptionTest_AddRemove *********************************");
-            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedResubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHBatchedResubscriptionTest *********************************");
-            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedResubscriptionAfterDeactivationTest()
         {
             this.fixture.Logger.LogInformation("************************ EHBatchedResubscriptionAfterDeactivationTest *********************************");
-            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedActiveSubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHBatchedActiveSubscriptionTest *********************************");
-            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHBatchedTwoIntermittentStreamTest()
         {
             this.fixture.Logger.LogInformation("************************ EHBatchedTwoIntermittentStreamTest *********************************");
-            await runner.TwoIntermittentStreamTest(Guid.NewGuid());
+            await runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHClientStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHClientStreamTests.cs
@@ -94,7 +94,10 @@ namespace ServiceBus.Tests.StreamingTests
         public async Task EHStreamProducerOnDroppedClientTest()
         {
             logger.LogInformation("************************ EHStreamProducerOnDroppedClientTest *********************************");
-            await runner.StreamProducerOnDroppedClientTest(StreamProviderName, StreamNamespace);
+            await runner.StreamProducerOnDroppedClientTest(
+                StreamProviderName,
+                StreamNamespace,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/5634")]
@@ -102,7 +105,9 @@ namespace ServiceBus.Tests.StreamingTests
         {
             logger.LogInformation("************************ EHStreamConsumerOnDroppedClientTest *********************************");
             await runner.StreamConsumerOnDroppedClientTest(StreamProviderName, StreamNamespace, output,
-                    () => TestAzureTableStorageStreamFailureHandler.GetDeliveryFailureCount(StreamProviderName), true);
+                    () => TestAzureTableStorageStreamFailureHandler.GetDeliveryFailureCount(StreamProviderName),
+                    true,
+                    TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -103,7 +103,10 @@ namespace ServiceBus.Tests.StreamingTests
             await Task.WhenAll(becomeConsumersTasks);
 
             await GenerateEvents(streamCount, eventsInStream);
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(consumers, streamCount * eventsInStream, lastTry, cancellationToken), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, cancellationToken) => CheckCounters(consumers, streamCount * eventsInStream, lastTry, cancellationToken),
+                TimeSpan.FromSeconds(30),
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         private async Task GenerateEvents(int streamCount, int eventsInStream)

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -98,7 +98,11 @@ namespace ServiceBus.Tests.StreamingTests
 
             // subscribe to each partition
             List<Task> becomeConsumersTasks = consumers
-                .Select( (consumer, i) => consumer.BecomeConsumer(StreamPerPartitionDataAdapter.GetPartitionGuid(i.ToString()), null!, StreamProviderName)) // This test intentionally uses the null stream namespace.
+                .Select((consumer, i) => consumer.BecomeConsumer(
+                    StreamPerPartitionDataAdapter.GetPartitionGuid(i.ToString()),
+                    null!,
+                    StreamProviderName,
+                    TestContext.Current.CancellationToken)) // This test intentionally uses the null stream namespace.
                 .ToList();
             await Task.WhenAll(becomeConsumersTasks);
 

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -89,17 +89,29 @@ namespace ServiceBus.Tests.StreamingTests
         public async Task ReloadFromCheckpointTest()
         {
             logger.LogInformation("************************ EHReloadFromCheckpointTest *********************************");
-            await this.ReloadFromCheckpointTestRunner(ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace, 1, 256);
+            await this.ReloadFromCheckpointTestRunner(
+                ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace,
+                1,
+                256,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/5356")]
         public async Task RestartSiloAfterCheckpointTest()
         {
             logger.LogInformation("************************ EHRestartSiloAfterCheckpointTest *********************************");
-            await this.RestartSiloAfterCheckpointTestRunner(ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace, 8, 32);
+            await this.RestartSiloAfterCheckpointTestRunner(
+                ImplicitSubscription_RecoverableStream_CollectorGrain.StreamNamespace,
+                8,
+                32,
+                TestContext.Current.CancellationToken);
         }
 
-        private async Task ReloadFromCheckpointTestRunner(string streamNamespace, int streamCount, int eventsInStream)
+        private async Task ReloadFromCheckpointTestRunner(
+            string streamNamespace,
+            int streamCount,
+            int eventsInStream,
+            CancellationToken cancellationToken)
         {
             List<Guid> streamGuids = Enumerable.Range(0, streamCount).Select(_ => Guid.NewGuid()).ToList();
             try
@@ -115,11 +127,15 @@ namespace ServiceBus.Tests.StreamingTests
             finally
             {
                 var reporter = this.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
-                reporter.Reset().Ignore();
+                reporter.Reset(cancellationToken).Ignore();
             }
         }
 
-        private async Task RestartSiloAfterCheckpointTestRunner(string streamNamespace, int streamCount, int eventsInStream)
+        private async Task RestartSiloAfterCheckpointTestRunner(
+            string streamNamespace,
+            int streamCount,
+            int eventsInStream,
+            CancellationToken cancellationToken)
         {
             List<Guid> streamGuids = Enumerable.Range(0, streamCount).Select(_ => Guid.NewGuid()).ToList();
             try
@@ -136,7 +152,7 @@ namespace ServiceBus.Tests.StreamingTests
             finally
             {
                 var reporter = this.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
-                reporter.Reset().Ignore();
+                reporter.Reset(cancellationToken).Ignore();
             }
         }
 

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHSubscriptionMultiplicityTests.cs
@@ -67,49 +67,49 @@ namespace ServiceBus.Tests.StreamingTests
         public async Task EHMultipleParallelSubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHMultipleParallelSubscriptionTest *********************************");
-            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleLinearSubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHMultipleLinearSubscriptionTest *********************************");
-            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHMultipleSubscriptionTest_AddRemove()
         {
             this.fixture.Logger.LogInformation("************************ EHMultipleSubscriptionTest_AddRemove *********************************");
-            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHResubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHResubscriptionTest *********************************");
-            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHResubscriptionAfterDeactivationTest()
         {
             this.fixture.Logger.LogInformation("************************ EHResubscriptionAfterDeactivationTest *********************************");
-            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHActiveSubscriptionTest()
         {
             this.fixture.Logger.LogInformation("************************ EHActiveSubscriptionTest *********************************");
-            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("EventHub"), TestCategory("Streaming")]
         public async Task EHTwoIntermittentStreamTest()
         {
             this.fixture.Logger.LogInformation("************************ EHTwoIntermittentStreamTest *********************************");
-            await runner.TwoIntermittentStreamTest(Guid.NewGuid());
+            await runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/DynamoDBStreamQueueCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/DynamoDBStreamQueueCheckpointerTests.cs
@@ -74,7 +74,7 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             });
         var store = CreateStore(client);
 
-        await store.Update(checkpoint, string.Empty, CancellationToken.None);
+        await store.Update(checkpoint, string.Empty, TestContext.Current.CancellationToken);
 
         Assert.NotNull(write);
         Assert.Equal(checkpoint, write.Item[DynamoDBStreamCheckpointStore.CheckpointAttribute].S);
@@ -99,12 +99,12 @@ public sealed class DynamoDBStreamCheckpointStoreTests
                 new ConditionalCheckFailedException("stale checkpoint")));
         var store = CreateStore(client);
 
-        Assert.Equal("20", await store.Update("10", string.Empty, CancellationToken.None));
+        Assert.Equal("20", await store.Update("10", string.Empty, TestContext.Current.CancellationToken));
 
         await client.Received(1).PutItemAsync(
             Arg.Any<PutItemRequest>(),
             Arg.Any<CancellationToken>());
-        Assert.Equal("20", await store.Load(CancellationToken.None));
+        Assert.Equal("20", await store.Load(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -131,8 +131,8 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             });
         var store = CreateStore(client);
 
-        Assert.Equal("20", await store.Update("30", string.Empty, CancellationToken.None));
-        Assert.Equal("30", await store.Update("30", "20", CancellationToken.None));
+        Assert.Equal("20", await store.Update("30", string.Empty, TestContext.Current.CancellationToken));
+        Assert.Equal("30", await store.Update("30", "20", TestContext.Current.CancellationToken));
 
         Assert.Equal(2, writes.Count);
         Assert.Equal("#version = :expectedVersion", writes[1].ConditionExpression);
@@ -142,7 +142,7 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             writes[1].ExpressionAttributeNames["#version"]);
         Assert.Equal("7", writes[1].ExpressionAttributeValues[":expectedVersion"].N);
         Assert.Equal("8", writes[1].Item[DynamoDBStreamCheckpointStore.VersionAttribute].N);
-        Assert.Equal("30", await store.Load(CancellationToken.None));
+        Assert.Equal("30", await store.Load(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             .Returns(Task.FromResult(CreateReadResponse("20", 7)));
         var store = CreateStore(client);
 
-        var result = await store.Update("30", "10", CancellationToken.None);
+        var result = await store.Update("30", "10", TestContext.Current.CancellationToken);
 
         Assert.Equal("20", result);
         await client.DidNotReceive().PutItemAsync(
@@ -166,7 +166,7 @@ public sealed class DynamoDBStreamCheckpointStoreTests
     {
         var client = Substitute.For<IAmazonDynamoDB>();
         var store = CreateStore(client);
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -190,7 +190,7 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             Options.Create(new ClusterOptions { ClusterId = "cluster", ServiceId = "service" }),
             NullLoggerFactory.Instance,
             client);
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.Cancel();
 
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
@@ -227,7 +227,8 @@ public sealed class DynamoDBStreamCheckpointStoreTests
         await DynamoDBStreamCheckpointStore.InitializeTable(
             client,
             options,
-            NullLogger<DynamoDBStreamCheckpointStore>.Instance);
+            NullLogger<DynamoDBStreamCheckpointStore>.Instance,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(create);
         Assert.Equal(BillingMode.PAY_PER_REQUEST, create.BillingMode);
@@ -266,7 +267,8 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             () => DynamoDBStreamCheckpointStore.InitializeTable(
                 client,
                 options,
-                NullLogger<DynamoDBStreamCheckpointStore>.Instance));
+                NullLogger<DynamoDBStreamCheckpointStore>.Instance,
+                TestContext.Current.CancellationToken));
 
         Assert.Contains(options.TableName, exception.Message, StringComparison.Ordinal);
     }
@@ -306,7 +308,8 @@ public sealed class DynamoDBStreamCheckpointStoreTests
         await DynamoDBStreamCheckpointStore.InitializeTable(
             client,
             options,
-            NullLogger<DynamoDBStreamCheckpointStore>.Instance);
+            NullLogger<DynamoDBStreamCheckpointStore>.Instance,
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(3, describeCount);
     }
@@ -334,7 +337,8 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             () => DynamoDBStreamCheckpointStore.InitializeTable(
                 client,
                 options,
-                NullLogger<DynamoDBStreamCheckpointStore>.Instance));
+                NullLogger<DynamoDBStreamCheckpointStore>.Instance,
+                TestContext.Current.CancellationToken));
 
         Assert.Contains(options.TableName, exception.Message, StringComparison.Ordinal);
         Assert.IsAssignableFrom<OperationCanceledException>(exception.InnerException);
@@ -355,7 +359,7 @@ public sealed class DynamoDBStreamCheckpointStoreTests
                 await Task.Delay(Timeout.InfiniteTimeSpan, call.Arg<CancellationToken>());
                 return null!;
             });
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         var operation = DynamoDBStreamCheckpointStore.InitializeTable(
             client,
@@ -401,8 +405,8 @@ public sealed class DynamoDBStreamCheckpointStoreTests
             client);
 
         await Assert.ThrowsAsync<AmazonDynamoDBException>(
-            () => factory.Create("shard-1", CancellationToken.None));
-        var checkpointer = await factory.Create("shard-1", CancellationToken.None);
+            () => factory.Create("shard-1", TestContext.Current.CancellationToken));
+        var checkpointer = await factory.Create("shard-1", TestContext.Current.CancellationToken);
 
         Assert.False(checkpointer.CheckpointExists);
         await client.Received(2).DescribeTableAsync(
@@ -468,6 +472,7 @@ public sealed class DynamoDBStreamQueueCheckpointerIntegrationTests
     public async Task CheckpointsAreDurableAndIsolatedByProviderAndPartition()
     {
         KinesisTestConstants.CheckDynamoDbPreconditionsOrThrow();
+        var cancellationToken = TestContext.Current.CancellationToken;
         var tableName = CreateTableName();
         var options = CreateOptions(tableName);
 
@@ -475,32 +480,32 @@ public sealed class DynamoDBStreamQueueCheckpointerIntegrationTests
         {
             using var factory = CreateFactory("provider-a", "service-a", options);
             using var otherProviderFactory = CreateFactory("provider-b", "service-a", options);
-            var first = await factory.Create("shard-1", CancellationToken.None);
-            var otherPartition = await factory.Create("shard-2", CancellationToken.None);
-            var otherProvider = await otherProviderFactory.Create("shard-1", CancellationToken.None);
+            var first = await factory.Create("shard-1", cancellationToken);
+            var otherPartition = await factory.Create("shard-2", cancellationToken);
+            var otherProvider = await otherProviderFactory.Create("shard-1", cancellationToken);
 
-            first.Update("123456789012345678901234567890123456789", TestTimeUtc, CancellationToken.None);
-            otherPartition.Update("20", TestTimeUtc, CancellationToken.None);
-            otherProvider.Update("30", TestTimeUtc, CancellationToken.None);
-            await first.FlushAsync(CancellationToken.None);
-            await otherPartition.FlushAsync(CancellationToken.None);
-            await otherProvider.FlushAsync(CancellationToken.None);
+            first.Update("123456789012345678901234567890123456789", TestTimeUtc, cancellationToken);
+            otherPartition.Update("20", TestTimeUtc, cancellationToken);
+            otherProvider.Update("30", TestTimeUtc, cancellationToken);
+            await first.FlushAsync(cancellationToken);
+            await otherPartition.FlushAsync(cancellationToken);
+            await otherProvider.FlushAsync(cancellationToken);
 
             using var reloadedFactory = CreateFactory("provider-a", "service-a", options);
             using var reloadedOtherProviderFactory = CreateFactory("provider-b", "service-a", options);
             Assert.Equal(
                 "123456789012345678901234567890123456789",
-                await (await reloadedFactory.Create("shard-1", CancellationToken.None)).Load(CancellationToken.None));
+                await (await reloadedFactory.Create("shard-1", cancellationToken)).Load(cancellationToken));
             Assert.Equal(
                 "20",
-                await (await reloadedFactory.Create("shard-2", CancellationToken.None)).Load(CancellationToken.None));
+                await (await reloadedFactory.Create("shard-2", cancellationToken)).Load(cancellationToken));
             Assert.Equal(
                 "30",
-                await (await reloadedOtherProviderFactory.Create("shard-1", CancellationToken.None)).Load(CancellationToken.None));
+                await (await reloadedOtherProviderFactory.Create("shard-1", cancellationToken)).Load(cancellationToken));
         }
         finally
         {
-            await DeleteTable(tableName, options);
+            await DeleteTable(tableName, options, cancellationToken);
         }
     }
 
@@ -508,6 +513,7 @@ public sealed class DynamoDBStreamQueueCheckpointerIntegrationTests
     public async Task StaleWriterCannotMoveCheckpointBackward()
     {
         KinesisTestConstants.CheckDynamoDbPreconditionsOrThrow();
+        var cancellationToken = TestContext.Current.CancellationToken;
         var tableName = CreateTableName();
         var options = CreateOptions(tableName);
 
@@ -515,29 +521,29 @@ public sealed class DynamoDBStreamQueueCheckpointerIntegrationTests
         {
             using var firstFactory = CreateFactory("provider", "service", options);
             using var staleFactory = CreateFactory("provider", "service", options);
-            var first = await firstFactory.Create("shard-1", CancellationToken.None);
-            var stale = await staleFactory.Create("shard-1", CancellationToken.None);
+            var first = await firstFactory.Create("shard-1", cancellationToken);
+            var stale = await staleFactory.Create("shard-1", cancellationToken);
 
-            first.Update("20", TestTimeUtc, CancellationToken.None);
-            await first.FlushAsync(CancellationToken.None);
-            stale.Update("10", TestTimeUtc, CancellationToken.None);
-            await stale.FlushAsync(CancellationToken.None);
+            first.Update("20", TestTimeUtc, cancellationToken);
+            await first.FlushAsync(cancellationToken);
+            stale.Update("10", TestTimeUtc, cancellationToken);
+            await stale.FlushAsync(cancellationToken);
 
             using var reloadedFactory = CreateFactory("provider", "service", options);
             Assert.Equal(
                 "20",
-                await (await reloadedFactory.Create("shard-1", CancellationToken.None)).Load(CancellationToken.None));
+                await (await reloadedFactory.Create("shard-1", cancellationToken)).Load(cancellationToken));
 
-            stale.Update("30", TestTimeUtc + options.PersistInterval, CancellationToken.None);
-            await stale.FlushAsync(CancellationToken.None);
+            stale.Update("30", TestTimeUtc + options.PersistInterval, cancellationToken);
+            await stale.FlushAsync(cancellationToken);
             using var finalFactory = CreateFactory("provider", "service", options);
             Assert.Equal(
                 "30",
-                await (await finalFactory.Create("shard-1", CancellationToken.None)).Load(CancellationToken.None));
+                await (await finalFactory.Create("shard-1", cancellationToken)).Load(cancellationToken));
         }
         finally
         {
-            await DeleteTable(tableName, options);
+            await DeleteTable(tableName, options, cancellationToken);
         }
     }
 
@@ -550,7 +556,7 @@ public sealed class DynamoDBStreamQueueCheckpointerIntegrationTests
         using var factory = CreateFactory("provider", "service", options);
 
         var exception = await Assert.ThrowsAsync<OrleansConfigurationException>(
-            () => factory.Create("shard-1", CancellationToken.None));
+            () => factory.Create("shard-1", TestContext.Current.CancellationToken));
 
         Assert.Contains(options.TableName, exception.Message, StringComparison.Ordinal);
     }
@@ -580,17 +586,23 @@ public sealed class DynamoDBStreamQueueCheckpointerIntegrationTests
 
     private static async Task DeleteTable(
         string tableName,
-        DynamoDBStreamQueueCheckpointerOptions options)
+        DynamoDBStreamQueueCheckpointerOptions options,
+        CancellationToken testCancellationToken)
     {
         using var client = DynamoDBStreamQueueCheckpointerFactory.CreateClient(options);
+        using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         try
         {
             _ = await client.DeleteTableAsync(
                 new DeleteTableRequest { TableName = tableName },
-                CancellationToken.None);
+                cleanup.Token);
         }
         catch (ResourceNotFoundException)
         {
+        }
+        catch (OperationCanceledException) when (testCancellationToken.IsCancellationRequested)
+        {
+            // Preserve the original test cancellation after bounded cleanup.
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisAdapterTests.cs
@@ -45,7 +45,7 @@ namespace Orleans.Streaming.Kinesis.Tests
 
         public async ValueTask InitializeAsync()
         {
-            await KinesisStreamTestResource.Create(KinesisStreamName);
+            await KinesisStreamTestResource.Create(KinesisStreamName, TestContext.Current.CancellationToken);
             streamCreated = true;
         }
 
@@ -53,7 +53,9 @@ namespace Orleans.Streaming.Kinesis.Tests
         {
             if (streamCreated)
             {
-                await KinesisStreamTestResource.Delete(KinesisStreamName);
+                await KinesisStreamTestResource.DeleteForCleanup(
+                    KinesisStreamName,
+                    TestContext.Current.CancellationToken);
             }
         }
 
@@ -81,12 +83,14 @@ namespace Orleans.Streaming.Kinesis.Tests
                 serviceProvider.GetRequiredService<Serializer<KinesisBatchContainer.Body>>(),
                 new TestStreamQueueCheckpointerFactory(),
                 NullLoggerFactory.Instance);
-            await SendAndReceiveFromQueueAdapter(adapterFactory);
+            await SendAndReceiveFromQueueAdapter(adapterFactory, TestContext.Current.CancellationToken);
         }
 
-        private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
+        private async Task SendAndReceiveFromQueueAdapter(
+            IQueueAdapterFactory adapterFactory,
+            CancellationToken cancellationToken)
         {
-            IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
+            IQueueAdapter adapter = await adapterFactory.CreateAdapter(cancellationToken);
             IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
             // Create receiver per queue
@@ -118,7 +122,7 @@ namespace Orleans.Streaming.Kinesis.Tests
             {
                 foreach (var (queueId, receiver) in receivers)
                 {
-                    var messages = (await receiver.GetQueueMessagesAsync(10, CancellationToken.None)).ToArray();
+                    var messages = (await receiver.GetQueueMessagesAsync(10, cancellationToken)).ToArray();
                     foreach (var message in messages.Cast<KinesisBatchContainer>())
                     {
                         output.WriteLine($"Queue {queueId} received message on stream {message.StreamId}");

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisClientStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisClientStreamTests.cs
@@ -34,7 +34,7 @@ namespace Orleans.Streaming.Kinesis.Tests
         public override async ValueTask InitializeAsync()
         {
             EnsurePreconditionsMet();
-            await KinesisStreamTestResource.Create(KinesisStreamName);
+            await KinesisStreamTestResource.Create(KinesisStreamName, TestContext.Current.CancellationToken);
             streamCreated = true;
             await base.InitializeAsync();
             if (!PreconditionsMet)
@@ -91,7 +91,9 @@ namespace Orleans.Streaming.Kinesis.Tests
             {
                 if (streamCreated)
                 {
-                    await KinesisStreamTestResource.Delete(KinesisStreamName);
+                    await KinesisStreamTestResource.DeleteForCleanup(
+                        KinesisStreamName,
+                        TestContext.Current.CancellationToken);
                 }
             }
         }

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisClientStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisClientStreamTests.cs
@@ -101,7 +101,10 @@ namespace Orleans.Streaming.Kinesis.Tests
         [Fact]
         public async Task KinesisStreamProducerOnDroppedClientTest()
         {
-            await runner.StreamProducerOnDroppedClientTest(KinesisStreamProviderName, StreamNamespace);
+            await runner.StreamProducerOnDroppedClientTest(
+                KinesisStreamProviderName,
+                StreamNamespace,
+                TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisRuntimeTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisRuntimeTests.cs
@@ -36,7 +36,10 @@ public sealed class KinesisRuntimeTests
                     });
             });
 
-        var result = await KinesisAdapterFactory.GetPartitionIdsAsync(client, "stream");
+        var result = await KinesisAdapterFactory.GetPartitionIdsAsync(
+            client,
+            "stream",
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(["shard-1", "shard-2", "shard-3"], result);
         await client.Received(2).ListShardsAsync(Arg.Any<ListShardsRequest>(), Arg.Any<CancellationToken>());
@@ -46,7 +49,7 @@ public sealed class KinesisRuntimeTests
     public async Task GetPartitionIdsForwardsCancellationToken()
     {
         var client = Substitute.For<IAmazonKinesis>();
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         client.ListShardsAsync(Arg.Any<ListShardsRequest>(), cancellation.Token)
             .Returns(async _ =>
             {
@@ -107,8 +110,8 @@ public sealed class KinesisRuntimeTests
             new FakeTimeProvider(),
             NullLogger<KinesisShardTopologyMonitor>.Instance);
 
-        Assert.False(await monitor.CheckTopology(force: true));
-        Assert.False(await monitor.CheckTopology(force: true));
+        Assert.False(await monitor.CheckTopology(force: true, TestContext.Current.CancellationToken));
+        Assert.False(await monitor.CheckTopology(force: true, TestContext.Current.CancellationToken));
         await client.Received(1).ListShardsAsync(Arg.Any<ListShardsRequest>(), Arg.Any<CancellationToken>());
     }
 
@@ -135,7 +138,7 @@ public sealed class KinesisRuntimeTests
         var receiver = CreateReceiver(client, checkpointerFactory, timeProvider);
 
         await receiver.Initialize(TimeSpan.FromSeconds(5));
-        var records = await receiver.GetQueueMessagesAsync(10);
+        var records = await receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken);
 
         Assert.Empty(records);
         await checkpointer.Received(2).Load(Arg.Any<CancellationToken>());
@@ -162,8 +165,8 @@ public sealed class KinesisRuntimeTests
         var receiver = CreateReceiver(client, checkpointerFactory, timeProvider);
         await receiver.Initialize(TimeSpan.FromSeconds(5));
 
-        await receiver.GetQueueMessagesAsync(10);
-        var secondRead = receiver.GetQueueMessagesAsync(10);
+        await receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken);
+        var secondRead = receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken);
 
         Assert.False(secondRead.IsCompleted);
         timeProvider.Advance(TimeSpan.FromMilliseconds(200));
@@ -188,8 +191,8 @@ public sealed class KinesisRuntimeTests
         var receiver = CreateReceiver(client, checkpointerFactory, new FakeTimeProvider());
         await receiver.Initialize(TimeSpan.FromSeconds(5));
 
-        Assert.Empty(await receiver.GetQueueMessagesAsync(10));
-        Assert.Empty(await receiver.GetQueueMessagesAsync(10));
+        Assert.Empty(await receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken));
+        Assert.Empty(await receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken));
 
         await client.Received(1).GetRecordsAsync(Arg.Any<GetRecordsRequest>(), Arg.Any<CancellationToken>());
     }
@@ -231,7 +234,7 @@ public sealed class KinesisRuntimeTests
         var receiver = CreateReceiver(client, checkpointerFactory, new FakeTimeProvider());
 
         var operation = receiver.Initialize(TimeSpan.FromMilliseconds(100));
-        var initializationToken = await tokenObserved.Task;
+        var initializationToken = await tokenObserved.Task.WaitAsync(TestContext.Current.CancellationToken);
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
 
         Assert.True(initializationToken.CanBeCanceled);
@@ -271,13 +274,13 @@ public sealed class KinesisRuntimeTests
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => receiver.Initialize(TimeSpan.FromMilliseconds(100)));
-        var messages = await receiver.GetQueueMessagesAsync(10, CancellationToken.None);
+        var messages = await receiver.GetQueueMessagesAsync(10, TestContext.Current.CancellationToken);
 
         Assert.Empty(messages);
         Assert.Equal(2, createCount);
         await client.Received(1).GetRecordsAsync(
             Arg.Any<GetRecordsRequest>(),
-            CancellationToken.None);
+            TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -302,10 +305,10 @@ public sealed class KinesisRuntimeTests
             });
         var receiver = CreateReceiver(client, checkpointerFactory, new FakeTimeProvider());
         await receiver.Initialize(TimeSpan.FromSeconds(5));
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         var operation = receiver.GetQueueMessagesAsync(10, cancellation.Token);
-        Assert.Equal(cancellation.Token, await tokenObserved.Task);
+        Assert.Equal(cancellation.Token, await tokenObserved.Task.WaitAsync(TestContext.Current.CancellationToken));
         cancellation.Cancel();
 
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTestResource.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTestResource.cs
@@ -7,33 +7,49 @@ internal static class KinesisStreamTestResource
 {
     private static readonly TimeSpan OperationTimeout = TimeSpan.FromMinutes(1);
 
-    public static async Task Create(string streamName)
+    public static async Task Create(string streamName, CancellationToken cancellationToken)
     {
-        await Delete(streamName);
+        await Delete(streamName, cancellationToken);
 
-        using var cancellation = new CancellationTokenSource(OperationTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellation.CancelAfter(OperationTimeout);
         using var client = CreateClient(streamName);
-        await client.CreateStreamAsync(
-            new CreateStreamRequest { StreamName = streamName, ShardCount = 4 },
-            cancellation.Token);
-
-        while (true)
+        var creationAttempted = false;
+        try
         {
-            var response = await client.DescribeStreamAsync(
-                new DescribeStreamRequest { StreamName = streamName },
+            creationAttempted = true;
+            await client.CreateStreamAsync(
+                new CreateStreamRequest { StreamName = streamName, ShardCount = 4 },
                 cancellation.Token);
-            if (response.StreamDescription.StreamStatus == StreamStatus.ACTIVE)
+
+            while (true)
             {
-                return;
+                var response = await client.DescribeStreamAsync(
+                    new DescribeStreamRequest { StreamName = streamName },
+                    cancellation.Token);
+                if (response.StreamDescription.StreamStatus == StreamStatus.ACTIVE)
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellation.Token);
+            }
+        }
+        catch
+        {
+            if (creationAttempted)
+            {
+                await DeleteForCleanup(streamName, cancellationToken);
             }
 
-            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellation.Token);
+            throw;
         }
     }
 
-    public static async Task Delete(string streamName)
+    public static async Task Delete(string streamName, CancellationToken cancellationToken)
     {
-        using var cancellation = new CancellationTokenSource(OperationTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellation.CancelAfter(OperationTimeout);
         using var client = CreateClient(streamName);
         try
         {
@@ -59,6 +75,19 @@ internal static class KinesisStreamTestResource
             {
                 return;
             }
+        }
+    }
+
+    public static async Task DeleteForCleanup(string streamName, CancellationToken testCancellationToken)
+    {
+        using var cleanup = new CancellationTokenSource(OperationTimeout);
+        try
+        {
+            await Delete(streamName, cleanup.Token);
+        }
+        catch (OperationCanceledException) when (testCancellationToken.IsCancellationRequested)
+        {
+            // Preserve the original test cancellation after bounded cleanup.
         }
     }
 

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTests.cs
@@ -142,25 +142,25 @@ namespace Orleans.Streaming.Kinesis.Tests
         [Fact]
         public async Task Kinesis_01_OneProducerGrainOneConsumerGrain()
         {
-            await runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+            await runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_02_OneProducerGrainOneConsumerClient()
         {
-            await runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+            await runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_03_OneProducerClientOneConsumerGrain()
         {
-            await runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+            await runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_04_OneProducerClientOneConsumerClient()
         {
-            await runner.StreamTest_04_OneProducerClientOneConsumerClient();
+            await runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         //------------------------- MANY to Many different grains ----------------------//
@@ -168,50 +168,50 @@ namespace Orleans.Streaming.Kinesis.Tests
         [Fact]
         public async Task Kinesis_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+            await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
         {
-            await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+            await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
         {
-            await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+            await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
         {
-            await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+            await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         //------------------------- MANY to Many Same grains ----------------------//
         [Fact]
         public async Task Kinesis_09_ManySame_ManyProducerGrainsManyConsumerGrains()
         {
-            await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+            await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_10_ManySame_ManyConsumerGrainsManyProducerGrains()
         {
-            await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+            await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_11_ManySame_ManyProducerGrainsManyConsumerClients()
         {
-            await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+            await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_12_ManySame_ManyProducerClientsManyConsumerGrains()
         {
-            await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+            await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many producer consumer same grain ----------------------//
@@ -219,13 +219,13 @@ namespace Orleans.Streaming.Kinesis.Tests
         [Fact]
         public async Task Kinesis_13_SameGrain_ConsumerFirstProducerLater()
         {
-            await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+            await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_14_SameGrain_ProducerFirstConsumerLater()
         {
-            await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+            await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
         }
 
         //----------------------------------------------//
@@ -233,14 +233,15 @@ namespace Orleans.Streaming.Kinesis.Tests
         [Fact]
         public async Task Kinesis_15_ConsumeAtProducersRequest()
         {
-            await runner.StreamTest_15_ConsumeAtProducersRequest();
+            await runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Kinesis_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
             var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, KINESIS_STREAM_PROVIDER_NAME, 16, false);
-            await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+            await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -248,7 +249,8 @@ namespace Orleans.Streaming.Kinesis.Tests
         {
             var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, KINESIS_STREAM_PROVIDER_NAME, 17, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
-                () => HostedCluster.StartAdditionalSilo());
+                () => HostedCluster.StartAdditionalSilo(),
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
 

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTests.cs
@@ -96,9 +96,9 @@ namespace Orleans.Streaming.Kinesis.Tests
         public override async ValueTask InitializeAsync()
         {
             EnsurePreconditionsMet();
-            await KinesisStreamTestResource.Create(KinesisStreamName);
+            await KinesisStreamTestResource.Create(KinesisStreamName, TestContext.Current.CancellationToken);
             streamCreated = true;
-            await KinesisStreamTestResource.Create(KinesisStreamName2);
+            await KinesisStreamTestResource.Create(KinesisStreamName2, TestContext.Current.CancellationToken);
             stream2Created = true;
             await base.InitializeAsync();
             if (!PreconditionsMet)
@@ -120,14 +120,18 @@ namespace Orleans.Streaming.Kinesis.Tests
                 {
                     if (streamCreated)
                     {
-                        await KinesisStreamTestResource.Delete(KinesisStreamName);
+                        await KinesisStreamTestResource.DeleteForCleanup(
+                            KinesisStreamName,
+                            TestContext.Current.CancellationToken);
                     }
                 }
                 finally
                 {
                     if (stream2Created)
                     {
-                        await KinesisStreamTestResource.Delete(KinesisStreamName2);
+                        await KinesisStreamTestResource.DeleteForCleanup(
+                            KinesisStreamName2,
+                            TestContext.Current.CancellationToken);
                     }
                 }
             }

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisSubscriptionMultiplicityTests.cs
@@ -94,56 +94,56 @@ namespace Orleans.Streaming.Kinesis.Tests
         public async Task KinesisMultipleParallelSubscriptionTest()
         {
             logger.LogInformation("************************ KinesisMultipleParallelSubscriptionTest *********************************");
-            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleParallelSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task KinesisMultipleLinearSubscriptionTest()
         {
             logger.LogInformation("************************ KinesisMultipleLinearSubscriptionTest *********************************");
-            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task KinesisMultipleSubscriptionTest_AddRemoveSubscriptions()
         {
             logger.LogInformation("************************ KinesisMultipleSubscriptionTest_AddRemoveSubscriptions *********************************");
-            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+            await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task KinesisResubscriptionTest()
         {
             logger.LogInformation("************************ KinesisResubscriptionTest *********************************");
-            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task KinesisResubscriptionAfterDeactivationTest()
         {
             logger.LogInformation("************************ KinesisResubscriptionAfterDeactivationTest *********************************");
-            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task KinesisActiveSubscriptionTest()
         {
             logger.LogInformation("************************ KinesisActiveSubscriptionTest *********************************");
-            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+            await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task KinesisTwoIntermitentStreamTest()
         {
             logger.LogInformation("************************ KinesisTwoIntermitentStreamTest *********************************");
-            await runner.TwoIntermittentStreamTest(Guid.NewGuid());
+            await runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task KinesisSubscribeFromClientTest()
         {
             logger.LogInformation("************************ KinesisSubscribeFromClientTest *********************************");
-            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
+            await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisSubscriptionMultiplicityTests.cs
@@ -63,7 +63,7 @@ namespace Orleans.Streaming.Kinesis.Tests
         public override async ValueTask InitializeAsync()
         {
             EnsurePreconditionsMet();
-            await KinesisStreamTestResource.Create(KinesisStreamName);
+            await KinesisStreamTestResource.Create(KinesisStreamName, TestContext.Current.CancellationToken);
             streamCreated = true;
             await base.InitializeAsync();
             if (!PreconditionsMet)
@@ -83,7 +83,9 @@ namespace Orleans.Streaming.Kinesis.Tests
             {
                 if (streamCreated)
                 {
-                    await KinesisStreamTestResource.Delete(KinesisStreamName);
+                    await KinesisStreamTestResource.DeleteForCleanup(
+                        KinesisStreamName,
+                        TestContext.Current.CancellationToken);
                 }
             }
         }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
@@ -51,9 +51,11 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
 
         try
         {
-            var stream = await natsContext.GetStreamAsync(this.testStreamName);
+            var stream = await natsContext.GetStreamAsync(
+                this.testStreamName,
+                cancellationToken: TestContext.Current.CancellationToken);
 
-            await stream.DeleteAsync();
+            await stream.DeleteAsync(TestContext.Current.CancellationToken);
         }
         catch (NatsJSApiException)
         {
@@ -65,11 +67,23 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
     {
         if (NatsTestConstants.IsNatsAvailable)
         {
-            var stream = await natsContext.GetStreamAsync(this.testStreamName);
+            using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            try
+            {
+                var stream = await natsContext.GetStreamAsync(
+                    this.testStreamName,
+                    cancellationToken: cleanup.Token);
 
-            await stream.DeleteAsync();
-
-            await natsConnection.DisposeAsync();
+                await stream.DeleteAsync(cleanup.Token);
+            }
+            catch (OperationCanceledException) when (TestContext.Current.CancellationToken.IsCancellationRequested)
+            {
+                // Preserve the original test cancellation after bounded cleanup.
+            }
+            finally
+            {
+                await natsConnection.DisposeAsync();
+            }
         }
     }
 
@@ -86,12 +100,14 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
             fixture.Serializer,
             NullLoggerFactory.Instance);
         adapterFactory.Init();
-        await SendAndReceiveFromQueueAdapter(adapterFactory);
+        await SendAndReceiveFromQueueAdapter(adapterFactory, TestContext.Current.CancellationToken);
     }
 
-    private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
+    private async Task SendAndReceiveFromQueueAdapter(
+        IQueueAdapterFactory adapterFactory,
+        CancellationToken cancellationToken)
     {
-        IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
+        IQueueAdapter adapter = await adapterFactory.CreateAdapter(cancellationToken);
         IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
         // Create receiver per queue
@@ -118,11 +134,11 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
             QueueId queueId = receiverKvp.Key;
             var receiver = receiverKvp.Value;
             var qCache = caches[queueId];
-            Task task = Task.Factory.StartNew(() =>
+            Task task = Task.Run(async () =>
             {
                 while (receivedBatches < NumBatches)
                 {
-                    var receivedMessages = receiver.GetQueueMessagesAsync(50, CancellationToken.None).Result;
+                    var receivedMessages = await receiver.GetQueueMessagesAsync(50, cancellationToken);
                     Assert.NotNull(receivedMessages);
                     var messages = receivedMessages.ToArray();
                     if (!messages.Any())
@@ -154,19 +170,23 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
                     Interlocked.Add(ref receivedBatches, messages.Length);
                     qCache.AddToCache(messages);
                 }
-            });
+            }, cancellationToken);
             work.Add(task);
         }
 
         // send events
         List<object> events = CreateEvents(NumMessagesPerBatch);
-        work.Add(Task.Factory.StartNew(() => Enumerable.Range(0, NumBatches)
-            .Select(i => i % 2 == 0 ? streamId1 : streamId2)
-            .ToList()
-            .ForEach(streamId =>
-                adapter.QueueMessageBatchAsync(StreamId.Create(streamId.ToString(), streamId),
-                    events.Take(NumMessagesPerBatch).ToArray(), null!,
-                    RequestContextExtensions.Export(this.fixture.DeepCopier)!).Wait())));
+        work.Add(Task.Run(async () =>
+        {
+            foreach (var streamId in Enumerable.Range(0, NumBatches).Select(i => i % 2 == 0 ? streamId1 : streamId2))
+            {
+                await adapter.QueueMessageBatchAsync(
+                    StreamId.Create(streamId.ToString(), streamId),
+                    events.Take(NumMessagesPerBatch).ToArray(),
+                    null!,
+                    RequestContextExtensions.Export(this.fixture.DeepCopier)!);
+            }
+        }, cancellationToken));
         await Task.WhenAll(work);
 
         // Make sure we got back everything we sent

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsClientStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsClientStreamTests.cs
@@ -126,6 +126,9 @@ public class NatsClientStreamTests : TestClusterPerTest
     {
         logger.LogInformation(
             "************************ NatStreamProducerOnDroppedClientTest *********************************");
-        await runner.StreamProducerOnDroppedClientTest(NatsStreamProviderName, StreamNamespace);
+        await runner.StreamProducerOnDroppedClientTest(
+            NatsStreamProviderName,
+            StreamNamespace,
+            TestContext.Current.CancellationToken);
     }
 }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
@@ -96,6 +96,8 @@ public sealed class NatsOptionsTests
     [Fact]
     public async Task NumReplicas_IsAppliedToJetStreamConfig()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         if (!NatsTestConstants.IsNatsAvailable)
         {
             throw Xunit.Sdk.SkipException.ForSkip("Nats Server is not available");
@@ -112,7 +114,7 @@ public sealed class NatsOptionsTests
         };
 
         var connectionManager = new NatsConnectionManager(providerName, NullLoggerFactory.Instance, options);
-        await connectionManager.Initialize();
+        await connectionManager.Initialize(cancellationToken);
 
         await using var natsConnection = new NatsConnection();
         var natsContext = new NatsJSContext(natsConnection);
@@ -120,7 +122,7 @@ public sealed class NatsOptionsTests
 
         try
         {
-            var stream = await natsContext.GetStreamAsync(streamName);
+            var stream = await natsContext.GetStreamAsync(streamName, cancellationToken: cancellationToken);
             var info = stream.Info;
 
             Assert.Equal(1, info.Config.NumReplicas);
@@ -128,14 +130,19 @@ public sealed class NatsOptionsTests
         }
         finally
         {
+            using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(2));
             try
             {
-                var stream = await natsContext.GetStreamAsync(streamName);
-                await stream.DeleteAsync();
+                var stream = await natsContext.GetStreamAsync(streamName, cancellationToken: cleanup.Token);
+                await stream.DeleteAsync(cleanup.Token);
             }
             catch (NatsJSApiException)
             {
                 // Ignore cleanup errors
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Preserve the original test cancellation after bounded cleanup.
             }
         }
     }
@@ -150,6 +157,8 @@ public sealed class NatsOptionsTests
     [InlineData(StreamConfigStorage.Memory)]
     public async Task StorageType_IsAppliedToJetStreamConfig(StreamConfigStorage storageType)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
         if (!NatsTestConstants.IsNatsAvailable)
         {
             throw Xunit.Sdk.SkipException.ForSkip("Nats Server is not available");
@@ -168,7 +177,7 @@ public sealed class NatsOptionsTests
         };
 
         var connectionManager = new NatsConnectionManager(providerName, NullLoggerFactory.Instance, options);
-        await connectionManager.Initialize();
+        await connectionManager.Initialize(cancellationToken);
 
         await using var natsConnection = new NatsConnection(NatsTestConstants.NatsClientOptions);
         var natsContext = new NatsJSContext(natsConnection);
@@ -176,21 +185,26 @@ public sealed class NatsOptionsTests
 
         try
         {
-            var stream = await natsContext.GetStreamAsync(streamName);
+            var stream = await natsContext.GetStreamAsync(streamName, cancellationToken: cancellationToken);
             var info = stream.Info;
 
             Assert.Equal(storageType, info.Config.Storage);
         }
         finally
         {
+            using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(2));
             try
             {
-                var stream = await natsContext.GetStreamAsync(streamName);
-                await stream.DeleteAsync();
+                var stream = await natsContext.GetStreamAsync(streamName, cancellationToken: cleanup.Token);
+                await stream.DeleteAsync(cleanup.Token);
             }
             catch (NatsJSApiException)
             {
                 // Ignore cleanup errors
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Preserve the original test cancellation after bounded cleanup.
             }
         }
     }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamTests.cs
@@ -148,25 +148,25 @@ public class NatsStreamTests : TestClusterPerTest
     [Fact]
     public async Task Nats_01_OneProducerGrainOneConsumerGrain()
     {
-        await runner.StreamTest_01_OneProducerGrainOneConsumerGrain();
+        await runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_02_OneProducerGrainOneConsumerClient()
     {
-        await runner.StreamTest_02_OneProducerGrainOneConsumerClient();
+        await runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_03_OneProducerClientOneConsumerGrain()
     {
-        await runner.StreamTest_03_OneProducerClientOneConsumerGrain();
+        await runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_04_OneProducerClientOneConsumerClient()
     {
-        await runner.StreamTest_04_OneProducerClientOneConsumerClient();
+        await runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
     }
 
     //------------------------ MANY to Many different grains ----------------------//
@@ -174,50 +174,50 @@ public class NatsStreamTests : TestClusterPerTest
     [Fact]
     public async Task Nats_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
-        await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+        await runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
     {
-        await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients();
+        await runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
     {
-        await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains();
+        await runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
     {
-        await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients();
+        await runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
     }
 
     //------------------------ MANY to Many Same grains ----------------------//
     [Fact]
     public async Task Nats_09_ManySame_ManyProducerGrainsManyConsumerGrains()
     {
-        await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains();
+        await runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_10_ManySame_ManyConsumerGrainsManyProducerGrains()
     {
-        await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains();
+        await runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_11_ManySame_ManyProducerGrainsManyConsumerClients()
     {
-        await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients();
+        await runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_12_ManySame_ManyProducerClientsManyConsumerGrains()
     {
-        await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains();
+        await runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
     }
 
     //------------------------ MANY to Many producer consumer same grain ----------------------//
@@ -225,13 +225,13 @@ public class NatsStreamTests : TestClusterPerTest
     [Fact]
     public async Task Nats_13_SameGrain_ConsumerFirstProducerLater()
     {
-        await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false);
+        await runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_14_SameGrain_ProducerFirstConsumerLater()
     {
-        await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false);
+        await runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
     }
 
     //----------------------------------------------//
@@ -239,14 +239,15 @@ public class NatsStreamTests : TestClusterPerTest
     [Fact]
     public async Task Nats_15_ConsumeAtProducersRequest()
     {
-        await runner.StreamTest_15_ConsumeAtProducersRequest();
+        await runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Nats_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
         var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, NatsStreamProviderName, 16, false);
-        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains();
+        await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -254,6 +255,7 @@ public class NatsStreamTests : TestClusterPerTest
     {
         var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, NatsStreamProviderName, 17, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
-            () => this.HostedCluster.StartAdditionalSilo());
+            () => this.HostedCluster.StartAdditionalSilo(),
+            cancellationToken: TestContext.Current.CancellationToken);
     }
 }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsSubscriptionMultiplicityTests.cs
@@ -121,7 +121,7 @@ public class NatsSubscriptionMultiplicityTests : TestClusterPerTest
     {
         logger.LogInformation(
             "************************ NatsMultipleLinearSubscriptionTest *********************************");
-        await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        await runner.MultipleLinearSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("NATS")]
@@ -129,14 +129,14 @@ public class NatsSubscriptionMultiplicityTests : TestClusterPerTest
     {
         logger.LogInformation(
             "************************ NatsMultipleSubscriptionTest_AddRemove *********************************");
-        await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+        await runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("NATS")]
     public async Task NatsResubscriptionTest()
     {
         logger.LogInformation("************************ NatsResubscriptionTest *********************************");
-        await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        await runner.ResubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("NATS")]
@@ -144,27 +144,27 @@ public class NatsSubscriptionMultiplicityTests : TestClusterPerTest
     {
         logger.LogInformation(
             "************************ ResubscriptionAfterDeactivationTest *********************************");
-        await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace);
+        await runner.ResubscriptionAfterDeactivationTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("NATS")]
     public async Task NatsActiveSubscriptionTest()
     {
         logger.LogInformation("************************ NatsActiveSubscriptionTest *********************************");
-        await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace);
+        await runner.ActiveSubscriptionTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("NATS")]
     public async Task NatsTwoIntermittentStreamTest()
     {
         logger.LogInformation("************************ NatsTwoIntermittentStreamTest *********************************");
-        await runner.TwoIntermittentStreamTest(Guid.NewGuid());
+        await runner.TwoIntermittentStreamTest(Guid.NewGuid(), TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("NATS")]
     public async Task NatsSubscribeFromClientTest()
     {
         logger.LogInformation("************************ NatsSubscribeFromClientTest *********************************");
-        await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace);
+        await runner.SubscribeFromClientTest(Guid.NewGuid(), StreamNamespace, TestContext.Current.CancellationToken);
     }
 }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsTestConstants.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsTestConstants.cs
@@ -9,28 +9,34 @@ public static class NatsTestConstants
         Url = "nats://127.0.0.1:4222"
     };
 
-    private static readonly Lazy<bool> _isNatsAvailable = new(() =>
-    {
-        try
+    private static readonly Lazy<bool> _isNatsAvailable = new(
+        () =>
         {
-            return IsNatsAvailableAsync().GetAwaiter().GetResult();
-        }
-        catch
-        {
-            return false;
-        }
-    });
+            try
+            {
+                return IsNatsAvailableAsync(Xunit.TestContext.Current.CancellationToken).GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException) when (Xunit.TestContext.Current.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch
+            {
+                return false;
+            }
+        },
+        LazyThreadSafetyMode.PublicationOnly);
 
     public static bool IsNatsAvailable => _isNatsAvailable.Value;
 
     public static NatsConnection CreateConnection() => new(NatsClientOptions);
 
-    private static async Task<bool> IsNatsAvailableAsync()
+    private static async Task<bool> IsNatsAvailableAsync(CancellationToken cancellationToken)
     {
         await using var nats = CreateConnection();
 
-        await nats.ConnectAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
-        await nats.PingAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await nats.ConnectAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        await nats.PingAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
 
         return nats.ConnectionState == NatsConnectionState.Open && nats.ServerInfo?.JetStreamAvailable == true;
     }

--- a/test/Grains/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
@@ -8,7 +8,7 @@ namespace TestGrainInterfaces
 
         Task<IDictionary<Guid,int>> GetReport(string streamProvider, string streamNamespace, CancellationToken cancellationToken = default);
 
-        Task Reset(CancellationToken cancellationToken);
+        Task Reset(CancellationToken cancellationToken = default);
 
         Task<bool> IsLocatedOnSilo(SiloAddress siloAddress);
     }

--- a/test/Grains/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
@@ -8,7 +8,7 @@ namespace TestGrainInterfaces
 
         Task<IDictionary<Guid,int>> GetReport(string streamProvider, string streamNamespace, CancellationToken cancellationToken = default);
 
-        Task Reset();
+        Task Reset(CancellationToken cancellationToken);
 
         Task<bool> IsLocatedOnSilo(SiloAddress siloAddress);
     }

--- a/test/Grains/TestGrainInterfaces/ISampleStreamingGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ISampleStreamingGrain.cs
@@ -2,23 +2,23 @@ namespace UnitTests.GrainInterfaces
 {
     public interface ISampleStreaming_ProducerGrain : IGrainWithGuidKey
     {
-        Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse);
+        Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse, CancellationToken cancellationToken);
 
-        Task StartPeriodicProducing();
+        Task StartPeriodicProducing(CancellationToken cancellationToken);
 
-        Task StopPeriodicProducing();
+        Task StopPeriodicProducing(CancellationToken cancellationToken);
 
         Task<int> GetNumberProduced(CancellationToken cancellationToken = default);
 
         Task ClearNumberProduced();
-        Task Produce();
+        Task Produce(CancellationToken cancellationToken);
     }
 
     public interface ISampleStreaming_ConsumerGrain : IGrainWithGuidKey
     {
-        Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse);
+        Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse, CancellationToken cancellationToken);
 
-        Task StopConsuming();
+        Task StopConsuming(CancellationToken cancellationToken);
 
         Task<int> GetNumberConsumed(CancellationToken cancellationToken = default);
     }

--- a/test/Grains/TestGrainInterfaces/ISampleStreamingGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ISampleStreamingGrain.cs
@@ -2,23 +2,23 @@ namespace UnitTests.GrainInterfaces
 {
     public interface ISampleStreaming_ProducerGrain : IGrainWithGuidKey
     {
-        Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse, CancellationToken cancellationToken);
+        Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse, CancellationToken cancellationToken = default);
 
-        Task StartPeriodicProducing(CancellationToken cancellationToken);
+        Task StartPeriodicProducing(CancellationToken cancellationToken = default);
 
-        Task StopPeriodicProducing(CancellationToken cancellationToken);
+        Task StopPeriodicProducing(CancellationToken cancellationToken = default);
 
         Task<int> GetNumberProduced(CancellationToken cancellationToken = default);
 
         Task ClearNumberProduced();
-        Task Produce(CancellationToken cancellationToken);
+        Task Produce(CancellationToken cancellationToken = default);
     }
 
     public interface ISampleStreaming_ConsumerGrain : IGrainWithGuidKey
     {
-        Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse, CancellationToken cancellationToken);
+        Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse, CancellationToken cancellationToken = default);
 
-        Task StopConsuming(CancellationToken cancellationToken);
+        Task StopConsuming(CancellationToken cancellationToken = default);
 
         Task<int> GetNumberConsumed(CancellationToken cancellationToken = default);
     }

--- a/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
@@ -55,8 +55,9 @@ namespace TestGrains
             return Task.FromResult<IDictionary<Guid, int>>(counts);
         }
 
-        public Task Reset()
+        public Task Reset(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             reports = new Dictionary<Tuple<string, string>, Dictionary<Guid, int>>();
             return Task.CompletedTask;
         }

--- a/test/Grains/TestGrains/SampleStreamingGrain.cs
+++ b/test/Grains/TestGrains/SampleStreamingGrain.cs
@@ -56,23 +56,30 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task BecomeProducer(Guid streamId, string streamNamespace, string providerToUse)
+        public Task BecomeProducer(
+            Guid streamId,
+            string streamNamespace,
+            string providerToUse,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation("BecomeProducer");
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
             producer = streamProvider.GetStream<int>(streamNamespace, streamId);
             return Task.CompletedTask;
         }
 
-        public Task StartPeriodicProducing()
+        public Task StartPeriodicProducing(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation("StartPeriodicProducing");
             producerTimer = this.RegisterGrainTimer(TimerCallback, TimeSpan.Zero, TimeSpan.FromMilliseconds(10));
             return Task.CompletedTask;
         }
 
-        public Task StopPeriodicProducing()
+        public Task StopPeriodicProducing(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation("StopPeriodicProducing");
             producerTimer!.Dispose();
             producerTimer = null;
@@ -92,18 +99,19 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task Produce()
+        public Task Produce(CancellationToken cancellationToken)
         {
-            return Fire();
+            return Fire(cancellationToken);
         }
 
         private Task TimerCallback()
         {
-            return producerTimer != null? Fire(): Task.CompletedTask;
+            return producerTimer != null ? Fire(CancellationToken.None) : Task.CompletedTask;
         }
 
-        private async Task Fire([CallerMemberName] string? caller = null)
+        private async Task Fire(CancellationToken cancellationToken, [CallerMemberName] string? caller = null)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             RequestContext.Set(RequestContextKey, RequestContextValue);
             await producer.OnNextAsync(numProducedItems);
             numProducedItems++;
@@ -138,8 +146,13 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
+        public async Task BecomeConsumer(
+            Guid streamId,
+            string streamNamespace,
+            string providerToUse,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation("BecomeConsumer");
             consumerObserver = new SampleConsumerObserver<int>(this);
             IStreamProvider streamProvider = this.GetStreamProvider(providerToUse);
@@ -147,8 +160,9 @@ namespace UnitTests.Grains
             consumerHandle = await consumer.SubscribeAsync(consumerObserver);
         }
 
-        public async Task StopConsuming()
+        public async Task StopConsuming(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation("StopConsuming");
             if (consumerHandle != null)
             {
@@ -190,16 +204,22 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public async Task BecomeConsumer(Guid streamId, string streamNamespace, string providerToUse)
+        public async Task BecomeConsumer(
+            Guid streamId,
+            string streamNamespace,
+            string providerToUse,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation( "BecomeConsumer" );
             IStreamProvider streamProvider = this.GetStreamProvider( providerToUse );
             consumer = streamProvider.GetStream<int>(streamNamespace, streamId);
             consumerHandle = await consumer.SubscribeAsync( OnNextAsync, OnErrorAsync, OnCompletedAsync );
         }
 
-        public async Task StopConsuming()
+        public async Task StopConsuming(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation( "StopConsuming" );
             if ( consumerHandle != null )
             {

--- a/test/Orleans.CodeGenerator.Tests/CustomReturnTypeTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/CustomReturnTypeTests.cs
@@ -891,7 +891,7 @@ public class CustomReturnTypeTests
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal(DiagnosticRuleId.InvalidInvokableBaseTypeMapping, diagnostic.Id);
         Assert.Contains("accessible parameterless constructor", diagnostic.GetMessage());
-        Assert.Equal("InvokableBaseType", diagnostic.Location.SourceTree!.GetText()
+        Assert.Equal("InvokableBaseType", diagnostic.Location.SourceTree!.GetText(TestContext.Current.CancellationToken)
             .ToString(diagnostic.Location.SourceSpan)
             .Split('(')[0]
             .TrimStart('['));
@@ -1098,7 +1098,8 @@ public class CustomReturnTypeTests
             }
             """;
         var validCompilation = await TestCompilationHelper.CreateCompilation(source, "CustomReturnTypes");
-        var invalidCompilation = validCompilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(registration));
+        var invalidCompilation = validCompilation.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText(registration, cancellationToken: TestContext.Current.CancellationToken));
         var invalidInterface = invalidCompilation.GetTypeByMetadataName("ICustomGrain")!;
         var taskType = invalidCompilation.GetTypeByMetadataName("System.Threading.Tasks.Task")!;
         var customRequest = invalidCompilation.GetTypeByMetadataName("CustomRequest")!;
@@ -1119,11 +1120,11 @@ public class CustomReturnTypeTests
         var validModel = ProxyInterfaceModelExtractor.ExtractProxyInterfaceModel(
             validCompilation.GetTypeByMetadataName("ICustomGrain")!,
             validCompilation,
-            CancellationToken.None);
+            TestContext.Current.CancellationToken);
         var invalidModel = ProxyInterfaceModelExtractor.ExtractProxyInterfaceModel(
             invalidInterface,
             invalidCompilation,
-            CancellationToken.None);
+            TestContext.Current.CancellationToken);
         Assert.Equal(validModel, invalidModel);
 
         var result = RunGenerator(invalidCompilation);

--- a/test/Orleans.CodeGenerator.Tests/DiagnosticTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/DiagnosticTests.cs
@@ -72,7 +72,7 @@ public class DiagnosticTests
         var assemblyAttr = SyntaxFactory.AttributeList(
             SyntaxFactory.SingletonSeparatedList(referenceAssemblyAttribute))
             .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)));
-        var root = (CompilationUnitSyntax)compilation.SyntaxTrees[0].GetRoot();
+        var root = (CompilationUnitSyntax)compilation.SyntaxTrees[0].GetRoot(TestContext.Current.CancellationToken);
         var newRoot = root.AddAttributeLists(assemblyAttr);
         var newTree = compilation.SyntaxTrees[0].WithRootAndOptions(newRoot, compilation.SyntaxTrees[0].Options);
         compilation = compilation.RemoveSyntaxTrees(compilation.SyntaxTrees[0]).AddSyntaxTrees(newTree);
@@ -339,7 +339,9 @@ public class DiagnosticTests
             """;
 
         var compilation = await CreateCompilation(code);
-        Assert.Contains(compilation.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            compilation.GetDiagnostics(TestContext.Current.CancellationToken),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
 
         var result = RunGeneratorOnCompilation(compilation);
 

--- a/test/Orleans.CodeGenerator.Tests/GeneratedWarningSuppressionTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/GeneratedWarningSuppressionTests.cs
@@ -58,7 +58,7 @@ public sealed class GeneratedWarningSuppressionTests
         var generatedTreePaths = result.GeneratedSources
             .Select(static source => source.HintName)
             .ToHashSet(StringComparer.Ordinal);
-        var missingXmlCommentErrors = generatedCompilation.GetDiagnostics()
+        var missingXmlCommentErrors = generatedCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
             .Where(diagnostic => diagnostic.Id == MissingXmlCommentDiagnosticId
                 && diagnostic.Severity == DiagnosticSeverity.Error
                 && diagnostic.Location.SourceTree is { } tree
@@ -130,7 +130,9 @@ public sealed class GeneratedWarningSuppressionTests
             """;
 
         var libraryCompilation = await TestCompilationHelper.CreateCompilation(librarySource, "LibraryProject");
-        Assert.Empty(libraryCompilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            libraryCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
 
         var compilation = await CreateCompilationWithDocumentationDiagnostics(
             consumerSource,
@@ -146,7 +148,7 @@ public sealed class GeneratedWarningSuppressionTests
         var generatedTreePaths = result.GeneratedSources
             .Select(static source => source.HintName)
             .ToHashSet(StringComparer.Ordinal);
-        var generatedErrors = generatedCompilation.GetDiagnostics()
+        var generatedErrors = generatedCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
             .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error
                 && diagnostic.Location.SourceTree is { } tree
                 && generatedTreePaths.Contains(tree.FilePath))

--- a/test/Orleans.CodeGenerator.Tests/IncrementalCachingTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/IncrementalCachingTests.cs
@@ -359,7 +359,8 @@ public class IncrementalCachingTests
             """;
 
         var compilation = await CreateCompilation(code);
-        var newCompilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(additionalFile));
+        var newCompilation = compilation.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText(additionalFile, cancellationToken: TestContext.Current.CancellationToken));
         var (result1, result2) = await RunTwice(compilation, newCompilation);
 
         AssertTrackedStepsCachedOrUnchanged(
@@ -401,8 +402,10 @@ public class IncrementalCachingTests
             }
             """;
 
-        var compilation = (await CreateCompilation(code)).AddSyntaxTrees(CSharpSyntaxTree.ParseText(registration));
-        var updatedCompilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(unrelated));
+        var compilation = (await CreateCompilation(code)).AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText(registration, cancellationToken: TestContext.Current.CancellationToken));
+        var updatedCompilation = compilation.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText(unrelated, cancellationToken: TestContext.Current.CancellationToken));
         var (result1, result2) = await RunTwice(compilation, updatedCompilation);
 
         AssertTrackedStepsCachedOrUnchanged(
@@ -445,9 +448,13 @@ public class IncrementalCachingTests
             """;
 
         var compilation = await CreateCompilation(code);
-        var registrationTree = CSharpSyntaxTree.ParseText(registrationA);
+        var registrationTree = CSharpSyntaxTree.ParseText(
+            registrationA,
+            cancellationToken: TestContext.Current.CancellationToken);
         compilation = compilation.AddSyntaxTrees(registrationTree);
-        var updatedCompilation = compilation.ReplaceSyntaxTree(registrationTree, CSharpSyntaxTree.ParseText(registrationB));
+        var updatedCompilation = compilation.ReplaceSyntaxTree(
+            registrationTree,
+            CSharpSyntaxTree.ParseText(registrationB, cancellationToken: TestContext.Current.CancellationToken));
         var (result1, result2) = await RunTwice(compilation, updatedCompilation);
 
         AssertTrackedStepsCachedOrUnchanged(
@@ -483,7 +490,8 @@ public class IncrementalCachingTests
             """;
 
         var compilation = await CreateCompilation(code);
-        var updatedCompilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(invalidRegistration));
+        var updatedCompilation = compilation.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText(invalidRegistration, cancellationToken: TestContext.Current.CancellationToken));
         var (result1, result2) = await RunTwice(compilation, updatedCompilation);
 
         Assert.Empty(result1.Diagnostics);
@@ -522,7 +530,8 @@ public class IncrementalCachingTests
             """;
 
         var compilation = await CreateCompilation(code);
-        var newCompilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(additionalFile));
+        var newCompilation = compilation.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText(additionalFile, cancellationToken: TestContext.Current.CancellationToken));
         var (result1, result2) = await RunTwice(compilation, newCompilation);
 
         AssertTrackedStepsCachedOrUnchanged(

--- a/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
@@ -368,7 +368,10 @@ public record DemoRecord([Id(42)] string Value);
     public async Task ExtractReferenceAssemblyData_CollectsCrossAssemblyMetadataAndDeterministicOrdering()
     {
         var consumerCompilation = await CreateReferenceExtractionCompilation();
-        var model = ModelExtractor.ExtractReferenceAssemblyData(consumerCompilation, new CodeGeneratorOptions(), default);
+        var model = ModelExtractor.ExtractReferenceAssemblyData(
+            consumerCompilation,
+            new CodeGeneratorOptions(),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal("ConsumerProject", model.ApplicationParts[0]);
         Assert.Equal(model.ApplicationParts.Length, model.ApplicationParts.Distinct(StringComparer.Ordinal).Count());
@@ -412,8 +415,14 @@ public record DemoRecord([Id(42)] string Value);
         var compilationA = await CreateReferenceExtractionCompilation();
         var compilationB = await CreateReferenceExtractionCompilation(reverseReferenceOrder: true);
 
-        var modelA = ModelExtractor.ExtractReferenceAssemblyData(compilationA, new CodeGeneratorOptions(), default);
-        var modelB = ModelExtractor.ExtractReferenceAssemblyData(compilationB, new CodeGeneratorOptions(), default);
+        var modelA = ModelExtractor.ExtractReferenceAssemblyData(
+            compilationA,
+            new CodeGeneratorOptions(),
+            TestContext.Current.CancellationToken);
+        var modelB = ModelExtractor.ExtractReferenceAssemblyData(
+            compilationB,
+            new CodeGeneratorOptions(),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(modelA, modelB);
         Assert.Equal(modelA.GetHashCode(), modelB.GetHashCode());
@@ -468,7 +477,10 @@ public record DemoRecord([Id(42)] string Value);
             "ConsumerProject",
             aliasedReference);
 
-        var model = ModelExtractor.ExtractReferenceAssemblyData(consumerCompilation, new CodeGeneratorOptions(), default);
+        var model = ModelExtractor.ExtractReferenceAssemblyData(
+            consumerCompilation,
+            new CodeGeneratorOptions(),
+            TestContext.Current.CancellationToken);
 
         Assert.Empty(model.RegisteredProviders);
     }
@@ -495,7 +507,10 @@ public record DemoRecord([Id(42)] string Value);
             """;
 
         var compilation = await CreateCompilation(code);
-        var model = ModelExtractor.ExtractReferenceAssemblyData(compilation, new CodeGeneratorOptions(), default);
+        var model = ModelExtractor.ExtractReferenceAssemblyData(
+            compilation,
+            new CodeGeneratorOptions(),
+            TestContext.Current.CancellationToken);
 
         Assert.Empty(model.RegisteredProviders);
     }

--- a/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
@@ -1036,7 +1036,7 @@ public class DemoClass
             """;
 
         var compilation = await CreateCompilation(code, "TestProject");
-        Assert.Empty(compilation.GetDiagnostics());
+        Assert.Empty(compilation.GetDiagnostics(TestContext.Current.CancellationToken));
 
         var result = RunSourceGenerator(compilation);
         Assert.Empty(result.Diagnostics);
@@ -1076,7 +1076,7 @@ public class DemoClass
             """;
 
         var compilation = await CreateCompilation(code, "TestProject");
-        Assert.Empty(compilation.GetDiagnostics());
+        Assert.Empty(compilation.GetDiagnostics(TestContext.Current.CancellationToken));
 
         var result = RunSourceGenerator(compilation);
         Assert.Empty(result.Diagnostics);
@@ -1111,7 +1111,9 @@ public class DemoClass
         """;
 
         var libraryCompilation = await CreateCompilation(libraryCode, "LibraryProject");
-        Assert.Empty(libraryCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            libraryCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         // Run the generator on the library so its output assembly includes the generated metadata
         var libraryGeneratorResult = RunSourceGenerator(libraryCompilation);
@@ -1128,7 +1130,9 @@ public class DemoClass
 
         // Add the library as a metadata reference so the consumer can see its types
         consumerCompilation = consumerCompilation.AddReferences(libraryCompilation.ToMetadataReference());
-        Assert.Empty(consumerCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            consumerCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         var consumerResult = RunSourceGenerator(consumerCompilation);
         Assert.Empty(consumerResult.Diagnostics);
@@ -1175,7 +1179,9 @@ public class DemoClass
         """;
 
         var libraryCompilation = await CreateCompilation(libraryCode, "LibraryProject");
-        Assert.Empty(libraryCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            libraryCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         var consumerCode = """
             using Orleans;
@@ -1185,7 +1191,9 @@ public class DemoClass
 
         var consumerCompilation = (await CreateCompilation(consumerCode, "ConsumerProject"))
             .AddReferences(libraryCompilation.ToMetadataReference());
-        Assert.Empty(consumerCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            consumerCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         var consumerResult = RunSourceGenerator(consumerCompilation);
         Assert.Empty(consumerResult.Diagnostics);
@@ -1231,7 +1239,9 @@ public class DemoClass
         """;
 
         var libraryCompilation = await CreateCompilation(libraryCode, "LibraryProject");
-        Assert.Empty(libraryCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            libraryCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         var consumerCode = """
             using Orleans;
@@ -1248,7 +1258,9 @@ public class DemoClass
 
         var consumerCompilation = (await CreateCompilation(consumerCode, "ConsumerProject"))
             .AddReferences(libraryCompilation.ToMetadataReference());
-        Assert.Empty(consumerCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            consumerCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         var consumerResult = RunSourceGenerator(consumerCompilation);
         Assert.Empty(consumerResult.Diagnostics);
@@ -1291,7 +1303,9 @@ public class DemoClass
         """;
 
         var compilation = await CreateCompilation(code, "TestProject");
-        Assert.Empty(compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            compilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         var result = RunSourceGenerator(compilation);
         Assert.Empty(result.Diagnostics);
@@ -1340,7 +1354,7 @@ public class DemoClass
         var assemblyAttr = SyntaxFactory.AttributeList(
             SyntaxFactory.SingletonSeparatedList(referenceAssemblyAttribute))
             .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)));
-        var root = (CSharpSyntaxNode)compilation.SyntaxTrees[0].GetRoot();
+        var root = (CSharpSyntaxNode)compilation.SyntaxTrees[0].GetRoot(TestContext.Current.CancellationToken);
         var newRoot = ((CompilationUnitSyntax)root).AddAttributeLists(assemblyAttr);
         var newTree = compilation.SyntaxTrees[0].WithRootAndOptions(newRoot, compilation.SyntaxTrees[0].Options);
 
@@ -1367,7 +1381,9 @@ public class DemoClass
             """;
 
         var compilation = await CreateCompilation(code, "TestProject");
-        Assert.Empty(compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            compilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error));
 
         var result = RunSourceGenerator(compilation);
         var diagnostic = Assert.Single(result.Diagnostics, d => d.Id == CanNotGenerateImplicitFieldIdsDiagnostic.DiagnosticId);
@@ -1576,7 +1592,9 @@ public class DemoClass
 
         var outputCompilation = compilation.AddSyntaxTrees(
             result.GeneratedSources.Select(static source => CSharpSyntaxTree.ParseText(source.SourceText, path: source.HintName)));
-        Assert.Empty(outputCompilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            outputCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
     }
 
     [Fact]
@@ -1608,7 +1626,9 @@ public class DemoClass
             .AddReferences(MetadataReference.CreateFromFile(typeof(Microsoft.Extensions.Options.IConfigureOptions<>).Assembly.Location))
             .AddSyntaxTrees(
             result.GeneratedSources.Select(static source => CSharpSyntaxTree.ParseText(source.SourceText, path: source.HintName)));
-        Assert.Empty(outputCompilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            outputCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
     }
 
     [Fact]
@@ -1758,12 +1778,18 @@ public class DemoClass
         GeneratorDriver driver = CSharpGeneratorDriver.Create(
             generators: [generator],
             driverOptions: new GeneratorDriverOptions(default));
-        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
+        driver = driver.RunGeneratorsAndUpdateCompilation(
+            compilation,
+            out var outputCompilation,
+            out var generatorDiagnostics,
+            TestContext.Current.CancellationToken);
         var result = driver.GetRunResult().Results.Single();
 
         Assert.Empty(generatorDiagnostics.Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
         Assert.Empty(result.Diagnostics);
-        Assert.Empty(outputCompilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            outputCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
 
         var serializerSource = Assert.Single(
             result.GeneratedSources,

--- a/test/Orleans.CodeGenerator.Tests/PartialDeclarationDeduplicationTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/PartialDeclarationDeduplicationTests.cs
@@ -153,7 +153,9 @@ public class PartialDeclarationDeduplicationTests
             """;
 
         var compilation = await CreateCompilation(code);
-        Assert.Empty(compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.Empty(
+            compilation.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
 
         var result = RunSourceGenerator(compilation);
 

--- a/test/Orleans.CodeGenerator.Tests/ReferencedAssemblyDiagnosticParityTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/ReferencedAssemblyDiagnosticParityTests.cs
@@ -219,7 +219,8 @@ public class ReferencedAssemblyDiagnosticParityTests
         libraryDriver = libraryDriver.RunGeneratorsAndUpdateCompilation(
             libraryCompilation,
             out var generatedLibraryCompilation,
-            out var libraryGeneratorDiagnostics);
+            out var libraryGeneratorDiagnostics,
+            TestContext.Current.CancellationToken);
         Assert.Empty(libraryGeneratorDiagnostics.Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
         AssertNoCompilationErrors(generatedLibraryCompilation);
 

--- a/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
+++ b/test/Orleans.CodeGenerator.Tests/TestCompilationHelper.cs
@@ -29,6 +29,8 @@ internal static class TestCompilationHelper
         string assemblyName = "TestProject",
         params MetadataReference[] additionalReferences)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
         var references = FrameworkReferences.AddRange(
             MetadataReference.CreateFromFile(typeof(GrainId).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(IClusterClientLifecycle).Assembly.Location),
@@ -42,7 +44,7 @@ internal static class TestCompilationHelper
             references = references.AddRange(additionalReferences);
         }
 
-        var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+        var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode, cancellationToken: cancellationToken);
         return Task.FromResult(CSharpCompilation.Create(
             assemblyName,
             [syntaxTree],

--- a/test/Orleans.Connections.Security.Tests/TlsConnectionTests.cs
+++ b/test/Orleans.Connections.Security.Tests/TlsConnectionTests.cs
@@ -156,6 +156,7 @@ namespace Orleans.Connections.Security.Tests
         [InlineData(new[] { TestCertificateHelper.ClientAuthenticationOid, TestCertificateHelper.ServerAuthenticationOid }, RemoteCertificateMode.RequireCertificate)]
         public async Task TlsEndToEnd(string[]? oids, RemoteCertificateMode certificateMode)
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             TestCluster? testCluster = default;
             try
             {
@@ -173,7 +174,7 @@ namespace Orleans.Connections.Security.Tests
                 builder.Properties[ClientCertificateModeKey] = certificateMode.ToString();
 
                 testCluster = builder.Build();
-                await testCluster.DeployAsync();
+                await testCluster.DeployAsync(cancellationToken);
 
                 var client = testCluster.Client;
 
@@ -187,8 +188,14 @@ namespace Orleans.Connections.Security.Tests
             {
                 if (testCluster != null)
                 {
-                    await testCluster.StopAllSilosAsync();
-                    testCluster.Dispose();
+                    try
+                    {
+                        await testCluster.StopAllSilosAsync(cancellationToken);
+                    }
+                    finally
+                    {
+                        testCluster.Dispose();
+                    }
                 }
             }
         }

--- a/test/Orleans.Core.Tests/Async_AsyncExecutorWithRetriesTests.cs
+++ b/test/Orleans.Core.Tests/Async_AsyncExecutorWithRetriesTests.cs
@@ -31,6 +31,7 @@ namespace NonSilo.Tests
         [Fact, TestCategory("Functional"), TestCategory("AsynchronyPrimitives")]
         public async Task Async_AsyncExecutorWithRetriesTest_1()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             int counter = 0;
             Func<int, Task<int>> myFunc = ((int funcCounter) =>
             {
@@ -49,15 +50,21 @@ namespace NonSilo.Tests
                 return true;
             });
 
-            Task<int> promise = AsyncExecutorWithRetries.ExecuteWithRetries(myFunc, 10, 10, null, errorFilter);
+            Task<int> promise = AsyncExecutorWithRetries.ExecuteWithRetries(
+                myFunc, 10, 10, null, errorFilter, cancellationToken: cancellationToken);
             int value = await promise;
             this.output.WriteLine("Value is {0}.", value);
             counter = 0;
             try
             {
-                promise = AsyncExecutorWithRetries.ExecuteWithRetries(myFunc, 3, 3, null, errorFilter);
+                promise = AsyncExecutorWithRetries.ExecuteWithRetries(
+                    myFunc, 3, 3, null, errorFilter, cancellationToken: cancellationToken);
                 value = await promise;
                 this.output.WriteLine("Value is {0}.", value);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception)
             {
@@ -87,7 +94,14 @@ namespace NonSilo.Tests
 
             int maxRetries = 10;
             int expectedRetries = countLimit;
-            Task<int> promise = AsyncExecutorWithRetries.ExecuteWithRetries(myFunc, maxRetries, maxRetries, successFilter, null, Timeout.InfiniteTimeSpan);
+            Task<int> promise = AsyncExecutorWithRetries.ExecuteWithRetries(
+                myFunc,
+                maxRetries,
+                maxRetries,
+                successFilter,
+                null,
+                Timeout.InfiniteTimeSpan,
+                cancellationToken: TestContext.Current.CancellationToken);
             int value = await promise;
             this.output.WriteLine("Value={0} Counter={1} ExpectedRetries={2}", value, counter, expectedRetries);
             Assert.Equal(expectedRetries, value); // "Returned value"
@@ -96,7 +110,13 @@ namespace NonSilo.Tests
             counter = 0;
             maxRetries = 3;
             expectedRetries = maxRetries;
-            promise = AsyncExecutorWithRetries.ExecuteWithRetries(myFunc, maxRetries, maxRetries, successFilter, null);
+            promise = AsyncExecutorWithRetries.ExecuteWithRetries(
+                myFunc,
+                maxRetries,
+                maxRetries,
+                successFilter,
+                null,
+                cancellationToken: TestContext.Current.CancellationToken);
             value = await promise;
             this.output.WriteLine("Value={0} Counter={1} ExpectedRetries={2}", value, counter, expectedRetries);
             Assert.Equal(expectedRetries, value); // "Returned value"
@@ -132,7 +152,8 @@ namespace NonSilo.Tests
                 maxRetries, 
                 errorFilter,
                 default,
-                new FixedBackoff(TimeSpan.FromSeconds(1)));
+                new FixedBackoff(TimeSpan.FromSeconds(1)),
+                TestContext.Current.CancellationToken);
 
             int value = await promise;
             this.output.WriteLine("Value={0} Counter={1} ExpectedRetries={2}", value, counter, 0);
@@ -175,7 +196,8 @@ namespace NonSilo.Tests
                 maxRetries,
                 errorFilter,
                 default,
-                new FixedBackoff(TimeSpan.FromSeconds(1)));
+                new FixedBackoff(TimeSpan.FromSeconds(1)),
+                TestContext.Current.CancellationToken);
             try
             {
                 int value = await promise;

--- a/test/Orleans.Core.Tests/Async_AsyncExecutorWithRetriesTests.cs
+++ b/test/Orleans.Core.Tests/Async_AsyncExecutorWithRetriesTests.cs
@@ -203,6 +203,10 @@ namespace NonSilo.Tests
                 int value = await promise;
                 Assert.Fail("Should have thrown");
             }
+            catch (OperationCanceledException) when (TestContext.Current.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception exc)
             {
                 Exception baseExc = exc.GetBaseException();

--- a/test/Orleans.Core.Tests/Caching/ConcurrentLruSoakTests.cs
+++ b/test/Orleans.Core.Tests/Caching/ConcurrentLruSoakTests.cs
@@ -220,7 +220,7 @@ public sealed class ConcurrentLruCacheSoakTests
             {
                 lru.TryRemove(new KeyValuePair<int, string>(5, "x"));
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
         for (var i = 0; i < 100_000; i++)
         {
@@ -290,12 +290,14 @@ public sealed class ConcurrentLruCacheSoakTests
     [Repeat(10)]
     public async Task WhenValueIsBigStructNoLiveLock(int _)
     {
-        using var source = new CancellationTokenSource();
+        using var source = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var started = new TaskCompletionSource<bool>();
         var cache = new ConcurrentLruCache<int, Guid>(Capacity, EqualityComparer<int>.Default);
 
-        var setTask = Task.Run(() => Setter(cache, source.Token, started));
-        await started.Task;
+        var setTask = Task.Run(
+            () => Setter(cache, source.Token, started),
+            source.Token);
+        await started.Task.WaitAsync(source.Token);
         Checker(cache, source);
 
         await setTask;

--- a/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
+++ b/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
@@ -878,7 +878,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
             lru.AddOrUpdate(1, item);
             timeProvider.Advance(TimeSpan.FromMinutes(2));
 
-            await item.Disposed.WaitAsync(TimeSpan.FromSeconds(10));
+            await item.Disposed.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
             timeProvider.Advance(TimeSpan.FromMinutes(1));
 

--- a/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
@@ -28,7 +28,8 @@ public class DiagnosticInfrastructureRegressionTests
         var waitTask = collector.WaitForEventAsync(
             "Value",
             evt => evt.Payload is int value && value == 2,
-            TimeSpan.FromMilliseconds(100));
+            TimeSpan.FromMilliseconds(100),
+            TestContext.Current.CancellationToken);
 
         listener.Write("Value", 1);
 
@@ -37,7 +38,8 @@ public class DiagnosticInfrastructureRegressionTests
         var secondWaitTask = collector.WaitForEventAsync(
             "Value",
             evt => evt.Payload is int value && value == 2,
-            TimeSpan.FromSeconds(1));
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
 
         listener.Write("Value", 2);
 

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -57,7 +57,7 @@ namespace UnitTests.Directory
 
             this.grainDirectoryResolver = new GrainDirectoryResolver(
                 services,
-                new GrainPropertiesResolver(new NoOpClusterManifestProvider()),
+                new GrainPropertiesResolver(new NoOpClusterManifestProvider(TestContext.Current.CancellationToken)),
                 Array.Empty<IGrainDirectoryResolver>());
             this.mockMembershipService = new MockClusterMembershipService();
 
@@ -88,20 +88,21 @@ namespace UnitTests.Directory
         [Fact]
         public async Task RegisterWhenNoOtherEntryExists()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var silo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(silo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expected = GenerateGrainAddress(silo);
 
-            this.grainDirectory.Register(expected, previousAddress: null).Returns(expected);
+            ConfigureLegacyRegister(expected, previousAddress: null, expected);
 
-            var actual = await this.grainLocator.Register(expected, previousAddress: null);
+            var actual = await this.grainLocator.Register(expected, previousAddress: null, cancellationToken);
             Assert.Equal(expected, actual);
-            await this.grainDirectory.Received(1).Register(expected, previousAddress: null);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), expected, null));
 
             // Now should be in cache
             Assert.True(this.grainLocator.TryLookupInCache(expected.GrainId, out var result));
@@ -112,6 +113,7 @@ namespace UnitTests.Directory
         [Fact]
         public async Task StopDoesNotDisposeRegisteredCustomCache()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var cache = new DisposableGrainDirectoryCache();
             var grainDirectory = Substitute.For<IGrainDirectory>();
             var services = new ServiceCollection()
@@ -120,7 +122,7 @@ namespace UnitTests.Directory
                 .BuildServiceProvider();
             var grainDirectoryResolver = new GrainDirectoryResolver(
                 services,
-                new GrainPropertiesResolver(new NoOpClusterManifestProvider()),
+                new GrainPropertiesResolver(new NoOpClusterManifestProvider(cancellationToken)),
                 Array.Empty<IGrainDirectoryResolver>());
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             var membershipService = new MockClusterMembershipService();
@@ -133,8 +135,8 @@ namespace UnitTests.Directory
 
             grainLocator.Participate(lifecycle);
 
-            await lifecycle.OnStart();
-            await lifecycle.OnStop();
+            await lifecycle.OnStart(cancellationToken);
+            await lifecycle.OnStop(cancellationToken);
 
             Assert.False(cache.Disposed);
             Assert.False(cache.AsyncDisposed);
@@ -143,6 +145,7 @@ namespace UnitTests.Directory
         [Fact]
         public async Task LocalGrainDirectoryStopDoesNotDisposeRegisteredCustomCache()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var cache = new DisposableGrainDirectoryCache();
             var localSiloDetails = Substitute.For<ILocalSiloDetails>();
             var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11111), 123);
@@ -186,7 +189,7 @@ namespace UnitTests.Directory
                 directoryInstruments: CreateDirectoryInstruments(),
                 systemTargetShared: systemTargetShared);
 
-            await localGrainDirectory.StopAsync();
+            await localGrainDirectory.StopAsync().WaitAsync(cancellationToken);
 
             Assert.False(cache.Disposed);
             Assert.False(cache.AsyncDisposed);
@@ -196,6 +199,7 @@ namespace UnitTests.Directory
         [Fact]
         public async Task LocalGrainDirectoryAppliesNewerMembershipBeforeRegisterForwarding()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var localSilo = GenerateSiloAddress();
             var remoteSilo = GenerateSiloAddress();
             var membershipService = new MockClusterMembershipService(new()
@@ -251,16 +255,16 @@ namespace UnitTests.Directory
 
             try
             {
-                var result = await localGrainDirectory.RegisterAsync(address, hopCount: 0);
+                var result = await localGrainDirectory.RegisterAsync(address, hopCount: 0).WaitAsync(cancellationToken);
 
                 Assert.Equal(address, result.Address);
                 Assert.Equal(0, membershipService.RefreshCallCount);
-                await remoteDirectory.Received(1).RegisterAsync(address, null, 1);
+                await remoteDirectory.Received(1).RegisterAsync(address, null, 1).WaitAsync(cancellationToken);
                 Assert.Null(localGrainDirectory.GetLocalDirectoryData(address.GrainId).Address);
             }
             finally
             {
-                await localGrainDirectory.StopAsync();
+                await localGrainDirectory.StopAsync().WaitAsync(cancellationToken);
             }
         }
 
@@ -270,6 +274,7 @@ namespace UnitTests.Directory
         [InlineData(SiloStatus.Dead)]
         public async Task LocalGrainDirectoryAppliesNewerMembershipBeforeLookupForwarding(SiloStatus status)
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var localSilo = GenerateSiloAddress();
             var remoteSilo = GenerateSiloAddress();
             var membershipService = new MockClusterMembershipService(new()
@@ -292,7 +297,7 @@ namespace UnitTests.Directory
             var services = new ServiceCollection()
                 .AddSingleton<GrainDirectoryResolver>(serviceProvider => new(
                     serviceProvider,
-                    new GrainPropertiesResolver(new NoOpClusterManifestProvider()),
+                    new GrainPropertiesResolver(new NoOpClusterManifestProvider(cancellationToken)),
                     Array.Empty<IGrainDirectoryResolver>()))
                 .BuildServiceProvider();
             Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
@@ -331,24 +336,25 @@ namespace UnitTests.Directory
 
             try
             {
-                await localGrainDirectory.RegisterAsync(address, hopCount: 0);
+                await localGrainDirectory.RegisterAsync(address, hopCount: 0).WaitAsync(cancellationToken);
                 membershipService.UpdateSiloStatus(remoteSilo, status, "remote");
 
-                var result = await localGrainDirectory.LookupAsync(address.GrainId);
+                var result = await localGrainDirectory.LookupAsync(address.GrainId).WaitAsync(cancellationToken);
 
                 Assert.Null(result.Address);
                 Assert.Equal(0, membershipService.RefreshCallCount);
-                await remoteDirectory.DidNotReceive().LookupAsync(address.GrainId, Arg.Any<int>());
+                await remoteDirectory.DidNotReceive().LookupAsync(address.GrainId, Arg.Any<int>()).WaitAsync(cancellationToken);
             }
             finally
             {
-                await localGrainDirectory.StopAsync();
+                await localGrainDirectory.StopAsync().WaitAsync(cancellationToken);
             }
         }
 
         [Fact]
         public async Task LocalGrainDirectoryTryLocalLookupFindsLocalPartitionEntryOnCacheMiss()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var localSilo = GenerateSiloAddress();
             var membershipService = new MockClusterMembershipService(new()
             {
@@ -399,7 +405,7 @@ namespace UnitTests.Directory
 
             try
             {
-                var registered = await localGrainDirectory.RegisterAsync(address, hopCount: 0);
+                var registered = await localGrainDirectory.RegisterAsync(address, hopCount: 0).WaitAsync(cancellationToken);
                 Assert.Equal(address, registered.Address);
 
                 localGrainDirectory.InvalidateCacheEntry(address.GrainId);
@@ -410,29 +416,30 @@ namespace UnitTests.Directory
             }
             finally
             {
-                await localGrainDirectory.StopAsync();
+                await localGrainDirectory.StopAsync().WaitAsync(cancellationToken);
             }
         }
 
         [Fact]
         public async Task RegisterWhenOtherEntryExists()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
             var otherSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expectedAddr = GenerateGrainAddress(expectedSilo);
             var otherAddr = GenerateGrainAddress(otherSilo);
 
-            this.grainDirectory.Register(otherAddr, previousAddress: null).Returns(expectedAddr);
+            ConfigureLegacyRegister(otherAddr, previousAddress: null, expectedAddr);
 
-            var actual = await this.grainLocator.Register(otherAddr, previousAddress: null);
+            var actual = await this.grainLocator.Register(otherAddr, previousAddress: null, cancellationToken);
             Assert.Equal(expectedAddr, actual);
-            await this.grainDirectory.Received(1).Register(otherAddr, previousAddress: null);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), otherAddr, null));
 
             // Now should be in cache
             Assert.True(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out var result));
@@ -443,12 +450,13 @@ namespace UnitTests.Directory
         [Fact]
         public async Task RegisterWhenOtherEntryExistsAndPreviousAddressMatches()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var silo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(silo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var existing = GenerateGrainAddress(silo);
             var replacement = new GrainAddress
@@ -459,16 +467,16 @@ namespace UnitTests.Directory
                 MembershipVersion = existing.MembershipVersion
             };
 
-            this.grainDirectory.Register(replacement, previousAddress: null).Returns(existing);
+            ConfigureLegacyRegister(replacement, previousAddress: null, existing);
 
-            var actual = await this.grainLocator.Register(replacement, previousAddress: null);
+            var actual = await this.grainLocator.Register(replacement, previousAddress: null, cancellationToken);
             Assert.Equal(existing, actual);
-            await this.grainDirectory.Received(1).Register(replacement, previousAddress: null);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), replacement, null));
             this.grainDirectory.ClearReceivedCalls();
 
-            this.grainDirectory.Register(replacement, previousAddress: existing).Returns(replacement);
-            actual = await this.grainLocator.Register(replacement, previousAddress: existing);
-            await this.grainDirectory.Received(1).Register(replacement, previousAddress: existing);
+            ConfigureLegacyRegister(replacement, previousAddress: existing, replacement);
+            actual = await this.grainLocator.Register(replacement, previousAddress: existing, cancellationToken);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), replacement, existing));
             Assert.Equal(replacement, actual);
 
             // Now should be in cache
@@ -480,12 +488,13 @@ namespace UnitTests.Directory
         [Fact]
         public async Task RegisterWhenOtherEntryExistsAndPreviousAddressDoesNotMatch()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var silo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(silo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var existing = GenerateGrainAddress(silo);
             var nonMatching = new GrainAddress
@@ -503,16 +512,16 @@ namespace UnitTests.Directory
                 MembershipVersion = existing.MembershipVersion
             };
 
-            this.grainDirectory.Register(replacement, previousAddress: null).Returns(existing);
+            ConfigureLegacyRegister(replacement, previousAddress: null, existing);
 
-            var actual = await this.grainLocator.Register(replacement, previousAddress: null);
+            var actual = await this.grainLocator.Register(replacement, previousAddress: null, cancellationToken);
             Assert.Equal(existing, actual);
-            await this.grainDirectory.Received(1).Register(replacement, previousAddress: null);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), replacement, null));
             this.grainDirectory.ClearReceivedCalls();
 
-            this.grainDirectory.Register(replacement, previousAddress: nonMatching).Returns(existing);
-            actual = await this.grainLocator.Register(replacement, previousAddress: nonMatching);
-            await this.grainDirectory.Received(1).Register(replacement, previousAddress: nonMatching);
+            ConfigureLegacyRegister(replacement, previousAddress: nonMatching, existing);
+            actual = await this.grainLocator.Register(replacement, previousAddress: nonMatching, cancellationToken);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), replacement, nonMatching));
             Assert.Equal(existing, actual);
 
             // Cache should contain original address
@@ -524,54 +533,56 @@ namespace UnitTests.Directory
         [Fact]
         public async Task RegisterWhenOtherEntryExistsButSiloIsDead()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
             var outdatedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
             this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Dead, "old");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expectedAddr = GenerateGrainAddress(expectedSilo);
             var outdatedAddr = GenerateGrainAddress(outdatedSilo);
 
-            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(outdatedAddr);
-            this.grainDirectory.Register(expectedAddr, previousAddress: outdatedAddr).Returns(expectedAddr);
+            ConfigureLegacyRegister(expectedAddr, previousAddress: null, outdatedAddr);
+            ConfigureLegacyRegister(expectedAddr, previousAddress: outdatedAddr, expectedAddr);
 
-            var actual = await this.grainLocator.Register(expectedAddr, previousAddress: null);
+            var actual = await this.grainLocator.Register(expectedAddr, previousAddress: null, cancellationToken);
             Assert.Equal(expectedAddr, actual);
-            await this.grainDirectory.Received(1).Register(expectedAddr, previousAddress: null);
-            await this.grainDirectory.Received(1).Register(expectedAddr, previousAddress: outdatedAddr);
-            await this.grainDirectory.DidNotReceive().Unregister(outdatedAddr);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), expectedAddr, null));
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Register), expectedAddr, outdatedAddr));
+            Assert.Equal(0, GetLegacyCallCount(nameof(IGrainDirectory.Unregister), outdatedAddr));
 
             // Now should be in cache
             Assert.True(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out var result));
             Assert.NotNull(result);
             Assert.Equal(expectedAddr, result);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task LookupPopulateTheCache()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var grainAddress = GenerateGrainAddress(expectedSilo);
 
-            this.grainDirectory.Lookup(grainAddress.GrainId).Returns(grainAddress);
+            ConfigureLegacyLookup(grainAddress.GrainId, grainAddress);
 
             // Cache should be empty
             Assert.False(this.grainLocator.TryLookupInCache(grainAddress.GrainId, out _));
 
             // Do a remote lookup
-            var result = await this.grainLocator.Lookup(grainAddress.GrainId);
+            var result = await this.grainLocator.Lookup(grainAddress.GrainId).AsTask().WaitAsync(cancellationToken);
             Assert.NotNull(result);
             Assert.Equal(grainAddress, result);
 
@@ -584,47 +595,49 @@ namespace UnitTests.Directory
         [Fact]
         public async Task LookupWhenEntryExistsButSiloIsDead()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var outdatedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Dead, "old");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var outdatedAddr = GenerateGrainAddress(outdatedSilo);
 
-            this.grainDirectory.Lookup(outdatedAddr.GrainId).Returns(outdatedAddr);
+            ConfigureLegacyLookup(outdatedAddr.GrainId, outdatedAddr);
 
-            var actual = await this.grainLocator.Lookup(outdatedAddr.GrainId);
+            var actual = await this.grainLocator.Lookup(outdatedAddr.GrainId).AsTask().WaitAsync(cancellationToken);
             Assert.Null(actual);
 
-            await this.grainDirectory.Received(1).Lookup(outdatedAddr.GrainId);
-            await this.grainDirectory.Received(1).Unregister(outdatedAddr);
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Lookup), outdatedAddr.GrainId));
+            Assert.Equal(1, GetLegacyCallCount(nameof(IGrainDirectory.Unregister), outdatedAddr));
             Assert.False(this.grainLocator.TryLookupInCache(outdatedAddr.GrainId, out _));
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task LocalLookupWhenEntryExistsButSiloIsDead()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var outdatedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Dead, "old");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var outdatedAddr = GenerateGrainAddress(outdatedSilo);
 
-            this.grainDirectory.Lookup(outdatedAddr.GrainId).Returns(outdatedAddr);
+            ConfigureLegacyLookup(outdatedAddr.GrainId, outdatedAddr);
             Assert.False(this.grainLocator.TryLookupInCache(outdatedAddr.GrainId, out _));
 
             // Local lookup should never call the directory
-            await this.grainDirectory.DidNotReceive().Lookup(outdatedAddr.GrainId);
-            await this.grainDirectory.DidNotReceive().Unregister(outdatedAddr);
+            Assert.Equal(0, GetLegacyCallCount(nameof(IGrainDirectory.Lookup), outdatedAddr.GrainId));
+            Assert.Equal(0, GetLegacyCallCount(nameof(IGrainDirectory.Unregister), outdatedAddr));
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Theory]
@@ -632,28 +645,29 @@ namespace UnitTests.Directory
         [InlineData(SiloStatus.Stopping)]
         public async Task LocalLookupWhenCachedEntrySiloIsTerminatingButNotDead(SiloStatus status)
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var silo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(silo, SiloStatus.Active, "silo");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var address = GenerateGrainAddress(silo);
-            this.grainDirectory.Register(address, previousAddress: null).Returns(address);
+            ConfigureLegacyRegister(address, previousAddress: null, address);
 
-            await this.grainLocator.Register(address, previousAddress: null);
+            await this.grainLocator.Register(address, previousAddress: null, cancellationToken);
             Assert.True(this.grainLocator.TryLookupInCache(address.GrainId, out var cached));
             Assert.Equal(address, cached);
 
             this.mockMembershipService.UpdateSiloStatus(silo, status, "silo");
-            await WaitUntilClusterChangePropagated();
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             Assert.True(this.grainLocator.TryLookupInCache(address.GrainId, out cached));
             Assert.Equal(address, cached);
-            await this.grainDirectory.DidNotReceive().UnregisterSilos(Arg.Any<List<SiloAddress>>());
+            Assert.Equal(0, GetLegacyUnregisterSilosCallCount(_ => true));
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         /// <summary>
@@ -663,79 +677,76 @@ namespace UnitTests.Directory
         [Fact]
         public async Task CleanupWhenSiloIsDead()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
             var outdatedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
             this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Active, "old");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expectedAddr = GenerateGrainAddress(expectedSilo);
             var outdatedAddr = GenerateGrainAddress(outdatedSilo);
 
             // Register two entries
-            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
-            this.grainDirectory.Register(outdatedAddr, previousAddress: null).Returns(outdatedAddr);
+            ConfigureLegacyRegister(expectedAddr, previousAddress: null, expectedAddr);
+            ConfigureLegacyRegister(outdatedAddr, previousAddress: null, outdatedAddr);
 
-            await this.grainLocator.Register(expectedAddr, previousAddress: null);
-            await this.grainLocator.Register(outdatedAddr, previousAddress: null);
+            await this.grainLocator.Register(expectedAddr, previousAddress: null, cancellationToken);
+            await this.grainLocator.Register(outdatedAddr, previousAddress: null, cancellationToken);
 
             // Simulate a dead silo
             this.mockMembershipService.UpdateSiloStatus(outdatedAddr.SiloAddress!, SiloStatus.Dead, "old");
 
             // Wait a bit for the update to be processed
-            await WaitUntilClusterChangePropagated();
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             // Cleanup function from grain directory should have been called
-            await this.grainDirectory
-                .Received(1)
-                .UnregisterSilos(Arg.Is<List<SiloAddress>>(list => list.Count == 1 && list.Contains(outdatedAddr.SiloAddress!)));
+            Assert.Equal(1, GetLegacyUnregisterSilosCallCount(list => list.Count == 1 && list.Contains(outdatedAddr.SiloAddress!)));
 
             // Cache should have been cleaned
             Assert.False(this.grainLocator.TryLookupInCache(outdatedAddr.GrainId, out var unused1));
             Assert.True(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out var unused2));
 
-            var result = await this.grainLocator.Lookup(expectedAddr.GrainId);
+            var result = await this.grainLocator.Lookup(expectedAddr.GrainId).AsTask().WaitAsync(cancellationToken);
             Assert.NotNull(result);
             Assert.Equal(expectedAddr, result);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task CleanupWhenSiloIsDeadOnlyProcessesIncrementalChanges()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
             var outdatedSilo = GenerateSiloAddress();
 
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
             this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Active, "old");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Dead, "old");
-            await WaitUntilClusterChangePropagated();
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
-            await this.grainDirectory
-                .Received(1)
-                .UnregisterSilos(Arg.Is<List<SiloAddress>>(list => list.Count == 1 && list.Contains(outdatedSilo)));
+            Assert.Equal(1, GetLegacyUnregisterSilosCallCount(list => list.Count == 1 && list.Contains(outdatedSilo)));
 
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp2");
-            await WaitUntilClusterChangePropagated();
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
-            await this.grainDirectory
-                .Received(1)
-                .UnregisterSilos(Arg.Is<List<SiloAddress>>(list => list.Count == 1 && list.Contains(outdatedSilo)));
+            Assert.Equal(1, GetLegacyUnregisterSilosCallCount(list => list.Count == 1 && list.Contains(outdatedSilo)));
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task UpdateCacheStampsCurrentMembershipVersion()
         {
-            await this.lifecycle.OnStart();
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await this.lifecycle.OnStart(cancellationToken);
 
             var grainId = GrainId.Create(GrainType.Create("test"), GrainIdKeyExtensions.CreateGuidKey(Guid.NewGuid()));
             var silo = GenerateSiloAddress();
@@ -746,137 +757,136 @@ namespace UnitTests.Directory
             Assert.Equal(silo, cached.SiloAddress);
             Assert.Equal(this.mockMembershipService.CurrentVersion, cached.MembershipVersion);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task UnregisterCallDirectoryAndCleanCache()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expectedAddr = GenerateGrainAddress(expectedSilo);
 
-            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
+            ConfigureLegacyRegister(expectedAddr, previousAddress: null, expectedAddr);
 
             // Register to populate cache
-            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+            await this.grainLocator.Register(expectedAddr, previousAddress: null, cancellationToken);
 
             // Unregister and check if cache was cleaned
-            await this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
+            await this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force).WaitAsync(cancellationToken);
             Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
         }
 
         [Fact]
         public async Task UnregisterRemovesFromCacheFirst()
-        {            
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expectedAddr = GenerateGrainAddress(expectedSilo);
 
-            // Give up control then Run forever
-            this.grainDirectory.Unregister(expectedAddr).Returns(async (t) => { await Task.Yield();  while (true) { } });
+            // Do not complete until the test is cancelled.
+            var unregisterCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var cancellationRegistration = cancellationToken.Register(() => unregisterCompletion.TrySetCanceled(cancellationToken));
+            ConfigureLegacyUnregister(expectedAddr, unregisterCompletion.Task);
 
-            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
+            ConfigureLegacyRegister(expectedAddr, previousAddress: null, expectedAddr);
 
             // Register to populate cache
-            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+            await this.grainLocator.Register(expectedAddr, previousAddress: null, cancellationToken);
 
             // Unregister and check if cache was cleaned
-            _ = this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
+            var unregisterTask = this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
             Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
+
+            unregisterCompletion.TrySetResult();
+            await unregisterTask.WaitAsync(cancellationToken);
         }
 
         [Fact]
         public async Task UnregisterRacesWithLookupSameId()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expectedAddr = GenerateGrainAddress(expectedSilo);
 
-            ManualResetEvent mre = new ManualResetEvent(false);
+            var unregisterCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var cancellationRegistration = cancellationToken.Register(() => unregisterCompletion.TrySetCanceled(cancellationToken));
+            ConfigureLegacyUnregister(expectedAddr, unregisterCompletion.Task);
 
-            // Give up control then Run forever
-            this.grainDirectory.Unregister(expectedAddr).Returns(async (t) =>
-            {
-                await Task.Yield();
-                mre.WaitOne();
-            });
-
-            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
+            ConfigureLegacyRegister(expectedAddr, previousAddress: null, expectedAddr);
 
             // Register to populate cache
-            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+            await this.grainLocator.Register(expectedAddr, previousAddress: null, cancellationToken);
 
             // Unregister and check if cache was cleaned
             Task t = this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
             Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
 
             // Add back to cache simulating a race from lookup
-            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+            await this.grainLocator.Register(expectedAddr, previousAddress: null, cancellationToken);
             Assert.True(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
 
             // Ensure when Unregister finishes if the race occured on the same id that it was removed
-            mre.Set();
-            await t;
+            unregisterCompletion.TrySetResult();
+            await t.WaitAsync(cancellationToken);
             Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
         }
 
         [Fact]
         public async Task UnregisterRacesWithLookupDifferentId()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var expectedSilo = GenerateSiloAddress();
             var secondSilo = GenerateSiloAddress();
 
             // Setup membership service
             this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
             this.mockMembershipService.UpdateSiloStatus(secondSilo, SiloStatus.Active, "exp");
-            await this.lifecycle.OnStart();
-            await WaitUntilClusterChangePropagated();
+            await this.lifecycle.OnStart(cancellationToken);
+            await WaitUntilClusterChangePropagated(cancellationToken);
 
             var expectedAddr = GenerateGrainAddress(expectedSilo);
             var secondAddr = GenerateGrainAddress(secondSilo);
 
-            ManualResetEvent mre = new ManualResetEvent(false);
+            var unregisterCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var cancellationRegistration = cancellationToken.Register(() => unregisterCompletion.TrySetCanceled(cancellationToken));
+            ConfigureLegacyUnregister(expectedAddr, unregisterCompletion.Task);
 
-            // Give up control then Run forever
-            this.grainDirectory.Unregister(expectedAddr).Returns(async (t) =>
-            {
-                await Task.Yield();
-                mre.WaitOne();
-            });
-
-            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(expectedAddr);
-            this.grainDirectory.Register(secondAddr, previousAddress: null).Returns(secondAddr);
+            ConfigureLegacyRegister(expectedAddr, previousAddress: null, expectedAddr);
+            ConfigureLegacyRegister(secondAddr, previousAddress: null, secondAddr);
 
             // Register to populate cache
-            await this.grainLocator.Register(expectedAddr, previousAddress: null);
+            await this.grainLocator.Register(expectedAddr, previousAddress: null, cancellationToken);
 
             // Unregister and check if cache was cleaned
             Task t = this.grainLocator.Unregister(expectedAddr, UnregistrationCause.Force);
             Assert.False(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out _));
 
             // Add back to cache simulating a race from lookup
-            await this.grainLocator.Register(secondAddr, previousAddress: null);
+            await this.grainLocator.Register(secondAddr, previousAddress: null, cancellationToken);
             Assert.True(this.grainLocator.TryLookupInCache(secondAddr.GrainId, out _));
 
             // Ensure when Unregister finishes if the race occured on the same id that it was removed
-            mre.Set();
-            await t;
+            unregisterCompletion.TrySetResult();
+            await t.WaitAsync(cancellationToken);
             Assert.True(this.grainLocator.TryLookupInCache(secondAddr.GrainId, out _));
         }
 
@@ -982,20 +992,52 @@ namespace UnitTests.Directory
         private int generation = 0;
         private SiloAddress GenerateSiloAddress() => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5000), ++generation);
 
-        private async Task WaitUntilClusterChangePropagated()
+        private void ConfigureLegacyLookup(GrainId grainId, GrainAddress result) =>
+            this.grainDirectory.Lookup(grainId).Returns(result);
+
+        private void ConfigureLegacyRegister(GrainAddress address, GrainAddress? previousAddress, GrainAddress result) =>
+            this.grainDirectory.Register(address, previousAddress).Returns(result);
+
+        private void ConfigureLegacyUnregister(GrainAddress address, Task result) =>
+            this.grainDirectory.Unregister(address).Returns(result);
+
+        private int GetLegacyCallCount(string methodName, params object?[] arguments) =>
+            this.grainDirectory.ReceivedCalls().Count(
+                call => call.GetMethodInfo().Name == methodName && call.GetArguments().SequenceEqual(arguments));
+
+        private int GetLegacyUnregisterSilosCallCount(Func<List<SiloAddress>, bool> predicate) =>
+            this.grainDirectory.ReceivedCalls().Count(
+                call => call.GetMethodInfo().Name == nameof(IGrainDirectory.UnregisterSilos)
+                    && call.GetArguments() is [List<SiloAddress> siloAddresses]
+                    && predicate(siloAddresses));
+
+        private async Task WaitUntilClusterChangePropagated(CancellationToken cancellationToken)
         {
-            await Until(() => this.mockMembershipService.CurrentVersion == ((CachedGrainLocator.ITestAccessor)this.grainLocator).LastMembershipVersion);
+            await Until(
+                () => this.mockMembershipService.CurrentVersion == ((CachedGrainLocator.ITestAccessor)this.grainLocator).LastMembershipVersion,
+                cancellationToken);
         }
 
-        private static async Task Until(Func<bool> condition)
+        private static async Task Until(Func<bool> condition, CancellationToken cancellationToken)
         {
             var maxTimeout = 40_000;
-            while (!condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
+            while (!condition() && (maxTimeout -= 10) > 0)
+            {
+                await Task.Delay(10, cancellationToken);
+            }
+
             Assert.True(maxTimeout > 0);
         }
 
         private class NoOpClusterManifestProvider : IClusterManifestProvider
         {
+            private readonly CancellationToken cancellationToken;
+
+            public NoOpClusterManifestProvider(CancellationToken cancellationToken)
+            {
+                this.cancellationToken = cancellationToken;
+            }
+
             public ClusterManifest Current => new ClusterManifest(
                 MajorMinorVersion.Zero,
                 ImmutableDictionary<SiloAddress, GrainManifest>.Empty);
@@ -1007,7 +1049,7 @@ namespace UnitTests.Directory
             private async IAsyncEnumerable<ClusterManifest> GetUpdates()
             {
                 yield return this.Current;
-                await Task.Delay(100);
+                await Task.Delay(100, this.cancellationToken);
                 yield break;
             }
         }

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -87,9 +87,9 @@ public class DurableJobReceiverExtensionTests
 
         firstAttemptCancellation.Cancel();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => attemptTask!.WaitAsync(TimeSpan.FromSeconds(5)));
+            () => attemptTask!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
 
-        var redelivery = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+        var redelivery = await extension.HandleDurableJobAsync(context, TestContext.Current.CancellationToken);
 
         Assert.Equal(DurableJobRunStatus.Completed, redelivery.Status);
         await handler.Received(2).ExecuteJobAsync(context, Arg.Any<CancellationToken>());

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -122,7 +122,7 @@ public class DurableJobReceiverExtensionTests
             jobStatusPollInterval: TimeSpan.FromHours(1),
             timeProvider: timeProvider);
         var context = CreateJobContext("run-1");
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         var firstCall = extension.HandleDurableJobAsync(context, cts.Token).AsTask();
         await timeProvider.TimerCreated;
@@ -130,7 +130,7 @@ public class DurableJobReceiverExtensionTests
         Assert.Equal(1, timeProvider.ActiveTimerCount);
 
         cts.Cancel();
-        var first = await firstCall.WaitAsync(TimeSpan.FromSeconds(5));
+        var first = await firstCall.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         var second = await extension.HandleDurableJobAsync(context, cts.Token);
 
         Assert.True(first.IsInProgress);
@@ -204,7 +204,9 @@ public class DurableJobReceiverExtensionTests
 
         executionTask.SetResult(true);
 
-        var completed = await first.AsTask().WaitAsync(TimeSpan.FromMinutes(1));
+        var completed = await first.AsTask().WaitAsync(
+            TimeSpan.FromMinutes(1),
+            TestContext.Current.CancellationToken);
         Assert.Equal(DurableJobRunStatus.Completed, completed.Status);
         await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
 

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -128,7 +128,7 @@ public class InMemoryJobQueueTests
 
         timeProvider.Advance(TimeSpan.FromSeconds(3));
 
-        Assert.True(await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         Assert.Equal(job.Id, enumerator.Current.Job.Id);
     }
 
@@ -145,7 +145,7 @@ public class InMemoryJobQueueTests
         var job = CreateJob("job1", timeProvider.GetUtcNow());
         queue.Enqueue(job, 0);
 
-        Assert.True(await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         Assert.Equal(job.Id, enumerator.Current.Job.Id);
     }
 
@@ -384,7 +384,7 @@ public class InMemoryJobQueueTests
     public async Task GetAsyncEnumerator_CancellationToken_StopsEnumeration()
     {
         var queue = new InMemoryJobQueue();
-        var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         cts.Cancel();
 
@@ -413,7 +413,7 @@ public class InMemoryJobQueueTests
 
         // Drain the first job. After this returns, the enumerator is between yields with
         // the bucket already dequeued from _queue.
-        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         Assert.Equal("job1", enumerator.Current.Job.Name);
         queue.RemoveJob(enumerator.Current.Job.Id);
 
@@ -422,11 +422,11 @@ public class InMemoryJobQueueTests
         queue.Enqueue(job2, 0);
         queue.MarkAsComplete();
 
-        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         Assert.Equal("job2", enumerator.Current.Job.Name);
         queue.RemoveJob(enumerator.Current.Job.Id);
 
-        Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -443,7 +443,7 @@ public class InMemoryJobQueueTests
 
         await using var enumerator = queue.GetAsyncEnumerator(CancellationToken.None);
 
-        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         Assert.Equal("job1", enumerator.Current.Job.Name);
         queue.RemoveJob(enumerator.Current.Job.Id);
 
@@ -453,11 +453,11 @@ public class InMemoryJobQueueTests
         queue.Enqueue(job2, 0);
         queue.MarkAsComplete();
 
-        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         Assert.Equal("job2", enumerator.Current.Job.Name);
         queue.RemoveJob(enumerator.Current.Job.Id);
 
-        Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
     }
 
     private static DurableJob CreateJob(string id, DateTimeOffset dueTime, string? traceParent = null, string? traceState = null)

--- a/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
@@ -152,6 +152,7 @@ public class JobShardTests
     [Fact]
     public async Task MarkAsCompleteAsync_WaitsForInFlightSchedulePersistence()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var now = DateTimeOffset.UtcNow;
         var shard = new GateableJobShard(now.AddMinutes(-1), now.AddMinutes(1));
         var scheduleTask = shard.TryScheduleJobAsync(
@@ -161,16 +162,16 @@ public class JobShardTests
                 JobName = "job",
                 DueTime = now
             },
-            CancellationToken.None);
+            cancellationToken);
 
-        await shard.PersistAddStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        var completionTask = shard.MarkAsCompleteAsync(CancellationToken.None);
+        await shard.PersistAddStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        var completionTask = shard.MarkAsCompleteAsync(cancellationToken);
 
         Assert.False(completionTask.IsCompleted);
         shard.AllowPersistAdd.SetResult();
 
-        Assert.NotNull(await scheduleTask.WaitAsync(TimeSpan.FromSeconds(5)));
-        await completionTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.NotNull(await scheduleTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken));
+        await completionTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
         Assert.True(shard.IsAddingCompleted);
         Assert.Equal(1, await shard.GetJobCountAsync());
         Assert.Null(await shard.TryScheduleJobAsync(
@@ -180,7 +181,7 @@ public class JobShardTests
                 JobName = "later",
                 DueTime = now
             },
-            CancellationToken.None));
+            cancellationToken));
     }
 
     private static async Task<TestJobShard> CreateShardWithDueJobAsync(string id, DateTimeOffset now)

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -43,21 +43,21 @@ public class LocalDurableJobManagerTests
         var shard = new BlockingQueueShard("active-shard", shardKey, shardKey.Add(options.ShardDuration));
 
         manager.Participate(lifecycle);
-        await lifecycle.OnStart();
+        await lifecycle.OnStart(TestContext.Current.CancellationToken);
         accessor.AddWritableShard(shardKey, shard);
         accessor.TryActivateShard(shard);
 
-        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.True(accessor.TryGetRunningShardTask(shard.Id, out var runTask));
         Assert.False(runTask!.IsCompleted);
 
-        var stopTask = lifecycle.OnStop();
-        await shard.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var stopTask = lifecycle.OnStop(TestContext.Current.CancellationToken);
+        await shard.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.False(stopTask.IsCompleted);
 
         shard.AllowDispose.SetResult();
-        await stopTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, shard.DisposeCallCount);
         Assert.False(accessor.TryGetRunningShardTask(shard.Id, out _));
@@ -79,13 +79,15 @@ public class LocalDurableJobManagerTests
         var shard = new FaultingOnCancellationShard("faulting-shard", shardKey, shardKey.Add(options.ShardDuration));
 
         manager.Participate(lifecycle);
-        await lifecycle.OnStart();
+        await lifecycle.OnStart(TestContext.Current.CancellationToken);
         accessor.AddWritableShard(shardKey, shard);
         accessor.TryActivateShard(shard);
 
-        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        await lifecycle.OnStop().WaitAsync(TimeSpan.FromSeconds(5));
+        await lifecycle.OnStop(TestContext.Current.CancellationToken).WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(1, shard.DisposeCallCount);
         Assert.Contains(
@@ -175,7 +177,7 @@ public class LocalDurableJobManagerTests
         Assert.True(accessor.TryGetRunningShardTask(shard.Id, out var runTask));
 
         await accessor.ProcessShardCheckCycleAsync(CancellationToken.None);
-        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal(1, shard.MarkAsCompleteCallCount);
         Assert.Equal(1, shard.DisposeCallCount);
@@ -209,9 +211,9 @@ public class LocalDurableJobManagerTests
 
         Assert.True(accessor.TryGetRunningShardTask(shard.Id, out var runTask));
 
-        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await shard.MarkAsCompleteAsync(CancellationToken.None);
-        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -230,9 +232,9 @@ public class LocalDurableJobManagerTests
 
         Assert.True(accessor.TryGetRunningShardTask(shard.Id, out var runTask));
 
-        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await shard.MarkAsCompleteAsync(CancellationToken.None);
-        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.False(accessor.HasWritableShard(shardKey));
         Assert.False(accessor.HasCachedShard(shard.Id));
@@ -258,10 +260,10 @@ public class LocalDurableJobManagerTests
 
         Assert.True(accessor.TryGetRunningShardTask(completedShard.Id, out var runTask));
 
-        await completedShard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await completedShard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         accessor.AddWritableShard(shardKey, replacementShard);
         await completedShard.MarkAsCompleteAsync(CancellationToken.None);
-        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.True(accessor.TryGetWritableShard(shardKey, out var currentShard));
         Assert.Same(replacementShard, currentShard);
@@ -342,7 +344,7 @@ public class LocalDurableJobManagerTests
             DueTime = shardKey
         }, CancellationToken.None);
 
-        await shard.ScheduleStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await shard.ScheduleStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var cycleTask = accessor.ProcessShardCheckCycleAsync(CancellationToken.None);
 
@@ -350,8 +352,8 @@ public class LocalDurableJobManagerTests
 
         shard.AllowScheduleToFinish.SetResult();
 
-        var job = await scheduleTask.WaitAsync(TimeSpan.FromSeconds(5));
-        await cycleTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var job = await scheduleTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await cycleTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         Assert.Equal("late-job", job.Name);
         Assert.Equal(1, shard.MarkAsCompleteCallCount);
@@ -593,11 +595,17 @@ public class LocalDurableJobManagerTests
         timeProvider.Advance(TimeSpan.FromSeconds(3));
         await accessor.ProcessShardCheckCycleAsync(CancellationToken.None);
 
-        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(job.Id, jobContext.Job.Id);
-        await AdvanceUntilCompletedAsync(timeProvider, runTask!, TimeSpan.FromSeconds(1));
-        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Null(await storageProvider.CreateStorage(JobShardId.Parse(job.ShardId).ToJournalId()).GetMetadataAsync());
+        await AdvanceUntilCompletedAsync(
+            timeProvider,
+            runTask!,
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Null(await storageProvider
+            .CreateStorage(JobShardId.Parse(job.ShardId).ToJournalId())
+            .GetMetadataAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -651,14 +659,18 @@ public class LocalDurableJobManagerTests
         }, CancellationToken.None);
 
         Assert.True(accessor.TryGetRunningShardTask(job.ShardId, out var runTask));
-        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(job.Id, jobContext.Job.Id);
         Assert.Equal(1, getHandleCount());
 
         timeProvider.Advance(TimeSpan.FromSeconds(3));
         await accessor.ProcessShardCheckCycleAsync(CancellationToken.None);
-        await AdvanceUntilCompletedAsync(timeProvider, runTask!, TimeSpan.FromSeconds(1));
-        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        await AdvanceUntilCompletedAsync(
+            timeProvider,
+            runTask!,
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(1, getHandleCount());
     }
 
@@ -676,7 +688,7 @@ public class LocalDurableJobManagerTests
 
         accessor.AddWritableShard(shardKey, shard);
         accessor.TryActivateShard(shard);
-        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         var job = await manager.ScheduleJobAsync(new()
         {
@@ -685,12 +697,14 @@ public class LocalDurableJobManagerTests
             DueTime = shardKey
         }, CancellationToken.None);
 
-        var unexpectedDispatch = await Task.WhenAny(handledJob.Task, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        var unexpectedDispatch = await Task.WhenAny(
+            handledJob.Task,
+            Task.Delay(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken));
         Assert.NotSame(handledJob.Task, unexpectedDispatch);
 
         shard.AllowConsume.SetResult();
 
-        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(job.Id, jobContext.Job.Id);
     }
 
@@ -932,10 +946,15 @@ public class LocalDurableJobManagerTests
         return (grainFactory, handledJob, () => Volatile.Read(ref handleCount));
     }
 
-    private static async Task AdvanceUntilCompletedAsync(FakeTimeProvider timeProvider, Task task, TimeSpan advanceBy)
+    private static async Task AdvanceUntilCompletedAsync(
+        FakeTimeProvider timeProvider,
+        Task task,
+        TimeSpan advanceBy,
+        CancellationToken cancellationToken)
     {
         for (var i = 0; i < 10 && !task.IsCompleted; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await Task.Yield();
             timeProvider.Advance(advanceBy);
         }

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -151,6 +151,7 @@ public class ShardExecutorTests
     [Fact]
     public async Task RunShardAsync_WhenCancelledDuringOverloadBackoff_CancelsCleanly()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var options = CreateOptions(maxConcurrentJobs: 10, overloadBackoffDelay: TimeSpan.FromSeconds(10));
         var overloadDetector = CreateOverloadDetector(isOverloaded: true);
         var jobs = CreateJobs(5);
@@ -162,13 +163,13 @@ public class ShardExecutorTests
         ConfigureGrainFactoryToTrackCompletions(grainFactory, completedJobs);
 
         // Cancel shortly after starting, while executor is waiting for overload to clear
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
             await executor.RunShardAsync(shard, cts.Token);
-        });
+        }).WaitAsync(cancellationToken);
 
         // No jobs should have executed since cancellation occurred during backoff wait
         Assert.Empty(completedJobs);
@@ -328,14 +329,14 @@ public class ShardExecutorTests
 
         var runTask = executor.RunShardAsync(shard, CancellationToken.None);
 
-        await firstCall.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromMinutes(1));
+        await firstCall.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromMinutes(1), TestContext.Current.CancellationToken);
         Assert.False(secondCall.Task.IsCompleted);
 
         timeProvider.Advance(TimeSpan.FromSeconds(5));
 
-        await secondCall.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await secondCall.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await shard.Received(1).RemoveJobAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
@@ -360,14 +361,14 @@ public class ShardExecutorTests
 
         var runTask = executor.RunShardAsync(shard, CancellationToken.None);
 
-        await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromSeconds(5));
+        await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.False(jobHandled.Task.IsCompleted);
 
         Volatile.Write(ref overloaded, false);
         timeProvider.Advance(options.Value.OverloadBackoffDelay);
 
-        await jobHandled.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await jobHandled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -432,7 +433,8 @@ public class ShardExecutorTests
 
         var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(5));
         var runTask = executor.RunShardAsync(shard, cts.Token);
 
         await Task.WhenAll(firstJobRegistered.Task, retryPersistenceStarted.Task).WaitAsync(cts.Token);
@@ -450,6 +452,7 @@ public class ShardExecutorTests
     [Fact]
     public async Task RunShardAsync_WhenHandlerCancelsWithoutAttemptCancellation_UsesFailureRetryPolicy()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var retryPolicyInvoked = false;
         var options = CreateOptions(
             maxConcurrentJobs: 10,
@@ -466,7 +469,7 @@ public class ShardExecutorTests
         var grainFactory = CreateGrainFactoryWithCanceledExecution();
         var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance);
 
-        await executor.RunShardAsync(shard, CancellationToken.None);
+        await executor.RunShardAsync(shard, cancellationToken);
 
         Assert.True(retryPolicyInvoked);
         await shard.Received(1).RetryJobLaterAsync(
@@ -798,7 +801,9 @@ public class ShardExecutorTests
         var runTask = executor.RunShardAsync(shard, CancellationToken.None);
         try
         {
-            var completedTask = await Task.WhenAny(concurrencyIncreased.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            var completedTask = await Task.WhenAny(
+                concurrencyIncreased.Task,
+                Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
             Assert.Same(concurrencyIncreased.Task, completedTask);
         }
         finally

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -482,6 +482,7 @@ public class ShardExecutorTests
     [Fact]
     public async Task RunShardAsync_WhenAttemptCancellationIsRequested_DoesNotRetryOrRemove()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var retryPolicyInvoked = false;
         var options = CreateOptions(
             maxConcurrentJobs: 10,
@@ -503,10 +504,10 @@ public class ShardExecutorTests
         using var attemptCancellation = new CancellationTokenSource();
 
         var runTask = executor.RunShardAsync(shard, attemptCancellation.Token);
-        await attemptStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await attemptStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
         attemptCancellation.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask.WaitAsync(cancellationToken));
         Assert.False(retryPolicyInvoked);
         await shard.DidNotReceive().RetryJobLaterAsync(
             Arg.Any<IJobRunContext>(),

--- a/test/Orleans.Core.Tests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/Orleans.Core.Tests/General/RequestContextTestsNonSiloRequired.cs
@@ -55,9 +55,9 @@ namespace UnitTests.General
                 RequestContext.Set(key, i);
                 promises[i] = Task.Run(() =>
                 {
-                    flag.Wait();
+                    flag.Wait(TestContext.Current.CancellationToken);
                     msg.RequestContextData = RequestContextExtensions.Export(this.fixture.DeepCopier);
-                });
+                }, TestContext.Current.CancellationToken);
                 flag.Set();
                 Thread.Sleep(1);
                 RequestContext.Remove(key);
@@ -198,17 +198,17 @@ namespace UnitTests.General
                 string str = i.ToString(CultureInfo.InvariantCulture);
                 promises[i] = Task.Run(async () =>
                 {
-                    await Task.Delay(5);
+                    await Task.Delay(5, TestContext.Current.CancellationToken);
                     Assert.Equal(data1, RequestContext.Get(name1));  // "RC.GetData-Task.Run-0"
-                    await Task.Delay(5);
+                    await Task.Delay(5, TestContext.Current.CancellationToken);
                     // Set New value
                     RequestContext.Set(name1, str);
                     Assert.Equal(str, RequestContext.Get(name1));  // "RC.GetData-Task.Run-1-" + str
-                    await Task.Delay(5);
+                    await Task.Delay(5, TestContext.Current.CancellationToken);
                     Assert.Equal(str, RequestContext.Get(name1));  // "RC.GetData-Task.Run-2-" + str
-                    await Task.Delay(5);
+                    await Task.Delay(5, TestContext.Current.CancellationToken);
                     Assert.Equal(str, RequestContext.Get(name1));  // "RC.GetData-Task.Run-3-" + str
-                });
+                }, TestContext.Current.CancellationToken);
             }
             await Task.WhenAll(promises);
             Assert.Equal(data1, RequestContext.Get(name1));  // "RC.GetData-Main-Final"

--- a/test/Orleans.Core.Tests/General/TimeProviderExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/General/TimeProviderExtensionsTests.cs
@@ -16,7 +16,7 @@ public class TimeProviderExtensionsTests
     {
         var start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var timeProvider = new FakeTimeProvider(start);
-        var delayTask = timeProvider.DelayUntilAsync(start.Add(delay));
+        var delayTask = timeProvider.DelayUntilAsync(start.Add(delay), TestContext.Current.CancellationToken);
 
         Assert.False(delayTask.IsCompleted);
 
@@ -26,7 +26,7 @@ public class TimeProviderExtensionsTests
 
         timeProvider.Advance(TimeSpan.FromMilliseconds(1));
 
-        await delayTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await delayTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Equal(start.Add(delay), timeProvider.GetUtcNow());
     }
 
@@ -37,7 +37,7 @@ public class TimeProviderExtensionsTests
     {
         var start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var timeProvider = new FakeTimeProvider(start);
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var delayTask = timeProvider.DelayUntilAsync(
             start.Add(MaximumTimerDelay).AddDays(1),
             cancellation.Token);

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -110,7 +110,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }
@@ -152,7 +152,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }
@@ -244,12 +244,12 @@ public class ClusterManifestProviderTests
         var suitableSilosRead = membership.ObserveNextSnapshotRead();
         var suitableSilosTask = Task.Run(
             () => selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1));
-        await suitableSilosRead.WaitAsync(TimeSpan.FromSeconds(10));
+        await suitableSilosRead.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.False(suitableSilosTask.IsCompleted);
 
         clusterManifestProvider.Current = CreateClusterManifest(2, 0, remoteSilo);
 
-        var suitableSilos = await suitableSilosTask.WaitAsync(TimeSpan.FromSeconds(10));
+        var suitableSilos = await suitableSilosTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.Equal(new[] { remoteSilo }, suitableSilos.SuitableSilos);
 
         membership.Update(CreateMembershipSnapshot(
@@ -258,12 +258,12 @@ public class ClusterManifestProviderTests
             (remoteSilo, SiloStatus.Active)));
         var supportedSilosRead = membership.ObserveNextSnapshotRead();
         var supportedSilosTask = Task.Run(() => selectorManager.GetSupportedSilos(TestGrainType));
-        await supportedSilosRead.WaitAsync(TimeSpan.FromSeconds(10));
+        await supportedSilosRead.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.False(supportedSilosTask.IsCompleted);
 
         clusterManifestProvider.Current = CreateClusterManifest(3, 0, localSilo, remoteSilo);
 
-        var supportedSilos = await supportedSilosTask.WaitAsync(TimeSpan.FromSeconds(10));
+        var supportedSilos = await supportedSilosTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.Equal(new[] { localSilo, remoteSilo }, supportedSilos.OrderBy(static silo => silo));
     }
 

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -94,7 +94,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_BasicScenario()
         {
-            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: true, numVotesForDeathDeclaration: 2);
+            await ClusterHealthMonitor_BasicScenario_Runner(
+                enableIndirectProbes: true,
+                numVotesForDeathDeclaration: 2,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -103,12 +106,17 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_MonitorAllStaleSilos()
         {
-            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: true, numVotesForDeathDeclaration: 2, otherSilosAreStale: true);
+            await ClusterHealthMonitor_BasicScenario_Runner(
+                enableIndirectProbes: true,
+                numVotesForDeathDeclaration: 2,
+                otherSilosAreStale: true,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task ClusterHealthMonitor_JoiningSiloMonitorsStaleAndSuspectedEvictableSilos()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var clusterMembershipOptions = new ClusterMembershipOptions
             {
@@ -116,7 +124,7 @@ namespace NonSilo.Tests.Membership
             };
 
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             var staleSilo = Silo("127.0.0.200:100@100");
             var freshSilo = Silo("127.0.0.200:200@100");
@@ -140,21 +148,21 @@ namespace NonSilo.Tests.Membership
                 Assert.True(await this.membershipTable.InsertRow(entry, table.Version.Next()));
             }
 
-            await testRig.Manager.Refresh();
-            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
+            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion, cancellationToken);
             Assert.Empty(testRig.TestAccessor.MonitoredSilos);
 
             lastVersion = testRig.TestAccessor.ObservedVersion;
             await testRig.Manager.UpdateStatus(SiloStatus.Joining);
-            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
-            await Until(() => testRig.TestAccessor.MonitoredSilos.Count == 3);
+            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion, cancellationToken);
+            await Until(() => testRig.TestAccessor.MonitoredSilos.Count == 3, cancellationToken);
 
             Assert.Contains(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(staleSilo));
             Assert.Contains(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(suspectedSilo));
             Assert.Contains(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(shuttingDownSilo));
             Assert.DoesNotContain(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(freshSilo));
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
         /// <summary>
@@ -163,7 +171,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_NoIndirectProbes()
         {
-            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: false, numVotesForDeathDeclaration: 2);
+            await ClusterHealthMonitor_BasicScenario_Runner(
+                enableIndirectProbes: false,
+                numVotesForDeathDeclaration: 2,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -172,7 +183,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_ThreeVotesNeededToKill()
         {
-            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: true, numVotesForDeathDeclaration: 3);
+            await ClusterHealthMonitor_BasicScenario_Runner(
+                enableIndirectProbes: true,
+                numVotesForDeathDeclaration: 3,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -181,7 +195,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_OneVoteNeededToKill()
         {
-            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: false, numVotesForDeathDeclaration: 1);
+            await ClusterHealthMonitor_BasicScenario_Runner(
+                enableIndirectProbes: false,
+                numVotesForDeathDeclaration: 1,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -190,7 +207,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_SilosWithStaleCreatedOrJoiningState_OneVoteNeededToKill()
         {
-            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(evictWhenMaxJoinAttemptTimeExceeded: true, numVotesForDeathDeclaration: 1);
+            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(
+                evictWhenMaxJoinAttemptTimeExceeded: true,
+                numVotesForDeathDeclaration: 1,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -199,7 +219,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_SilosWithStaleCreatedOrJoiningState_TwoVotesNeededToKill()
         {
-            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(evictWhenMaxJoinAttemptTimeExceeded: true, numVotesForDeathDeclaration: 2);
+            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(
+                evictWhenMaxJoinAttemptTimeExceeded: true,
+                numVotesForDeathDeclaration: 2,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -208,7 +231,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_SilosWithStaleCreatedOrJoiningState_ThreeVotesNeededToKill()
         {
-            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(evictWhenMaxJoinAttemptTimeExceeded: true, numVotesForDeathDeclaration: 3);
+            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(
+                evictWhenMaxJoinAttemptTimeExceeded: true,
+                numVotesForDeathDeclaration: 3,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -217,7 +243,10 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_SilosWithStaleCreatedOrJoiningState_Disabled()
         {
-            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(evictWhenMaxJoinAttemptTimeExceeded: false, numVotesForDeathDeclaration: 3);
+            await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(
+                evictWhenMaxJoinAttemptTimeExceeded: false,
+                numVotesForDeathDeclaration: 3,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -227,6 +256,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_ConnectionCanary_SuppressesVoteWhenConnectionActive()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var clusterMembershipOptions = new ClusterMembershipOptions
             {
@@ -244,21 +274,21 @@ namespace NonSilo.Tests.Membership
 
             // Set up probes to always fail.
             var probeCalls = new ConcurrentQueue<SiloAddress>();
-            this.prober.Probe(default!, default).ReturnsForAnyArgs(info =>
+            this.prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue(info.ArgAt<SiloAddress>(0));
                 return Task.FromException(new Exception("probe failed"));
             });
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             var targetSilo = Silo("127.0.0.200:100@100");
             await this.membershipTable.InsertRow(Entry(targetSilo, SiloStatus.Active, now), this.membershipTable.Version.Next());
-            await testRig.Manager.Refresh();
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
             await testRig.Manager.UpdateStatus(SiloStatus.Active);
-            await testRig.Manager.Refresh();
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
 
-            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0);
+            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0, cancellationToken);
 
             // Register a test connection and simulate recent message activity.
             var testConnection = CreateTestConnection(this.loggerFactory);
@@ -275,11 +305,11 @@ namespace NonSilo.Tests.Membership
 
                 // Keep re-stamping the canary so it stays fresh.
                 testConnection.SimulateMessageReceived();
-                await Task.Delay(50);
+                await Task.Delay(50, cancellationToken);
             }
 
-            await Until(() => probeCalls.Count >= clusterMembershipOptions.NumMissedProbesLimit);
-            await Task.Delay(100);
+            await Until(() => probeCalls.Count >= clusterMembershipOptions.NumMissedProbesLimit, cancellationToken);
+            await Task.Delay(100, cancellationToken);
 
             // The silo should NOT be dead because the canary detected active connection traffic.
             var table = await this.membershipTable.ReadAll();
@@ -287,7 +317,7 @@ namespace NonSilo.Tests.Membership
             Assert.NotNull(entry);
             Assert.NotEqual(SiloStatus.Dead, entry.Item1.Status);
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
         /// <summary>
@@ -298,7 +328,10 @@ namespace NonSilo.Tests.Membership
         public async Task ClusterHealthMonitor_ConnectionCanary_AllowsVoteWhenNoConnection()
         {
             // With no connections in the connection manager, canary returns null -> vote proceeds.
-            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: false, numVotesForDeathDeclaration: 1);
+            await ClusterHealthMonitor_BasicScenario_Runner(
+                enableIndirectProbes: false,
+                numVotesForDeathDeclaration: 1,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -308,6 +341,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_ConnectionCanary_DisabledByOption()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var clusterMembershipOptions = new ClusterMembershipOptions
             {
@@ -325,21 +359,21 @@ namespace NonSilo.Tests.Membership
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions, canaryConnectionManager);
 
             var probeCalls = new ConcurrentQueue<SiloAddress>();
-            this.prober.Probe(default!, default).ReturnsForAnyArgs(info =>
+            this.prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue(info.ArgAt<SiloAddress>(0));
                 return Task.FromException(new Exception("probe failed"));
             });
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             var targetSilo = Silo("127.0.0.200:100@100");
             await this.membershipTable.InsertRow(Entry(targetSilo, SiloStatus.Active, now), this.membershipTable.Version.Next());
-            await testRig.Manager.Refresh();
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
             await testRig.Manager.UpdateStatus(SiloStatus.Active);
-            await testRig.Manager.Refresh();
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
 
-            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0);
+            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0, cancellationToken);
 
             // Register a test connection and simulate recent message activity.
             var testConnection = CreateTestConnection(this.loggerFactory);
@@ -355,14 +389,14 @@ namespace NonSilo.Tests.Membership
                 }
 
                 testConnection.SimulateMessageReceived();
-                await Task.Delay(50);
+                await Task.Delay(50, cancellationToken);
             }
 
             await Until(async () =>
             {
                 var snapshot = await this.membershipTable.ReadAll();
                 return snapshot.Members.Any(m => m.Item1.SiloAddress.Equals(targetSilo) && m.Item1.Status == SiloStatus.Dead);
-            });
+            }, cancellationToken);
 
             // Despite an active connection, the silo SHOULD be dead because the option is disabled.
             var table = await this.membershipTable.ReadAll();
@@ -370,10 +404,14 @@ namespace NonSilo.Tests.Membership
             Assert.NotNull(entry);
             Assert.Equal(SiloStatus.Dead, entry.Item1.Status);
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
-        private async Task ClusterHealthMonitor_BasicScenario_Runner(bool enableIndirectProbes, int? numVotesForDeathDeclaration = default, bool otherSilosAreStale = false)
+        private async Task ClusterHealthMonitor_BasicScenario_Runner(
+            bool enableIndirectProbes,
+            int? numVotesForDeathDeclaration,
+            CancellationToken cancellationToken,
+            bool otherSilosAreStale = false)
         {
             var now = DateTimeOffset.UtcNow;
             var clusterMembershipOptions = new ClusterMembershipOptions
@@ -390,12 +428,12 @@ namespace NonSilo.Tests.Membership
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions);
             using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
             var probeCalls = new ConcurrentQueue<(SiloAddress Target, int ProbeNumber, bool IsIndirect)>();
-            this.prober.Probe(default!, default).ReturnsForAnyArgs(info =>
+            this.prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue((info.ArgAt<SiloAddress>(0), info.ArgAt<int>(1), false));
                 return Task.CompletedTask;
             });
-            this.prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(info =>
+            this.prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue((info.ArgAt<SiloAddress>(1), info.ArgAt<int>(3), true));
                 return Task.FromResult(new IndirectProbeResponse
@@ -406,7 +444,7 @@ namespace NonSilo.Tests.Membership
                 });
             });
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             Assert.Empty(testRig.TestAccessor.MonitoredSilos);
 
             var iAmAliveTime = otherSilosAreStale ? now.Subtract(TimeSpan.FromHours(1)) : now;
@@ -433,9 +471,9 @@ namespace NonSilo.Tests.Membership
                 Assert.True(await this.membershipTable.InsertRow(entry, table.Version.Next()));
             }
 
-            await testRig.Manager.Refresh();
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
 
-            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
+            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion, cancellationToken);
             lastVersion = testRig.TestAccessor.ObservedVersion;
 
             // No silos should be monitored by this silo until it becomes active.
@@ -443,11 +481,11 @@ namespace NonSilo.Tests.Membership
 
             await testRig.Manager.UpdateStatus(SiloStatus.Active);
 
-            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
+            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion, cancellationToken);
             lastVersion = testRig.TestAccessor.ObservedVersion;
 
             // Now that this silo is active, it should be monitoring some fraction of the other active silos
-            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0);
+            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0, cancellationToken);
             Assert.NotEmpty(this.timers);
             Assert.DoesNotContain(testRig.TestAccessor.MonitoredSilos, s => s.Key.Equals(this.localSilo));
             var expectedNumProbedSilos = otherSilosAreStale ? otherSilos.Length : clusterMembershipOptions.NumProbedSilos;
@@ -464,7 +502,7 @@ namespace NonSilo.Tests.Membership
                 }
 
                 return probeCalls.Count;
-            });
+            }, cancellationToken);
             Assert.Equal(expectedNumProbedSilos, probeCalls.Count);
             while (probeCalls.TryDequeue(out var call)) Assert.Contains(testRig.TestAccessor.MonitoredSilos, k => k.Key.Equals(call.Item1));
 
@@ -475,12 +513,12 @@ namespace NonSilo.Tests.Membership
             }
 
             // Make the probes fail.
-            this.prober.Probe(default!, default).ReturnsForAnyArgs(info =>
+            this.prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue((info.ArgAt<SiloAddress>(0), info.ArgAt<int>(1), true));
                 return Task.FromException(new Exception("no"));
             });
-            this.prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(info =>
+            this.prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue((info.ArgAt<SiloAddress>(1), info.ArgAt<int>(3), true));
                 return Task.FromResult(new IndirectProbeResponse
@@ -508,7 +546,7 @@ namespace NonSilo.Tests.Membership
                     }
 
                     return probeCalls.Count;
-                });
+                }, cancellationToken);
 
                 while (probeCalls.TryDequeue(out var call)) ;
 
@@ -527,7 +565,7 @@ namespace NonSilo.Tests.Membership
                             var votes = entry.GetFreshVotes(now.UtcDateTime, clusterMembershipOptions.DeathVoteExpirationTimeout);
                             return votes.Any(vote => vote.Item1.Equals(localSiloDetails.SiloAddress)) && (!expectDead || entry.Status == SiloStatus.Dead);
                         });
-                    });
+                    }, cancellationToken);
                 }
 
                 // Check that probes match the expected missed probes
@@ -563,15 +601,15 @@ namespace NonSilo.Tests.Membership
                 return;
             }
 
-            await testRig.Manager.Refresh();
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
 
             // Make the probes succeed again.
-            this.prober.Probe(default!, default).ReturnsForAnyArgs(info =>
+            this.prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue((info.ArgAt<SiloAddress>(0), info.ArgAt<int>(1), false));
                 return Task.CompletedTask;
             });
-            this.prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(info =>
+            this.prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue((info.ArgAt<SiloAddress>(1), info.ArgAt<int>(3), true));
                 return Task.FromResult(new IndirectProbeResponse
@@ -601,7 +639,7 @@ namespace NonSilo.Tests.Membership
                 }
 
                 return probesReceived.Count;
-            });
+            }, cancellationToken);
 
             foreach (var siloMonitor in testRig.TestAccessor.MonitoredSilos.Values)
             {
@@ -609,10 +647,13 @@ namespace NonSilo.Tests.Membership
                 Assert.Equal(0, ((SiloHealthMonitor.ITestAccessor)siloMonitor).MissedProbes);
             }
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
-        private async Task ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(bool evictWhenMaxJoinAttemptTimeExceeded = true, int? numVotesForDeathDeclaration = default)
+        private async Task ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(
+            bool evictWhenMaxJoinAttemptTimeExceeded,
+            int? numVotesForDeathDeclaration,
+            CancellationToken cancellationToken)
         {
             var now = DateTimeOffset.UtcNow;
             var clusterMembershipOptions = new ClusterMembershipOptions
@@ -714,9 +755,9 @@ namespace NonSilo.Tests.Membership
             }
 
             // now we start the lifecycle and let the local silo add the final vote.
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
-            await testRig.Manager.Refresh();
+            await testRig.Manager.Refresh(cancellationToken: cancellationToken);
 
             if (evictWhenMaxJoinAttemptTimeExceeded)
             {
@@ -726,10 +767,10 @@ namespace NonSilo.Tests.Membership
                         && joining.Status == SiloStatus.Dead
                         && snapshot.Entries.TryGetValue(Silo(createdSilo), out var created)
                         && created.Status == SiloStatus.Dead;
-                });
+                }, cancellationToken);
             }
 
-            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
+            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion, cancellationToken);
             
             lastVersion = testRig.TestAccessor.ObservedVersion;
 
@@ -757,7 +798,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(expected: evictWhenMaxJoinAttemptTimeExceeded ? SiloStatus.Dead : SiloStatus.Joining, actual: joiningEntry.Item1.Status);
             Assert.Equal(expected: evictWhenMaxJoinAttemptTimeExceeded ? SiloStatus.Dead : SiloStatus.Created, actual: createdEntry.Item1.Status);
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
 
             static Tuple<MembershipEntry, string>? GetEntryFromTable(MembershipTableData table, string siloAddress)
             {
@@ -769,14 +810,17 @@ namespace NonSilo.Tests.Membership
 
         private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTimeOffset startTime = default) => new MembershipEntry { SiloAddress = address, Status = status, StartTime = startTime.UtcDateTime, IAmAliveTime = startTime.UtcDateTime };
 
-        private static async Task UntilEqual<T>(T expected, Func<T> getActual)
+        private static async Task UntilEqual<T>(
+            T expected,
+            Func<T> getActual,
+            CancellationToken cancellationToken)
         {
             var maxTimeout = 40_000;
             var equalityComparer = EqualityComparer<T>.Default;
             var actual = getActual();
             while (!equalityComparer.Equals(expected, actual) && (maxTimeout -= 10) > 0)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, cancellationToken);
                 actual = getActual();
             }
 
@@ -784,38 +828,48 @@ namespace NonSilo.Tests.Membership
             Assert.True(maxTimeout > 0);
         }
 
-        private static async Task Until(Func<bool> condition)
+        private static async Task Until(Func<bool> condition, CancellationToken cancellationToken)
         {
             var maxTimeout = 40_000;
-            while (!condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
+            while (!condition() && (maxTimeout -= 10) > 0) await Task.Delay(10, cancellationToken);
             Assert.True(maxTimeout > 0);
         }
 
-        private static async Task Until(Func<Task<bool>> condition)
+        private static async Task Until(
+            Func<Task<bool>> condition,
+            CancellationToken cancellationToken)
         {
             var maxTimeout = 40_000;
-            while (!await condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
+            while (!await condition() && (maxTimeout -= 10) > 0)
+            {
+                await Task.Delay(10, cancellationToken);
+            }
+
             Assert.True(maxTimeout > 0);
         }
 
-        private static async Task<MembershipTableSnapshot> WaitForMembershipSnapshot(DiagnosticEventCollector membershipEvents, Func<MembershipTableSnapshot, bool> condition)
+        private static async Task<MembershipTableSnapshot> WaitForMembershipSnapshot(
+            DiagnosticEventCollector membershipEvents,
+            Func<MembershipTableSnapshot, bool> condition,
+            CancellationToken cancellationToken)
         {
             var diagnosticEvent = await membershipEvents.WaitForEventAsync(
                 nameof(MembershipEvents.ViewChanged),
                 evt => evt.Payload is MembershipEvents.ViewChanged viewChanged && condition(viewChanged.Snapshot),
-                TimeSpan.FromSeconds(40));
+                TimeSpan.FromSeconds(40),
+                cancellationToken);
 
             return Assert.IsType<MembershipEvents.ViewChanged>(diagnosticEvent.Payload).Snapshot;
         }
 
-        private async Task StopLifecycle(CancellationToken cancellation = default)
+        private async Task StopLifecycle(CancellationToken cancellationToken)
         {
-            var stopped = this.lifecycle.OnStop(cancellation);
+            var stopped = this.lifecycle.OnStop(cancellationToken);
 
             while (!stopped.IsCompleted)
             {
                 while (this.timerCalls.TryDequeue(out var call)) call.Completion.TrySetResult(false);
-                await Task.Delay(15);
+                await Task.Delay(15, cancellationToken);
             }
 
             await stopped;
@@ -934,6 +988,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task ClusterHealthMonitor_StaleJoinEvictionUsesInjectedTimeProvider()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var start = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
             var maxJoinAttemptTime = TimeSpan.FromMinutes(5);
             var timeProvider = new FakeTimeProvider(start);
@@ -943,7 +998,7 @@ namespace NonSilo.Tests.Membership
                 MembershipVersion.MinValue,
                 ImmutableDictionary<SiloAddress, MembershipEntry>.Empty));
             manager.MembershipUpdates.Returns(updates);
-            manager.TrySuspectSilo(default!, default, default).ReturnsForAnyArgs(true);
+            manager.TrySuspectSilo(default!, default, cancellationToken).ReturnsForAnyArgs(true);
             var options = new ClusterMembershipOptions
             {
                 EvictWhenMaxJoinAttemptTimeExceeded = true,
@@ -967,13 +1022,13 @@ namespace NonSilo.Tests.Membership
             var joiningSilo = Silo("127.0.0.200:111@100");
             var joiningEntry = Entry(joiningSilo, SiloStatus.Joining, start);
 
-            await lifecycle.OnStart();
+            await lifecycle.OnStart(cancellationToken);
             try
             {
-                await updates.WaitForReadAsync(1);
+                await updates.WaitForReadAsync(1, cancellationToken);
                 timeProvider.Advance(maxJoinAttemptTime);
                 updates.Publish(CreateSnapshot(1, joiningEntry));
-                await updates.WaitForReadAsync(2);
+                await updates.WaitForReadAsync(2, cancellationToken);
 
                 Assert.Equal(new MembershipVersion(1), accessor.ObservedVersion);
                 await manager.DidNotReceive().TrySuspectSilo(
@@ -983,7 +1038,7 @@ namespace NonSilo.Tests.Membership
 
                 timeProvider.Advance(TimeSpan.FromTicks(1));
                 updates.Publish(CreateSnapshot(2, joiningEntry));
-                await updates.WaitForReadAsync(3);
+                await updates.WaitForReadAsync(3, cancellationToken);
 
                 Assert.Equal(new MembershipVersion(2), accessor.ObservedVersion);
                 await manager.Received(1).TrySuspectSilo(
@@ -993,10 +1048,10 @@ namespace NonSilo.Tests.Membership
             }
             finally
             {
-                var stopTask = lifecycle.OnStop();
+                var stopTask = lifecycle.OnStop(cancellationToken);
                 updates.Complete();
                 await stopTask;
-                await updates.Completed;
+                await updates.Completed.WaitAsync(cancellationToken);
             }
 
             static MembershipTableSnapshot CreateSnapshot(long version, MembershipEntry joiningEntry)
@@ -1019,7 +1074,7 @@ namespace NonSilo.Tests.Membership
 
             public void Complete() => _updates.Writer.TryComplete();
 
-            public Task WaitForReadAsync(int readCount)
+            public Task WaitForReadAsync(int readCount, CancellationToken cancellationToken)
             {
                 lock (_lock)
                 {
@@ -1034,7 +1089,7 @@ namespace NonSilo.Tests.Membership
                         _readWaiters.Add(readCount, waiter);
                     }
 
-                    return waiter.Task;
+                    return waiter.Task.WaitAsync(cancellationToken);
                 }
             }
 

--- a/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/LocalSiloHealthMonitorTests.cs
@@ -459,6 +459,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task GetLocalHealthStatus_ConcurrentCallersShareOneNonOverlappingParticipantPass()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var activeCalls = 0;
@@ -487,14 +488,14 @@ namespace NonSilo.Tests.Membership
                 .Select(index => Task.Run(async () =>
                 {
                     ready[index].SetResult();
-                    await start.Task;
+                    await start.Task.WaitAsync(cancellationToken);
                     return monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
-                }))
+                }, cancellationToken))
                 .ToArray();
 
-            await Task.WhenAll(ready.Select(item => item.Task));
+            await Task.WhenAll(ready.Select(item => item.Task)).WaitAsync(cancellationToken);
             start.SetResult();
-            await entered.Task;
+            await entered.Task.WaitAsync(cancellationToken);
             try
             {
                 Assert.Equal(1, participant.CallCount);
@@ -507,7 +508,7 @@ namespace NonSilo.Tests.Membership
                 release.TrySetResult();
             }
 
-            var results = await Task.WhenAll(workers);
+            var results = await Task.WhenAll(workers).WaitAsync(cancellationToken);
             var expected = results[0];
             var expectedEvents = expected.Events
                 .Select(item => (item.Timestamp, item.Kind, item.Category, item.Source, item.Score, item.Complaint, item.Duration))
@@ -532,6 +533,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task RecordHealthEvent_DoesNotWaitForHealthCheckParticipants()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var participant = new TestHealthCheckParticipant(_ =>
@@ -542,9 +544,10 @@ namespace NonSilo.Tests.Membership
             });
             var monitor = CreateMonitor(participant);
             var checkTask = Task.Run(
-                () => monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local));
+                () => monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local),
+                cancellationToken);
 
-            await entered.Task;
+            await entered.Task.WaitAsync(cancellationToken);
             try
             {
                 var recordTask = Task.Run(
@@ -552,9 +555,10 @@ namespace NonSilo.Tests.Membership
                         LocalSiloHealthCheckKind.ComponentHealthCheckStall,
                         score: 1,
                         complaint: "participant check stalled",
-                        duration: TimeSpan.FromSeconds(2)));
+                        duration: TimeSpan.FromSeconds(2)),
+                    cancellationToken);
 
-                await recordTask.WaitAsync(TimeSpan.FromSeconds(5));
+                await recordTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
                 Assert.False(checkTask.IsCompleted);
             }
             finally
@@ -562,7 +566,7 @@ namespace NonSilo.Tests.Membership
                 release.TrySetResult();
             }
 
-            await checkTask;
+            await checkTask.WaitAsync(cancellationToken);
             var status = monitor.GetLocalHealthStatus(TimeSpan.Zero, LocalSiloHealthCheckCategory.Local);
             Assert.Contains(
                 status.Events,

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -105,7 +105,7 @@ namespace NonSilo.Tests.Membership
             ((ILifecycleParticipant<ISiloLifecycle>)this.clusterHealthMonitor).Participate(this.lifecycle);
 
             this.remoteSiloProber = Substitute.For<IRemoteSiloProber>();
-            remoteSiloProber.Probe(default!, default).ReturnsForAnyArgs(Task.CompletedTask);
+            remoteSiloProber.Probe(default!, default, TestContext.Current.CancellationToken).ReturnsForAnyArgs(Task.CompletedTask);
 
             this.localSiloHealthMonitor = Substitute.For<ILocalSiloHealthMonitor>();
             this.localSiloHealthMonitor.GetLocalHealthStatus(default, default, default).ReturnsForAnyArgs(new LocalSiloHealthStatus(0, []));
@@ -127,6 +127,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipAgent_LifecycleStages_GracefulShutdown()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var levels = new ConcurrentDictionary<int, SiloStatus>();
             Func<CancellationToken, Task> Callback(int level) => ct =>
             {
@@ -155,13 +156,13 @@ namespace NonSilo.Tests.Membership
                 Callback(l - 1));
             }
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             Assert.Equal(SiloStatus.Created, levels[ServiceLifecycleStage.RuntimeInitialize + 1]);
             Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.AfterRuntimeGrainServices + 1]);
             Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.ValidateInitialConnectivity + 1]);
             Assert.Equal(SiloStatus.Active, levels[ServiceLifecycleStage.BecomeActive + 1]);
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
 
             Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.GrainDeactivation]);
             Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.ValidateInitialConnectivity - 1]);
@@ -172,6 +173,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipAgent_LifecycleStages_UngracefulShutdown()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var levels = new ConcurrentDictionary<int, SiloStatus>();
             Func<CancellationToken, Task> Callback(int level) => ct =>
             {
@@ -200,15 +202,15 @@ namespace NonSilo.Tests.Membership
                 Callback(l - 1));
             }
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             Assert.Equal(SiloStatus.Created, levels[ServiceLifecycleStage.RuntimeInitialize + 1]);
             Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.AfterRuntimeGrainServices + 1]);
             Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.ValidateInitialConnectivity + 1]);
             Assert.Equal(SiloStatus.Active, levels[ServiceLifecycleStage.BecomeActive + 1]);
 
-            using var cancellation = new CancellationTokenSource();
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cancellation.Cancel();
-            await StopLifecycle(cancellation.Token);
+            await StopLifecycle(cancellationToken, cancellation.Token);
 
             Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.GrainDeactivation]);
             Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.ValidateInitialConnectivity - 1]);
@@ -219,48 +221,50 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipAgent_UpdateIAmAlive()
         {
-            await this.lifecycle.OnStart();
-            await Until(() => this.timerCalls.ContainsKey("UpdateIAmAlive"));
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await this.lifecycle.OnStart(cancellationToken);
+            await Until(() => this.timerCalls.ContainsKey("UpdateIAmAlive"), cancellationToken);
 
             var updateCounter = 0;
             var testAccessor = (MembershipAgent.ITestAccessor)this.agent;
             testAccessor.OnUpdateIAmAlive = () => ++updateCounter;
 
             (TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion) timer = (default, default!);
-            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1);
+            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1, cancellationToken);
             timer.Completion.TrySetResult(true);
-            await Until(() => updateCounter == 1);
+            await Until(() => updateCounter == 1, cancellationToken);
 
             testAccessor.OnUpdateIAmAlive = () => { ++updateCounter; throw new Exception("no"); };
 
-            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1);
+            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1, cancellationToken);
             timer.Completion.TrySetResult(true);
             Assert.False(timer.DelayOverride.HasValue);
-            await Until(() => updateCounter == 2);
+            await Until(() => updateCounter == 2, cancellationToken);
 
             testAccessor.OnUpdateIAmAlive = () => ++updateCounter;
 
-            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1);
+            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1, cancellationToken);
             Assert.True(timer.DelayOverride.HasValue);
             timer.Completion.TrySetResult(true);
-            await Until(() => updateCounter == 3);
+            await Until(() => updateCounter == 3, cancellationToken);
             Assert.Equal(3, updateCounter);
 
             // When something goes horribly awry (eg, the timer throws an exception), the silo should fault.
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
-            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1);
+            while (!this.timerCalls["UpdateIAmAlive"].TryDequeue(out timer)) await Task.Delay(1, cancellationToken);
             timer.Completion.TrySetException(new Exception("no"));
             Assert.False(timer.DelayOverride.HasValue);
-            await Until(() => this.fatalErrorHandler.ReceivedCalls().Any());
+            await Until(() => this.fatalErrorHandler.ReceivedCalls().Any(), cancellationToken);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
             // Stop & cancel all timers.
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipAgent_LifecycleStages_ValidateInitialConnectivity_Success()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var otherSilos = new[]
             {
                 Entry(Silo("127.0.0.200:100@100"), SiloStatus.Active),
@@ -295,24 +299,25 @@ namespace NonSilo.Tests.Membership
                 manager,
                 this.localSiloDetails,
                 TimeProvider.System);
-            var started = this.lifecycle.OnStart();
+            var started = this.lifecycle.OnStart(cancellationToken);
 
-            await Until(() => remoteSiloProber.ReceivedCalls().Count() >= otherSilos.Length);
+            await Until(() => remoteSiloProber.ReceivedCalls().Count() >= otherSilos.Length, cancellationToken);
 
 
-            await Until(() => started.IsCompleted);
+            await Until(() => started.IsCompleted, cancellationToken);
             await started;
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipAgent_LifecycleStages_ValidateInitialConnectivity_WaitsForStaleSilosToBeEvicted()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             this.clusterMembershipOptions.Value.NumMissedProbesLimit = 1;
             this.clusterMembershipOptions.Value.NumVotesForDeathDeclaration = 1;
             this.clusterMembershipOptions.Value.ProbeTimeout = TimeSpan.FromMilliseconds(20);
-            this.remoteSiloProber.Probe(default!, default).ReturnsForAnyArgs(Task.FromException(new Exception("no")));
+            this.remoteSiloProber.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(Task.FromException(new Exception("no")));
 
             var staleSilo = Silo("127.0.0.200:100@100");
             var staleEntry = Entry(staleSilo, SiloStatus.Active, DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
@@ -332,8 +337,8 @@ namespace NonSilo.Tests.Membership
                 this.localSiloDetails,
                 TimeProvider.System);
 
-            var started = this.lifecycle.OnStart();
-            await Until(() => this.timerCalls.ContainsKey(nameof(SiloHealthMonitor)));
+            var started = this.lifecycle.OnStart(cancellationToken);
+            await Until(() => this.timerCalls.ContainsKey(nameof(SiloHealthMonitor)), cancellationToken);
 
             while (!started.IsCompleted)
             {
@@ -342,7 +347,7 @@ namespace NonSilo.Tests.Membership
                     timer.Completion.TrySetResult(true);
                 }
 
-                await Task.Delay(1);
+                await Task.Delay(1, cancellationToken);
             }
 
             await started;
@@ -351,12 +356,13 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(SiloStatus.Dead, table.Members.Single(member => member.Item1.SiloAddress.Equals(staleSilo)).Item1.Status);
             Assert.Equal(SiloStatus.Active, this.manager.CurrentStatus);
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipAgent_LifecycleStages_ValidateInitialConnectivity_Failure()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             this.timerFactory.CreateDelegate = (period, name) => new DelegateAsyncTimer(_ => Task.FromResult(false));
 
             var otherSilos = new[]
@@ -379,7 +385,7 @@ namespace NonSilo.Tests.Membership
                 Assert.True(await this.membershipTable.InsertRow(entry, table.Version.Next()));
             }
 
-            this.remoteSiloProber.Probe(default!, default).ReturnsForAnyArgs(Task.FromException(new Exception("no")));
+            this.remoteSiloProber.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(Task.FromException(new Exception("no")));
 
             var dateTimeIndex = 0;
             var dateTimes = new DateTime[] { DateTime.UtcNow, DateTime.UtcNow.AddMinutes(1) };
@@ -397,15 +403,15 @@ namespace NonSilo.Tests.Membership
                 manager,
                 this.localSiloDetails,
                 TimeProvider.System);
-            var started = this.lifecycle.OnStart();
+            var started = this.lifecycle.OnStart(cancellationToken);
 
-            await Until(() => this.remoteSiloProber.ReceivedCalls().Count() >= otherSilos.Length);
-            await Until(() => started.IsCompleted);
+            await Until(() => this.remoteSiloProber.ReceivedCalls().Count() >= otherSilos.Length, cancellationToken);
+            await Until(() => started.IsCompleted, cancellationToken);
 
             // Startup should have faulted.
             Assert.True(started.IsFaulted);
 
-            await StopLifecycle();
+            await StopLifecycle(cancellationToken);
         }
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
@@ -417,21 +423,23 @@ namespace NonSilo.Tests.Membership
             return new MembershipEntry { SiloAddress = address, Status = status, StartTime = entryTime, IAmAliveTime = entryTime };
         }
 
-        private static async Task Until(Func<bool> condition)
+        private static async Task Until(Func<bool> condition, CancellationToken cancellationToken)
         {
             var maxTimeout = 40_000;
-            while (!condition() && (maxTimeout -= 10) >= 0) await Task.Delay(10);
+            while (!condition() && (maxTimeout -= 10) >= 0) await Task.Delay(10, cancellationToken);
             Assert.True(maxTimeout > 0);
         }
 
-        private async Task StopLifecycle(CancellationToken cancellation = default)
+        private async Task StopLifecycle(
+            CancellationToken cancellationToken,
+            CancellationToken? lifecycleCancellationToken = null)
         {
-            var stopped = this.lifecycle.OnStop(cancellation);
+            var stopped = this.lifecycle.OnStop(lifecycleCancellationToken ?? cancellationToken);
 
             while (!stopped.IsCompleted)
             {
                 foreach (var pair in this.timerCalls) while (pair.Value.TryDequeue(out var call)) call.Completion.TrySetResult(false);
-                await Task.Delay(15);
+                await Task.Delay(15, cancellationToken);
             }
 
             await stopped;

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -42,18 +42,23 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableCleanupAgent_Enabled_BasicScenario()
         {
-            await this.BasicScenario(enabled: true);
+            await this.BasicScenario(
+                enabled: true,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableCleanupAgent_Disabled_BasicScenario()
         {
-            await this.BasicScenario(enabled: false);
+            await this.BasicScenario(
+                enabled: false,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableCleanupAgent_NonFirstActiveSilo_DoesNotCleanup()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = TimeSpan.FromMinutes(90), MaxDefunctSiloEntries = null };
             var membershipManager = new TestMembershipManager();
             var cleanupCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -66,20 +71,21 @@ namespace NonSilo.Tests.Membership
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
 
-            await lifecycle.OnStart();
+            await lifecycle.OnStart(cancellationToken);
             await membershipManager.PublishAndWaitForProcessing(Snapshot(
                 Entry(Silo("127.0.0.1:200@1"), SiloStatus.Active, now),
-                Entry(this.localSilo, SiloStatus.Active, now)));
+                Entry(this.localSilo, SiloStatus.Active, now)), cancellationToken);
 
             Assert.False(cleanupCalled.Task.IsCompleted);
             Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
 
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableCleanupAgent_ThresholdCleanup_RemovesExcessDefunctEntries()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = this.timeProvider.GetUtcNow();
             var retainedDefunctSilo = Silo("127.0.0.1:700@100");
             var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = null, MaxDefunctSiloEntries = 1 };
@@ -96,25 +102,26 @@ namespace NonSilo.Tests.Membership
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
 
-            await lifecycle.OnStart();
+            await lifecycle.OnStart(cancellationToken);
             await membershipManager.PublishAndWaitForProcessing(Snapshot(
                 Entry(this.localSilo, SiloStatus.Active, now),
                 Entry(Silo("127.0.0.1:200@200"), SiloStatus.Active, now),
                 oldestDefunctEntry,
                 removedDefunctEntry,
-                retainedDefunctEntry));
+                retainedDefunctEntry), cancellationToken);
             Assert.DoesNotContain(table.Calls, call => call.Method == nameof(IMembershipTable.ReadAll));
 
             var updatedTable = await table.ReadAll();
             Assert.Single(updatedTable.Members, member => member.Item1.Status == SiloStatus.Dead);
             Assert.Contains(updatedTable.Members, member => member.Item1.SiloAddress.Equals(retainedDefunctSilo));
 
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableCleanupAgent_ThresholdCleanup_RetainsRecentlySuspectedEntries()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = this.timeProvider.GetUtcNow();
             var recentlySuspectedSilo = Silo("127.0.0.1:700@100");
             var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = null, MaxDefunctSiloEntries = 1 };
@@ -137,23 +144,24 @@ namespace NonSilo.Tests.Membership
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
 
-            await lifecycle.OnStart();
+            await lifecycle.OnStart(cancellationToken);
             await membershipManager.PublishAndWaitForProcessing(Snapshot(
                 Entry(this.localSilo, SiloStatus.Active, now),
                 Entry(Silo("127.0.0.1:200@200"), SiloStatus.Active, now),
                 newerAliveEntry,
-                recentlySuspectedEntry));
+                recentlySuspectedEntry), cancellationToken);
 
             var updatedTable = await table.ReadAll();
             Assert.Single(updatedTable.Members, member => member.Item1.Status == SiloStatus.Dead);
             Assert.Contains(updatedTable.Members, member => member.Item1.SiloAddress.Equals(recentlySuspectedSilo));
 
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableCleanupAgent_ExpirationCleanup_SkipsUntilExpiredNonActiveEntryOrCleanupPeriodElapsed()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var options = new ClusterMembershipOptions
             {
                 DefunctSiloCleanupPeriod = TimeSpan.FromMinutes(90),
@@ -166,13 +174,13 @@ namespace NonSilo.Tests.Membership
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
 
-            await lifecycle.OnStart();
+            await lifecycle.OnStart(cancellationToken);
             var now = this.timeProvider.GetUtcNow();
-            await membershipManager.PublishAndWaitForProcessing(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
+            await membershipManager.PublishAndWaitForProcessing(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)), cancellationToken);
             Assert.Equal(1, CleanupCallCount(table));
 
             table.ClearCalls();
-            await membershipManager.PublishAndWaitForProcessing(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
+            await membershipManager.PublishAndWaitForProcessing(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)), cancellationToken);
             Assert.Equal(0, CleanupCallCount(table));
 
             var expiredNonActiveEntry = Entry(
@@ -181,19 +189,19 @@ namespace NonSilo.Tests.Membership
                 now - options.DefunctSiloExpiration - TimeSpan.FromTicks(1));
             await membershipManager.PublishAndWaitForProcessing(Snapshot(
                 Entry(this.localSilo, SiloStatus.Active, now),
-                expiredNonActiveEntry));
+                expiredNonActiveEntry), cancellationToken);
             Assert.Equal(1, CleanupCallCount(table));
 
             table.ClearCalls();
             this.timeProvider.Advance(options.DefunctSiloCleanupPeriod.Value);
             var later = this.timeProvider.GetUtcNow();
-            await membershipManager.PublishAndWaitForProcessing(Snapshot(Entry(this.localSilo, SiloStatus.Active, later)));
+            await membershipManager.PublishAndWaitForProcessing(Snapshot(Entry(this.localSilo, SiloStatus.Active, later)), cancellationToken);
             Assert.Equal(1, CleanupCallCount(table));
 
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(cancellationToken);
         }
 
-        private async Task BasicScenario(bool enabled)
+        private async Task BasicScenario(bool enabled, CancellationToken cancellationToken)
         {
             var options = new ClusterMembershipOptions
             {
@@ -208,19 +216,21 @@ namespace NonSilo.Tests.Membership
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
 
-            await lifecycle.OnStart();
+            await lifecycle.OnStart(cancellationToken);
             Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
 
             if (enabled)
             {
-                await membershipManager.PublishAndWaitForProcessing(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
+                await membershipManager.PublishAndWaitForProcessing(
+                    Snapshot(Entry(this.localSilo, SiloStatus.Active, now)),
+                    cancellationToken);
             }
             else
             {
                 membershipManager.Publish(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
             }
 
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(cancellationToken);
 
             if (enabled)
             {
@@ -279,12 +289,14 @@ namespace NonSilo.Tests.Membership
                 Assert.True(this.updates.Writer.TryWrite((snapshot, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))));
             }
 
-            public async Task PublishAndWaitForProcessing(MembershipTableSnapshot snapshot)
+            public async Task PublishAndWaitForProcessing(
+                MembershipTableSnapshot snapshot,
+                CancellationToken cancellationToken)
             {
                 this.CurrentSnapshot = snapshot;
                 var processed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 Assert.True(this.updates.Writer.TryWrite((snapshot, processed)));
-                await processed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                await processed.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
             }
 
             public Task UpdateLocalStatus(SiloStatus status, CancellationToken cancellationToken) => Task.CompletedTask;

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -56,7 +56,10 @@ namespace NonSilo.Tests.Membership
         public async Task MembershipTableManager_NewCluster()
         {
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
-            await this.BasicScenarioTest(membershipTable, gracefulShutdown: true);
+            await this.BasicScenarioTest(
+                membershipTable,
+                gracefulShutdown: true,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -76,10 +79,16 @@ namespace NonSilo.Tests.Membership
             };
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"), otherSilos);
 
-            await this.BasicScenarioTest(membershipTable, gracefulShutdown: false);
+            await this.BasicScenarioTest(
+                membershipTable,
+                gracefulShutdown: false,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
-        private async Task BasicScenarioTest(InMemoryMembershipTable membershipTable, bool gracefulShutdown = true)
+        private async Task BasicScenarioTest(
+            InMemoryMembershipTable membershipTable,
+            bool gracefulShutdown,
+            CancellationToken cancellationToken)
         {
             var timers = new List<DelegateAsyncTimer>();
             var timerCalls = new BlockingCollection<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)>();
@@ -121,7 +130,7 @@ namespace NonSilo.Tests.Membership
 
             Assert.NotNull(manager.MembershipTableUpdates);
             var changes = manager.MembershipTableUpdates;
-            var currentEnumerator = changes.GetAsyncEnumerator();
+            var currentEnumerator = changes.GetAsyncEnumerator(cancellationToken);
             Assert.True(currentEnumerator.MoveNextAsync().Result);
             Assert.Equal(currentEnumerator.Current.Version, manager.MembershipTableSnapshot.Version);
             Assert.Empty(membershipTable.Calls);
@@ -131,7 +140,7 @@ namespace NonSilo.Tests.Membership
             // see the correct results regardless of initialization order.
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             var calls = membershipTable.Calls;
             Assert.NotEmpty(calls);
@@ -141,7 +150,7 @@ namespace NonSilo.Tests.Membership
 
             // During initialization, a first read from the table will be performed, transitioning
             // membership to a valid version.currentEnumerator = changes.GetAsyncEnumerator();
-            currentEnumerator = changes.GetAsyncEnumerator();
+            currentEnumerator = changes.GetAsyncEnumerator(cancellationToken);
             Assert.True(currentEnumerator.MoveNextAsync().Result);
             var update1 = currentEnumerator.Current;
 
@@ -154,7 +163,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(SiloStatus.Joining, localSiloEntry.Status);
 
             // An update should have been issued.
-            currentEnumerator = changes.GetAsyncEnumerator();
+            currentEnumerator = changes.GetAsyncEnumerator(cancellationToken);
             Assert.True(currentEnumerator.MoveNextAsync().Result);
             Assert.NotEqual(update1.Version, manager.MembershipTableSnapshot.Version);
 
@@ -173,16 +182,16 @@ namespace NonSilo.Tests.Membership
             {
                 // Check that a timer is being requested and that after it expires a call to
                 // refresh the membership table is made.
-                using var cts = new CancellationTokenSource();
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 cts.CancelAfter(TimeSpan.FromSeconds(10));
                 var (_, completion) = timerCalls.Take(cts.Token);
                 membershipTable.ClearCalls();
                 completion.TrySetResult(true);
-                while (membershipTable.Calls.Count == 0) await Task.Delay(10);
+                while (membershipTable.Calls.Count == 0) await Task.Delay(10, cancellationToken);
                 Assert.Contains(membershipTable.Calls, c => c.Method.Equals(nameof(IMembershipTable.ReadAll)));
             }
 
-            var shutdownCts = new CancellationTokenSource();
+            using var shutdownCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             if (!gracefulShutdown) shutdownCts.Cancel();
             Assert.Equal(0, timers.First().DisposedCounter);
             var stopped = this.lifecycle.OnStop(shutdownCts.Token);
@@ -206,6 +215,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_Restarted()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
 
             // The table includes a predecessor which is still marked as active
@@ -244,7 +254,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(SiloStatus.Created, manager.CurrentStatus);
 
             Assert.NotNull(manager.MembershipTableUpdates);
-            var membershipUpdates = manager.MembershipTableUpdates.GetAsyncEnumerator();
+            var membershipUpdates = manager.MembershipTableUpdates.GetAsyncEnumerator(cancellationToken);
             Assert.True(await membershipUpdates.MoveNextAsync());
             var firstSnapshot = membershipUpdates.Current;
             Assert.Equal(firstSnapshot.Version, manager.MembershipTableSnapshot.Version);
@@ -255,7 +265,7 @@ namespace NonSilo.Tests.Membership
             // see the correct results regardless of initialization order.
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             var calls = membershipTable.Calls;
             Assert.NotEmpty(calls);
@@ -293,7 +303,7 @@ namespace NonSilo.Tests.Membership
             Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.InsertRow)));
             Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.ReadAll)));
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
         }
 
@@ -304,6 +314,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_Superseded()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
 
             // The table includes a successor to this silo.
@@ -332,14 +343,14 @@ namespace NonSilo.Tests.Membership
 
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             // Silo should kill itself during the joining phase
             await manager.UpdateStatus(SiloStatus.Joining);
 
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         /// <summary>
@@ -351,6 +362,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_AlreadyDeclaredDead()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var otherSilos = new[]
             {
@@ -375,14 +387,14 @@ namespace NonSilo.Tests.Membership
 
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             // Silo should kill itself during the joining phase
             await manager.UpdateStatus(SiloStatus.Joining);
 
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
-            var cts = new CancellationTokenSource();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.Cancel();
             await this.lifecycle.OnStop(cts.Token);
         }
@@ -394,6 +406,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_DeclaredDead_AfterJoining()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var otherSilos = new[]
             {
@@ -412,7 +425,7 @@ namespace NonSilo.Tests.Membership
                 siloLifecycle: this.lifecycle,
                 timeProvider: TimeProvider.System);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             // Silo should kill itself during the joining phase
             await manager.UpdateStatus(SiloStatus.Joining);
@@ -429,21 +442,22 @@ namespace NonSilo.Tests.Membership
             }
 
             // Refresh silo status and check that it determines it's dead.
-            await manager.Refresh();
+            await manager.Refresh(cancellationToken: cancellationToken);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableManager_DeclaredDead_DuringShutdown_DoesNotTerminate()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
 
             while (true)
             {
@@ -455,17 +469,18 @@ namespace NonSilo.Tests.Membership
                 }
             }
 
-            await manager.Refresh();
+            await manager.Refresh(cancellationToken: cancellationToken);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
         }
 
         [Fact]
         public async Task MembershipTableManager_ExplicitDeadSnapshot_Terminates()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
 
             var version = manager.MembershipTableSnapshot.Version;
@@ -478,28 +493,30 @@ namespace NonSilo.Tests.Membership
                 new MembershipVersion(version.Value + 1),
                 Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)));
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableManager_DeadTransitionOutsideShutdown_Terminates()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
 
             await manager.UpdateStatus(SiloStatus.Dead);
 
             Assert.Equal(SiloStatus.Dead, manager.CurrentStatus);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableManager_DeadTransitionDuringLaterStopStage_DoesNotTerminate()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
@@ -508,10 +525,10 @@ namespace NonSilo.Tests.Membership
                 ServiceLifecycleStage.Active + 1,
                 _ => Task.CompletedTask,
                 _ => manager.UpdateStatus(SiloStatus.Dead));
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
 
             Assert.Equal(SiloStatus.Dead, manager.CurrentStatus);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
@@ -520,21 +537,23 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_StopBeforeStart_DoesNotMarkLifecycleStopping()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
 
-            await this.lifecycle.OnStop();
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStop(cancellationToken);
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Dead);
 
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableManager_MissingLocalEntry_OnlyNewerSnapshotAfterJoiningTerminates()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var otherSilo = Silo("127.0.0.1:200@100");
             var membershipTable = new InMemoryMembershipTable(
@@ -546,7 +565,7 @@ namespace NonSilo.Tests.Membership
             await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(1)));
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
             var currentVersion = manager.MembershipTableSnapshot.Version;
 
@@ -557,7 +576,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(SiloStatus.Joining, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
-            await using var membershipUpdates = manager.MembershipTableUpdates.GetAsyncEnumerator();
+            await using var membershipUpdates = manager.MembershipTableUpdates.GetAsyncEnumerator(cancellationToken);
             Assert.True(await membershipUpdates.MoveNextAsync());
 
             await manager.RefreshFromSnapshot(Snapshot(
@@ -568,16 +587,17 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableManager_MissingLocalEntry_WhenJoinSnapshotWasNotPublished_DoesNotTerminate()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
 
             await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(125)));
             await manager.UpdateStatus(SiloStatus.Joining);
@@ -587,16 +607,17 @@ namespace NonSilo.Tests.Membership
             await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(126)));
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         [Fact]
         public async Task MembershipTableManager_DeclaredDeadThenPrunedBeforeRefresh_Terminates()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
 
             while (true)
@@ -613,11 +634,11 @@ namespace NonSilo.Tests.Membership
             var prunedTable = await membershipTable.ReadAll();
             Assert.DoesNotContain(prunedTable.Members, row => row.Item1.SiloAddress.Equals(this.localSilo));
 
-            await manager.Refresh();
+            await manager.Refresh(cancellationToken: cancellationToken);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         /// <summary>
@@ -626,6 +647,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_TrySuspectOrKill_ButIAmKill()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var otherSilos = new[]
             {
@@ -644,7 +666,7 @@ namespace NonSilo.Tests.Membership
                 siloLifecycle: this.lifecycle,
                 timeProvider: TimeProvider.System);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Active);
             using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
@@ -659,7 +681,7 @@ namespace NonSilo.Tests.Membership
 
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
             var victim = otherSilos.First().SiloAddress;
-            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim, cancellationToken);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
@@ -671,6 +693,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_TrySuspectOrKill_AlreadyDead()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var otherSilos = new[]
             {
@@ -690,12 +713,12 @@ namespace NonSilo.Tests.Membership
                 siloLifecycle: this.lifecycle,
                 timeProvider: TimeProvider.System);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Active);
             using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
             var victim = otherSilos.Last().SiloAddress;
-            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim, cancellationToken);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.GetSiloStatus(victim));
@@ -707,6 +730,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_TrySuspectOrKill_DeclareDead_SmallCluster()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var otherSilos = new[]
             {
@@ -726,12 +750,12 @@ namespace NonSilo.Tests.Membership
                 siloLifecycle: this.lifecycle,
                 timeProvider: TimeProvider.System);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Active);
             using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
             var victim = otherSilos.First().SiloAddress;
-            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim, cancellationToken);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.GetSiloStatus(victim));
@@ -745,6 +769,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_TrySuspectOrKill_ClocksNotSynchronized()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTime.UtcNow;
             var otherSilos = new[]
             {
@@ -775,7 +800,7 @@ namespace NonSilo.Tests.Membership
             manager.GetDateTimeUtcNow = () => now;
 
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Active);
             using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
@@ -807,13 +832,13 @@ namespace NonSilo.Tests.Membership
             //   a) Adding our vote changes nothing, since our clock is too far behind
             //   b) The silo is not mistakenly declared dead, since the difference between the two votes is larger than DeathVoteExpirationTimeout.
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
-            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim, cancellationToken);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
             // The victim should be alive as no second vote fell within the recency window of the latest vote.
-            await manager.Refresh();
+            await manager.Refresh(cancellationToken: cancellationToken);
             Assert.Equal(SiloStatus.Active, manager.MembershipTableSnapshot.GetSiloStatus(victim));
         }
 
@@ -823,6 +848,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_TrySuspectOrKill_DeclareDead_LargerCluster()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var now = DateTimeOffset.UtcNow;
             var otherSilos = new[]
             {
@@ -848,13 +874,17 @@ namespace NonSilo.Tests.Membership
                 siloLifecycle: this.lifecycle,
                 timeProvider: TimeProvider.System);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Active);
             using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
             // Multiple votes from the same node should not result in the node being declared dead.
             var victim = otherSilos.First().SiloAddress;
-            var completions = WaitForSuspectOrKillCompletions(membershipEvents, victim, expectedCount: 3);
+            var completions = WaitForSuspectOrKillCompletions(
+                membershipEvents,
+                victim,
+                expectedCount: 3,
+                cancellationToken: cancellationToken);
             await manager.TryToSuspectOrKill(victim);
             await manager.TryToSuspectOrKill(victim);
             await manager.TryToSuspectOrKill(victim);
@@ -872,7 +902,7 @@ namespace NonSilo.Tests.Membership
                 if (await membershipTable.UpdateRow(entry, row.Item2, table.Version.Next())) break;
             }
 
-            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim, cancellationToken);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.GetSiloStatus(victim));
@@ -892,13 +922,13 @@ namespace NonSilo.Tests.Membership
             }
 
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
-            completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
+            completion = WaitForSuspectOrKillCompletion(membershipEvents, victim, cancellationToken);
             await manager.TryToSuspectOrKill(victim);
             Assert.False((await completion).Success);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
             // We killed ourselves and should not have marked the other silo as dead.
-            await manager.Refresh();
+            await manager.Refresh(cancellationToken: cancellationToken);
             Assert.Equal(SiloStatus.Active, manager.MembershipTableSnapshot.GetSiloStatus(victim));
         }
 
@@ -908,6 +938,7 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_Refresh()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var timers = new List<DelegateAsyncTimer>();
             var timerCalls = new ConcurrentQueue<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)>();
             var timerFactory = new DelegateAsyncTimerFactory(
@@ -942,33 +973,33 @@ namespace NonSilo.Tests.Membership
                 siloLifecycle: this.lifecycle,
                 timeProvider: TimeProvider.System);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
-            await this.lifecycle.OnStart();
+            await this.lifecycle.OnStart(cancellationToken);
             
             // Test that retries occur after an exception.
             (TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion) timer = (default, default!);
-            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(1);
+            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(1, cancellationToken);
             var counter = 0;
             membershipTable.OnReadAll = () => { if (counter++ == 0) throw new Exception("no"); };
             timer.Completion.TrySetResult(true);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
             // A shorter delay should be provided after a transient failure.
-            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(10);
+            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(10, cancellationToken);
             membershipTable.OnReadAll = null;
             Assert.True(timer.DelayOverride.HasValue);
             timer.Completion.TrySetResult(true);
 
             // The standard delay should be used thereafter.
-            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(10);
+            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(10, cancellationToken);
             Assert.False(timer.DelayOverride.HasValue);
             timer.Completion.TrySetResult(true);
 
             // If for some reason the timer itself fails (or something else), the silo should crash
-            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(10);
+            while (!timerCalls.TryDequeue(out timer)) await Task.Delay(10, cancellationToken);
             timer.Completion.TrySetException(new Exception("no again"));
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
             Assert.False(timerCalls.TryDequeue(out timer));
-            await this.lifecycle.OnStop();
+            await this.lifecycle.OnStop(cancellationToken);
         }
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
@@ -992,16 +1023,24 @@ namespace NonSilo.Tests.Membership
             return new MembershipTableSnapshot(version, entries.ToImmutableDictionary(entry => entry.SiloAddress));
         }
 
-        private async Task<MembershipEvents.SuspectOrKillRequestCompleted> WaitForSuspectOrKillCompletion(DiagnosticEventCollector membershipEvents, SiloAddress silo)
+        private async Task<MembershipEvents.SuspectOrKillRequestCompleted> WaitForSuspectOrKillCompletion(
+            DiagnosticEventCollector membershipEvents,
+            SiloAddress silo,
+            CancellationToken cancellationToken)
         {
-            var completions = await WaitForSuspectOrKillCompletions(membershipEvents, silo, expectedCount: 1);
+            var completions = await WaitForSuspectOrKillCompletions(
+                membershipEvents,
+                silo,
+                expectedCount: 1,
+                cancellationToken: cancellationToken);
             return completions[0];
         }
 
         private async Task<List<MembershipEvents.SuspectOrKillRequestCompleted>> WaitForSuspectOrKillCompletions(
             DiagnosticEventCollector membershipEvents,
             SiloAddress silo,
-            int expectedCount)
+            int expectedCount,
+            CancellationToken cancellationToken)
         {
             Assert.True(expectedCount > 0);
 
@@ -1017,7 +1056,8 @@ namespace NonSilo.Tests.Membership
                         && completed.RequestType == MembershipEvents.SuspectOrKillRequestType.SuspectOrKill
                         && completed.SiloAddress.Equals(silo)
                         && !completions.Contains(completed),
-                    TimeSpan.FromSeconds(40));
+                    TimeSpan.FromSeconds(40),
+                    cancellationToken);
 
                 completions.Add(Assert.IsType<MembershipEvents.SuspectOrKillRequestCompleted>(diagnosticEvent.Payload));
             }

--- a/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/SiloHealthMonitorTests.cs
@@ -92,7 +92,8 @@ namespace NonSilo.Tests.Membership
                 timeProvider: TimeProvider.System);
 
             _probeResults = Channel.CreateBounded<ProbeResult>(new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.Wait });
-            Task onProbeResult(SiloHealthMonitor mon, ProbeResult res) => _probeResults.Writer.WriteAsync(res).AsTask();
+            Task onProbeResult(SiloHealthMonitor mon, ProbeResult res)
+                => _probeResults.Writer.WriteAsync(res, TestContext.Current.CancellationToken).AsTask();
 
             _monitor = new SiloHealthMonitor(
                 _targetSilo,
@@ -107,13 +108,13 @@ namespace NonSilo.Tests.Membership
                 TimeProvider.System);
         }
 
-        private async Task Shutdown()
+        private async Task Shutdown(CancellationToken cancellationToken)
         {
-            var stopTask = _monitor.StopAsync(CancellationToken.None);
+            var stopTask = _monitor.StopAsync(cancellationToken);
 
             Task.Run(async () =>
             {
-                while (!stopTask.IsCompleted && await _timerCalls.Reader.WaitToReadAsync())
+                while (!stopTask.IsCompleted && await _timerCalls.Reader.WaitToReadAsync(cancellationToken))
                 {
                     while (_timerCalls.Reader.TryRead(out var timerCall))
                     {
@@ -124,42 +125,45 @@ namespace NonSilo.Tests.Membership
 
             await stopTask;
             _timerCalls.Writer.TryComplete();
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         [Fact]
         public async Task SiloHealthMonitor_SuccessfulProbe()
         {
-            _prober.Probe(default!, default).ReturnsForAnyArgs(Task.CompletedTask);
-            _prober.ProbeIndirectly(default!, default!, default, default).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
+            var cancellationToken = TestContext.Current.CancellationToken;
+            _prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(Task.CompletedTask);
+            _prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
 
             _monitor.Start();
 
             // Let a timer complete
-            var timerCall = await _timerCalls.Reader.ReadAsync();
+            var timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
             // Check the resulting probe result.
-            var probeResult = await _probeResults.Reader.ReadAsync();
+            var probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Succeeded, probeResult.Status);
             Assert.Equal(0, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
             Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
-            await _localSiloHealthMonitor.DidNotReceiveWithAnyArgs().GetStallDurationAsync(default, default, default);
+            await _localSiloHealthMonitor.DidNotReceiveWithAnyArgs().GetStallDurationAsync(default, default, cancellationToken);
 
-            await Shutdown();
+            await Shutdown(cancellationToken);
         }
 
         [Fact]
         public async Task SiloHealthMonitor_SuccessfulDirectProbesAdaptTimeout()
         {
-            _prober.Probe(default!, default).ReturnsForAnyArgs(Task.CompletedTask);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            _prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(Task.CompletedTask);
             _monitor.Start();
 
             for (var i = 0; i < 4; i++)
             {
-                var timerCall = await _timerCalls.Reader.ReadAsync();
+                var timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
                 timerCall.Completion.TrySetResult(true);
-                var probeResult = await _probeResults.Reader.ReadAsync();
+                var probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
                 Assert.Equal(ProbeResultStatus.Succeeded, probeResult.Status);
                 Assert.True(probeResult.IsDirectProbe);
             }
@@ -171,50 +175,53 @@ namespace NonSilo.Tests.Membership
                 _clusterMembershipOptions.MinProbeTimeout,
                 _clusterMembershipOptions.ProbeTimeout);
 
-            await Shutdown();
+            await Shutdown(cancellationToken);
         }
 
         [Fact]
         public async Task SiloHealthMonitor_SuccessfulIndirectProbeDoesNotAdaptTimeout()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             _clusterMembershipOptions.NumMissedProbesLimit = 1;
             var intermediary = Silo("127.0.0.1:1234@1234");
             await _membershipTable.InsertRow(
                 Entry(intermediary, SiloStatus.Active, DateTime.UtcNow),
                 _membershipTable.Version.Next());
-            await _membershipService.Refresh();
-            _prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            await _membershipService.Refresh(cancellationToken: cancellationToken);
+            _prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ReturnsForAnyArgs(new IndirectProbeResponse
             {
                 Succeeded = true,
                 ProbeResponseTime = TimeSpan.FromMilliseconds(1),
             });
 
             _monitor.Start();
-            var timerCall = await _timerCalls.Reader.ReadAsync();
+            var timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
-            var probeResult = await _probeResults.Reader.ReadAsync();
+            var probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
 
             Assert.Equal(ProbeResultStatus.Succeeded, probeResult.Status);
             Assert.False(probeResult.IsDirectProbe);
             Assert.Equal(0, ((ITestAccessor)_monitor).ProbeTimeoutSampleCount);
 
-            await Shutdown();
+            await Shutdown(cancellationToken);
         }
 
         [Fact]
         public async Task SiloHealthMonitor_FailedProbe_Timeout()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
 
-            _prober.Probe(default!, default, default).ReturnsForAnyArgs(info => Task.Delay(TimeSpan.FromSeconds(30)));
-            _prober.ProbeIndirectly(default!, default!, default, default).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
+            _prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(
+                info => Task.Delay(TimeSpan.FromSeconds(30), info.ArgAt<CancellationToken>(2)));
+            _prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
             _monitor.Start();
 
             // Let a timer complete
-            var timerCall = await _timerCalls.Reader.ReadAsync();
+            var timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
-            var probeResult = await _probeResults.Reader.ReadAsync();
+            var probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
             Assert.Equal(1, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
@@ -224,12 +231,13 @@ namespace NonSilo.Tests.Membership
                 Arg.Any<long>(),
                 Arg.Any<long>(),
                 Arg.Any<CancellationToken>());
-            await Shutdown();
+            await Shutdown(cancellationToken);
         }
 
         [Fact]
         public async Task SiloHealthMonitor_TimeoutDuringLocalStall_WaitsForDetectorCycleAndIsInconclusive()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(
                 new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
             var options = new ClusterMembershipOptions
@@ -243,7 +251,7 @@ namespace NonSilo.Tests.Membership
             var prober = Substitute.For<IRemoteSiloProber>();
             var probeEntered = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
             var pendingProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            prober.Probe(default!, default, default).ReturnsForAnyArgs(call =>
+            prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(call =>
             {
                 probeEntered.TrySetResult(call.ArgAt<CancellationToken>(2));
                 return pendingProbe.Task;
@@ -271,7 +279,7 @@ namespace NonSilo.Tests.Membership
                 timeProvider);
             _localSiloHealthMonitor.GetTimestamp().Returns(ExpectedStartTimestamp, ExpectedEndTimestamp);
             _localSiloHealthMonitor
-                .GetStallDurationAsync(default, default, default)
+                .GetStallDurationAsync(default, default, cancellationToken)
                 .ReturnsForAnyArgs(call =>
                 {
                     detectorQuery.TrySetResult((call.ArgAt<long>(0), call.ArgAt<long>(1)));
@@ -281,70 +289,72 @@ namespace NonSilo.Tests.Membership
             try
             {
                 monitor.Start();
-                var firstTick = await timer.Ticks.ReadAsync();
+                var firstTick = await timer.Ticks.ReadAsync(cancellationToken);
                 firstTick.Completion.SetResult(true);
-                var cancellationToken = await probeEntered.Task;
+                var probeCancellationToken = await probeEntered.Task.WaitAsync(cancellationToken);
 
                 timeProvider.Advance(options.ProbeTimeout);
 
-                Assert.True(cancellationToken.IsCancellationRequested);
-                var interval = await detectorQuery.Task;
+                Assert.True(probeCancellationToken.IsCancellationRequested);
+                var interval = await detectorQuery.Task.WaitAsync(cancellationToken);
                 Assert.Equal(ExpectedStartTimestamp, interval.Start);
                 Assert.Equal(ExpectedEndTimestamp, interval.End);
                 Assert.False(probeResult.Task.IsCompleted);
 
                 detectorResult.SetResult(options.ProbeTimeout.Multiply(0.25));
-                var result = await probeResult.Task;
+                var result = await probeResult.Task.WaitAsync(cancellationToken);
                 Assert.Equal(ProbeResultStatus.Unknown, result.Status);
                 Assert.Equal(0, result.FailedProbeCount);
                 Assert.Equal(0, ((ITestAccessor)monitor).MissedProbes);
 
-                var nextTick = await timer.Ticks.ReadAsync();
+                var nextTick = await timer.Ticks.ReadAsync(cancellationToken);
                 nextTick.Completion.SetResult(false);
             }
             finally
             {
-                await monitor.StopAsync(CancellationToken.None);
+                await monitor.StopAsync(cancellationToken);
             }
         }
 
         [Fact]
         public async Task SiloHealthMonitor_FailedProbe_Exception()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
 
-            _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(new Exception("nope"));
-            _prober.ProbeIndirectly(default!, default!, default, default).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
+            _prober.Probe(default!, default, cancellationToken).ThrowsAsyncForAnyArgs(new Exception("nope"));
+            _prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ThrowsAsyncForAnyArgs(new InvalidOperationException("No"));
             _monitor.Start();
 
             // Let a timer complete
-            var timerCall = await _timerCalls.Reader.ReadAsync();
+            var timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
             // Throw directly, instead of timing out the probe
-            _prober.WhenForAnyArgs(s => s.Probe(default!, default)).Throw(new Exception("nope"));
-            timerCall = await _timerCalls.Reader.ReadAsync();
+            _prober.WhenForAnyArgs(s => s.Probe(default!, default, cancellationToken)).Throw(new Exception("nope"));
+            timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
-            var probeResult = await _probeResults.Reader.ReadAsync();
+            var probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
             Assert.Equal(1, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
             Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
             Assert.Equal(0, ((ITestAccessor)_monitor).ProbeTimeoutSampleCount);
-            await _localSiloHealthMonitor.DidNotReceiveWithAnyArgs().GetStallDurationAsync(default, default, default);
+            await _localSiloHealthMonitor.DidNotReceiveWithAnyArgs().GetStallDurationAsync(default, default, cancellationToken);
 
-            await Shutdown();
+            await Shutdown(cancellationToken);
         }
 
         [Fact]
         public async Task SiloHealthMonitor_Indirect_FailedProbe()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
             _clusterMembershipOptions.EnableIndirectProbes = true;
 
-            _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(info => new Exception("nonono!"));
-            _prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            _prober.Probe(default!, default, cancellationToken).ThrowsAsyncForAnyArgs(info => new Exception("nonono!"));
+            _prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ReturnsForAnyArgs(new IndirectProbeResponse
             {
                 FailureMessage = "fail",
                 IntermediaryHealthScore = 0,
@@ -354,25 +364,25 @@ namespace NonSilo.Tests.Membership
             _monitor.Start();
 
             // Let a timer complete
-            var timerCall = await _timerCalls.Reader.ReadAsync();
+            var timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
-            var probeResult = await _probeResults.Reader.ReadAsync();
+            var probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
             Assert.Equal(1, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
             Assert.Equal(0, probeResult.IntermediaryHealthDegradationScore);
 
-            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
             var otherSilo = Silo("127.0.0.1:1234@1234");
             await _membershipTable.InsertRow(Entry(_monitor.TargetSiloAddress, SiloStatus.Active), _membershipTable.Version.Next());
             await _membershipTable.InsertRow(Entry(otherSilo, SiloStatus.Joining), _membershipTable.Version.Next());
-            await _membershipService.Refresh();
+            await _membershipService.Refresh(cancellationToken: cancellationToken);
 
             // There is only one other active silo (the target silo), so an indirect probe cannot be performed.
-            probeResult = await _probeResults.Reader.ReadAsync();
+            probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
             Assert.Equal(2, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
@@ -381,14 +391,14 @@ namespace NonSilo.Tests.Membership
             // Make the other silo active so that there is an intermediary to use for an indirect probe.
             var etag = (await _membershipTable.ReadAll()).Members.Where(kv => kv.Item1.SiloAddress.Equals(otherSilo)).Single().Item2;
             await _membershipTable.UpdateRow(Entry(otherSilo, SiloStatus.Active, iAmAliveTime: DateTime.UtcNow), etag, _membershipTable.Version.Next());
-            await _membershipService.Refresh();
+            await _membershipService.Refresh(cancellationToken: cancellationToken);
 
             _prober.ClearReceivedCalls();
-            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
             // Since there is another active silo, an indirect probe will be performed.
-            probeResult = await _probeResults.Reader.ReadAsync();
+            probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
             Assert.Equal(3, probeResult.FailedProbeCount);
             Assert.False(probeResult.IsDirectProbe);
@@ -402,7 +412,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(TimeSpan.FromSeconds(2), Assert.IsType<TimeSpan>(args[2]));
 
             // Ensure that negative results from unhealthy intermediaries are not considered.
-            _prober.ProbeIndirectly(default!, default!, default, default).ReturnsForAnyArgs(new IndirectProbeResponse
+            _prober.ProbeIndirectly(default!, default!, default, default, cancellationToken).ReturnsForAnyArgs(new IndirectProbeResponse
             {
                 FailureMessage = "fail",
                 IntermediaryHealthScore = 1,
@@ -411,11 +421,11 @@ namespace NonSilo.Tests.Membership
             });
 
             _prober.ClearReceivedCalls();
-            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
             // The number of failed probes should not be incremented, the status should be "unknown", and the health score should be 1.
-            probeResult = await _probeResults.Reader.ReadAsync();
+            probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Unknown, probeResult.Status);
             Assert.Equal(3, probeResult.FailedProbeCount);
             Assert.False(probeResult.IsDirectProbe);
@@ -430,10 +440,10 @@ namespace NonSilo.Tests.Membership
             // After seeing that the chosen intermediary is unhealthy, a subsequent probe should be
             // performed directly (since there are no other silos to use as an intermediary).
             _prober.ClearReceivedCalls();
-            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
 
-            probeResult = await _probeResults.Reader.ReadAsync();
+            probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.Equal(ProbeResultStatus.Failed, probeResult.Status);
             Assert.Equal(4, probeResult.FailedProbeCount);
             Assert.True(probeResult.IsDirectProbe);
@@ -445,23 +455,24 @@ namespace NonSilo.Tests.Membership
             var target = Assert.IsType<SiloAddress>(args[0]);
             Assert.Equal(_monitor.TargetSiloAddress, target);
 
-            await Shutdown();
+            await Shutdown(cancellationToken);
         }
 
         [Fact]
         public async Task SiloHealthMonitor_IndirectProbe_SkipsStaleSilo()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             _clusterMembershipOptions.EnableIndirectProbes = true;
             _clusterMembershipOptions.ProbeTimeout = TimeSpan.FromSeconds(2);
 
             // Make direct probes fail.
-            _prober.Probe(default!, default).ThrowsAsyncForAnyArgs(new Exception("Direct probe failing."));
+            _prober.Probe(default!, default, cancellationToken).ThrowsAsyncForAnyArgs(new Exception("Direct probe failing."));
 
             // Start the monitor and trigger one timer cycle for a direct-probe attempt (which fails).
             _monitor.Start();
-            var timerCall = await _timerCalls.Reader.ReadAsync();
+            var timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
-            var firstProbeResult = await _probeResults.Reader.ReadAsync();
+            var firstProbeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
             Assert.True(firstProbeResult.IsDirectProbe);
             Assert.Equal(ProbeResultStatus.Failed, firstProbeResult.Status);
 
@@ -474,9 +485,9 @@ namespace NonSilo.Tests.Membership
             _prober.ClearReceivedCalls();
 
             // Trigger another timer cycle which will now attempt an indirect probe.
-            timerCall = await _timerCalls.Reader.ReadAsync();
+            timerCall = await _timerCalls.Reader.ReadAsync(cancellationToken);
             timerCall.Completion.TrySetResult(true);
-            var probeResult = await _probeResults.Reader.ReadAsync();
+            var probeResult = await _probeResults.Reader.ReadAsync(cancellationToken);
 
             // Verify that this time the probe is direct since it skipped the stale intermediary silos.
             Assert.True(probeResult.IsDirectProbe);
@@ -486,7 +497,7 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(_targetSilo, probedSilo);
             Assert.Equal(_targetSilo, _monitor.TargetSiloAddress);
 
-            await Shutdown();
+            await Shutdown(cancellationToken);
         }
 
         [Theory]
@@ -497,6 +508,7 @@ namespace NonSilo.Tests.Membership
             int localHealthScore,
             int expectedTimeoutFactor)
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider(
                 new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
             var options = new ClusterMembershipOptions
@@ -515,7 +527,7 @@ namespace NonSilo.Tests.Membership
             var prober = Substitute.For<IRemoteSiloProber>();
             var probeEntered = new TaskCompletionSource<CancellationToken>(TaskCreationOptions.RunContinuationsAsynchronously);
             var pendingProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            prober.Probe(default!, default, default).ReturnsForAnyArgs(call =>
+            prober.Probe(default!, default, cancellationToken).ReturnsForAnyArgs(call =>
             {
                 probeEntered.TrySetResult(call.ArgAt<CancellationToken>(2));
                 return pendingProbe.Task;
@@ -542,9 +554,9 @@ namespace NonSilo.Tests.Membership
             try
             {
                 monitor.Start();
-                var firstTick = await timer.Ticks.ReadAsync();
+                var firstTick = await timer.Ticks.ReadAsync(cancellationToken);
                 firstTick.Completion.SetResult(true);
-                var cancellationToken = await probeEntered.Task;
+                var probeCancellationToken = await probeEntered.Task.WaitAsync(cancellationToken);
 
                 if (extendProbeTimeout)
                 {
@@ -557,29 +569,29 @@ namespace NonSilo.Tests.Membership
                     localHealthMonitor.DidNotReceiveWithAnyArgs().GetLocalHealthStatus(default, default);
                 }
 
-                await prober.Received(1).Probe(_targetSilo, 1, cancellationToken);
+                await prober.Received(1).Probe(_targetSilo, 1, probeCancellationToken);
 
                 var dilatedTimeout = options.ProbeTimeout.Multiply(expectedTimeoutFactor);
                 timeProvider.Advance(dilatedTimeout - TimeSpan.FromTicks(1));
-                Assert.False(cancellationToken.IsCancellationRequested);
+                Assert.False(probeCancellationToken.IsCancellationRequested);
                 Assert.False(probeResult.Task.IsCompleted);
 
                 timeProvider.Advance(TimeSpan.FromTicks(1));
-                Assert.True(cancellationToken.IsCancellationRequested);
+                Assert.True(probeCancellationToken.IsCancellationRequested);
 
-                var result = await probeResult.Task;
+                var result = await probeResult.Task.WaitAsync(cancellationToken);
                 Assert.Equal(ProbeResultStatus.Failed, result.Status);
                 Assert.Equal(1, result.FailedProbeCount);
                 Assert.True(result.IsDirectProbe);
                 Assert.Equal(0, result.IntermediaryHealthDegradationScore);
 
-                var nextTick = await timer.Ticks.ReadAsync();
+                var nextTick = await timer.Ticks.ReadAsync(cancellationToken);
                 Assert.Equal(TimeSpan.Zero, nextTick.DelayOverride);
                 nextTick.Completion.SetResult(false);
             }
             finally
             {
-                await monitor.StopAsync(CancellationToken.None);
+                await monitor.StopAsync(cancellationToken);
             }
         }
 

--- a/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
@@ -109,7 +109,7 @@ namespace Orleans.Core.Tests.Networking
             var lengthBytes = new byte[4];
             System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(lengthBytes, 2_000_000);
             output.Write(lengthBytes);
-            await output.FlushAsync();
+            await output.FlushAsync(TestContext.Current.CancellationToken);
             await output.CompleteAsync();
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -126,7 +126,7 @@ namespace Orleans.Core.Tests.Networking
             var lengthBytes = new byte[4];
             System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(lengthBytes, 0);
             output.Write(lengthBytes);
-            await output.FlushAsync();
+            await output.FlushAsync(TestContext.Current.CancellationToken);
             await output.CompleteAsync();
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -171,7 +171,9 @@ namespace Orleans.Core.Tests.Networking
             var writeTask = WriteFrameInChunksAsync(pipe.Writer, 0x04, expectedPayload, 16);
             var readTask = ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None).AsTask();
 
-            await Task.WhenAll(writeTask, readTask).WaitAsync(TimeSpan.FromSeconds(10));
+            await Task.WhenAll(writeTask, readTask).WaitAsync(
+                TimeSpan.FromSeconds(10),
+                TestContext.Current.CancellationToken);
 
             var (frameType, payload) = await readTask;
             Assert.Equal(0x04, frameType);

--- a/test/Orleans.Core.Tests/ObserverManagerTests.cs
+++ b/test/Orleans.Core.Tests/ObserverManagerTests.cs
@@ -559,6 +559,7 @@ public sealed class ObserverManagerTests
     [Fact]
     public async Task ClearDuringNotification_WorksCorrectly()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var observerManager = new ObserverManager<int, int>(TimeSpan.FromHours(1), NullLogger.Instance);
         var notifiedObservers = new ConcurrentBag<int>();
 
@@ -577,14 +578,14 @@ public sealed class ObserverManagerTests
                 notifyStartedTcs.TrySetResult();
                 notifiedObservers.Add(observer);
             });
-        });
+        }, cancellationToken);
 
         // Clear while notification is happening.
-        await notifyStartedTcs.Task;
+        await notifyStartedTcs.Task.WaitAsync(cancellationToken);
         observerManager.Clear();
 
         // Wait for notification to complete.
-        await notifyTask;
+        await notifyTask.WaitAsync(cancellationToken);
 
         // Assert - We should still have notified all the original observers in the snapshot.
         Assert.Equal(10, notifiedObservers.Count);

--- a/test/Orleans.Core.Tests/OrleansRuntime/AsyncSerialExecutorTests.cs
+++ b/test/Orleans.Core.Tests/OrleansRuntime/AsyncSerialExecutorTests.cs
@@ -62,7 +62,7 @@ namespace UnitTests.OrleansRuntime
                     {
                         output.WriteLine("Submitting Task {0}.", capture);
                         tasks.Push(executor.AddNext(() => Operation(capture)));
-                    }));
+                    }, TestContext.Current.CancellationToken));
             }
             await Task.WhenAll(enqueueTasks);
             await Task.WhenAll(tasks);

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -313,6 +313,10 @@ namespace UnitTests.Runtime
                         await collector.DeactivateInDueTimeOrder(50, cts.Token);
                         await Task.Delay(1, cts.Token);
                     }
+                    catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                    {
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         exceptions.Add(ex);

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -255,7 +255,7 @@ namespace UnitTests.Runtime
 
             // Now we have 500 buckets. Let's trigger the race condition.
             var exceptions = new ConcurrentBag<Exception>();
-            var cts = new CancellationTokenSource();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
             // Task 1: Aggressively ADD new activations (creates NEW buckets in the dictionary)
             var addTask = Task.Run(async () =>
@@ -275,7 +275,7 @@ namespace UnitTests.Runtime
 
                     await Task.Yield();
                 }
-            });
+            }, cts.Token);
 
             // Task 2: Aggressively REMOVE activations (empties buckets, causing REMOVAL from dictionary)
             var removeTask = Task.Run(async () =>
@@ -298,7 +298,7 @@ namespace UnitTests.Runtime
 
                     await Task.Yield();
                 }
-            });
+            }, cts.Token);
 
             // Task 3: Run DeactivateInDueTimeOrder MANY times concurrently
             // This is where the collector snapshots and sorts buckets while they are being added and removed.
@@ -310,15 +310,15 @@ namespace UnitTests.Runtime
                     {
                         // Deactivation iterates through the buckets, and if code is not resilient for concurrent modification,
                         // it will blow up with some form of collection modification exception.                        
-                        await collector.DeactivateInDueTimeOrder(50, CancellationToken.None);
-                        await Task.Delay(1);
+                        await collector.DeactivateInDueTimeOrder(50, cts.Token);
+                        await Task.Delay(1, cts.Token);
                     }
                     catch (Exception ex)
                     {
                         exceptions.Add(ex);
                     }
                 }
-            })).ToArray();
+            }, cts.Token)).ToArray();
 
             // Wait for all deactivation attempts
             await Task.WhenAll(deactivateTasks);

--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -49,10 +49,10 @@ namespace UnitTests.Runtime
             var testAccessor = GetTestAccessor(target);
             using var collector = new DiagnosticEventCollector(PlacementServiceEvents.ListenerName);
 
-            await StopAsync(target);
+            await StopAsync(target, TestContext.Current.CancellationToken);
 
             Assert.All(testAccessor.WorkerTasks, task => Assert.True(task.IsCompleted));
-            await AssertWorkerStopEventsAsync(target, collector);
+            await AssertWorkerStopEventsAsync(target, collector, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -61,13 +61,14 @@ namespace UnitTests.Runtime
             var target = CreateTarget();
             var testAccessor = GetTestAccessor(target);
             using var collector = new DiagnosticEventCollector(PlacementServiceEvents.ListenerName);
-            using var cts = new CancellationTokenSource();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.Cancel();
 
-            await StopAsync(target, cts.Token);
+            var lifecycle = await StartAsync(target, TestContext.Current.CancellationToken);
+            await lifecycle.OnStop(cts.Token);
 
             Assert.All(testAccessor.WorkerTasks, task => Assert.True(task.IsCompleted));
-            await AssertWorkerStopEventsAsync(target, collector);
+            await AssertWorkerStopEventsAsync(target, collector, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -79,7 +80,7 @@ namespace UnitTests.Runtime
                 TargetGrain = GrainId.Create("test", "grain-1"),
             };
 
-            await StopAsync(target);
+            await StopAsync(target, TestContext.Current.CancellationToken);
 
             await Assert.ThrowsAsync<SiloUnavailableException>(() => target.AddressMessage(message));
         }
@@ -95,7 +96,7 @@ namespace UnitTests.Runtime
                 InterfaceVersion = 1,
             };
 
-            await StopAsync(target);
+            await StopAsync(target, TestContext.Current.CancellationToken);
 
             await Assert.ThrowsAsync<SiloUnavailableException>(() => GetTestAccessor(target).GetOrPlaceActivationAsync(message));
         }
@@ -113,7 +114,7 @@ namespace UnitTests.Runtime
             };
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => GetTestAccessor(target).GetOrPlaceActivationAsync(message));
-            await StopAsync(target);
+            await StopAsync(target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -149,13 +150,15 @@ namespace UnitTests.Runtime
             await lookupStarted.Task;
             timeProvider.Advance(messagingOptions.PlacementTimeout);
 
-            var completedTask = await Task.WhenAny(placementTask, Task.Delay(TimeSpan.FromSeconds(1)));
+            var completedTask = await Task.WhenAny(
+                placementTask,
+                Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken));
             Assert.Same(placementTask, completedTask);
             var exception = await Assert.ThrowsAsync<TimeoutException>(() => placementTask);
             Assert.IsType<Polly.Timeout.TimeoutRejectedException>(exception.InnerException);
 
             lookupCompletion.TrySetResult(default);
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -182,7 +185,7 @@ namespace UnitTests.Runtime
 
             var placementTask = GetTestAccessor(fixture.Target).GetOrPlaceActivationAsync(message);
             await lookupStarted.Task;
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
 
             await Assert.ThrowsAsync<SiloUnavailableException>(() => placementTask);
             lookupCompletion.TrySetResult(default);
@@ -194,7 +197,7 @@ namespace UnitTests.Runtime
             var target = CreateTarget();
             var placementTarget = new PlacementTarget(GrainId.Create("test", "grain-1"), new Dictionary<string, object>(), default, 0);
 
-            await StopAsync(target);
+            await StopAsync(target, TestContext.Current.CancellationToken);
 
             Assert.Throws<SiloUnavailableException>(() => target.GetCompatibleSilos(placementTarget));
         }
@@ -209,7 +212,7 @@ namespace UnitTests.Runtime
                 GrainInterfaceType.Create("test.interface"),
                 1);
 
-            await StopAsync(target);
+            await StopAsync(target, TestContext.Current.CancellationToken);
 
             Assert.Throws<SiloUnavailableException>(() => target.GetCompatibleSilosWithVersions(placementTarget));
         }
@@ -227,7 +230,7 @@ namespace UnitTests.Runtime
             Assert.Same(first, second);
             Assert.True(silos.ToHashSet().SetEquals(first));
 
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -243,7 +246,7 @@ namespace UnitTests.Runtime
 
             Assert.Same(first, second);
 
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -259,7 +262,7 @@ namespace UnitTests.Runtime
 
             Assert.Equal(new[] { silos[1] }, result);
 
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -281,7 +284,7 @@ namespace UnitTests.Runtime
 
             Assert.Equal(new[] { silos[1] }, result[1]);
 
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -300,7 +303,7 @@ namespace UnitTests.Runtime
             Assert.NotSame(first, second);
             Assert.Equal(new[] { silos[1] }, second);
 
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -321,7 +324,7 @@ namespace UnitTests.Runtime
             Assert.NotSame(first, second);
             Assert.Equal(new[] { silos[1] }, second);
 
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -337,7 +340,7 @@ namespace UnitTests.Runtime
             Assert.Equal(new[] { silos[1] }, second);
             Assert.Equal(2, fixture.FilterDirector!.CallCount);
 
-            await StopAsync(fixture.Target);
+            await StopAsync(fixture.Target, TestContext.Current.CancellationToken);
         }
 
         private static PlacementService CreateTarget()
@@ -498,23 +501,28 @@ namespace UnitTests.Runtime
             return new GrainLocator(grainLocatorResolver, null!);
         }
 
-        private static async Task<SiloLifecycleSubject> StartAsync(PlacementService target)
+        private static async Task<SiloLifecycleSubject> StartAsync(
+            PlacementService target,
+            CancellationToken cancellationToken)
         {
             var lifecycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)target).Participate(lifecycle);
-            await lifecycle.OnStart();
+            await lifecycle.OnStart(cancellationToken);
             return lifecycle;
         }
 
-        private static async Task StopAsync(PlacementService target, CancellationToken cancellationToken = default)
+        private static async Task StopAsync(PlacementService target, CancellationToken cancellationToken)
         {
-            var lifecycle = await StartAsync(target);
+            var lifecycle = await StartAsync(target, cancellationToken);
             await lifecycle.OnStop(cancellationToken);
         }
 
         private static PlacementService.ITestAccessor GetTestAccessor(PlacementService target) => target;
 
-        private static async Task AssertWorkerStopEventsAsync(PlacementService target, DiagnosticEventCollector collector)
+        private static async Task AssertWorkerStopEventsAsync(
+            PlacementService target,
+            DiagnosticEventCollector collector,
+            CancellationToken cancellationToken)
         {
             var workerCount = GetTestAccessor(target).WorkerTasks.Length;
             var stoppedEvents = new List<PlacementServiceEvents.WorkerStopped>(workerCount);
@@ -526,7 +534,8 @@ namespace UnitTests.Runtime
                     evt => evt.Payload is PlacementServiceEvents.WorkerStopped stopped
                         && stopped.SiloAddress == target.LocalSilo
                         && stoppedEvents.All(existing => existing.WorkerIndex != stopped.WorkerIndex),
-                    TimeSpan.FromSeconds(10));
+                    TimeSpan.FromSeconds(10),
+                    cancellationToken);
 
                 stoppedEvents.Add(Assert.IsType<PlacementServiceEvents.WorkerStopped>(diagnosticEvent.Payload));
             }

--- a/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
+++ b/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests.cs
@@ -124,7 +124,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromMilliseconds(3000);
             try
             {
-                await result.Task.WaitAsync(timeoutLimit);
+                await result.Task.WaitAsync(timeoutLimit, TestContext.Current.CancellationToken);
             }
             catch (TimeoutException)
             {
@@ -174,9 +174,9 @@ namespace UnitTests.SchedulerTests
             // Release the gate to allow main turn to complete
             mainTurnGate.SetResult(true);
 
-            try { await result1.Task.WaitAsync(WaitTimeout); }
+            try { await result1.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken); }
             catch (TimeoutException) { Assert.Fail("Timeout-1"); }
-            try { await result2.Task.WaitAsync(WaitTimeout); }
+            try { await result2.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken); }
             catch (TimeoutException) { Assert.Fail("Timeout-2"); }
 
             Assert.NotEqual(0, stageNum1); // "Work items did not get executed-1"
@@ -236,17 +236,21 @@ namespace UnitTests.SchedulerTests
             await await ScheduleTask();
 
             var taskAfterStopped = ScheduleTask();
-            var resultTask = await Task.WhenAny(taskAfterStopped, Task.Delay(WaitTimeout));
+            var resultTask = await Task.WhenAny(
+                taskAfterStopped,
+                Task.Delay(WaitTimeout, TestContext.Current.CancellationToken));
             Assert.Same(taskAfterStopped, resultTask);
 
             await await taskAfterStopped;
 
             // Wait for the WorkItemGroup to upgrade the warning to an error and try again.
             // This delay is based upon SchedulingOptions.StoppedActivationWarningInterval.
-            await Task.Delay(TimeSpan.FromMilliseconds(300));
+            await Task.Delay(TimeSpan.FromMilliseconds(300), TestContext.Current.CancellationToken);
 
             taskAfterStopped = ScheduleTask();
-            resultTask = await Task.WhenAny(taskAfterStopped, Task.Delay(WaitTimeout));
+            resultTask = await Task.WhenAny(
+                taskAfterStopped,
+                Task.Delay(WaitTimeout, TestContext.Current.CancellationToken));
             Assert.Same(taskAfterStopped, resultTask);
 
             await await taskAfterStopped;
@@ -368,7 +372,7 @@ namespace UnitTests.SchedulerTests
             });
 
             Log(17, "Waiting for ClosureWorkItem to spawn wrapper Task");
-            wrapper = await wrapperCreated.Task.WaitAsync(WaitTimeout);
+            wrapper = await wrapperCreated.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.NotNull(wrapper); // Wrapper Task was not created
 
             // Release gates to allow execution to proceed
@@ -376,7 +380,7 @@ namespace UnitTests.SchedulerTests
             mainTurnGate.SetResult(true);
 
             Log(18, "Waiting for wrapper Task Id=" + wrapper.Id + " to complete");
-            await wrapper.WaitAsync(WaitTimeout);
+            await wrapper.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.False(wrapper.IsFaulted, "Wrapper Task faulted: " + wrapper.Exception);
             Assert.True(wrapper.IsCompleted, "Wrapper Task should be completed");
 
@@ -384,7 +388,7 @@ namespace UnitTests.SchedulerTests
             // Wait for mainDone using a reasonable timeout
             for (var i = 0; i < 100 && !mainDone; i++)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, TestContext.Current.CancellationToken);
             }
             Log(21, "Done waiting for TaskWorkItem to complete MainDone=" + mainDone);
             Assert.True(mainDone, "Main Task should be completed");
@@ -392,13 +396,13 @@ namespace UnitTests.SchedulerTests
             Assert.NotNull(finalPromise2); // Task chain #2 not created
 
             Log(22, "Waiting for final task #1 to complete");
-            await finalTask1.WaitAsync(WaitTimeout);
+            await finalTask1.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.False(finalTask1.IsFaulted, "Final Task faulted: " + finalTask1.Exception);
             Assert.True(finalTask1.IsCompleted, "Final Task completed");
             Assert.True(await result1.Task, "Timeout-1");
 
             Log(24, "Waiting for final promise #2 to complete");
-            await finalPromise2.WaitAsync(WaitTimeout);
+            await finalPromise2.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Log(25, "Done waiting for final promise #2");
             Assert.False(finalPromise2.IsFaulted, "Final Task faulted: " + finalPromise2.Exception);
             Assert.True(finalPromise2.IsCompleted, "Final Task completed");
@@ -487,7 +491,7 @@ namespace UnitTests.SchedulerTests
             });
 
             Log(13, "Waiting for ClosureWorkItem to spawn wrapper Task");
-            wrapper = await wrapperCreated.Task.WaitAsync(WaitTimeout);
+            wrapper = await wrapperCreated.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.NotNull(wrapper); // Wrapper Task was not created
 
             // Release gates to allow execution to proceed
@@ -495,7 +499,7 @@ namespace UnitTests.SchedulerTests
             mainTurnGate.SetResult(true);
 
             Log(14, "Waiting for wrapper Task Id=" + wrapper.Id + " to complete");
-            await wrapper.WaitAsync(WaitTimeout);
+            await wrapper.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.False(wrapper.IsFaulted, "Wrapper Task faulted: " + wrapper.Exception);
             Assert.True(wrapper.IsCompleted, "Wrapper Task should be completed");
 
@@ -503,14 +507,14 @@ namespace UnitTests.SchedulerTests
             // Wait for mainDone using a reasonable timeout
             for (var i = 0; i < 100 && !mainDone; i++)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, TestContext.Current.CancellationToken);
             }
             Log(17, "Done waiting for TaskWorkItem to complete MainDone=" + mainDone);
             Assert.True(mainDone, "Main Task should be completed");
             Assert.NotNull(finalPromise); // AC chain not created
 
             Log(18, "Waiting for final AC promise to complete");
-            await finalPromise.WaitAsync(WaitTimeout);
+            await finalPromise.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Log(19, "Done waiting for final promise");
             Assert.False(finalPromise.IsFaulted, "Final AC faulted: " + finalPromise.Exception);
             Assert.True(finalPromise.IsCompleted, "Final AC completed");
@@ -542,7 +546,7 @@ namespace UnitTests.SchedulerTests
             });
             // ReSharper restore AccessToModifiedClosure
 
-            await result.Task.WaitAsync(WaitTimeout);
+            await result.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.True(n != 0, "Work items did not get executed");
             Assert.Equal(1, n);  // "Work items executed out of order"
         }
@@ -580,7 +584,7 @@ namespace UnitTests.SchedulerTests
                 }
             });
 
-            await result.Task.WaitAsync(WaitTimeout); // Wait for main (one that creates tasks) work item to finish.
+            await result.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken); // Wait for main (one that creates tasks) work item to finish.
 
             var promise = Task<int[]>.Factory.ContinueWhenAll(tasks, (res) =>
             {
@@ -601,7 +605,7 @@ namespace UnitTests.SchedulerTests
                 return results;
             });
 
-            await promise.WaitAsync(WaitTimeout);
+            await promise.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
 
             Assert.True(n != 0, "Work items did not get executed");
             Assert.Equal(12, n);  // "Not all work items executed"
@@ -658,8 +662,8 @@ namespace UnitTests.SchedulerTests
             // Release the gate to allow task1 to throw
             gate.Release();
 
-            await result1.Task.WaitAsync(WaitTimeout);
-            await result2.Task.WaitAsync(WaitTimeout);
+            await result1.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+            await result2.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.True(failed1);  // "First ContinueWith did not fire error handler."
             Assert.True(failed2);  // "Second ContinueWith did not fire error handler."
         }
@@ -719,11 +723,11 @@ namespace UnitTests.SchedulerTests
                 gate.Release();
             });
             wrapper.Start(context.WorkItemGroup.TaskScheduler);
-            await wrapper.WaitAsync(WaitTimeout);
+            await wrapper.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
 
             Assert.False(wrapper.IsFaulted, "Wrapper Task Faulted with Exception=" + wrapper.Exception);
             Assert.True(wrapper.IsCompleted, "Wrapper Task completed");
-            await result.Task.WaitAsync(WaitTimeout);
+            await result.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             Assert.NotNull(endOfChain); // End of chain Task created successfully
             Assert.False(endOfChain.IsFaulted, "Task chain Faulted with Exception=" + endOfChain.Exception);
             Assert.True(n != 0, "Work items did not get executed");

--- a/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -97,7 +97,7 @@ namespace UnitTests.SchedulerTests
                 return t1;
             });
             wrapped.Start(scheduler);
-            await wrapped.Unwrap().WaitAsync(TimeSpan.FromSeconds(10));
+            await wrapped.Unwrap().WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
@@ -198,7 +198,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromSeconds(10);
             try
             {
-                await result.Task.WaitAsync(timeoutLimit);
+                await result.Task.WaitAsync(timeoutLimit, TestContext.Current.CancellationToken);
             }
             catch (TimeoutException)
             {
@@ -246,7 +246,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromSeconds(10);
             try
             {
-                await finish.Task.WaitAsync(timeoutLimit);
+                await finish.Task.WaitAsync(timeoutLimit, TestContext.Current.CancellationToken);
             }
             catch (TimeoutException)
             {
@@ -301,7 +301,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromSeconds(10);
             try
             {
-                await finish.Task.WaitAsync(timeoutLimit);
+                await finish.Task.WaitAsync(timeoutLimit, TestContext.Current.CancellationToken);
             }
             catch (TimeoutException)
             {
@@ -369,7 +369,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromSeconds(10);
             try
             {
-                await finish.Task.WaitAsync(timeoutLimit);
+                await finish.Task.WaitAsync(timeoutLimit, TestContext.Current.CancellationToken);
             }
             catch (TimeoutException)
             {
@@ -429,7 +429,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromSeconds(10);
             try
             {
-                await finish.Task.WaitAsync(timeoutLimit);
+                await finish.Task.WaitAsync(timeoutLimit, TestContext.Current.CancellationToken);
             }
             catch (TimeoutException)
             {
@@ -492,7 +492,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromSeconds(10);
             try
             {
-                await finish.Task.WaitAsync(timeoutLimit);
+                await finish.Task.WaitAsync(timeoutLimit, TestContext.Current.CancellationToken);
             }
             catch (TimeoutException)
             {
@@ -514,9 +514,9 @@ namespace UnitTests.SchedulerTests
             Task<Task> wrapper = new Task<Task>(async () =>
             {
                 Assert.Equal(scheduler, TaskScheduler.Current);
-                await DoDelay(1);
+                await DoDelay(1, TestContext.Current.CancellationToken);
                 Assert.Equal(scheduler, TaskScheduler.Current);
-                await DoDelay(2);
+                await DoDelay(2, TestContext.Current.CancellationToken);
                 Assert.Equal(scheduler, TaskScheduler.Current);
             });
             wrapper.Start(scheduler);
@@ -524,12 +524,12 @@ namespace UnitTests.SchedulerTests
             await wrapper.Unwrap();
         }
 
-        private async Task DoDelay(int i)
+        private async Task DoDelay(int i, CancellationToken cancellationToken)
         {
             try
             {
                 this.output.WriteLine("Before Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
-                await Task.Delay(1);
+                await Task.Delay(1, cancellationToken);
                 this.output.WriteLine("After Task.Delay #{0} TaskScheduler.Current={1}", i, TaskScheduler.Current);
             }
             catch (ObjectDisposedException)
@@ -631,7 +631,7 @@ namespace UnitTests.SchedulerTests
 
                 try
                 {
-                    await resultHandles[i].Task.WaitAsync(waitCheckTime);
+                    await resultHandles[i].Task.WaitAsync(waitCheckTime, TestContext.Current.CancellationToken);
                 }
                 catch (TimeoutException)
                 {
@@ -643,7 +643,9 @@ namespace UnitTests.SchedulerTests
                 try
                 {
                     // since resultHandle being complete doesn't directly imply that the final chain was completed (there's a chance for a race condition), give a small chance for it to complete.
-                    await taskChainEnds[i].WaitAsync(TimeSpan.FromMilliseconds(10));
+                    await taskChainEnds[i].WaitAsync(
+                        TimeSpan.FromMilliseconds(10),
+                        TestContext.Current.CancellationToken);
                 }
                 catch (TimeoutException)
                 {
@@ -660,16 +662,19 @@ namespace UnitTests.SchedulerTests
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Test1()
         {
-            await Run_ActivationSched_Test1(scheduler, false);
+            await Run_ActivationSched_Test1(scheduler, false, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Scheduler")]
         public async Task ActivationSched_Test1_Bounce()
         {
-            await Run_ActivationSched_Test1(scheduler, true);
+            await Run_ActivationSched_Test1(scheduler, true, TestContext.Current.CancellationToken);
         }
 
-        internal async Task Run_ActivationSched_Test1(TaskScheduler scheduler, bool bounceToThreadPool)
+        internal async Task Run_ActivationSched_Test1(
+            TaskScheduler scheduler,
+            bool bounceToThreadPool,
+            CancellationToken cancellationToken)
         {
             var grainId = LegacyGrainId.GetGrainId(0, Guid.NewGuid());
             var silo = new MockSiloDetails
@@ -712,7 +717,7 @@ namespace UnitTests.SchedulerTests
             var timeoutLimit = TimeSpan.FromSeconds(10);
             try
             {
-                await wrapperDone.Task.WaitAsync(timeoutLimit);
+                await wrapperDone.Task.WaitAsync(timeoutLimit, cancellationToken);
             }
             catch (TimeoutException)
             {
@@ -728,7 +733,7 @@ namespace UnitTests.SchedulerTests
             await wrapped;
             try
             {
-                await wrappedDone.Task.WaitAsync(timeoutLimit);
+                await wrappedDone.Task.WaitAsync(timeoutLimit, cancellationToken);
             }
             catch (TimeoutException)
             {

--- a/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -132,7 +132,7 @@ namespace UnitTests.SchedulerTests
             _rootContext.Scheduler.QueueAction(item2);
 
             // Wait for completion
-            await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await completed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             // N should be 15, because the two tasks should execute in order
             Assert.True(n != 0, "Work items did not get executed");
@@ -160,7 +160,9 @@ namespace UnitTests.SchedulerTests
             // Release task1 to proceed
             gate.Release();
 
-            await Task.WhenAll(task1, task2).WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.WhenAll(task1, task2).WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
 
             // N should be 15, because the two tasks should execute in order
             Assert.True(n != 0, "Work items did not get executed");
@@ -201,7 +203,7 @@ namespace UnitTests.SchedulerTests
             }
 
             foreach (var flag in flags) flag.Set();
-            await Task.WhenAll(workItems).WaitAsync(workItemCompletionTimeout);
+            await Task.WhenAll(workItems).WaitAsync(workItemCompletionTimeout, TestContext.Current.CancellationToken);
 
 
             for (var i = 0; i < tasks.Length; i++)
@@ -245,14 +247,14 @@ namespace UnitTests.SchedulerTests
                 }
             });
 
-            await result0.Task.WaitAsync(TimeSpan.FromMinutes(1));
+            await result0.Task.WaitAsync(TimeSpan.FromMinutes(1), TestContext.Current.CancellationToken);
             Assert.True(result0.Task.Exception == null, "Task-0 should not throw exception: " + result0.Task.Exception);
             Assert.True(await result0.Task, "Task-0 completed");
 
             Assert.NotNull(t1); // Task-1 started
-            await result1.Task.WaitAsync(TimeSpan.FromMinutes(1));
+            await result1.Task.WaitAsync(TimeSpan.FromMinutes(1), TestContext.Current.CancellationToken);
             // give a minimum extra chance to yield after result0 has been set, as it might not have finished the t1 task
-            await t1.WaitAsync(TimeSpan.FromMilliseconds(1));
+            await t1.WaitAsync(TimeSpan.FromMilliseconds(1), TestContext.Current.CancellationToken);
 
             Assert.True(t1.IsCompleted, "Task-1 completed");
             Assert.False(t1.IsFaulted, "Task-1 faulted: " + t1.Exception);
@@ -318,7 +320,7 @@ namespace UnitTests.SchedulerTests
 
             // Wait for completion
             _output.WriteLine("Main-task waiting");
-            await finished.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await finished.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
             _output.WriteLine("Main-task done");
 
             // N should be 10, because all tasks should execute serially
@@ -359,7 +361,7 @@ namespace UnitTests.SchedulerTests
                 });
                 await t2.WaitAsync(TimeSpan.FromSeconds(5));
             }).Unwrap();
-            await t0.WaitAsync(TimeSpan.FromSeconds(10));
+            await t0.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
             Assert.True(t0.IsCompleted, "Task #0 FAULTED=" + t0.Exception);
         }
 

--- a/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
@@ -49,7 +49,7 @@ namespace UnitTests.Serialization
             var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
 
             message.TimeToLive = TimeSpan.FromSeconds(1);
-            await Task.Delay(TimeSpan.FromMilliseconds(500));
+            await Task.Delay(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
             Assert.InRange(message.TimeToLive.Value, TimeSpan.FromMilliseconds(-1000), TimeSpan.FromMilliseconds(900));
         }
 
@@ -61,7 +61,7 @@ namespace UnitTests.Serialization
             var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
 
             message.TimeToLive = TimeSpan.FromSeconds(1);
-            await Task.Delay(TimeSpan.FromMilliseconds(500));
+            await Task.Delay(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
             var deserializedMessage = RoundTripMessage(message);
 
             Assert.NotNull(deserializedMessage.TimeToLive);

--- a/test/Orleans.Core.Tests/ServiceLifecycleTests.cs
+++ b/test/Orleans.Core.Tests/ServiceLifecycleTests.cs
@@ -63,21 +63,21 @@ public class ServiceLifecycleTests
 
         var (task, _) = RegisterCallback(_lifecycle.Started, (state, ct) => { }, callbackState);
 
-        await _subject.OnStart();
+        await _subject.OnStart(TestContext.Current.CancellationToken);
 
-        var result = await task.WaitAsync(Timeout);
+        var result = await task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
         Assert.Equal(callbackState, result);
     }
 
     [Fact]
     public async Task Stage_WaitAsync()
     {
-        var waitTask = _lifecycle.Started.WaitAsync();
+        var waitTask = _lifecycle.Started.WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.False(waitTask.IsCompleted);
 
-        await _subject.OnStart();
-        await waitTask.WaitAsync(Timeout);
+        await _subject.OnStart(TestContext.Current.CancellationToken);
+        await waitTask.WaitAsync(Timeout, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class ServiceLifecycleTests
     {
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         // We register a blocking callback to keep the stage in a "running" state.
         // This forces WaitAsync to actually block, allowing us to verify that cancelling
@@ -93,7 +93,7 @@ public class ServiceLifecycleTests
 
         _lifecycle.Started.Register((_, _) => tcs.Task);
 
-        var startTask = _subject.OnStart();
+        var startTask = _subject.OnStart(TestContext.Current.CancellationToken);
         var waitTask = _lifecycle.Started.WaitAsync(cts.Token);
 
         Assert.False(waitTask.IsCompleted, "WaitAsync should be paused waiting for the stage to complete");
@@ -125,9 +125,9 @@ public class ServiceLifecycleTests
         Assert.False(second.IsCompleted);
 
         gate.SetResult();
-        await Task.WhenAll(first, second).WaitAsync(Timeout);
+        await Task.WhenAll(first, second).WaitAsync(Timeout, TestContext.Current.CancellationToken);
 
-        await stage.NotifyCompleted(CancellationToken.None).WaitAsync(Timeout);
+        await stage.NotifyCompleted(TestContext.Current.CancellationToken).WaitAsync(Timeout, TestContext.Current.CancellationToken);
 
         Assert.Equal(1, executionCount);
     }
@@ -139,8 +139,8 @@ public class ServiceLifecycleTests
 
         registration.Dispose();
 
-        await _subject.OnStart();
-        await _subject.OnStop();
+        await _subject.OnStart(TestContext.Current.CancellationToken);
+        await _subject.OnStop(TestContext.Current.CancellationToken);
 
         Assert.False(task.IsCompleted);
     }
@@ -152,10 +152,10 @@ public class ServiceLifecycleTests
 
         using var registration = _lifecycle.Stopping.Token.Register(tcs.SetResult);
 
-        await _subject.OnStart();
-        await _subject.OnStop();
+        await _subject.OnStart(TestContext.Current.CancellationToken);
+        await _subject.OnStop(TestContext.Current.CancellationToken);
 
-        await tcs.Task.WaitAsync(Timeout);
+        await tcs.Task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -166,9 +166,10 @@ public class ServiceLifecycleTests
         (state, ct) => throw new InvalidOperationException("Test"),
         terminateOnError: false);
 
-        await _subject.OnStart();
+        await _subject.OnStart(TestContext.Current.CancellationToken);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => task.WaitAsync(Timeout));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => task.WaitAsync(Timeout, TestContext.Current.CancellationToken));
         Assert.Equal("Test", ex.Message);
     }
 
@@ -180,10 +181,11 @@ public class ServiceLifecycleTests
             (state, ct) => throw new InvalidOperationException("Test"),
             terminateOnError: true);
 
-        var startTask = _subject.OnStart();
+        var startTask = _subject.OnStart(TestContext.Current.CancellationToken);
 
         // This ensures the callback actually executed and we aren't just catching the lifecycle aborting.
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => task.WaitAsync(Timeout));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => task.WaitAsync(Timeout, TestContext.Current.CancellationToken));
         Assert.Equal("Test", ex.Message);
 
         // Now verify the lifecycle start failed as expected.
@@ -203,7 +205,7 @@ public class ServiceLifecycleTests
             (_, _) => throw new ArgumentException("second"),
             terminateOnError: true);
 
-        var startTask = _subject.OnStart();
+        var startTask = _subject.OnStart(TestContext.Current.CancellationToken);
 
         // We swallow the start exception initially so we can inspect the individual tasks.
         try
@@ -218,8 +220,8 @@ public class ServiceLifecycleTests
         // Now we wait for both TCS signals to complete (rather 'fail') before asserting.
         // This prevents racing between the OnStart exception propagation and the TCS setting.
 
-        try { await task1.WaitAsync(Timeout); } catch { }
-        try { await task2.WaitAsync(Timeout); } catch { }
+        try { await task1.WaitAsync(Timeout, TestContext.Current.CancellationToken); } catch { }
+        try { await task2.WaitAsync(Timeout, TestContext.Current.CancellationToken); } catch { }
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => task1);
         await Assert.ThrowsAsync<ArgumentException>(() => task2);
@@ -228,13 +230,13 @@ public class ServiceLifecycleTests
     [Fact]
     public async Task LateRegistration_ExecutedImmediately()
     {
-        await _subject.OnStart();
-        await _subject.OnStop();
+        await _subject.OnStart(TestContext.Current.CancellationToken);
+        await _subject.OnStop(TestContext.Current.CancellationToken);
 
         // Registering after stage completes should run immediately
         var (task, _) = RegisterCallback(_lifecycle.Stopping);
 
-        await task.WaitAsync(Timeout);
+        await task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -250,15 +252,15 @@ public class ServiceLifecycleTests
         {
             tasks[i] = Task.Run(() =>
             {
-                startSignal.Wait();
+                startSignal.Wait(TestContext.Current.CancellationToken);
                 RegisterCallback(_lifecycle.Started, (_, _) => Interlocked.Increment(ref executionCount));
-            });
+            }, TestContext.Current.CancellationToken);
         }
 
         startSignal.Set();
 
         await Task.WhenAll(tasks);
-        await _subject.OnStart();
+        await _subject.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(Count, executionCount);
     }
@@ -274,9 +276,9 @@ public class ServiceLifecycleTests
         // We capture the stopped task to wait on it specifically.
         var (stoppedTask, _) = RegisterCallback(_lifecycle.Stopped, (_, _) => executionOrder.Enqueue("Stopped"));
 
-        await _subject.OnStart();
-        await _subject.OnStop();
-        await stoppedTask.WaitAsync(Timeout);
+        await _subject.OnStart(TestContext.Current.CancellationToken);
+        await _subject.OnStop(TestContext.Current.CancellationToken);
+        await stoppedTask.WaitAsync(Timeout, TestContext.Current.CancellationToken);
 
         var order = executionOrder.ToArray();
 
@@ -302,17 +304,18 @@ public class ServiceLifecycleTests
             {
                 workerExited.SetResult();
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
-        await _subject.OnStart();
-        await _subject.OnStop();
+        await _subject.OnStart(TestContext.Current.CancellationToken);
+        await _subject.OnStop(TestContext.Current.CancellationToken);
 
-        await workerExited.Task.WaitAsync(Timeout);
+        await workerExited.Task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task Lifecycle_CancellationToken_PassedToCallback()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var tcs = new TaskCompletionSource<bool>();
 
         // We manually register here because the logic is specific to CT handling inside the callback
@@ -323,13 +326,13 @@ public class ServiceLifecycleTests
             {
                 await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, ct);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 tcs.SetResult(true);
             }
         });
 
-        var startTask = _subject.OnStart();
+        var startTask = _subject.OnStart(cancellationToken);
 
         await _subject.CancelStartAsync();
 
@@ -337,12 +340,12 @@ public class ServiceLifecycleTests
         {
             await startTask;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
 
         }
 
-        var tokenWasCancelled = await tcs.Task.WaitAsync(Timeout);
+        var tokenWasCancelled = await tcs.Task.WaitAsync(Timeout, cancellationToken);
         Assert.True(tokenWasCancelled);
     }
 

--- a/test/Orleans.Core.Tests/ServiceLifecycleTests.cs
+++ b/test/Orleans.Core.Tests/ServiceLifecycleTests.cs
@@ -195,6 +195,7 @@ public class ServiceLifecycleTests
     [Fact]
     public async Task ErrorHandling_TerminateOnErrorTrue_MultipleFailures()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (task1, _) = RegisterCallback(
             _lifecycle.Started,
             (_, _) => throw new InvalidOperationException("first"),
@@ -205,12 +206,16 @@ public class ServiceLifecycleTests
             (_, _) => throw new ArgumentException("second"),
             terminateOnError: true);
 
-        var startTask = _subject.OnStart(TestContext.Current.CancellationToken);
+        var startTask = _subject.OnStart(cancellationToken);
 
         // We swallow the start exception initially so we can inspect the individual tasks.
         try
         {
             await startTask;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {
@@ -220,11 +225,13 @@ public class ServiceLifecycleTests
         // Now we wait for both TCS signals to complete (rather 'fail') before asserting.
         // This prevents racing between the OnStart exception propagation and the TCS setting.
 
-        try { await task1.WaitAsync(Timeout, TestContext.Current.CancellationToken); } catch { }
-        try { await task2.WaitAsync(Timeout, TestContext.Current.CancellationToken); } catch { }
+        var firstException = await Record.ExceptionAsync(() => task1.WaitAsync(Timeout, cancellationToken));
+        cancellationToken.ThrowIfCancellationRequested();
+        Assert.IsType<InvalidOperationException>(firstException);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => task1);
-        await Assert.ThrowsAsync<ArgumentException>(() => task2);
+        var secondException = await Record.ExceptionAsync(() => task2.WaitAsync(Timeout, cancellationToken));
+        cancellationToken.ThrowIfCancellationRequested();
+        Assert.IsType<ArgumentException>(secondException);
     }
 
     [Fact]

--- a/test/Orleans.Core.Tests/SiloBuilderTests.cs
+++ b/test/Orleans.Core.Tests/SiloBuilderTests.cs
@@ -114,7 +114,7 @@ namespace NonSilo.Tests
                         .Configure<GrainCollectionOptions>(options => options
                                     .ClassSpecificCollectionAge
                                     .Add(typeof(CollectionSpecificAgeLimitForZeroSecondsActivationGcTestGrain).FullName!, TimeSpan.Zero));
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
         }
 
@@ -131,7 +131,7 @@ namespace NonSilo.Tests
                     siloBuilder
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options => { options.NumVotesForDeathDeclaration = 10; options.NumProbedSilos = 1; });
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -141,7 +141,7 @@ namespace NonSilo.Tests
                     siloBuilder
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options => { options.NumVotesForDeathDeclaration = 0; });
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -151,7 +151,7 @@ namespace NonSilo.Tests
                     siloBuilder
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options => options.MaxDefunctSiloEntries = -1);
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -161,7 +161,7 @@ namespace NonSilo.Tests
                     siloBuilder
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options => options.ProbeTimeout = TimeSpan.Zero);
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -171,7 +171,7 @@ namespace NonSilo.Tests
                     siloBuilder
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options => options.MinProbeTimeout = TimeSpan.FromSeconds(6));
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -185,7 +185,7 @@ namespace NonSilo.Tests
                             options.MinProbeTimeout = TimeSpan.FromSeconds(1);
                             options.MaxProbeTimeout = TimeSpan.FromSeconds(4);
                         });
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -195,7 +195,7 @@ namespace NonSilo.Tests
                     siloBuilder
                         .UseLocalhostClustering()
                         .Configure<ClusterMembershipOptions>(options => options.MaxProbeTimeout = TimeSpan.FromDays(50));
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -210,7 +210,7 @@ namespace NonSilo.Tests
                             options.MaxProbeTimeout = TimeSpan.FromDays(49);
                             options.NumMissedProbesLimit = int.MaxValue;
                         });
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
 
             await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
@@ -225,7 +225,7 @@ namespace NonSilo.Tests
                             options.MaxProbeTimeout = options.ProbeTimeout;
                             options.NumMissedProbesLimit = 2_000_000_000;
                         });
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
         }
 
@@ -249,7 +249,7 @@ namespace NonSilo.Tests
                             options.LoadSheddingEnabled = true;
                             options.CpuThreshold = 101;
                         });
-                }).RunConsoleAsync();
+                }).RunConsoleAsync(TestContext.Current.CancellationToken);
             });
         }
 
@@ -272,7 +272,8 @@ namespace NonSilo.Tests
                     });
                 }).Build();
 
-            await Assert.ThrowsAsync<OrleansConfigurationException>(() => host.StartAsync());
+            await Assert.ThrowsAsync<OrleansConfigurationException>(
+                () => host.StartAsync(TestContext.Current.CancellationToken));
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/Storage/StateStorageBridgeConcurrencyTests.cs
+++ b/test/Orleans.Core.Tests/Storage/StateStorageBridgeConcurrencyTests.cs
@@ -139,7 +139,7 @@ public class StateStorageBridgeConcurrencyTests
         InvalidOperationException invalidOperation;
         try
         {
-            await pendingWrite.Task.WaitAsync(WaitTimeout);
+            await pendingWrite.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             invalidOperation = Assert.Throws<InvalidOperationException>(() => { _ = bridge.WriteStateAsync(); });
         }
         finally
@@ -361,7 +361,7 @@ public class StateStorageBridgeConcurrencyTests
         InvalidOperationException invalidOperation;
         try
         {
-            await pendingClear.Task.WaitAsync(WaitTimeout);
+            await pendingClear.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
             invalidOperation = Assert.Throws<InvalidOperationException>(() => { _ = bridge.ClearStateAsync(); });
         }
         finally
@@ -619,7 +619,8 @@ public class StateStorageBridgeConcurrencyTests
         var storage = new ControllableGrainStorage();
         IStorage bridge = CreateBridge(context, storage);
         var readCompletion = CreateCompletionSource();
-        using var cancellationTokenSource = new CancellationTokenSource();
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
         storage.ReadAsync = _ => readCompletion.Task;
         storage.WriteWithCancellationAsync = (_, cancellationToken) =>
         {
@@ -653,7 +654,8 @@ public class StateStorageBridgeConcurrencyTests
         var storage = new ControllableGrainStorage();
         IStorage bridge = CreateBridge(context, storage);
         var readCompletion = CreateCompletionSource();
-        using var cancellationTokenSource = new CancellationTokenSource();
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
         storage.ReadAsync = _ => readCompletion.Task;
 
         await RunInGrainContextAsync(context, async () =>
@@ -737,18 +739,22 @@ public class StateStorageBridgeConcurrencyTests
 
     private static Task RunInGrainContextAsync(TestGrainContext context, Func<Task> action)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var task = Task.Factory.StartNew(
             action,
-            CancellationToken.None,
+            cancellationToken,
             TaskCreationOptions.None,
             context.WorkItemGroup.TaskScheduler).Unwrap();
 
-        return task.WaitAsync(WaitTimeout);
+        return task.WaitAsync(WaitTimeout, cancellationToken);
     }
 
     private static async Task WaitUntilAsync(Func<bool> condition)
     {
-        using var cancellationTokenSource = new CancellationTokenSource(WaitTimeout);
+        using var timeoutTokenSource = new CancellationTokenSource(WaitTimeout);
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutTokenSource.Token,
+            TestContext.Current.CancellationToken);
 
         while (!condition())
         {

--- a/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -13,7 +13,7 @@ public class TimeProviderExtensionsTests
     {
         var timeProvider = new FakeTimeProvider();
 
-        var task = timeProvider.DelayAsync(TimeSpan.Zero);
+        var task = timeProvider.DelayAsync(TimeSpan.Zero, TestContext.Current.CancellationToken);
 
         Assert.True(task.IsCompletedSuccessfully);
         await task;
@@ -25,7 +25,7 @@ public class TimeProviderExtensionsTests
     public async Task DelayAsync_SupportsInfiniteDelay()
     {
         var timeProvider = new FakeTimeProvider();
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
 
         var task = timeProvider.DelayAsync(Timeout.InfiniteTimeSpan, cancellation.Token);
 
@@ -45,7 +45,9 @@ public class TimeProviderExtensionsTests
         var timeProvider = new FakeTimeProvider();
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-            () => timeProvider.DelayAsync(TimeSpan.FromMilliseconds(milliseconds)));
+            () => timeProvider.DelayAsync(
+                TimeSpan.FromMilliseconds(milliseconds),
+                TestContext.Current.CancellationToken));
     }
 
     [TestSuite("BVT")]
@@ -56,7 +58,7 @@ public class TimeProviderExtensionsTests
         var timeProvider = new FakeTimeProvider();
         var delay = TimeSpan.FromDays(60);
 
-        var task = timeProvider.DelayAsync(delay);
+        var task = timeProvider.DelayAsync(delay, TestContext.Current.CancellationToken);
 
         Assert.False(task.IsCompleted);
         timeProvider.Advance(TimeSpan.FromDays(50));
@@ -76,7 +78,7 @@ public class TimeProviderExtensionsTests
         var timeProvider = new FakeTimeProvider();
         var dueTime = timeProvider.GetUtcNow() + TimeSpan.FromMilliseconds(milliseconds);
 
-        var task = timeProvider.DelayUntilAsync(dueTime);
+        var task = timeProvider.DelayUntilAsync(dueTime, TestContext.Current.CancellationToken);
 
         Assert.True(task.IsCompletedSuccessfully);
         await task;
@@ -89,7 +91,9 @@ public class TimeProviderExtensionsTests
     {
         var timeProvider = new FakeTimeProvider();
         var delay = TimeSpan.FromDays(60);
-        var task = timeProvider.DelayUntilAsync(timeProvider.GetUtcNow() + delay);
+        var task = timeProvider.DelayUntilAsync(
+            timeProvider.GetUtcNow() + delay,
+            TestContext.Current.CancellationToken);
 
         Assert.False(task.IsCompleted);
         timeProvider.Advance(TimeSpan.FromDays(50));

--- a/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
@@ -55,21 +55,22 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         var producer = Task.Run(async () =>
         {
             foreach (var value in Enumerable.Range(0, 5))
             {
-                await Task.Delay(200);
+                await Task.Delay(200, cancellationToken);
                 await grain.OnNext(value.ToString());
             }
 
             await grain.Complete();
-        });
+        }, cancellationToken);
 
         var values = new List<string>();
-        await foreach (var entry in grain.GetValues())
+        await foreach (var entry in grain.GetValues(cancellationToken).WithCancellation(cancellationToken))
         {
             values.Add(entry);
             Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
@@ -93,11 +94,13 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_CancelBeforeYield()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         // Set up cancellation tokens - one for test timeout, one for the grain call
-        using var testCts = new CancellationTokenSource(TimeSpan.FromSeconds(35));
-        using var callCts = new CancellationTokenSource();
+        using var testCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        testCts.CancelAfter(TimeSpan.FromSeconds(35));
+        using var callCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var callId = Guid.NewGuid();
 
         // Task to cancel the enumeration after it starts but before it yields
@@ -105,7 +108,7 @@ public class AsyncEnumerableGrainCallTests
         {
             await grain.WaitForCall(callId); // Wait for enumeration to begin
             callCts.Cancel(); // Cancel before any values are yielded
-        });
+        }, cancellationToken);
 
         try
         {
@@ -119,6 +122,8 @@ public class AsyncEnumerableGrainCallTests
         }
         catch (OperationCanceledException)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Verify the cancellation token was indeed cancelled
             Assert.True(callCts.Token.IsCancellationRequested);
         }
@@ -134,9 +139,10 @@ public class AsyncEnumerableGrainCallTests
                 break;
             }
 
-            await Task.Delay(TimeSpan.FromMilliseconds(10));
+            await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
             if (testCts.IsCancellationRequested)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 Assert.Fail("Test timed out waiting for cancellation to be recorded.");
             }
         }
@@ -163,13 +169,14 @@ public class AsyncEnumerableGrainCallTests
     [InlineData(11, true)]
     public async Task ObservableGrain_AsyncEnumerable_Throws(int errorIndex, bool waitAfterYield)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         const string ErrorMessage = "This is my error!";
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         var values = new List<int>();
         try
         {
-            await foreach (var entry in grain.GetValuesWithError(errorIndex, waitAfterYield, ErrorMessage).WithBatchSize(10))
+            await foreach (var entry in grain.GetValuesWithError(errorIndex, waitAfterYield, ErrorMessage, cancellationToken).WithBatchSize(10).WithCancellation(cancellationToken))
             {
                 values.Add(entry);
                 Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
@@ -207,6 +214,7 @@ public class AsyncEnumerableGrainCallTests
     [InlineData(11, true)]
     public async Task ObservableGrain_AsyncEnumerable_Cancellation(int errorIndex, bool waitAfterYield)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         // This special error message is interpreted to indicate that cancellation
         // should occur when the index is reached.
         const string ErrorMessage = "cancel";
@@ -215,7 +223,7 @@ public class AsyncEnumerableGrainCallTests
         var values = new List<int>();
         try
         {
-            await foreach (var entry in grain.GetValuesWithError(errorIndex, waitAfterYield, ErrorMessage).WithBatchSize(10))
+            await foreach (var entry in grain.GetValuesWithError(errorIndex, waitAfterYield, ErrorMessage, cancellationToken).WithBatchSize(10).WithCancellation(cancellationToken))
             {
                 values.Add(entry);
                 Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
@@ -223,6 +231,7 @@ public class AsyncEnumerableGrainCallTests
         }
         catch (OperationCanceledException oce)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var expectedMessage = new OperationCanceledException().Message;
             Assert.Equal(expectedMessage, oce.Message);
         }
@@ -256,13 +265,14 @@ public class AsyncEnumerableGrainCallTests
     [InlineData(11, true)]
     public async Task ObservableGrain_AsyncEnumerable_CancellationToken(int errorIndex, bool waitAfterYield)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         const string ErrorMessage = "Throwing!";
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         var values = new List<int>();
         try
         {
-            using var cts = new CancellationTokenSource();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             if (errorIndex == 0)
             {
                 cts.Cancel();
@@ -281,6 +291,7 @@ public class AsyncEnumerableGrainCallTests
         }
         catch (OperationCanceledException oce)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var expectedMessage = new OperationCanceledException().Message;
             Assert.Equal(expectedMessage, oce.Message);
         }
@@ -323,19 +334,20 @@ public class AsyncEnumerableGrainCallTests
     [InlineData(11, true)]
     public async Task ObservableGrain_AsyncEnumerable_CancellationToken_WithCancellationExtension(int errorIndex, bool waitAfterYield)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         const string ErrorMessage = "Throwing!";
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         var values = new List<int>();
         try
         {
-            using var cts = new CancellationTokenSource();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             if (errorIndex == 0)
             {
                 cts.Cancel();
             }
 
-            await foreach (var entry in grain.GetValuesWithError(int.MaxValue, waitAfterYield, ErrorMessage).WithBatchSize(10).WithCancellation(cts.Token))
+            await foreach (var entry in grain.GetValuesWithError(int.MaxValue, waitAfterYield, ErrorMessage, cancellationToken).WithBatchSize(10).WithCancellation(cts.Token))
             {
                 values.Add(entry);
                 if (values.Count == errorIndex)
@@ -348,6 +360,7 @@ public class AsyncEnumerableGrainCallTests
         }
         catch (OperationCanceledException oce)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var expectedMessage = new OperationCanceledException().Message;
             Assert.Equal(expectedMessage, oce.Message);
         }
@@ -380,6 +393,7 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_Batch()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         foreach (var value in Enumerable.Range(0, 50))
@@ -390,7 +404,7 @@ public class AsyncEnumerableGrainCallTests
         await grain.Complete();
 
         var values = new List<string>();
-        await foreach (var entry in grain.GetValues())
+        await foreach (var entry in grain.GetValues(cancellationToken).WithCancellation(cancellationToken))
         {
             values.Add(entry);
             Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
@@ -418,6 +432,7 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_SplitBatch()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         foreach (var value in Enumerable.Range(0, 50))
@@ -428,7 +443,7 @@ public class AsyncEnumerableGrainCallTests
         await grain.Complete();
 
         var values = new List<string>();
-        await foreach (var entry in grain.GetValues().WithBatchSize(25))
+        await foreach (var entry in grain.GetValues(cancellationToken).WithBatchSize(25).WithCancellation(cancellationToken))
         {
             values.Add(entry);
             Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
@@ -456,6 +471,7 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_NoBatching()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         foreach (var value in Enumerable.Range(0, 50))
@@ -466,7 +482,7 @@ public class AsyncEnumerableGrainCallTests
         await grain.Complete();
 
         var values = new List<string>();
-        await foreach (var entry in grain.GetValues().WithBatchSize(1))
+        await foreach (var entry in grain.GetValues(cancellationToken).WithBatchSize(1).WithCancellation(cancellationToken))
         {
             values.Add(entry);
             Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
@@ -496,24 +512,25 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_WithCancellation()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         var producer = Task.Run(async () =>
         {
             foreach (var value in Enumerable.Range(0, 5))
             {
-                await Task.Delay(200);
+                await Task.Delay(200, cancellationToken);
                 await grain.OnNext(value.ToString());
             }
 
             await grain.Complete();
-        });
+        }, cancellationToken);
 
         var values = new List<string>();
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         try
         {
-            await foreach (var entry in grain.GetValues().WithCancellation(cts.Token))
+            await foreach (var entry in grain.GetValues(cancellationToken).WithCancellation(cts.Token))
             {
                 values.Add(entry);
                 if (values.Count == 3)
@@ -528,6 +545,7 @@ public class AsyncEnumerableGrainCallTests
         }
         catch (OperationCanceledException)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             // Expected
         }
 
@@ -548,21 +566,22 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_SlowProducer()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         var producer = Task.Run(async () =>
         {
             foreach (var value in Enumerable.Range(0, 5))
             {
-                await Task.Delay(2000);
+                await Task.Delay(2000, cancellationToken);
                 await grain.OnNext(value.ToString());
             }
 
             await grain.Complete();
-        });
+        }, cancellationToken);
 
         var values = new List<string>();
-        await foreach (var entry in grain.GetValues())
+        await foreach (var entry in grain.GetValues(cancellationToken).WithCancellation(cancellationToken))
         {
             values.Add(entry);
             if (values.Count == 2)
@@ -590,7 +609,8 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_SlowConsumer()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
         using var listener = new AsyncEnumerableGrainExtensionListener(grain.GetGrainId());
 
@@ -602,10 +622,10 @@ public class AsyncEnumerableGrainCallTests
             }
 
             await grain.Complete();
-        });
+        }, cts.Token);
 
         var values = new List<string>();
-        await foreach (var entry in grain.GetValues().WithBatchSize(1))
+        await foreach (var entry in grain.GetValues(cts.Token).WithBatchSize(1).WithCancellation(cts.Token))
         {
             values.Add(entry);
 
@@ -631,7 +651,8 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_SlowConsumer_Evicted()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
         using var listener = new AsyncEnumerableGrainExtensionListener(grain.GetGrainId());
 
@@ -643,12 +664,12 @@ public class AsyncEnumerableGrainCallTests
             }
 
             await grain.Complete();
-        });
+        }, cts.Token);
 
         var values = new List<string>();
         try
         {
-            await foreach (var entry in grain.GetValues().WithBatchSize(1))
+            await foreach (var entry in grain.GetValues(cts.Token).WithBatchSize(1).WithCancellation(cts.Token))
             {
                 values.Add(entry);
 
@@ -685,28 +706,29 @@ public class AsyncEnumerableGrainCallTests
     [Fact, TestCategory("BVT"), TestCategory("Observable")]
     public async Task ObservableGrain_AsyncEnumerable_Deactivate()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
 
         var producer = Task.Run(async () =>
         {
             foreach (var value in Enumerable.Range(0, 2))
             {
-                await Task.Delay(200);
+                await Task.Delay(200, cancellationToken);
                 await grain.OnNext(value.ToString());
             }
 
             await grain.Deactivate();
-        });
+        }, cancellationToken);
 
         var values = new List<string>();
         await Assert.ThrowsAsync<EnumerationAbortedException>(async () =>
         {
-            await foreach (var entry in grain.GetValues())
+            await foreach (var entry in grain.GetValues(cancellationToken))
             {
                 values.Add(entry);
                 Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
             }
-        });
+        }).WaitAsync(cancellationToken);
 
         Assert.Equal(2, values.Count);
     }
@@ -716,7 +738,7 @@ public class AsyncEnumerableGrainCallTests
         var cleanupCount = listener.CleanupCount + 1;
         var timer = listener.Timer;
         var timerChangeCount = _fixture.GetTimerChangeCount(timer);
-        await _fixture.AdvanceTimeByResponseTimeoutAsync();
+        await _fixture.AdvanceTimeByResponseTimeoutAsync().WaitAsync(cancellationToken);
         await listener.WaitForCleanupCountAsync(cleanupCount, cancellationToken);
 
         // Cleanup is reported from inside the callback, before the one-shot timer is rearmed.

--- a/test/Orleans.DefaultCluster.Tests/DurableJobsTracingTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/DurableJobsTracingTests.cs
@@ -97,6 +97,7 @@ public class DurableJobsTracingTests : IClassFixture<DurableJobsTracingTests.Fix
     [Fact, TestCategory("BVT"), TestCategory("DurableJobs")]
     public async Task ScheduleAndExecuteShareTraceId()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 
         var grain = _fixture.GrainFactory.GetGrain<IDurableJobGrain>(Guid.NewGuid().ToString());
@@ -113,7 +114,8 @@ public class DurableJobsTracingTests : IClassFixture<DurableJobsTracingTests.Fix
                 scheduledTime: DateTimeOffset.UtcNow.AddMilliseconds(250));
         }
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(1));
         await grain.WaitForJobToRun(job.Id).WaitAsync(cts.Token);
 
         Assert.False(string.IsNullOrEmpty(job.TraceParent), "TraceParent should be persisted on the scheduled job.");
@@ -123,7 +125,7 @@ public class DurableJobsTracingTests : IClassFixture<DurableJobsTracingTests.Fix
         Assert.Equal(expectedTraceId, handlerTraceId);
 
         // Allow the post-execute follow-up storage write (RemoveJob) to settle before snapshotting.
-        await Task.Delay(250);
+        await Task.Delay(250, testCancellationToken);
 
         var traceActivities = CapturedActivities
             .Where(a => a.TraceId.ToString() == expectedTraceId)

--- a/test/Orleans.DefaultCluster.Tests/EchoTaskGrainTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/EchoTaskGrainTests.cs
@@ -90,6 +90,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoGrain_EchoError()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
 
             Task<string> promise = grain.EchoErrorAsync(expectedEchoError);
@@ -101,7 +102,7 @@ namespace DefaultCluster.Tests.General
                 while (exc is AggregateException) exc = exc.InnerException!;
                 string received = exc.Message;
                 Assert.Equal(expectedEchoError, received);
-            }).WaitAsync(timeout);
+            }, cancellationToken).WaitAsync(timeout, cancellationToken);
         }
 
         /// <summary>
@@ -117,6 +118,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("SlowBVT"), TestCategory("Echo"), TestCategory("Timeout")]
         public async Task EchoGrain_Timeout_ContinueWith()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
 
             TimeSpan delay5 = TimeSpan.FromSeconds(30); // grain call timeout (set in config)
@@ -133,7 +135,7 @@ namespace DefaultCluster.Tests.General
                     Exception exc = t.Exception!;
                     while (exc is AggregateException) exc = exc.InnerException!;
                     Assert.IsAssignableFrom<TimeoutException>(exc);
-                }).WaitAsync(delay45);
+                }, cancellationToken).WaitAsync(delay45, cancellationToken);
             sw.Stop();
             Assert.True(TimeIsLonger(sw.Elapsed, delay5), $"Elapsed time out of range: {sw.Elapsed}");
             Assert.True(TimeIsShorter(sw.Elapsed, delay60), $"Elapsed time out of range: {sw.Elapsed}");
@@ -149,6 +151,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("SlowBVT"), TestCategory("Echo")]
         public async Task EchoGrain_Timeout_Await()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
 
             TimeSpan delay5 = TimeSpan.FromSeconds(5);
@@ -157,11 +160,12 @@ namespace DefaultCluster.Tests.General
             sw.Start();
             try
             {
-                int res = await grain.BlockingCallTimeoutAsync(delay25);
+                int res = await grain.BlockingCallTimeoutAsync(delay25).WaitAsync(cancellationToken);
                 Assert.Fail($"BlockingCallTimeout should not have completed successfully, but returned {res}");
             }
             catch (Exception exc)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 while (exc is AggregateException) exc = exc.InnerException!;
                 Assert.IsAssignableFrom<TimeoutException>(exc);
             }
@@ -180,6 +184,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("SlowBVT"), TestCategory("Echo"), TestCategory("Timeout")]
         public async Task EchoGrain_Timeout_Result()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.GrainFactory.GetGrain<IEchoTaskGrain>(Guid.NewGuid());
 
             TimeSpan delay5 = TimeSpan.FromSeconds(5);
@@ -194,12 +199,13 @@ namespace DefaultCluster.Tests.General
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
                     return grain.BlockingCallTimeoutAsync(delay25).Result;
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
-                });
+                }, cancellationToken).WaitAsync(cancellationToken);
 
                 Assert.Fail($"BlockingCallTimeout should not have completed successfully, but returned {res}");
             }
             catch (Exception exc)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 while (exc is AggregateException) exc = exc.InnerException!;
                 Assert.IsAssignableFrom<TimeoutException>(exc);
             }
@@ -221,6 +227,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoGrain_LastEcho()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Stopwatch clock = new Stopwatch();
 
             clock.Start();
@@ -249,7 +256,7 @@ namespace DefaultCluster.Tests.General
                 while (exc is AggregateException) exc = exc.InnerException!;
                 string received = exc.Message;
                 Assert.Equal(expectedEchoError, received);
-            }).WaitAsync(timeout);
+            }, cancellationToken).WaitAsync(timeout, cancellationToken);
 
             clock.Restart();
             received = await grain.GetLastEchoAsync();
@@ -268,6 +275,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoGrain_Ping()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Stopwatch clock = new Stopwatch();
 
             string what = "CreateGrain";
@@ -278,7 +286,7 @@ namespace DefaultCluster.Tests.General
             what = "EchoGrain.Ping";
             clock.Restart();
 
-            await grain.PingAsync().WaitAsync(timeout);
+            await grain.PingAsync().WaitAsync(timeout, cancellationToken);
             this.Logger.LogInformation("{What} took {Elapsed}", what, clock.Elapsed);
         }
 
@@ -292,6 +300,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoGrain_PingSilo_Local()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Stopwatch clock = new Stopwatch();
 
             string what = "CreateGrain";
@@ -301,7 +310,7 @@ namespace DefaultCluster.Tests.General
 
             what = "EchoGrain.PingLocalSilo";
             clock.Restart();
-            await grain.PingLocalSiloAsync().WaitAsync(timeout);
+            await grain.PingLocalSiloAsync().WaitAsync(timeout, cancellationToken);
             this.Logger.LogInformation("{What} took {Elapsed}", what, clock.Elapsed);
         }
 
@@ -315,6 +324,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoGrain_PingSilo_Remote()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Stopwatch clock = new Stopwatch();
 
             string what = "CreateGrain";
@@ -327,12 +337,12 @@ namespace DefaultCluster.Tests.General
 
             what = "EchoGrain.PingRemoteSilo[1]";
             clock.Restart();
-            await grain.PingRemoteSiloAsync(silo1).WaitAsync(timeout);
+            await grain.PingRemoteSiloAsync(silo1).WaitAsync(timeout, cancellationToken);
             this.Logger.LogInformation("{What} took {Elapsed}", what, clock.Elapsed);
 
             what = "EchoGrain.PingRemoteSilo[2]";
             clock.Restart();
-            await grain.PingRemoteSiloAsync(silo2).WaitAsync(timeout);
+            await grain.PingRemoteSiloAsync(silo2).WaitAsync(timeout, cancellationToken);
             this.Logger.LogInformation("{What} took {Elapsed}", what, clock.Elapsed);
         }
 
@@ -346,6 +356,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoGrain_PingSilo_OtherSilo()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Stopwatch clock = new Stopwatch();
 
             string what = "CreateGrain";
@@ -355,7 +366,7 @@ namespace DefaultCluster.Tests.General
 
             what = "EchoGrain.PingOtherSilo";
             clock.Restart();
-            await grain.PingOtherSiloAsync().WaitAsync(timeout);
+            await grain.PingOtherSiloAsync().WaitAsync(timeout, cancellationToken);
             this.Logger.LogInformation("{What} took {Elapsed}", what, clock.Elapsed);
         }
 
@@ -369,6 +380,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT"), TestCategory("Echo")]
         public async Task EchoGrain_PingSilo_OtherSilo_Membership()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Stopwatch clock = new Stopwatch();
 
             string what = "CreateGrain";
@@ -378,7 +390,7 @@ namespace DefaultCluster.Tests.General
 
             what = "EchoGrain.PingOtherSiloMembership";
             clock.Restart();
-            await grain.PingClusterMemberAsync().WaitAsync(timeout);
+            await grain.PingClusterMemberAsync().WaitAsync(timeout, cancellationToken);
             this.Logger.LogInformation("{What} took {Elapsed}", what, clock.Elapsed);
         }
 

--- a/test/Orleans.DefaultCluster.Tests/ErrorGrainTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/ErrorGrainTest.cs
@@ -123,23 +123,24 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]
         public async Task ErrorHandlingTimedMethod()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grainFullName = typeof(ErrorGrain).FullName;
             IErrorGrain grain = this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId(), grainFullName);
 
             Task promise = grain.LongMethodUntilReleased();
             try
             {
-                await grain.WaitForLongMethodToStart().WaitAsync(timeout);
+                await grain.WaitForLongMethodToStart().WaitAsync(timeout, cancellationToken);
                 Assert.False(promise.IsCompleted, "The task shouldn't complete before the grain method is released.");
 
-                await grain.ReleaseLongMethod().WaitAsync(timeout);
-                await promise.WaitAsync(timeout);
+                await grain.ReleaseLongMethod().WaitAsync(timeout, cancellationToken);
+                await promise.WaitAsync(timeout, cancellationToken);
 
                 Assert.Equal(TaskStatus.RanToCompletion, promise.Status);
             }
             finally
             {
-                await grain.ReleaseLongMethod().WaitAsync(timeout);
+                await grain.ReleaseLongMethod().WaitAsync(timeout, cancellationToken);
             }
         }
 
@@ -178,6 +179,7 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("Functional"), TestCategory("ErrorHandling"), TestCategory("Stress")]
         public async Task StressHandlingMultipleDelayedRequests()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             IErrorGrain grain = this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId());
             bool once = true;
             List<Task> tasks = new List<Task>();
@@ -192,7 +194,7 @@ namespace DefaultCluster.Tests
                 }
 
             }
-            await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(20));
+            await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(20), cancellationToken);
         }
 
         /// <summary>
@@ -206,12 +208,13 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("BVT"), TestCategory("ErrorHandling"), TestCategory("GrainReference")]
         public async Task ArgumentTypes_ListOfGrainReferences()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grainFullName = typeof(ErrorGrain).FullName;
             List<IErrorGrain> list = new List<IErrorGrain>();
             IErrorGrain grain = this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId(), grainFullName);
             list.Add(this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId(), grainFullName));
             list.Add(this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId(), grainFullName));
-            await grain.AddChildren(list).WaitAsync(timeout);
+            await grain.AddChildren(list).WaitAsync(timeout, cancellationToken);
         }
 
         /// <summary>

--- a/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
@@ -342,6 +342,7 @@ namespace DefaultCluster.Tests.General
         [Fact]
         public void Generic_SimpleGrainControlFlow_Blocking()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var a = Random.Shared.Next(100);
             var b = a + 1;
             var expected = a + "x" + b;
@@ -350,9 +351,9 @@ namespace DefaultCluster.Tests.General
 
             // explicitly use .Wait() and .Result to make sure the client does not deadlock in these cases.
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-            grain.SetA(a).Wait();
+            grain.SetA(a).Wait(cancellationToken);
 
-            grain.SetB(b).Wait();
+            grain.SetB(b).Wait(cancellationToken);
 
             Task<string> stringPromise = grain.GetAxB();
             Assert.Equal(expected, stringPromise.Result);
@@ -362,6 +363,7 @@ namespace DefaultCluster.Tests.General
         [Fact]
         public async Task Generic_SimpleGrainDataFlow()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var a = Random.Shared.Next(100);
             var b = a + 1;
             var expected = a + "x" + b;
@@ -370,7 +372,7 @@ namespace DefaultCluster.Tests.General
 
             var setAPromise = grain.SetA(a);
             var setBPromise = grain.SetB(b);
-            var stringPromise = Task.WhenAll(setAPromise, setBPromise).ContinueWith((_) => grain.GetAxB()).Unwrap();
+            var stringPromise = Task.WhenAll(setAPromise, setBPromise).ContinueWith((_) => grain.GetAxB(), cancellationToken).Unwrap();
 
             var x = await stringPromise;
             Assert.Equal(expected, x);
@@ -753,7 +755,8 @@ namespace DefaultCluster.Tests.General
                     return false;
                 },
                 timeout: TimeSpan.FromSeconds(30),
-                delayOnFail: TimeSpan.FromMilliseconds(200));
+                delayOnFail: TimeSpan.FromMilliseconds(200),
+                cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(s1, s2);
         }
 

--- a/test/Orleans.DefaultCluster.Tests/GrainReferenceCastTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/GrainReferenceCastTests.cs
@@ -213,10 +213,11 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task FailSideCastAfterContinueWith()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = GrainFactory.GetGrain<IGeneratorTestDerivedGrain1>(GetRandomGrainId());
             IGeneratorTestDerivedGrain2? cast = null;
             var av = grain.StringIsNullOrEmpty();
-            var av2 = av.ContinueWith(t => Assert.True(t.Result))
+            var av2 = av.ContinueWith(t => Assert.True(t.Result), cancellationToken)
                 .ContinueWith(
                     t =>
                     {
@@ -224,14 +225,16 @@ namespace DefaultCluster.Tests
 
                         // Casting is always allowed, so this should succeed.
                         cast = grain.AsReference<IGeneratorTestDerivedGrain2>();
-                    })
+                    },
+                    cancellationToken)
                 .ContinueWith(
                     t =>
                     {
                         // Call a method which the grain does not implement, resulting in a cast failure.
                         Assert.True(t.IsCompletedSuccessfully);
                         return cast!.StringConcat("a", "b", "c");
-                    })
+                    },
+                    cancellationToken)
                 .Unwrap()
                 .ContinueWith(
                     t =>
@@ -240,7 +243,8 @@ namespace DefaultCluster.Tests
                         // This should not throw.
                         Assert.True(t.IsFaulted);
                         return cast!.StringIsNullOrEmpty();
-                    })
+                    },
+                    cancellationToken)
                 .Unwrap();
 
             // Ensure that the last task did not throw.
@@ -443,20 +447,21 @@ namespace DefaultCluster.Tests
         [Fact, TestCategory("BVT"), TestCategory("Cast")]
         public async Task CastCallMethodInheritedFromBaseClass()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Task<bool> isNullStr;
 
             IGeneratorTestDerivedGrain1 grain = this.GrainFactory.GetGrain<IGeneratorTestDerivedGrain1>(GetRandomGrainId());
             isNullStr = grain.StringIsNullOrEmpty();
             Assert.True(await isNullStr, "Value should be null initially");
 
-            isNullStr = grain.StringSet("a").ContinueWith((_) => grain.StringIsNullOrEmpty()).Unwrap();
+            isNullStr = grain.StringSet("a").ContinueWith((_) => grain.StringIsNullOrEmpty(), cancellationToken).Unwrap();
             Assert.False(await isNullStr, "Value should not be null after SetString(a)");
 
-            isNullStr = grain.StringSet(null!).ContinueWith((_) => grain.StringIsNullOrEmpty()).Unwrap();
+            isNullStr = grain.StringSet(null!).ContinueWith((_) => grain.StringIsNullOrEmpty(), cancellationToken).Unwrap();
             Assert.True(await isNullStr, "Value should be null after SetString(null)");
 
             IGeneratorTestGrain cast = grain.AsReference<IGeneratorTestGrain>();
-            isNullStr = cast.StringSet("b").ContinueWith((_) => grain.StringIsNullOrEmpty()).Unwrap();
+            isNullStr = cast.StringSet("b").ContinueWith((_) => grain.StringIsNullOrEmpty(), cancellationToken).Unwrap();
             Assert.False(await isNullStr, "Value should not be null after cast.SetString(b)");
         }
     }

--- a/test/Orleans.DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/HostedClientTests.cs
@@ -44,6 +44,7 @@ namespace DefaultCluster.Tests.General
 
             public async ValueTask InitializeAsync()
             {
+                var cancellationToken = TestContext.Current.CancellationToken;
                 var (siloPort, gatewayPort) = portAllocator.AllocateConsecutivePortPairs(1);
                 Host = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder()
                     .UseOrleans(siloBuilder =>
@@ -60,14 +61,15 @@ namespace DefaultCluster.Tests.General
                             .AddMemoryStreams<DefaultMemoryMessageBodySerializer>("MemStream");
                     })
                     .Build();
-                await Host.StartAsync();
+                await Host.StartAsync(cancellationToken);
             }
 
             public async ValueTask DisposeAsync()
             {
+                var cancellationToken = TestContext.Current.CancellationToken;
                 try
                 {
-                    await Host.StopAsync();
+                    await Host.StopAsync(cancellationToken);
                 }
                 finally
                 {
@@ -107,6 +109,7 @@ namespace DefaultCluster.Tests.General
         [Fact]
         public async Task HostedClient_TimeoutTest()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var client = _host.Services.GetRequiredService<IClusterClient>();
             var runtimeClient = _host.Services.GetRequiredService<IRuntimeClient>();
             var typeResolver = _host.Services.GetRequiredService<GrainInterfaceTypeResolver>();
@@ -128,7 +131,7 @@ namespace DefaultCluster.Tests.General
                             var grain = client.GetGrain<IStuckGrain>(Guid.NewGuid());
                             await grain.RunForever();
                         })
-                    .WaitAsync(maxTimeout);
+                    .WaitAsync(maxTimeout, cancellationToken);
 
                 Assert.Equal(expected: 1, actual: runtimeClient.GetRunningRequestsCount(stuckGrainType));
 
@@ -188,6 +191,7 @@ namespace DefaultCluster.Tests.General
         [Fact]
         public async Task HostedClient_ObserverTest()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var client = _host.Services.GetRequiredService<IClusterClient>();
 
             var handle = new AsyncResultHandle();
@@ -231,7 +235,7 @@ namespace DefaultCluster.Tests.General
             await grain.SetA(3);
             await grain.SetB(2);
 
-            Assert.True(await handle.WaitForFinished(_timeout));
+            Assert.True(await handle.WaitForFinished(_timeout).WaitAsync(cancellationToken));
 
             client.DeleteObjectReference<ISimpleGrainObserver>(reference);
             Assert.NotNull(observer);
@@ -246,6 +250,7 @@ namespace DefaultCluster.Tests.General
         [Fact]
         public async Task HostedClient_StreamTest()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var client = _host.Services.GetRequiredService<IClusterClient>();
 
             var handle = new AsyncResultHandle();
@@ -261,7 +266,7 @@ namespace DefaultCluster.Tests.General
             var stream = client.GetStreamProvider("MemStream").GetStream<int>("hi", Guid.Empty);
             await stream.OnNextAsync(1);
             await stream.OnNextAsync(409);
-            Assert.True(await handle.WaitForFinished(_timeout));
+            Assert.True(await handle.WaitForFinished(_timeout).WaitAsync(cancellationToken));
             Assert.Equal(new[] { 1, 409 }, vals);
         }
     }

--- a/test/Orleans.DefaultCluster.Tests/LifecycleObserverCreationTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/LifecycleObserverCreationTests.cs
@@ -45,7 +45,7 @@ namespace DefaultCluster.Tests.General
             });
 
             var cluster = builder.Build();
-            await cluster.DeployAsync();
+            await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
             try
             {

--- a/test/Orleans.DefaultCluster.Tests/Migration/MigrationTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/Migration/MigrationTests.cs
@@ -246,7 +246,8 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT")]
         public async Task FailDehydrationTest()
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TimeSpan.FromMinutes(1));
             var grain = GrainFactory.GetGrain<IMigrationTestGrain>(GetRandomGrainId());
             var expectedState = Random.Shared.Next();
             await grain.SetState(expectedState);
@@ -264,7 +265,7 @@ namespace DefaultCluster.Tests.General
                 var grainOnOtherSilo = primaryGrainFactory.GetGrain<IMigrationTestGrain>(GetRandomGrainId());
                 var addr = await grainOnOtherSilo.GetGrainAddress();
                 grainOnOtherSiloAddr = addr.SiloAddress;
-                await Task.Delay(100);
+                await Task.Delay(100, cts.Token);
             } while (!targetHost.Equals(grainOnOtherSiloAddr));
 
             // Trigger migration, setting a placement hint to coerce the placement director to use the target silo
@@ -321,6 +322,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("BVT")]
         public async Task StuckDeactivatingActivationIsAbandoned()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = GrainFactory.GetGrain<IStuckDeactivationTestGrain>(GetRandomGrainId());
             var grainId = grain.GetGrainId();
             var originalAddress = await grain.GetGrainAddress();
@@ -329,11 +331,11 @@ namespace DefaultCluster.Tests.General
 
             try
             {
-                await grain.WaitUntilBlocked().WaitAsync(TimeSpan.FromSeconds(10));
-                await grain.StartMigrationTo(targetHost).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
-                await Task.Delay(TimeSpan.FromSeconds(1));
+                await grain.WaitUntilBlocked().WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+                await grain.StartMigrationTo(targetHost).AsTask().WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
 
-                var newAddress = await grain.GetGrainAddress().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+                var newAddress = await grain.GetGrainAddress().AsTask().WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
 
                 Assert.NotEqual(originalAddress.ActivationId, newAddress.ActivationId);
             }
@@ -342,7 +344,8 @@ namespace DefaultCluster.Tests.General
                 StuckDeactivationTestGrain.Release(grainId);
             }
 
-            var completed = await Task.WhenAny(blockingCall, Task.Delay(TimeSpan.FromSeconds(10)));
+            var completed = await Task.WhenAny(blockingCall, Task.Delay(TimeSpan.FromSeconds(10), cancellationToken));
+            cancellationToken.ThrowIfCancellationRequested();
             Assert.Same(blockingCall, completed);
             await blockingCall;
         }

--- a/test/Orleans.DefaultCluster.Tests/MultifacetGrainTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/MultifacetGrainTest.cs
@@ -37,11 +37,12 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("Functional"), TestCategory("Cast")]
         public async Task RWReferences()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             writer = this.GrainFactory.GetGrain<IMultifacetWriter>(GetRandomGrainId());
             reader = writer.AsReference<IMultifacetReader>();
 
             int x = 1234;
-            await writer.SetValue(x).WaitAsync(timeout);
+            await writer.SetValue(x).WaitAsync(timeout, cancellationToken);
             int y = await reader.GetValue();
             Assert.Equal(x, y);
         }

--- a/test/Orleans.DefaultCluster.Tests/StatelessWorkerTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/StatelessWorkerTests.cs
@@ -63,6 +63,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("SlowBVT"), TestCategory("StatelessWorker")]
         public async Task StatelessWorkerActivationsPerSiloDoNotExceedMaxLocalWorkersCount()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var gatewayOptions = this.Fixture.Client.ServiceProvider.GetRequiredService<IOptions<StaticGatewayListProviderOptions>>();
             var gatewaysCount = gatewayOptions.Value.Gateways.Count;
             // do extra calls to trigger activation of ExpectedMaxLocalActivations local activations
@@ -76,7 +77,7 @@ namespace DefaultCluster.Tests.General
                 promises.Add(grain.LongCall());
             await Task.WhenAll(promises);
 
-            await Task.Delay(2000);
+            await Task.Delay(2000, cancellationToken);
 
             promises.Clear();
             var stopwatch = Stopwatch.StartNew();
@@ -187,13 +188,14 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("SlowBVT"), TestCategory("StatelessWorker")]
         public async Task StatelessWorker_DoesNotThrow_IfMarkedWithMayInterleave()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = GrainFactory.GetGrain<IStatelessWorkerWithMayInterleaveGrain>(0);
             var observer = new CallbackObserver();
             var reference = GrainFactory.CreateObjectReference<ICallbackGrainObserver>(observer);
             var task = grain.GoFast(reference);
-            await observer.OnCallback.WaitAsync(TimeSpan.FromSeconds(10));
+            await observer.OnCallback.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
             observer.Signal();
-            await task;
+            await task.WaitAsync(cancellationToken);
         }
 
         /// <summary>
@@ -207,6 +209,7 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("SlowBVT"), TestCategory("StatelessWorker")]
         public async Task StatelessWorker_ShouldNotInterleaveCalls_IfMayInterleavePredicatedDoesntMatch()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = GrainFactory.GetGrain<IStatelessWorkerWithMayInterleaveGrain>(0);
 
             List<CallbackObserver> callbacks = [new(), new(), new()];
@@ -214,11 +217,19 @@ namespace DefaultCluster.Tests.General
             List<Task> completions = [grain.GoSlow(callbackReferences[0]), grain.GoSlow(callbackReferences[1]), grain.GoSlow(callbackReferences[2])];
             var callbackSignals = callbacks.Select(c => c.OnCallback).ToList();
 
-            var triggered = await Task.WhenAny(callbackSignals).WaitAsync(TimeSpan.FromSeconds(10));
+            var triggered = await Task.WhenAny(callbackSignals).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
             callbackSignals.Remove(triggered);
-            await Assert.ThrowsAsync<TimeoutException>(async () => await Task.WhenAny(callbackSignals).WaitAsync(TimeSpan.FromSeconds(5)));
+            try
+            {
+                await Task.WhenAny(callbackSignals).WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+                Assert.Fail("A second callback should not have been triggered.");
+            }
+            catch (TimeoutException)
+            {
+            }
+
             callbacks.ForEach(c => c.Signal());
-            await Task.WhenAll(completions).WaitAsync(TimeSpan.FromSeconds(10));
+            await Task.WhenAll(completions).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
         }
 
         /// <summary>
@@ -232,7 +243,8 @@ namespace DefaultCluster.Tests.General
         [Fact, TestCategory("SlowBVT"), TestCategory("StatelessWorker")]
         public async Task StatelessWorker_ShouldInterleaveCalls_IfMayInterleavePredicatedMatches()
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
             var grain = GrainFactory.GetGrain<IStatelessWorkerWithMayInterleaveGrain>(0);
 
             List<CallbackObserver> callbacks = [new(), new(), new()];
@@ -243,7 +255,7 @@ namespace DefaultCluster.Tests.General
             await Task.WhenAll(callbacks.Select(c => c.OnCallback)).WaitAsync(cts.Token);
             callbacks.ForEach(c => c.Signal());
 
-            await completion;
+            await completion.WaitAsync(cts.Token);
         }
 
         private sealed class CallbackObserver : ICallbackGrainObserver

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/IJobShardManagerTestFixture.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/IJobShardManagerTestFixture.cs
@@ -15,7 +15,7 @@ namespace Orleans.DurableJobs.Tests;
 
 public interface IJobShardManagerTestFixture
 {
-    Task<IJobShardManagerTestScope> CreateScopeAsync();
+    Task<IJobShardManagerTestScope> CreateScopeAsync(CancellationToken cancellationToken);
 }
 
 public interface IJobShardManagerTestScope : IAsyncDisposable
@@ -39,8 +39,9 @@ public sealed record TestSilo(SiloAddress SiloAddress);
 
 public sealed class VolatileJobShardManagerTestFixture : IJobShardManagerTestFixture
 {
-    public Task<IJobShardManagerTestScope> CreateScopeAsync()
+    public Task<IJobShardManagerTestScope> CreateScopeAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var builder = new TestSiloBuilder();
         builder.AddJournalStorage();
         builder.UseJsonJournalFormat(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -35,14 +35,15 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task ShardCreationAndAssignmentUsesDistinctShardIdsForSameWindow()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var manager = scope.CreateManager(scope.ActiveSilo);
         var now = scope.Now;
 
-        var shard1 = await manager.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string> { ["index"] = "1" }, CancellationToken.None);
-        var shard2 = await manager.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string> { ["index"] = "2" }, CancellationToken.None);
+        var shard1 = await manager.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string> { ["index"] = "1" }, cancellationToken);
+        var shard2 = await manager.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string> { ["index"] = "2" }, cancellationToken);
 
-        var assigned = await manager.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None);
+        var assigned = await manager.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken);
 
         Assert.Equal(2, assigned.Count);
         Assert.NotEqual(shard1.Id, shard2.Id);
@@ -53,19 +54,20 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task DeadOwnerShardIsReassignedAndPreservesQueuedJobOrderAndMetadata()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var formerOwner = scope.CreateManager(scope.FormerOwnerSilo);
         var newOwner = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var shard = await formerOwner.CreateShardAsync(now.AddMinutes(-5), now.AddMinutes(5), Metadata("stream", "alpha"), CancellationToken.None);
-        var later = await ScheduleJobAsync(shard, now.AddSeconds(-1), "later", Metadata("kind", "later"));
-        var earlier = await ScheduleJobAsync(shard, now.AddSeconds(-2), "earlier", Metadata("kind", "symbols=+/&?"));
+        var shard = await formerOwner.CreateShardAsync(now.AddMinutes(-5), now.AddMinutes(5), Metadata("stream", "alpha"), cancellationToken);
+        var later = await ScheduleJobAsync(shard, now.AddSeconds(-1), "later", cancellationToken, Metadata("kind", "later"));
+        var earlier = await ScheduleJobAsync(shard, now.AddSeconds(-2), "earlier", cancellationToken, Metadata("kind", "symbols=+/&?"));
 
         scope.SetSiloStatus(scope.FormerOwnerSilo, SiloStatus.Dead);
 
-        var assigned = await newOwner.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None);
+        var assigned = await newOwner.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken);
         var reassigned = Assert.Single(assigned);
-        var runs = await TakeAsync(reassigned, 2);
+        var runs = await TakeAsync(reassigned, 2, cancellationToken);
 
         Assert.Equal(shard.Id, reassigned.Id);
         Assert.True(reassigned.IsAddingCompleted);
@@ -77,19 +79,20 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task OpenAndClosedShardsAreReassignedAfterFailover()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var formerOwner = scope.CreateManager(scope.FormerOwnerSilo);
         var newOwner = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var closed = await formerOwner.CreateShardAsync(now, now.AddMinutes(5), Metadata("state", "closed"), CancellationToken.None);
-        await ScheduleJobAsync(closed, now.AddMinutes(-1), "closed-job");
-        await formerOwner.UnregisterShardAsync(closed, CancellationToken.None);
-        var open = await formerOwner.CreateShardAsync(now.AddMinutes(1), now.AddMinutes(6), Metadata("state", "open"), CancellationToken.None);
-        await ScheduleJobAsync(open, now.AddMinutes(1), "open-job");
+        var closed = await formerOwner.CreateShardAsync(now, now.AddMinutes(5), Metadata("state", "closed"), cancellationToken);
+        await ScheduleJobAsync(closed, now.AddMinutes(-1), "closed-job", cancellationToken);
+        await formerOwner.UnregisterShardAsync(closed, cancellationToken);
+        var open = await formerOwner.CreateShardAsync(now.AddMinutes(1), now.AddMinutes(6), Metadata("state", "open"), cancellationToken);
+        await ScheduleJobAsync(open, now.AddMinutes(1), "open-job", cancellationToken);
 
         scope.SetSiloStatus(scope.FormerOwnerSilo, SiloStatus.Dead);
 
-        var assigned = await newOwner.AssignJobShardsAsync(now.AddMinutes(10), int.MaxValue, CancellationToken.None);
+        var assigned = await newOwner.AssignJobShardsAsync(now.AddMinutes(10), int.MaxValue, cancellationToken);
 
         Assert.Equal(2, assigned.Count);
         Assert.Contains(assigned, shard => shard.Id == open.Id);
@@ -100,15 +103,16 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task LiveShardSchedulesAndConsumesJobsInDueTimeOrder()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var manager = scope.CreateManager(scope.ActiveSilo);
         var now = scope.Now;
-        var shard = await manager.CreateShardAsync(now.AddMinutes(-1), now.AddMinutes(5), Metadata("stream", "live"), CancellationToken.None);
-        var later = await ScheduleJobAsync(shard, now.AddSeconds(-1), "later");
-        var earlier = await ScheduleJobAsync(shard, now.AddSeconds(-2), "earlier");
+        var shard = await manager.CreateShardAsync(now.AddMinutes(-1), now.AddMinutes(5), Metadata("stream", "live"), cancellationToken);
+        var later = await ScheduleJobAsync(shard, now.AddSeconds(-1), "later", cancellationToken);
+        var earlier = await ScheduleJobAsync(shard, now.AddSeconds(-2), "earlier", cancellationToken);
 
-        var assignedShard = Assert.Single(await manager.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
-        var runs = await TakeAsync(assignedShard, 2);
+        var assignedShard = Assert.Single(await manager.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken));
+        var runs = await TakeAsync(assignedShard, 2, cancellationToken);
 
         Assert.Equal([earlier!.Id, later!.Id], runs.Select(run => run.Job.Id).ToArray());
     }
@@ -116,18 +120,19 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task ConcurrentOwnershipConflictAllowsOnlyOneManagerToClaimShard()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var creator = scope.CreateManager(scope.ActiveSilo);
         var claimant1 = scope.CreateManager(scope.SecondActiveSilo);
         var claimant2 = scope.CreateManager(scope.ThirdActiveSilo);
         var now = scope.Now;
-        var shard = await creator.CreateShardAsync(now, now.AddMinutes(5), Metadata("conflict", "true"), CancellationToken.None);
-        await ScheduleJobAsync(shard, now.AddMinutes(-1), "conflict-job");
-        await creator.UnregisterShardAsync(shard, CancellationToken.None);
+        var shard = await creator.CreateShardAsync(now, now.AddMinutes(5), Metadata("conflict", "true"), cancellationToken);
+        await ScheduleJobAsync(shard, now.AddMinutes(-1), "conflict-job", cancellationToken);
+        await creator.UnregisterShardAsync(shard, cancellationToken);
 
         var claims = await Task.WhenAll(
-            claimant1.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None),
-            claimant2.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
+            claimant1.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken),
+            claimant2.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken)).WaitAsync(cancellationToken);
 
         Assert.Single(claims.SelectMany(static claim => claim));
     }
@@ -135,7 +140,8 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task MetadataIsPreservedAcrossGracefulReassignmentIncludingSpecialCharacters()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var first = scope.CreateManager(scope.ActiveSilo);
         var second = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
@@ -145,11 +151,11 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
             ["symbols-key"] = "symbols=+/&?",
             ["slash/key"] = "slash-value"
         };
-        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), metadata, CancellationToken.None);
-        await ScheduleJobAsync(shard, now.AddMinutes(-1), "metadata-job");
-        await first.UnregisterShardAsync(shard, CancellationToken.None);
+        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), metadata, cancellationToken);
+        await ScheduleJobAsync(shard, now.AddMinutes(-1), "metadata-job", cancellationToken);
+        await first.UnregisterShardAsync(shard, cancellationToken);
 
-        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken));
 
         Assert.Equal(metadata, reassigned.Metadata);
     }
@@ -157,21 +163,22 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task UnregisterWithJobsRemainingPreservesShardForLaterReassignment()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var first = scope.CreateManager(scope.ActiveSilo);
         var second = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), Metadata("purpose", "stop-processing"), CancellationToken.None);
-        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "remaining-job");
+        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), Metadata("purpose", "stop-processing"), cancellationToken);
+        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "remaining-job", cancellationToken);
 
-        await first.UnregisterShardAsync(shard, CancellationToken.None);
+        await first.UnregisterShardAsync(shard, cancellationToken);
 
-        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
-        var run = await TakeOneAsync(reassigned);
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken));
+        var run = await TakeOneAsync(reassigned, cancellationToken);
 
         Assert.True(reassigned.IsAddingCompleted);
         Assert.Equal(job!.Id, run.Job.Id);
-        Assert.Null(await reassigned.TryScheduleJobAsync(CreateRequest(now.AddMinutes(1), "rejected"), CancellationToken.None));
+        Assert.Null(await reassigned.TryScheduleJobAsync(CreateRequest(now.AddMinutes(1), "rejected"), cancellationToken));
     }
 
     [Fact]
@@ -198,19 +205,20 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task RetryLaterPersistsThroughShardReassignment()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var first = scope.CreateManager(scope.ActiveSilo);
         var second = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), CancellationToken.None);
-        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "retry-job");
-        var run = await TakeOneAsync(shard);
+        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), cancellationToken);
+        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "retry-job", cancellationToken);
+        var run = await TakeOneAsync(shard, cancellationToken);
 
-        await shard.RetryJobLaterAsync(run, now.AddMinutes(-1), CancellationToken.None);
-        await first.UnregisterShardAsync(shard, CancellationToken.None);
+        await shard.RetryJobLaterAsync(run, now.AddMinutes(-1), cancellationToken);
+        await first.UnregisterShardAsync(shard, cancellationToken);
 
-        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
-        var retried = await TakeOneAsync(reassigned);
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken));
+        var retried = await TakeOneAsync(reassigned, cancellationToken);
 
         Assert.Equal(job!.Id, retried.Job.Id);
         Assert.Equal(run.DequeueCount + 1, retried.DequeueCount);
@@ -219,19 +227,20 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task SuccessfulReschedulePersistsResetAttemptThroughShardReassignment()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var first = scope.CreateManager(scope.ActiveSilo);
         var second = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), CancellationToken.None);
-        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "rescheduled-job");
-        var run = await TakeOneAsync(shard);
+        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), cancellationToken);
+        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "rescheduled-job", cancellationToken);
+        var run = await TakeOneAsync(shard, cancellationToken);
 
-        await shard.RescheduleJobAsync(run, now.AddMinutes(-1), CancellationToken.None);
-        await first.UnregisterShardAsync(shard, CancellationToken.None);
+        await shard.RescheduleJobAsync(run, now.AddMinutes(-1), cancellationToken);
+        await first.UnregisterShardAsync(shard, cancellationToken);
 
-        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
-        var rescheduled = await TakeOneAsync(reassigned);
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken));
+        var rescheduled = await TakeOneAsync(reassigned, cancellationToken);
 
         Assert.Equal(job!.Id, rescheduled.Job.Id);
         Assert.Equal(1, rescheduled.DequeueCount);
@@ -242,28 +251,29 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task CancellationsBeforeAndDuringProcessingPersistAfterReassignment()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var first = scope.CreateManager(scope.ActiveSilo);
         var second = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var shard = await first.CreateShardAsync(now.AddMinutes(-5), now.AddMinutes(5), new Dictionary<string, string>(), CancellationToken.None);
-        var cancelBeforeRun = await ScheduleJobAsync(shard, now.AddMinutes(-3), "cancel-before");
-        var cancelDuringRun = await ScheduleJobAsync(shard, now.AddMinutes(-2), "cancel-during");
-        var remaining = await ScheduleJobAsync(shard, now.AddMinutes(-1), "remaining");
+        var shard = await first.CreateShardAsync(now.AddMinutes(-5), now.AddMinutes(5), new Dictionary<string, string>(), cancellationToken);
+        var cancelBeforeRun = await ScheduleJobAsync(shard, now.AddMinutes(-3), "cancel-before", cancellationToken);
+        var cancelDuringRun = await ScheduleJobAsync(shard, now.AddMinutes(-2), "cancel-during", cancellationToken);
+        var remaining = await ScheduleJobAsync(shard, now.AddMinutes(-1), "remaining", cancellationToken);
 
         Assert.Equal(
             DurableJobMutationResult.Applied,
-            await shard.RemoveJobAsync(cancelBeforeRun!.Id, CancellationToken.None));
-        var running = await TakeOneAsync(shard);
+            await shard.RemoveJobAsync(cancelBeforeRun!.Id, cancellationToken));
+        var running = await TakeOneAsync(shard, cancellationToken);
         Assert.Equal(cancelDuringRun!.Id, running.Job.Id);
         Assert.Equal(
             DurableJobMutationResult.Applied,
-            await shard.RemoveJobAsync(running.Job.Id, CancellationToken.None));
-        await shard.RetryJobLaterAsync(running, now.AddMinutes(-1), CancellationToken.None);
-        await first.UnregisterShardAsync(shard, CancellationToken.None);
+            await shard.RemoveJobAsync(running.Job.Id, cancellationToken));
+        await shard.RetryJobLaterAsync(running, now.AddMinutes(-1), cancellationToken);
+        await first.UnregisterShardAsync(shard, cancellationToken);
 
-        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
-        var run = await TakeOneAsync(reassigned);
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken));
+        var run = await TakeOneAsync(reassigned, cancellationToken);
 
         Assert.Equal(remaining!.Id, run.Job.Id);
         Assert.Equal(1, await reassigned.GetJobCountAsync());
@@ -272,25 +282,26 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task SlowStartRespectsZeroLimitedUnlimitedAndRepeatedBudgets()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var creator = scope.CreateManager(scope.ActiveSilo);
         var claimant = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var ownedShard = await claimant.CreateShardAsync(now, now.AddMinutes(1), Metadata("owner", "claimant"), CancellationToken.None);
+        var ownedShard = await claimant.CreateShardAsync(now, now.AddMinutes(1), Metadata("owner", "claimant"), cancellationToken);
         var orphanedShardIds = new List<string>();
 
         for (var i = 0; i < 3; i++)
         {
-            var shard = await creator.CreateShardAsync(now.AddMinutes(i), now.AddMinutes(i + 1), Metadata("index", i.ToString()), CancellationToken.None);
+            var shard = await creator.CreateShardAsync(now.AddMinutes(i), now.AddMinutes(i + 1), Metadata("index", i.ToString()), cancellationToken);
             orphanedShardIds.Add(shard.Id);
         }
 
         scope.SetSiloStatus(scope.ActiveSilo, SiloStatus.Dead);
 
-        var zeroBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), maxNewClaims: 0, CancellationToken.None);
-        var firstLimitedBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), maxNewClaims: 1, CancellationToken.None);
-        var secondLimitedBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), maxNewClaims: 1, CancellationToken.None);
-        var unlimitedBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), int.MaxValue, CancellationToken.None);
+        var zeroBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), maxNewClaims: 0, cancellationToken);
+        var firstLimitedBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), maxNewClaims: 1, cancellationToken);
+        var secondLimitedBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), maxNewClaims: 1, cancellationToken);
+        var unlimitedBudget = await claimant.AssignJobShardsAsync(now.AddMinutes(10), int.MaxValue, cancellationToken);
 
         Assert.Collection(zeroBudget, shard => Assert.Equal(ownedShard.Id, shard.Id));
         Assert.Equal(2, firstLimitedBudget.Count);
@@ -309,7 +320,12 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
             Metadata = metadata
         };
 
-    private static async Task<DurableJob?> ScheduleJobAsync(IJobShard shard, DateTimeOffset dueTime, string jobName, IReadOnlyDictionary<string, string>? metadata = null)
+    private static async Task<DurableJob?> ScheduleJobAsync(
+        IJobShard shard,
+        DateTimeOffset dueTime,
+        string jobName,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, string>? metadata = null)
     {
         if (dueTime < shard.StartTime)
         {
@@ -320,15 +336,17 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
             dueTime = shard.EndTime;
         }
 
-        return await shard.TryScheduleJobAsync(CreateRequest(dueTime, jobName, metadata), CancellationToken.None);
+        return await shard.TryScheduleJobAsync(CreateRequest(dueTime, jobName, metadata), cancellationToken);
     }
 
-    private static async Task<IJobRunContext> TakeOneAsync(IJobShard shard) => (await TakeAsync(shard, 1))[0];
+    private static async Task<IJobRunContext> TakeOneAsync(IJobShard shard, CancellationToken cancellationToken)
+        => (await TakeAsync(shard, 1, cancellationToken))[0];
 
-    private static async Task<List<IJobRunContext>> TakeAsync(IJobShard shard, int count)
+    private static async Task<List<IJobRunContext>> TakeAsync(IJobShard shard, int count, CancellationToken cancellationToken)
     {
         var result = new List<IJobRunContext>();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(30));
         await foreach (var run in shard.ConsumeDurableJobsAsync().WithCancellation(cts.Token))
         {
             result.Add(run);

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JobShardManagerTestsRunner.cs
@@ -15,10 +15,11 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [InlineData(" ")]
     public async Task TryScheduleJobAsync_InvalidJobName_Throws(string? jobName)
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var manager = scope.CreateManager(scope.ActiveSilo);
         var now = scope.Now;
-        var shard = await manager.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), CancellationToken.None);
+        var shard = await manager.CreateShardAsync(now, now.AddMinutes(5), new Dictionary<string, string>(), cancellationToken);
         var request = new ScheduleJobRequest
         {
             Target = GrainId.Create("durable-job-test", "target"),
@@ -27,7 +28,7 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
         };
 
         var exception = await Assert.ThrowsAnyAsync<ArgumentException>(
-            () => shard.TryScheduleJobAsync(request, CancellationToken.None));
+            () => shard.TryScheduleJobAsync(request, cancellationToken));
 
         Assert.Equal("JobName", exception.ParamName);
     }
@@ -184,18 +185,19 @@ public abstract class JobShardManagerTestsRunner(IJobShardManagerTestFixture fix
     [Fact]
     public async Task AttemptCancellationPreservesJobForReassignment()
     {
-        await using var scope = await fixture.CreateScopeAsync();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var scope = await fixture.CreateScopeAsync(cancellationToken);
         var first = scope.CreateManager(scope.ActiveSilo);
         var second = scope.CreateManager(scope.SecondActiveSilo);
         var now = scope.Now;
-        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), Metadata("purpose", "attempt-cancellation"), CancellationToken.None);
-        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "attempt-canceled-job");
-        var firstAttempt = await TakeOneAsync(shard);
+        var shard = await first.CreateShardAsync(now, now.AddMinutes(5), Metadata("purpose", "attempt-cancellation"), cancellationToken);
+        var job = await ScheduleJobAsync(shard, now.AddMinutes(-1), "attempt-canceled-job", cancellationToken);
+        var firstAttempt = await TakeOneAsync(shard, cancellationToken);
 
-        await first.UnregisterShardAsync(shard, CancellationToken.None);
+        await first.UnregisterShardAsync(shard, cancellationToken);
 
-        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, CancellationToken.None));
-        var secondAttempt = await TakeOneAsync(reassigned);
+        var reassigned = Assert.Single(await second.AssignJobShardsAsync(now.AddMinutes(5), int.MaxValue, cancellationToken));
+        var secondAttempt = await TakeOneAsync(reassigned, cancellationToken);
 
         Assert.Equal(job!.Id, secondAttempt.Job.Id);
         Assert.NotEqual(firstAttempt.RunId, secondAttempt.RunId);

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
@@ -296,6 +296,7 @@ public class JournaledJobShardManagerTests
     [Fact]
     public async Task AttemptReservation_WaitsForPrecedingRemovalToPersist()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new CountingJournalStorageProvider(delayAppends: false);
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -311,24 +312,24 @@ public class JournaledJobShardManagerTests
             start,
             start.AddHours(1),
             new Dictionary<string, string> { ["Purpose"] = "AttemptReservationPersistence" },
-            CancellationToken.None);
-        var scheduled = await ScheduleJobAsync(shard, "attempt-reservation-persistence");
-        await using var enumerator = shard.ConsumeDurableJobsAsync().GetAsyncEnumerator(TestContext.Current.CancellationToken);
+            cancellationToken);
+        var scheduled = await ScheduleJobAsync(shard, "attempt-reservation-persistence", cancellationToken);
+        await using var enumerator = shard.ConsumeDurableJobsAsync().GetAsyncEnumerator(cancellationToken);
         Assert.True(await enumerator.MoveNextAsync());
         var jobContext = enumerator.Current;
 
         storageProvider.BlockAppends();
-        var removeTask = shard.RemoveJobAsync(scheduled.Id, CancellationToken.None);
-        var startAttemptTask = shard.TryStartAttemptAsync(jobContext, CancellationToken.None);
+        var removeTask = shard.RemoveJobAsync(scheduled.Id, cancellationToken);
+        var startAttemptTask = shard.TryStartAttemptAsync(jobContext, cancellationToken);
 
-        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
         Assert.False(startAttemptTask.IsCompleted);
 
         storageProvider.AllowAppends();
         Assert.Equal(DurableJobMutationResult.Applied, await removeTask);
         Assert.Equal(DurableJobMutationResult.JobNotFound, await startAttemptTask);
 
-        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+        await manager.UnregisterShardAsync(shard, cancellationToken);
     }
 
     [Fact]

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
@@ -26,6 +26,7 @@ public class JournaledJobShardManagerTests
     [Fact]
     public async Task ReleasedShard_IsClaimedClosedAndReplayedFromJournal()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -42,7 +43,7 @@ public class JournaledJobShardManagerTests
             start,
             end,
             new Dictionary<string, string> { ["Purpose"] = "JournaledManagerTest" },
-            CancellationToken.None);
+            cancellationToken);
 
         var scheduled = await shard.TryScheduleJobAsync(new()
         {
@@ -50,12 +51,12 @@ public class JournaledJobShardManagerTests
             JobName = "job",
             DueTime = DateTimeOffset.UtcNow.AddSeconds(-1),
             Metadata = new Dictionary<string, string> { ["Kind"] = "Replay" }
-        }, CancellationToken.None);
+        }, cancellationToken);
         Assert.NotNull(scheduled);
 
-        await manager1.UnregisterShardAsync(shard, CancellationToken.None);
+        await manager1.UnregisterShardAsync(shard, cancellationToken);
 
-        var claimed = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
+        var claimed = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken);
         var claimedShard = Assert.Single(claimed);
         Assert.True(claimedShard.IsAddingCompleted);
         Assert.Equal("JournaledManagerTest", claimedShard.Metadata!["Purpose"]);
@@ -66,14 +67,14 @@ public class JournaledJobShardManagerTests
             JobName = "new-job",
             DueTime = DateTimeOffset.UtcNow,
             Metadata = null
-        }, CancellationToken.None);
+        }, cancellationToken);
         Assert.Null(rejected);
 
         var consumed = new List<IJobRunContext>();
-        await foreach (var jobContext in claimedShard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
+        await foreach (var jobContext in claimedShard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
         {
             consumed.Add(jobContext);
-            await claimedShard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None);
+            await claimedShard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
         }
 
         var replayed = Assert.Single(consumed);
@@ -81,13 +82,14 @@ public class JournaledJobShardManagerTests
         Assert.Equal("Replay", replayed.Job.Metadata!["Kind"]);
         Assert.Equal(1, replayed.DequeueCount);
 
-        await manager2.UnregisterShardAsync(claimedShard, CancellationToken.None);
-        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None));
+        await manager2.UnregisterShardAsync(claimedShard, cancellationToken);
+        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken));
     }
 
     [Fact]
     public async Task EmptyShard_IsDeletedWhenUnregistered()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -100,22 +102,23 @@ public class JournaledJobShardManagerTests
             start,
             start.AddHours(1),
             new Dictionary<string, string> { ["Purpose"] = "EmptyShardDelete" },
-            CancellationToken.None);
+            cancellationToken);
         var storageId = ((JournaledJobShard)shard).StorageId;
 
-        Assert.NotNull(await storageProvider.CreateStorage(storageId).GetMetadataAsync(TestContext.Current.CancellationToken));
+        Assert.NotNull(await storageProvider.CreateStorage(storageId).GetMetadataAsync(cancellationToken));
 
-        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+        await manager.UnregisterShardAsync(shard, cancellationToken);
 
-        Assert.Null(await storageProvider.CreateStorage(storageId).GetMetadataAsync(TestContext.Current.CancellationToken));
+        Assert.Null(await storageProvider.CreateStorage(storageId).GetMetadataAsync(cancellationToken));
         Assert.Empty(await ToListAsync(storageProvider.ListAsync(
             JobShardId.StoragePrefix,
-            TestContext.Current.CancellationToken)));
+            cancellationToken), cancellationToken));
     }
 
     [Fact]
     public async Task ClosedLocalShard_CanStillPersistRemovals()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -128,21 +131,21 @@ public class JournaledJobShardManagerTests
             start,
             start.AddHours(1),
             new Dictionary<string, string> { ["Purpose"] = "ClosedLocalShard" },
-            CancellationToken.None);
+            cancellationToken);
         var scheduled = await shard.TryScheduleJobAsync(new()
         {
             Target = GrainId.Create("type", "target"),
             JobName = "closed-local-job",
             DueTime = DateTimeOffset.UtcNow.AddSeconds(-1),
             Metadata = null
-        }, CancellationToken.None);
+        }, cancellationToken);
         Assert.NotNull(scheduled);
 
-        await shard.MarkAsCompleteAsync(CancellationToken.None);
-        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+        await shard.MarkAsCompleteAsync(cancellationToken);
+        await manager.UnregisterShardAsync(shard, cancellationToken);
 
         var reopenedManager = CreateManager(services, membership, silo);
-        var reopened = await reopenedManager.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
+        var reopened = await reopenedManager.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken);
         shard = Assert.Single(reopened);
         Assert.True(shard.IsAddingCompleted);
 
@@ -152,24 +155,25 @@ public class JournaledJobShardManagerTests
             JobName = "rejected-job",
             DueTime = DateTimeOffset.UtcNow,
             Metadata = null
-        }, CancellationToken.None);
+        }, cancellationToken);
         Assert.Null(rejected);
 
-        await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
+        await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
         {
             Assert.Equal(scheduled.Id, jobContext.Job.Id);
             Assert.Equal(
                 DurableJobMutationResult.Applied,
-                await shard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None));
+                await shard.RemoveJobAsync(jobContext.Job.Id, cancellationToken));
         }
 
         Assert.Equal(0, await shard.GetJobCountAsync());
-        await reopenedManager.UnregisterShardAsync(shard, CancellationToken.None);
+        await reopenedManager.UnregisterShardAsync(shard, cancellationToken);
     }
 
     [Fact]
     public async Task ConcurrentSchedules_ArePersistedInStorageBatches()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         const int JobCount = 32;
         var storageProvider = new CountingJournalStorageProvider(delayAppends: true);
         using var services = CreateServices(storageProvider);
@@ -183,7 +187,7 @@ public class JournaledJobShardManagerTests
             start,
             end,
             new Dictionary<string, string> { ["Purpose"] = "ConcurrentBatching" },
-            CancellationToken.None);
+            cancellationToken);
         var observedBatchSizes = new ConcurrentBag<long>();
         using var listener = CreateStorageBatchSizeListener(observedBatchSizes);
 
@@ -194,14 +198,14 @@ public class JournaledJobShardManagerTests
                 JobName = $"batched-job-{index}",
                 DueTime = start.AddSeconds(1),
                 Metadata = null
-            }, CancellationToken.None))
+            }, cancellationToken))
             .ToArray();
 
-        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
         storageProvider.AllowAppends();
         var scheduledJobs = await Task.WhenAll(scheduleTasks).WaitAsync(
             TimeSpan.FromSeconds(5),
-            TestContext.Current.CancellationToken);
+            cancellationToken);
 
         Assert.All(scheduledJobs, job => Assert.NotNull(job));
         Assert.True(
@@ -209,16 +213,16 @@ public class JournaledJobShardManagerTests
             $"Expected fewer storage appends than scheduled jobs, but saw {storageProvider.AppendCount} appends for {JobCount} jobs.");
         Assert.Contains(observedBatchSizes, size => size > 1);
 
-        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+        await manager.UnregisterShardAsync(shard, cancellationToken);
 
         var reopenedManager = CreateManager(services, membership, silo);
-        var reopened = await reopenedManager.AssignJobShardsAsync(end, int.MaxValue, CancellationToken.None);
+        var reopened = await reopenedManager.AssignJobShardsAsync(end, int.MaxValue, cancellationToken);
         var reopenedShard = Assert.Single(reopened);
         var consumed = new List<IJobRunContext>();
-        await foreach (var jobContext in reopenedShard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
+        await foreach (var jobContext in reopenedShard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
         {
             consumed.Add(jobContext);
-            await reopenedShard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None);
+            await reopenedShard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
         }
 
         Assert.Equal(JobCount, consumed.Count);
@@ -226,12 +230,13 @@ public class JournaledJobShardManagerTests
             consumed.Select(context => context.Job.Id).ToHashSet(StringComparer.Ordinal),
             scheduledJobs.Select(job => job!.Id).ToHashSet(StringComparer.Ordinal));
 
-        await reopenedManager.UnregisterShardAsync(reopenedShard, CancellationToken.None);
+        await reopenedManager.UnregisterShardAsync(reopenedShard, cancellationToken);
     }
 
     [Fact]
     public async Task ConcurrentSchedules_WhenOneRequestIsInvalid_PersistsOtherRequests()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         const int JobCount = 8;
         const int InvalidIndex = 3;
         var storageProvider = new CountingJournalStorageProvider(delayAppends: true);
@@ -246,7 +251,7 @@ public class JournaledJobShardManagerTests
             start,
             end,
             new Dictionary<string, string> { ["Purpose"] = "ConcurrentBatchingInvalidItem" },
-            CancellationToken.None);
+            cancellationToken);
 
         var scheduleTasks = Enumerable.Range(0, JobCount)
             .Select(index => shard.TryScheduleJobAsync(new()
@@ -255,37 +260,37 @@ public class JournaledJobShardManagerTests
                 JobName = $"batched-job-{index}",
                 DueTime = index == InvalidIndex ? end.AddSeconds(1) : start.AddSeconds(1),
                 Metadata = null
-            }, CancellationToken.None))
+            }, cancellationToken))
             .ToArray();
 
-        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
         storageProvider.AllowAppends();
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => scheduleTasks[InvalidIndex].WaitAsync(
             TimeSpan.FromSeconds(5),
-            TestContext.Current.CancellationToken));
+            cancellationToken));
         var scheduledJobs = await Task.WhenAll(scheduleTasks.Where((_, index) => index != InvalidIndex)).WaitAsync(
             TimeSpan.FromSeconds(5),
-            TestContext.Current.CancellationToken);
+            cancellationToken);
 
         Assert.All(scheduledJobs, job => Assert.NotNull(job));
         Assert.True(
             storageProvider.AppendCount < JobCount,
             $"Expected fewer storage appends than scheduled jobs, but saw {storageProvider.AppendCount} appends for {JobCount - 1} valid jobs.");
 
-        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+        await manager.UnregisterShardAsync(shard, cancellationToken);
 
         var reopenedManager = CreateManager(services, membership, silo);
-        var reopened = await reopenedManager.AssignJobShardsAsync(end, int.MaxValue, CancellationToken.None);
+        var reopened = await reopenedManager.AssignJobShardsAsync(end, int.MaxValue, cancellationToken);
         var reopenedShard = Assert.Single(reopened);
         var consumed = new List<IJobRunContext>();
-        await foreach (var jobContext in reopenedShard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
+        await foreach (var jobContext in reopenedShard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
         {
             consumed.Add(jobContext);
-            await reopenedShard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None);
+            await reopenedShard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
         }
 
         Assert.Equal(JobCount - 1, consumed.Count);
-        await reopenedManager.UnregisterShardAsync(reopenedShard, CancellationToken.None);
+        await reopenedManager.UnregisterShardAsync(reopenedShard, cancellationToken);
     }
 
     [Fact]
@@ -329,6 +334,7 @@ public class JournaledJobShardManagerTests
     [Fact]
     public async Task DeadOwnerShard_IsAdoptedClosedAndReplayedFromJournal()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -344,29 +350,29 @@ public class JournaledJobShardManagerTests
             start,
             start.AddHours(1),
             new Dictionary<string, string> { ["Purpose"] = "DeadOwnerAdoption" },
-            CancellationToken.None);
+            cancellationToken);
         var scheduled = await shard.TryScheduleJobAsync(new()
         {
             Target = GrainId.Create("type", "target"),
             JobName = "dead-owner-job",
             DueTime = DateTimeOffset.UtcNow.AddSeconds(-1),
             Metadata = new Dictionary<string, string> { ["Kind"] = "Adopted" }
-        }, CancellationToken.None);
+        }, cancellationToken);
         Assert.NotNull(scheduled);
 
         membership.SetSiloStatus(silo1, SiloStatus.Dead);
 
-        var claimed = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
+        var claimed = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken);
         var claimedShard = Assert.Single(claimed);
         Assert.True(claimedShard.IsAddingCompleted);
         Assert.Equal("DeadOwnerAdoption", claimedShard.Metadata!["Purpose"]);
-        Assert.Equal(silo2, await manager2.GetShardOwnerAsync(claimedShard.Id, CancellationToken.None));
+        Assert.Equal(silo2, await manager2.GetShardOwnerAsync(claimedShard.Id, cancellationToken));
 
         var consumed = new List<IJobRunContext>();
-        await foreach (var jobContext in claimedShard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
+        await foreach (var jobContext in claimedShard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
         {
             consumed.Add(jobContext);
-            await claimedShard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None);
+            await claimedShard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
         }
 
         var replayed = Assert.Single(consumed);
@@ -374,13 +380,14 @@ public class JournaledJobShardManagerTests
         Assert.Equal("Adopted", replayed.Job.Metadata!["Kind"]);
         Assert.Equal(1, replayed.DequeueCount);
 
-        await manager2.UnregisterShardAsync(claimedShard, CancellationToken.None);
+        await manager2.UnregisterShardAsync(claimedShard, cancellationToken);
         await shard.DisposeAsync();
     }
 
     [Fact]
     public async Task DeadOwnerShard_IsPoisonedAfterAdoptionLimitExceeded()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -396,21 +403,21 @@ public class JournaledJobShardManagerTests
             start,
             start.AddHours(1),
             new Dictionary<string, string> { ["Purpose"] = "PoisonedShard" },
-            CancellationToken.None);
+            cancellationToken);
         var scheduled = await shard.TryScheduleJobAsync(new()
         {
             Target = GrainId.Create("type", "target"),
             JobName = "poisoned-job",
             DueTime = DateTimeOffset.UtcNow.AddSeconds(-1),
             Metadata = null
-        }, CancellationToken.None);
+        }, cancellationToken);
         Assert.NotNull(scheduled);
 
         membership.SetSiloStatus(silo1, SiloStatus.Dead);
 
-        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None));
-        Assert.Null(await manager2.GetShardOwnerAsync(shard.Id, CancellationToken.None));
-        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None));
+        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken));
+        Assert.Null(await manager2.GetShardOwnerAsync(shard.Id, cancellationToken));
+        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken));
 
         await shard.DisposeAsync();
     }
@@ -418,6 +425,7 @@ public class JournaledJobShardManagerTests
     [Fact]
     public async Task LiveLocalShard_IsReturnedAndRemainsWritable()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -430,25 +438,26 @@ public class JournaledJobShardManagerTests
             start,
             start.AddHours(1),
             new Dictionary<string, string> { ["Purpose"] = "LiveShard" },
-            CancellationToken.None);
+            cancellationToken);
 
-        await ScheduleJobAsync(shard, "first-live-job");
+        await ScheduleJobAsync(shard, "first-live-job", cancellationToken);
 
-        var assigned = await manager.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
+        var assigned = await manager.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken);
         var assignedShard = Assert.Single(assigned);
         Assert.Equal(shard.Id, assignedShard.Id);
         Assert.False(assignedShard.IsAddingCompleted);
         Assert.Equal("LiveShard", assignedShard.Metadata!["Purpose"]);
 
-        await ScheduleJobAsync(assignedShard, "second-live-job");
+        await ScheduleJobAsync(assignedShard, "second-live-job", cancellationToken);
         Assert.Equal(2, await assignedShard.GetJobCountAsync());
 
-        await DrainAndUnregisterAsync(manager, assignedShard, expectedJobs: 2);
+        await DrainAndUnregisterAsync(manager, assignedShard, cancellationToken, expectedJobs: 2);
     }
 
     [Fact]
     public async Task ActiveRemoteOwnerShard_IsNotClaimedUntilOwnerDies()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -464,27 +473,28 @@ public class JournaledJobShardManagerTests
             start,
             start.AddHours(1),
             new Dictionary<string, string> { ["Purpose"] = "ActiveOwner" },
-            CancellationToken.None);
-        await ScheduleJobAsync(shard, "active-owner-job");
+            cancellationToken);
+        await ScheduleJobAsync(shard, "active-owner-job", cancellationToken);
 
-        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None));
-        Assert.Equal(silo1, await manager2.GetShardOwnerAsync(shard.Id, CancellationToken.None));
+        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken));
+        Assert.Equal(silo1, await manager2.GetShardOwnerAsync(shard.Id, cancellationToken));
 
         membership.SetSiloStatus(silo1, SiloStatus.Dead);
 
-        var adopted = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
+        var adopted = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken);
         var adoptedShard = Assert.Single(adopted);
         Assert.True(adoptedShard.IsAddingCompleted);
         Assert.Equal("ActiveOwner", adoptedShard.Metadata!["Purpose"]);
-        Assert.Equal(silo2, await manager2.GetShardOwnerAsync(adoptedShard.Id, CancellationToken.None));
+        Assert.Equal(silo2, await manager2.GetShardOwnerAsync(adoptedShard.Id, cancellationToken));
 
-        await DrainAndUnregisterAsync(manager2, adoptedShard);
+        await DrainAndUnregisterAsync(manager2, adoptedShard, cancellationToken);
         await shard.DisposeAsync();
     }
 
     [Fact]
     public async Task ShardMetadata_RoundTripsKeysRequiringEncoding()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -504,21 +514,22 @@ public class JournaledJobShardManagerTests
                 ["key/with/slashes"] = "slash-value",
                 ["key+with=base64"] = "base64-value"
             },
-            CancellationToken.None);
-        await ScheduleJobAsync(shard, "metadata-job");
-        await manager1.UnregisterShardAsync(shard, CancellationToken.None);
+            cancellationToken);
+        await ScheduleJobAsync(shard, "metadata-job", cancellationToken);
+        await manager1.UnregisterShardAsync(shard, cancellationToken);
 
-        var assigned = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
+        var assigned = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken);
         var assignedShard = Assert.Single(assigned);
         Assert.Equal("slash-value", assignedShard.Metadata!["key/with/slashes"]);
         Assert.Equal("base64-value", assignedShard.Metadata["key+with=base64"]);
 
-        await DrainAndUnregisterAsync(manager2, assignedShard);
+        await DrainAndUnregisterAsync(manager2, assignedShard, cancellationToken);
     }
 
     [Fact]
     public async Task SlowStart_LimitsOrphanedShardClaims()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storageProvider = new VolatileJournalStorageProvider();
         using var services = CreateServices(storageProvider);
         var membership = new TestClusterMembershipService();
@@ -536,22 +547,22 @@ public class JournaledJobShardManagerTests
                 start,
                 start.AddHours(1),
                 new Dictionary<string, string> { ["Index"] = i.ToString() },
-                CancellationToken.None);
-            await ScheduleJobAsync(shard, $"orphaned-job-{i}");
-            await manager1.UnregisterShardAsync(shard, CancellationToken.None);
+                cancellationToken);
+            await ScheduleJobAsync(shard, $"orphaned-job-{i}", cancellationToken);
+            await manager1.UnregisterShardAsync(shard, cancellationToken);
         }
 
-        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), maxNewClaims: 0, CancellationToken.None));
+        Assert.Empty(await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), maxNewClaims: 0, cancellationToken));
 
-        var firstClaim = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), maxNewClaims: 1, CancellationToken.None);
+        var firstClaim = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), maxNewClaims: 1, cancellationToken);
         var firstShard = Assert.Single(firstClaim);
-        await DrainAndUnregisterAsync(manager2, firstShard);
+        await DrainAndUnregisterAsync(manager2, firstShard, cancellationToken);
 
-        var remainingClaims = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
+        var remainingClaims = await manager2.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, cancellationToken);
         Assert.Equal(2, remainingClaims.Count);
         foreach (var shard in remainingClaims)
         {
-            await DrainAndUnregisterAsync(manager2, shard);
+            await DrainAndUnregisterAsync(manager2, shard, cancellationToken);
         }
     }
 
@@ -699,7 +710,7 @@ public class JournaledJobShardManagerTests
             Options.Create(options ?? new DurableJobsOptions()),
             services.GetRequiredService<IOptions<JournaledStateManagerOptions>>());
 
-    private static async Task<DurableJob> ScheduleJobAsync(IJobShard shard, string jobName)
+    private static async Task<DurableJob> ScheduleJobAsync(IJobShard shard, string jobName, CancellationToken cancellationToken)
     {
         var scheduled = await shard.TryScheduleJobAsync(new()
         {
@@ -707,15 +718,20 @@ public class JournaledJobShardManagerTests
             JobName = jobName,
             DueTime = DateTimeOffset.UtcNow.AddSeconds(-1),
             Metadata = null
-        }, CancellationToken.None);
+        }, cancellationToken);
         Assert.NotNull(scheduled);
         return scheduled;
     }
 
-    private static async Task DrainAndUnregisterAsync(JournaledJobShardManager manager, IJobShard shard, int expectedJobs = 1)
+    private static async Task DrainAndUnregisterAsync(
+        JournaledJobShardManager manager,
+        IJobShard shard,
+        CancellationToken cancellationToken,
+        int expectedJobs = 1)
     {
         var consumed = 0;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
         await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(cts.Token))
         {
             consumed++;
@@ -730,13 +746,13 @@ public class JournaledJobShardManagerTests
 
         Assert.Equal(expectedJobs, consumed);
         Assert.Equal(0, await shard.GetJobCountAsync());
-        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+        await manager.UnregisterShardAsync(shard, cancellationToken);
     }
 
-    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source, CancellationToken cancellationToken)
     {
         var result = new List<T>();
-        await foreach (var item in source)
+        await foreach (var item in source.WithCancellation(cancellationToken))
         {
             result.Add(item);
         }

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardStateTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardStateTests.cs
@@ -136,6 +136,7 @@ public class JournaledJobShardStateTests
     [Fact]
     public async Task ConsumeDurableJobsAsync_YieldsDueJobsInDueTimeOrderAndIncrementsDequeueCount()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var shardId = new JobShardId("shard-d");
         var start = DateTimeOffset.UtcNow.AddMinutes(-1);
         var state = new JournaledJobShardState(shardId, start, DateTimeOffset.UtcNow.AddMinutes(1));
@@ -148,7 +149,7 @@ public class JournaledJobShardStateTests
         state.Apply(DurableJobShardJournalRecord.ForSchedule(second));
 
         var consumed = new List<IJobRunContext>();
-        await foreach (var jobContext in state.ConsumeDurableJobsAsync())
+        await foreach (var jobContext in state.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
         {
             consumed.Add(jobContext);
             if (consumed.Count == 3)

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
@@ -38,6 +38,7 @@ public sealed class DistributedGrainDirectoryMembershipTests
     [Fact]
     public async Task OwnerResolutionWaitsForActiveDirectoryMembership()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
 #pragma warning disable ORLEANSEXP003
         builder.Options.UseDistributedGrainDirectory = true;
@@ -56,13 +57,14 @@ public sealed class DistributedGrainDirectoryMembershipTests
 
         try
         {
-            await cluster.DeployAsync();
+            await cluster.DeployAsync().WaitAsync(cancellationToken);
             var silo = cluster.Silos[0];
             var membership = silo.ServiceProvider.GetRequiredService<DirectoryMembershipService>();
             var directory = silo.ServiceProvider.GetRequiredService<DistributedGrainDirectory>();
             var testHooks = (DistributedGrainDirectory.ITestHooks)directory;
             var controlledMembership = silo.ServiceProvider.GetRequiredService<ControlledMembershipService>();
-            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(30));
 
             await controlledMembership.ActiveUpdateBlocked.WaitAsync(timeout.Token);
             var siloAddress = silo.SiloAddress;
@@ -78,7 +80,8 @@ public sealed class DistributedGrainDirectoryMembershipTests
         }
         finally
         {
-            await cluster.DisposeAsync();
+            using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await cluster.DisposeAsync().AsTask().WaitAsync(cleanupCancellation.Token);
         }
     }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
@@ -57,7 +57,7 @@ public sealed class DistributedGrainDirectoryMembershipTests
 
         try
         {
-            await cluster.DeployAsync().WaitAsync(cancellationToken);
+            await cluster.DeployAsync(cancellationToken);
             var silo = cluster.Silos[0];
             var membership = silo.ServiceProvider.GetRequiredService<DirectoryMembershipService>();
             var directory = silo.ServiceProvider.GetRequiredService<DistributedGrainDirectory>();

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -147,7 +147,7 @@ public class GrainDirectoryLeaseTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, _) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync().WaitAsync(cancellationToken);
+        await cluster.DeployAsync(cancellationToken);
 
         try
         {
@@ -179,7 +179,7 @@ public class GrainDirectoryLeaseTests
 
             // Graceful shutdown transitions through ShuttingDown → Dead,
             // which does not create a silo lease hold.
-            await cluster.StopSiloAsync(secondary).WaitAsync(cancellationToken);
+            await cluster.StopSiloAsync(secondary, cancellationToken);
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
             var fakeAddress = GrainAddress.NewActivationAddress(primary.SiloAddress, leaseGrain.GetGrainId());
@@ -451,7 +451,7 @@ public class GrainDirectoryLeaseTests
         InProcessTestCluster cluster,
         CancellationToken cancellationToken)
     {
-        await cluster.DeployAsync().WaitAsync(cancellationToken);
+        await cluster.DeployAsync(cancellationToken);
         await cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken);
     }
 
@@ -460,7 +460,7 @@ public class GrainDirectoryLeaseTests
         try
         {
             using var stopCancellation = new CancellationTokenSource(EventTimeout);
-            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            await cluster.StopAllSilosAsync(stopCancellation.Token);
         }
         finally
         {

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -38,9 +38,10 @@ public class GrainDirectoryLeaseTests
     [Fact]
     public async Task BlocksReactivations_AfterUngracefulShutdown()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, timeProvider) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await DeployAndWaitForClusterManifestAsync(cluster);
+        await DeployAndWaitForClusterManifestAsync(cluster, cancellationToken);
 
         try
         {
@@ -52,8 +53,12 @@ public class GrainDirectoryLeaseTests
             var leaseGrain = cluster.Client.GetGrain<ILeaseTestGrain>(0);
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
-            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
+            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(
+                events,
+                primary.SiloAddress,
+                secondary.SiloAddress,
+                cancellationToken);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary, cancellationToken);
             await leaseCreated;
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
 
@@ -61,17 +66,21 @@ public class GrainDirectoryLeaseTests
             var fakeAddress = GrainAddress.NewActivationAddress(primary.SiloAddress, leaseGrain.GetGrainId());
 
             // A stale deregistration must not remove the dead activation's lease tombstone.
-            await directory.Unregister(fakeAddress);
+            await directory.Unregister(fakeAddress, cancellationToken);
 
             // The registration should block while the lease hold is active.
-            var retryDelayScheduled = WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, leaseGrain.GetGrainId());
-            var registerTask = directory.Register(fakeAddress);
+            var retryDelayScheduled = WaitForLeaseRetryScheduledAsync(
+                events,
+                primary.SiloAddress,
+                leaseGrain.GetGrainId(),
+                cancellationToken);
+            var registerTask = directory.Register(fakeAddress, cancellationToken);
             await retryDelayScheduled;
             Assert.False(registerTask.IsCompleted, "Registration should be blocked by the lease hold.");
 
             // The diagnostic event is emitted after the retry delay is armed, so advancing time cannot race timer creation.
             timeProvider.Advance(RangeLeaseDuration);
-            var result = await registerTask.WaitAsync(EventTimeout);
+            var result = await registerTask.WaitAsync(EventTimeout, cancellationToken);
             Assert.NotNull(result);
 
             // The grain should now reactivate on the primary since it's the only silo alive.
@@ -86,9 +95,10 @@ public class GrainDirectoryLeaseTests
     [Fact]
     public async Task CancelsRegistrationDuringActiveLeaseHold()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, timeProvider) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await DeployAndWaitForClusterManifestAsync(cluster);
+        await DeployAndWaitForClusterManifestAsync(cluster, cancellationToken);
 
         try
         {
@@ -99,23 +109,31 @@ public class GrainDirectoryLeaseTests
             var leaseGrain = cluster.Client.GetGrain<ILeaseTestGrain>(1);
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
-            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
+            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(
+                events,
+                primary.SiloAddress,
+                secondary.SiloAddress,
+                cancellationToken);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary, cancellationToken);
             await leaseCreated;
 
             var grainLocator = primary.ServiceProvider.GetRequiredService<CachedGrainLocator>();
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
             var fakeAddress = GrainAddress.NewActivationAddress(primary.SiloAddress, leaseGrain.GetGrainId());
-            using var cancellation = new CancellationTokenSource();
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            var retryDelayScheduled = WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, leaseGrain.GetGrainId());
+            var retryDelayScheduled = WaitForLeaseRetryScheduledAsync(
+                events,
+                primary.SiloAddress,
+                leaseGrain.GetGrainId(),
+                cancellationToken);
             var registerTask = grainLocator.Register(fakeAddress, null, cancellation.Token);
             await retryDelayScheduled;
             cancellation.Cancel();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => registerTask);
             timeProvider.Advance(RangeLeaseDuration);
-            Assert.Null(await directory.Lookup(leaseGrain.GetGrainId()));
+            Assert.Null(await directory.Lookup(leaseGrain.GetGrainId(), cancellationToken));
         }
         finally
         {
@@ -126,9 +144,10 @@ public class GrainDirectoryLeaseTests
     [Fact]
     public async Task InitialClusterStartup_DoesNotCreateRangeLeaseHold()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, _) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await cluster.DeployAsync();
+        await cluster.DeployAsync().WaitAsync(cancellationToken);
 
         try
         {
@@ -143,9 +162,10 @@ public class GrainDirectoryLeaseTests
     [Fact]
     public async Task GracefulShutdown_DoesNotCreateLeaseHold()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, _) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await DeployAndWaitForClusterManifestAsync(cluster);
+        await DeployAndWaitForClusterManifestAsync(cluster, cancellationToken);
 
         try
         {
@@ -159,13 +179,13 @@ public class GrainDirectoryLeaseTests
 
             // Graceful shutdown transitions through ShuttingDown → Dead,
             // which does not create a silo lease hold.
-            await cluster.StopSiloAsync(secondary);
+            await cluster.StopSiloAsync(secondary).WaitAsync(cancellationToken);
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
             var fakeAddress = GrainAddress.NewActivationAddress(primary.SiloAddress, leaseGrain.GetGrainId());
 
             // Should succeed immediately — no lease hold for graceful shutdown.
-            var result = await directory.Register(fakeAddress);
+            var result = await directory.Register(fakeAddress, cancellationToken);
             Assert.NotNull(result);
             Assert.Equal(primary.SiloAddress, result.SiloAddress);
             Assert.DoesNotContain(events.Events, e => IsSiloLeaseHoldCreated(e, primary.SiloAddress, secondary.SiloAddress));
@@ -259,9 +279,10 @@ public class GrainDirectoryLeaseTests
     [Fact]
     public async Task DisabledLeaseHold_AllowsImmediateReregistration()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, _) = CreateCluster(TimeSpan.Zero);
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await DeployAndWaitForClusterManifestAsync(cluster);
+        await DeployAndWaitForClusterManifestAsync(cluster, cancellationToken);
 
         try
         {
@@ -274,13 +295,13 @@ public class GrainDirectoryLeaseTests
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
             // Ungraceful kill, but leases are disabled (duration = Zero).
-            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary, cancellationToken);
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
             var fakeAddress = GrainAddress.NewActivationAddress(primary.SiloAddress, leaseGrain.GetGrainId());
 
             // Should succeed immediately — lease holds are disabled.
-            var result = await directory.Register(fakeAddress);
+            var result = await directory.Register(fakeAddress, cancellationToken);
             Assert.NotNull(result);
             Assert.Equal(primary.SiloAddress, result.SiloAddress);
             Assert.DoesNotContain(events.Events, e => IsSiloLeaseHoldCreated(e, primary.SiloAddress, secondary.SiloAddress));
@@ -294,9 +315,10 @@ public class GrainDirectoryLeaseTests
     [Fact]
     public async Task LookupReturnsNull_DuringActiveLeaseHold()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, _) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await DeployAndWaitForClusterManifestAsync(cluster);
+        await DeployAndWaitForClusterManifestAsync(cluster, cancellationToken);
 
         try
         {
@@ -308,15 +330,19 @@ public class GrainDirectoryLeaseTests
             var leaseGrain = cluster.Client.GetGrain<ILeaseTestGrain>(30);
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
-            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
+            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(
+                events,
+                primary.SiloAddress,
+                secondary.SiloAddress,
+                cancellationToken);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary, cancellationToken);
             await leaseCreated;
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
 
             // Lookup should return null: the entry is retained for the lease hold,
             // but the silo is dead so the directory filters it out.
-            var result = await directory.Lookup(leaseGrain.GetGrainId());
+            var result = await directory.Lookup(leaseGrain.GetGrainId(), cancellationToken);
             Assert.Null(result);
         }
         finally
@@ -328,9 +354,10 @@ public class GrainDirectoryLeaseTests
     [Fact]
     public async Task BlocksMultipleGrains_AfterUngracefulShutdown()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var (cluster, timeProvider) = CreateCluster();
         using var events = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
-        await DeployAndWaitForClusterManifestAsync(cluster);
+        await DeployAndWaitForClusterManifestAsync(cluster, cancellationToken);
 
         try
         {
@@ -346,8 +373,12 @@ public class GrainDirectoryLeaseTests
             Assert.Equal(secondary.SiloAddress, await grain2.GetAddress());
             Assert.Equal(secondary.SiloAddress, await grain3.GetAddress());
 
-            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
+            var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(
+                events,
+                primary.SiloAddress,
+                secondary.SiloAddress,
+                cancellationToken);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary, cancellationToken);
             await leaseCreated;
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
@@ -355,14 +386,20 @@ public class GrainDirectoryLeaseTests
             // All grains on the dead silo should be blocked by the lease hold.
             var blockedTasks = new[]
             {
-                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain1.GetGrainId()),
-                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain2.GetGrainId()),
-                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain3.GetGrainId())
+                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain1.GetGrainId(), cancellationToken),
+                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain2.GetGrainId(), cancellationToken),
+                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain3.GetGrainId(), cancellationToken)
             };
 
-            var task1 = directory.Register(GrainAddress.NewActivationAddress(primary.SiloAddress, grain1.GetGrainId()));
-            var task2 = directory.Register(GrainAddress.NewActivationAddress(primary.SiloAddress, grain2.GetGrainId()));
-            var task3 = directory.Register(GrainAddress.NewActivationAddress(primary.SiloAddress, grain3.GetGrainId()));
+            var task1 = directory.Register(
+                GrainAddress.NewActivationAddress(primary.SiloAddress, grain1.GetGrainId()),
+                cancellationToken);
+            var task2 = directory.Register(
+                GrainAddress.NewActivationAddress(primary.SiloAddress, grain2.GetGrainId()),
+                cancellationToken);
+            var task3 = directory.Register(
+                GrainAddress.NewActivationAddress(primary.SiloAddress, grain3.GetGrainId()),
+                cancellationToken);
             await Task.WhenAll(blockedTasks);
             Assert.False(task1.IsCompleted, "Registration for grain1 should be blocked by the lease hold.");
             Assert.False(task2.IsCompleted, "Registration for grain2 should be blocked by the lease hold.");
@@ -370,7 +407,7 @@ public class GrainDirectoryLeaseTests
 
             // After the lease expires, all registrations should complete.
             timeProvider.Advance(RangeLeaseDuration);
-            var registrations = await Task.WhenAll(task1, task2, task3).WaitAsync(EventTimeout);
+            var registrations = await Task.WhenAll(task1, task2, task3).WaitAsync(EventTimeout, cancellationToken);
 
             Assert.All(registrations, registration =>
             {
@@ -410,30 +447,36 @@ public class GrainDirectoryLeaseTests
         return (builder.Build(), timeProvider);
     }
 
-    private static async Task DeployAndWaitForClusterManifestAsync(InProcessTestCluster cluster)
+    private static async Task DeployAndWaitForClusterManifestAsync(
+        InProcessTestCluster cluster,
+        CancellationToken cancellationToken)
     {
-        await cluster.DeployAsync();
-        await cluster.WaitForClusterManifestToStabilizeAsync();
+        await cluster.DeployAsync().WaitAsync(cancellationToken);
+        await cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken);
     }
 
     private static async Task DisposeClusterAsync(InProcessTestCluster cluster)
     {
         try
         {
-            await cluster.StopAllSilosAsync();
+            using var stopCancellation = new CancellationTokenSource(EventTimeout);
+            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
         }
         finally
         {
-            await cluster.DisposeAsync();
+            using var disposeCancellation = new CancellationTokenSource(EventTimeout);
+            await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
         }
     }
 
     private static async Task KillSiloAndWaitForDirectoryMembershipAsync(
         InProcessTestCluster cluster,
         InProcessSiloHandle observer,
-        InProcessSiloHandle victim)
+        InProcessSiloHandle victim,
+        CancellationToken cancellationToken)
     {
-        using var timeout = new CancellationTokenSource(EventTimeout);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(EventTimeout);
         var membership = observer.ServiceProvider.GetRequiredService<ClusterMembershipService>();
         var directoryMembership = observer.ServiceProvider.GetRequiredService<DirectoryMembershipService>();
 
@@ -445,8 +488,8 @@ public class GrainDirectoryLeaseTests
             timeout.Token);
         Assert.Equal(SiloStatus.Active, initialView.ClusterMembershipSnapshot.GetSiloStatus(victim.SiloAddress));
 
-        await cluster.KillSiloAsync(victim);
-        await cluster.WaitForLivenessToStabilizeAsync(didKill: true);
+        await cluster.KillSiloAsync(victim).WaitAsync(cancellationToken);
+        await cluster.WaitForLivenessToStabilizeAsync(didKill: true).WaitAsync(cancellationToken);
         var deadMembership = membership.CurrentSnapshot;
         Assert.Equal(SiloStatus.Dead, deadMembership.GetSiloStatus(victim.SiloAddress));
 
@@ -486,11 +529,13 @@ public class GrainDirectoryLeaseTests
     private static Task<DiagnosticEvent> WaitForSiloLeaseHoldCreatedAsync(
         DiagnosticEventCollector events,
         SiloAddress observerSiloAddress,
-        SiloAddress deadSiloAddress) =>
+        SiloAddress deadSiloAddress,
+        CancellationToken cancellationToken) =>
         events.WaitForEventAsync(
             nameof(GrainDirectoryEvents.SiloLeaseHoldCreated),
             e => IsSiloLeaseHoldCreated(e, observerSiloAddress, deadSiloAddress),
-            EventTimeout);
+            EventTimeout,
+            cancellationToken);
 
     private static bool IsSiloLeaseHoldCreated(
         DiagnosticEvent diagnosticEvent,
@@ -503,14 +548,16 @@ public class GrainDirectoryLeaseTests
     private static Task<DiagnosticEvent> WaitForLeaseRetryScheduledAsync(
         DiagnosticEventCollector events,
         SiloAddress observerSiloAddress,
-        GrainId grainId) =>
+        GrainId grainId,
+        CancellationToken cancellationToken) =>
         events.WaitForEventAsync(
             nameof(GrainDirectoryEvents.OperationDelayedByLeaseHold),
             e => e.Payload is GrainDirectoryEvents.OperationDelayedByLeaseHold delayed
                 && delayed.ObserverSiloAddress.Equals(observerSiloAddress)
                 && delayed.GrainId.Equals(grainId)
                 && delayed.Operation == "RegisterAsync",
-            EventTimeout);
+            EventTimeout,
+            cancellationToken);
 
 }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryOptionsTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryOptionsTests.cs
@@ -16,6 +16,7 @@ public sealed class GrainDirectoryOptionsTests
     [Fact]
     public async Task PartitionsPerSilo_IsConfigurable()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         builder.ConfigureSilo((_, siloBuilder) =>
         {
@@ -28,7 +29,7 @@ public sealed class GrainDirectoryOptionsTests
         var cluster = builder.Build();
         try
         {
-            await cluster.DeployAsync();
+            await cluster.DeployAsync(cancellationToken);
             var membershipService = cluster.Silos[0].ServiceProvider.GetRequiredService<DirectoryMembershipService>();
 
             Assert.Equal(3, membershipService.PartitionsPerSilo);

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryResilienceTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryResilienceTests.cs
@@ -45,7 +45,7 @@ public sealed class GrainDirectoryResilienceTests
         var testClusterBuilder = new TestClusterBuilder(1);
         testClusterBuilder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         var testCluster = testClusterBuilder.Build();
-        await testCluster.DeployAsync().WaitAsync(cancellationToken);
+        await testCluster.DeployAsync(cancellationToken);
         var log = testCluster.ServiceProvider.GetRequiredService<ILogger<GrainDirectoryResilienceTests>>();
         log.LogInformation("ServiceId: '{ServiceId}'", testCluster.Options.ServiceId);
         log.LogInformation("ClusterId: '{ClusterId}'.", testCluster.Options.ClusterId);
@@ -119,7 +119,7 @@ public sealed class GrainDirectoryResilienceTests
                                 if (currentCount % 2 == 0)
                                 {
                                     log.LogInformation("Stopping '{Silo}'.", victim.SiloAddress);
-                                    await testCluster.StopSiloAsync(victim).WaitAsync(cts.Token);
+                                    await testCluster.StopSiloAsync(victim, cts.Token);
                                     log.LogInformation("Stopped '{Silo}'.", victim.SiloAddress);
                                 }
                                 else
@@ -179,7 +179,7 @@ public sealed class GrainDirectoryResilienceTests
             try
             {
                 using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                await testCluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+                await testCluster.StopAllSilosAsync(stopCancellation.Token);
             }
             finally
             {
@@ -197,7 +197,7 @@ public sealed class GrainDirectoryResilienceTests
         var testClusterBuilder = new TestClusterBuilder(1);
         testClusterBuilder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         var testCluster = testClusterBuilder.Build();
-        await testCluster.DeployAsync().WaitAsync(cancellationToken);
+        await testCluster.DeployAsync(cancellationToken);
         var log = testCluster.ServiceProvider.GetRequiredService<ILogger<GrainDirectoryResilienceTests>>();
         var client = ((InProcessSiloHandle)testCluster.Primary!).SiloHost.Services.GetRequiredService<IGrainFactory>();
         var previousDirectoryView = await WaitForDirectoryViewAsync(
@@ -272,7 +272,7 @@ public sealed class GrainDirectoryResilienceTests
             try
             {
                 using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                await testCluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+                await testCluster.StopAllSilosAsync(stopCancellation.Token);
             }
             finally
             {

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryResilienceTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryResilienceTests.cs
@@ -41,15 +41,17 @@ public sealed class GrainDirectoryResilienceTests
     [Fact]
     public async Task ElasticChaos()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var testClusterBuilder = new TestClusterBuilder(1);
         testClusterBuilder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         var testCluster = testClusterBuilder.Build();
-        await testCluster.DeployAsync();
+        await testCluster.DeployAsync().WaitAsync(cancellationToken);
         var log = testCluster.ServiceProvider.GetRequiredService<ILogger<GrainDirectoryResilienceTests>>();
         log.LogInformation("ServiceId: '{ServiceId}'", testCluster.Options.ServiceId);
         log.LogInformation("ClusterId: '{ClusterId}'.", testCluster.Options.ClusterId);
 
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(5));
         var reconfigurationTimer = CoarseStopwatch.StartNew();
         var upperLimit = 10;
         var lowerLimit = 1; // Membership is kept on the primary, so we can't go below 1
@@ -67,7 +69,11 @@ public sealed class GrainDirectoryResilienceTests
 
                 try
                 {
-                    await workTask;
+                    await workTask.WaitAsync(cts.Token);
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                    break;
                 }
                 catch (SiloUnavailableException sue)
                 {
@@ -85,7 +91,7 @@ public sealed class GrainDirectoryResilienceTests
 
                 idBase += CallsPerIteration;
             }
-        });
+        }, cts.Token);
 
         var chaosTask = Task.Run(async () =>
         {
@@ -98,9 +104,9 @@ public sealed class GrainDirectoryResilienceTests
                     if (remaining <= TimeSpan.Zero)
                     {
                         reconfigurationTimer.Restart();
-                        await clusterOperation;
+                        await clusterOperation.WaitAsync(cts.Token);
 
-                        await CheckIntegrityAsync(testCluster, client);
+                        await CheckIntegrityAsync(testCluster, client, cts.Token);
 
                         clusterOperation = Task.Run(async () =>
                         {
@@ -113,20 +119,20 @@ public sealed class GrainDirectoryResilienceTests
                                 if (currentCount % 2 == 0)
                                 {
                                     log.LogInformation("Stopping '{Silo}'.", victim.SiloAddress);
-                                    await testCluster.StopSiloAsync(victim);
+                                    await testCluster.StopSiloAsync(victim).WaitAsync(cts.Token);
                                     log.LogInformation("Stopped '{Silo}'.", victim.SiloAddress);
                                 }
                                 else
                                 {
                                     log.LogInformation("Killing '{Silo}'.", victim.SiloAddress);
-                                    await testCluster.KillSiloAsync(victim);
+                                    await testCluster.KillSiloAsync(victim).WaitAsync(cts.Token);
                                     log.LogInformation("Killed '{Silo}'.", victim.SiloAddress);
                                 }
                             }
                             else if (currentCount < target)
                             {
                                 log.LogInformation("Starting new silo.");
-                                var result = await testCluster.StartAdditionalSiloAsync();
+                                var result = await testCluster.StartAdditionalSiloAsync().WaitAsync(cts.Token);
                                 log.LogInformation("Started '{Silo}'.", result.SiloAddress);
                             }
 
@@ -138,11 +144,11 @@ public sealed class GrainDirectoryResilienceTests
                             {
                                 target = lowerLimit;
                             }
-                        });
+                        }, cts.Token);
                     }
                     else
                     {
-                        await Task.Delay(remaining);
+                        await Task.Delay(remaining, cts.Token);
                     }
                 }
                 catch (Exception exception)
@@ -150,29 +156,55 @@ public sealed class GrainDirectoryResilienceTests
                     log.LogInformation(exception, "Ignoring chaos exception.");
                 }
             }
-        });
+        }, cts.Token);
 
-        await await Task.WhenAny(loadTask, chaosTask);
-        cts.Cancel();
-        await Task.WhenAll(loadTask, chaosTask);
-        await testCluster.StopAllSilosAsync();
-        await testCluster.DisposeAsync();
+        try
+        {
+            await await Task.WhenAny(loadTask, chaosTask).WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            cts.Cancel();
+            using var joinCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            try
+            {
+                await Task.WhenAll(loadTask, chaosTask).WaitAsync(joinCancellation.Token);
+            }
+            catch (OperationCanceledException) when (
+                cts.IsCancellationRequested
+                && !joinCancellation.IsCancellationRequested)
+            {
+            }
+
+            try
+            {
+                using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await testCluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            }
+            finally
+            {
+                using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await testCluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+            }
+        }
     }
 
     [Fact]
     public async Task JoiningSilo_DoesNotLeaveStaleEntriesOnPreviousOwner()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var directoryEvents = new DiagnosticEventCollector(GrainDirectoryEvents.ListenerName);
         var testClusterBuilder = new TestClusterBuilder(1);
         testClusterBuilder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
         var testCluster = testClusterBuilder.Build();
-        await testCluster.DeployAsync();
+        await testCluster.DeployAsync().WaitAsync(cancellationToken);
         var log = testCluster.ServiceProvider.GetRequiredService<ILogger<GrainDirectoryResilienceTests>>();
         var client = ((InProcessSiloHandle)testCluster.Primary!).SiloHost.Services.GetRequiredService<IGrainFactory>();
         var previousDirectoryView = await WaitForDirectoryViewAsync(
             ((InProcessSiloHandle)testCluster.Primary).ServiceProvider.GetRequiredService<DirectoryMembershipService>(),
             view => view.Members.Contains(testCluster.Primary.SiloAddress),
-            "initial directory membership view");
+            "initial directory membership view",
+            cancellationToken);
         const int CallsPerIteration = 100;
         var nextGrainId = 0L;
 
@@ -180,48 +212,80 @@ public sealed class GrainDirectoryResilienceTests
         {
             for (var i = 0; i < 10; i++)
             {
-                await RunPingBatchAsync(client, log, nextGrainId, CallsPerIteration);
+                await RunPingBatchAsync(client, log, nextGrainId, CallsPerIteration, cancellationToken);
                 nextGrainId += CallsPerIteration;
             }
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromMinutes(1));
             var loadGrainId = nextGrainId;
             var loadTask = Task.Run(async () =>
             {
-                while (!cts.IsCancellationRequested)
+                try
                 {
-                    await RunPingBatchAsync(client, log, loadGrainId, CallsPerIteration);
-                    loadGrainId += CallsPerIteration;
+                    while (!cts.IsCancellationRequested)
+                    {
+                        await RunPingBatchAsync(client, log, loadGrainId, CallsPerIteration, cts.Token);
+                        loadGrainId += CallsPerIteration;
+                    }
                 }
-            });
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                }
+            }, cts.Token);
 
             try
             {
                 log.LogInformation("Starting new silo.");
-                var newSilo = await testCluster.StartAdditionalSiloAsync();
+                var newSilo = await testCluster.StartAdditionalSiloAsync().WaitAsync(cancellationToken);
                 log.LogInformation("Started '{Silo}'.", newSilo.SiloAddress);
 
                 var currentDirectoryView = await WaitForDirectoryViewAsync(
                     ((InProcessSiloHandle)newSilo).ServiceProvider.GetRequiredService<DirectoryMembershipService>(),
                     view => view.Members.Contains(newSilo.SiloAddress),
-                    $"directory membership view containing '{newSilo.SiloAddress}'");
-                await WaitForDirectoryMigrationAsync(directoryEvents, previousDirectoryView, currentDirectoryView);
-                await CheckIntegrityAsync(testCluster, client);
+                    $"directory membership view containing '{newSilo.SiloAddress}'",
+                    cancellationToken);
+                await WaitForDirectoryMigrationAsync(
+                    directoryEvents,
+                    previousDirectoryView,
+                    currentDirectoryView,
+                    cancellationToken);
+                await CheckIntegrityAsync(testCluster, client, cancellationToken);
             }
             finally
             {
                 cts.Cancel();
-                await loadTask;
+                using var joinCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                try
+                {
+                    await loadTask.WaitAsync(joinCancellation.Token);
+                }
+                catch (OperationCanceledException) when (
+                    cts.IsCancellationRequested
+                    && !joinCancellation.IsCancellationRequested)
+                {
+                }
             }
         }
         finally
         {
-            await testCluster.StopAllSilosAsync();
-            await testCluster.DisposeAsync();
+            try
+            {
+                using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await testCluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            }
+            finally
+            {
+                using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await testCluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+            }
         }
     }
 
-    private static async Task CheckIntegrityAsync(TestCluster testCluster, IGrainFactory client)
+    private static async Task CheckIntegrityAsync(
+        TestCluster testCluster,
+        IGrainFactory client,
+        CancellationToken cancellationToken)
     {
         var integrityChecks = new List<Task>();
         var internalGrainFactory = (IInternalGrainFactory)client;
@@ -232,19 +296,21 @@ public sealed class GrainDirectoryResilienceTests
             for (var partitionIndex = 0; partitionIndex < partitionsPerSilo; partitionIndex++)
             {
                 var replica = internalGrainFactory.GetSystemTarget<IGrainDirectoryTestHooks>(GrainDirectoryPartition.CreateGrainId(address, partitionIndex).GrainId);
-                integrityChecks.Add(replica.CheckIntegrityAsync().AsTask());
+                integrityChecks.Add(replica.CheckIntegrityAsync().AsTask().WaitAsync(cancellationToken));
             }
         }
 
-        await Task.WhenAll(integrityChecks);
+        await Task.WhenAll(integrityChecks).WaitAsync(cancellationToken);
     }
 
     private static async Task<DirectoryMembershipSnapshot> WaitForDirectoryViewAsync(
         DirectoryMembershipService directoryMembershipService,
         Func<DirectoryMembershipSnapshot, bool> predicate,
-        string description)
+        string description,
+        CancellationToken cancellationToken)
     {
-        using var cts = new CancellationTokenSource(DirectoryMigrationTimeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(DirectoryMigrationTimeout);
         try
         {
             await foreach (var view in directoryMembershipService.ViewUpdates.WithCancellation(cts.Token))
@@ -255,7 +321,7 @@ public sealed class GrainDirectoryResilienceTests
                 }
             }
         }
-        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && cts.IsCancellationRequested)
         {
             throw new TimeoutException($"Timed out waiting for {description} after {DirectoryMigrationTimeout}.");
         }
@@ -266,12 +332,15 @@ public sealed class GrainDirectoryResilienceTests
     private static async Task WaitForDirectoryMigrationAsync(
         DiagnosticEventCollector directoryEvents,
         DirectoryMembershipSnapshot previousView,
-        DirectoryMembershipSnapshot currentView)
+        DirectoryMembershipSnapshot currentView,
+        CancellationToken cancellationToken)
     {
         var expectedOperations = GetExpectedRangeOperations(previousView, currentView).ToArray();
         Assert.NotEmpty(expectedOperations);
 
-        await Task.WhenAll(expectedOperations.Select(operation => WaitForRangeOperationCompletedAsync(directoryEvents, operation)));
+        await Task.WhenAll(expectedOperations.Select(
+            operation => WaitForRangeOperationCompletedAsync(directoryEvents, operation, cancellationToken)))
+            .WaitAsync(cancellationToken);
     }
 
     private static IEnumerable<ExpectedRangeOperation> GetExpectedRangeOperations(
@@ -316,7 +385,8 @@ public sealed class GrainDirectoryResilienceTests
 
     private static async Task WaitForRangeOperationCompletedAsync(
         DiagnosticEventCollector directoryEvents,
-        ExpectedRangeOperation expectedOperation)
+        ExpectedRangeOperation expectedOperation,
+        CancellationToken cancellationToken)
     {
         await directoryEvents.WaitForEventAsync(
             nameof(GrainDirectoryEvents.RangeOperationCompleted),
@@ -327,17 +397,23 @@ public sealed class GrainDirectoryResilienceTests
                 && completed.Version == expectedOperation.Version
                 && completed.Range.Equals(expectedOperation.Range)
                 && string.Equals(completed.OperationName, expectedOperation.OperationName, StringComparison.Ordinal),
-            DirectoryMigrationTimeout);
+            DirectoryMigrationTimeout,
+            cancellationToken);
     }
 
-    private static async Task RunPingBatchAsync(IGrainFactory client, ILogger log, long idBase, int callsPerIteration)
+    private static async Task RunPingBatchAsync(
+        IGrainFactory client,
+        ILogger log,
+        long idBase,
+        int callsPerIteration,
+        CancellationToken cancellationToken)
     {
         var tasks = Enumerable.Range(0, callsPerIteration).Select(i => client.GetGrain<IMyDirectoryTestGrain>(idBase + i).Ping().AsTask()).ToList();
         var workTask = Task.WhenAll(tasks);
 
         try
         {
-            await workTask;
+            await workTask.WaitAsync(cancellationToken);
         }
         catch (SiloUnavailableException sue)
         {

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -81,7 +81,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
         try
         {
-            await cluster.DeployAsync().WaitAsync(cancellationToken);
+            await cluster.DeployAsync(cancellationToken);
             output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
 
             IGrainFactory client = cluster.Client!;
@@ -126,7 +126,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     await DriveLoad(client, nextGrainId, count: 100, cancellationToken, id => failingGrainKey = id);
                 }
 
-                await cluster.InitializeClientAsync().WaitAsync(cancellationToken);
+                await cluster.InitializeClientAsync(cancellationToken);
                 client = cluster.Client!;
 
                 // Phase 3: Stop old silos one at a time, non-primary first.
@@ -139,7 +139,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                         cluster,
                         $"before removing local silo {transitionIndex}/{oldSilos.Count}",
                         cancellationToken);
-                    await cluster.StopSiloAsync(oldSilo).WaitAsync(cancellationToken);
+                    await cluster.StopSiloAsync(oldSilo, cancellationToken);
                     output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
                     await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
                     await WaitForDirectoryConvergenceAsync(
@@ -181,7 +181,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 try
                 {
                     using var stopCancellation = new CancellationTokenSource(DirectoryConvergenceTimeout);
-                    await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+                    await cluster.StopAllSilosAsync(stopCancellation.Token);
                 }
                 finally
                 {
@@ -890,7 +890,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         var deployed = false;
         try
         {
-            await cluster.DeployAsync().WaitAsync(operationTimeout, cancellationToken);
+            using var deployCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            deployCancellation.CancelAfter(operationTimeout);
+            await cluster.DeployAsync(deployCancellation.Token);
             deployed = true;
 
             var originalClient = cluster.Client;
@@ -1234,7 +1236,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     if (deployed)
                     {
                         using var stopCancellation = new CancellationTokenSource(cleanupTimeout);
-                        await cluster.StopAllSilosAsync().WaitAsync(cleanupTimeout, stopCancellation.Token);
+                        await cluster.StopAllSilosAsync(stopCancellation.Token);
                     }
                 }
                 finally

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -49,6 +49,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     [Fact]
     public async Task RollingUpgrade_LocalToDistributed_NoErrors()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(3);
         // Initial silos use LocalGrainDirectory only; later silos opt into DistributedGrainDirectory.
         builder.Options.UseTestClusterGrainDirectory = false;
@@ -80,7 +81,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
         try
         {
-            await cluster.DeployAsync();
+            await cluster.DeployAsync().WaitAsync(cancellationToken);
             output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
 
             IGrainFactory client = cluster.Client!;
@@ -91,7 +92,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             {
                 // Phase 1: Drive load on the LocalGrainDirectory cluster.
                 output.WriteLine("Phase 1: Driving load on LocalGrainDirectory cluster...");
-                await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+                await DriveLoad(client, nextGrainId, count: 100, cancellationToken, id => failingGrainKey = id);
 
                 // Phase 2: Add DistributedGrainDirectory silos one at a time.
                 output.WriteLine("Phase 2: Rolling upgrade — adding DistributedGrainDirectory silos...");
@@ -100,18 +101,32 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
                 for (var i = 0; i < oldSilos.Count; i++)
                 {
-                    await ValidateDirectoryPhaseInvariantsAsync(cluster, $"before adding distributed silo {i + 1}/{oldSilos.Count}");
+                    await ValidateDirectoryPhaseInvariantsAsync(
+                        cluster,
+                        $"before adding distributed silo {i + 1}/{oldSilos.Count}",
+                        cancellationToken);
                     var preSplitPartitions = CaptureLocalDirectoryPartitions(cluster);
-                    var newSilo = await cluster.StartAdditionalSiloAsync();
+                    var newSilo = await cluster.StartAdditionalSiloAsync().WaitAsync(cancellationToken);
                     output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
-                    await cluster.WaitForLivenessToStabilizeAsync();
-                    await WaitForDirectoryConvergenceAsync(cluster, $"after adding distributed silo {i + 1}/{oldSilos.Count}");
-                    await AssertSplitPartitionHandoffAsync(cluster, preSplitPartitions, newSilo, handoffLogs);
-                    await ValidateDirectoryPhaseInvariantsAsync(cluster, $"after adding distributed silo {i + 1}/{oldSilos.Count}");
-                    await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+                    await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+                    await WaitForDirectoryConvergenceAsync(
+                        cluster,
+                        $"after adding distributed silo {i + 1}/{oldSilos.Count}",
+                        cancellationToken);
+                    await AssertSplitPartitionHandoffAsync(
+                        cluster,
+                        preSplitPartitions,
+                        newSilo,
+                        handoffLogs,
+                        cancellationToken);
+                    await ValidateDirectoryPhaseInvariantsAsync(
+                        cluster,
+                        $"after adding distributed silo {i + 1}/{oldSilos.Count}",
+                        cancellationToken);
+                    await DriveLoad(client, nextGrainId, count: 100, cancellationToken, id => failingGrainKey = id);
                 }
 
-                await cluster.InitializeClientAsync();
+                await cluster.InitializeClientAsync().WaitAsync(cancellationToken);
                 client = cluster.Client!;
 
                 // Phase 3: Stop old silos one at a time, non-primary first.
@@ -120,23 +135,42 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 foreach (var oldSilo in oldSilos.OrderBy(static s => s.InstanceNumber == 0 ? 1 : 0))
                 {
                     transitionIndex++;
-                    await ValidateDirectoryPhaseInvariantsAsync(cluster, $"before removing local silo {transitionIndex}/{oldSilos.Count}");
-                    await cluster.StopSiloAsync(oldSilo);
+                    await ValidateDirectoryPhaseInvariantsAsync(
+                        cluster,
+                        $"before removing local silo {transitionIndex}/{oldSilos.Count}",
+                        cancellationToken);
+                    await cluster.StopSiloAsync(oldSilo).WaitAsync(cancellationToken);
                     output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
-                    await cluster.WaitForLivenessToStabilizeAsync();
-                    await WaitForDirectoryConvergenceAsync(cluster, $"after removing local silo {transitionIndex}/{oldSilos.Count}");
-                    await ValidateDirectoryPhaseInvariantsAsync(cluster, $"after removing local silo {transitionIndex}/{oldSilos.Count}");
-                    await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+                    await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+                    await WaitForDirectoryConvergenceAsync(
+                        cluster,
+                        $"after removing local silo {transitionIndex}/{oldSilos.Count}",
+                        cancellationToken);
+                    await ValidateDirectoryPhaseInvariantsAsync(
+                        cluster,
+                        $"after removing local silo {transitionIndex}/{oldSilos.Count}",
+                        cancellationToken);
+                    await DriveLoad(client, nextGrainId, count: 100, cancellationToken, id => failingGrainKey = id);
                 }
 
                 // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
                 output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
-                await DriveLoad(client, nextGrainId, count: 200, id => failingGrainKey = id);
-                await ValidateDirectoryPhaseInvariantsAsync(cluster, "after final verification");
+                await DriveLoad(client, nextGrainId, count: 200, cancellationToken, id => failingGrainKey = id);
+                await ValidateDirectoryPhaseInvariantsAsync(cluster, "after final verification", cancellationToken);
             }
             catch
             {
-                await DumpFailureDiagnosticsAsync(cluster, errorLogs, diagnosticLogs, failingGrainKey);
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    using var diagnosticsCancellation = new CancellationTokenSource(DirectoryConvergenceTimeout);
+                    await DumpFailureDiagnosticsAsync(
+                        cluster,
+                        errorLogs,
+                        diagnosticLogs,
+                        failingGrainKey,
+                        diagnosticsCancellation.Token);
+                }
+
                 throw;
             }
         }
@@ -144,8 +178,16 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         {
             try
             {
-                await cluster.StopAllSilosAsync();
-                await cluster.DisposeAsync();
+                try
+                {
+                    using var stopCancellation = new CancellationTokenSource(DirectoryConvergenceTimeout);
+                    await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+                }
+                finally
+                {
+                    using var disposeCancellation = new CancellationTokenSource(DirectoryConvergenceTimeout);
+                    await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+                }
             }
             finally
             {
@@ -190,7 +232,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         InProcessTestCluster cluster,
         LocalDirectoryPartitionSnapshot[] preSplitPartitions,
         InProcessSiloHandle recipient,
-        PhaseAwareLogCapture logs)
+        PhaseAwareLogCapture logs,
+        CancellationToken cancellationToken)
     {
         var recipientAddress = recipient.SiloAddress;
         var ownerDirectory = recipient.ServiceProvider.GetRequiredService<LocalGrainDirectory>();
@@ -203,7 +246,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             .Where(static group => group.Count() > 1)
             .ToArray();
         Assert.Empty(duplicateTransfers);
-        await AssertSplitPartitionHandoffIsDurableAsync(logs, recipient, expectedTransfers);
+        await AssertSplitPartitionHandoffIsDurableAsync(logs, recipient, expectedTransfers, cancellationToken);
 
         foreach (var snapshot in preSplitPartitions)
         {
@@ -242,7 +285,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         var liveActivations = GetDirectoryActivations(cluster);
         foreach (var transfer in expectedTransfers)
         {
-            var winner = await distributedDirectory.Lookup(transfer.Address.GrainId);
+            var winner = await distributedDirectory.Lookup(transfer.Address.GrainId, cancellationToken);
             Assert.NotNull(winner);
             Assert.Equal(transfer.Address.GrainId, winner.GrainId);
             Assert.Contains(
@@ -255,7 +298,10 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             + $"{expectedTransfers.Length} registrations transferred.");
     }
 
-    private async Task WaitForDirectoryConvergenceAsync(InProcessTestCluster cluster, string stage)
+    private async Task WaitForDirectoryConvergenceAsync(
+        InProcessTestCluster cluster,
+        string stage,
+        CancellationToken cancellationToken)
     {
         var distributedSilos = new List<(InProcessSiloHandle Silo, DirectoryMembershipService MembershipService)>();
         foreach (var silo in cluster.Silos)
@@ -276,7 +322,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         var targetVersion = new MembershipVersion(cluster.Silos.Max(static silo =>
             silo.ServiceProvider.GetRequiredService<ClusterMembershipService>().CurrentSnapshot.Version.Value));
 
-        using var timeout = new CancellationTokenSource(DirectoryConvergenceTimeout);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(DirectoryConvergenceTimeout);
         try
         {
             var views = await Task.WhenAll(distributedSilos.Select(silo =>
@@ -291,13 +338,14 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 {
                     var replica = cluster.InternalClient!.GetSystemTarget<IGrainDirectoryTestHooks>(
                         GrainDirectoryPartition.CreateGrainId(silo.SiloAddress, partitionIndex).GrainId);
-                    partitionWaits.Add(replica.WaitForMembershipVersionAsync(view.Version).AsTask());
+                    partitionWaits.Add(
+                        replica.WaitForMembershipVersionAsync(view.Version).AsTask().WaitAsync(timeout.Token));
                 }
             }
 
             await Task.WhenAll(partitionWaits).WaitAsync(timeout.Token);
         }
-        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested)
         {
             throw new TimeoutException($"Timed out waiting for grain directory convergence {stage} after {DirectoryConvergenceTimeout}.");
         }
@@ -350,7 +398,10 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         return true;
     }
 
-    private async Task ValidateDirectoryPhaseInvariantsAsync(InProcessTestCluster cluster, string stage)
+    private async Task ValidateDirectoryPhaseInvariantsAsync(
+        InProcessTestCluster cluster,
+        string stage,
+        CancellationToken cancellationToken)
     {
         output.WriteLine($"  Validating grain directory invariants {stage}...");
 
@@ -396,13 +447,15 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
         if (distributedPartitions.Count == 0)
         {
-            await CheckActivationRegistrationsWithLocalDirectoryAsync(activations, stage);
+            await CheckActivationRegistrationsWithLocalDirectoryAsync(activations, stage, cancellationToken);
         }
         else
         {
             var activationAddresses = activations.Select(static activation => activation.Address).ToList().AsImmutable();
-            var activationChecks = distributedPartitions.Select(partition => partition.CheckActivationsAsync(activationAddresses).AsTask()).ToArray();
-            await Task.WhenAll(activationChecks);
+            var activationChecks = distributedPartitions
+                .Select(partition => partition.CheckActivationsAsync(activationAddresses).AsTask().WaitAsync(cancellationToken))
+                .ToArray();
+            await Task.WhenAll(activationChecks).WaitAsync(cancellationToken);
             var distributedCheckedGrains = new HashSet<GrainId>();
             foreach (var task in activationChecks)
             {
@@ -421,17 +474,25 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 }
 
                 var grainLocator = activation.Silo.ServiceProvider.GetRequiredService<GrainLocator>();
-                localActivationChecks.Add(CheckActivationRegistrationAsync(grainLocator, activation.Address, activation.Silo.SiloAddress, stage));
+                localActivationChecks.Add(
+                    CheckActivationRegistrationAsync(
+                        grainLocator,
+                        activation.Address,
+                        activation.Silo.SiloAddress,
+                        stage,
+                        cancellationToken));
             }
 
-            await Task.WhenAll(localActivationChecks);
+            await Task.WhenAll(localActivationChecks).WaitAsync(cancellationToken);
             foreach (var task in localActivationChecks)
             {
                 await task;
             }
 
-            var integrityChecks = distributedPartitions.Select(static partition => partition.CheckIntegrityAsync().AsTask()).ToArray();
-            await Task.WhenAll(integrityChecks);
+            var integrityChecks = distributedPartitions
+                .Select(partition => partition.CheckIntegrityAsync().AsTask().WaitAsync(cancellationToken))
+                .ToArray();
+            await Task.WhenAll(integrityChecks).WaitAsync(cancellationToken);
         }
 
         output.WriteLine($"  Validated {activations.Count} activations and {distributedPartitions.Count} DistributedGrainDirectory partitions {stage}.");
@@ -467,25 +528,38 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         return activation is not SystemTarget && activation.GetComponent<PlacementStrategy>() is { IsUsingGrainDirectory: true };
     }
 
-    private static async Task CheckActivationRegistrationsWithLocalDirectoryAsync(List<(InProcessSiloHandle Silo, GrainAddress Address)> activations, string stage)
+    private static async Task CheckActivationRegistrationsWithLocalDirectoryAsync(
+        List<(InProcessSiloHandle Silo, GrainAddress Address)> activations,
+        string stage,
+        CancellationToken cancellationToken)
     {
         var activationChecks = activations.Select(activation =>
         {
             var grainLocator = activation.Silo.ServiceProvider.GetRequiredService<GrainLocator>();
-            return CheckActivationRegistrationAsync(grainLocator, activation.Address, activation.Silo.SiloAddress, stage);
+            return CheckActivationRegistrationAsync(
+                grainLocator,
+                activation.Address,
+                activation.Silo.SiloAddress,
+                stage,
+                cancellationToken);
         }).ToArray();
 
-        await Task.WhenAll(activationChecks);
+        await Task.WhenAll(activationChecks).WaitAsync(cancellationToken);
         foreach (var task in activationChecks)
         {
             await task;
         }
     }
 
-    private static async Task CheckActivationRegistrationAsync(GrainLocator grainLocator, GrainAddress activationAddress, SiloAddress siloAddress, string stage)
+    private static async Task CheckActivationRegistrationAsync(
+        GrainLocator grainLocator,
+        GrainAddress activationAddress,
+        SiloAddress siloAddress,
+        string stage,
+        CancellationToken cancellationToken)
     {
         grainLocator.InvalidateCache(activationAddress.GrainId);
-        var registeredAddress = await grainLocator.Lookup(activationAddress.GrainId);
+        var registeredAddress = await grainLocator.Lookup(activationAddress.GrainId).AsTask().WaitAsync(cancellationToken);
         Assert.True(
             activationAddress.Matches(registeredAddress),
             $"Activation '{activationAddress.ToFullString()}' on silo '{siloAddress}' did not have a matching directory registration during '{stage}'. Registered address: '{registeredAddress?.ToFullString() ?? "<null>"}'.");
@@ -504,7 +578,12 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     /// Activates grains by calling each one. Retries individual calls that fail with transient
     /// exceptions expected during directory ownership transitions in a rolling upgrade.
     /// </summary>
-    private async Task DriveLoad(IGrainFactory client, Func<long> nextGrainId, int count, Action<long>? onPersistentFailure = null)
+    private async Task DriveLoad(
+        IGrainFactory client,
+        Func<long> nextGrainId,
+        int count,
+        CancellationToken cancellationToken,
+        Action<long>? onPersistentFailure = null)
     {
         var ids = new long[count];
         for (var i = 0; i < count; i++)
@@ -519,7 +598,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             var tasks = remainingIds.Select(id => client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost().AsTask()).ToArray();
             try
             {
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks).WaitAsync(cancellationToken);
                 return;
             }
             catch
@@ -559,12 +638,17 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             }
 
             output.WriteLine($"    {failedIds.Count}/{remainingIds.Length} calls failed on attempt {attempt}, retrying...");
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
             remainingIds = [.. failedIds];
         }
     }
 
-    private async Task DumpFailureDiagnosticsAsync(InProcessTestCluster cluster, ErrorLogCapture errorLogs, DiagnosticLogCapture diagnosticLogs, long? failingGrainKey)
+    private async Task DumpFailureDiagnosticsAsync(
+        InProcessTestCluster cluster,
+        ErrorLogCapture errorLogs,
+        DiagnosticLogCapture diagnosticLogs,
+        long? failingGrainKey,
+        CancellationToken cancellationToken)
     {
         DumpCapturedMessages("ERROR LOGS", errorLogs.ToArray());
         DumpCapturedMessages("ROLLING UPGRADE DIAGNOSTICS", diagnosticLogs.ToArray(), limit: 200);
@@ -582,10 +666,10 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             try
             {
                 var siloControl = cluster.InternalClient!.GetSystemTarget<ISiloControl>(Constants.SiloControlType, silo.SiloAddress);
-                var report = await siloControl.GetDetailedGrainReport(grainId);
+                var report = await siloControl.GetDetailedGrainReport(grainId).WaitAsync(cancellationToken);
                 output.WriteLine(report.ToString());
             }
-            catch (Exception exception)
+            catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
             {
                 output.WriteLine($"Failed to get detailed grain report from silo {silo.SiloAddress}: {exception}");
             }
@@ -760,6 +844,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     [Fact]
     public async Task RollingUpgrade_RestartInPlace_PreservesTrafficAndDirectoryIntegrity()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         const int SiloCount = 3;
         var operationTimeout = TimeSpan.FromSeconds(45);
         var cleanupTimeout = TimeSpan.FromSeconds(30);
@@ -805,7 +890,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         var deployed = false;
         try
         {
-            await cluster.DeployAsync().WaitAsync(operationTimeout);
+            await cluster.DeployAsync().WaitAsync(operationTimeout, cancellationToken);
             deployed = true;
 
             var originalClient = cluster.Client;
@@ -818,8 +903,16 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 $"Phase '{phase.Current}': {SiloCount} LocalGrainDirectory silos: "
                 + string.Join(", ", cluster.Silos.Select(static silo => $"{silo.Name}={silo.SiloAddress}")));
 
-            var initialObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
-            var repeatedInitialObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
+            var initialObservations = await CallIdentityGrainsAsync(
+                originalClient,
+                trackedGrainKeys,
+                operationTimeout,
+                cancellationToken);
+            var repeatedInitialObservations = await CallIdentityGrainsAsync(
+                originalClient,
+                trackedGrainKeys,
+                operationTimeout,
+                cancellationToken);
             AssertStableActivationProgress(initialObservations, repeatedInitialObservations, "initial LocalGrainDirectory phase");
             await ValidateTrackedDirectoryCheckpointAsync(
                 cluster,
@@ -827,7 +920,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet(),
                 retiredAddresses,
                 "initial LocalGrainDirectory phase",
-                staleCacheEvidence);
+                staleCacheEvidence,
+                cancellationToken);
 
             traffic = new SustainedRollingUpgradeTraffic(
                 originalClient,
@@ -835,14 +929,20 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 phase,
                 trackedGrainKeys.ToArray(),
                 expectedMaximumSilos: SiloCount,
-                callTimeout: TimeSpan.FromSeconds(10));
+                callTimeout: TimeSpan.FromSeconds(10),
+                cancellationToken);
             traffic.Start(workerCount: 3);
             var initialWorkerProgress = traffic.GetWorkerProgress();
-            await traffic.WaitForPhaseSuccessesAsync(phase.Current, minimumSuccesses: 12, operationTimeout);
+            await traffic.WaitForPhaseSuccessesAsync(
+                phase.Current,
+                minimumSuccesses: 12,
+                operationTimeout,
+                cancellationToken);
             await traffic.WaitForAllWorkersProgressAsync(
                 initialWorkerProgress,
                 "initial LocalGrainDirectory traffic",
-                operationTimeout);
+                operationTimeout,
+                cancellationToken);
             AssertNoTrafficFailures(traffic, phase.Current);
             AssertTransientTrafficFailuresWithinLimit(traffic, 0, phase.Current);
 
@@ -866,7 +966,11 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 Assert.Equal(SiloCount, cluster.Silos.Count);
                 Assert.Same(originalClient, cluster.Client);
 
-                await traffic.WaitForPhaseSuccessesAsync(restartPhase, minimumSuccesses: 4, operationTimeout);
+                await traffic.WaitForPhaseSuccessesAsync(
+                    restartPhase,
+                    minimumSuccesses: 4,
+                    operationTimeout,
+                    cancellationToken);
                 var oldAddress = oldSilo.SiloAddress;
                 output.WriteLine(
                     $"Phase '{restartPhase}': restarting {oldSilo.Name} ({oldAddress}) in place; "
@@ -882,7 +986,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 var restartStartedAt = DateTimeOffset.UtcNow;
                 var workerProgressBeforeRestart = traffic.GetWorkerProgress();
                 var successCountBeforeRestart = traffic.SuccessfulCalls;
-                using var progressRaceCancellation = new CancellationTokenSource();
+                using var progressRaceCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var progressDuringRestartTask = traffic.WaitForTotalProgressAsync(
                     successCountBeforeRestart + 1,
                     progressRaceCancellation.Token);
@@ -915,7 +1019,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 {
                 }
 
-                var replacement = await restartTask.WaitAsync(operationTimeout);
+                var replacement = await restartTask.WaitAsync(operationTimeout, cancellationToken);
                 Assert.NotNull(replacement);
                 Assert.Equal(oldSilo.Name, replacement.Name);
                 Assert.Equal(oldSilo.InstanceNumber, replacement.InstanceNumber);
@@ -941,14 +1045,23 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     Assert.Equal(2, distributedSilos);
                 }
 
-                await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(operationTimeout);
-                await WaitForClusterMembershipConvergenceAsync(cluster, retiredAddresses, restartPhase, operationTimeout);
-                await WaitForDirectoryConvergenceAsync(cluster, $"during {restartPhase}");
+                await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(operationTimeout, cancellationToken);
+                await WaitForClusterMembershipConvergenceAsync(
+                    cluster,
+                    retiredAddresses,
+                    restartPhase,
+                    operationTimeout,
+                    cancellationToken);
+                await WaitForDirectoryConvergenceAsync(
+                    cluster,
+                    $"during {restartPhase}",
+                    cancellationToken);
                 AssertCachesWereNotCleared(cacheClearBaselines, restartPhase);
                 await traffic.WaitForAllWorkersProgressAsync(
                     workerProgressAfterRetirement,
                     $"post-retirement portion of restart phase '{restartPhase}'",
-                    operationTimeout);
+                    operationTimeout,
+                    cancellationToken);
                 AssertNoTrafficFailures(traffic, restartPhase);
                 AssertTransientTrafficFailuresWithinLimit(traffic, SiloCount, restartPhase);
                 var liveAddresses = cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet();
@@ -962,15 +1075,27 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 var verificationPhase = $"{restartPhase}-post-convergence";
                 verificationPhases.Add(verificationPhase);
                 phase.Set(verificationPhase);
-                await traffic.WaitForPhaseSuccessesAsync(verificationPhase, minimumSuccesses: 12, operationTimeout);
+                await traffic.WaitForPhaseSuccessesAsync(
+                    verificationPhase,
+                    minimumSuccesses: 12,
+                    operationTimeout,
+                    cancellationToken);
                 AssertTrafficUsesOnlyLiveAddresses(traffic, verificationPhase, liveAddresses, retiredAddresses);
 
                 var freshKeys = Enumerable.Range(0, 4)
                     .Select(_ => Interlocked.Increment(ref nextVerificationGrainKey))
                     .ToArray();
                 trackedGrainKeys.AddRange(freshKeys);
-                var observations = await CallIdentityGrainsAsync(originalClient, freshKeys, operationTimeout);
-                var repeatedObservations = await CallIdentityGrainsAsync(originalClient, freshKeys, operationTimeout);
+                var observations = await CallIdentityGrainsAsync(
+                    originalClient,
+                    freshKeys,
+                    operationTimeout,
+                    cancellationToken);
+                var repeatedObservations = await CallIdentityGrainsAsync(
+                    originalClient,
+                    freshKeys,
+                    operationTimeout,
+                    cancellationToken);
                 AssertStableActivationProgress(observations, repeatedObservations, verificationPhase);
                 await ValidateTrackedDirectoryCheckpointAsync(
                     cluster,
@@ -978,7 +1103,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     liveAddresses,
                     retiredAddresses,
                     verificationPhase,
-                    staleCacheEvidence);
+                    staleCacheEvidence,
+                    cancellationToken);
                 AssertNoTrafficFailures(traffic, restartPhase, verificationPhase);
                 AssertTransientTrafficFailuresWithinLimit(traffic, SiloCount, restartPhase);
                 AssertTransientTrafficFailuresWithinLimit(traffic, 0, verificationPhase);
@@ -1003,14 +1129,19 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 static silo => Assert.NotNull(silo.ServiceProvider.GetService<DirectoryMembershipService>()));
             Assert.Same(originalClient, cluster.Client);
 
-            await traffic.WaitForPhaseSuccessesAsync(phase.Current, minimumSuccesses: 20, operationTimeout);
+            await traffic.WaitForPhaseSuccessesAsync(
+                phase.Current,
+                minimumSuccesses: 20,
+                operationTimeout,
+                cancellationToken);
             await traffic.WaitForAllWorkersProgressAsync(
                 finalWorkerProgress,
                 "final all-DistributedGrainDirectory phase",
-                operationTimeout);
+                operationTimeout,
+                cancellationToken);
             var finalLiveAddresses = cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet();
             AssertTrafficUsesOnlyLiveAddresses(traffic, phase.Current, finalLiveAddresses, retiredAddresses);
-            await traffic.StopSchedulingAndDrainAsync(operationTimeout);
+            await traffic.StopSchedulingAndDrainAsync(operationTimeout, cancellationToken);
             foreach (var restartPhase in restartPhases)
             {
                 AssertTransientTrafficFailuresWithinLimit(traffic, SiloCount, restartPhase);
@@ -1021,8 +1152,16 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 AssertTransientTrafficFailuresWithinLimit(traffic, 0, verificationPhase);
             }
 
-            var finalObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
-            var repeatedFinalObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
+            var finalObservations = await CallIdentityGrainsAsync(
+                originalClient,
+                trackedGrainKeys,
+                operationTimeout,
+                cancellationToken);
+            var repeatedFinalObservations = await CallIdentityGrainsAsync(
+                originalClient,
+                trackedGrainKeys,
+                operationTimeout,
+                cancellationToken);
             AssertStableActivationProgress(finalObservations, repeatedFinalObservations, phase.Current);
             await ValidateTrackedDirectoryCheckpointAsync(
                 cluster,
@@ -1030,10 +1169,19 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 finalLiveAddresses,
                 retiredAddresses,
                 phase.Current,
-                staleCacheEvidence);
-            await WaitForClusterMembershipConvergenceAsync(cluster, retiredAddresses, phase.Current, operationTimeout);
-            await WaitForDirectoryConvergenceAsync(cluster, "in the final all-DistributedGrainDirectory phase");
-            await ValidateDirectoryPhaseInvariantsAsync(cluster, phase.Current);
+                staleCacheEvidence,
+                cancellationToken);
+            await WaitForClusterMembershipConvergenceAsync(
+                cluster,
+                retiredAddresses,
+                phase.Current,
+                operationTimeout,
+                cancellationToken);
+            await WaitForDirectoryConvergenceAsync(
+                cluster,
+                "in the final all-DistributedGrainDirectory phase",
+                cancellationToken);
+            await ValidateDirectoryPhaseInvariantsAsync(cluster, phase.Current, cancellationToken);
 
             Assert.Equal(SiloCount, traffic.MaximumObservedSiloCount);
             Assert.True(traffic.MaximumObservedSiloCount <= SiloCount);
@@ -1051,8 +1199,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         }
         catch
         {
-            if (deployed)
+            if (deployed && !cancellationToken.IsCancellationRequested)
             {
+                using var diagnosticsCancellation = new CancellationTokenSource(cleanupTimeout);
                 await DumpInPlaceFailureDiagnosticsAsync(
                     cluster,
                     phase,
@@ -1061,7 +1210,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     trackedGrainKeys,
                     traffic,
                     logs,
-                    staleCacheEvidence);
+                    staleCacheEvidence,
+                    diagnosticsCancellation.Token);
             }
 
             throw;
@@ -1073,7 +1223,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             {
                 if (traffic is not null)
                 {
-                    await traffic.CancelAsync(cleanupTimeout);
+                    using var trafficCancellation = new CancellationTokenSource(cleanupTimeout);
+                    await traffic.CancelAsync(cleanupTimeout, trafficCancellation.Token);
                 }
             }
             finally
@@ -1082,12 +1233,14 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 {
                     if (deployed)
                     {
-                        await cluster.StopAllSilosAsync().WaitAsync(cleanupTimeout);
+                        using var stopCancellation = new CancellationTokenSource(cleanupTimeout);
+                        await cluster.StopAllSilosAsync().WaitAsync(cleanupTimeout, stopCancellation.Token);
                     }
                 }
                 finally
                 {
-                    await cluster.DisposeAsync().AsTask().WaitAsync(cleanupTimeout);
+                    using var disposeCancellation = new CancellationTokenSource(cleanupTimeout);
+                    await cluster.DisposeAsync().AsTask().WaitAsync(cleanupTimeout, disposeCancellation.Token);
                 }
             }
         }
@@ -1096,12 +1249,13 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     private static async Task<Dictionary<long, RollingUpgradeGrainObservation>> CallIdentityGrainsAsync(
         IGrainFactory client,
         IEnumerable<long> grainKeys,
-        TimeSpan timeout)
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
     {
         var calls = grainKeys.Distinct().Select(async grainKey =>
         {
             var grain = client.GetGrain<IRollingUpgradeIdentityGrain>(grainKey);
-            var observation = await grain.Observe().AsTask().WaitAsync(timeout);
+            var observation = await grain.Observe().AsTask().WaitAsync(timeout, cancellationToken);
             Assert.Equal(grain.GetGrainId(), observation.Address.GrainId);
             Assert.NotNull(observation.Address.SiloAddress);
             Assert.False(observation.Address.ActivationId.IsDefault);
@@ -1109,7 +1263,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             return (GrainKey: grainKey, Observation: observation);
         }).ToArray();
 
-        return (await Task.WhenAll(calls)).ToDictionary(static result => result.GrainKey, static result => result.Observation);
+        return (await Task.WhenAll(calls).WaitAsync(cancellationToken))
+            .ToDictionary(static result => result.GrainKey, static result => result.Observation);
     }
 
     private static void AssertCachesWereNotCleared(
@@ -1151,7 +1306,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         HashSet<SiloAddress> liveAddresses,
         HashSet<SiloAddress> retiredAddresses,
         string stage,
-        StaleCacheEvidenceCapture staleCacheEvidence)
+        StaleCacheEvidenceCapture staleCacheEvidence,
+        CancellationToken cancellationToken)
     {
         // Validate bounded grains using fresh directory lookups before checking phase-wide activation invariants.
         await ValidateObservedAddressesAsync(
@@ -1160,9 +1316,10 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             liveAddresses,
             retiredAddresses,
             stage,
-            staleCacheEvidence);
+            staleCacheEvidence,
+            cancellationToken);
 
-        await ValidateDirectoryPhaseInvariantsAsync(cluster, stage);
+        await ValidateDirectoryPhaseInvariantsAsync(cluster, stage, cancellationToken);
         output.WriteLine($"  Validated {observations.Count} bounded tracked grains during '{stage}'.");
     }
 
@@ -1172,7 +1329,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         HashSet<SiloAddress> liveAddresses,
         HashSet<SiloAddress> retiredAddresses,
         string stage,
-        StaleCacheEvidenceCapture staleCacheEvidence)
+        StaleCacheEvidenceCapture staleCacheEvidence,
+        CancellationToken cancellationToken)
     {
         var activations = GetDirectoryActivations(cluster);
         var distributedSiloCount = cluster.Silos.Count(
@@ -1216,7 +1374,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 }
 
                 grainLocator.InvalidateCache(observedAddress.GrainId);
-                var resolvedAddress = await grainLocator.Lookup(observedAddress.GrainId);
+                var resolvedAddress = await grainLocator.Lookup(observedAddress.GrainId)
+                    .AsTask()
+                    .WaitAsync(cancellationToken);
                 Assert.NotNull(resolvedAddress);
                 AssertAddressMatchesObservation(
                     resolvedAddress,
@@ -1285,10 +1445,12 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         InProcessTestCluster cluster,
         HashSet<SiloAddress> retiredAddresses,
         string stage,
-        TimeSpan timeout)
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
     {
         output.WriteLine($"  Waiting for cluster membership convergence during '{stage}'...");
-        using var cancellation = new CancellationTokenSource(timeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellation.CancelAfter(timeout);
         try
         {
             while (true)
@@ -1316,7 +1478,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 await Task.Delay(TimeSpan.FromMilliseconds(50), cancellation.Token);
             }
         }
-        catch (OperationCanceledException exception) when (cancellation.IsCancellationRequested)
+        catch (OperationCanceledException exception)
+            when (!cancellationToken.IsCancellationRequested && cancellation.IsCancellationRequested)
         {
             var statusReport = string.Join(
                 Environment.NewLine,
@@ -1413,7 +1576,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     private static async Task AssertSplitPartitionHandoffIsDurableAsync(
         PhaseAwareLogCapture logs,
         InProcessSiloHandle recipient,
-        SplitPartitionTransfer[] expectedTransfers)
+        SplitPartitionTransfer[] expectedTransfers,
+        CancellationToken cancellationToken)
     {
         var target = recipient.SiloAddress.ToString();
         if (expectedTransfers.Length == 0)
@@ -1425,7 +1589,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                         "LogInformationAcceptSplitPartitionStarted",
                         StringComparison.Ordinal),
                 DirectoryConvergenceTimeout,
-                $"zero-count split-partition handoff to {recipient.Name} ({target})");
+                $"zero-count split-partition handoff to {recipient.Name} ({target})",
+                cancellationToken);
             Assert.Equal(recipient.Name, acceptedHandoff.SiloName);
             Assert.Equal(0, acceptedHandoff.HandoffCount);
             return;
@@ -1438,7 +1603,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     "LogInformationAcceptSplitPartitionCompleted",
                     StringComparison.Ordinal),
             DirectoryConvergenceTimeout,
-            $"recipient completion for split-partition handoff to {recipient.Name} ({target})");
+            $"recipient completion for split-partition handoff to {recipient.Name} ({target})",
+            cancellationToken);
         await logs.WaitForAsync(
             entry => string.Equals(entry.HandoffSilo, target, StringComparison.Ordinal)
                 && string.Equals(
@@ -1446,7 +1612,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     "LogInformationRemovedTransferredEntries",
                     StringComparison.Ordinal),
             DirectoryConvergenceTimeout,
-            $"sender removal for split-partition handoff to {recipient.Name} ({target})");
+            $"sender removal for split-partition handoff to {recipient.Name} ({target})",
+            cancellationToken);
 
         var relevantEntries = logs.ToArray()
             .Where(entry => string.Equals(entry.HandoffSilo, target, StringComparison.Ordinal))
@@ -1602,7 +1769,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         List<long> trackedGrainKeys,
         SustainedRollingUpgradeTraffic? traffic,
         PhaseAwareLogCapture logs,
-        StaleCacheEvidenceCapture staleCacheEvidence)
+        StaleCacheEvidenceCapture staleCacheEvidence,
+        CancellationToken cancellationToken)
     {
         output.WriteLine($"ROLLING UPGRADE FAILURE in phase '{phase.Current}'.");
         output.WriteLine($"Upgraded stable silo names: [{string.Join(", ", upgradedSiloNames.Keys.Order())}]");
@@ -1642,7 +1810,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             output.WriteLine($"  STALE CACHE HINT {entry}");
         }
 
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellation.CancelAfter(TimeSpan.FromSeconds(20));
         foreach (var grainKey in trackedGrainKeys.Take(6))
         {
             var grainId = cluster.Client.GetGrain<IRollingUpgradeIdentityGrain>(grainKey).GetGrainId();
@@ -1657,7 +1826,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     var report = await siloControl.GetDetailedGrainReport(grainId).WaitAsync(cancellation.Token);
                     output.WriteLine(report.ToString());
                 }
-                catch (Exception exception)
+                catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
                 {
                     output.WriteLine(
                         $"  Failed to get report from {silo.Name} ({silo.SiloAddress}): "
@@ -1686,9 +1855,11 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         RollingUpgradePhase phase,
         long[] hotGrainKeys,
         int expectedMaximumSilos,
-        TimeSpan callTimeout)
+        TimeSpan callTimeout,
+        CancellationToken cancellationToken)
     {
-        private readonly CancellationTokenSource _shutdown = new();
+        private readonly CancellationTokenSource _shutdown =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         private readonly ConcurrentDictionary<string, long> _phaseSuccesses = new(StringComparer.Ordinal);
         private readonly ConcurrentQueue<RollingUpgradeTrafficFailure> _failures = new();
         private readonly ConcurrentQueue<RollingUpgradeTrafficFailure> _transientFailures = new();
@@ -1745,9 +1916,14 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 .Where(observation => string.Equals(observation.Phase, targetPhase, StringComparison.Ordinal))
                 .ToArray();
 
-        public async Task WaitForPhaseSuccessesAsync(string targetPhase, long minimumSuccesses, TimeSpan timeout)
+        public async Task WaitForPhaseSuccessesAsync(
+            string targetPhase,
+            long minimumSuccesses,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
         {
-            using var cancellation = new CancellationTokenSource(timeout);
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellation.CancelAfter(timeout);
             try
             {
                 while (GetPhaseSuccesses(targetPhase) < minimumSuccesses)
@@ -1755,7 +1931,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     await Task.Delay(TimeSpan.FromMilliseconds(20), cancellation.Token);
                 }
             }
-            catch (OperationCanceledException exception) when (cancellation.IsCancellationRequested)
+            catch (OperationCanceledException exception)
+                when (!cancellationToken.IsCancellationRequested && cancellation.IsCancellationRequested)
             {
                 throw new TimeoutException(
                     $"Traffic made {GetPhaseSuccesses(targetPhase)}/{minimumSuccesses} successful calls "
@@ -1764,10 +1941,15 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             }
         }
 
-        public async Task WaitForAllWorkersProgressAsync(long[] baseline, string stage, TimeSpan timeout)
+        public async Task WaitForAllWorkersProgressAsync(
+            long[] baseline,
+            string stage,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
         {
             Assert.Equal(_workerSuccesses.Length, baseline.Length);
-            using var cancellation = new CancellationTokenSource(timeout);
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellation.CancelAfter(timeout);
             try
             {
                 while (true)
@@ -1782,7 +1964,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     await progressSignal.Task.WaitAsync(cancellation.Token);
                 }
             }
-            catch (OperationCanceledException exception) when (cancellation.IsCancellationRequested)
+            catch (OperationCanceledException exception)
+                when (!cancellationToken.IsCancellationRequested && cancellation.IsCancellationRequested)
             {
                 throw new TimeoutException(
                     $"Not every traffic worker made progress during {stage} after {timeout}: "
@@ -1806,12 +1989,14 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             }
         }
 
-        public async Task StopSchedulingAndDrainAsync(TimeSpan timeout)
+        public async Task StopSchedulingAndDrainAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
         {
             Volatile.Write(ref _stopScheduling, 1);
             try
             {
-                await _runTask.WaitAsync(timeout);
+                await _runTask.WaitAsync(timeout, cancellationToken);
             }
             catch (TimeoutException exception)
             {
@@ -1823,12 +2008,18 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             }
         }
 
-        public async Task CancelAsync(TimeSpan timeout)
+        public async Task CancelAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             Volatile.Write(ref _stopScheduling, 1);
             _shutdown.Cancel();
-            await _runTask.WaitAsync(timeout);
-            _shutdown.Dispose();
+            try
+            {
+                await _runTask.WaitAsync(timeout, cancellationToken);
+            }
+            finally
+            {
+                _shutdown.Dispose();
+            }
         }
 
         private long GetPhaseSuccesses(string targetPhase) =>
@@ -2137,9 +2328,11 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         public async Task<PhaseAwareLogEntry> WaitForAsync(
             Func<PhaseAwareLogEntry, bool> predicate,
             TimeSpan timeout,
-            string description)
+            string description,
+            CancellationToken cancellationToken)
         {
-            using var cancellation = new CancellationTokenSource(timeout);
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellation.CancelAfter(timeout);
             while (true)
             {
                 var signal = Volatile.Read(ref _entryAdded);
@@ -2152,7 +2345,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 {
                     await signal.Task.WaitAsync(cancellation.Token);
                 }
-                catch (OperationCanceledException exception) when (cancellation.IsCancellationRequested)
+                catch (OperationCanceledException exception)
+                    when (!cancellationToken.IsCancellationRequested && cancellation.IsCancellationRequested)
                 {
                     throw new TimeoutException($"Timed out waiting for {description} after {timeout}.", exception);
                 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -20,6 +20,7 @@ public sealed class GrainDirectoryShutdownMigrationTests
     [Fact]
     public async Task PreferLocalGrain_MigratesWhenHostingSiloShutsDown()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(2);
         builder.ConfigureSilo((_, siloBuilder) =>
         {
@@ -31,10 +32,10 @@ public sealed class GrainDirectoryShutdownMigrationTests
         });
 
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
-        await cluster.WaitForLivenessToStabilizeAsync();
-        await cluster.WaitForClusterManifestToStabilizeAsync();
-        await WaitForDirectoryMembershipAsync(cluster);
+        await cluster.DeployAsync().WaitAsync(cancellationToken);
+        await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+        await cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken);
+        await WaitForDirectoryMembershipAsync(cluster, cancellationToken);
 
         var survivingSilo = cluster.Silos[0];
         var shuttingDownSilo = cluster.Silos[1];
@@ -45,10 +46,14 @@ public sealed class GrainDirectoryShutdownMigrationTests
         RequestContext.Set(IPlacementDirector.PlacementHintKey, shuttingDownSilo.SiloAddress);
         try
         {
-            await immediateGrain.SetState(42, waitForDirectoryHandoff: false);
-            await postHandoffGrain.SetState(43, waitForDirectoryHandoff: true);
-            Assert.Equal(shuttingDownSilo.SiloAddress, await immediateGrain.GetLocation());
-            Assert.Equal(shuttingDownSilo.SiloAddress, await postHandoffGrain.GetLocation());
+            await immediateGrain.SetState(42, waitForDirectoryHandoff: false).AsTask().WaitAsync(cancellationToken);
+            await postHandoffGrain.SetState(43, waitForDirectoryHandoff: true).AsTask().WaitAsync(cancellationToken);
+            Assert.Equal(
+                shuttingDownSilo.SiloAddress,
+                await immediateGrain.GetLocation().AsTask().WaitAsync(cancellationToken));
+            Assert.Equal(
+                shuttingDownSilo.SiloAddress,
+                await postHandoffGrain.GetLocation().AsTask().WaitAsync(cancellationToken));
         }
         finally
         {
@@ -59,47 +64,64 @@ public sealed class GrainDirectoryShutdownMigrationTests
         var stopTask = cluster.StopSiloAsync(shuttingDownSilo);
         try
         {
-            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(30));
             await WaitForDirectoryMembershipAsync(
                 survivingSilo.ServiceProvider.GetRequiredService<DirectoryMembershipService>(),
                 [survivingSilo.SiloAddress],
-                timeout.Token);
+                timeout.Token,
+                cancellationToken);
         }
         finally
         {
             ShutdownMigrationTestCoordinator.CompleteDirectoryHandoff();
-            await stopTask;
+            using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await stopTask.WaitAsync(cleanupCancellation.Token);
         }
 
-        await cluster.WaitForLivenessToStabilizeAsync();
+        await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
 
-        await AssertMigrated(immediateGrain, 42);
-        await AssertMigrated(postHandoffGrain, 43);
+        await AssertMigrated(immediateGrain, 42, cancellationToken);
+        await AssertMigrated(postHandoffGrain, 43, cancellationToken);
 
-        async Task AssertMigrated(IShutdownMigrationGrain grain, int expectedState)
+        async Task AssertMigrated(
+            IShutdownMigrationGrain grain,
+            int expectedState,
+            CancellationToken cancellationToken)
         {
-            Assert.Equal(survivingSilo.SiloAddress, await grain.GetLocation());
-            Assert.Equal(expectedState, await grain.GetState());
-            Assert.Equal(DeactivationReasonCode.ShuttingDown, await grain.GetPreviousDeactivationReason());
-            Assert.Equal(SiloStatus.ShuttingDown, await grain.GetPreviousSiloStatus());
+            Assert.Equal(
+                survivingSilo.SiloAddress,
+                await grain.GetLocation().AsTask().WaitAsync(cancellationToken));
+            Assert.Equal(expectedState, await grain.GetState().AsTask().WaitAsync(cancellationToken));
+            Assert.Equal(
+                DeactivationReasonCode.ShuttingDown,
+                await grain.GetPreviousDeactivationReason().AsTask().WaitAsync(cancellationToken));
+            Assert.Equal(
+                SiloStatus.ShuttingDown,
+                await grain.GetPreviousSiloStatus().AsTask().WaitAsync(cancellationToken));
         }
     }
 
-    private static async Task WaitForDirectoryMembershipAsync(InProcessTestCluster cluster)
+    private static async Task WaitForDirectoryMembershipAsync(
+        InProcessTestCluster cluster,
+        CancellationToken cancellationToken)
     {
         var expectedMembers = cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet();
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
         await Task.WhenAll(cluster.Silos.Select(
             silo => WaitForDirectoryMembershipAsync(
                 silo.ServiceProvider.GetRequiredService<DirectoryMembershipService>(),
                 expectedMembers,
-                timeout.Token)));
+                timeout.Token,
+                cancellationToken)));
     }
 
     private static async Task WaitForDirectoryMembershipAsync(
         DirectoryMembershipService membershipService,
         HashSet<SiloAddress> expectedMembers,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        CancellationToken testCancellationToken)
     {
         if (expectedMembers.SetEquals(membershipService.CurrentView.Members))
         {
@@ -116,7 +138,8 @@ public sealed class GrainDirectoryShutdownMigrationTests
                 }
             }
         }
-        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception)
+            when (!testCancellationToken.IsCancellationRequested && cancellationToken.IsCancellationRequested)
         {
             throw new TimeoutException("Timed out waiting for the distributed grain directory membership to stabilize.", exception);
         }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -32,7 +32,7 @@ public sealed class GrainDirectoryShutdownMigrationTests
         });
 
         await using var cluster = builder.Build();
-        await cluster.DeployAsync().WaitAsync(cancellationToken);
+        await cluster.DeployAsync(cancellationToken);
         await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
         await cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken);
         await WaitForDirectoryMembershipAsync(cluster, cancellationToken);
@@ -61,7 +61,7 @@ public sealed class GrainDirectoryShutdownMigrationTests
         }
 
         ShutdownMigrationTestCoordinator.Reset();
-        var stopTask = cluster.StopSiloAsync(shuttingDownSilo);
+        var stopTask = cluster.StopSiloAsync(shuttingDownSilo, cancellationToken);
         try
         {
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/test/Orleans.Journaling.Json.Tests/CodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Json.Tests/CodecRecoveryTests.cs
@@ -35,7 +35,7 @@ public class CodecRecoveryTests : JournalingTestBase
         var keyCodec = CodecProvider.GetCodec<string>();
         var valueCodec = CodecProvider.GetCodec<int>();
         var dict = new DurableDictionary<string, int>("dict", sut.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(keyCodec, valueCodec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         dict.Add("alpha", 1);
         dict.Add("beta", 2);
@@ -47,7 +47,7 @@ public class CodecRecoveryTests : JournalingTestBase
         var keyCodec2 = CodecProvider.GetCodec<string>();
         var valueCodec2 = CodecProvider.GetCodec<int>();
         var dict2 = new DurableDictionary<string, int>("dict", sut2.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(keyCodec2, valueCodec2, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(3, dict2.Count);
         Assert.Equal(1, dict2["alpha"]);
@@ -68,7 +68,7 @@ public class CodecRecoveryTests : JournalingTestBase
         // Write phase
         var sut = CreateTestSystemWithJsonCodec(storage, jsonOptions);
         var dict = new DurableDictionary<string, int>("dict", sut.Manager, new JsonDurableDictionaryCommandCodec<string, int>(jsonOptions));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         dict.Add("alpha", 1);
         dict.Add("beta", 2);
@@ -83,7 +83,7 @@ public class CodecRecoveryTests : JournalingTestBase
         // Recovery phase
         var sut2 = CreateTestSystemWithJsonCodec(storage, jsonOptions);
         var dict2 = new DurableDictionary<string, int>("dict", sut2.Manager, new JsonDurableDictionaryCommandCodec<string, int>(jsonOptions));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, dict2.Count);
         Assert.Equal(1, dict2["alpha"]);
@@ -102,7 +102,7 @@ public class CodecRecoveryTests : JournalingTestBase
         // Write phase
         var sut = CreateTestSystemWithJsonCodec(storage, jsonOptions);
         var list = new DurableList<string>("list", sut.Manager, new JsonDurableListCommandCodec<string>(jsonOptions));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         list.Add("one");
         list.Add("two");
@@ -112,7 +112,7 @@ public class CodecRecoveryTests : JournalingTestBase
         // Recovery phase
         var sut2 = CreateTestSystemWithJsonCodec(storage, jsonOptions);
         var list2 = new DurableList<string>("list", sut2.Manager, new JsonDurableListCommandCodec<string>(jsonOptions));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(3, list2.Count);
         Assert.Equal("one", list2[0]);
@@ -132,7 +132,7 @@ public class CodecRecoveryTests : JournalingTestBase
         // Write phase
         var sut = CreateTestSystemWithJsonCodec(storage, jsonOptions);
         var value = new DurableValue<int>("val", sut.Manager, new JsonDurableValueCommandCodec<int>(jsonOptions));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         value.Value = 42;
         await sut.Manager.WriteStateAsync(CancellationToken.None);
@@ -140,7 +140,7 @@ public class CodecRecoveryTests : JournalingTestBase
         // Recovery phase
         var sut2 = CreateTestSystemWithJsonCodec(storage, jsonOptions);
         var value2 = new DurableValue<int>("val", sut2.Manager, new JsonDurableValueCommandCodec<int>(jsonOptions));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(42, value2.Value);
     }
@@ -161,7 +161,7 @@ public class CodecRecoveryTests : JournalingTestBase
             new JsonDurableTaskCompletionSourceCommandCodec<int>(jsonOptions),
             Copier<int>(),
             Copier<Exception>());
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         queue.Enqueue("first");
         queue.Enqueue("second");
@@ -181,7 +181,7 @@ public class CodecRecoveryTests : JournalingTestBase
             new JsonDurableTaskCompletionSourceCommandCodec<int>(jsonOptions),
             Copier<int>(),
             Copier<Exception>());
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, queue2.Count);
         Assert.Equal("first", queue2.Dequeue());
@@ -199,7 +199,7 @@ public class CodecRecoveryTests : JournalingTestBase
         var storage = new VolatileJournalStorage(OrleansBinaryJournalFormat.JournalFormatKey);
         using var first = CreateFormatAwareTestSystem(storage, OrleansBinaryJournalFormat.JournalFormatKey);
         var dict = CreateFormatAwareDictionary(first, OrleansBinaryJournalFormat.JournalFormatKey);
-        await first.Lifecycle.OnStart();
+        await first.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dict.Add("alpha", 1);
         await first.Manager.WriteStateAsync(CancellationToken.None);
         Assert.Equal(OrleansBinaryJournalFormat.JournalFormatKey, storage.StoredJournalFormatKey);
@@ -207,7 +207,7 @@ public class CodecRecoveryTests : JournalingTestBase
         storage.SetConfiguredJournalFormatKey(JsonJournalExtensions.JournalFormatKey);
         using var recovered = CreateFormatAwareTestSystem(storage, JsonJournalExtensions.JournalFormatKey);
         var recoveredDict = CreateFormatAwareDictionary(recovered, JsonJournalExtensions.JournalFormatKey);
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, recoveredDict["alpha"]);
 
@@ -227,7 +227,7 @@ public class CodecRecoveryTests : JournalingTestBase
         var storage = new VolatileJournalStorage(JsonJournalExtensions.JournalFormatKey);
         using var first = CreateFormatAwareTestSystem(storage, JsonJournalExtensions.JournalFormatKey);
         var dict = CreateFormatAwareDictionary(first, JsonJournalExtensions.JournalFormatKey);
-        await first.Lifecycle.OnStart();
+        await first.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dict.Add("alpha", 1);
         await first.Manager.WriteStateAsync(CancellationToken.None);
         Assert.Equal(JsonJournalExtensions.JournalFormatKey, storage.StoredJournalFormatKey);
@@ -235,7 +235,7 @@ public class CodecRecoveryTests : JournalingTestBase
         storage.SetConfiguredJournalFormatKey(OrleansBinaryJournalFormat.JournalFormatKey);
         using var recovered = CreateFormatAwareTestSystem(storage, OrleansBinaryJournalFormat.JournalFormatKey);
         var recoveredDict = CreateFormatAwareDictionary(recovered, OrleansBinaryJournalFormat.JournalFormatKey);
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, recoveredDict["alpha"]);
 
@@ -247,7 +247,7 @@ public class CodecRecoveryTests : JournalingTestBase
 
         using var final = CreateFormatAwareTestSystem(storage, OrleansBinaryJournalFormat.JournalFormatKey);
         var finalDict = CreateFormatAwareDictionary(final, OrleansBinaryJournalFormat.JournalFormatKey);
-        await final.Lifecycle.OnStart();
+        await final.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         Assert.Equal(1, finalDict["alpha"]);
         Assert.Equal(2, finalDict["beta"]);
     }
@@ -258,14 +258,14 @@ public class CodecRecoveryTests : JournalingTestBase
         var storage = new VolatileJournalStorage(JsonJournalExtensions.JournalFormatKey);
         using var first = CreateFormatAwareTestSystem(storage, JsonJournalExtensions.JournalFormatKey);
         var dict = CreateFormatAwareDictionary(first, JsonJournalExtensions.JournalFormatKey);
-        await first.Lifecycle.OnStart();
+        await first.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dict.Add("alpha", 1);
         await first.Manager.WriteStateAsync(CancellationToken.None);
         var metadataLessStorage = new MetadataOverridingStorage(storage, storedJournalFormatKey: null);
 
         using var recovered = CreateFormatAwareTestSystem(metadataLessStorage, JsonJournalExtensions.JournalFormatKey);
         var recoveredDict = CreateFormatAwareDictionary(recovered, JsonJournalExtensions.JournalFormatKey);
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, recoveredDict["alpha"]);
 
@@ -284,7 +284,7 @@ public class CodecRecoveryTests : JournalingTestBase
         var staleMetadataStorage = new MetadataOverridingStorage(storage, OrleansBinaryJournalFormat.JournalFormatKey);
         using var system = CreateFormatAwareTestSystem(staleMetadataStorage, JsonJournalExtensions.JournalFormatKey);
         var dict = CreateFormatAwareDictionary(system, JsonJournalExtensions.JournalFormatKey);
-        await system.Lifecycle.OnStart();
+        await system.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         dict.Add("alpha", 1);
         await system.Manager.WriteStateAsync(CancellationToken.None);
@@ -299,14 +299,14 @@ public class CodecRecoveryTests : JournalingTestBase
         var storage = new VolatileJournalStorage(OrleansBinaryJournalFormat.JournalFormatKey);
         using var first = CreateFormatAwareTestSystem(storage, OrleansBinaryJournalFormat.JournalFormatKey);
         var dict = CreateFormatAwareDictionary(first, OrleansBinaryJournalFormat.JournalFormatKey, "dict");
-        await first.Lifecycle.OnStart();
+        await first.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dict.Add("alpha", 1);
         await first.Manager.WriteStateAsync(CancellationToken.None);
 
         storage.SetConfiguredJournalFormatKey(JsonJournalExtensions.JournalFormatKey);
         using var recovered = CreateFormatAwareTestSystem(storage, JsonJournalExtensions.JournalFormatKey);
         var other = CreateFormatAwareDictionary(recovered, JsonJournalExtensions.JournalFormatKey, "other");
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         other.Add("beta", 2);
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -321,10 +321,13 @@ public class CodecRecoveryTests : JournalingTestBase
     [InlineData("[8,[\"set\",42]]\n[9,[\"set\",43]]{}\n", "invalid JSON journal entry")]
     public async Task JsonRecovery_MalformedJournal_ThrowsFormatKeyError(string jsonLines, string expectedInnerMessage)
     {
-        var storage = await CreateJsonStorageWithSegment(jsonLines);
+        var storage = await CreateJsonStorageWithSegment(jsonLines, TestContext.Current.CancellationToken);
         var sut = CreateTestSystemWithJsonCodec(storage);
 
-        var exception = await AssertRecoveryFailsAsync(sut.Lifecycle, JsonJournalExtensions.JournalFormatKey);
+        var exception = await AssertRecoveryFailsAsync(
+            sut.Lifecycle,
+            JsonJournalExtensions.JournalFormatKey,
+            TestContext.Current.CancellationToken);
 
         Assert.Contains(expectedInnerMessage, exception.InnerException!.Message, StringComparison.Ordinal);
     }
@@ -432,24 +435,29 @@ public class CodecRecoveryTests : JournalingTestBase
 
     private IFieldCodec<T> ValueCodec<T>() => CodecProvider.GetCodec<T>();
 
-    private static async Task<VolatileJournalStorage> CreateJsonStorageWithSegment(string jsonLines)
+    private static async Task<VolatileJournalStorage> CreateJsonStorageWithSegment(
+        string jsonLines,
+        CancellationToken cancellationToken)
     {
         var storage = CreateJsonStorage();
-        await storage.AppendAsync(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(jsonLines)), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(jsonLines)), cancellationToken);
         return storage;
     }
 
-    private static async Task<InvalidOperationException> AssertRecoveryFailsAsync(ILifecycleSubject lifecycle, string journalFormatKey)
+    private static async Task<InvalidOperationException> AssertRecoveryFailsAsync(
+        ILifecycleSubject lifecycle,
+        string journalFormatKey,
+        CancellationToken cancellationToken)
     {
         InvalidOperationException exception;
         try
         {
             exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
+                () => lifecycle.OnStart(cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken));
         }
         finally
         {
-            await lifecycle.OnStop(CancellationToken.None);
+            await lifecycle.OnStop(cancellationToken);
         }
 
         Assert.Contains($"journal format key '{journalFormatKey}'", exception.Message, StringComparison.Ordinal);

--- a/test/Orleans.Journaling.Tests/AzureTableJournalStorageConcurrencyTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureTableJournalStorageConcurrencyTests.cs
@@ -25,7 +25,9 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var storage = CreateStorage(store, maxRetries: 2);
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "original" }));
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "original" },
+            TestContext.Current.CancellationToken));
         var originalGeneration = store.HeaderGeneration;
         var metadataWriter = CreateStorage(store);
         store.BeforeTransactionAsync = async (attempt, _, cancellationToken) =>
@@ -38,7 +40,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
             }
         };
 
-        await storage.AppendAsync(new ReadOnlySequence<byte>([4, 5]), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>([4, 5]), TestContext.Current.CancellationToken);
 
         Assert.Equal(3, store.TransactionAttempts);
         Assert.Equal(1, store.SuccessfulTransactions);
@@ -53,7 +55,8 @@ public sealed class AzureTableJournalStorageConcurrencyTests
             store.TransactionCalls,
             transaction => Assert.Equal(store.TransactionCalls[0][1].RowKey, transaction[1].RowKey));
 
-        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(await storage.GetMetadataAsync());
+        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(
+            await storage.GetMetadataAsync(TestContext.Current.CancellationToken));
         Assert.Equal(
             new Dictionary<string, string>
             {
@@ -62,7 +65,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
                 ["conflict-2"] = "2",
             },
             metadata.Properties);
-        Assert.Equal([4, 5], await ReadBytesAsync(store));
+        Assert.Equal([4, 5], await ReadBytesAsync(store, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -70,7 +73,9 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var storage = CreateStorage(store, maxRetries: 2);
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "original" }));
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "original" },
+            TestContext.Current.CancellationToken));
         var originalGeneration = store.HeaderGeneration;
         var metadataWriter = CreateStorage(store);
         store.BeforeTransactionAsync = async (attempt, _, cancellationToken) =>
@@ -81,7 +86,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         };
 
         var exception = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => storage.AppendAsync(new ReadOnlySequence<byte>([7, 8, 9]), CancellationToken.None).AsTask());
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([7, 8, 9]), TestContext.Current.CancellationToken).AsTask());
 
         Assert.Equal(412, Assert.IsType<RequestFailedException>(exception.InnerException).Status);
         Assert.Equal(3, store.TransactionAttempts);
@@ -99,10 +104,11 @@ public sealed class AzureTableJournalStorageConcurrencyTests
                 Assert.Equal(store.TransactionCalls[0][1].RowKey, transaction[1].RowKey);
             });
 
-        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(await storage.GetMetadataAsync());
+        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(
+            await storage.GetMetadataAsync(TestContext.Current.CancellationToken));
         Assert.Equal(4, metadata.Properties.Count);
         Assert.Equal("3", metadata.Properties["conflict-3"]);
-        Assert.Empty(await ReadBytesAsync(store));
+        Assert.Empty(await ReadBytesAsync(store, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -110,7 +116,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var storage = CreateStorage(store, maxRetries: 0);
-        Assert.True(await storage.CreateIfNotExistsAsync());
+        Assert.True(await storage.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken));
         var originalGeneration = store.HeaderGeneration;
         store.BeforeTransactionAsync = (attempt, _, _) =>
         {
@@ -120,7 +126,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         };
 
         await Assert.ThrowsAsync<InconsistentStateException>(
-            () => storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None).AsTask());
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken).AsTask());
 
         Assert.Equal(1, store.TransactionAttempts);
         Assert.Equal(0, store.SuccessfulTransactions);
@@ -129,7 +135,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         Assert.Equal(originalGeneration, store.HeaderGeneration);
         Assert.Equal(0L, store.HeaderRowCount);
         Assert.Equal(0L, store.HeaderLength);
-        Assert.Equal("injected", (await storage.GetMetadataAsync())!.Properties["conflict"]);
+        Assert.Equal("injected", (await storage.GetMetadataAsync(TestContext.Current.CancellationToken))!.Properties["conflict"]);
     }
 
     [Fact]
@@ -141,7 +147,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
             maxRetries: 3,
             initialBackoff: TimeSpan.FromDays(1),
             maxBackoff: TimeSpan.FromDays(1));
-        Assert.True(await storage.CreateIfNotExistsAsync());
+        Assert.True(await storage.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken));
         var originalGeneration = store.HeaderGeneration;
         var conflictObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         store.BeforeTransactionAsync = (_, _, _) =>
@@ -169,7 +175,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         Assert.Equal(originalGeneration, store.HeaderGeneration);
         Assert.Equal(0L, store.HeaderRowCount);
         Assert.Equal(0L, store.HeaderLength);
-        Assert.Equal("before-backoff", (await storage.GetMetadataAsync())!.Properties["conflict"]);
+        Assert.Equal("before-backoff", (await storage.GetMetadataAsync(TestContext.Current.CancellationToken))!.Properties["conflict"]);
     }
 
     [Fact]
@@ -190,10 +196,12 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         var second = CreateStorage(store);
 
         var firstTask = first.CreateIfNotExistsAsync(
-            new Dictionary<string, string> { ["owner"] = "first" }).AsTask();
-        await firstAddEntered.Task;
+            new Dictionary<string, string> { ["owner"] = "first" },
+            TestContext.Current.CancellationToken).AsTask();
+        await firstAddEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
         var secondResult = await second.CreateIfNotExistsAsync(
-            new Dictionary<string, string> { ["owner"] = "second" });
+            new Dictionary<string, string> { ["owner"] = "second" },
+            TestContext.Current.CancellationToken);
         releaseFirstAdd.TrySetResult();
         var firstResult = await firstTask;
 
@@ -206,7 +214,8 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         Assert.False(string.IsNullOrWhiteSpace(store.HeaderGeneration));
         Assert.Equal(0L, store.HeaderRowCount);
         Assert.Equal(0L, store.HeaderLength);
-        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(await CreateStorage(store).GetMetadataAsync());
+        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(
+            await CreateStorage(store).GetMetadataAsync(TestContext.Current.CancellationToken));
         Assert.Equal(new Dictionary<string, string> { ["owner"] = "second" }, metadata.Properties);
     }
 
@@ -215,12 +224,12 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var seed = CreateStorage(store);
-        await seed.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await seed.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
         var originalGeneration = store.HeaderGeneration;
         var blockedWriter = CreateStorage(store, maxRetries: 3);
         var winningWriter = CreateStorage(store, maxRetries: 3);
-        await RecoverAsync(blockedWriter);
-        await RecoverAsync(winningWriter);
+        await RecoverAsync(blockedWriter, TestContext.Current.CancellationToken);
+        await RecoverAsync(winningWriter, TestContext.Current.CancellationToken);
         var baselineAttempts = store.TransactionAttempts;
         var blockedAttemptEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseBlockedAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -233,9 +242,9 @@ public sealed class AzureTableJournalStorageConcurrencyTests
             }
         };
 
-        var blockedTask = blockedWriter.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask();
-        await blockedAttemptEntered.Task;
-        await winningWriter.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
+        var blockedTask = blockedWriter.AppendAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken).AsTask();
+        await blockedAttemptEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await winningWriter.AppendAsync(new ReadOnlySequence<byte>([3]), TestContext.Current.CancellationToken);
         releaseBlockedAttempt.TrySetResult();
         var exception = await Assert.ThrowsAsync<InconsistentStateException>(() => blockedTask);
 
@@ -247,7 +256,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         Assert.Equal(2L, store.HeaderLength);
         Assert.Equal(2, store.DataRowCount);
         Assert.Equal(2, store.DataRowKeys.Distinct(StringComparer.Ordinal).Count());
-        Assert.Equal([1, 3], await ReadBytesAsync(store));
+        Assert.Equal([1, 3], await ReadBytesAsync(store, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -255,7 +264,8 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         Assert.True(await CreateStorage(store).CreateIfNotExistsAsync(
-            new Dictionary<string, string> { ["owner"] = "seed" }));
+            new Dictionary<string, string> { ["owner"] = "seed" },
+            TestContext.Current.CancellationToken));
         var originalGeneration = store.HeaderGeneration;
         var firstUpdateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFirstUpdate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -272,11 +282,11 @@ public sealed class AzureTableJournalStorageConcurrencyTests
 
         var firstTask = first.UpdateMetadataAsync(
             set: new Dictionary<string, string> { ["alpha"] = "A" },
-            cancellationToken: CancellationToken.None).AsTask();
-        await firstUpdateEntered.Task;
+            cancellationToken: TestContext.Current.CancellationToken).AsTask();
+        await firstUpdateEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
         var secondResult = await second.UpdateMetadataAsync(
             set: new Dictionary<string, string> { ["beta"] = "B" },
-            cancellationToken: CancellationToken.None);
+            cancellationToken: TestContext.Current.CancellationToken);
         releaseFirstUpdate.TrySetResult();
         var firstResult = await firstTask;
 
@@ -293,7 +303,8 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         Assert.Equal(
             new Dictionary<string, string> { ["owner"] = "seed", ["beta"] = "B" },
             secondResult.Properties);
-        var final = Assert.IsAssignableFrom<IJournalMetadata>(await CreateStorage(store).GetMetadataAsync());
+        var final = Assert.IsAssignableFrom<IJournalMetadata>(
+            await CreateStorage(store).GetMetadataAsync(TestContext.Current.CancellationToken));
         Assert.Equal(firstResult.Properties, final.Properties);
         Assert.Equal(firstResult.ETag, final.ETag);
         Assert.Equal(1, store.EntityCount);
@@ -305,7 +316,8 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         var store = new CoordinatedTableStore();
         var storage = CreateStorage(store);
         Assert.True(await storage.CreateIfNotExistsAsync(
-            new Dictionary<string, string> { ["owner"] = "seed" }));
+            new Dictionary<string, string> { ["owner"] = "seed" },
+            TestContext.Current.CancellationToken));
         store.BeforeUpdateAsync = (attempt, entity, _, _, _) =>
         {
             Assert.Equal(AzureTableJournalStorage.HeaderRowKey, entity.RowKey);
@@ -315,12 +327,13 @@ public sealed class AzureTableJournalStorageConcurrencyTests
 
         var result = await storage.UpdateMetadataAsync(
             set: new Dictionary<string, string> { ["owner"] = "overwritten" },
-            cancellationToken: CancellationToken.None);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Null(result);
         Assert.Equal(3, store.UpdateAttempts);
         Assert.Equal(0, store.SuccessfulUpdates);
-        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(await storage.GetMetadataAsync());
+        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(
+            await storage.GetMetadataAsync(TestContext.Current.CancellationToken));
         Assert.Equal("seed", metadata.Properties["owner"]);
         Assert.Equal(["1", "2", "3"], Enumerable.Range(1, 3).Select(index => metadata.Properties[$"conflict-{index}"]));
     }
@@ -330,7 +343,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var storage = CreateStorage(store, maxRetries: 2);
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
         var oldGeneration = store.HeaderGeneration;
         store.BeforeUpdateAsync = (attempt, entity, _, _, _) =>
         {
@@ -343,15 +356,16 @@ public sealed class AzureTableJournalStorageConcurrencyTests
             return Task.CompletedTask;
         };
 
-        await storage.ReplaceAsync(new ReadOnlySequence<byte>([8, 9]), CancellationToken.None);
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([8, 9]), TestContext.Current.CancellationToken);
 
         Assert.Equal(3, store.UpdateAttempts);
         Assert.Equal(1, store.SuccessfulUpdates);
         Assert.NotEqual(oldGeneration, store.HeaderGeneration);
         Assert.Equal(1L, store.HeaderRowCount);
         Assert.Equal(2L, store.HeaderLength);
-        Assert.Equal([8, 9], await ReadBytesAsync(store));
-        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(await storage.GetMetadataAsync());
+        Assert.Equal([8, 9], await ReadBytesAsync(store, TestContext.Current.CancellationToken));
+        var metadata = Assert.IsAssignableFrom<IJournalMetadata>(
+            await storage.GetMetadataAsync(TestContext.Current.CancellationToken));
         Assert.Equal("1", metadata.Properties["conflict-1"]);
         Assert.Equal("2", metadata.Properties["conflict-2"]);
     }
@@ -361,7 +375,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var storage = CreateStorage(store, maxRetries: 2);
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
         store.BeforeDeleteAsync = (attempt, _, _, _) =>
         {
             if (attempt <= 2)
@@ -372,7 +386,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
             return Task.CompletedTask;
         };
 
-        await storage.DeleteAsync(CancellationToken.None);
+        await storage.DeleteAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(3, store.DeleteAttempts);
         Assert.Equal(1, store.SuccessfulDeletes);
@@ -385,7 +399,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var storage = CreateStorage(store, maxRetries: 2);
-        Assert.True(await storage.CreateIfNotExistsAsync());
+        Assert.True(await storage.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken));
         store.BeforeTransactionAsync = (_, _, _) =>
         {
             store.RemoveHeader();
@@ -393,7 +407,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         };
 
         var exception = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None).AsTask());
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken).AsTask());
 
         Assert.Equal(404, Assert.IsType<RequestFailedException>(exception.InnerException).Status);
         Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
@@ -408,10 +422,10 @@ public sealed class AzureTableJournalStorageConcurrencyTests
     {
         var store = new CoordinatedTableStore();
         var replacement = CreateStorage(store, maxRetries: 3);
-        await replacement.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await replacement.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
         var originalGeneration = store.HeaderGeneration;
         var appender = CreateStorage(store, maxRetries: 3);
-        await RecoverAsync(appender);
+        await RecoverAsync(appender, TestContext.Current.CancellationToken);
         var baselineTransactions = store.TransactionAttempts;
         var flipEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFlip = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -424,9 +438,9 @@ public sealed class AzureTableJournalStorageConcurrencyTests
             }
         };
 
-        var replaceTask = replacement.ReplaceAsync(new ReadOnlySequence<byte>([9]), CancellationToken.None).AsTask();
-        await flipEntered.Task;
-        await appender.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
+        var replaceTask = replacement.ReplaceAsync(new ReadOnlySequence<byte>([9]), TestContext.Current.CancellationToken).AsTask();
+        await flipEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await appender.AppendAsync(new ReadOnlySequence<byte>([3]), TestContext.Current.CancellationToken);
         releaseFlip.TrySetResult();
         var exception = await Assert.ThrowsAsync<InconsistentStateException>(() => replaceTask);
 
@@ -441,7 +455,7 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         Assert.Equal(2, store.DataRowCount);
         Assert.Equal(2, store.DataRowKeys.Count(key => key.StartsWith(originalGeneration + "-", StringComparison.Ordinal)));
         Assert.DoesNotContain(store.DataRowKeys, key => !key.StartsWith(originalGeneration + "-", StringComparison.Ordinal));
-        Assert.Equal([1, 3], await ReadBytesAsync(store));
+        Assert.Equal([1, 3], await ReadBytesAsync(store, TestContext.Current.CancellationToken));
     }
 
     private static AzureTableJournalStorage CreateStorage(
@@ -472,13 +486,17 @@ public sealed class AzureTableJournalStorageConcurrencyTests
         return services.BuildServiceProvider().GetRequiredService<AzureTableJournalStorageInstruments>();
     }
 
-    private static async Task RecoverAsync(AzureTableJournalStorage storage)
-        => await storage.ReadAsync(DiscardingConsumer.Instance, CancellationToken.None);
+    private static async Task RecoverAsync(
+        AzureTableJournalStorage storage,
+        CancellationToken cancellationToken)
+        => await storage.ReadAsync(DiscardingConsumer.Instance, cancellationToken);
 
-    private static async Task<byte[]> ReadBytesAsync(CoordinatedTableStore store)
+    private static async Task<byte[]> ReadBytesAsync(
+        CoordinatedTableStore store,
+        CancellationToken cancellationToken)
     {
         var consumer = new CapturingConsumer();
-        await CreateStorage(store).ReadAsync(consumer, CancellationToken.None);
+        await CreateStorage(store).ReadAsync(consumer, cancellationToken);
         return consumer.Bytes.ToArray();
     }
 

--- a/test/Orleans.Journaling.Tests/AzureTableJournalStorageOptionsTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureTableJournalStorageOptionsTests.cs
@@ -208,7 +208,7 @@ public sealed class AzureTableJournalStorageOptionsTests
         var client = await options.CreateClient!(CancellationToken.None);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => client.GetPropertiesAsync());
+            () => client.GetPropertiesAsync(TestContext.Current.CancellationToken));
 
         Assert.Equal(ThrowingPipelinePolicy.ExceptionMessage, exception.Message);
         Assert.Equal(1, policy.InvocationCount);

--- a/test/Orleans.Journaling.Tests/AzureTableJournalStorageProviderTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureTableJournalStorageProviderTests.cs
@@ -40,10 +40,11 @@ public sealed class AzureTableJournalStorageProviderTests
             return $"tenant!{Uri.EscapeDataString(journalId.Value)}";
         };
         using var context = CreateProvider(options);
-        await StartAsync(context.Provider);
+        await StartAsync(context.Provider, TestContext.Current.CancellationToken);
         var journalId = new JournalId("orders/42");
 
-        var created = await context.Provider.CreateStorage(journalId).CreateIfNotExistsAsync();
+        var created = await context.Provider.CreateStorage(journalId)
+            .CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(created);
         Assert.Equal(journalId, mappedJournalId);
@@ -84,7 +85,7 @@ public sealed class AzureTableJournalStorageProviderTests
         using var cts = new CancellationTokenSource();
 
         await lifecycle.StartAsync(cts.Token);
-        var listed = await ToListAsync(context.Provider.ListAsync(cancellationToken: cts.Token));
+        var listed = await ToListAsync(context.Provider.ListAsync(cancellationToken: cts.Token), cts.Token);
 
         Assert.Equal(cts.Token, receivedToken);
         Assert.Equal("tenantJournal", service.RequestedTableName);
@@ -111,7 +112,9 @@ public sealed class AzureTableJournalStorageProviderTests
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => StartAsync(context.Provider, cts.Token));
         var unavailable = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ToListAsync(context.Provider.ListAsync()));
+            () => ToListAsync(
+                context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+                TestContext.Current.CancellationToken));
 
         Assert.Equal(cts.Token, receivedToken);
         Assert.Equal(cts.Token, exception.CancellationToken);
@@ -128,9 +131,12 @@ public sealed class AzureTableJournalStorageProviderTests
         options.ConfigureTableServiceClient(_ => Task.FromException<TableServiceClient>(expected));
         using var context = CreateProvider(options);
 
-        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => StartAsync(context.Provider));
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => StartAsync(context.Provider, TestContext.Current.CancellationToken));
         var unavailable = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ToListAsync(context.Provider.ListAsync()));
+            () => ToListAsync(
+                context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+                TestContext.Current.CancellationToken));
 
         Assert.Same(expected, actual);
         Assert.Contains("has not been initialized", unavailable.Message);
@@ -141,7 +147,8 @@ public sealed class AzureTableJournalStorageProviderTests
     {
         using var context = CreateProvider(new AzureTableJournalStorageOptions());
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => StartAsync(context.Provider));
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => StartAsync(context.Provider, TestContext.Current.CancellationToken));
 
         Assert.Contains(nameof(AzureTableJournalStorageOptions.TableServiceClient), exception.Message);
         Assert.Contains(nameof(AzureTableJournalStorageOptions.ConfigureTableServiceClient), exception.Message);
@@ -154,7 +161,8 @@ public sealed class AzureTableJournalStorageProviderTests
         options.ConfigureTableServiceClient(_ => Task.FromResult<TableServiceClient>(null!));
         using var context = CreateProvider(options);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => StartAsync(context.Provider));
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => StartAsync(context.Provider, TestContext.Current.CancellationToken));
 
         Assert.Equal("The configured Azure Table service client factory returned null.", exception.Message);
     }
@@ -166,9 +174,12 @@ public sealed class AzureTableJournalStorageProviderTests
         var table = new FakeTableClient { CreateException = expected };
         using var context = CreateProvider(CreateOptions(table));
 
-        var actual = await Assert.ThrowsAsync<RequestFailedException>(() => StartAsync(context.Provider));
+        var actual = await Assert.ThrowsAsync<RequestFailedException>(
+            () => StartAsync(context.Provider, TestContext.Current.CancellationToken));
         var unavailable = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ToListAsync(context.Provider.ListAsync()));
+            () => ToListAsync(
+                context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+                TestContext.Current.CancellationToken));
 
         Assert.Same(expected, actual);
         Assert.Equal(1, table.CreateIfNotExistsCalls);
@@ -242,12 +253,12 @@ public sealed class AzureTableJournalStorageProviderTests
     {
         var table = new FakeTableClient();
         using var context = CreateProvider(CreateOptions(table));
-        await StartAsync(context.Provider);
+        await StartAsync(context.Provider, TestContext.Current.CancellationToken);
 
         var storage = context.Provider.CreateStorage(new JournalId("matching-format"));
 
         Assert.IsType<AzureTableJournalStorage>(storage);
-        Assert.True(await storage.CreateIfNotExistsAsync());
+        Assert.True(await storage.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken));
         var header = Assert.Single(table.AddedEntities);
         Assert.Equal(FormatKey, header[AzureTableJournalStorage.FormatPropertyName]);
         Assert.Equal(0L, header[AzureTableJournalStorage.RowCountPropertyName]);
@@ -258,9 +269,11 @@ public sealed class AzureTableJournalStorageProviderTests
     public async Task ListAsync_EmptyTable_ReturnsEmptyAndSelectsOnlyCanonicalJournalId()
     {
         var table = new FakeTableClient();
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync());
+        var result = await ToListAsync(
+            context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         Assert.Empty(result);
         var query = Assert.Single(table.QueryCalls);
@@ -280,9 +293,11 @@ public sealed class AzureTableJournalStorageProviderTests
         table.AddHeader(last);
         table.AddHeader(lower);
         table.AddHeader(upper);
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync());
+        var result = await ToListAsync(
+            context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal([upper, lower, last], result);
         Assert.Equal(3, result.Count);
@@ -300,9 +315,11 @@ public sealed class AzureTableJournalStorageProviderTests
         table.AddHeader(new JournalId("tenant/payments"));
         table.AddHeader(child);
         table.AddHeader(exact);
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync(prefix));
+        var result = await ToListAsync(
+            context.Provider.ListAsync(prefix, TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal([exact, child], result);
         var query = Assert.Single(table.QueryCalls);
@@ -320,9 +337,11 @@ public sealed class AzureTableJournalStorageProviderTests
         table.AddHeader(retained);
         table.AddHeader(deleted);
         table.RemoveHeader(deleted);
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync());
+        var result = await ToListAsync(
+            context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal([retained], result);
         Assert.DoesNotContain(deleted, result);
@@ -339,9 +358,11 @@ public sealed class AzureTableJournalStorageProviderTests
             AzureTableJournalStorageOptions.GetDefaultPartitionKey(orphan),
             "g00000000000000000001-r0000000000");
         table.AddEntity("%20", AzureTableJournalStorage.HeaderRowKey);
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync());
+        var result = await ToListAsync(
+            context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal([valid], result);
         Assert.DoesNotContain(orphan, result);
@@ -353,9 +374,11 @@ public sealed class AzureTableJournalStorageProviderTests
         var table = new FakeTableClient();
         var escaped = new JournalId("tenant/slash\\hash#query?control\u0001");
         table.AddHeader(escaped);
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync());
+        var result = await ToListAsync(
+            context.Provider.ListAsync(cancellationToken: TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         var listed = Assert.Single(result);
         Assert.Equal(escaped, listed);
@@ -375,9 +398,11 @@ public sealed class AzureTableJournalStorageProviderTests
         var options = CreateOptions(table);
         options.GetPartitionKey = static journalId => journalId.Value == "tenant/orders/42" ? "hash-a" : "hash-b";
         using var context = CreateProvider(options);
-        await StartAsync(context.Provider);
+        await StartAsync(context.Provider, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync(new JournalId("tenant/orders")));
+        var result = await ToListAsync(
+            context.Provider.ListAsync(new JournalId("tenant/orders"), TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal([included], result);
         Assert.Equal(
@@ -391,9 +416,11 @@ public sealed class AzureTableJournalStorageProviderTests
         var table = new FakeTableClient();
         var journalId = new JournalId("legacy/orders/42");
         table.AddLegacyHeader(journalId);
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
-        var result = await ToListAsync(context.Provider.ListAsync(new JournalId("legacy/orders")));
+        var result = await ToListAsync(
+            context.Provider.ListAsync(new JournalId("legacy/orders"), TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal([journalId], result);
     }
@@ -403,12 +430,12 @@ public sealed class AzureTableJournalStorageProviderTests
     {
         var table = new FakeTableClient();
         table.AddHeader(new JournalId("never-returned"));
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => ToListAsync(context.Provider.ListAsync(cancellationToken: cts.Token)));
+            () => ToListAsync(context.Provider.ListAsync(cancellationToken: cts.Token), cts.Token));
 
         Assert.Equal(cts.Token, exception.CancellationToken);
         Assert.Empty(table.QueryCalls);
@@ -420,10 +447,10 @@ public sealed class AzureTableJournalStorageProviderTests
         using var cts = new CancellationTokenSource();
         var table = new FakeTableClient { AfterQuery = cts.Cancel };
         table.AddHeader(new JournalId("buffered"));
-        using var context = await CreateStartedProviderAsync(table);
+        using var context = await CreateStartedProviderAsync(table, TestContext.Current.CancellationToken);
 
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => ToListAsync(context.Provider.ListAsync(cancellationToken: cts.Token)));
+            () => ToListAsync(context.Provider.ListAsync(cancellationToken: cts.Token), cts.Token));
 
         Assert.Equal(cts.Token, exception.CancellationToken);
         Assert.Single(table.QueryCalls);
@@ -462,12 +489,14 @@ public sealed class AzureTableJournalStorageProviderTests
             serviceProvider,
             NullLogger<AzureTableJournalStorage>.Instance);
 
-    private static async Task<ProviderContext> CreateStartedProviderAsync(FakeTableClient table)
+    private static async Task<ProviderContext> CreateStartedProviderAsync(
+        FakeTableClient table,
+        CancellationToken cancellationToken)
     {
         var context = CreateProvider(CreateOptions(table));
         try
         {
-            await StartAsync(context.Provider);
+            await StartAsync(context.Provider, cancellationToken);
             return context;
         }
         catch
@@ -486,10 +515,12 @@ public sealed class AzureTableJournalStorageProviderTests
         return lifecycle.StartAsync(cancellationToken);
     }
 
-    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    private static async Task<List<T>> ToListAsync<T>(
+        IAsyncEnumerable<T> source,
+        CancellationToken cancellationToken)
     {
         var result = new List<T>();
-        await foreach (var item in source)
+        await foreach (var item in source.WithCancellation(cancellationToken))
         {
             result.Add(item);
         }

--- a/test/Orleans.Journaling.Tests/AzureTableJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureTableJournalStorageTests.cs
@@ -176,9 +176,9 @@ public sealed class AzureTableJournalStorageTests
         var first = CreateStorage(store, configure: Configure, journalId: new JournalId("journal-a"));
         var second = CreateStorage(store, configure: Configure, journalId: new JournalId("journal-b"));
 
-        Assert.True(await first.CreateIfNotExistsAsync());
+        Assert.True(await first.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken));
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => second.CreateIfNotExistsAsync().AsTask());
+            () => second.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken).AsTask());
 
         Assert.Contains("journal-a", exception.Message);
         Assert.Contains("journal-b", exception.Message);
@@ -635,8 +635,12 @@ public sealed class AzureTableJournalStorageTests
         var store = new FakeTableStore();
         var storage = CreateStorage(store);
 
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "first" }));
-        Assert.False(await CreateStorage(store).CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "second" }));
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "first" },
+            TestContext.Current.CancellationToken));
+        Assert.False(await CreateStorage(store).CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "second" },
+            TestContext.Current.CancellationToken));
 
         var metadata = await storage.GetMetadataAsync(CancellationToken.None);
         Assert.NotNull(metadata);
@@ -669,7 +673,9 @@ public sealed class AzureTableJournalStorageTests
     {
         var store = new FakeTableStore();
         var storage = CreateStorage(store);
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" }));
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" },
+            TestContext.Current.CancellationToken));
 
         var updated = await storage.UpdateMetadataAsync(
             set: new Dictionary<string, string> { ["c"] = "3" },
@@ -689,7 +695,9 @@ public sealed class AzureTableJournalStorageTests
     {
         var store = new FakeTableStore();
         var storage = CreateStorage(store);
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["a"] = "1" }));
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["a"] = "1" },
+            TestContext.Current.CancellationToken));
 
         var updated = await storage.UpdateMetadataAsync(
             set: new Dictionary<string, string> { ["a"] = "2" },
@@ -708,11 +716,17 @@ public sealed class AzureTableJournalStorageTests
         var storage = CreateStorage(new FakeTableStore());
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["$provider"] = "1" }).AsTask());
+            () => storage.CreateIfNotExistsAsync(
+                new Dictionary<string, string> { ["$provider"] = "1" },
+                TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.UpdateMetadataAsync(set: new Dictionary<string, string> { ["$provider"] = "1" }).AsTask());
+            () => storage.UpdateMetadataAsync(
+                set: new Dictionary<string, string> { ["$provider"] = "1" },
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.UpdateMetadataAsync(remove: ["$provider"]).AsTask());
+            () => storage.UpdateMetadataAsync(
+                remove: ["$provider"],
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
     }
 
     [Fact]
@@ -1610,7 +1624,9 @@ public sealed class AzureTableJournalStorageTests
     {
         var store = new FakeTableStore();
         var storage = CreateStorage(store);
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "alice" }));
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "alice" },
+            TestContext.Current.CancellationToken));
         var before = await storage.GetMetadataAsync(CancellationToken.None);
         Assert.NotNull(before);
 
@@ -1714,21 +1730,30 @@ public sealed class AzureTableJournalStorageTests
         var storage = CreateStorage(store);
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.CreateIfNotExistsAsync(new Dictionary<string, string> { [" \t"] = "value" }).AsTask());
+            () => storage.CreateIfNotExistsAsync(
+                new Dictionary<string, string> { [" \t"] = "value" },
+                TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.UpdateMetadataAsync(remove: ["bad\0key"]).AsTask());
+            () => storage.UpdateMetadataAsync(
+                remove: ["bad\0key"],
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<ArgumentNullException>(
-            () => storage.UpdateMetadataAsync(set: new Dictionary<string, string> { ["key"] = null! }).AsTask());
+            () => storage.UpdateMetadataAsync(
+                set: new Dictionary<string, string> { ["key"] = null! },
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAsync<ArgumentException>(
             () => storage.UpdateMetadataAsync(
                 set: new Dictionary<string, string> { ["same"] = "value" },
-                remove: ["same"]).AsTask());
+                remove: ["same"],
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
         Assert.Empty(store.AddCalls);
         Assert.Empty(store.UpdateCalls);
 
-        Assert.True(await storage.CreateIfNotExistsAsync());
+        Assert.True(await storage.CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken));
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.UpdateMetadataAsync(expectedETag: " \t").AsTask());
+            () => storage.UpdateMetadataAsync(
+                expectedETag: " \t",
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
         Assert.Empty(store.UpdateCalls);
     }
 

--- a/test/Orleans.Journaling.Tests/DurableDictionaryTests.cs
+++ b/test/Orleans.Journaling.Tests/DurableDictionaryTests.cs
@@ -31,7 +31,7 @@ public class DurableDictionaryTests : JournalingTestBase
         var keyCodec = CodecProvider.GetCodec<string>();
         var valueCodec = CodecProvider.GetCodec<int>();
         var dictionary = new DurableDictionary<string, int>("testDict", sut.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(keyCodec, valueCodec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Add items to the dictionary
         // Each operation is journaled but not persisted until WriteStateAsync is called
@@ -76,7 +76,7 @@ public class DurableDictionaryTests : JournalingTestBase
         var keyCodec = CodecProvider.GetCodec<string>();
         var valueCodec = CodecProvider.GetCodec<int>();
         var dictionary1 = new DurableDictionary<string, int>("testDict", sut.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(keyCodec, valueCodec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Add items and persist
         dictionary1.Add("one", 1);
@@ -88,7 +88,7 @@ public class DurableDictionaryTests : JournalingTestBase
         // This tests the journaling system's ability to replay operations and restore state
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var dictionary2 = new DurableDictionary<string, int>("testDict", sut2.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(keyCodec, valueCodec, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Assert - Dictionary should be recovered
         Assert.Equal(3, dictionary2.Count);
@@ -111,7 +111,7 @@ public class DurableDictionaryTests : JournalingTestBase
         var keyCodec = CodecProvider.GetCodec<TestKey>();
         var valueCodec = CodecProvider.GetCodec<string>();
         var dictionary = new DurableDictionary<TestKey, string>("complexDict", manager, new OrleansBinaryDurableDictionaryCommandCodec<TestKey, string>(keyCodec, valueCodec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act
         var key1 = new TestKey { Id = 1, Name = "Key1" };
@@ -141,7 +141,7 @@ public class DurableDictionaryTests : JournalingTestBase
         var keyCodec = CodecProvider.GetCodec<string>();
         var valueCodec = CodecProvider.GetCodec<TestPerson>();
         var dictionary = new DurableDictionary<string, TestPerson>("peopleDict", manager, new OrleansBinaryDurableDictionaryCommandCodec<string, TestPerson>(keyCodec, valueCodec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act
         var person1 = new TestPerson { Id = 1, Name = "John", Age = 30 };
@@ -177,7 +177,7 @@ public class DurableDictionaryTests : JournalingTestBase
         var keyCodec = CodecProvider.GetCodec<string>();
         var valueCodec = CodecProvider.GetCodec<int>();
         var dictionary = new DurableDictionary<string, int>("clearDict", manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(keyCodec, valueCodec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Add items
         dictionary.Add("one", 1);
@@ -207,7 +207,7 @@ public class DurableDictionaryTests : JournalingTestBase
         var keyCodec = CodecProvider.GetCodec<string>();
         var valueCodec = CodecProvider.GetCodec<int>();
         var dictionary = new DurableDictionary<string, int>("enumDict", manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(keyCodec, valueCodec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Add items
         var expectedPairs = new Dictionary<string, int>

--- a/test/Orleans.Journaling.Tests/DurableQueueTests.cs
+++ b/test/Orleans.Journaling.Tests/DurableQueueTests.cs
@@ -28,7 +28,7 @@ public class DurableQueueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var queue = new DurableQueue<string>("testQueue", manager, new OrleansBinaryDurableQueueCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Enqueue items
         queue.Enqueue("one");
@@ -83,7 +83,7 @@ public class DurableQueueTests : JournalingTestBase
         var sut = CreateTestSystem();
         var codec = CodecProvider.GetCodec<string>();
         var queue1 = new DurableQueue<string>("testQueue", sut.Manager, new OrleansBinaryDurableQueueCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Enqueue items and persist
         queue1.Enqueue("one");
@@ -94,7 +94,7 @@ public class DurableQueueTests : JournalingTestBase
         // Create a new manager with the same storage
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var queue2 = new DurableQueue<string>("testQueue", sut2.Manager, new OrleansBinaryDurableQueueCommandCodec<string>(codec, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Assert - Queue should be recovered
         Assert.Equal(3, queue2.Count);
@@ -122,7 +122,7 @@ public class DurableQueueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<TestPerson>();
         var queue = new DurableQueue<TestPerson>("personQueue", manager, new OrleansBinaryDurableQueueCommandCodec<TestPerson>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act
         var person1 = new TestPerson { Id = 1, Name = "John", Age = 30 };
@@ -159,7 +159,7 @@ public class DurableQueueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var queue = new DurableQueue<string>("clearQueue", manager, new OrleansBinaryDurableQueueCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Add items
         queue.Enqueue("one");
@@ -189,7 +189,7 @@ public class DurableQueueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var queue = new DurableQueue<string>("emptyQueue", manager, new OrleansBinaryDurableQueueCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         await manager.WriteStateAsync(CancellationToken.None);
         
         // Assert
@@ -213,7 +213,7 @@ public class DurableQueueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var queue = new DurableQueue<string>("enumQueue", manager, new OrleansBinaryDurableQueueCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Add items
         var expectedItems = new List<string> { "one", "two", "three" };
@@ -245,7 +245,7 @@ public class DurableQueueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<int>();
         var queue = new DurableQueue<int>("largeQueue", manager, new OrleansBinaryDurableQueueCommandCodec<int>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Enqueue many items
         const int itemCount = 1000;
@@ -263,7 +263,7 @@ public class DurableQueueTests : JournalingTestBase
         // Create a new manager with the same storage to test recovery
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var queue2 = new DurableQueue<int>("largeQueue", sut2.Manager, new OrleansBinaryDurableQueueCommandCodec<int>(codec, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Assert - Large queue is correctly recovered
         Assert.Equal(itemCount, queue2.Count);
@@ -292,7 +292,7 @@ public class DurableQueueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<int>();
         var queue = new DurableQueue<int>("concurrentQueue", manager, new OrleansBinaryDurableQueueCommandCodec<int>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Simulate a queue with concurrent operations
         const int batchSize = 100;
@@ -324,7 +324,7 @@ public class DurableQueueTests : JournalingTestBase
         // Create a new manager with the same storage to test recovery
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var queue2 = new DurableQueue<int>("concurrentQueue", sut2.Manager, new OrleansBinaryDurableQueueCommandCodec<int>(codec, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Assert - Queue should be recovered with correct state and ordering
         Assert.Equal(batchSize + batchSize / 2, queue2.Count);

--- a/test/Orleans.Journaling.Tests/DurableSetTests.cs
+++ b/test/Orleans.Journaling.Tests/DurableSetTests.cs
@@ -28,7 +28,7 @@ public class DurableSetTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var set = new DurableSet<string>("testSet", manager, new OrleansBinaryDurableSetCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Add items
         bool added1 = set.Add("one");
@@ -69,7 +69,7 @@ public class DurableSetTests : JournalingTestBase
         var sut = CreateTestSystem();
         var codec = CodecProvider.GetCodec<string>();
         var set1 = new DurableSet<string>("testSet", sut.Manager, new OrleansBinaryDurableSetCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Add items and persist
         set1.Add("one");
@@ -80,7 +80,7 @@ public class DurableSetTests : JournalingTestBase
         // Create a new manager with the same storage
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var set2 = new DurableSet<string>("testSet", sut2.Manager, new OrleansBinaryDurableSetCommandCodec<string>(codec, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Assert - Set should be recovered
         Assert.Equal(3, set2.Count);
@@ -100,7 +100,7 @@ public class DurableSetTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<TestPerson>();
         var set = new DurableSet<TestPerson>("personSet", manager, new OrleansBinaryDurableSetCommandCodec<TestPerson>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act
         var person1 = new TestPerson { Id = 1, Name = "John", Age = 30 };
@@ -130,7 +130,7 @@ public class DurableSetTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var set = new DurableSet<string>("clearSet", manager, new OrleansBinaryDurableSetCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Add items
         set.Add("one");
@@ -159,7 +159,7 @@ public class DurableSetTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var set = new DurableSet<string>("enumSet", manager, new OrleansBinaryDurableSetCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Add items
         var expectedItems = new HashSet<string> { "one", "two", "three" };
@@ -191,7 +191,7 @@ public class DurableSetTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<int>();
         var set = new DurableSet<int>("largeSet", manager, new OrleansBinaryDurableSetCommandCodec<int>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Act - Add many items
         const int itemCount = 1000;
@@ -214,7 +214,7 @@ public class DurableSetTests : JournalingTestBase
         // Create a new manager with the same storage to test recovery
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var set2 = new DurableSet<int>("largeSet", sut2.Manager, new OrleansBinaryDurableSetCommandCodec<int>(codec, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Assert - Large set is correctly recovered
         Assert.Equal(itemCount, set2.Count);
@@ -238,7 +238,7 @@ public class DurableSetTests : JournalingTestBase
         var codec = CodecProvider.GetCodec<int>();
         var set1 = new DurableSet<int>("set1", manager, new OrleansBinaryDurableSetCommandCodec<int>(codec, SessionPool));
         var set2 = new DurableSet<int>("set2", manager, new OrleansBinaryDurableSetCommandCodec<int>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Populate set1 with even numbers from 0 to 10
         for (int i = 0; i <= 10; i += 2)
@@ -287,7 +287,7 @@ public class DurableSetTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<int>();
         var set = new DurableSet<int>("exceptSet", manager, new OrleansBinaryDurableSetCommandCodec<int>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // Add numbers from 0 to 9
         for (int i = 0; i < 10; i++)

--- a/test/Orleans.Journaling.Tests/DurableStateAndTcsRecoveryTests.cs
+++ b/test/Orleans.Journaling.Tests/DurableStateAndTcsRecoveryTests.cs
@@ -24,7 +24,7 @@ public sealed class DurableStateAndTcsRecoveryTests : JournalingTestBase
             new OrleansBinaryDurableTaskCompletionSourceCommandCodec<int>(ValueCodec<int>(), ValueCodec<Exception>(), SessionPool),
             Copier<int>(),
             Copier<Exception>());
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         ((IStorage<string>)state).State = "state-value";
         Assert.True(tcs.TrySetResult(17));
@@ -38,7 +38,7 @@ public sealed class DurableStateAndTcsRecoveryTests : JournalingTestBase
             new OrleansBinaryDurableTaskCompletionSourceCommandCodec<int>(ValueCodec<int>(), ValueCodec<Exception>(), SessionPool),
             Copier<int>(),
             Copier<Exception>());
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         var recoveredState = (IStorage<string>)state2;
         Assert.True(recoveredState.RecordExists);
@@ -57,7 +57,7 @@ public sealed class DurableStateAndTcsRecoveryTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var state = new DurableState<string>("state", sut.Manager, codec);
         var grainState = (IStorage<string>)state;
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         grainState.State = "state-value";
         await grainState.WriteStateAsync(CancellationToken.None);
@@ -69,7 +69,7 @@ public sealed class DurableStateAndTcsRecoveryTests : JournalingTestBase
 
         var recovered = CreateTestSystem(storage: storage);
         var recoveredState = new DurableState<string>("state", recovered.Manager, new OrleansBinaryPersistentStateCommandCodec<string>(ValueCodec<string>(), SessionPool));
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         var recoveredStorage = (IStorage<string>)recoveredState;
         Assert.False(recoveredStorage.RecordExists);
@@ -86,7 +86,7 @@ public sealed class DurableStateAndTcsRecoveryTests : JournalingTestBase
             new OrleansBinaryDurableTaskCompletionSourceCommandCodec<int>(ValueCodec<int>(), ValueCodec<Exception>(), SessionPool),
             Copier<int>(),
             Copier<Exception>());
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         Assert.True(tcs.TrySetResult(17));
         await sut.Manager.WriteStateAsync(CancellationToken.None);
         Assert.Equal(17, await tcs.Task);

--- a/test/Orleans.Journaling.Tests/DurableValueTests.cs
+++ b/test/Orleans.Journaling.Tests/DurableValueTests.cs
@@ -28,7 +28,7 @@ public class DurableValueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string>();
         var durableValue = new DurableValue<string>("testValue", manager, new OrleansBinaryDurableValueCommandCodec<string>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Set initial value
         durableValue.Value = "Hello World";
@@ -57,7 +57,7 @@ public class DurableValueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<int>();
         var durableValue = new DurableValue<int>("counter", manager, new OrleansBinaryDurableValueCommandCodec<int>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Modify and persist
         durableValue.Value = 42;
@@ -66,7 +66,7 @@ public class DurableValueTests : JournalingTestBase
         // Create a new manager with the same storage
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var durableValue2 = new DurableValue<int>("counter", sut2.Manager, new OrleansBinaryDurableValueCommandCodec<int>(codec, SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Assert - Value should be recovered
         Assert.Equal(42, durableValue2.Value);
@@ -85,7 +85,7 @@ public class DurableValueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<string?>();
         var durableValue = new DurableValue<string?>("nullableValue", manager, new OrleansBinaryDurableValueCommandCodec<string?>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Set to null
         durableValue.Value = null;
@@ -122,7 +122,7 @@ public class DurableValueTests : JournalingTestBase
         var manager = sut.Manager;
         var codec = CodecProvider.GetCodec<TestPerson>();
         var durableValue = new DurableValue<TestPerson>("person", manager, new OrleansBinaryDurableValueCommandCodec<TestPerson>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act
         var person = new TestPerson { Id = 1, Name = "John Doe", Age = 30 };

--- a/test/Orleans.Journaling.Tests/FormatMigrationClusterTests.cs
+++ b/test/Orleans.Journaling.Tests/FormatMigrationClusterTests.cs
@@ -39,7 +39,7 @@ public sealed class FormatMigrationClusterTests
 
         try
         {
-            await cluster.DeployAsync();
+            await cluster.DeployAsync(TestContext.Current.CancellationToken);
             var binarySilo = Assert.Single(cluster.Silos);
             var grainId = Guid.NewGuid();
             var grain = cluster.Client!.GetGrain<ITestDurableGrain>(grainId); // DeployAsync initializes the client.
@@ -51,9 +51,9 @@ public sealed class FormatMigrationClusterTests
 
             var jsonSilo = await cluster.StartAdditionalSiloAsync();
             await cluster.WaitForLivenessToStabilizeAsync();
-            await cluster.StopSiloAsync(binarySilo);
+            await cluster.StopSiloAsync(binarySilo, TestContext.Current.CancellationToken);
             await cluster.WaitForLivenessToStabilizeAsync();
-            await cluster.InitializeClientAsync();
+            await cluster.InitializeClientAsync(TestContext.Current.CancellationToken);
 
             grain = cluster.Client.GetGrain<ITestDurableGrain>(grainId);
             Assert.Equal("binary", await grain.GetName());
@@ -70,7 +70,8 @@ public sealed class FormatMigrationClusterTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
+            using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await cluster.StopAllSilosAsync(cleanup.Token);
             await cluster.DisposeAsync();
         }
     }

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -42,7 +42,7 @@ public class StateManagerTests : JournalingTestBase
         var dictionary = new DurableDictionary<string, int>("dict1", manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(CodecProvider.GetCodec<string>(), codec, SessionPool));
         var list = new DurableList<string>("list1", manager, new OrleansBinaryDurableListCommandCodec<string>(CodecProvider.GetCodec<string>(), SessionPool));
         var queue = new DurableQueue<int>("queue1", manager, new OrleansBinaryDurableQueueCommandCodec<int>(codec, SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Add some data
         dictionary.Add("key1", 1);
@@ -64,7 +64,7 @@ public class StateManagerTests : JournalingTestBase
         var storage = new StreamingOnlyStorage();
         var sut = CreateTestSystem(storage: storage);
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.True(storage.StreamingReadCalled);
     }
@@ -81,7 +81,8 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage, journalFormat: new NonConsumingJournalFormat());
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
+            sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
 
         Assert.NotNull(exception.InnerException);
         Assert.Contains("did not read the completed journal data", exception.InnerException.Message, StringComparison.Ordinal);
@@ -152,7 +153,8 @@ public class StateManagerTests : JournalingTestBase
         await storage.AppendAsync(data.AsReadOnlySequence(), CancellationToken.None);
         var sut = CreateTestSystem(storage: storage);
 
-        await sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
         var segmentBytes = Assert.Single(storage.Segments);
@@ -173,7 +175,8 @@ public class StateManagerTests : JournalingTestBase
         var format = new DecodedPayloadOnlyJournalFormat(new JournalStreamId(99), decodedPayload, SessionPool);
         var sut = CreateTestSystem(storage: storage, journalFormat: format);
 
-        await sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
         var replacement = Assert.Single(storage.Replaces);
@@ -193,7 +196,7 @@ public class StateManagerTests : JournalingTestBase
         var initial = CreateTestSystem(storage: storage);
         var dictionary = new DurableDictionary<string, int>("retired", initial.Manager, CreateDictionaryCodec<string, int>());
 
-        await initial.Lifecycle.OnStart();
+        await initial.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("key", 7);
         await initial.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -201,7 +204,7 @@ public class StateManagerTests : JournalingTestBase
         var format = new TrackingJournalFormat(SessionPool);
         var compacting = CreateTestSystem(storage: storage, journalFormat: format);
 
-        await compacting.Lifecycle.OnStart();
+        await compacting.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         await compacting.Manager.WriteStateAsync(CancellationToken.None);
 
         Assert.Contains(format.Writers, writer => writer.BeganEntryIds.Any(id => id >= 8));
@@ -209,7 +212,7 @@ public class StateManagerTests : JournalingTestBase
 
         var recovered = CreateTestSystem(storage: storage);
         var recoveredDictionary = new DurableDictionary<string, int>("retired", recovered.Manager, CreateDictionaryCodec<string, int>());
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(7, recoveredDictionary["key"]);
     }
@@ -222,7 +225,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage, journalFormat: format);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("key", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -241,7 +244,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage, journalFormat: format);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 42;
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -258,7 +261,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("key", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -274,7 +277,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 42;
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -289,7 +292,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 42;
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -304,7 +307,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("key", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -322,7 +325,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 42;
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -356,15 +359,15 @@ public class StateManagerTests : JournalingTestBase
         var state = new AlwaysWritingState();
         sut.Manager.RegisterState("state", state);
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         var firstWrite = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
-        await storage.FirstAppendStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await storage.FirstAppendStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         var secondWrite = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
         timeProvider.Advance(TimeSpan.FromMilliseconds(250));
         storage.AllowFirstAppend.SetResult();
 
-        await Task.WhenAll(firstWrite, secondWrite).WaitAsync(TimeSpan.FromSeconds(10));
+        await Task.WhenAll(firstWrite, secondWrite).WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.Equal(2, storage.Appends.Count);
         Assert.Contains(observedDurations, measurement => measurement.Operation == "append" && measurement.Status == "ok" && measurement.Value >= 250);
@@ -377,7 +380,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("before", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -392,7 +395,7 @@ public class StateManagerTests : JournalingTestBase
 
         var recovered = CreateTestSystem(storage: storage);
         var recoveredDictionary = new DurableDictionary<string, int>("dict", recovered.Manager, CreateDictionaryCodec<string, int>());
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Single(recoveredDictionary);
         Assert.Equal(2, recoveredDictionary["after"]);
@@ -405,7 +408,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 1;
         await sut.Manager.WriteStateAsync(CancellationToken.None);
         value.Value = 2;
@@ -427,7 +430,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage, journalFormat: format);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("key", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -437,7 +440,7 @@ public class StateManagerTests : JournalingTestBase
 
         var recovered = CreateTestSystem(storage: storage, journalFormat: new TrackingJournalFormat(SessionPool));
         var recoveredDictionary = new DurableDictionary<string, int>("dict", recovered.Manager, CreateDictionaryCodec<string, int>());
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, recoveredDictionary["key"]);
     }
@@ -502,7 +505,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage, journalFormat: format);
         var dictionary = new DurableDictionary<int, int>("dict", sut.Manager, new ThrowingDictionarySetCodec<int, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         var writer = Assert.Single(format.Writers);
         var lengthBefore = GetCommittedLength(writer);
 
@@ -523,7 +526,7 @@ public class StateManagerTests : JournalingTestBase
         var codec = new ToggleThrowingDictionarySetCodec<int, int>(CreateDictionaryCodec<int, int>());
         var dictionary = new DurableDictionary<int, int>("dict", sut.Manager, codec);
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         codec.ThrowOnSet = true;
         Assert.Throws<InvalidOperationException>(() => dictionary.Add(1, 1));
 
@@ -533,7 +536,7 @@ public class StateManagerTests : JournalingTestBase
 
         var recovered = CreateTestSystem(storage: storage, journalFormat: new TrackingJournalFormat(SessionPool));
         var recoveredDictionary = new DurableDictionary<int, int>("dict", recovered.Manager, CreateDictionaryCodec<int, int>());
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Single(recoveredDictionary);
         Assert.Equal(1, recoveredDictionary[1]);
@@ -546,7 +549,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("first", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -556,22 +559,23 @@ public class StateManagerTests : JournalingTestBase
         dictionary.Add("second", 2);
 
         var failedWrite = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
-        await storage.BlockedReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await storage.BlockedReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.False(failedWrite.IsCompleted);
 
         storage.AllowBlockedRead.SetResult();
         var exception = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => failedWrite.WaitAsync(TimeSpan.FromSeconds(10)));
+            () => failedWrite.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
         Assert.Same(expected, exception);
 
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.True(dictionary.ContainsKey("first"));
         Assert.False(dictionary.ContainsKey("second"));
 
         var recovered = CreateTestSystem(storage: storage);
         var recoveredDictionary = new DurableDictionary<string, int>("dict", recovered.Manager, CreateDictionaryCodec<string, int>());
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, recoveredDictionary["first"]);
         Assert.False(recoveredDictionary.ContainsKey("second"));
@@ -584,7 +588,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("first", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
         storage.ResetReadConsumeCount();
@@ -597,14 +601,15 @@ public class StateManagerTests : JournalingTestBase
             () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
         Assert.Same(expected, exception);
 
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.Equal(0, storage.ReadConsumeCount);
         Assert.Equal(2, dictionary["second"]);
 
         var recovered = CreateTestSystem(storage: storage);
         var recoveredDictionary = new DurableDictionary<string, int>("dict", recovered.Manager, CreateDictionaryCodec<string, int>());
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, recoveredDictionary["first"]);
         Assert.Equal(2, recoveredDictionary["second"]);
@@ -617,7 +622,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("first", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -628,16 +633,19 @@ public class StateManagerTests : JournalingTestBase
         dictionary.Add("second", 2);
 
         var conflictException = await Assert.ThrowsAsync<InconsistentStateException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10)));
+            () => sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
         Assert.Same(conflict, conflictException);
 
         var secondRecoveryFailure = new IOException("Expected second recovery failure.");
         storage.NextReadException = secondRecoveryFailure;
         var recoveryException = await Assert.ThrowsAsync<IOException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10)));
+            () => sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
         Assert.Same(secondRecoveryFailure, recoveryException);
 
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.True(dictionary.ContainsKey("first"));
         Assert.False(dictionary.ContainsKey("second"));
@@ -735,15 +743,16 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var state = new AlwaysWritingState();
         sut.Manager.RegisterState("state", state);
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
-        var first = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
-        await storage.FirstAppendStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
-        var second = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
-        var third = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
+        var first = sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask();
+        await storage.FirstAppendStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        var second = sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask();
+        var third = sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask();
 
         storage.AllowFirstAppend.SetResult();
-        await Task.WhenAll(first, second, third).WaitAsync(TimeSpan.FromSeconds(10));
+        await Task.WhenAll(first, second, third)
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.Equal(2, state.AppendEntriesCount);
         Assert.Equal(2, storage.Appends.Count);
@@ -754,15 +763,16 @@ public class StateManagerTests : JournalingTestBase
     {
         var storage = new BlockingDeleteStorage();
         var sut = CreateTestSystem(storage: storage);
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
-        var first = sut.Manager.DeleteStateAsync(CancellationToken.None).AsTask();
-        await storage.FirstDeleteStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
-        var second = sut.Manager.DeleteStateAsync(CancellationToken.None).AsTask();
-        var third = sut.Manager.DeleteStateAsync(CancellationToken.None).AsTask();
+        var first = sut.Manager.DeleteStateAsync(TestContext.Current.CancellationToken).AsTask();
+        await storage.FirstDeleteStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        var second = sut.Manager.DeleteStateAsync(TestContext.Current.CancellationToken).AsTask();
+        var third = sut.Manager.DeleteStateAsync(TestContext.Current.CancellationToken).AsTask();
 
         storage.AllowFirstDelete.SetResult();
-        await Task.WhenAll(first, second, third).WaitAsync(TimeSpan.FromSeconds(10));
+        await Task.WhenAll(first, second, third)
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.Equal(2, storage.DeleteCount);
     }
@@ -776,7 +786,7 @@ public class StateManagerTests : JournalingTestBase
         var state = new ManualDirectWriteState();
         sut.Manager.RegisterState("manual", state);
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Task writeTask = Task.CompletedTask;
         using var writeStarted = new ManualResetEventSlim();
@@ -787,9 +797,9 @@ public class StateManagerTests : JournalingTestBase
             writeTask = Task.Run(async () =>
             {
                 writeStarted.Set();
-                await sut.Manager.WriteStateAsync(CancellationToken.None);
-            });
-            Assert.True(writeStarted.Wait(TimeSpan.FromSeconds(10)));
+                await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken);
+            }, TestContext.Current.CancellationToken);
+            Assert.True(writeStarted.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
 
             Assert.True(SpinWait.SpinUntil(() => writeTask.IsCompleted, TimeSpan.FromSeconds(10)));
             Assert.True(writeTask.IsCompletedSuccessfully, writeTask.Exception?.ToString());
@@ -806,7 +816,8 @@ public class StateManagerTests : JournalingTestBase
             entry.Dispose();
         }
 
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         Assert.Equal(2, storage.Appends.Count);
         Assert.Contains(ReadBinaryEntries(storage.Appends[1]), entry => entry.StreamId.Value >= 8);
     }
@@ -820,17 +831,18 @@ public class StateManagerTests : JournalingTestBase
         var state = new ManualDirectWriteState();
         sut.Manager.RegisterState("manual", state);
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         var writeTask = StartSnapshotAndCommitActiveEntry();
 
-        await writeTask.WaitAsync(TimeSpan.FromSeconds(10));
+        await writeTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         var replacement = Assert.Single(storage.Replaces);
         Assert.DoesNotContain(ReadBinaryEntries(replacement), entry => entry.StreamId.Value >= 8);
         Assert.Empty(storage.Appends);
 
         storage.IsCompactionRequested = false;
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.Single(storage.Appends);
         var append = storage.Appends[0];
@@ -874,7 +886,7 @@ public class StateManagerTests : JournalingTestBase
         // Create and populate states
         var dictionary = new DurableDictionary<string, int>("dict1", sut.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(CodecProvider.GetCodec<string>(), CodecProvider.GetCodec<int>(), SessionPool));
         var list = new DurableList<string>("list1", sut.Manager, new OrleansBinaryDurableListCommandCodec<string>(CodecProvider.GetCodec<string>(), SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         dictionary.Add("key1", 1);
         dictionary.Add("key2", 2);
@@ -887,7 +899,7 @@ public class StateManagerTests : JournalingTestBase
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var recoveredDict = new DurableDictionary<string, int>("dict1", sut2.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(CodecProvider.GetCodec<string>(), CodecProvider.GetCodec<int>(), SessionPool));
         var recoveredList = new DurableList<string>("list1", sut2.Manager, new OrleansBinaryDurableListCommandCodec<string>(CodecProvider.GetCodec<string>(), SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Assert - State should be recovered
         Assert.Equal(2, recoveredDict.Count);
@@ -906,7 +918,7 @@ public class StateManagerTests : JournalingTestBase
         var initial = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", initial.Manager, CreateValueCodec<int>());
 
-        await initial.Lifecycle.OnStart();
+        await initial.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 42;
         await initial.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -914,7 +926,7 @@ public class StateManagerTests : JournalingTestBase
         var recovered = CreateTestSystem(storage: storage, journalFormat: format);
         var recoveredValue = new DurableValue<int>("value", recovered.Manager, CreateValueCodec<int>());
 
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(42, recoveredValue.Value);
         Assert.True(format.ReadCount > 0);
@@ -937,7 +949,7 @@ public class StateManagerTests : JournalingTestBase
         var existing = new DurableValue<int>("existing", sut.Manager, CreateValueCodec<int>());
         var next = new DurableValue<int>("next", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         next.Value = 99;
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
@@ -953,7 +965,7 @@ public class StateManagerTests : JournalingTestBase
         var initial = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", initial.Manager, CreateValueCodec<int>());
 
-        await initial.Lifecycle.OnStart();
+        await initial.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 1;
         await initial.Manager.WriteStateAsync(CancellationToken.None);
         value.Value = 2;
@@ -963,7 +975,7 @@ public class StateManagerTests : JournalingTestBase
         var recovered = CreateTestSystem(storage: storage);
         var recoveredValue = new DurableValue<int>("value", recovered.Manager, CreateValueCodec<int>());
 
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, recoveredValue.Value);
         Assert.Equal(1, storage.ReadConsumeCount);
@@ -976,7 +988,7 @@ public class StateManagerTests : JournalingTestBase
         var initial = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", initial.Manager, CreateValueCodec<int>());
 
-        await initial.Lifecycle.OnStart();
+        await initial.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 1;
         await initial.Manager.WriteStateAsync(CancellationToken.None);
         value.Value = 2;
@@ -987,7 +999,7 @@ public class StateManagerTests : JournalingTestBase
         var recovered = CreateTestSystem(storage: splitStorage);
         var recoveredValue = new DurableValue<int>("value", recovered.Manager, CreateValueCodec<int>());
 
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, recoveredValue.Value);
         Assert.Equal(persistedBytes.Length, splitStorage.ReadConsumeCount);
@@ -1016,7 +1028,8 @@ public class StateManagerTests : JournalingTestBase
         try
         {
             exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
+                () => sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+                    .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
         }
         finally
         {
@@ -1040,13 +1053,16 @@ public class StateManagerTests : JournalingTestBase
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
+            () => sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
 
-        await sut.Manager.InitializeAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.InitializeAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.Equal(42, value.Value);
-        await sut.Lifecycle.OnStop(CancellationToken.None);
+        await sut.Lifecycle.OnStop(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1057,15 +1073,18 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
+            () => sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
 
-        await sut.Manager.InitializeAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.InitializeAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         var replacement = Assert.Single(storage.Replaces);
         var preserved = Assert.Single(ReadBinaryEntries(replacement), entry => entry.StreamId.Value == 99);
         Assert.Equal([1, 2, 3], preserved.Payload);
-        await sut.Lifecycle.OnStop(CancellationToken.None);
+        await sut.Lifecycle.OnStop(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1075,13 +1094,16 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
+            () => sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
 
-        await sut.Manager.InitializeAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
-        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.Manager.InitializeAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.False(sut.Manager.TryGetState("stale", out _));
-        await sut.Lifecycle.OnStop(CancellationToken.None);
+        await sut.Lifecycle.OnStop(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -1094,7 +1116,8 @@ public class StateManagerTests : JournalingTestBase
         try
         {
             exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
+                () => sut.Lifecycle.OnStart(TestContext.Current.CancellationToken)
+                    .WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
         }
         finally
         {
@@ -1117,7 +1140,7 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem();
         var manager = sut.Manager;
         var dictionary = new DurableDictionary<string, int>("dict1", sut.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(CodecProvider.GetCodec<string>(), CodecProvider.GetCodec<int>(), SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Multiple operations with WriteState in between
         dictionary.Add("key1", 1);
@@ -1140,7 +1163,7 @@ public class StateManagerTests : JournalingTestBase
         // Create new manager to verify recovery
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var recoveredDict = new DurableDictionary<string, int>("dict1", sut2.Manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(CodecProvider.GetCodec<string>(), CodecProvider.GetCodec<int>(), SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Assert - Recovery should have final state
         Assert.Single(recoveredDict);
@@ -1164,7 +1187,7 @@ public class StateManagerTests : JournalingTestBase
         var intDict = new DurableDictionary<int, string>("intDict", manager, new OrleansBinaryDurableDictionaryCommandCodec<int, string>(CodecProvider.GetCodec<int>(), CodecProvider.GetCodec<string>(), SessionPool));
         var stringList = new DurableList<string>("stringList", manager, new OrleansBinaryDurableListCommandCodec<string>(CodecProvider.GetCodec<string>(), SessionPool));
         var personValue = new DurableValue<TestPerson>("personValue", manager, new OrleansBinaryDurableValueCommandCodec<TestPerson>(CodecProvider.GetCodec<TestPerson>(), SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Populate all states
         intDict.Add(1, "one");
@@ -1193,7 +1216,7 @@ public class StateManagerTests : JournalingTestBase
         var recoveredIntDict = new DurableDictionary<int, string>("intDict", sut2.Manager, new OrleansBinaryDurableDictionaryCommandCodec<int, string>(CodecProvider.GetCodec<int>(), CodecProvider.GetCodec<string>(), SessionPool));
         var recoveredStringList = new DurableList<string>("stringList", sut2.Manager, new OrleansBinaryDurableListCommandCodec<string>(CodecProvider.GetCodec<string>(), SessionPool));
         var recoveredPersonValue = new DurableValue<TestPerson>("personValue", sut2.Manager, new OrleansBinaryDurableValueCommandCodec<TestPerson>(CodecProvider.GetCodec<TestPerson>(), SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Assert - All should be recovered with correct values
         Assert.Equal(2, recoveredIntDict.Count);
@@ -1219,7 +1242,7 @@ public class StateManagerTests : JournalingTestBase
         var manager = sut.Manager;
         var dict1 = new DurableDictionary<string, int>("dict1", manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(CodecProvider.GetCodec<string>(), CodecProvider.GetCodec<int>(), SessionPool));
         var dict2 = new DurableDictionary<string, int>("dict2", manager, new OrleansBinaryDurableDictionaryCommandCodec<string, int>(CodecProvider.GetCodec<string>(), CodecProvider.GetCodec<int>(), SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Simulate concurrent operations on different states
         dict1.Add("key1", 1);
@@ -1252,7 +1275,7 @@ public class StateManagerTests : JournalingTestBase
         // Arrange
         var sut = CreateTestSystem();
         var largeDict = new DurableDictionary<int, string>("largeDict", sut.Manager, new OrleansBinaryDurableDictionaryCommandCodec<int, string>(CodecProvider.GetCodec<int>(), CodecProvider.GetCodec<string>(), SessionPool));
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Act - Add many items
         const int itemCount = 1000;
@@ -1266,7 +1289,7 @@ public class StateManagerTests : JournalingTestBase
         // Create new manager for recovery
         var sut2 = CreateTestSystem(storage: sut.Storage);
         var recoveredDict = new DurableDictionary<int, string>("largeDict", sut2.Manager, new OrleansBinaryDurableDictionaryCommandCodec<int, string>(CodecProvider.GetCodec<int>(), CodecProvider.GetCodec<string>(), SessionPool));
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // Assert - All items should be recovered
         Assert.Equal(itemCount, recoveredDict.Count);
@@ -1298,7 +1321,7 @@ public class StateManagerTests : JournalingTestBase
         var dictToKeep1 = CreateTestState(DictToKeepKey, sut1.Manager);
         var dictToRetire2 = CreateTestState(DictToRetireKey, sut1.Manager);
 
-        await sut1.Lifecycle.OnStart();
+        await sut1.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         dictToKeep1.Add("a", 1);
         dictToRetire2.Add("b", 1);
@@ -1311,7 +1334,7 @@ public class StateManagerTests : JournalingTestBase
         var sut2 = CreateTestSystem(storage, timeProvider);
         var dictToKeep2 = CreateTestState(DictToKeepKey, sut2.Manager);
 
-        await sut2.Lifecycle.OnStart();
+        await sut2.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         
         // The manager should have recovered the state for dictToKeep,
         // and created a DurableNothing placeholder for dictToRetire (we cant test for it at this point). 
@@ -1329,7 +1352,7 @@ public class StateManagerTests : JournalingTestBase
         var dictToKeep3 = CreateTestState(DictToKeepKey, sut3.Manager);
         var dictToRetire3 = CreateTestState(DictToRetireKey, sut3.Manager);
 
-        await sut3.Lifecycle.OnStart();
+        await sut3.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(10, dictToKeep3["a"]);
 
@@ -1345,7 +1368,7 @@ public class StateManagerTests : JournalingTestBase
 
         var sut3Recovered = CreateTestSystem(storage, timeProvider);
         var dictToRetire3Recovered = CreateTestState(DictToRetireKey, sut3Recovered.Manager);
-        await sut3Recovered.Lifecycle.OnStart();
+        await sut3Recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         Assert.Equal(2, dictToRetire3Recovered["b"]);
 
         // -------------- STEP 4 --------------
@@ -1355,7 +1378,7 @@ public class StateManagerTests : JournalingTestBase
         var sut4 = CreateTestSystem(storage, timeProvider);
         var dictToKeep4 = CreateTestState(DictToKeepKey, sut4.Manager);
 
-        await sut4.Lifecycle.OnStart();
+        await sut4.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         // The manager should have recovered the state for dictToKeep.
         // It should have created a DurableNothing placeholder for dictToRetire, but we can not test for that.
@@ -1377,7 +1400,7 @@ public class StateManagerTests : JournalingTestBase
         var dictToKeep5 = CreateTestState(DictToKeepKey, sut5.Manager);
         var dictToRetire5 = CreateTestState(DictToRetireKey, sut5.Manager);
 
-        await sut5.Lifecycle.OnStart();
+        await sut5.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         Assert.Equal(10, dictToKeep5["a"]);
 
         // The retired dictionary should now be empty because its state was purged during the compaction.

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -111,12 +111,12 @@ public class StateManagerTests : JournalingTestBase
         };
         var sut = CreateTestSystem(storage: storage);
 
-        await Assert.ThrowsAsync<IOException>(() => sut.Lifecycle.OnStart());
+        await Assert.ThrowsAsync<IOException>(() => sut.Lifecycle.OnStart(TestContext.Current.CancellationToken));
 
         var writeException = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask());
         var deleteException = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Manager.DeleteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.DeleteStateAsync(TestContext.Current.CancellationToken).AsTask());
 
         Assert.Contains("not been initialized", writeException.Message, StringComparison.Ordinal);
         Assert.Contains("not been initialized", deleteException.Message, StringComparison.Ordinal);
@@ -126,15 +126,15 @@ public class StateManagerTests : JournalingTestBase
     public async Task StateManager_WriteOperations_ObserveShutdown()
     {
         var sut = CreateTestSystem();
-        await sut.Lifecycle.OnStart();
-        await sut.Lifecycle.OnStop(CancellationToken.None);
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
+        await sut.Lifecycle.OnStop(TestContext.Current.CancellationToken);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => sut.Manager.DeleteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.DeleteStateAsync(TestContext.Current.CancellationToken).AsTask());
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => sut.Manager.RevertPendingChangesAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.RevertPendingChangesAsync(TestContext.Current.CancellationToken).AsTask());
     }
 
     [Fact]
@@ -455,10 +455,10 @@ public class StateManagerTests : JournalingTestBase
         var notifications = new AlwaysWritingState();
         sut.Manager.RegisterState("notifications", notifications);
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("persisted", 1);
         value.Value = 1;
-        await sut.Manager.WriteStateAsync(CancellationToken.None);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken);
         Assert.Equal(1, notifications.WriteCompletedCount);
 
         storage.IsCompactionRequested = true;
@@ -469,7 +469,7 @@ public class StateManagerTests : JournalingTestBase
         storage.NextReplaceException = expected;
 
         var exception = await Assert.ThrowsAsync<IOException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask());
 
         Assert.Same(expected, exception);
         Assert.Single(storage.Appends);
@@ -479,7 +479,7 @@ public class StateManagerTests : JournalingTestBase
         Assert.Equal(2, dictionary["pending"]);
         Assert.Equal(2, value.Value);
 
-        await sut.Manager.WriteStateAsync(CancellationToken.None);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken);
 
         Assert.Single(storage.Appends);
         Assert.Single(storage.Replaces);
@@ -490,7 +490,7 @@ public class StateManagerTests : JournalingTestBase
         var recovered = CreateTestSystem(storage: storage);
         var recoveredDictionary = new DurableDictionary<string, int>("dict", recovered.Manager, CreateDictionaryCodec<string, int>());
         var recoveredValue = new DurableValue<int>("value", recovered.Manager, CreateValueCodec<int>());
-        await recovered.Lifecycle.OnStart();
+        await recovered.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
         Assert.Equal(1, recoveredDictionary["persisted"]);
         Assert.Equal(2, recoveredDictionary["pending"]);
@@ -659,16 +659,16 @@ public class StateManagerTests : JournalingTestBase
         var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         dictionary.Add("persisted", 1);
         value.Value = 1;
-        await sut.Manager.WriteStateAsync(CancellationToken.None);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken);
 
         dictionary.Add("pending", 2);
         value.Value = 2;
         Assert.True(sut.Manager.PendingWriteByteCount > 0);
 
-        await sut.Manager.RevertPendingChangesAsync(CancellationToken.None);
+        await sut.Manager.RevertPendingChangesAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(0, sut.Manager.PendingWriteByteCount);
         Assert.Equal(1, dictionary["persisted"]);
@@ -683,32 +683,32 @@ public class StateManagerTests : JournalingTestBase
         var sut = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
         value.Value = 1;
-        await sut.Manager.WriteStateAsync(CancellationToken.None);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken);
         value.Value = 2;
 
         var expected = new IOException("Expected recovery failure.");
         storage.NextReadException = expected;
         var exception = await Assert.ThrowsAsync<IOException>(
-            () => sut.Manager.RevertPendingChangesAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.RevertPendingChangesAsync(TestContext.Current.CancellationToken).AsTask());
         Assert.Same(expected, exception);
 
         var writeException = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask());
         Assert.Contains("state operations are fenced", writeException.Message, StringComparison.Ordinal);
         Assert.Contains("fenced", writeException.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Call RevertPendingChangesAsync", writeException.Message, StringComparison.Ordinal);
         var deleteException = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Manager.DeleteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.DeleteStateAsync(TestContext.Current.CancellationToken).AsTask());
         Assert.Contains("state operations are fenced", deleteException.Message, StringComparison.Ordinal);
         Assert.Contains("Call RevertPendingChangesAsync", deleteException.Message, StringComparison.Ordinal);
 
-        await sut.Manager.RevertPendingChangesAsync(CancellationToken.None);
+        await sut.Manager.RevertPendingChangesAsync(TestContext.Current.CancellationToken);
         Assert.Equal(1, value.Value);
 
         value.Value = 3;
-        await sut.Manager.WriteStateAsync(CancellationToken.None);
+        await sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken);
         Assert.Equal(3, value.Value);
     }
 
@@ -717,15 +717,17 @@ public class StateManagerTests : JournalingTestBase
     {
         var storage = new BlockingRecoveryStorage();
         var sut = CreateTestSystem(storage: storage);
-        await sut.Lifecycle.OnStart();
+        await sut.Lifecycle.OnStart(TestContext.Current.CancellationToken);
 
-        var recovery = sut.Manager.RevertPendingChangesAsync(CancellationToken.None).AsTask();
-        await storage.RecoveryReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var recovery = sut.Manager.RevertPendingChangesAsync(TestContext.Current.CancellationToken).AsTask();
+        await storage.RecoveryReadStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(10),
+            TestContext.Current.CancellationToken);
 
         var writeException = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.WriteStateAsync(TestContext.Current.CancellationToken).AsTask());
         var deleteException = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.Manager.DeleteStateAsync(CancellationToken.None).AsTask());
+            () => sut.Manager.DeleteStateAsync(TestContext.Current.CancellationToken).AsTask());
 
         Assert.Contains("state operations are unavailable while recovery is in progress", writeException.Message, StringComparison.Ordinal);
         Assert.Contains("state operations are unavailable while recovery is in progress", deleteException.Message, StringComparison.Ordinal);
@@ -733,7 +735,7 @@ public class StateManagerTests : JournalingTestBase
         Assert.DoesNotContain("RevertPendingChangesAsync", deleteException.Message, StringComparison.Ordinal);
 
         storage.AllowRecoveryRead.SetResult();
-        await recovery.WaitAsync(TimeSpan.FromSeconds(10));
+        await recovery.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/test/Orleans.Journaling.Tests/UpstreamMainCompatibilityTests.cs
+++ b/test/Orleans.Journaling.Tests/UpstreamMainCompatibilityTests.cs
@@ -36,7 +36,7 @@ public sealed class UpstreamMainCompatibilityTests : JournalingTestBase
     {
         var journalBytes = LoadUpstreamMainJournal();
         var storage = new VolatileJournalStorage();
-        await storage.AppendAsync(new ReadOnlySequence<byte>(journalBytes), default);
+        await storage.AppendAsync(new ReadOnlySequence<byte>(journalBytes), TestContext.Current.CancellationToken);
 
         var states = CreateStates(storage);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/test/Orleans.Journaling.Tests/VolatileJournalStorageProviderTests.cs
+++ b/test/Orleans.Journaling.Tests/VolatileJournalStorageProviderTests.cs
@@ -18,26 +18,32 @@ public sealed class VolatileJournalStorageProviderTests
         var other = JournalId.Create("named", "other", "a");
 
         var storageA = provider.CreateStorage(idA);
-        var created = await storageA.CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "one" });
-        await provider.CreateStorage(idB).CreateIfNotExistsAsync();
-        await provider.CreateStorage(idChild).CreateIfNotExistsAsync();
-        await provider.CreateStorage(other).CreateIfNotExistsAsync();
+        var created = await storageA.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "one" },
+            TestContext.Current.CancellationToken);
+        await provider.CreateStorage(idB).CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await provider.CreateStorage(idChild).CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await provider.CreateStorage(other).CreateIfNotExistsAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(created);
-        var metadata = await storageA.GetMetadataAsync();
+        var metadata = await storageA.GetMetadataAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(metadata);
         Assert.NotNull(metadata.ETag);
         Assert.Equal("one", metadata.Properties["owner"]);
 
-        var alreadyExists = await storageA.CreateIfNotExistsAsync(new Dictionary<string, string> { ["owner"] = "two" });
+        var alreadyExists = await storageA.CreateIfNotExistsAsync(
+            new Dictionary<string, string> { ["owner"] = "two" },
+            TestContext.Current.CancellationToken);
         Assert.False(alreadyExists);
-        Assert.Equal("one", (await storageA.GetMetadataAsync())!.Properties["owner"]);
+        Assert.Equal("one", (await storageA.GetMetadataAsync(TestContext.Current.CancellationToken))!.Properties["owner"]);
 
-        var listed = await ToListAsync(provider.ListAsync(JournalId.Create("named", "logs")));
+        var listed = await ToListAsync(
+            provider.ListAsync(JournalId.Create("named", "logs"), TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
         Assert.Equal([idA, idChild, idB], listed);
 
-        Assert.NotNull(await provider.CreateStorage(idB).GetMetadataAsync());
-        Assert.Null(await provider.CreateStorage(JournalId.Create("named", "missing")).GetMetadataAsync());
+        Assert.NotNull(await provider.CreateStorage(idB).GetMetadataAsync(TestContext.Current.CancellationToken));
+        Assert.Null(await provider.CreateStorage(JournalId.Create("named", "missing")).GetMetadataAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -45,17 +51,20 @@ public sealed class VolatileJournalStorageProviderTests
     {
         var provider = new VolatileJournalStorageProvider();
         var storage = provider.CreateStorage(JournalId.Create("named", "properties", "cas"));
-        Assert.True(await storage.CreateIfNotExistsAsync(new Dictionary<string, string>
-        {
-            ["keep"] = "1",
-            ["remove"] = "2"
-        }));
-        var original = (await storage.GetMetadataAsync())!;
+        Assert.True(await storage.CreateIfNotExistsAsync(
+            new Dictionary<string, string>
+            {
+                ["keep"] = "1",
+                ["remove"] = "2"
+            },
+            TestContext.Current.CancellationToken));
+        var original = (await storage.GetMetadataAsync(TestContext.Current.CancellationToken))!;
 
         var updated = await storage.UpdateMetadataAsync(
             new Dictionary<string, string> { ["keep"] = "3", ["add"] = "4" },
             ["remove"],
-            original.ETag);
+            original.ETag,
+            TestContext.Current.CancellationToken);
 
         Assert.NotNull(updated);
         Assert.NotEqual(original.ETag, updated.ETag);
@@ -66,14 +75,16 @@ public sealed class VolatileJournalStorageProviderTests
         var stale = await storage.UpdateMetadataAsync(
             new Dictionary<string, string> { ["keep"] = "5" },
             remove: null,
-            original.ETag);
+            original.ETag,
+            TestContext.Current.CancellationToken);
         Assert.Null(stale);
-        Assert.Equal("3", (await storage.GetMetadataAsync())!.Properties["keep"]);
+        Assert.Equal("3", (await storage.GetMetadataAsync(TestContext.Current.CancellationToken))!.Properties["keep"]);
 
         var noChange = await storage.UpdateMetadataAsync(
             new Dictionary<string, string> { ["keep"] = "3" },
             remove: null,
-            updated.ETag);
+            updated.ETag,
+            TestContext.Current.CancellationToken);
         Assert.NotNull(noChange);
         Assert.Equal(updated.ETag, noChange.ETag);
     }
@@ -85,29 +96,35 @@ public sealed class VolatileJournalStorageProviderTests
         var storageId = JournalId.Create("named", "conditional", "storage");
         var storage = provider.CreateStorage(storageId);
 
-        Assert.Null(await storage.GetMetadataAsync());
+        Assert.Null(await storage.GetMetadataAsync(TestContext.Current.CancellationToken));
 
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        var appendProperties = await storage.GetMetadataAsync();
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), TestContext.Current.CancellationToken);
+        var appendProperties = await storage.GetMetadataAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(appendProperties);
         Assert.NotNull(appendProperties.ETag);
 
-        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
-        var replaceProperties = await storage.GetMetadataAsync();
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), TestContext.Current.CancellationToken);
+        var replaceProperties = await storage.GetMetadataAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(replaceProperties);
         Assert.NotEqual(appendProperties.ETag, replaceProperties.ETag);
 
-        await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
-        var finalProperties = await storage.GetMetadataAsync();
+        await storage.AppendAsync(new ReadOnlySequence<byte>([3]), TestContext.Current.CancellationToken);
+        var finalProperties = await storage.GetMetadataAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(finalProperties);
         Assert.NotEqual(replaceProperties.ETag, finalProperties.ETag);
 
-        Assert.Equal([storageId], await ToListAsync(provider.ListAsync(storageId)));
+        Assert.Equal(
+            [storageId],
+            await ToListAsync(
+                provider.ListAsync(storageId, TestContext.Current.CancellationToken),
+                TestContext.Current.CancellationToken));
 
-        await storage.DeleteAsync(CancellationToken.None);
+        await storage.DeleteAsync(TestContext.Current.CancellationToken);
 
-        Assert.Null(await storage.GetMetadataAsync());
-        Assert.Empty(await ToListAsync(provider.ListAsync(storageId)));
+        Assert.Null(await storage.GetMetadataAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await ToListAsync(
+            provider.ListAsync(storageId, TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -117,16 +134,22 @@ public sealed class VolatileJournalStorageProviderTests
         var storage = provider.CreateStorage(JournalId.Create("named", "reserved", "properties"));
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.CreateIfNotExistsAsync(new Dictionary<string, string> { ["$owner"] = "provider" }).AsTask());
+            () => storage.CreateIfNotExistsAsync(
+                new Dictionary<string, string> { ["$owner"] = "provider" },
+                TestContext.Current.CancellationToken).AsTask());
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => storage.UpdateMetadataAsync(new Dictionary<string, string> { ["$owner"] = "provider" }).AsTask());
+            () => storage.UpdateMetadataAsync(
+                new Dictionary<string, string> { ["$owner"] = "provider" },
+                cancellationToken: TestContext.Current.CancellationToken).AsTask());
     }
 
-    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
+    private static async Task<List<T>> ToListAsync<T>(
+        IAsyncEnumerable<T> source,
+        CancellationToken cancellationToken)
     {
         var result = new List<T>();
-        await foreach (var item in source)
+        await foreach (var item in source.WithCancellation(cancellationToken))
         {
             result.Add(item);
         }

--- a/test/Orleans.Persistence.FileStorage.Tests/FileGrainStorageBoundaryTests.cs
+++ b/test/Orleans.Persistence.FileStorage.Tests/FileGrainStorageBoundaryTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Runtime;
+using Orleans.Storage;
 using Xunit;
 
 namespace Orleans.Persistence.FileStorage.Tests;
@@ -10,20 +11,21 @@ public sealed class FileGrainStorageBoundaryTests
     [Fact]
     public async Task BinaryPayload_RoundTripsWithoutTextConversion()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var directory = new TemporaryDirectory();
         byte[] bytes = [0x00, 0x80, 0xFF, 0xC3, 0x28, 0xFE];
         var expected = new FileStorageTestState { Value = "binary", Revision = 1 };
         var serializer = new RecordingGrainStorageSerializer(bytes, expected);
-        var storage = FileGrainStorageTestContext.CreateStorage(
+        IGrainStorage storage = FileGrainStorageTestContext.CreateStorage(
             directory.RootDirectory,
             serializer: serializer);
         var grainId = GrainId.Create("binary/type", "binary/key");
         var written = new GrainState<FileStorageTestState>(
             new FileStorageTestState { Value = "source", Revision = 2 });
 
-        await storage.WriteStateAsync("binary/state", grainId, written);
+        await storage.WriteStateAsync("binary/state", grainId, written, cancellationToken);
         var read = new GrainState<FileStorageTestState>(new FileStorageTestState());
-        await storage.ReadStateAsync("binary/state", grainId, read);
+        await storage.ReadStateAsync("binary/state", grainId, read, cancellationToken);
 
         Assert.Equal(bytes, serializer.DeserializedBytes);
         Assert.Same(expected, read.State);
@@ -34,9 +36,10 @@ public sealed class FileGrainStorageBoundaryTests
     [Fact]
     public async Task UnsafeIdentityValues_ProduceSafeDistinctFileNames()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var directory = new TemporaryDirectory();
-        var firstStorage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory, "../service");
-        var secondStorage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory, "service");
+        IGrainStorage firstStorage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory, "../service");
+        IGrainStorage secondStorage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory, "service");
         var first = new GrainState<FileStorageTestState>(
             new FileStorageTestState { Value = "first", Revision = 1 });
         var second = new GrainState<FileStorageTestState>(
@@ -45,11 +48,13 @@ public sealed class FileGrainStorageBoundaryTests
         await firstStorage.WriteStateAsync(
             @"..\state",
             GrainId.Create(@"type\one", "../key"),
-            first);
+            first,
+            cancellationToken);
         await secondStorage.WriteStateAsync(
             "state",
             GrainId.Create("type", "key"),
-            second);
+            second,
+            cancellationToken);
 
         var files = FileGrainStorageTestContext.GetRecordFiles(directory.RootDirectory);
         Assert.Equal(2, files.Length);
@@ -62,24 +67,27 @@ public sealed class FileGrainStorageBoundaryTests
     [Fact]
     public async Task InvalidRecord_ThrowsInvalidDataException()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var directory = new TemporaryDirectory();
-        var storage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory);
+        IGrainStorage storage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory);
         var grainId = GrainId.Create("invalid", "record");
         var state = new GrainState<FileStorageTestState>(new FileStorageTestState());
-        await storage.WriteStateAsync("state", grainId, state);
+        await storage.WriteStateAsync("state", grainId, state, cancellationToken);
         var path = Assert.Single(FileGrainStorageTestContext.GetRecordFiles(directory.RootDirectory));
-        await File.WriteAllBytesAsync(path, "invalid"u8.ToArray());
+        await File.WriteAllBytesAsync(path, "invalid"u8.ToArray(), cancellationToken);
 
         await Assert.ThrowsAsync<InvalidDataException>(
             () => storage.ReadStateAsync(
                 "state",
                 grainId,
-                new GrainState<FileStorageTestState>(new FileStorageTestState())));
+                new GrainState<FileStorageTestState>(new FileStorageTestState()),
+                cancellationToken));
     }
 
     [Fact]
     public async Task LifecycleStart_CreatesRootDirectory()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var directory = new TemporaryDirectory();
         var storage = FileGrainStorageTestContext.CreateStorage(
             directory.RootDirectory,
@@ -88,23 +96,24 @@ public sealed class FileGrainStorageBoundaryTests
         Assert.False(Directory.Exists(directory.RootDirectory));
 
         storage.Participate(lifecycle);
-        await lifecycle.OnStart();
+        await lifecycle.OnStart(cancellationToken);
 
         Assert.True(Directory.Exists(directory.RootDirectory));
-        await lifecycle.OnStop();
+        await lifecycle.OnStop(cancellationToken);
     }
 
     [Fact]
     public async Task MissingRecord_CreatesConstructorlessState()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var directory = new TemporaryDirectory();
-        var storage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory);
+        IGrainStorage storage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory);
         var state = new GrainState<ConstructorlessState>(new ConstructorlessState("stale"), "stale")
         {
             RecordExists = true,
         };
 
-        await storage.ReadStateAsync("state", GrainId.Create("type", "key"), state);
+        await storage.ReadStateAsync("state", GrainId.Create("type", "key"), state, cancellationToken);
 
         Assert.NotNull(state.State);
         Assert.Null(state.State.Value);

--- a/test/Orleans.Persistence.FileStorage.Tests/FileGrainStorageBoundaryTests.cs
+++ b/test/Orleans.Persistence.FileStorage.Tests/FileGrainStorageBoundaryTests.cs
@@ -121,6 +121,24 @@ public sealed class FileGrainStorageBoundaryTests
         Assert.False(state.RecordExists);
     }
 
+    [Fact]
+    public async Task CancellationToken_CancelsStorageOperations()
+    {
+        using var directory = new TemporaryDirectory();
+        IGrainStorage storage = FileGrainStorageTestContext.CreateStorage(directory.RootDirectory);
+        var grainId = GrainId.Create("type", "key");
+        var state = new GrainState<FileStorageTestState>(new FileStorageTestState());
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => storage.ReadStateAsync("state", grainId, state, cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => storage.WriteStateAsync("state", grainId, state, cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => storage.ClearStateAsync("state", grainId, state, cancellation.Token));
+    }
+
     private sealed class ConstructorlessState(string value)
     {
         public string? Value { get; } = value;

--- a/test/Orleans.Persistence.FileStorage.Tests/FileGrainStorageConformanceTests.cs
+++ b/test/Orleans.Persistence.FileStorage.Tests/FileGrainStorageConformanceTests.cs
@@ -15,44 +15,45 @@ public sealed class FileGrainStorageConformanceTests
 
     [Fact]
     public Task PersistenceStorage_ReadIfNotExists() =>
-        base.PersistenceStorage_ReadNonExistentState();
+        base.PersistenceStorage_ReadNonExistentStateAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_WriteRead() =>
-        base.PersistenceStorage_WriteReadIdCyrillic();
+        base.PersistenceStorage_WriteReadIdCyrillicAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_WriteReadWithIntegerKey() =>
-        base.PersistenceStorage_WriteRead_IntegerKey();
+        base.PersistenceStorage_WriteRead_IntegerKeyAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_WriteReadWithStringKey() =>
-        base.PersistenceStorage_WriteRead_StringKey();
+        base.PersistenceStorage_WriteRead_StringKeyAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_StateNamesAreIndependent() =>
-        base.PersistenceStorage_StateNamesUseIndependentRecords();
+        base.PersistenceStorage_StateNamesUseIndependentRecordsAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public async Task PersistenceStorage_WriteReadWriteRead()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var grainId = GrainId.Create("write-read-write-read", Guid.NewGuid().ToString("N"));
         var written = new GrainState<FileStorageTestState>(
             new FileStorageTestState { Value = "first", Revision = 1 });
-        await Storage.WriteStateAsync("state", grainId, written);
+        await Storage.WriteStateAsync("state", grainId, written, cancellationToken);
         var firstETag = Assert.IsType<string>(written.ETag);
         var firstRead = new GrainState<FileStorageTestState>(new FileStorageTestState());
-        await Storage.ReadStateAsync("state", grainId, firstRead);
+        await Storage.ReadStateAsync("state", grainId, firstRead, cancellationToken);
 
         Assert.Equal(new FileStorageTestState { Value = "first", Revision = 1 }, firstRead.State);
         Assert.Equal(firstETag, firstRead.ETag);
         Assert.True(firstRead.RecordExists);
 
         written.State = new FileStorageTestState { Value = "second", Revision = 2 };
-        await Storage.WriteStateAsync("state", grainId, written);
+        await Storage.WriteStateAsync("state", grainId, written, cancellationToken);
         var secondETag = Assert.IsType<string>(written.ETag);
         var secondRead = new GrainState<FileStorageTestState>(new FileStorageTestState());
-        await Storage.ReadStateAsync("state", grainId, secondRead);
+        await Storage.ReadStateAsync("state", grainId, secondRead, cancellationToken);
 
         Assert.NotEqual(firstETag, secondETag);
         Assert.Equal(new FileStorageTestState { Value = "second", Revision = 2 }, secondRead.State);
@@ -62,61 +63,64 @@ public sealed class FileGrainStorageConformanceTests
 
     [Fact]
     public Task PersistenceStorage_Delete() =>
-        base.PersistenceStorage_WriteReadClearReadCycle();
+        base.PersistenceStorage_WriteReadClearReadCycleAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_DeleteIfNotExists() =>
-        base.PersistenceStorage_ClearBeforeWrite();
+        base.PersistenceStorage_ClearBeforeWriteAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_WriteClearWrite() =>
-        base.PersistenceStorage_WriteClearWrite();
+        base.PersistenceStorage_WriteClearWriteAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_WriteClearRead() =>
-        base.PersistenceStorage_WriteClearRead();
+        base.PersistenceStorage_WriteClearReadAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_ClearStateDoesNotNullifyState() =>
-        base.PersistenceStorage_ClearStateDoesNotNullifyState();
+        base.PersistenceStorage_ClearStateDoesNotNullifyStateAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_ClearUpdatesETag() =>
-        base.PersistenceStorage_ClearUpdatesETag();
+        base.PersistenceStorage_ClearUpdatesETagAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_ReadAfterClear() =>
-        base.PersistenceStorage_ReadAfterClear();
+        base.PersistenceStorage_ReadAfterClearAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_MultipleClearOperations() =>
-        base.PersistenceStorage_MultipleClearOperations();
+        base.PersistenceStorage_MultipleClearOperationsAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_ReadNonExistentStateHasNonNullState() =>
-        base.PersistenceStorage_ReadNonExistentStateHasNonNullState();
+        base.PersistenceStorage_ReadNonExistentStateHasNonNullStateAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_ETagChangesOnWrite() =>
-        base.PersistenceStorage_ETagChangesOnWrite();
+        base.PersistenceStorage_ETagChangesOnWriteAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task PersistenceStorage_WriteWithSameValuesUpdatesETag() =>
-        base.PersistenceStorage_WriteWithSameValuesUpdatesETag();
+        base.PersistenceStorage_WriteWithSameValuesUpdatesETagAsync(TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_DuplicateWriteThrowsInconsistentStateException() =>
-        base.PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException();
+        base.PersistenceStorage_WriteDuplicateFailsWithInconsistentStateExceptionAsync(
+            TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_StaleWriteThrowsInconsistentStateException() =>
-        base.PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException();
+        base.PersistenceStorage_WriteInconsistentFailsWithInconsistentStateExceptionAsync(
+            TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_StaleClearThrowsInconsistentStateException() =>
-        base.PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException();
+        base.PersistenceStorage_ClearInconsistentFailsWithInconsistentStateExceptionAsync(
+            TestContext.Current.CancellationToken);
 
     [Fact]
     public Task PersistenceStorage_ParallelWritesRespectETags() =>
-        base.PersistenceStorage_WriteReadWriteReadStatesInParallel();
+        base.PersistenceStorage_WriteReadWriteReadStatesInParallelAsync(TestContext.Current.CancellationToken);
 }

--- a/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageTests.cs
+++ b/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageTests.cs
@@ -56,7 +56,7 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
         var runner = new TestRunner(new NullStateGrainStorage());
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => runner.PersistenceStorage_WriteRead_StringKey(cancellationToken));
+            () => runner.PersistenceStorage_WriteRead_StringKeyAsync(cancellationToken));
 
         Assert.Contains("found '<null>'", exception.Message);
     }
@@ -83,19 +83,19 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
     [Fact]
     public override Task PersistenceStorage_WriteReadIdCyrillic()
     {
-        return base.PersistenceStorage_WriteReadIdCyrillic(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteReadIdCyrillicAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()
     {
-        return base.PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteDuplicateFailsWithInconsistentStateExceptionAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException()
     {
-        return base.PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteInconsistentFailsWithInconsistentStateExceptionAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -107,97 +107,97 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
     [Fact]
     public override Task PersistenceStorage_ReadNonExistentState()
     {
-        return base.PersistenceStorage_ReadNonExistentState(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ReadNonExistentStateAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ReadNonExistentStateHasNonNullState()
     {
-        return base.PersistenceStorage_ReadNonExistentStateHasNonNullState(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ReadNonExistentStateHasNonNullStateAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteClearWrite()
     {
-        return base.PersistenceStorage_WriteClearWrite(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteClearWriteAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteClearRead()
     {
-        return base.PersistenceStorage_WriteClearRead(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteClearReadAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteReadClearReadCycle()
     {
-        return base.PersistenceStorage_WriteReadClearReadCycle(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteReadClearReadCycleAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteRead_StringKey()
     {
-        return base.PersistenceStorage_WriteRead_StringKey(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteRead_StringKeyAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteRead_IntegerKey()
     {
-        return base.PersistenceStorage_WriteRead_IntegerKey(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteRead_IntegerKeyAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ETagChangesOnWrite()
     {
-        return base.PersistenceStorage_ETagChangesOnWrite(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ETagChangesOnWriteAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearBeforeWrite()
     {
-        return base.PersistenceStorage_ClearBeforeWrite(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ClearBeforeWriteAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearStateDoesNotNullifyState()
     {
-        return base.PersistenceStorage_ClearStateDoesNotNullifyState(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ClearStateDoesNotNullifyStateAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearUpdatesETag()
     {
-        return base.PersistenceStorage_ClearUpdatesETag(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ClearUpdatesETagAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ReadAfterClear()
     {
-        return base.PersistenceStorage_ReadAfterClear(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ReadAfterClearAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_MultipleClearOperations()
     {
-        return base.PersistenceStorage_MultipleClearOperations(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_MultipleClearOperationsAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteWithSameValuesUpdatesETag()
     {
-        return base.PersistenceStorage_WriteWithSameValuesUpdatesETag(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_WriteWithSameValuesUpdatesETagAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_StateNamesUseIndependentRecords()
     {
-        return base.PersistenceStorage_StateNamesUseIndependentRecords(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_StateNamesUseIndependentRecordsAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException()
     {
-        return base.PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException(TestContext.Current.CancellationToken);
+        return base.PersistenceStorage_ClearInconsistentFailsWithInconsistentStateExceptionAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("ModelBased")]

--- a/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageTests.cs
+++ b/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageTests.cs
@@ -52,9 +52,11 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
     [Fact]
     public async Task ProviderViolation_ThrowsFrameworkNeutralException()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var runner = new TestRunner(new NullStateGrainStorage());
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(runner.PersistenceStorage_WriteRead_StringKey);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runner.PersistenceStorage_WriteRead_StringKey(cancellationToken));
 
         Assert.Contains("found '<null>'", exception.Message);
     }
@@ -81,147 +83,149 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
     [Fact]
     public override Task PersistenceStorage_WriteReadIdCyrillic()
     {
-        return base.PersistenceStorage_WriteReadIdCyrillic();
+        return base.PersistenceStorage_WriteReadIdCyrillic(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException()
     {
-        return base.PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException();
+        return base.PersistenceStorage_WriteDuplicateFailsWithInconsistentStateException(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException()
     {
-        return base.PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException();
+        return base.PersistenceStorage_WriteInconsistentFailsWithInconsistentStateException(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteReadWriteReadStatesInParallel()
     {
-        return RunPersistenceStorage_WriteReadWriteReadStatesInParallel("MemoryTest", 50);
+        return RunPersistenceStorage_WriteReadWriteReadStatesInParallel("MemoryTest", 50, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ReadNonExistentState()
     {
-        return base.PersistenceStorage_ReadNonExistentState();
+        return base.PersistenceStorage_ReadNonExistentState(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ReadNonExistentStateHasNonNullState()
     {
-        return base.PersistenceStorage_ReadNonExistentStateHasNonNullState();
+        return base.PersistenceStorage_ReadNonExistentStateHasNonNullState(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteClearWrite()
     {
-        return base.PersistenceStorage_WriteClearWrite();
+        return base.PersistenceStorage_WriteClearWrite(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteClearRead()
     {
-        return base.PersistenceStorage_WriteClearRead();
+        return base.PersistenceStorage_WriteClearRead(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteReadClearReadCycle()
     {
-        return base.PersistenceStorage_WriteReadClearReadCycle();
+        return base.PersistenceStorage_WriteReadClearReadCycle(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteRead_StringKey()
     {
-        return base.PersistenceStorage_WriteRead_StringKey();
+        return base.PersistenceStorage_WriteRead_StringKey(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteRead_IntegerKey()
     {
-        return base.PersistenceStorage_WriteRead_IntegerKey();
+        return base.PersistenceStorage_WriteRead_IntegerKey(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ETagChangesOnWrite()
     {
-        return base.PersistenceStorage_ETagChangesOnWrite();
+        return base.PersistenceStorage_ETagChangesOnWrite(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearBeforeWrite()
     {
-        return base.PersistenceStorage_ClearBeforeWrite();
+        return base.PersistenceStorage_ClearBeforeWrite(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearStateDoesNotNullifyState()
     {
-        return base.PersistenceStorage_ClearStateDoesNotNullifyState();
+        return base.PersistenceStorage_ClearStateDoesNotNullifyState(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearUpdatesETag()
     {
-        return base.PersistenceStorage_ClearUpdatesETag();
+        return base.PersistenceStorage_ClearUpdatesETag(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ReadAfterClear()
     {
-        return base.PersistenceStorage_ReadAfterClear();
+        return base.PersistenceStorage_ReadAfterClear(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_MultipleClearOperations()
     {
-        return base.PersistenceStorage_MultipleClearOperations();
+        return base.PersistenceStorage_MultipleClearOperations(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_WriteWithSameValuesUpdatesETag()
     {
-        return base.PersistenceStorage_WriteWithSameValuesUpdatesETag();
+        return base.PersistenceStorage_WriteWithSameValuesUpdatesETag(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_StateNamesUseIndependentRecords()
     {
-        return base.PersistenceStorage_StateNamesUseIndependentRecords();
+        return base.PersistenceStorage_StateNamesUseIndependentRecords(TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public override Task PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException()
     {
-        return base.PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException();
+        return base.PersistenceStorage_ClearInconsistentFailsWithInconsistentStateException(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("ModelBased")]
     public Task GrainStorage_ModelBasedGeneratedConformance()
     {
         var runner = new GrainStorageModelBasedTestRunner(Storage, "MemoryStore");
-        return runner.RunGeneratedConformanceTests();
+        return runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("ModelBased")]
     public Task GrainStorageWithLatency_ModelBasedGeneratedConformance()
     {
         var runner = new GrainStorageModelBasedTestRunner(_fixture.CreateStorageWithLatency(), "MemoryStoreWithLatency");
-        return runner.RunGeneratedConformanceTests();
+        return runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("ModelBased")]
     public async Task GrainStorage_ModelBasedGeneratedConformance_ReportsInvalidProviderBehavior()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         string? failureOutput = null;
         var runner = new GrainStorageModelBasedTestRunner(
             new InvalidGrainStorage(),
             "InvalidStorage",
             message => failureOutput = message);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(runner.RunGeneratedConformanceTests);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runner.RunGeneratedConformanceTests(cancellationToken));
 
         Assert.Contains("Model-based grain storage conformance test failed.", exception.Message);
         Assert.NotNull(failureOutput);
@@ -231,10 +235,11 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
     [Fact, TestCategory("ModelBased")]
     public async Task GrainStorage_ModelBasedGeneratedConformance_ExcludesCurrentETagSameValueWrites()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var storage = new StableNoOpETagGrainStorage();
         var runner = new GrainStorageModelBasedTestRunner(storage, "StableNoOpETagStorage");
 
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(cancellationToken);
 
         Assert.Equal(0, storage.SameValueWriteCount);
     }

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -20,11 +20,12 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
     [Fact]
     public async Task Rebalancer_Should_Be_Controllable_And_Report_To_Listeners()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var serviceProvider = Cluster.GetSiloServiceProvider();
         var rebalancer = serviceProvider.GetRequiredService<IActivationRebalancer>();
         using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
 
-        var sessionStarted = rebalancerEvents.WaitForSessionStartAsync(WaitTimeout);
+        var sessionStarted = rebalancerEvents.WaitForSessionStartAsync(WaitTimeout).WaitAsync(cancellationToken);
         await rebalancer.ResumeRebalancing();
         var host = (await sessionStarted).SiloAddress;
         var report = await rebalancer.GetRebalancingReport();
@@ -46,19 +47,21 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
             report => report.Status == RebalancerStatus.Suspended &&
                 report.SuspensionDuration.HasValue &&
                 report.Host.Equals(host),
-            "a fresh suspended report");
+            "a fresh suspended report",
+            cancellationToken);
         await rebalancer.SuspendRebalancing();
         await listenerReport;
 
         reportCount = listener.Snapshot.ReportCount;
         var resumed = rebalancerEvents.WaitForSessionStartAsync(
             sessionStart => sessionStart.SiloAddress.Equals(host),
-            WaitTimeout);
+            WaitTimeout).WaitAsync(cancellationToken);
         listenerReport = listener.WaitForReportAsync(
             reportCount,
             report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
                 report.Host.Equals(host),
-            "a fresh executing report");
+            "a fresh executing report",
+            cancellationToken);
         await rebalancer.ResumeRebalancing();
         await resumed;
         await listenerReport;
@@ -69,7 +72,8 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
             report => report.Status == RebalancerStatus.Suspended &&
                 report.SuspensionDuration.HasValue &&
                 report.Host.Equals(host),
-            "a fresh suspended report before unsubscribing");
+            "a fresh suspended report before unsubscribing",
+            cancellationToken);
         await rebalancer.SuspendRebalancing();
         await listenerReport;
 
@@ -77,7 +81,7 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
         var unsubscribedSnapshot = listener.Snapshot;
         resumed = rebalancerEvents.WaitForSessionStartAsync(
             sessionStart => sessionStart.SiloAddress.Equals(host),
-            WaitTimeout);
+            WaitTimeout).WaitAsync(cancellationToken);
         await rebalancer.ResumeRebalancing();
         await resumed;
 
@@ -100,7 +104,7 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
 
         resumed = rebalancerEvents.WaitForSessionStartAsync(
             sessionStart => sessionStart.SiloAddress.Equals(host),
-            WaitTimeout);
+            WaitTimeout).WaitAsync(cancellationToken);
         await resumed;
 
         await rebalancer.SuspendRebalancing(); // Suspend indefinitely
@@ -163,7 +167,8 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
         public Task<RebalancingReport> WaitForReportAsync(
             int previousReportCount,
             Func<RebalancingReport, bool> predicate,
-            string expectedState)
+            string expectedState,
+            CancellationToken cancellationToken)
         {
             lock (_lock)
             {
@@ -176,7 +181,7 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
 
                 var waiter = new ReportWaiter(previousReportCount, predicate);
                 _waiters.Add(waiter);
-                return WaitWithTimeoutAsync(waiter, expectedState);
+                return WaitWithTimeoutAsync(waiter, expectedState, cancellationToken);
             }
         }
 
@@ -197,23 +202,35 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
             }
         }
 
-        private async Task<RebalancingReport> WaitWithTimeoutAsync(ReportWaiter waiter, string expectedState)
+        private async Task<RebalancingReport> WaitWithTimeoutAsync(
+            ReportWaiter waiter,
+            string expectedState,
+            CancellationToken cancellationToken)
         {
             try
             {
-                return await waiter.Task.WaitAsync(WaitTimeout);
+                return await waiter.Task.WaitAsync(WaitTimeout, cancellationToken);
             }
             catch (TimeoutException)
             {
-                lock (_lock)
-                {
-                    _waiters.Remove(waiter);
-                }
-
+                RemoveWaiter(waiter);
                 var snapshot = Snapshot;
                 var lastReport = snapshot.Report is { } value ? Format(value) : "<none>";
                 throw new TimeoutException(
                     $"Timed out waiting for {expectedState}. Last listener report count: {snapshot.ReportCount}. Last report: {lastReport}");
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                RemoveWaiter(waiter);
+                throw;
+            }
+        }
+
+        private void RemoveWaiter(ReportWaiter waiter)
+        {
+            lock (_lock)
+            {
+                _waiters.Remove(waiter);
             }
         }
 

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/DynamicRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/DynamicRebalancingTests.cs
@@ -15,6 +15,7 @@ public class DynamicRebalancingTests(RebalancerFixture fixture, ITestOutputHelpe
     [Fact]
     public async Task Should_Move_Activations_From_Silo1_And_Silo3_To_Silo2_And_Silo4_While_New_Activations_Are_Created()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var tasks = new List<Task>();
 
         AddTestActivations(tasks, Silo1, 300);
@@ -53,7 +54,7 @@ public class DynamicRebalancingTests(RebalancerFixture fixture, ITestOutputHelpe
 
         while (index < 5)
         {
-            await Task.Delay(RebalancerFixture.SessionCyclePeriod);
+            await Task.Delay(RebalancerFixture.SessionCyclePeriod, cancellationToken);
 
             if (index % 2 == 0)
             {

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
@@ -32,6 +32,7 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
     [Fact]
     public async Task Should_Migrate_And_Preserve_State_When_Hosting_Silo_Dies()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var tasks = new List<Task>();
         using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
         var rebalancer = Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0);
@@ -73,7 +74,9 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
         Assert.Equal(targetHost, rebalancerHost);
         Assert.NotEqual(rebalancerHost, Cluster.Silos[0].SiloAddress);
 
-        await Cluster.StopSiloAsync(Cluster.Silos.First(x => x.SiloAddress.Equals(rebalancerHost)));
+        await Cluster.StopSiloAsync(
+            Cluster.Silos.First(x => x.SiloAddress.Equals(rebalancerHost)),
+            cancellationToken);
 
         var reportAfterStop = await rebalancer.GetReport();
         var newHost = reportAfterStop.Host;

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
@@ -15,6 +15,7 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
     [Fact]
     public async Task Should_Move_Activations_From_Silo1_And_Silo3_To_Silo2_And_Silo4()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var tasks = new List<Task>();
 
         AddTestActivations(tasks, Silo1, 300);
@@ -46,7 +47,7 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
         var index = 0;
         while (index < 3)
         {
-            await Task.Delay(RebalancerFixture.SessionCyclePeriod);
+            await Task.Delay(RebalancerFixture.SessionCyclePeriod, cancellationToken);
             stats = await MgmtGrain.GetDetailedGrainStatistics();
 
             silo1Activations = GetActivationCount(stats, Silo1);

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
@@ -22,6 +22,7 @@ public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrat
     [Fact]
     public async Task FinalizeProtocol_DoesNotAwaitDeactivated_ForNonActivationDataContext()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var services = PrimarySilo.SiloHost.Services;
         var directory = services.GetRequiredService<ActivationDirectory>();
         var repartitioner = services.GetRequiredService<ActivationRepartitioner>();
@@ -30,7 +31,8 @@ public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrat
         directory.RecordNewTarget(context);
         try
         {
-            await repartitioner.FinalizeProtocol([context.GrainId], [], SiloAddress.Zero, []).WaitAsync(TimeSpan.FromSeconds(3));
+            await repartitioner.FinalizeProtocol([context.GrainId], [], SiloAddress.Zero, [])
+                .WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
 
             Assert.Equal(1, context.MigrateCallCount);
             Assert.False(context.Deactivated.IsCompleted);

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/CustomToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/CustomToleranceTests.cs
@@ -24,8 +24,10 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
     [Fact]
     public async Task Should_ConvertAllRemoteCalls_ToLocalCalls_WhileRespectingTolerance()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-        await AdjustActivationCountOffsets();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(1));
+        var cancellationToken = cts.Token;
+        await AdjustActivationCountOffsets(cancellationToken);
 
         var e1 = GrainFactory.GetGrain<IE>(1);
         var e2 = GrainFactory.GetGrain<IE>(2);
@@ -73,7 +75,7 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
 
         Assert.Equal(Silo2, await x.GetAddress()); // X remains in silo 2
 
-        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner, cancellationToken);
 
         // At this point the layout is like follows:
 
@@ -84,7 +86,7 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
         // we end up with a total of 4 activations in silo1, and 2 in silo 2, which means the tolerance has been respected, and all remote calls have
         // been converted to local calls.
 
-        await Test();
+        await Test().WaitAsync(cancellationToken);
 
         // To make sure, we trigger 's1_rebalancer' again, which should yield to no further migrations.
         i = 0;
@@ -97,10 +99,10 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
             i++;
         }
 
-        await LogEdgesAsync(Silo1Repartitioner);
-        await LogEdgesAsync(Silo2Repartitioner);
-        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
-        await Test();
+        await LogEdgesAsync(Silo1Repartitioner, cancellationToken);
+        await LogEdgesAsync(Silo2Repartitioner, cancellationToken);
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner, cancellationToken);
+        await Test().WaitAsync(cancellationToken);
 
         // To make extra sure, we now trigger 's2_rebalancer', which again should yield to no further migrations.
         i = 0;
@@ -113,9 +115,9 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
             i++;
         }
 
-        await TriggerExchangeRequestAfterFlushingBuffers(Silo2Repartitioner);
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo2Repartitioner, cancellationToken);
 
-        await Test();
+        await Test().WaitAsync(cancellationToken);
 
         async Task Test()
         {
@@ -140,9 +142,11 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
         }
     }
 
-    private async Task LogEdgesAsync(IActivationRepartitionerSystemTarget repartitioner)
+    private async Task LogEdgesAsync(
+        IActivationRepartitionerSystemTarget repartitioner,
+        CancellationToken cancellationToken)
     {
-        var edgeCounts = await repartitioner.GetGrainCallFrequencies();
+        var edgeCounts = await repartitioner.GetGrainCallFrequencies().AsTask().WaitAsync(cancellationToken);
         output.WriteLine($"{repartitioner.GetGrainId()} call frequencies:");
         foreach (var (edge, freq) in edgeCounts)
         {

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
@@ -27,6 +27,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
     [Fact]
     public async Task A_ShouldMoveToSilo2__B_And_C_ShouldStayOnSilo2()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         RequestContext.Set(IPlacementDirector.PlacementHintKey, Silo1);
 
         var scenario = Scenario._1;
@@ -51,12 +52,13 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo2, b_host);
         Assert.Equal(Silo2, c_host);
 
-        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner, cancellationToken);
 
         await WaitForConditionAsync(
             async () => (a_host = await a.GetAddress()) != Silo1,
             MigrationTimeout,
-            () => $"Expected A to move from {Silo1}, but it remained on {a_host}.");
+            () => $"Expected A to move from {Silo1}, but it remained on {a_host}.",
+            cancellationToken);
 
         // refresh
         a_host = await a.GetAddress();
@@ -67,12 +69,13 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo2, b_host);
         Assert.Equal(Silo2, c_host);
 
-        await ResetCounters();
+        await ResetCounters(cancellationToken);
     }
 
     [Fact]
     public async Task C_ShouldMoveToSilo1__A_And_B_ShouldStayOnSilo1()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         RequestContext.Set(IPlacementDirector.PlacementHintKey, Silo1);
 
         var scenario = Scenario._2;
@@ -100,12 +103,13 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo1, b_host);
         Assert.Equal(Silo2, c_host);
 
-        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner, cancellationToken);
 
         await WaitForConditionAsync(
             async () => (c_host = await c.GetAddress()) != Silo2,
             MigrationTimeout,
-            () => $"Expected C to move from {Silo2}, but it remained on {c_host}.");
+            () => $"Expected C to move from {Silo2}, but it remained on {c_host}.",
+            cancellationToken);
 
         // refresh
         a_host = await a.GetAddress();
@@ -116,12 +120,13 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo1, b_host);
         Assert.Equal(Silo1, c_host);  // C is now in silo 1
 
-        await ResetCounters();
+        await ResetCounters(cancellationToken);
     }
 
     [Fact]
     public async Task Immovable_C_ShouldStayOnSilo2__A_And_B_ShouldMoveToSilo2()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         RequestContext.Set(IPlacementDirector.PlacementHintKey, Silo1);
 
         var scenario = Scenario._3;
@@ -149,7 +154,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo1, b_host);
         Assert.Equal(Silo2, c_host);
 
-        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner, cancellationToken);
 
         await WaitForConditionAsync(
             async () =>
@@ -159,7 +164,8 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
                 return a_host != Silo1 && b_host != Silo1;
             },
             MigrationTimeout,
-            () => $"Expected A and B to move from {Silo1}, but A was on {a_host} and B was on {b_host}.");
+            () => $"Expected A and B to move from {Silo1}, but A was on {a_host} and B was on {b_host}.",
+            cancellationToken);
 
         // refresh
         a_host = await a.GetAddress();
@@ -170,12 +176,13 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo2, b_host);  // B is now in silo 2
         Assert.Equal(Silo2, c_host);  // C is still in silo 2
 
-        await ResetCounters();
+        await ResetCounters(cancellationToken);
     }
 
     [Fact]
     public async Task A_ShouldMoveToSilo2_Or_C_ShouldMoveToSilo1__B_And_D_ShouldStayOnTheirSilos()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         RequestContext.Set(IPlacementDirector.PlacementHintKey, Silo1);
 
         var scenario = Scenario._4;
@@ -204,7 +211,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo2, c_host);
         Assert.Equal(Silo2, d_host);
 
-        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner);
+        await TriggerExchangeRequestAfterFlushingBuffers(Silo1Repartitioner, cancellationToken);
 
         await WaitForConditionAsync(
             async () =>
@@ -214,7 +221,8 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
                 return a_host != Silo1 || c_host != Silo2;
             },
             MigrationTimeout,
-            () => $"Expected A to move from {Silo1} or C to move from {Silo2}, but A was on {a_host} and C was on {c_host}.");
+            () => $"Expected A to move from {Silo1} or C to move from {Silo2}, but A was on {a_host} and C was on {c_host}.",
+            cancellationToken);
 
         // refresh
         a_host = await a.GetAddress();
@@ -243,12 +251,13 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
             return;
         }
 
-        await ResetCounters();
+        await ResetCounters(cancellationToken);
     }
 
     [Fact]
     public async Task Receivers_ShouldMoveCloseTo_PullingAgent()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var silo1Control = GrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, Silo1);
         var silo2Control = GrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, Silo2);
         var allowedDuration = TimeSpan.FromSeconds(3);
@@ -293,7 +302,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
                 break;
             }
 
-            await Task.Delay(50);
+            await Task.Delay(50, cancellationToken);
         }
         while (stopwatch.Elapsed < allowedDuration);
 
@@ -342,7 +351,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
 
             if (!sr1_GotHit || !sr2_GotHit || !sr3_GotHit)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, cancellationToken);
             }
         }
 
@@ -358,7 +367,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(receiverSilo, sr2_host);
         Assert.Equal(pullingAgentSilo, sr3_host);
 
-        await TriggerExchangeRequestAfterFlushingBuffers(receiverRepartitioner);
+        await TriggerExchangeRequestAfterFlushingBuffers(receiverRepartitioner, cancellationToken);
 
         stopwatch.Restart();
 
@@ -372,7 +381,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
                 break;
             }
 
-            await Task.Delay(10);
+            await Task.Delay(10, cancellationToken);
         }
 
         Assert.True(
@@ -388,7 +397,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(pullingAgentSilo, sr2_host);
         Assert.Equal(pullingAgentSilo, sr3_host);
 
-        await ResetCounters();
+        await ResetCounters(cancellationToken);
     }
 
     public enum Scenario { _1, _2, _3, _4 }

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/RepartitioningTestBase.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/RepartitioningTestBase.cs
@@ -31,9 +31,12 @@ public abstract class RepartitioningTestBase<TFixture> : IAsyncLifetime where TF
 
     public virtual async ValueTask InitializeAsync()
     {
-        await GrainFactory.GetGrain<IManagementGrain>(0).ForceActivationCollection(TimeSpan.FromSeconds(0));
-        await ResetCounters();
-        await AdjustActivationCountOffsets();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await GrainFactory.GetGrain<IManagementGrain>(0)
+            .ForceActivationCollection(TimeSpan.FromSeconds(0))
+            .WaitAsync(cancellationToken);
+        await ResetCounters(cancellationToken);
+        await AdjustActivationCountOffsets(cancellationToken);
     }
 
     public virtual ValueTask DisposeAsync()
@@ -41,20 +44,26 @@ public abstract class RepartitioningTestBase<TFixture> : IAsyncLifetime where TF
         return ValueTask.CompletedTask;
     }
 
-    public async ValueTask ResetCounters()
+    public async ValueTask ResetCounters(CancellationToken cancellationToken)
     {
-        await Silo1Repartitioner.ResetCounters();
-        await Silo2Repartitioner.ResetCounters();
+        await Silo1Repartitioner.ResetCounters().AsTask().WaitAsync(cancellationToken);
+        await Silo2Repartitioner.ResetCounters().AsTask().WaitAsync(cancellationToken);
     }
 
-    private protected async ValueTask TriggerExchangeRequestAfterFlushingBuffers(IActivationRepartitionerSystemTarget repartitioner)
+    private protected async ValueTask TriggerExchangeRequestAfterFlushingBuffers(
+        IActivationRepartitionerSystemTarget repartitioner,
+        CancellationToken cancellationToken)
     {
-        await Silo1Repartitioner.FlushBuffers();
-        await Silo2Repartitioner.FlushBuffers();
-        await repartitioner.TriggerExchangeRequest();
+        await Silo1Repartitioner.FlushBuffers().AsTask().WaitAsync(cancellationToken);
+        await Silo2Repartitioner.FlushBuffers().AsTask().WaitAsync(cancellationToken);
+        await repartitioner.TriggerExchangeRequest().AsTask().WaitAsync(cancellationToken);
     }
 
-    private protected static Task WaitForConditionAsync(Func<Task<bool>> predicate, TimeSpan timeout, Func<string> timeoutMessage)
+    private protected static Task WaitForConditionAsync(
+        Func<Task<bool>> predicate,
+        TimeSpan timeout,
+        Func<string> timeoutMessage,
+        CancellationToken cancellationToken)
         => TestingUtils.WaitUntilAsync(
             async (lastTry, _) =>
             {
@@ -68,9 +77,9 @@ public abstract class RepartitioningTestBase<TFixture> : IAsyncLifetime where TF
             },
             timeout,
             TimeSpan.FromMilliseconds(10),
-            TestContext.Current.CancellationToken);
+            cancellationToken);
 
-    public async Task AdjustActivationCountOffsets()
+    public async Task AdjustActivationCountOffsets(CancellationToken cancellationToken)
     {
         // Account for imbalances in the initial activation counts.
         Dictionary<SiloAddress, int> counts = [];
@@ -78,7 +87,7 @@ public abstract class RepartitioningTestBase<TFixture> : IAsyncLifetime where TF
         foreach (var silo in (IEnumerable<SiloHandle>)_fixture.HostedCluster.Silos)
         {
             var sysTarget = GrainFactory.GetSystemTarget<IActivationRepartitionerSystemTarget>(Constants.ActivationRepartitionerType, silo.SiloAddress);
-            var count = counts[silo.SiloAddress] = await sysTarget.GetActivationCount();
+            var count = counts[silo.SiloAddress] = await sysTarget.GetActivationCount().AsTask().WaitAsync(cancellationToken);
             max = Math.Max(max, count);
         }
 
@@ -86,7 +95,7 @@ public abstract class RepartitioningTestBase<TFixture> : IAsyncLifetime where TF
         {
             var sysTarget = GrainFactory.GetSystemTarget<IActivationRepartitionerSystemTarget>(Constants.ActivationRepartitionerType, silo.SiloAddress);
             var myCount = counts[silo.SiloAddress];
-            await sysTarget.SetActivationCountOffset(max - myCount);
+            await sysTarget.SetActivationCountOffset(max - myCount).AsTask().WaitAsync(cancellationToken);
         }
     }
 

--- a/test/Orleans.Placement.Tests/General/ElasticPlacementTest.cs
+++ b/test/Orleans.Placement.Tests/General/ElasticPlacementTest.cs
@@ -97,7 +97,11 @@ namespace UnitTests.General
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/4008"), TestCategory("Functional")]
         public async Task ElasticityTest_StoppingSilos()
         {
-            List<SiloHandle> runtimes = await this.HostedCluster.StartAdditionalSilosAsync(2);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            List<SiloHandle> runtimes = await this.HostedCluster.StartAdditionalSilosAsync(
+                2,
+                startAdditionalSiloOnNewPort: false,
+                cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
             int stopLeavy = leavy;
 
@@ -115,7 +119,7 @@ namespace UnitTests.General
             AssertIsInRange(activationCounts[runtimes[0]], perSilo, stopLeavy);
             AssertIsInRange(activationCounts[runtimes[1]], perSilo, stopLeavy);
 
-            await this.HostedCluster.StopSiloAsync(runtimes[0]);
+            await this.HostedCluster.StopSiloAsync(runtimes[0], cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
             await InvokeAllGrains();
 

--- a/test/Orleans.Placement.Tests/General/GrainPlacementClusterChangeTests.cs
+++ b/test/Orleans.Placement.Tests/General/GrainPlacementClusterChangeTests.cs
@@ -20,6 +20,7 @@ namespace UnitTests.General
         [TestCategory("BVT"), TestCategory("Placement")]
         public async Task PreferLocalPlacementGrain_ShouldMigrateWhenHostSiloKilled(string value)
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             foreach (SiloHandle silo in HostedCluster.GetActiveSilos())
             {
                 output.WriteLine(
@@ -57,7 +58,7 @@ namespace UnitTests.General
 
             SiloHandle siloToKill = HostedCluster.GetActiveSilos().First(s => s.SiloAddress.Endpoint.Equals(expected));
             output.WriteLine("Killing silo {0} hosting locally placed grain", siloToKill);
-            await HostedCluster.StopSiloAsync(siloToKill);
+            await HostedCluster.StopSiloAsync(siloToKill, cancellationToken);
             await HostedCluster.WaitForLivenessToStabilizeAsync();
 
             IPEndPoint newActual = await grain.GetEndpoint();

--- a/test/Orleans.Placement.Tests/PlacementFilterTests/GrainPlacementFilterTests.cs
+++ b/test/Orleans.Placement.Tests/PlacementFilterTests/GrainPlacementFilterTests.cs
@@ -56,11 +56,12 @@ public class GrainPlacementFilterTests(GrainPlacementFilterTests.Fixture fixture
     [Fact, TestCategory("Functional")]
     public async Task PlacementFilter_FilterIsTriggered()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var triggered = false;
         var task = Task.Run(async () =>
         {
-            triggered = await TestPlacementFilterDirector.Triggered.WaitAsync(TimeSpan.FromSeconds(1));
-        });
+            triggered = await TestPlacementFilterDirector.Triggered.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken);
+        }, cancellationToken);
         var localOnlyGrain = fixture.Cluster.Client!.GetGrain<ITestFilteredGrain>(0);
         await localOnlyGrain.Ping();
         await task;

--- a/test/Orleans.Reminders.TestKit.Tests/FaultyReminderTableTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/FaultyReminderTableTests.cs
@@ -63,7 +63,8 @@ public sealed class FaultyReminderTableTests : IDisposable
     {
         var runner = CreateRunner(new ConstantETagReminderTable(), "ConstantETag");
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.ReminderTable_UpsertRow_ReplacesETagOnEachWrite);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunReminderTable_UpsertRow_ReplacesETagOnEachWrite(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(exception.Message, "ConstantETag", nameof(ReminderTableTestRunner.ReminderTable_UpsertRow_ReplacesETagOnEachWrite), "UpsertRow");
         Assert.Contains("ETag different from 'constant-etag'", exception.Message, StringComparison.Ordinal);
@@ -76,7 +77,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(new TornConcurrentWriteReminderTable(), "TornConcurrentWrite");
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            runner.ReminderTable_ConcurrentUpserts_ProduceDistinctETags);
+            () => runner.RunReminderTable_ConcurrentUpserts_ProduceDistinctETags(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(
             exception.Message,
@@ -93,7 +94,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(table, "OneTimeReusedETag");
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            runner.ReminderTable_UpsertRow_ReplacesETagOnEachWrite);
+            () => runner.RunReminderTable_UpsertRow_ReplacesETagOnEachWrite(TestContext.Current.CancellationToken));
 
         Assert.Equal(2, table.UpsertAttempts);
         Assert.Contains("successful replacement returned the reused ETag", exception.Message, StringComparison.Ordinal);
@@ -104,7 +105,8 @@ public sealed class FaultyReminderTableTests : IDisposable
     {
         var runner = CreateRunner(new ETagIgnoringRemoveReminderTable(), "ETagIgnoringRemove");
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(exception.Message, "ETagIgnoringRemove", nameof(ReminderTableTestRunner.ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow), "RemoveRow");
         Assert.Contains("false when removing with a stale ETag", exception.Message, StringComparison.Ordinal);
@@ -117,7 +119,8 @@ public sealed class FaultyReminderTableTests : IDisposable
     {
         var runner = CreateRunner(new InclusiveBeginRangeReminderTable(), "InclusiveBeginRange");
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(exception.Message, "InclusiveBeginRange", nameof(ReminderTableTestRunner.ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd), "ReadRows(low, middle)");
         Assert.Contains("Expected exact identities", exception.Message, StringComparison.Ordinal);
@@ -129,7 +132,8 @@ public sealed class FaultyReminderTableTests : IDisposable
     {
         var runner = CreateRunner(new NoWrapAroundRangeReminderTable(), "NoWrapAround");
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(exception.Message, "NoWrapAround", nameof(ReminderTableTestRunner.ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment), "ReadRows(high, low)");
         Assert.Contains("Expected exact identities", exception.Message, StringComparison.Ordinal);
@@ -141,7 +145,8 @@ public sealed class FaultyReminderTableTests : IDisposable
     {
         var runner = CreateRunner(new PeriodLosingReminderTable(), "PeriodLosing");
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.ReminderTable_UpsertRow_PersistsScheduleForPointRead);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunReminderTable_UpsertRow_PersistsScheduleForPointRead(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(exception.Message, "PeriodLosing", nameof(ReminderTableTestRunner.ReminderTable_UpsertRow_PersistsScheduleForPointRead), "ReadRow");
         Assert.Contains("Period=00:03:00", exception.Message, StringComparison.Ordinal);
@@ -153,7 +158,8 @@ public sealed class FaultyReminderTableTests : IDisposable
     {
         var runner = CreateRunner(new ResurrectingReminderTable(), "Resurrecting");
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.ReminderTable_RemoveRow_WithCurrentETag_RemovesRow);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunReminderTable_RemoveRow_WithCurrentETag_RemovesRow(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(exception.Message, "Resurrecting", nameof(ReminderTableTestRunner.ReminderTable_RemoveRow_WithCurrentETag_RemovesRow), "ReadRow");
         Assert.Contains("Expected null after successful removal", exception.Message, StringComparison.Ordinal);
@@ -164,7 +170,8 @@ public sealed class FaultyReminderTableTests : IDisposable
     {
         var runner = CreateRunner(new ResurrectingReminderTable(), "Resurrecting");
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.ReminderTable_ReadRow_AfterRemoval_ReturnsNull);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunReminderTable_ReadRow_AfterRemoval_ReturnsNull(TestContext.Current.CancellationToken));
 
         AssertDiagnostics(exception.Message, "Resurrecting", nameof(ReminderTableTestRunner.ReminderTable_ReadRow_AfterRemoval_ReturnsNull), "ReadRow");
         Assert.Contains("Expected null after successful removal", exception.Message, StringComparison.Ordinal);
@@ -176,7 +183,8 @@ public sealed class FaultyReminderTableTests : IDisposable
         string? failureOutput = null;
         var runner = new ReminderTableModelBasedTestRunner(new ResurrectingReminderTable(), "Resurrecting", message => failureOutput = message);
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.RunGeneratedConformanceTests);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken));
 
         Assert.Contains("Model-based reminder table conformance test failed [provider=Resurrecting, seed=0]", exception.Message, StringComparison.Ordinal);
         Assert.NotNull(failureOutput);
@@ -190,7 +198,8 @@ public sealed class FaultyReminderTableTests : IDisposable
         string? failureOutput = null;
         var runner = new ReminderTableModelBasedTestRunner(new ConstantETagReminderTable(), "ConstantETag", message => failureOutput = message);
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.RunGeneratedConformanceTests);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken));
 
         Assert.Contains("Model-based reminder table conformance test failed [provider=ConstantETag, seed=0]", exception.Message, StringComparison.Ordinal);
         Assert.NotNull(failureOutput);
@@ -211,7 +220,8 @@ public sealed class FaultyReminderTableTests : IDisposable
             },
             message => failureOutput = message);
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.RunGeneratedConformanceTests);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken));
 
         Assert.Contains(
             "Model-based reminder table conformance test failed [provider=CollateralDeleting, seed=0]",
@@ -231,9 +241,9 @@ public sealed class FaultyReminderTableTests : IDisposable
             table,
             "Control");
 
-        await runner.RunGeneratedConformanceTests();
+        await runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
 
-        Assert.Empty((await table.ReadRows(0, 0)).Reminders);
+        Assert.Empty((await table.ReadRows(0, 0).WaitAsync(TestContext.Current.CancellationToken)).Reminders);
     }
 
     [Fact, TestCategory("ModelBased")]
@@ -245,7 +255,8 @@ public sealed class FaultyReminderTableTests : IDisposable
             "NoWrapAroundModel",
             message => failureOutput = message);
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.RunGeneratedConformanceTests);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken));
 
         Assert.Contains(
             "Model-based reminder table conformance test failed [provider=NoWrapAroundModel, seed=0]",
@@ -509,7 +520,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(new DuplicateGrainEnumerationReminderTable(), "DuplicateGrainEnumeration");
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            runner.ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders);
+            () => runner.RunReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders(TestContext.Current.CancellationToken));
 
         AssertExactEnumerationFailure(
             exception,
@@ -526,7 +537,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(new DuplicateRangeEnumerationReminderTable(), "DuplicateRangeEnumeration");
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            runner.ReminderTable_ReadRows_FullRange_ReturnsAllReminders);
+            () => runner.RunReminderTable_ReadRows_FullRange_ReturnsAllReminders(TestContext.Current.CancellationToken));
 
         AssertExactEnumerationFailure(
             exception,
@@ -615,7 +626,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(new StaleLoadingWindowEnumerationReminderTable(), "StaleLoadingWindowEnumeration");
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            runner.ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows);
+            () => runner.RunReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows(TestContext.Current.CancellationToken));
 
         AssertExactEnumerationFailure(
             exception,
@@ -633,7 +644,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(new DuplicateFullRangeCardinalityReminderTable(), "DuplicateFullRangeCardinality");
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            () => runner.ReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(7));
+            () => runner.RunReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(7, TestContext.Current.CancellationToken));
 
         AssertExactEnumerationFailure(
             exception,
@@ -663,7 +674,8 @@ public sealed class FaultyReminderTableTests : IDisposable
             options,
             message => failureOutput = message);
 
-        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(runner.RunGeneratedConformanceTests);
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+            () => runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken));
 
         Assert.Contains(
             "Model-based reminder table conformance test failed [provider=EnumerationOnlyPayloadMutation, seed=17]",
@@ -686,7 +698,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(new CorruptGrainEnumerationReminderTable(mutation), provider);
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            runner.ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders);
+            () => runner.RunReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders(TestContext.Current.CancellationToken));
 
         AssertExactEnumerationFailure(
             exception,
@@ -706,7 +718,7 @@ public sealed class FaultyReminderTableTests : IDisposable
         var runner = CreateRunner(new CorruptRangeEnumerationReminderTable(mutation), provider);
 
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            runner.ReminderTable_ReadRows_FullRange_ReturnsAllReminders);
+            () => runner.RunReminderTable_ReadRows_FullRange_ReturnsAllReminders(TestContext.Current.CancellationToken));
 
         AssertExactEnumerationFailure(
             exception,

--- a/test/Orleans.Reminders.TestKit.Tests/IdealizedReminderTableTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/IdealizedReminderTableTests.cs
@@ -39,83 +39,83 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     // -------------------------------------------------------------------------------------------------------------
 
     [Fact]
-    public override Task ReminderTable_StartAsync_IsIdempotent() => base.ReminderTable_StartAsync_IsIdempotent();
+    public override Task ReminderTable_StartAsync_IsIdempotent() => base.RunReminderTable_StartAsync_IsIdempotent(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_StopAsync_ThenRestart_ResumesService() => base.ReminderTable_StopAsync_ThenRestart_ResumesService();
+    public override Task ReminderTable_StopAsync_ThenRestart_ResumesService() => base.RunReminderTable_StopAsync_ThenRestart_ResumesService(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_ReturnsNewNonEmptyETag() => base.ReminderTable_UpsertRow_ReturnsNewNonEmptyETag();
+    public override Task ReminderTable_UpsertRow_ReturnsNewNonEmptyETag() => base.RunReminderTable_UpsertRow_ReturnsNewNonEmptyETag(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_PersistsScheduleForPointRead() => base.ReminderTable_UpsertRow_PersistsScheduleForPointRead();
+    public override Task ReminderTable_UpsertRow_PersistsScheduleForPointRead() => base.RunReminderTable_UpsertRow_PersistsScheduleForPointRead(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRow_MissingReminder_ReturnsNull() => base.ReminderTable_ReadRow_MissingReminder_ReturnsNull();
+    public override Task ReminderTable_ReadRow_MissingReminder_ReturnsNull() => base.RunReminderTable_ReadRow_MissingReminder_ReturnsNull(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders() => base.ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders();
+    public override Task ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders() => base.RunReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty() => base.ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty();
+    public override Task ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty() => base.RunReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_Identity_IsGrainIdAndReminderName() => base.ReminderTable_Identity_IsGrainIdAndReminderName();
+    public override Task ReminderTable_Identity_IsGrainIdAndReminderName() => base.RunReminderTable_Identity_IsGrainIdAndReminderName(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_Identity_WithSpecialCharacters_RoundTrips() => base.ReminderTable_Identity_WithSpecialCharacters_RoundTrips();
+    public override Task ReminderTable_Identity_WithSpecialCharacters_RoundTrips() => base.RunReminderTable_Identity_WithSpecialCharacters_RoundTrips(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_ReplacesETagOnEachWrite() => base.ReminderTable_UpsertRow_ReplacesETagOnEachWrite();
+    public override Task ReminderTable_UpsertRow_ReplacesETagOnEachWrite() => base.RunReminderTable_UpsertRow_ReplacesETagOnEachWrite(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_WithCurrentETag_RemovesRow() => base.ReminderTable_RemoveRow_WithCurrentETag_RemovesRow();
+    public override Task ReminderTable_RemoveRow_WithCurrentETag_RemovesRow() => base.RunReminderTable_RemoveRow_WithCurrentETag_RemovesRow(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow() => base.ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow();
+    public override Task ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow() => base.RunReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse() => base.ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse();
+    public override Task ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse() => base.RunReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess() => base.ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess();
+    public override Task ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess() => base.RunReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_UpdatesStartAtAndPeriod() => base.ReminderTable_UpsertRow_UpdatesStartAtAndPeriod();
+    public override Task ReminderTable_UpsertRow_UpdatesStartAtAndPeriod() => base.RunReminderTable_UpsertRow_UpdatesStartAtAndPeriod(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows() => base.ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows();
+    public override Task ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows() => base.RunReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_FullRange_ReturnsAllReminders() => base.ReminderTable_ReadRows_FullRange_ReturnsAllReminders();
+    public override Task ReminderTable_ReadRows_FullRange_ReturnsAllReminders() => base.RunReminderTable_ReadRows_FullRange_ReturnsAllReminders(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering()
-        => base.ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering();
+        => base.RunReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd() => base.ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd();
+    public override Task ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd() => base.RunReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment() => base.ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment();
+    public override Task ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment() => base.RunReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder() => base.ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder();
+    public override Task ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder() => base.RunReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder() => base.ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder();
+    public override Task ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder() => base.RunReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRow_AfterRemoval_ReturnsNull() => base.ReminderTable_ReadRow_AfterRemoval_ReturnsNull();
+    public override Task ReminderTable_ReadRow_AfterRemoval_ReturnsNull() => base.RunReminderTable_ReadRow_AfterRemoval_ReturnsNull(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ConcurrentUpserts_ProduceDistinctETags() => base.ReminderTable_ConcurrentUpserts_ProduceDistinctETags();
+    public override Task ReminderTable_ConcurrentUpserts_ProduceDistinctETags() => base.RunReminderTable_ConcurrentUpserts_ProduceDistinctETags(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated() => base.ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated();
+    public override Task ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated() => base.RunReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_TestOnlyClearTable_RemovesAllReminders() => base.ReminderTable_TestOnlyClearTable_RemovesAllReminders();
+    public override Task ReminderTable_TestOnlyClearTable_RemovesAllReminders() => base.RunReminderTable_TestOnlyClearTable_RemovesAllReminders(TestContext.Current.CancellationToken);
 
     // -------------------------------------------------------------------------------------------------------------
     // Model-based conformance.
@@ -125,7 +125,7 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     public Task Oracle_ModelBasedGeneratedConformance()
     {
         var runner = new ReminderTableModelBasedTestRunner(_oracle, "Oracle");
-        return runner.RunGeneratedConformanceTests();
+        return runner.RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
     }
 
     [Fact, TestCategory("ModelBased")]
@@ -142,8 +142,8 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
             MaxSequenceLength = 2
         };
 
-        await new ReminderTableModelBasedTestRunner(first, options).RunGeneratedConformanceTests();
-        await new ReminderTableModelBasedTestRunner(second, options).RunGeneratedConformanceTests();
+        await new ReminderTableModelBasedTestRunner(first, options).RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
+        await new ReminderTableModelBasedTestRunner(second, options).RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
 
         Assert.NotEmpty(first.Operations);
         Assert.Equal(first.Operations.Count, second.Operations.Count);
@@ -174,8 +174,14 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     public async Task Oracle_Snapshot_ExposesPersistedRecordsWithETagLineage()
     {
         var grainId = NewGrainId("introspection");
-        var first = await UpsertAsync(NewEntry(grainId, "introspection", BaseTime, TimeSpan.FromMinutes(2)), nameof(Oracle_Snapshot_ExposesPersistedRecordsWithETagLineage));
-        var second = await UpsertAsync(NewEntry(grainId, "introspection", BaseTime.AddMinutes(5), TimeSpan.FromMinutes(3)), nameof(Oracle_Snapshot_ExposesPersistedRecordsWithETagLineage));
+        var first = await UpsertAsync(
+            NewEntry(grainId, "introspection", BaseTime, TimeSpan.FromMinutes(2)),
+            nameof(Oracle_Snapshot_ExposesPersistedRecordsWithETagLineage),
+            TestContext.Current.CancellationToken);
+        var second = await UpsertAsync(
+            NewEntry(grainId, "introspection", BaseTime.AddMinutes(5), TimeSpan.FromMinutes(3)),
+            nameof(Oracle_Snapshot_ExposesPersistedRecordsWithETagLineage),
+            TestContext.Current.CancellationToken);
 
         var record = Assert.Single(_oracle.Snapshot());
         Assert.Equal(grainId, record.GrainId);
@@ -197,9 +203,12 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
         var grainId = NewGrainId("operation-log");
         _oracle.ClearOperations();
 
-        var etag = await UpsertAsync(NewEntry(grainId, "operation-log"), nameof(Oracle_Operations_RecordSequenceIdentityAndOutcome));
-        _ = await ReminderTable.ReadRow(grainId, "operation-log");
-        var removed = await ReminderTable.RemoveRow(grainId, "operation-log", "not-the-current-etag");
+        var etag = await UpsertAsync(
+            NewEntry(grainId, "operation-log"),
+            nameof(Oracle_Operations_RecordSequenceIdentityAndOutcome),
+            TestContext.Current.CancellationToken);
+        _ = await ReminderTable.ReadRow(grainId, "operation-log").WaitAsync(TestContext.Current.CancellationToken);
+        var removed = await ReminderTable.RemoveRow(grainId, "operation-log", "not-the-current-etag").WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.False(removed);
 
@@ -233,15 +242,21 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
         var etags = new List<string>();
         for (var index = 0; index < 4; index++)
         {
-            etags.Add(await UpsertAsync(NewEntry(grainId, $"etag-sequence-{index.ToString(CultureInfo.InvariantCulture)}"), nameof(Oracle_ETags_AreMonotonicAndNeverReused)));
+            etags.Add(await UpsertAsync(
+                NewEntry(grainId, $"etag-sequence-{index.ToString(CultureInfo.InvariantCulture)}"),
+                nameof(Oracle_ETags_AreMonotonicAndNeverReused),
+                TestContext.Current.CancellationToken));
         }
 
         Assert.Equal(etags.Count, etags.Distinct(StringComparer.Ordinal).Count());
         Assert.Equal(new[] { "etag-000001", "etag-000002", "etag-000003", "etag-000004" }, etags);
 
         // Removing and re-adding must not recycle an ETag.
-        Assert.True(await ReminderTable.RemoveRow(grainId, "etag-sequence-0", etags[0]));
-        var reAdded = await UpsertAsync(NewEntry(grainId, "etag-sequence-0"), nameof(Oracle_ETags_AreMonotonicAndNeverReused));
+        Assert.True(await ReminderTable.RemoveRow(grainId, "etag-sequence-0", etags[0]).WaitAsync(TestContext.Current.CancellationToken));
+        var reAdded = await UpsertAsync(
+            NewEntry(grainId, "etag-sequence-0"),
+            nameof(Oracle_ETags_AreMonotonicAndNeverReused),
+            TestContext.Current.CancellationToken);
         Assert.Equal("etag-000005", reAdded);
         Assert.DoesNotContain(reAdded, etags);
     }
@@ -254,21 +269,27 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     public async Task Oracle_Unavailable_FailsEveryOperationUntilRecovered()
     {
         var grainId = NewGrainId("outage");
-        var etag = await UpsertAsync(NewEntry(grainId, "outage"), nameof(Oracle_Unavailable_FailsEveryOperationUntilRecovered));
+        var etag = await UpsertAsync(
+            NewEntry(grainId, "outage"),
+            nameof(Oracle_Unavailable_FailsEveryOperationUntilRecovered),
+            TestContext.Current.CancellationToken);
 
         _oracle.SetAvailable(false);
         Assert.False(_oracle.IsAvailable);
 
-        await Assert.ThrowsAsync<ReminderTableUnavailableException>(() => ReminderTable.ReadRow(grainId, "outage"));
-        await Assert.ThrowsAsync<ReminderTableUnavailableException>(() => ReminderTable.ReadRows(0, 0));
-        await Assert.ThrowsAsync<ReminderTableUnavailableException>(() => ReminderTable.UpsertRow(NewEntry(grainId, "outage-2")));
+        await Assert.ThrowsAsync<ReminderTableUnavailableException>(
+            () => ReminderTable.ReadRow(grainId, "outage").WaitAsync(TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<ReminderTableUnavailableException>(
+            () => ReminderTable.ReadRows(0, 0).WaitAsync(TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<ReminderTableUnavailableException>(
+            () => ReminderTable.UpsertRow(NewEntry(grainId, "outage-2")).WaitAsync(TestContext.Current.CancellationToken));
 
         // The outage is recorded so a test can assert on what the reminder service attempted while storage was down.
         Assert.Equal(3, _oracle.Operations.Count(operation => operation.Failure == nameof(ReminderTableUnavailableException)));
 
         // Durable state survives the outage: it was an availability failure, not a deletion.
         _oracle.SetAvailable(true);
-        var recovered = await ReminderTable.ReadRow(grainId, "outage");
+        var recovered = await ReminderTable.ReadRow(grainId, "outage").WaitAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(recovered);
         Assert.Equal(etag, recovered.ETag);
         Assert.Null(_oracle.Find(grainId, "outage-2"));
@@ -280,19 +301,21 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
         var grainId = NewGrainId("injected-failure");
         _oracle.InjectFailure(ReminderTableOperationKind.UpsertRow, count: 2, () => new InvalidOperationException("transient store failure"));
 
-        var first = await Assert.ThrowsAsync<InvalidOperationException>(() => ReminderTable.UpsertRow(NewEntry(grainId, "injected-failure")));
+        var first = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ReminderTable.UpsertRow(NewEntry(grainId, "injected-failure")).WaitAsync(TestContext.Current.CancellationToken));
         Assert.Equal("transient store failure", first.Message);
-        await Assert.ThrowsAsync<InvalidOperationException>(() => ReminderTable.UpsertRow(NewEntry(grainId, "injected-failure")));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ReminderTable.UpsertRow(NewEntry(grainId, "injected-failure")).WaitAsync(TestContext.Current.CancellationToken));
 
         // The third attempt is not affected, and the failures did not create partial state.
-        var etag = await ReminderTable.UpsertRow(NewEntry(grainId, "injected-failure"));
+        var etag = await ReminderTable.UpsertRow(NewEntry(grainId, "injected-failure")).WaitAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(etag);
         Assert.Equal("etag-000001", etag);
         Assert.Equal(2, _oracle.Operations.Count(operation => operation.Failure == nameof(InvalidOperationException)));
         Assert.Single(_oracle.Snapshot());
 
         // Reads were never targeted, so they were never failed.
-        Assert.NotNull(await ReminderTable.ReadRow(grainId, "injected-failure"));
+        Assert.NotNull(await ReminderTable.ReadRow(grainId, "injected-failure").WaitAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -302,7 +325,7 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
         _oracle.InjectFailure(ReminderTableOperationKind.ReadRow, count: 2);
 
         _oracle.ClearInjectedFailures();
-        var result = await ReminderTable.ReadRow(grainId, "missing");
+        var result = await ReminderTable.ReadRow(grainId, "missing").WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.Null(result);
         Assert.Single(_oracle.Operations, operation =>
@@ -317,9 +340,13 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     public async Task Oracle_BlockNext_ProvidesADeterministicBarrierWithoutSleeping()
     {
         var grainId = NewGrainId("barrier");
-        var etag = await UpsertAsync(NewEntry(grainId, "barrier", BaseTime, TimeSpan.FromMinutes(1)), nameof(Oracle_BlockNext_ProvidesADeterministicBarrierWithoutSleeping));
+        var etag = await UpsertAsync(
+            NewEntry(grainId, "barrier", BaseTime, TimeSpan.FromMinutes(1)),
+            nameof(Oracle_BlockNext_ProvidesADeterministicBarrierWithoutSleeping),
+            TestContext.Current.CancellationToken);
 
-        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
         await using var gate = _oracle.BlockNext(ReminderTableOperationKind.ReadRange);
 
         var rangeRead = ReminderTable.ReadRows(0, 0);
@@ -327,7 +354,10 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
         Assert.False(rangeRead.IsCompleted);
 
         // While the range read is parked at the barrier, a concurrent write is applied and observed by the oracle.
-        var updated = await UpsertAsync(NewEntry(grainId, "barrier", BaseTime.AddMinutes(5), TimeSpan.FromMinutes(2)), nameof(Oracle_BlockNext_ProvidesADeterministicBarrierWithoutSleeping));
+        var updated = await UpsertAsync(
+            NewEntry(grainId, "barrier", BaseTime.AddMinutes(5), TimeSpan.FromMinutes(2)),
+            nameof(Oracle_BlockNext_ProvidesADeterministicBarrierWithoutSleeping),
+            cancellation.Token);
         Assert.NotEqual(etag, updated);
         Assert.False(rangeRead.IsCompleted);
 
@@ -342,7 +372,8 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     public async Task Oracle_DisposingBlockGate_ReleasesTheWaitingOperation()
     {
         var grainId = NewGrainId("disposed-barrier");
-        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
         var gate = _oracle.BlockNext(ReminderTableOperationKind.ReadRow);
 
         var read = ReminderTable.ReadRow(grainId, "missing");
@@ -364,14 +395,20 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     public async Task Oracle_FreezeReads_ServesAStaleSnapshotWhileWritesStillApply()
     {
         var grainId = NewGrainId("stale-snapshot");
-        var original = await UpsertAsync(NewEntry(grainId, "stale-snapshot", BaseTime, TimeSpan.FromMinutes(1)), nameof(Oracle_FreezeReads_ServesAStaleSnapshotWhileWritesStillApply));
+        var original = await UpsertAsync(
+            NewEntry(grainId, "stale-snapshot", BaseTime, TimeSpan.FromMinutes(1)),
+            nameof(Oracle_FreezeReads_ServesAStaleSnapshotWhileWritesStillApply),
+            TestContext.Current.CancellationToken);
 
         using (_oracle.FreezeReads())
         {
-            var updated = await UpsertAsync(NewEntry(grainId, "stale-snapshot", BaseTime.AddMinutes(20), TimeSpan.FromMinutes(9)), nameof(Oracle_FreezeReads_ServesAStaleSnapshotWhileWritesStillApply));
+            var updated = await UpsertAsync(
+                NewEntry(grainId, "stale-snapshot", BaseTime.AddMinutes(20), TimeSpan.FromMinutes(9)),
+                nameof(Oracle_FreezeReads_ServesAStaleSnapshotWhileWritesStillApply),
+                TestContext.Current.CancellationToken);
             Assert.NotEqual(original, updated);
 
-            var stale = await ReminderTable.ReadRow(grainId, "stale-snapshot");
+            var stale = await ReminderTable.ReadRow(grainId, "stale-snapshot").WaitAsync(TestContext.Current.CancellationToken);
             Assert.NotNull(stale);
             Assert.Equal(original, stale.ETag);
             Assert.Equal(BaseTime.Ticks, stale.StartAt.Ticks);
@@ -380,7 +417,7 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
             Assert.Equal(updated, _oracle.Find(grainId, "stale-snapshot")!.ETag);
         }
 
-        var live = await ReminderTable.ReadRow(grainId, "stale-snapshot");
+        var live = await ReminderTable.ReadRow(grainId, "stale-snapshot").WaitAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(live);
         Assert.Equal(BaseTime.AddMinutes(20).Ticks, live.StartAt.Ticks);
         Assert.Equal(TimeSpan.FromMinutes(9), live.Period);
@@ -389,7 +426,7 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     [Fact]
     public async Task Oracle_StopAsync_WithCanceledToken_IsObservable()
     {
-        using var cancellation = new CancellationTokenSource();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         await cancellation.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ReminderTable.StopAsync(cancellation.Token));
@@ -404,12 +441,13 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     {
         if (operationKind == ReminderTableOperationKind.Stop)
         {
-            await ReminderTable.StartAsync();
+            await ReminderTable.StartAsync(TestContext.Current.CancellationToken);
         }
 
         var expectedStarted = operationKind == ReminderTableOperationKind.Stop;
-        using var operationCancellation = new CancellationTokenSource();
-        using var waitCancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var operationCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        waitCancellation.CancelAfter(TestConstants.InitTimeout);
         await using var gate = _oracle.BlockNext(operationKind);
 
         var operation = operationKind == ReminderTableOperationKind.Start
@@ -449,7 +487,7 @@ public sealed class IdealizedReminderTableTests : ReminderTableTestRunner
     {
         _oracle.ClearOperations();
 
-        await base.ReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(7);
+        await base.RunReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(7, TestContext.Current.CancellationToken);
 
         var upserts = _oracle.Operations.Where(operation => operation.Kind == ReminderTableOperationKind.UpsertRow).ToList();
         Assert.Equal(7, upserts.Count);

--- a/test/Orleans.Reminders.TestKit.Tests/InMemoryReminderTableConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/InMemoryReminderTableConformanceTests.cs
@@ -10,6 +10,14 @@ namespace Orleans.Reminders.TestKit.Tests;
 public sealed class InMemoryReminderTableFixture : ReminderTableTestFixture, IAsyncLifetime
 {
     protected override void ConfigureSilo(ISiloBuilder siloBuilder) => siloBuilder.UseInMemoryReminderService();
+
+    public override ValueTask InitializeAsync() => base.InitializeAsync(TestContext.Current.CancellationToken);
+
+    public override async ValueTask DisposeAsync()
+    {
+        using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        await base.DisposeAsync(cleanupCancellation.Token);
+    }
 }
 
 /// <summary>
@@ -35,89 +43,89 @@ public sealed class InMemoryReminderTableConformanceTests : ReminderTableTestRun
     }
 
     [Fact]
-    public override Task ReminderTable_StartAsync_IsIdempotent() => base.ReminderTable_StartAsync_IsIdempotent();
+    public override Task ReminderTable_StartAsync_IsIdempotent() => base.RunReminderTable_StartAsync_IsIdempotent(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_StopAsync_ThenRestart_ResumesService() => base.ReminderTable_StopAsync_ThenRestart_ResumesService();
+    public override Task ReminderTable_StopAsync_ThenRestart_ResumesService() => base.RunReminderTable_StopAsync_ThenRestart_ResumesService(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_ReturnsNewNonEmptyETag() => base.ReminderTable_UpsertRow_ReturnsNewNonEmptyETag();
+    public override Task ReminderTable_UpsertRow_ReturnsNewNonEmptyETag() => base.RunReminderTable_UpsertRow_ReturnsNewNonEmptyETag(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_PersistsScheduleForPointRead() => base.ReminderTable_UpsertRow_PersistsScheduleForPointRead();
+    public override Task ReminderTable_UpsertRow_PersistsScheduleForPointRead() => base.RunReminderTable_UpsertRow_PersistsScheduleForPointRead(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRow_MissingReminder_ReturnsNull() => base.ReminderTable_ReadRow_MissingReminder_ReturnsNull();
+    public override Task ReminderTable_ReadRow_MissingReminder_ReturnsNull() => base.RunReminderTable_ReadRow_MissingReminder_ReturnsNull(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders() => base.ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders();
+    public override Task ReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders() => base.RunReminderTable_ReadRows_ForGrain_ReturnsOnlyThatGrainsReminders(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty() => base.ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty();
+    public override Task ReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty() => base.RunReminderTable_ReadRows_ForUnknownGrain_ReturnsEmpty(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_Identity_IsGrainIdAndReminderName() => base.ReminderTable_Identity_IsGrainIdAndReminderName();
+    public override Task ReminderTable_Identity_IsGrainIdAndReminderName() => base.RunReminderTable_Identity_IsGrainIdAndReminderName(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_Identity_WithSpecialCharacters_RoundTrips() => base.ReminderTable_Identity_WithSpecialCharacters_RoundTrips();
+    public override Task ReminderTable_Identity_WithSpecialCharacters_RoundTrips() => base.RunReminderTable_Identity_WithSpecialCharacters_RoundTrips(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_ReplacesETagOnEachWrite() => base.ReminderTable_UpsertRow_ReplacesETagOnEachWrite();
+    public override Task ReminderTable_UpsertRow_ReplacesETagOnEachWrite() => base.RunReminderTable_UpsertRow_ReplacesETagOnEachWrite(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_WithCurrentETag_RemovesRow() => base.ReminderTable_RemoveRow_WithCurrentETag_RemovesRow();
+    public override Task ReminderTable_RemoveRow_WithCurrentETag_RemovesRow() => base.RunReminderTable_RemoveRow_WithCurrentETag_RemovesRow(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow() => base.ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow();
+    public override Task ReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow() => base.RunReminderTable_RemoveRow_WithStaleETag_FailsAndRetainsRow(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse() => base.ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse();
+    public override Task ReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse() => base.RunReminderTable_RemoveRow_WithUnknownReminderName_ReturnsFalse(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess() => base.ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess();
+    public override Task ReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess() => base.RunReminderTable_RemoveRow_Repeated_ReturnsFalseAfterFirstSuccess(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_UpdatesStartAtAndPeriod() => base.ReminderTable_UpsertRow_UpdatesStartAtAndPeriod();
+    public override Task ReminderTable_UpsertRow_UpdatesStartAtAndPeriod() => base.RunReminderTable_UpsertRow_UpdatesStartAtAndPeriod(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows() => base.ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows();
+    public override Task ReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows() => base.RunReminderTable_UpsertRow_MovesReminderBetweenLoadingWindows(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_FullRange_ReturnsAllReminders() => base.ReminderTable_ReadRows_FullRange_ReturnsAllReminders();
+    public override Task ReminderTable_ReadRows_FullRange_ReturnsAllReminders() => base.RunReminderTable_ReadRows_FullRange_ReturnsAllReminders(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering()
-        => base.ReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering();
+        => base.RunReminderTable_ReadRows_UnsignedBoundary_UsesUInt32Ordering(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd() => base.ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd();
+    public override Task ReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd() => base.RunReminderTable_ReadRows_Range_ExcludesBeginAndIncludesEnd(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment() => base.ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment();
+    public override Task ReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment() => base.RunReminderTable_ReadRows_WrapAroundRange_ReturnsWrappedSegment(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder() => base.ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder();
+    public override Task ReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder() => base.RunReminderTable_ReadRows_OutsideRange_DoesNotDeleteReminder(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder() => base.ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder();
+    public override Task ReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder() => base.RunReminderTable_ReadRows_AfterRemoval_OmitsRemovedReminder(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ReadRow_AfterRemoval_ReturnsNull() => base.ReminderTable_ReadRow_AfterRemoval_ReturnsNull();
+    public override Task ReminderTable_ReadRow_AfterRemoval_ReturnsNull() => base.RunReminderTable_ReadRow_AfterRemoval_ReturnsNull(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ConcurrentUpserts_ProduceDistinctETags() => base.ReminderTable_ConcurrentUpserts_ProduceDistinctETags();
+    public override Task ReminderTable_ConcurrentUpserts_ProduceDistinctETags() => base.RunReminderTable_ConcurrentUpserts_ProduceDistinctETags(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated() => base.ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated();
+    public override Task ReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated() => base.RunReminderTable_ParallelUpserts_AcrossGrains_RemainIsolated(TestContext.Current.CancellationToken);
 
     [Fact]
-    public override Task ReminderTable_TestOnlyClearTable_RemovesAllReminders() => base.ReminderTable_TestOnlyClearTable_RemovesAllReminders();
+    public override Task ReminderTable_TestOnlyClearTable_RemovesAllReminders() => base.RunReminderTable_TestOnlyClearTable_RemovesAllReminders(TestContext.Current.CancellationToken);
 
     [Fact]
     public Task InMemoryReminderTable_FullRangeReturnsExactCardinality()
-        => base.ReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(32);
+        => base.RunReminderTable_ReadRows_FullRange_ReturnsExactRequestedCardinality(32, TestContext.Current.CancellationToken);
 
     [Fact, TestCategory("ModelBased")]
     public Task InMemoryReminderTable_ModelBasedGeneratedConformance()
-        => new ReminderTableModelBasedTestRunner(ReminderTable, "InMemoryReminderTable").RunGeneratedConformanceTests();
+        => new ReminderTableModelBasedTestRunner(ReminderTable, "InMemoryReminderTable").RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
 }

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceConformanceTests.cs
@@ -21,7 +21,7 @@ public sealed class IdealizedReminderServiceFixture : IAsyncLifetime
         var builder = new InProcessTestClusterBuilder(1);
         builder.UseIdealizedReminderTable(Oracle);
         _cluster = builder.Build();
-        await _cluster.DeployAsync();
+        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.Same(
             Oracle,
@@ -35,8 +35,16 @@ public sealed class IdealizedReminderServiceFixture : IAsyncLifetime
             return;
         }
 
-        await cluster.StopAllSilosAsync();
-        await cluster.DisposeAsync();
+        try
+        {
+            using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+        }
+        finally
+        {
+            using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+        }
     }
 }
 
@@ -54,11 +62,11 @@ public sealed class ReminderServiceConformanceTests : ReminderServiceTestRunner,
 
     [Fact]
     public override Task ReminderService_RegisterLookupEnumerateAndUnregister()
-        => base.ReminderService_RegisterLookupEnumerateAndUnregister();
+        => base.RunReminderService_RegisterLookupEnumerateAndUnregister(TestContext.Current.CancellationToken);
 
     [Fact]
     public override Task ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate()
-        => base.ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate();
+        => base.RunReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate(TestContext.Current.CancellationToken);
 }
 
 public sealed class EventuallyVisibleReminderServiceFixture : IAsyncLifetime
@@ -80,7 +88,7 @@ public sealed class EventuallyVisibleReminderServiceFixture : IAsyncLifetime
             siloBuilder.Services.AddSingleton<IReminderTable>(Table);
         });
         _cluster = builder.Build();
-        await _cluster.DeployAsync();
+        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
     }
 
     public async ValueTask DisposeAsync()
@@ -90,8 +98,16 @@ public sealed class EventuallyVisibleReminderServiceFixture : IAsyncLifetime
             return;
         }
 
-        await cluster.StopAllSilosAsync();
-        await cluster.DisposeAsync();
+        try
+        {
+            using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+        }
+        finally
+        {
+            using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+        }
     }
 }
 
@@ -113,7 +129,7 @@ public sealed class EventuallyVisibleReminderServiceTests
     [Fact]
     public override async Task ReminderService_RegisterLookupEnumerateAndUnregister()
     {
-        await base.ReminderService_RegisterLookupEnumerateAndUnregister();
+        await base.RunReminderService_RegisterLookupEnumerateAndUnregister(TestContext.Current.CancellationToken);
 
         Assert.True(_table.HiddenPointReads > 0);
         Assert.True(_table.HiddenEnumerationReads > 0);
@@ -122,7 +138,7 @@ public sealed class EventuallyVisibleReminderServiceTests
     [Fact]
     public override async Task ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate()
     {
-        await base.ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate();
+        await base.RunReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate(TestContext.Current.CancellationToken);
 
         Assert.True(_table.HiddenPointReads > 0);
         Assert.True(_table.HiddenEnumerationReads > 0);
@@ -148,7 +164,7 @@ public sealed class NonRotatingReminderServiceFixture : IAsyncLifetime
             siloBuilder.Services.AddSingleton<IReminderTable>(Table);
         });
         _cluster = builder.Build();
-        await _cluster.DeployAsync();
+        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.Same(
             Table,
@@ -162,8 +178,16 @@ public sealed class NonRotatingReminderServiceFixture : IAsyncLifetime
             return;
         }
 
-        await cluster.StopAllSilosAsync();
-        await cluster.DisposeAsync();
+        try
+        {
+            using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+        }
+        finally
+        {
+            using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+        }
     }
 }
 
@@ -189,7 +213,7 @@ public sealed class NonRotatingReminderServiceConformanceTests
     public override async Task ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate()
     {
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            base.ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate);
+            () => base.RunReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate(TestContext.Current.CancellationToken));
 
         Assert.Equal(2, _table.UpsertCount);
         Assert.Equal(["non-rotating-etag", "non-rotating-etag"], _table.ReturnedETags);
@@ -221,7 +245,7 @@ public abstract class CorruptingReminderServiceFixture : IAsyncLifetime
             siloBuilder.Services.AddSingleton<IReminderTable>(Table);
         });
         _cluster = builder.Build();
-        await _cluster.DeployAsync();
+        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
     }
 
     public async ValueTask DisposeAsync()
@@ -231,8 +255,16 @@ public abstract class CorruptingReminderServiceFixture : IAsyncLifetime
             return;
         }
 
-        await cluster.StopAllSilosAsync();
-        await cluster.DisposeAsync();
+        try
+        {
+            using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+        }
+        finally
+        {
+            using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+        }
     }
 }
 
@@ -258,7 +290,7 @@ public sealed class DuplicateEnumerationReminderServiceTests
     public async Task ReminderService_UpdateRejectsDuplicateEnumeratedIdentity()
     {
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate);
+            () => RunReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate(TestContext.Current.CancellationToken));
 
         Assert.Contains("provider=DuplicateEnumeration", exception.Message, StringComparison.Ordinal);
         Assert.Contains("rowCount=2", exception.Message, StringComparison.Ordinal);
@@ -282,7 +314,7 @@ public sealed class StaleScheduleReminderServiceTests
     public async Task ReminderService_UpdateRejectsStaleEnumeratedSchedule()
     {
         var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
-            ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate);
+            () => RunReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate(TestContext.Current.CancellationToken));
 
         Assert.Contains("provider=StaleScheduleEnumeration", exception.Message, StringComparison.Ordinal);
         Assert.Contains("rowCount=1", exception.Message, StringComparison.Ordinal);

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceConformanceTests.cs
@@ -21,7 +21,7 @@ public sealed class IdealizedReminderServiceFixture : IAsyncLifetime
         var builder = new InProcessTestClusterBuilder(1);
         builder.UseIdealizedReminderTable(Oracle);
         _cluster = builder.Build();
-        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
+        await _cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         Assert.Same(
             Oracle,
@@ -38,7 +38,7 @@ public sealed class IdealizedReminderServiceFixture : IAsyncLifetime
         try
         {
             using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            await cluster.StopAllSilosAsync(stopCancellation.Token);
         }
         finally
         {
@@ -88,7 +88,7 @@ public sealed class EventuallyVisibleReminderServiceFixture : IAsyncLifetime
             siloBuilder.Services.AddSingleton<IReminderTable>(Table);
         });
         _cluster = builder.Build();
-        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
+        await _cluster.DeployAsync(TestContext.Current.CancellationToken);
     }
 
     public async ValueTask DisposeAsync()
@@ -101,7 +101,7 @@ public sealed class EventuallyVisibleReminderServiceFixture : IAsyncLifetime
         try
         {
             using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            await cluster.StopAllSilosAsync(stopCancellation.Token);
         }
         finally
         {
@@ -164,7 +164,7 @@ public sealed class NonRotatingReminderServiceFixture : IAsyncLifetime
             siloBuilder.Services.AddSingleton<IReminderTable>(Table);
         });
         _cluster = builder.Build();
-        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
+        await _cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         Assert.Same(
             Table,
@@ -181,7 +181,7 @@ public sealed class NonRotatingReminderServiceFixture : IAsyncLifetime
         try
         {
             using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            await cluster.StopAllSilosAsync(stopCancellation.Token);
         }
         finally
         {
@@ -245,7 +245,7 @@ public abstract class CorruptingReminderServiceFixture : IAsyncLifetime
             siloBuilder.Services.AddSingleton<IReminderTable>(Table);
         });
         _cluster = builder.Build();
-        await _cluster.DeployAsync().WaitAsync(TestContext.Current.CancellationToken);
+        await _cluster.DeployAsync(TestContext.Current.CancellationToken);
     }
 
     public async ValueTask DisposeAsync()
@@ -258,7 +258,7 @@ public abstract class CorruptingReminderServiceFixture : IAsyncLifetime
         try
         {
             using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            await cluster.StopAllSilosAsync(stopCancellation.Token);
         }
         finally
         {

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
@@ -12,7 +12,7 @@ public class ReminderTableRetryPolicyTests
         var table = new TransientReminderTable();
         var runner = new TestRunner(table, "TransientTable");
 
-        await runner.ReminderTable_UpsertRow_PersistsScheduleForPointRead();
+        await runner.RunReminderTable_UpsertRow_PersistsScheduleForPointRead(TestContext.Current.CancellationToken);
 
         Assert.Equal(3, table.UpsertAttempts);
         Assert.Equal(2, table.HiddenPointReads);
@@ -33,7 +33,8 @@ public class ReminderTableRetryPolicyTests
             value => value.ToString(),
             "read convergence",
             TimeSpan.FromSeconds(1),
-            TimeSpan.FromMilliseconds(1));
+            TimeSpan.FromMilliseconds(1),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(3, result);
         Assert.Equal(3, attempts);
@@ -63,7 +64,8 @@ public class ReminderTableRetryPolicyTests
             value => value ?? "<null>",
             "mutation retry",
             TimeSpan.FromSeconds(1),
-            TimeSpan.FromMilliseconds(1));
+            TimeSpan.FromMilliseconds(1),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal("etag-3", result);
         Assert.Equal(3, attempts);
@@ -83,7 +85,8 @@ public class ReminderTableRetryPolicyTests
                 value => value,
                 "read convergence",
                 TimeSpan.FromMilliseconds(40),
-                TimeSpan.FromMilliseconds(5)));
+                TimeSpan.FromMilliseconds(5),
+                TestContext.Current.CancellationToken));
 
         Assert.Contains("provider=EventuallyConsistent", exception.Message, StringComparison.Ordinal);
         Assert.Contains("operation=ReadRow", exception.Message, StringComparison.Ordinal);
@@ -110,7 +113,8 @@ public class ReminderTableRetryPolicyTests
                 value => value ?? "<null>",
                 "mutation retry",
                 TimeSpan.FromMilliseconds(40),
-                TimeSpan.FromMilliseconds(5)));
+                TimeSpan.FromMilliseconds(5),
+                TestContext.Current.CancellationToken));
 
         Assert.True(attempts > 1);
         Assert.Contains("provider=PersistentlyContended", exception.Message, StringComparison.Ordinal);
@@ -140,7 +144,8 @@ public class ReminderTableRetryPolicyTests
                 value => value,
                 "read convergence",
                 TimeSpan.FromTicks(1),
-                TimeSpan.FromMilliseconds(5)));
+                TimeSpan.FromMilliseconds(5),
+                TestContext.Current.CancellationToken));
 
         Assert.Equal(1, invocations);
         Assert.Contains("attempts=1", exception.Message, StringComparison.Ordinal);
@@ -168,7 +173,8 @@ public class ReminderTableRetryPolicyTests
                 value => value,
                 "read convergence",
                 TimeSpan.FromMilliseconds(1),
-                TimeSpan.FromMilliseconds(5)));
+                TimeSpan.FromMilliseconds(5),
+                TestContext.Current.CancellationToken));
 
         Assert.Equal(1, invocations);
         Assert.Contains("attempts=1", exception.Message, StringComparison.Ordinal);

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -28,7 +28,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await cluster.DeployAsync().WaitAsync(cancellationToken);
+            await cluster.DeployAsync(cancellationToken);
 
             Assert.Equal(2, cluster.Silos.Count);
             foreach (var silo in cluster.Silos)
@@ -454,7 +454,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
         ReminderDiagnosticObserver observer,
         CancellationToken cancellationToken)
     {
-        await cluster.DeployAsync().WaitAsync(cancellationToken);
+        await cluster.DeployAsync(cancellationToken);
 
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cancellation.CancelAfter(TimeSpan.FromSeconds(30));

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -440,7 +440,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
         try
         {
             using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+            await cluster.StopAllSilosAsync(stopCancellation.Token);
         }
         finally
         {

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -21,13 +21,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
     [Fact]
     public async Task ReminderTestKit_ClusterUsesOneOracleInstanceInEverySilo()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(2);
         var oracle = builder.UseIdealizedReminderTable();
         var cluster = builder.Build();
 
         try
         {
-            await cluster.DeployAsync();
+            await cluster.DeployAsync().WaitAsync(cancellationToken);
 
             Assert.Equal(2, cluster.Silos.Count);
             foreach (var silo in cluster.Silos)
@@ -38,14 +39,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_ClusterRegistrationAndUnregistrationAreVisibleInTheOracle()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
         using var observer = ReminderDiagnosticObserver.Create();
@@ -53,12 +54,12 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var period = TimeSpan.FromMinutes(5);
 
-            var registeredName = await grain.RegisterReminderAsync("cluster-reminder", period, period);
+            var registeredName = await grain.RegisterReminderAsync("cluster-reminder", period, period).WaitAsync(cancellationToken);
 
             var persisted = Assert.Single(oracle.Snapshot());
             Assert.Equal("cluster-reminder", registeredName);
@@ -68,13 +69,13 @@ public sealed class ReminderTestKitClusterIntegrationTests
             Assert.Equal(1, persisted.Version);
             Assert.False(string.IsNullOrEmpty(persisted.ETag));
             Assert.Null(persisted.PreviousETag);
-            Assert.Equal(["cluster-reminder"], await grain.GetReminderNamesAsync());
+            Assert.Equal(["cluster-reminder"], await grain.GetReminderNamesAsync().WaitAsync(cancellationToken));
 
-            var unregistered = await grain.UnregisterReminderAsync("cluster-reminder");
+            var unregistered = await grain.UnregisterReminderAsync("cluster-reminder").WaitAsync(cancellationToken);
 
             Assert.True(unregistered);
             Assert.Empty(oracle.Snapshot());
-            Assert.Empty(await grain.GetReminderNamesAsync());
+            Assert.Empty(await grain.GetReminderNamesAsync().WaitAsync(cancellationToken));
             Assert.Contains(
                 oracle.Operations,
                 operation => operation.Kind == ReminderTableOperationKind.RemoveRow
@@ -84,14 +85,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_ClusterReminderUpdateRotatesTheOracleETagWithoutDuplicatingTheRow()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
         using var observer = ReminderDiagnosticObserver.Create();
@@ -99,13 +100,13 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
-            await grain.RegisterReminderAsync("updated-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
+            await grain.RegisterReminderAsync("updated-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)).WaitAsync(cancellationToken);
             var initial = Assert.Single(oracle.Snapshot());
 
-            await grain.RegisterReminderAsync("updated-reminder", TimeSpan.FromMinutes(9), TimeSpan.FromMinutes(9));
+            await grain.RegisterReminderAsync("updated-reminder", TimeSpan.FromMinutes(9), TimeSpan.FromMinutes(9)).WaitAsync(cancellationToken);
             var updated = Assert.Single(oracle.Snapshot());
 
             Assert.Equal(TimeSpan.FromMinutes(5), initial.Period);
@@ -117,14 +118,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_StorageOutageFailsRegistrationAndRecoveryAllowsRetry()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
         using var observer = ReminderDiagnosticObserver.Create();
@@ -132,12 +133,12 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
             oracle.SetAvailable(false);
             var failure = await Assert.ThrowsAsync<ReminderTableUnavailableException>(
-                () => grain.RegisterReminderAsync("outage-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)));
+                () => grain.RegisterReminderAsync("outage-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)).WaitAsync(cancellationToken));
 
             Assert.Contains("simulated storage outage", failure.Message, StringComparison.Ordinal);
             Assert.Empty(oracle.Snapshot());
@@ -149,7 +150,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
                     && operation.Failure == nameof(ReminderTableUnavailableException));
 
             oracle.SetAvailable(true);
-            var registered = await grain.RegisterReminderAsync("outage-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
+            var registered = await grain.RegisterReminderAsync("outage-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)).WaitAsync(cancellationToken);
 
             Assert.Equal("outage-reminder", registered);
             var record = Assert.Single(oracle.Snapshot());
@@ -158,14 +159,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_FakeClockFiresAtExactDueTimeWithoutSleeping()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
         using var clock = ReminderTestClock.Attach(
@@ -177,12 +178,13 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
-            await grain.RegisterReminderAsync("exact-due", TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
+            await grain.RegisterReminderAsync("exact-due", TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10)).WaitAsync(cancellation.Token);
             await observer.WaitForLocalReminderScheduleAsync(grainId, "exact-due", cancellation.Token);
 
             var tick = observer.WaitForReminderTickAsync(grainId, cancellation.Token, "exact-due");
@@ -199,14 +201,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_DueTimeBeyondTimerLimitLoadsAndFiresOnPersistedSchedule()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         var loadingWindow = TimeSpan.FromSeconds(5);
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable(
@@ -220,15 +222,16 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var timerLimit = TimeSpan.FromMilliseconds(0xfffffffe) + TimeSpan.FromMilliseconds(1);
             var dueTime = timerLimit + TimeSpan.FromDays(1);
             var firstTickTime = clock.UtcNow.UtcDateTime + dueTime;
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
-            await grain.RegisterReminderAsync("long-due", dueTime, dueTime);
+            await grain.RegisterReminderAsync("long-due", dueTime, dueTime).WaitAsync(cancellation.Token);
 
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, "long-due"));
             var activated = observer.WaitForActiveReminderCountAsync(grainId, 1, cancellation.Token, "long-due");
@@ -249,14 +252,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_StorageRecoveryAtExactDueTimeDeliversDueOccurrence()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         var loadingWindow = TimeSpan.FromSeconds(10);
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable(
@@ -270,15 +273,16 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = loadingWindow + TimeSpan.FromMinutes(1);
             var period = TimeSpan.FromSeconds(30);
             var firstTickTime = clock.UtcNow.UtcDateTime + dueTime;
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
-            await grain.RegisterReminderAsync("exact-due-recovery", dueTime, period);
+            await grain.RegisterReminderAsync("exact-due-recovery", dueTime, period).WaitAsync(cancellation.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, "exact-due-recovery"));
 
             await using var blockedRead = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
@@ -291,7 +295,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
             blockedRead.Release();
             await activated;
             await observer.WaitForLocalReminderScheduleAsync(grainId, "exact-due-recovery", cancellation.Token);
-            Assert.Equal(["exact-due-recovery"], await grain.GetReminderNamesAsync());
+            Assert.Equal(["exact-due-recovery"], await grain.GetReminderNamesAsync().WaitAsync(cancellation.Token));
 
             var tick = observer.WaitForReminderTickAsync(grainId, cancellation.Token, "exact-due-recovery");
             await clock.AdvanceAsync(clock.RefreshReminderListPeriod, cancellation.Token);
@@ -303,14 +307,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_StaleRefreshCannotRestoreUnregisteredReminder()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable(
             configureReminderOptions: options => options.ReminderLoadingWindow = TimeSpan.FromHours(2));
@@ -323,13 +327,14 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
             var activated = observer.WaitForActiveReminderCountAsync(grainId, 1, cancellation.Token, "stale-unregister");
-            await grain.RegisterReminderAsync("stale-unregister", TimeSpan.FromHours(1), TimeSpan.FromHours(2));
+            await grain.RegisterReminderAsync("stale-unregister", TimeSpan.FromHours(1), TimeSpan.FromHours(2)).WaitAsync(cancellation.Token);
             await activated;
             await observer.WaitForLocalReminderScheduleAsync(grainId, "stale-unregister", cancellation.Token);
 
@@ -340,7 +345,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
                 await AdvanceUntilAsync(clock, staleRead.WaitUntilBlockedAsync(cancellation.Token), cancellation.Token);
 
                 var quiescence = observer.WaitForReminderQuiescenceAsync(grainId, "stale-unregister", cancellation.Token);
-                Assert.True(await grain.UnregisterReminderAsync("stale-unregister"));
+                Assert.True(await grain.UnregisterReminderAsync("stale-unregister").WaitAsync(cancellation.Token));
                 await quiescence;
                 staleRead.Release();
 
@@ -352,18 +357,18 @@ public sealed class ReminderTestKitClusterIntegrationTests
             }
 
             followingRead.Release();
-            Assert.Empty(await grain.GetReminderNamesAsync());
+            Assert.Empty(await grain.GetReminderNamesAsync().WaitAsync(cancellation.Token));
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
         }
     }
 
     [Fact]
     public async Task ReminderTestKit_TwoSilosMaintainOneOwnerAndOneDelivery()
     {
+        var testCancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(2);
         builder.ConfigureSilo((_, siloBuilder) =>
             siloBuilder.Configure<ConsistentRingOptions>(options => options.UseVirtualBucketsConsistentRing = false));
@@ -377,19 +382,20 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer);
+            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = TimeSpan.FromMinutes(10);
             var firstTickTime = clock.UtcNow.UtcDateTime + dueTime;
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
             await using var firstRefreshA = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             await using var firstRefreshB = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             await using var followingRefreshA = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             await using var followingRefreshB = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             var oneOwner = observer.WaitForActiveReminderCountAsync(grainId, 1, cancellation.Token, "single-owner");
-            await grain.RegisterReminderAsync("single-owner", dueTime, TimeSpan.FromMinutes(2));
+            await grain.RegisterReminderAsync("single-owner", dueTime, TimeSpan.FromMinutes(2)).WaitAsync(cancellation.Token);
 
             await AdvanceUntilAsync(
                 clock,
@@ -425,18 +431,33 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
         finally
         {
-            await cluster.StopAllSilosAsync();
-            await cluster.DisposeAsync();
+            await DisposeClusterAsync(cluster);
+        }
+    }
+
+    private static async Task DisposeClusterAsync(InProcessTestCluster cluster)
+    {
+        try
+        {
+            using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.StopAllSilosAsync().WaitAsync(stopCancellation.Token);
+        }
+        finally
+        {
+            using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
         }
     }
 
     private static async Task DeployAndWaitForReminderServicesAsync(
         InProcessTestCluster cluster,
-        ReminderDiagnosticObserver observer)
+        ReminderDiagnosticObserver observer,
+        CancellationToken cancellationToken)
     {
-        await cluster.DeployAsync();
+        await cluster.DeployAsync().WaitAsync(cancellationToken);
 
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellation.CancelAfter(TimeSpan.FromSeconds(30));
         var started = cluster.Silos.Select(silo =>
             observer.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress));
         await Task.WhenAll(started);

--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -43,7 +43,8 @@ public class ReminderEventsTests
 
         ReminderEvents.EmitTickCompleted(grainId, reminderName, status, siloAddress);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(1));
         var tickCompleted = await observer.WaitForReminderTickAsync(grainId, cts.Token, reminderName);
 
         Assert.Equal(grainId, tickCompleted.GrainId);
@@ -69,7 +70,7 @@ public class ReminderEventsTests
             new TickStatus(now, TimeSpan.FromSeconds(5), now),
             siloAddress);
 
-        var waitTask = observer.WaitForAdditionalTickCountAsync(grainId, 1, CancellationToken.None, reminderName);
+        var waitTask = observer.WaitForAdditionalTickCountAsync(grainId, 1, TestContext.Current.CancellationToken, reminderName);
         Assert.False(waitTask.IsCompleted);
 
         ReminderEvents.EmitTickCompleted(
@@ -88,7 +89,8 @@ public class ReminderEventsTests
     public async Task ReminderDiagnosticObserver_WaitsForTickCondition_UntilConditionIsSatisfied()
     {
         using var observer = ReminderDiagnosticObserver.Create();
-        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var now = DateTime.UtcNow;
@@ -179,7 +181,7 @@ public class ReminderEventsTests
         ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, identity2, siloAddress2);
         Assert.Equal(2, observer.GetActiveReminderCount(grainId, reminderName));
 
-        var waitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, CancellationToken.None);
+        var waitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, TestContext.Current.CancellationToken);
         Assert.False(waitTask.IsCompleted);
 
         ReminderEvents.EmitLocalReminderStopped(grainId, reminderName, identity1, ReminderEvents.LocalReminderStopReason.RemovedFromTable, siloAddress1);
@@ -199,7 +201,7 @@ public class ReminderEventsTests
     public async Task ReminderDiagnosticObserver_CanceledQuiescenceWait_RemainsCanceled()
     {
         using var observer = ReminderDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var identity = new object();
@@ -213,7 +215,7 @@ public class ReminderEventsTests
         Assert.True(canceledWaitTask.IsCanceled);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledWaitTask);
 
-        var currentWaitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, CancellationToken.None);
+        var currentWaitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, TestContext.Current.CancellationToken);
         ReminderEvents.EmitLocalReminderStopped(
             grainId,
             reminderName,
@@ -252,7 +254,7 @@ public class ReminderEventsTests
             new TickStatus(now, TimeSpan.FromSeconds(5), now),
             previousSilo);
 
-        var waitTask = observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, CancellationToken.None);
+        var waitTask = observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, TestContext.Current.CancellationToken);
         Assert.False(waitTask.IsCompleted);
 
         ReminderEvents.EmitLocalReminderStopped(

--- a/test/Orleans.Reminders.Tests/MinimalReminderTests.cs
+++ b/test/Orleans.Reminders.Tests/MinimalReminderTests.cs
@@ -27,7 +27,8 @@ namespace UnitTests.CatalogTests
             {
                 try
                 {
-                    await base.DisposeAsync();
+                    using var cleanupCancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+                    await base.DisposeAsync().AsTask().WaitAsync(cleanupCancellation.Token);
                 }
                 finally
                 {
@@ -64,7 +65,8 @@ namespace UnitTests.CatalogTests
             var grainId = reminderGrain.GetGrainId();
             var observer = this.fixture.ReminderObserver;
 
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
             foreach (var silo in this.fixture.HostedCluster.Silos)
             {
                 await observer.WaitForReminderServiceStartedAsync(cts.Token, silo.SiloAddress);

--- a/test/Orleans.Reminders.Tests/TimerTests/ControllableReminderTable.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ControllableReminderTable.cs
@@ -35,9 +35,9 @@ internal sealed class ReminderTableReadController
     private readonly object _lock = new();
     private readonly List<ReminderTableReadGate> _gates = [];
 
-    public ReminderTableReadGate BlockNextRangeRead(GrainId grainId)
+    public ReminderTableReadGate BlockNextRangeRead(GrainId grainId, CancellationToken cancellationToken)
     {
-        var gate = new ReminderTableReadGate(this, grainId.GetUniformHashCode());
+        var gate = new ReminderTableReadGate(this, grainId.GetUniformHashCode(), cancellationToken);
         lock (_lock)
         {
             _gates.Add(gate);
@@ -78,7 +78,10 @@ internal sealed class ReminderTableReadController
     }
 }
 
-internal sealed class ReminderTableReadGate(ReminderTableReadController owner, uint grainHash) : IAsyncDisposable
+internal sealed class ReminderTableReadGate(
+    ReminderTableReadController owner,
+    uint grainHash,
+    CancellationToken cancellationToken) : IAsyncDisposable
 {
     private readonly TaskCompletionSource _blocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -91,7 +94,7 @@ internal sealed class ReminderTableReadGate(ReminderTableReadController owner, u
 
     internal void MarkBlocked() => _blocked.TrySetResult();
 
-    internal Task WaitForReleaseAsync() => _release.Task;
+    internal Task WaitForReleaseAsync() => _release.Task.WaitAsync(cancellationToken);
 
     public Task WaitUntilBlockedAsync(CancellationToken cancellationToken)
         => _blocked.Task.WaitAsync(cancellationToken);

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -241,7 +241,8 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     public async Task InitialRead_TreatsNullTableResultAsNoWork()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
-        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
 
         var started = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
 
@@ -256,7 +257,8 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     public async Task RangeChangeBarrier_FollowsLatestReconciliation()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
-        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
         _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
@@ -264,7 +266,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
         var intermediateRange = RangeFactory.CreateRange(0, uint.MaxValue / 3);
         var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
-        var firstReadGate = reminderTable.BlockNextRangeRead();
+        var firstReadGate = reminderTable.BlockNextRangeRead(cancellation.Token);
         RangeReadGate? secondReadGate = null;
         try
         {
@@ -274,7 +276,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
             Assert.False(reconciliationTask.IsCompleted);
 
-            secondReadGate = reminderTable.BlockNextRangeRead();
+            secondReadGate = reminderTable.BlockNextRangeRead(cancellation.Token);
             var secondRangeChangeTask = reminderService.TestOnlyChangeRange(intermediateRange, newRange, increased: false);
             await secondReadGate.WaitUntilBlockedAsync(cancellation.Token);
             Assert.False(reconciliationTask.IsCompleted);
@@ -299,20 +301,21 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     public async Task RangeChangeBarrier_StopsWaitingWhenCanceled()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
-        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
         _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
         var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
         var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
-        var readGate = reminderTable.BlockNextRangeRead();
+        var readGate = reminderTable.BlockNextRangeRead(cancellation.Token);
         try
         {
             var rangeChangeTask = reminderService.TestOnlyChangeRange(oldRange, newRange, increased: false);
             await readGate.WaitUntilBlockedAsync(cancellation.Token);
 
-            using var barrierCancellation = new CancellationTokenSource();
+            using var barrierCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(barrierCancellation.Token);
             Assert.False(reconciliationTask.IsCompleted);
 
@@ -334,7 +337,8 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     public async Task RangeChangeBarrier_DoesNotDependOnServiceSchedulerAvailability()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
-        using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
         _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
 
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
@@ -352,7 +356,8 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
 
         try
         {
-            using var barrierCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            using var barrierCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            barrierCancellation.CancelAfter(TimeSpan.FromSeconds(1));
             await reminderService.TestOnlyWaitForRangeChangeReconciliation(barrierCancellation.Token);
         }
         finally
@@ -385,7 +390,8 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         {
             try
             {
-                await base.DisposeAsync();
+                using var cleanupCancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+                await base.DisposeAsync().AsTask().WaitAsync(cleanupCancellation.Token);
             }
             finally
             {
@@ -401,9 +407,9 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
 
         public int RangeReadCount => Volatile.Read(ref rangeReadCount);
 
-        public RangeReadGate BlockNextRangeRead()
+        public RangeReadGate BlockNextRangeRead(CancellationToken cancellationToken)
         {
-            var gate = new RangeReadGate();
+            var gate = new RangeReadGate(cancellationToken);
             if (Interlocked.CompareExchange(ref nextRangeRead, gate, null) is not null)
             {
                 throw new InvalidOperationException("A range read is already blocked.");
@@ -438,7 +444,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         public Task TestOnlyClearTable() => throw new NotSupportedException();
     }
 
-    private sealed class RangeReadGate
+    private sealed class RangeReadGate(CancellationToken cancellationToken)
     {
         private readonly TaskCompletionSource blocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -447,7 +453,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
 
         public Task WaitUntilBlockedAsync(CancellationToken cancellationToken) => blocked.Task.WaitAsync(cancellationToken);
 
-        public Task WaitForReleaseAsync() => release.Task;
+        public Task WaitForReleaseAsync() => release.Task.WaitAsync(cancellationToken);
 
         public void Release() => release.TrySetResult();
     }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -81,19 +81,22 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         // ReminderTable.Clear() cannot be called from a non-Orleans thread,
         // so we must proxy the call through a grain.
         var controlProxy = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout).Wait();
+        controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken).Wait();
     }
 
-    public async Task Test_Reminders_Basic_StopByRef()
+    public Task Test_Reminders_Basic_StopByRef()
+        => Test_Reminders_Basic_StopByRef(TestContext.Current.CancellationToken);
+
+    public async Task Test_Reminders_Basic_StopByRef(CancellationToken cancellationToken)
     {
         IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
 
-        IGrainReminder r1 = await grain.StartReminder(DR);
-        IGrainReminder r2 = await grain.StartReminder(DR);
+        IGrainReminder r1 = await grain.StartReminder(DR).WaitAsync(cancellationToken);
+        IGrainReminder r2 = await grain.StartReminder(DR).WaitAsync(cancellationToken);
         try
         {
             // First handle should now be out of date once the second handle to the same reminder was obtained
-            await grain.StopReminder(r1);
+            await grain.StopReminder(r1).WaitAsync(cancellationToken);
             Assert.Fail("Removed reminder1, which shouldn't be possible.");
         }
         catch (Exception exc)
@@ -101,21 +104,24 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             log.LogInformation(exc, "Couldn't remove {Reminder}, as expected.", r1);
         }
 
-        await grain.StopReminder(r2);
+        await grain.StopReminder(r2).WaitAsync(cancellationToken);
         log.LogInformation("Removed reminder2 successfully");
 
         // trying to see if readreminder works
-        _ = await grain.StartReminder(DR);
-        _ = await grain.StartReminder(DR);
-        _ = await grain.StartReminder(DR);
-        _ = await grain.StartReminder(DR);
+        _ = await grain.StartReminder(DR).WaitAsync(cancellationToken);
+        _ = await grain.StartReminder(DR).WaitAsync(cancellationToken);
+        _ = await grain.StartReminder(DR).WaitAsync(cancellationToken);
+        _ = await grain.StartReminder(DR).WaitAsync(cancellationToken);
 
-        IGrainReminder? r = await grain.GetReminderObject(DR);
-        await grain.StopReminder(r!);
+        IGrainReminder? r = await grain.GetReminderObject(DR).WaitAsync(cancellationToken);
+        await grain.StopReminder(r!).WaitAsync(cancellationToken);
         log.LogInformation("Removed got reminder successfully");
     }
 
-    public async Task Test_Reminders_Basic_ListOps()
+    public Task Test_Reminders_Basic_ListOps()
+        => Test_Reminders_Basic_ListOps(TestContext.Current.CancellationToken);
+
+    public async Task Test_Reminders_Basic_ListOps(CancellationToken cancellationToken)
     {
         Guid id = Guid.NewGuid();
         log.LogInformation("Start Grain Id = {GrainId}", id);
@@ -128,13 +134,13 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             log.LogInformation("Started {ReminderName}_{ReminderNumber}", DR, i);
         }
 
-        await Task.WhenAll(startReminderTasks);
+        await Task.WhenAll(startReminderTasks).WaitAsync(cancellationToken);
         // do comparison on strings
         List<string> registered = (from reminder in startReminderTasks select reminder.Result.ReminderName).ToList();
 
         log.LogInformation("Waited");
 
-        List<IGrainReminder> remindersList = await grain.GetRemindersList();
+        List<IGrainReminder> remindersList = await grain.GetRemindersList().WaitAsync(cancellationToken);
         List<string> fetched = (from reminder in remindersList select reminder.ReminderName).ToList();
 
         foreach (var remRegistered in registered)
@@ -147,18 +153,22 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
         // Wait for each reminder to tick twice using the observer
         log.LogInformation("Time tests");
-        using var cts = new CancellationTokenSource(ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(ENDWAIT);
         var reminderNames = Enumerable.Range(0, count).Select(i => DR + "_" + i).ToArray();
         await AdvanceRemindersByTicksAsync(2, cts.Token, GetReminderIdentities([grain], reminderNames));
 
         // Verify via grain counters
         foreach (var reminderName in reminderNames)
         {
-            Assert.Equal(2, await grain.GetCounter(reminderName));
+            Assert.Equal(2, await grain.GetCounter(reminderName).WaitAsync(cts.Token));
         }
     }
 
-    public async Task Test_Reminders_1J_MultiGrainMultiReminders()
+    public Task Test_Reminders_1J_MultiGrainMultiReminders()
+        => Test_Reminders_1J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
+
+    public async Task Test_Reminders_1J_MultiGrainMultiReminders(CancellationToken cancellationToken)
     {
         IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -166,7 +176,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
-        using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(CHURN_ENDWAIT);
         Task<List<InProcessSiloHandle>>? startSilosTask = null;
         try
         {
@@ -190,11 +201,14 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, cancellationToken);
         }
     }
 
-    public async Task Test_Reminders_2J_MultiGrainMultiReminders()
+    public Task Test_Reminders_2J_MultiGrainMultiReminders()
+        => Test_Reminders_2J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
+
+    public async Task Test_Reminders_2J_MultiGrainMultiReminders(CancellationToken cancellationToken)
     {
         IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -202,7 +216,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
-        using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(CHURN_ENDWAIT);
         Task<List<InProcessSiloHandle>>? startSilosTask = null;
         try
         {
@@ -225,20 +240,26 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, cancellationToken);
         }
     }
 
-    public async Task Test_Reminders_ReminderNotFound()
+    public Task Test_Reminders_ReminderNotFound()
+        => Test_Reminders_ReminderNotFound(TestContext.Current.CancellationToken);
+
+    public async Task Test_Reminders_ReminderNotFound(CancellationToken cancellationToken)
     {
         IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
 
         // request a reminder that does not exist
-        IGrainReminder? reminder = await g1.GetReminderObject("blarg");
+        IGrainReminder? reminder = await g1.GetReminderObject("blarg").WaitAsync(cancellationToken);
         Assert.Null(reminder);
     }
 
-    public async Task Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder(CancellationToken cancellationToken = default)
+    public Task Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder()
+        => Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder(TestContext.Current.CancellationToken);
+
+    public async Task Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder(CancellationToken cancellationToken)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(ENDWAIT);
@@ -246,13 +267,13 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         var grainId = grain.GetGrainId();
 
-        await grain.StartReminder(DR);
+        await grain.StartReminder(DR).WaitAsync(cts.Token);
         var firstTickCount = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 1, cts.Token);
         Assert.Equal(1, observer.GetActiveReminderCount(grainId, DR));
 
         using (var recorder = new ReminderEventRecorder(ReminderEvents.AllEvents))
         {
-            await grain.StartReminder(DR);
+            await grain.StartReminder(DR).WaitAsync(cts.Token);
             await SynchronizeReminderSchedulesAsync(cts.Token, (grain, DR));
             await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), firstTickCount + 1, cts.Token);
 
@@ -306,7 +327,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
     private async Task CleanupAdditionalSilosAsync(
         HashSet<InProcessSiloHandle> initialSilos,
-        Task<List<InProcessSiloHandle>>? startSilosTask)
+        Task<List<InProcessSiloHandle>>? startSilosTask,
+        CancellationToken cancellationToken)
     {
         if (startSilosTask is null)
         {
@@ -315,7 +337,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
         try
         {
-            using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
+            using var startupCompletionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            startupCompletionCts.CancelAfter(CHURN_ENDWAIT);
             await startSilosTask.WaitAsync(startupCompletionCts.Token);
         }
         catch (Exception exception)
@@ -331,7 +354,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             return;
         }
 
-        using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
+        using var cleanupCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cleanupCts.CancelAfter(CHURN_ENDWAIT);
         await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
         await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
     }
@@ -375,11 +399,11 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         foreach (var grain in grains)
         {
             ArgumentNullException.ThrowIfNull(grain);
-            await ExecuteWithRetries(grain.StartReminder, DR);
+            await ExecuteWithRetries(grain.StartReminder, DR, cancellationToken);
         }
 
         await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR));
-        await AssertReminderCountersAsync(grains, (DR, 1));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 1));
 
         if (afterFirstTick is not null)
         {
@@ -387,38 +411,38 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
 
         await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR));
-        await AssertReminderCountersAsync(grains, (DR, 2));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 2));
 
         foreach (var grain in grains)
         {
-            await ExecuteWithRetries(grain.StartReminder, R1);
+            await ExecuteWithRetries(grain.StartReminder, R1, cancellationToken);
         }
 
         await AdvanceRemindersByTicksAsync(2, cancellationToken, GetReminderIdentities(grains, DR, R1));
-        await AssertReminderCountersAsync(grains, (DR, 4), (R1, 2));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 4), (R1, 2));
 
         foreach (var grain in grains)
         {
-            await ExecuteWithRetries(grain.StartReminder, R2);
+            await ExecuteWithRetries(grain.StartReminder, R2, cancellationToken);
         }
 
         await AdvanceRemindersByTicksAsync(2, cancellationToken, GetReminderIdentities(grains, DR, R1, R2));
-        await AssertReminderCountersAsync(grains, (DR, 6), (R1, 4), (R2, 2));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 6), (R1, 4), (R2, 2));
 
         await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR, R1, R2));
-        await AssertReminderCountersAsync(grains, (DR, 7), (R1, 5), (R2, 3));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 7), (R1, 5), (R2, 3));
 
         await StopRemindersAsync(grains, R1, cancellationToken);
         await AdvanceRemindersByTicksAsync(2, cancellationToken, GetReminderIdentities(grains, DR, R2));
-        await AssertReminderCountersAsync(grains, (DR, 9), (R1, 5), (R2, 5));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 9), (R1, 5), (R2, 5));
 
         await StopRemindersAsync(grains, R2, cancellationToken);
         await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR));
-        await AssertReminderCountersAsync(grains, (DR, 10), (R1, 5), (R2, 5));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 10), (R1, 5), (R2, 5));
 
         await StopRemindersAsync(grains, DR, cancellationToken);
         await AdvanceReminderTimeAsync(await grains[0].GetReminderPeriod(DR), cancellationToken);
-        await AssertReminderCountersAsync(grains, (DR, 10), (R1, 5), (R2, 5));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, 10), (R1, 5), (R2, 5));
     }
 
     protected async Task PrepareForGrainFailureAsync(CancellationToken cancellationToken, params IAddressable[] grains)
@@ -436,7 +460,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
 
         await AdvanceRemindersByTicksAsync((int)failAfter, cancellationToken, GetReminderIdentities(grains, DR));
-        await AssertReminderCountersAsync(grains, (DR, failAfter));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, failAfter));
     }
 
     protected async Task CompleteGrainFailureTestAsync(CancellationToken cancellationToken, params IAddressable[] grains)
@@ -446,11 +470,13 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
         await WaitForGrainsReachableAsync(cancellationToken, grains);
         await AdvanceRemindersByTicksAsync((int)(failCheckAfter - failAfter), cancellationToken, GetReminderIdentities(grains, DR));
-        await AssertReminderCountersAsync(grains, (DR, failCheckAfter));
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, failCheckAfter));
 
         await StopRemindersAsync(grains, DR, cancellationToken);
-        await AdvanceReminderTimeAsync(await GetReminderPeriodAsync(grains[0], DR), cancellationToken);
-        await AssertReminderCountersAsync(grains, (DR, failCheckAfter));
+        await AdvanceReminderTimeAsync(
+            await GetReminderPeriodAsync(grains[0], DR).WaitAsync(cancellationToken),
+            cancellationToken);
+        await AssertReminderCountersAsync(grains, cancellationToken, (DR, failCheckAfter));
     }
 
     private async Task WaitForGrainsReachableAsync(CancellationToken cancellationToken, params IAddressable[] grains)
@@ -485,7 +511,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                 }
             }
         }
-        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (
+            cancellationToken.IsCancellationRequested
+            && !TestContext.Current.CancellationToken.IsCancellationRequested)
         {
             throw new InvalidOperationException(
                 $"Timed out waiting for reminder grains to become reachable after a topology change: {string.Join(", ", grains.Select(grain => grain.GetGrainId()))}.",
@@ -530,7 +558,10 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
             foreach (var reminder in reminders)
             {
-                var current = await GetReminderCounterOrZeroAsync(reminder.Grain, reminder.ReminderName);
+                var current = await GetReminderCounterOrZeroAsync(
+                    reminder.Grain,
+                    reminder.ReminderName,
+                    cancellationToken);
                 counterWaitTasks.Add(GetReminderCounterWaitTask(
                     reminder.Grain,
                     reminder.ReminderName,
@@ -539,7 +570,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             }
 
             var periods = await Task.WhenAll(reminders.Select(reminder =>
-                GetReminderPeriodAsync(reminder.Grain, reminder.ReminderName)));
+                GetReminderPeriodAsync(reminder.Grain, reminder.ReminderName))).WaitAsync(cancellationToken);
             var period = Assert.Single(periods.Distinct());
 
             log.LogInformation(
@@ -571,6 +602,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
     protected async Task AssertReminderCountersAsync(
         IEnumerable<IAddressable> grains,
+        CancellationToken cancellationToken,
         params (string ReminderName, long ExpectedCount)[] expectedCounters)
     {
         ArgumentNullException.ThrowIfNull(grains);
@@ -583,10 +615,15 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             {
                 Assert.Equal(
                     expected.ExpectedCount,
-                    await GetReminderCounterAsync(grain, expected.ReminderName));
+                    await GetReminderCounterAsync(grain, expected.ReminderName).WaitAsync(cancellationToken));
             }
         }
     }
+
+    protected Task AssertReminderCountersAsync(
+        IEnumerable<IAddressable> grains,
+        params (string ReminderName, long ExpectedCount)[] expectedCounters)
+        => AssertReminderCountersAsync(grains, TestContext.Current.CancellationToken, expectedCounters);
 
     protected static (IAddressable Grain, string ReminderName)[] GetReminderIdentities(
         IEnumerable<IAddressable> grains,
@@ -617,7 +654,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             await ExecuteWithRetriesStop(
                 name => StopReminderAsync(grain, name),
-                reminderName);
+                reminderName,
+                cancellationToken);
         }
 
         await Task.WhenAll(unregisteredTasks);
@@ -626,7 +664,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             await Task.WhenAll(quiescenceTasks);
         }
-        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (
+            cancellationToken.IsCancellationRequested
+            && !TestContext.Current.CancellationToken.IsCancellationRequested)
         {
             var activeOwners = grainArray.Select(grain =>
                 $"{grain.GetGrainId()}={observer.GetActiveReminderCount(grain.GetGrainId(), reminderName)}");
@@ -641,7 +681,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         string reminderName,
         Func<Task<long>> getCounter,
         long minimumCount,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(grain);
         ArgumentNullException.ThrowIfNull(getCounter);
@@ -653,9 +693,10 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             try
             {
-                result = await getCounter();
+                result = await getCounter().WaitAsync(ct);
                 return result >= minimumCount;
             }
+
             catch (FileNotFoundException) when (!ct.IsCancellationRequested)
             {
                 return false;
@@ -673,18 +714,30 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             var nextTickTarget = observer.GetTickCount(grainId, reminderName) + 1;
             var waitTask = observer.WaitForTickCountAsync(grainId, nextTickTarget, cancellationToken, reminderName);
             await SynchronizeReminderSchedulesAsync(cancellationToken, (grain, reminderName));
-            var reminderPeriod = await GetReminderPeriodAsync(grain, reminderName);
+            var reminderPeriod = await GetReminderPeriodAsync(grain, reminderName).WaitAsync(cancellationToken);
             await AdvanceReminderTimeAsync(reminderPeriod, cancellationToken);
             await waitTask;
         }
     }
+
+    protected Task<long> WaitForReminderCounterAsync(
+        IAddressable grain,
+        string reminderName,
+        Func<Task<long>> getCounter,
+        long minimumCount)
+        => WaitForReminderCounterAsync(
+            grain,
+            reminderName,
+            getCounter,
+            minimumCount,
+            TestContext.Current.CancellationToken);
 
     protected async Task<long> WaitForAdditionalReminderCounterAsync(
         IAddressable grain,
         string reminderName,
         Func<Task<long>> getCounter,
         long additionalCount,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(grain);
         ArgumentNullException.ThrowIfNull(getCounter);
@@ -695,6 +748,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             currentCount = await getCounter();
         }
+
         catch (FileNotFoundException) when (!cancellationToken.IsCancellationRequested)
         {
         }
@@ -707,7 +761,22 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             cancellationToken);
     }
 
-    protected async Task<bool> PerGrainMultiReminderTest(IReminderTestGrain2 g, CancellationToken cancellationToken = default)
+    protected Task<long> WaitForAdditionalReminderCounterAsync(
+        IAddressable grain,
+        string reminderName,
+        Func<Task<long>> getCounter,
+        long additionalCount)
+        => WaitForAdditionalReminderCounterAsync(
+            grain,
+            reminderName,
+            getCounter,
+            additionalCount,
+            TestContext.Current.CancellationToken);
+
+    protected Task<bool> PerGrainMultiReminderTest(IReminderTestGrain2 g)
+        => PerGrainMultiReminderTest(g, TestContext.Current.CancellationToken);
+
+    protected async Task<bool> PerGrainMultiReminderTest(IReminderTestGrain2 g, CancellationToken cancellationToken)
     {
         await Test_Reminders_MultiGrainMultiReminders(
             afterFirstTick: null,
@@ -716,12 +785,18 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         return true;
     }
 
-    protected async Task AdvanceReminderTimeAsync(TimeSpan amount, CancellationToken cancellationToken = default)
+    protected Task AdvanceReminderTimeAsync(TimeSpan amount)
+        => AdvanceReminderTimeAsync(amount, TestContext.Current.CancellationToken);
+
+    protected async Task AdvanceReminderTimeAsync(TimeSpan amount, CancellationToken cancellationToken)
     {
         await ReminderClock.AdvanceAsync(amount, cancellationToken);
     }
 
-    protected async Task<IAsyncDisposable> PauseReminderTimeAsync(CancellationToken cancellationToken = default)
+    protected Task<IAsyncDisposable> PauseReminderTimeAsync()
+        => PauseReminderTimeAsync(TestContext.Current.CancellationToken);
+
+    protected async Task<IAsyncDisposable> PauseReminderTimeAsync(CancellationToken cancellationToken)
     {
         return await ReminderClock.FreezeAsync(cancellationToken);
     }
@@ -752,6 +827,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
     protected async Task ExecuteWithRetries(
         Func<string, TimeSpan?, bool, Task> function,
         string reminderName,
+        CancellationToken cancellationToken,
         TimeSpan? period = null,
         bool validate = false)
     {
@@ -759,60 +835,73 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             try
             {
-                await function(reminderName, period, validate).WaitAsync(TestConstants.InitTimeout);
+                await function(reminderName, period, validate).WaitAsync(TestConstants.InitTimeout, cancellationToken);
                 return; // success ... no need to retry
             }
             catch (AggregateException aggEx)
             {
                 foreach (var exception in aggEx.InnerExceptions)
                 {
-                    await HandleError(exception, i);
+                    await HandleError(exception, i, cancellationToken);
                 }
             }
             catch (ReminderException exc)
             {
-                await HandleError(exc, i);
+                await HandleError(exc, i, cancellationToken);
             }
         }
 
         // execute one last time and bubble up errors if any
-        await function(reminderName, period, validate).WaitAsync(TestConstants.InitTimeout);
+        await function(reminderName, period, validate).WaitAsync(TestConstants.InitTimeout, cancellationToken);
     }
 
     // Func<> doesnt take optional parameters, thats why we need a separate method
-    protected async Task ExecuteWithRetriesStop(Func<string, Task> function, string reminderName)
+    protected async Task ExecuteWithRetriesStop(
+        Func<string, Task> function,
+        string reminderName,
+        CancellationToken cancellationToken)
     {
         for (long i = 1; i <= retries; i++)
         {
             try
             {
-                await function(reminderName).WaitAsync(TestConstants.InitTimeout);
+                await function(reminderName).WaitAsync(TestConstants.InitTimeout, cancellationToken);
                 return; // success ... no need to retry
             }
             catch (Exception exception)
             {
-                await HandleError(exception, i);
+                await HandleError(exception, i, cancellationToken);
             }
         }
 
         // execute one last time and bubble up errors if any
-        await function(reminderName).WaitAsync(TestConstants.InitTimeout);
+        await function(reminderName).WaitAsync(TestConstants.InitTimeout, cancellationToken);
     }
 
     protected async Task StopReminderAndWaitForQuiescenceAsync(
         IAddressable grain,
         string reminderName,
         Func<string, Task> stopReminder,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(grain);
         ArgumentNullException.ThrowIfNull(stopReminder);
 
         var unregisteredTask = observer.WaitForReminderUnregisteredAsync(grain, reminderName, cancellationToken);
-        await ExecuteWithRetriesStop(stopReminder, reminderName);
+        await ExecuteWithRetriesStop(stopReminder, reminderName, cancellationToken);
         await unregisteredTask;
         await WaitForReminderQuiescenceAsync(grain, reminderName, cancellationToken);
     }
+
+    protected Task StopReminderAndWaitForQuiescenceAsync(
+        IAddressable grain,
+        string reminderName,
+        Func<string, Task> stopReminder)
+        => StopReminderAndWaitForQuiescenceAsync(
+            grain,
+            reminderName,
+            stopReminder,
+            TestContext.Current.CancellationToken);
 
     private async Task WaitForReminderQuiescenceAsync(IAddressable grain, string reminderName, CancellationToken cancellationToken)
     {
@@ -863,7 +952,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                     cancellationToken);
             }));
         }
-        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (
+            cancellationToken.IsCancellationRequested
+            && !TestContext.Current.CancellationToken.IsCancellationRequested)
         {
             var states = reminders.Select(reminder =>
             {
@@ -879,7 +970,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
     }
 
-    private async Task<bool> HandleError(Exception ex, long i)
+    private async Task<bool> HandleError(Exception ex, long i, CancellationToken cancellationToken)
     {
         if (ex is AggregateException aggregateException)
         {
@@ -889,7 +980,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         if (ex is ReminderException)
         {
             this.log.LogInformation(ex, "Retryable operation failed on attempt {Attempt}", i);
-            await Task.Delay(TimeSpan.FromMilliseconds(10));
+            await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
             return true;
         }
 
@@ -926,11 +1017,14 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         };
     }
 
-    private static async Task<long> GetReminderCounterOrZeroAsync(IAddressable grain, string reminderName)
+    private static async Task<long> GetReminderCounterOrZeroAsync(
+        IAddressable grain,
+        string reminderName,
+        CancellationToken cancellationToken)
     {
         try
         {
-            return await GetReminderCounterAsync(grain, reminderName);
+            return await GetReminderCounterAsync(grain, reminderName).WaitAsync(cancellationToken);
         }
         catch (FileNotFoundException)
         {
@@ -949,7 +1043,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var current = await GetReminderCounterOrZeroAsync(grain, reminderName);
+                var current = await GetReminderCounterOrZeroAsync(grain, reminderName, cancellationToken);
                 if (!HostedCluster.TryGetGrainContext(grain.GetGrainId(), out var grainContext))
                 {
                     await Task.Yield();
@@ -969,9 +1063,15 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                 }
             }
         }
-        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (
+            cancellationToken.IsCancellationRequested
+            && !TestContext.Current.CancellationToken.IsCancellationRequested)
         {
-            var current = await GetReminderCounterOrZeroAsync(grain, reminderName);
+            using var diagnosticsCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var current = await GetReminderCounterOrZeroAsync(
+                grain,
+                reminderName,
+                diagnosticsCancellation.Token);
             var activeOwners = observer.GetActiveReminderCount(grain.GetGrainId(), reminderName);
             throw new InvalidOperationException(
                 $"Timed out waiting for reminder '{reminderName}' on grain {grain.GetGrainId()} to reach counter {target}. Current counter: {current}. Active owners: {activeOwners}.",

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -81,7 +81,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         // ReminderTable.Clear() cannot be called from a non-Orleans thread,
         // so we must proxy the call through a grain.
         var controlProxy = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken).Wait();
+        controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout).Wait();
     }
 
     public Task Test_Reminders_Basic_StopByRef()
@@ -201,7 +201,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, cancellationToken);
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
         }
     }
 
@@ -240,7 +240,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, cancellationToken);
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
         }
     }
 
@@ -327,8 +327,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
     private async Task CleanupAdditionalSilosAsync(
         HashSet<InProcessSiloHandle> initialSilos,
-        Task<List<InProcessSiloHandle>>? startSilosTask,
-        CancellationToken cancellationToken)
+        Task<List<InProcessSiloHandle>>? startSilosTask)
     {
         if (startSilosTask is null)
         {
@@ -337,8 +336,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
         try
         {
-            using var startupCompletionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            startupCompletionCts.CancelAfter(CHURN_ENDWAIT);
+            using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
             await startSilosTask.WaitAsync(startupCompletionCts.Token);
         }
         catch (Exception exception)
@@ -354,8 +352,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             return;
         }
 
-        using var cleanupCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cleanupCts.CancelAfter(CHURN_ENDWAIT);
+        using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
         await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
         await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
     }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -65,13 +65,14 @@ namespace UnitTests.TimerTests
 
             public override async ValueTask InitializeAsync()
             {
-                await base.InitializeAsync();
+                await base.InitializeAsync().AsTask().WaitAsync(TestContext.Current.CancellationToken);
                 if (!PreconditionsMet)
                 {
                     return;
                 }
 
-                using var cancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+                using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+                cancellation.CancelAfter(TestConstants.InitTimeout);
                 var started = HostedCluster.Silos.Select(silo =>
                     _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress));
                 _startedReminderServices = (await Task.WhenAll(started)).Select(e => e.SiloAddress!).ToArray();
@@ -81,7 +82,8 @@ namespace UnitTests.TimerTests
             {
                 try
                 {
-                    await base.DisposeAsync();
+                    using var cleanupCancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+                    await base.DisposeAsync().AsTask().WaitAsync(cleanupCancellation.Token);
                 }
                 finally
                 {
@@ -105,7 +107,7 @@ namespace UnitTests.TimerTests
             // ReminderTable.Clear() cannot be called from a non-Orleans thread,
             // so we must proxy the call through a grain.
             var controlProxy = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            await controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout);
+            await controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken);
         }
 
         ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
@@ -139,7 +141,7 @@ namespace UnitTests.TimerTests
         [Fact]
         public async Task Rem_Grain_Basic_StopByRef()
         {
-            await Test_Reminders_Basic_StopByRef();
+            await Test_Reminders_Basic_StopByRef(TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -148,7 +150,7 @@ namespace UnitTests.TimerTests
         [Fact]
         public async Task Rem_Grain_Basic_ListOps()
         {
-            await Test_Reminders_Basic_ListOps();
+            await Test_Reminders_Basic_ListOps(TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -170,32 +172,34 @@ namespace UnitTests.TimerTests
         [Fact]
         public async Task Rem_Grain_ConcurrentCounterWaitersUseSingleClockDriver()
         {
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
             var grains = Enumerable.Range(0, 16)
                 .Select(_ => this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid()))
                 .ToArray();
 
-            await Task.WhenAll(grains.Select(grain => grain.StartReminder(DR)));
+            await Task.WhenAll(grains.Select(grain => grain.StartReminder(DR))).WaitAsync(cts.Token);
             await AdvanceRemindersByTicksAsync(1, cts.Token, GetReminderIdentities(grains, DR));
-            await AssertReminderCountersAsync(grains, (DR, 1));
+            await AssertReminderCountersAsync(grains, cts.Token, (DR, 1));
             await StopRemindersAsync(grains, DR, cts.Token);
         }
 
         [Fact]
         public async Task Rem_Grain_CanRestartBeforeRemovedReminderIsPurged()
         {
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
             var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
 
-            await grain.StartReminder(DR);
+            await grain.StartReminder(DR).WaitAsync(cts.Token);
             await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 1, cts.Token);
 
             var unregisteredTask = observer.WaitForReminderUnregisteredAsync(grainId, DR, cts.Token);
-            await grain.StopReminder(DR);
+            await grain.StopReminder(DR).WaitAsync(cts.Token);
             await unregisteredTask;
 
-            await grain.StartReminder(DR);
+            await grain.StartReminder(DR).WaitAsync(cts.Token);
             var restartedCount = await WaitForAdditionalReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 1, cts.Token);
             Assert.Equal(1, restartedCount);
 
@@ -210,13 +214,14 @@ namespace UnitTests.TimerTests
             var grainId = grain.GetGrainId();
             var dueTime = ReminderLoadingWindow + TimeSpan.FromSeconds(5);
             var period = ReminderLoadingWindow + TimeSpan.FromSeconds(10);
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
             var registeredTask = observer.WaitForReminderRegisteredAsync(grainId, reminderName, cts.Token);
-            var reminder = await grain.StartReminder(reminderName, dueTime, period);
+            var reminder = await grain.StartReminder(reminderName, dueTime, period).WaitAsync(cts.Token);
             await registeredTask;
 
-            var storedReminder = await grain.GetReminderObject(reminderName);
+            var storedReminder = await grain.GetReminderObject(reminderName).WaitAsync(cts.Token);
             Assert.NotNull(storedReminder);
             Assert.Equal(reminder.ReminderName, storedReminder.ReminderName);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
@@ -231,7 +236,7 @@ namespace UnitTests.TimerTests
             await AdvanceUntilAsync(firstTickTask, cts.Token);
             await firstEvictionTask;
 
-            Assert.NotNull(await grain.GetReminderObject(reminderName));
+            Assert.NotNull(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
 
             var reactivatedTask = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
             await AdvanceUntilAsync(reactivatedTask, cts.Token);
@@ -241,8 +246,8 @@ namespace UnitTests.TimerTests
             await AdvanceUntilAsync(secondTickTask, cts.Token);
             await secondEvictionTask;
 
-            await grain.StopReminder(reminderName);
-            Assert.Null(await grain.GetReminderObject(reminderName));
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
+            Assert.Null(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
         }
 
         [Fact]
@@ -254,9 +259,10 @@ namespace UnitTests.TimerTests
             var dueTime = ReminderLoadingWindow + TimeSpan.FromSeconds(5);
             var period = ReminderLoadingWindow + TimeSpan.FromSeconds(10);
             var firstTickTime = ReminderUtcNow.UtcDateTime + dueTime;
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
-            await grain.StartReminder(reminderName, dueTime, period);
+            await grain.StartReminder(reminderName, dueTime, period).WaitAsync(cts.Token);
 
             var activatedTask = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
             await AdvanceUntilAsync(activatedTask, cts.Token);
@@ -272,12 +278,12 @@ namespace UnitTests.TimerTests
             Assert.Equal(1, observer.GetTickCount(grainId, reminderName));
 
             var reminderService = HostedCluster.Silos.Single().ServiceProvider.GetRequiredService<LocalReminderService>();
-            await reminderService.TestOnlyRefresh();
+            await reminderService.TestOnlyRefresh().WaitAsync(cts.Token);
 
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
             Assert.Equal(1, observer.GetTickCount(grainId, reminderName));
 
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
         }
 
         [Fact]
@@ -286,21 +292,22 @@ namespace UnitTests.TimerTests
             const string reminderName = "updated_reminder";
             var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
-            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
 
             var activatedTask = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
-            await grain.StartReminder(reminderName, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await activatedTask;
 
             var evictedTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, cts.Token);
-            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await evictedTask;
 
-            Assert.NotNull(await grain.GetReminderObject(reminderName));
-            await grain.StopReminder(reminderName);
+            Assert.NotNull(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
         }
 
         [Fact]
@@ -309,26 +316,27 @@ namespace UnitTests.TimerTests
             const string reminderName = "stale_refresh_distant_update";
             var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
             var activatedTask = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
-            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await activatedTask;
 
-            await using var staleRead = _readController.BlockNextRangeRead(grainId);
+            await using var staleRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(staleRead, cts.Token);
 
             var quiescenceTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, cts.Token);
-            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await quiescenceTask;
             staleRead.Release();
 
-            await using var followingRead = _readController.BlockNextRangeRead(grainId);
+            await using var followingRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(followingRead, cts.Token);
 
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
             followingRead.Release();
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
         }
 
         [Fact]
@@ -337,25 +345,26 @@ namespace UnitTests.TimerTests
             const string reminderName = "stale_refresh_unregister";
             var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
             var activatedTask = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
-            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await activatedTask;
 
-            await using var staleRead = _readController.BlockNextRangeRead(grainId);
+            await using var staleRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(staleRead, cts.Token);
 
             var quiescenceTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, cts.Token);
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
             await quiescenceTask;
             staleRead.Release();
 
-            await using var followingRead = _readController.BlockNextRangeRead(grainId);
+            await using var followingRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(followingRead, cts.Token);
 
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
-            Assert.Null(await grain.GetReminderObject(reminderName));
+            Assert.Null(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
             followingRead.Release();
         }
 
@@ -366,24 +375,25 @@ namespace UnitTests.TimerTests
             var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = ReminderLoadingWindow + MaximumInitialRefreshStagger + TimeSpan.FromSeconds(5);
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
-            await grain.StartReminder(reminderName, dueTime, TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, dueTime, TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
 
-            await using var staleRead = _readController.BlockNextRangeRead(grainId);
+            await using var staleRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(staleRead, cts.Token);
 
-            await grain.StartReminder(reminderName, dueTime + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, dueTime + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await AdvanceReminderTimeAsync(TimeSpan.FromSeconds(6), cts.Token);
             staleRead.Release();
 
-            await using var followingRead = _readController.BlockNextRangeRead(grainId);
+            await using var followingRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(followingRead, cts.Token);
 
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
             followingRead.Release();
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
         }
 
         [Fact]
@@ -393,23 +403,24 @@ namespace UnitTests.TimerTests
             var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = ReminderLoadingWindow + MaximumInitialRefreshStagger + TimeSpan.FromSeconds(5);
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
-            await grain.StartReminder(reminderName, dueTime, TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, dueTime, TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
 
-            await using var staleRead = _readController.BlockNextRangeRead(grainId);
+            await using var staleRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(staleRead, cts.Token);
 
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
             await AdvanceReminderTimeAsync(TimeSpan.FromSeconds(6), cts.Token);
             staleRead.Release();
 
-            await using var followingRead = _readController.BlockNextRangeRead(grainId);
+            await using var followingRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(followingRead, cts.Token);
 
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
-            Assert.Null(await grain.GetReminderObject(reminderName));
+            Assert.Null(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
             followingRead.Release();
         }
 
@@ -419,30 +430,31 @@ namespace UnitTests.TimerTests
             const string reminderName = "replace_pending_removal";
             var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
             var initialActivation = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
-            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await initialActivation;
 
-            await using var staleRead = _readController.BlockNextRangeRead(grainId);
+            await using var staleRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(staleRead, cts.Token);
 
             var quiescenceTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, cts.Token);
-            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow + TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await quiescenceTask;
 
             var replacementActivation = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
-            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2));
+            await grain.StartReminder(reminderName, ReminderLoadingWindow, TimeSpan.FromMinutes(2)).WaitAsync(cts.Token);
             await replacementActivation;
             staleRead.Release();
 
-            await using var followingRead = _readController.BlockNextRangeRead(grainId);
+            await using var followingRead = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(followingRead, cts.Token);
 
             Assert.Equal(1, observer.GetActiveReminderCount(grainId, reminderName));
             followingRead.Release();
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
         }
 
         private async Task AdvanceUntilBlockedAsync(ReminderTableReadGate gate, CancellationToken cancellationToken)
@@ -470,13 +482,14 @@ namespace UnitTests.TimerTests
             var grainId = grain.GetGrainId();
             var unsupportedTimerDelay = TimeSpan.FromMilliseconds(0xfffffffe) + TimeSpan.FromMilliseconds(1);
 
-            await grain.StartReminder(reminderName, unsupportedTimerDelay, unsupportedTimerDelay);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await grain.StartReminder(reminderName, unsupportedTimerDelay, unsupportedTimerDelay).WaitAsync(cancellationToken);
 
-            Assert.NotNull(await grain.GetReminderObject(reminderName));
+            Assert.NotNull(await grain.GetReminderObject(reminderName).WaitAsync(cancellationToken));
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
 
-            await grain.StopReminder(reminderName);
-            Assert.Null(await grain.GetReminderObject(reminderName));
+            await grain.StopReminder(reminderName).WaitAsync(cancellationToken);
+            Assert.Null(await grain.GetReminderObject(reminderName).WaitAsync(cancellationToken));
         }
 
         [Fact]
@@ -489,7 +502,8 @@ namespace UnitTests.TimerTests
 
             var dueTime = unsupportedTimerDelay + TimeSpan.FromDays(1);
             var period = unsupportedTimerDelay + TimeSpan.FromDays(1);
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
             // Subscribe before registration so Skip(1) captures the second tick instead of replaying the first.
             var secondTickTask = ReminderEvents.AllEvents
@@ -500,10 +514,10 @@ namespace UnitTests.TimerTests
                 .ToTask(cts.Token);
 
             var registeredTask = observer.WaitForReminderRegisteredAsync(grainId, reminderName, cts.Token);
-            await grain.StartReminder(reminderName, dueTime, period);
+            await grain.StartReminder(reminderName, dueTime, period).WaitAsync(cts.Token);
             await registeredTask;
 
-            Assert.NotNull(await grain.GetReminderObject(reminderName));
+            Assert.NotNull(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
             Assert.Equal(0, observer.GetTickCount(grainId, reminderName));
 
@@ -520,7 +534,7 @@ namespace UnitTests.TimerTests
 
             Assert.Equal(1, observer.GetTickCount(grainId, reminderName));
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
-            Assert.NotNull(await grain.GetReminderObject(reminderName));
+            Assert.NotNull(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
             Assert.Equal(firstTick.Status.FirstTickTime, firstTick.Status.CurrentTickTime);
 
             var reactivatedTask = observer.WaitForActiveReminderCountAsync(grainId, 1, cts.Token, reminderName);
@@ -537,8 +551,8 @@ namespace UnitTests.TimerTests
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
             Assert.Equal(firstTick.Status.CurrentTickTime + period, secondTick.Status.CurrentTickTime);
 
-            await grain.StopReminder(reminderName);
-            Assert.Null(await grain.GetReminderObject(reminderName));
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
+            Assert.Null(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
         }
 
         [Fact]
@@ -550,12 +564,13 @@ namespace UnitTests.TimerTests
             var dueTime = ReminderLoadingWindow + TimeSpan.FromSeconds(20);
             var period = TimeSpan.FromSeconds(90);
             var firstTickTime = ReminderUtcNow.UtcDateTime + dueTime;
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
-            await grain.StartReminder(reminderName, dueTime, period);
+            await grain.StartReminder(reminderName, dueTime, period).WaitAsync(cts.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
 
-            await using var outage = _readController.BlockNextRangeRead(grainId);
+            await using var outage = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(outage, cts.Token);
             await AdvanceReminderTimeAsync(firstTickTime - ReminderUtcNow.UtcDateTime, cts.Token);
 
@@ -564,7 +579,7 @@ namespace UnitTests.TimerTests
             await activatedTask;
             await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
             // Complete a reminder-service round trip so the recovery reconciliation turn cannot overlap time advancement.
-            Assert.NotNull(await grain.GetReminderObject(reminderName));
+            Assert.NotNull(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
 
             var tickTask = observer.WaitForReminderTickAsync(grainId, cts.Token, reminderName);
             await AdvanceReminderTimeAsync(ReminderRefreshPeriod, cts.Token);
@@ -573,7 +588,7 @@ namespace UnitTests.TimerTests
             Assert.Equal(firstTickTime, tick.Status.FirstTickTime);
             Assert.Equal(firstTickTime + ReminderRefreshPeriod, tick.Status.CurrentTickTime);
 
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
         }
 
         [Fact]
@@ -585,18 +600,19 @@ namespace UnitTests.TimerTests
             var dueTime = ReminderLoadingWindow + TimeSpan.FromSeconds(20);
             var period = TimeSpan.FromSeconds(90);
             var firstTickTime = ReminderUtcNow.UtcDateTime + dueTime;
-            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
 
-            await grain.StartReminder(reminderName, dueTime, period);
+            await grain.StartReminder(reminderName, dueTime, period).WaitAsync(cts.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
 
-            await using var outage = _readController.BlockNextRangeRead(grainId);
+            await using var outage = _readController.BlockNextRangeRead(grainId, cts.Token);
             await AdvanceUntilBlockedAsync(outage, cts.Token);
 
             await AdvanceReminderTimeAsync(dueTime + TimeSpan.FromSeconds(10), cts.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
             Assert.Equal(0, observer.GetTickCount(grainId, reminderName));
-            Assert.NotNull(await grain.GetReminderObject(reminderName));
+            Assert.NotNull(await grain.GetReminderObject(reminderName).WaitAsync(cts.Token));
 
             outage.Release();
 
@@ -614,7 +630,7 @@ namespace UnitTests.TimerTests
             Assert.Equal(1, observer.GetTickCount(grainId, reminderName));
             Assert.Equal(expectedTickTime, tick.Status.CurrentTickTime);
 
-            await grain.StopReminder(reminderName);
+            await grain.StopReminder(reminderName).WaitAsync(cts.Token);
         }
 
         // Single join tests ... multi grain, multi reminders
@@ -625,7 +641,7 @@ namespace UnitTests.TimerTests
         [Fact]
         public async Task Rem_Grain_1J_MultiGrainMultiReminders()
         {
-            await Test_Reminders_1J_MultiGrainMultiReminders();
+            await Test_Reminders_1J_MultiGrainMultiReminders(TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -634,7 +650,7 @@ namespace UnitTests.TimerTests
         [Fact]
         public async Task Rem_Grain_ReminderNotFounds()
         {
-            await Test_Reminders_ReminderNotFound();
+            await Test_Reminders_ReminderNotFound(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -32,14 +32,14 @@ namespace UnitTests.ActivationsLifeCycleTests
 
         private ILogger logger = null!;
 
-        private async Task Initialize(TimeSpan collectionAgeLimit, TimeSpan quantum)
+        private async Task Initialize(TimeSpan collectionAgeLimit, TimeSpan quantum, CancellationToken cancellationToken)
         {
             var builder = new TestClusterBuilder(1);
             builder.Properties["CollectionQuantum"] = quantum.ToString();
             builder.Properties["DefaultCollectionAgeLimit"] = collectionAgeLimit.ToString();
             builder.AddSiloBuilderConfigurator<SiloConfigurator>();
             testCluster = builder.Build();
-            await testCluster.DeployAsync();
+            await testCluster.DeployAsync(cancellationToken);
             this.logger = this.testCluster.Client!.ServiceProvider.GetRequiredService<ILogger<ActivationCollectorTests>>();
         }
 
@@ -72,9 +72,9 @@ namespace UnitTests.ActivationsLifeCycleTests
 
         ValueTask IAsyncLifetime.InitializeAsync() => ValueTask.CompletedTask;
 
-        private async Task Initialize(TimeSpan collectionAgeLimit)
+        private async Task Initialize(TimeSpan collectionAgeLimit, CancellationToken cancellationToken)
         {
-            await Initialize(collectionAgeLimit, DEFAULT_COLLECTION_QUANTUM);
+            await Initialize(collectionAgeLimit, DEFAULT_COLLECTION_QUANTUM, cancellationToken);
         }
 
         private static async Task CancelWorkerAsync(CancellationTokenSource cancellation, Task worker)
@@ -84,7 +84,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             {
                 await worker;
             }
-            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellation.Token)
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
             {
             }
         }
@@ -109,7 +109,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorForceCollection()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
             const int grainCount = 1000;
             var fullGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(IdleActivationGcTestGrain1));
@@ -123,7 +124,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             }
             await Task.WhenAll(tasks);
 
-            await Task.Delay(FORCED_COLLECTION_WAIT_TIME);
+            await Task.Delay(FORCED_COLLECTION_WAIT_TIME, cancellationToken);
 
             var grain = this.testCluster.GrainFactory!.GetGrain<IManagementGrain>(0);
 
@@ -133,7 +134,8 @@ namespace UnitTests.ActivationsLifeCycleTests
                 fullGrainTypeName,
                 grainCount,
                 DeactivationReasonCode.ActivationIdle,
-                TestConstants.InitTimeout);
+                TestConstants.InitTimeout,
+                cancellationToken);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
@@ -146,7 +148,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorShouldCollectIdleActivations()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
             const int grainCount = 1000;
             var fullGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(IdleActivationGcTestGrain1));
@@ -166,7 +169,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             logger.LogInformation(
                 "IdleActivationCollectorShouldCollectIdleActivations: grains activated; waiting for activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                 DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0, cancellationToken);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
@@ -177,7 +180,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorShouldNotCollectBusyActivations()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
             const int idleGrainCount = 500;
             const int busyGrainCount = 500;
@@ -194,7 +198,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 tasks0.Add(g.Nop());
             }
             await Task.WhenAll(tasks0);
-            using var workerCancellation = new CancellationTokenSource();
+            using var workerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             async Task busyWorker(CancellationToken cancellationToken)
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: busyWorker started");
@@ -207,7 +211,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                     await Task.WhenAll(tasks1);
                 }
             }
-            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token));
+            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token), cancellationToken);
             try
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
@@ -225,7 +229,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 logger.LogInformation(
                     "ActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                     DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
+                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0, cancellationToken);
 
                 // we should have only collected grains from the idle category (IdleActivationGcTestGrain1).
                 int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
@@ -244,7 +248,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ManualCollectionShouldNotCollectBusyActivations()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
             TimeSpan shortIdleTimeout = FORCED_COLLECTION_WAIT_TIME;
             const int idleGrainCount = 500;
@@ -262,7 +267,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 tasks0.Add(g.Nop());
             }
             await Task.WhenAll(tasks0);
-            using var workerCancellation = new CancellationTokenSource();
+            using var workerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             async Task busyWorker(CancellationToken cancellationToken)
             {
                 logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: busyWorker started");
@@ -275,7 +280,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                     await Task.WhenAll(tasks1);
                 }
             }
-            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token));
+            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token), cancellationToken);
             try
             {
                 logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
@@ -294,7 +299,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                     "ManualCollectionShouldNotCollectBusyActivations: grains activated; waiting {TotalSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
                     shortIdleTimeout.TotalSeconds,
                     DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-                await Task.Delay(shortIdleTimeout);
+                await Task.Delay(shortIdleTimeout, cancellationToken);
 
                 TimeSpan everything = TimeSpan.FromMinutes(10);
                 logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (timespan is {TotalSeconds} sec).",  everything.TotalSeconds);
@@ -304,7 +309,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 logger.LogInformation(
                     "ManualCollectionShouldNotCollectBusyActivations: waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                     DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
+                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0, cancellationToken);
 
                 // we should have only collected grains from the idle category (IdleActivationGcTestGrain).
                 int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
@@ -323,9 +328,10 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             //make sure default value won't cause activation collection during wait time
             var defaultCollectionAgeLimit = WAIT_TIME.Multiply(2);
-            await Initialize(defaultCollectionAgeLimit);
+            await Initialize(defaultCollectionAgeLimit, cancellationToken);
 
             const int grainCount = 1000;
             var fullGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(IdleActivationGcTestGrain2));
@@ -345,7 +351,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             logger.LogInformation(
                 "ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration: grains activated; waiting for activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                 DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0, cancellationToken);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
@@ -356,9 +362,10 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             //make sure default value won't cause activation collection during wait time
             var defaultCollectionAgeLimit = WAIT_TIME.Multiply(2);
-            await Initialize(defaultCollectionAgeLimit);
+            await Initialize(defaultCollectionAgeLimit, cancellationToken);
 
             const int idleGrainCount = 500;
             const int busyGrainCount = 500;
@@ -375,7 +382,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 tasks0.Add(g.Nop());
             }
             await Task.WhenAll(tasks0);
-            using var workerCancellation = new CancellationTokenSource();
+            using var workerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             async Task busyWorker(CancellationToken cancellationToken)
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: busyWorker started");
@@ -388,7 +395,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                     await Task.WhenAll(tasks1);
                 }
             }
-            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token));
+            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token), cancellationToken);
             try
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: activating {Count} idle grains.", idleGrainCount);
@@ -406,7 +413,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 logger.LogInformation(
                     "IdleActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                     DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
+                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0, cancellationToken);
 
                 // we should have only collected grains from the idle category (IdleActivationGcTestGrain2).
                 int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
@@ -425,7 +432,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact(Skip = "Flaky test. Needs to be investigated."), TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorShouldNotCollectBusyStatelessWorkers()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
             // the purpose of this test is to determine whether idle stateless worker activations are properly identified by the activation collector.
             // in this test, we:
@@ -454,20 +462,20 @@ namespace UnitTests.ActivationsLifeCycleTests
             bool[] quit = new bool[] { false };
             bool[] matched = new bool[grainCount];
             string[] activationIds = new string[grainCount];
-            async Task workFunc(int index)
+            async Task workFunc(int index, CancellationToken cancellationToken)
             {
                 // (part of) 4. periodically send a message to each grain...
 
                 // take a grain and call Delay to keep it busy.
                 IStatelessWorkerActivationCollectorTestGrain1 g = grains[index];
-                await g.Delay(DEFAULT_IDLE_TIMEOUT.Divide(2));
+                await g.Delay(DEFAULT_IDLE_TIMEOUT.Divide(2)).WaitAsync(cancellationToken);
                 // identify the activation and record whether it matches the activation ID last reported. it probably won't match in the beginning but should always converge on a match as other activations get collected.
                 string aid = await g.IdentifyActivation();
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: identified {Activation}", aid);
                 matched[index] = aid == activationIds[index];
                 activationIds[index] = aid;
             }
-            async Task workerFunc()
+            async Task workerFunc(CancellationToken cancellationToken)
             {
                 // (part of) 4. periodically send a message to each grain...
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: busyWorker started");
@@ -475,6 +483,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 List<Task> tasks1 = new List<Task>();
                 while (!quit[0])
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     for (int index = 0; index < grains.Count; ++index)
                     {
                         if (quit[0])
@@ -482,7 +491,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                             break;
                         }
 
-                        tasks1.Add(workFunc(index));
+                        tasks1.Add(workFunc(index, cancellationToken));
                     }
                     await Task.WhenAll(tasks1);
                 }
@@ -511,21 +520,21 @@ namespace UnitTests.ActivationsLifeCycleTests
 
                 // 4. periodically send a message to each grain...
                 this.logger.LogInformation("ActivationCollectorShouldNotCollectBusyStatelessWorkers: grains activated; sending heartbeat to {Count} stateless worker grains.", grainCount);
-                Task workerTask = Task.Run(workerFunc);
+                Task workerTask = Task.Run(() => workerFunc(cancellationToken), cancellationToken);
 
                 // 5. wait long enough for idle activations to be collected.
                 this.logger.LogInformation(
                     "ActivationCollectorShouldNotCollectBusyStatelessWorkers: grains activated; waiting {WaitSeconds} sec (activation GC idle timeout is {DefaultIdleTimeout} sec).",
                     WAIT_TIME.TotalSeconds,
                     DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-                await Task.Delay(WAIT_TIME);
+                await Task.Delay(WAIT_TIME, cancellationToken);
 
                 // 6. verify that only one activation is still active per grain.
                 int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, grainTypeName);
 
                 // signal that the worker task should stop and wait for it to finish.
                 quit[0] = true;
-                await workerTask;
+                await workerTask.WaitAsync(cancellationToken);
                 quit[0] = false;
 
                 Assert.Equal(grainCount, busyActivationsNotCollected);
@@ -543,9 +552,10 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorShouldCollectByCollectionSpecificAgeLimit()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var defaultCollectionAge = COLLECTION_SPECIFIC_AGE_LIMIT.Multiply(4);
             //make sure defaultCollectionAge value won't cause activation collection before the per-type limit
-            await Initialize(defaultCollectionAge);
+            await Initialize(defaultCollectionAge, cancellationToken);
 
             const int grainCount = 1000;
 
@@ -569,14 +579,17 @@ namespace UnitTests.ActivationsLifeCycleTests
                 COLLECTION_SPECIFIC_AGE_LIMIT.TotalSeconds);
 
             var activationCollector = this.testCluster.GetSiloServiceProvider().GetRequiredService<ActivationCollector>();
-            await activationCollector.CollectStaleActivations(CancellationToken.None);
+            await activationCollector.CollectStaleActivations(cancellationToken);
             int activationsAfterDefaultCollection = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, fullGrainTypeName);
             Assert.Equal(grainCount, activationsAfterDefaultCollection);
 
-            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0, cancellationToken);
         }
 
-        private async Task WaitForActivationCountToConverge(string grainTypeName, int expectedCount)
+        private async Task WaitForActivationCountToConverge(
+            string grainTypeName,
+            int expectedCount,
+            CancellationToken cancellationToken)
         {
             using var collectionObserver = ActivationCollectionObserver.Create();
             var activationCount = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, grainTypeName);
@@ -592,7 +605,8 @@ namespace UnitTests.ActivationsLifeCycleTests
                 grainTypeName,
                 expectedCollectedCount,
                 DeactivationReasonCode.ActivationIdle,
-                TestConstants.InitTimeout);
+                TestConstants.InitTimeout,
+                cancellationToken);
 
             activationCount = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, grainTypeName);
             Assert.Equal(expectedCount, activationCount);
@@ -616,7 +630,8 @@ namespace UnitTests.ActivationsLifeCycleTests
                 string grainTypeName,
                 int expectedCount,
                 DeactivationReasonCode reasonCode,
-                TimeSpan timeout)
+                TimeSpan timeout,
+                CancellationToken cancellationToken)
             {
                 var waiter = new Waiter(grainTypeName, expectedCount, reasonCode);
                 lock (_lock)
@@ -629,14 +644,15 @@ namespace UnitTests.ActivationsLifeCycleTests
                     _waiters.Add(waiter);
                 }
 
-                using var cancellation = new CancellationTokenSource(timeout);
+                using var timeoutCancellation = new CancellationTokenSource(timeout);
+                using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(timeoutCancellation.Token, cancellationToken);
                 using var registration = cancellation.Token.Register(static state => ((Waiter)state!).TrySetCanceled(), waiter);
 
                 try
                 {
                     await waiter.Task;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (timeoutCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     var count = GetCollectedCount(waiter);
                     throw new TimeoutException($"Timed out waiting for {expectedCount} collected activations of grain type '{grainTypeName}' with reason {reasonCode}. Current count: {count} after {timeout}.");
@@ -736,7 +752,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
         public async Task ActivationCollectorShouldCollectAfterCancellingKeepAlive()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
             var fullGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(KeepAliveActivationGcTestGrain));
 
@@ -753,7 +770,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             // Cancel the keep-alive. The grain should now be collectable after the standard idle timeout.
             await grain.CancelKeepAlive();
 
-            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0, cancellationToken);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
@@ -764,7 +781,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("SlowBVT"), TestCategory("Timers")]
         public async Task NonReentrantGrainTimer_NoKeepAlive_Test()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT, DEFAULT_COLLECTION_QUANTUM);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, DEFAULT_COLLECTION_QUANTUM, cancellationToken);
 
             const string testName = "NonReentrantGrainTimer_NoKeepAlive_Test";
 
@@ -773,7 +791,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             // Schedule a timer to fire at the 30s mark which will not extend the grain's lifetime.
             await grain.StartTimer(testName, TimeSpan.FromSeconds(30), keepAlive: false);
-            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0, cancellationToken);
 
             var tickCount = await grain.GetTickCount();
 
@@ -786,7 +804,8 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("Functional"), TestCategory("Diagnostics"), TestCategory("Timers")]
         public async Task GrainAndTimerDiagnosticsExposeRuntimeInstances()
         {
-            await Initialize(DEFAULT_IDLE_TIMEOUT);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
             using var grainObserver = GrainDiagnosticObserver.Create();
             using var timerObserver = TimerDiagnosticObserver.Create();

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
@@ -20,31 +20,33 @@ public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture f
     [Fact]
     public async Task TryStartMigration_ReturnsTrue_WhenActivationCanStartMigration()
     {
-        var activation = await GetActivation();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var activation = await GetActivation(cancellationToken);
 
-        Assert.True(activation.TryStartMigration(requestContext: null));
+        Assert.True(activation.TryStartMigration(requestContext: null, cancellationToken));
 
         Assert.Equal(ActivationState.Deactivating, activation.State);
 
-        await activation.Deactivated.WaitAsync(TimeSpan.FromSeconds(10));
+        await activation.Deactivated.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
     }
 
     [Fact]
     public async Task TryStartMigration_ReturnsFalse_WhenActivationIsInvalid()
     {
-        var activation = await GetActivation();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var activation = await GetActivation(cancellationToken);
         var originalDeactivated = activation.Deactivated;
-        activation.Deactivate(new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "test"), CancellationToken.None);
-        await originalDeactivated.WaitAsync(TimeSpan.FromSeconds(10));
+        activation.Deactivate(new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "test"), cancellationToken);
+        await originalDeactivated.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
 
         Assert.Equal(ActivationState.Invalid, activation.State);
-        Assert.False(activation.TryStartMigration(requestContext: null));
+        Assert.False(activation.TryStartMigration(requestContext: null, cancellationToken));
     }
 
-    private async Task<ActivationData> GetActivation()
+    private async Task<ActivationData> GetActivation(CancellationToken cancellationToken)
     {
         var grain = _fixture.GrainFactory.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
-        await grain.Nop();
+        await grain.Nop().WaitAsync(cancellationToken);
 
         var grainId = ((GrainReference)grain).GrainId;
         var directory = PrimarySilo.SiloHost.Services.GetRequiredService<ActivationDirectory>();

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -58,6 +58,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("Functional")]
         public async Task DeactivateOnIdleTestInside_Basic()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Initialize();
 
             var a = this.testCluster.GrainFactory!.GetGrain<ICollectionTestGrain>(1);
@@ -65,8 +66,8 @@ namespace UnitTests.ActivationsLifeCycleTests
             await a.SetOther(b);
             await a.GetOtherAge(); // prime a's routing cache
             await b.DeactivateSelf();
-            Thread.Sleep(5000);
-            var age = await a.GetOtherAge().WaitAsync(TimeSpan.FromMilliseconds(2000));
+            await Task.Delay(5000, cancellationToken);
+            var age = await a.GetOtherAge().WaitAsync(TimeSpan.FromMilliseconds(2000), cancellationToken);
             Assert.True(age.TotalMilliseconds < 2000, "Should be newly activated grain");
         }
 
@@ -93,6 +94,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("Functional")]
         public async Task DeactivateOnIdleTest_Stress_2_NonReentrant()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Initialize();
             var a = this.testCluster.GrainFactory!.GetGrain<ICollectionTestGrain>(1, "UnitTests.Grains.CollectionTestGrain");
             await a.IncrCounter();
@@ -104,12 +106,12 @@ namespace UnitTests.ActivationsLifeCycleTests
                 {
                     tasks.Add(a.IncrCounter());
                 }
-                await Task.WhenAll(tasks);
-            });
+                await Task.WhenAll(tasks).WaitAsync(cancellationToken);
+            }, cancellationToken);
 
-            await Task.Delay(1);
+            await Task.Delay(1, cancellationToken);
             Task t2 = a.DeactivateSelf();
-            await Task.WhenAll(t1, t2);
+            await Task.WhenAll(t1, t2).WaitAsync(cancellationToken);
         }
 
         [TestSuite("Functional")]
@@ -118,6 +120,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("Functional")]
         public async Task DeactivateOnIdleTest_Stress_3_Reentrant()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Initialize();
             var a = this.testCluster.GrainFactory!.GetGrain<ICollectionTestGrain>(1, "UnitTests.Grains.ReentrantCollectionTestGrain");
             await a.IncrCounter();
@@ -129,12 +132,12 @@ namespace UnitTests.ActivationsLifeCycleTests
                 {
                     tasks.Add(a.IncrCounter());
                 }
-                await Task.WhenAll(tasks);
-            });
+                await Task.WhenAll(tasks).WaitAsync(cancellationToken);
+            }, cancellationToken);
 
-            await Task.Delay(TimeSpan.FromMilliseconds(1));
+            await Task.Delay(TimeSpan.FromMilliseconds(1), cancellationToken);
             Task t2 = a.DeactivateSelf();
-            await Task.WhenAll(t1, t2);
+            await Task.WhenAll(t1, t2).WaitAsync(cancellationToken);
         }
 
         [TestSuite("Functional")]
@@ -159,6 +162,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("Functional")]
         public async Task DeactivateOnIdleTest_Stress_5()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             Initialize();
             var a = this.testCluster.GrainFactory!.GetGrain<ICollectionTestGrain>(1);
             await a.IncrCounter();
@@ -170,19 +174,19 @@ namespace UnitTests.ActivationsLifeCycleTests
                 {
                     tasks.Add(a.IncrCounter());
                 }
-                await Task.WhenAll(tasks);
-            });
+                await Task.WhenAll(tasks).WaitAsync(cancellationToken);
+            }, cancellationToken);
             Task t2 = Task.Run(async () =>
             {
                 List<Task> tasks = new List<Task>();
                 for (int i = 0; i < 1; i++)
                 {
-                    await Task.Delay(1);
+                    await Task.Delay(1, cancellationToken);
                     tasks.Add(a.DeactivateSelf());
                 }
-                await Task.WhenAll(tasks);
-            });
-            await Task.WhenAll(t1, t2);
+                await Task.WhenAll(tasks).WaitAsync(cancellationToken);
+            }, cancellationToken);
+            await Task.WhenAll(t1, t2).WaitAsync(cancellationToken);
         }
 
         [TestSuite("Functional")]
@@ -206,7 +210,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("Functional")]
         public async Task DeactivateOnIdle_NonExistentActivation_1()
         {
-            await DeactivateOnIdle_NonExistentActivation_Runner(0);
+            await DeactivateOnIdle_NonExistentActivation_Runner(0, TestContext.Current.CancellationToken);
         }
 
         [TestSuite("Functional")]
@@ -215,7 +219,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("Functional")]
         public async Task DeactivateOnIdle_NonExistentActivation_2()
         {
-            await DeactivateOnIdle_NonExistentActivation_Runner(1);
+            await DeactivateOnIdle_NonExistentActivation_Runner(1, TestContext.Current.CancellationToken);
         }
 
         public class ClientConfigurator : IClientBuilderConfigurator
@@ -239,7 +243,7 @@ namespace UnitTests.ActivationsLifeCycleTests
             }
         }
 
-        private async Task DeactivateOnIdle_NonExistentActivation_Runner(int forwardCount)
+        private async Task DeactivateOnIdle_NonExistentActivation_Runner(int forwardCount, CancellationToken cancellationToken)
         {
             var builder = new TestClusterBuilder(2);
             builder.AddClientBuilderConfigurator<ClientConfigurator>();
@@ -247,24 +251,24 @@ namespace UnitTests.ActivationsLifeCycleTests
             builder.Properties["MaxForwardCount"] = forwardCount.ToString();
             Initialize(builder);
 
-            ICollectionTestGrain grain = await PickGrainInNonPrimary();
+            ICollectionTestGrain grain = await PickGrainInNonPrimary(cancellationToken);
 
             output.WriteLine("About to make a 1st GetAge() call.");
             TimeSpan age = await grain.GetAge();
             output.WriteLine(age.ToString());
 
             await grain.DeactivateSelf();
-            await Task.Delay(3000);
+            await Task.Delay(3000, cancellationToken);
 
-            var thrownException = await Record.ExceptionAsync(() => grain.GetAge());
+            var thrownException = await Record.ExceptionAsync(() => grain.GetAge().WaitAsync(cancellationToken));
             Assert.Null(thrownException);
             output.WriteLine("\nThe 1st call after DeactivateSelf has NOT thrown any exception as expected, since forwardCount is {0}.\n", forwardCount);
         }
 
-        private async Task<ICollectionTestGrain> PickGrainInNonPrimary()
+        private async Task<ICollectionTestGrain> PickGrainInNonPrimary(CancellationToken cancellationToken)
         {
             var targetSilo = this.testCluster.SecondarySilos.First().SiloAddress;
-            var directoryView = await WaitForDirectoryView(targetSilo);
+            var directoryView = await WaitForDirectoryView(targetSilo, cancellationToken);
             var grainType = this.testCluster.GrainFactory!.GetGrain<ICollectionTestGrain>(0).GetGrainId().Type;
 
             const int maxCandidateGrainKeys = 1_000_000;
@@ -274,6 +278,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 if (i > 0 && i % candidateYieldInterval == 0)
                 {
                     await Task.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
                 }
 
                 // Create grain such that:
@@ -290,7 +295,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 try
                 {
                     RequestContext.Set(IPlacementDirector.PlacementHintKey, targetSilo);
-                    siloHostingActivation = await grain.GetRuntimeInstanceId();
+                    siloHostingActivation = await grain.GetRuntimeInstanceId().WaitAsync(cancellationToken);
                 }
                 finally
                 {
@@ -310,13 +315,14 @@ namespace UnitTests.ActivationsLifeCycleTests
             return null;
         }
 
-        private async Task<DirectoryMembershipSnapshot> WaitForDirectoryView(SiloAddress targetSilo)
+        private async Task<DirectoryMembershipSnapshot> WaitForDirectoryView(SiloAddress targetSilo, CancellationToken cancellationToken)
         {
             var directoryMembership = ((InProcessSiloHandle)this.testCluster.Primary!).ServiceProvider.GetRequiredService<DirectoryMembershipService>();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var timeoutCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(timeoutCancellation.Token, cancellationToken);
             try
             {
-                await foreach (var view in directoryMembership.ViewUpdates.WithCancellation(cts.Token))
+                await foreach (var view in directoryMembership.ViewUpdates.WithCancellation(cancellation.Token))
                 {
                     if (view.Members.Contains(targetSilo))
                     {
@@ -324,7 +330,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                     }
                 }
             }
-            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            catch (OperationCanceledException) when (timeoutCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 Assert.Fail($"Timed out waiting for target silo {targetSilo} to join the directory view.");
             }

--- a/test/Orleans.Runtime.Internal.Tests/CancellationTests/SystemTargetCancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/CancellationTests/SystemTargetCancellationTokenTests.cs
@@ -98,6 +98,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
     [InlineData(300)]
     public async Task SystemTargetTaskCancellation(int delay)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var siloAddress = fixture.HostedCluster.Silos.First().SiloAddress;
         var systemTarget = fixture.GetSystemTarget(siloAddress);
 
@@ -108,7 +109,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         if (delay > 0)
         {
-            await WaitForCallCancellation(systemTarget, callId);
+            await WaitForCallCancellation(systemTarget, callId, cancellationToken);
         }
     }
 
@@ -118,6 +119,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
     [InlineData(300)]
     public async Task MultipleSystemTargetsTaskCancellation(int delay)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
         var systemTargets = fixture.HostedCluster.Silos
@@ -135,7 +137,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         {
             foreach (var st in systemTargets)
             {
-                await WaitForCallCancellation(st, callId);
+                await WaitForCallCancellation(st, callId, cancellationToken);
             }
         }
     }
@@ -150,6 +152,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
     [InlineData(300)]
     public async Task SystemTargetMultipleConcurrentCancellations(int delay)
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var siloAddress = fixture.HostedCluster.Silos.First().SiloAddress;
         var systemTarget = fixture.GetSystemTarget(siloAddress);
 
@@ -170,7 +173,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         {
             foreach (var callId in callIds)
             {
-                await WaitForCallCancellation(systemTarget, callId);
+                await WaitForCallCancellation(systemTarget, callId, cancellationToken);
             }
         }
     }
@@ -209,6 +212,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
     [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
     public async Task CancellationTokenCallbacksExecutionContext()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var siloAddress = fixture.HostedCluster.Silos.First().SiloAddress;
         var systemTarget = fixture.GetSystemTarget(siloAddress);
 
@@ -227,12 +231,13 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         }
 
-        await WaitForCallCancellation(systemTarget, callId);
+        await WaitForCallCancellation(systemTarget, callId, cancellationToken);
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
     public async Task CancellationTokenCallbacksTaskSchedulerContext()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var silos = fixture.HostedCluster.Silos.ToArray();
         var sourceTarget = fixture.GetSystemTarget(silos[0].SiloAddress);
         var destinationTarget = fixture.GetSystemTarget(silos.Length > 1 ? silos[1].SiloAddress : silos[0].SiloAddress);
@@ -250,12 +255,13 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         }
 
-        await WaitForCallCancellation(destinationTarget, callId);
+        await WaitForCallCancellation(destinationTarget, callId, cancellationToken);
     }
 
     [Fact, TestCategory("Cancellation")]
     public async Task CancellationTokenCallbacksThrow_ExceptionDoesNotPropagate()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var siloAddress = fixture.HostedCluster.Silos.First().SiloAddress;
         var systemTarget = fixture.GetSystemTarget(siloAddress);
 
@@ -264,7 +270,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         systemTarget.CancellationTokenCallbackThrow(cts.Token, callId).Ignore();
         // Cancellation is a cooperative mechanism, so we don't expect the exception to propagate
         cts.CancelAfter(100);
-        await WaitForCallCancellation(systemTarget, callId);
+        await WaitForCallCancellation(systemTarget, callId, cancellationToken);
     }
 
     [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -274,7 +280,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
     public async Task InSiloCancellation(int delay)
     {
         var siloAddress = fixture.HostedCluster.Silos.First().SiloAddress;
-        await CancellationTestCore(siloAddress, siloAddress, delay);
+        await CancellationTestCore(siloAddress, siloAddress, delay, TestContext.Current.CancellationToken);
     }
 
     [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -290,7 +296,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
             return;
         }
 
-        await CancellationTestCore(silos[0].SiloAddress, silos[1].SiloAddress, delay);
+        await CancellationTestCore(silos[0].SiloAddress, silos[1].SiloAddress, delay, TestContext.Current.CancellationToken);
     }
 
     [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -306,7 +312,11 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
             return;
         }
 
-        await ClientCancellationTokenPassing(delay, silos[0].SiloAddress, silos[1].SiloAddress);
+        await ClientCancellationTokenPassing(
+            delay,
+            silos[0].SiloAddress,
+            silos[1].SiloAddress,
+            TestContext.Current.CancellationToken);
     }
 
     [Theory, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -316,10 +326,14 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
     public async Task InSiloClientCancellationTokenPassing(int delay)
     {
         var siloAddress = fixture.HostedCluster.Silos.First().SiloAddress;
-        await ClientCancellationTokenPassing(delay, siloAddress, siloAddress);
+        await ClientCancellationTokenPassing(delay, siloAddress, siloAddress, TestContext.Current.CancellationToken);
     }
 
-    private async Task ClientCancellationTokenPassing(int delay, SiloAddress sourceAddress, SiloAddress targetAddress)
+    private async Task ClientCancellationTokenPassing(
+        int delay,
+        SiloAddress sourceAddress,
+        SiloAddress targetAddress,
+        CancellationToken cancellationToken)
     {
         var sourceTarget = fixture.GetSystemTarget(sourceAddress);
         var target = fixture.GetSystemTarget(targetAddress);
@@ -331,11 +345,15 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         if (delay > 0)
         {
-            await WaitForCallCancellation(target, callId);
+            await WaitForCallCancellation(target, callId, cancellationToken);
         }
     }
 
-    private async Task CancellationTestCore(SiloAddress sourceAddress, SiloAddress targetAddress, int delay)
+    private async Task CancellationTestCore(
+        SiloAddress sourceAddress,
+        SiloAddress targetAddress,
+        int delay,
+        CancellationToken cancellationToken)
     {
         var sourceTarget = fixture.GetSystemTarget(sourceAddress);
         var target = fixture.GetSystemTarget(targetAddress);
@@ -345,13 +363,18 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         if (delay > 0)
         {
-            await WaitForCallCancellation(target, callId);
+            await WaitForCallCancellation(target, callId, cancellationToken);
         }
     }
 
-    private static async Task WaitForCallCancellation(ICancellationTestSystemTarget systemTarget, Guid callId)
+    private static async Task WaitForCallCancellation(
+        ICancellationTestSystemTarget systemTarget,
+        Guid callId,
+        CancellationToken cancellationToken)
     {
-        var (wasCancelled, error) = await systemTarget.WaitForCancellation(callId, TimeSpan.FromSeconds(30));
+        var (wasCancelled, error) = await systemTarget
+            .WaitForCancellation(callId, TimeSpan.FromSeconds(30))
+            .WaitAsync(cancellationToken);
         if (!wasCancelled)
         {
             Assert.Fail($"Did not encounter the expected call id {callId}");
@@ -370,6 +393,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
     [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
     public async Task MultipleConcurrentSystemTargetRequestsCancellation()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var siloAddress = fixture.HostedCluster.Silos.First().SiloAddress;
         var systemTarget = fixture.GetSystemTarget(siloAddress);
 
@@ -387,12 +411,12 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         var task3 = systemTarget.LongWait(cts3.Token, TimeSpan.FromSeconds(10), callId3);
 
         // Wait for all to be running
-        await Task.Delay(100);
+        await Task.Delay(100, cancellationToken);
 
         // Cancel only the second request
         await cts2.CancelAsync();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task2);
-        await WaitForCallCancellation(systemTarget, callId2);
+        await WaitForCallCancellation(systemTarget, callId2, cancellationToken);
 
         // First and third should still be running, cancel them
         await cts1.CancelAsync();
@@ -401,8 +425,8 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task1);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task3);
 
-        await WaitForCallCancellation(systemTarget, callId1);
-        await WaitForCallCancellation(systemTarget, callId3);
+        await WaitForCallCancellation(systemTarget, callId1, cancellationToken);
+        await WaitForCallCancellation(systemTarget, callId3, cancellationToken);
     }
 }
 

--- a/test/Orleans.Runtime.Internal.Tests/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/Orleans.Runtime.Internal.Tests/General/ConsistentRingProviderTests_Silo.cs
@@ -52,56 +52,57 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_Basic()
         {
-            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos, false, cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
-            await VerificationScenario(0);
+            await VerificationScenario(0, cancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_1F_Random()
         {
-            await FailureTest(Fail.Random, 1);
+            await FailureTest(Fail.Random, 1, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_1F_Beginning()
         {
-            await FailureTest(Fail.First, 1);
+            await FailureTest(Fail.First, 1, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_1F_End()
         {
-            await FailureTest(Fail.Last, 1);
+            await FailureTest(Fail.Last, 1, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_2F_Random()
         {
-            await FailureTest(Fail.Random, 2);
+            await FailureTest(Fail.Random, 2, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_2F_Beginning()
         {
-            await FailureTest(Fail.First, 2);
+            await FailureTest(Fail.First, 2, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_2F_End()
         {
-            await FailureTest(Fail.Last, 2);
+            await FailureTest(Fail.Last, 2, TestContext.Current.CancellationToken);
         }
 
-        private async Task FailureTest(Fail failCode, int numOfFailures)
+        private async Task FailureTest(Fail failCode, int numOfFailures, CancellationToken cancellationToken)
         {
-            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos);
+            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos, false, cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
-            List<SiloHandle> failures = await getSilosToFail(failCode, numOfFailures);
+            List<SiloHandle> failures = await getSilosToFail(failCode, numOfFailures, cancellationToken);
             foreach (SiloHandle fail in failures) // verify before failure
             {
-                await VerificationScenario(PickKey(fail.SiloAddress)); // fail.SiloAddress.GetConsistentHashCode());
+                await VerificationScenario(PickKey(fail.SiloAddress), cancellationToken); // fail.SiloAddress.GetConsistentHashCode());
             }
 
             logger.LogInformation(
@@ -113,7 +114,7 @@ namespace UnitTests.General
             foreach (SiloHandle fail in failures) // verify before failure
             {
                 keysToTest.Add(PickKey(fail.SiloAddress)); //fail.SiloAddress.GetConsistentHashCode());
-                await this.HostedCluster.StopSiloAsync(fail);
+                await this.HostedCluster.StopSiloAsync(fail, cancellationToken);
             }
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
@@ -121,67 +122,69 @@ namespace UnitTests.General
             {
                 foreach (var key in keysToTest) // verify after failure
                 {
-                    await VerificationScenario(key);
+                    await VerificationScenario(key, cancellationToken);
                 }
-            }, failureTimeout);
+            }, failureTimeout, cancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_1J()
         {
-            await JoinTest(1);
+            await JoinTest(1, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_2J()
         {
-            await JoinTest(2);
+            await JoinTest(2, TestContext.Current.CancellationToken);
         }
 
-        private async Task JoinTest(int numOfJoins)
+        private async Task JoinTest(int numOfJoins, CancellationToken cancellationToken)
         {
             logger.LogInformation("JoinTest {NumOfJoins}", numOfJoins);
-            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos - numOfJoins);
+            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos - numOfJoins, false, cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
-            List<SiloHandle> silos = await this.HostedCluster.StartAdditionalSilosAsync(numOfJoins);
+            List<SiloHandle> silos = await this.HostedCluster.StartAdditionalSilosAsync(numOfJoins, false, cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
             foreach (SiloHandle sh in silos)
             {
-                await VerificationScenario(PickKey(sh.SiloAddress));
+                await VerificationScenario(PickKey(sh.SiloAddress), cancellationToken);
             }
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_1F1J()
         {
-            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos, false, cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
-            List<SiloHandle> failures = await getSilosToFail(Fail.Random, 1);
+            List<SiloHandle> failures = await getSilosToFail(Fail.Random, 1, cancellationToken);
             uint keyToCheck = PickKey(failures[0].SiloAddress);// failures[0].SiloAddress.GetConsistentHashCode();
 
             // kill a silo and join a new one in parallel
             logger.LogInformation("Killing silo {SiloAddress} and joining a silo", failures[0].SiloAddress);
 
-            var killTask = this.HostedCluster.StopSiloAsync(failures[0]);
-            var joinTask = this.HostedCluster.StartAdditionalSilosAsync(1);
-            await Task.WhenAll([killTask, joinTask]).WaitAsync(endWait);
+            var killTask = this.HostedCluster.StopSiloAsync(failures[0], cancellationToken);
+            var joinTask = this.HostedCluster.StartAdditionalSilosAsync(1, false, cancellationToken);
+            await Task.WhenAll([killTask, joinTask]).WaitAsync(endWait, cancellationToken);
             List<SiloHandle> joinedSilos = await joinTask;
 
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
             await AssertEventually(async () =>
             {
-                await VerificationScenario(keyToCheck); // verify failed silo's key
-                await VerificationScenario(PickKey(joinedSilos[0].SiloAddress)); // verify newly joined silo's key
-            }, failureTimeout);
+                await VerificationScenario(keyToCheck, cancellationToken); // verify failed silo's key
+                await VerificationScenario(PickKey(joinedSilos[0].SiloAddress), cancellationToken); // verify newly joined silo's key
+            }, failureTimeout, cancellationToken);
         }
 
         // failing the secondary in this scenario exposed the bug in DomainGrain ... so, we keep it as a separate test than Ring_1F1J
         [Fact, TestCategory("Functional"), TestCategory("Ring")]
         public async Task Ring_1Fsec1J()
         {
-            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos);
+            var cancellationToken = TestContext.Current.CancellationToken;
+            await this.HostedCluster.StartAdditionalSilosAsync(numAdditionalSilos, false, cancellationToken);
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
             //List<SiloHandle> failures = getSilosToFail(Fail.Random, 1);
             SiloHandle fail = this.HostedCluster.SecondarySilos.First();
@@ -189,18 +192,18 @@ namespace UnitTests.General
 
             // kill a silo and join a new one in parallel
             logger.LogInformation("Killing secondary silo {SiloAddress} and joining a silo", fail.SiloAddress);
-            var killTask = this.HostedCluster.StopSiloAsync(fail);
-            var joinTask = this.HostedCluster.StartAdditionalSilosAsync(1);
-            await Task.WhenAll([killTask, joinTask]).WaitAsync(endWait);
+            var killTask = this.HostedCluster.StopSiloAsync(fail, cancellationToken);
+            var joinTask = this.HostedCluster.StartAdditionalSilosAsync(1, false, cancellationToken);
+            await Task.WhenAll([killTask, joinTask]).WaitAsync(endWait, cancellationToken);
             var joinedSilo = (await joinTask).Single();
 
             await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
             await AssertEventually(async () =>
             {
-                await VerificationScenario(keyToCheck); // verify failed silo's key
-                await VerificationScenario(PickKey(joinedSilo.SiloAddress));
-            }, failureTimeout);
+                await VerificationScenario(keyToCheck, cancellationToken); // verify failed silo's key
+                await VerificationScenario(PickKey(joinedSilo.SiloAddress), cancellationToken);
+            }, failureTimeout, cancellationToken);
         }
 
         private uint PickKey(SiloAddress responsibleSilo)
@@ -219,7 +222,7 @@ namespace UnitTests.General
                 responsibleSilo, testHooks.GetConsistentRingProviderDiagnosticInfo().Result));
         }
 
-        private async Task VerificationScenario(uint testKey)
+        private async Task VerificationScenario(uint testKey, CancellationToken cancellationToken)
         {
             // setup
             List<SiloAddress> silos = new List<SiloAddress>();
@@ -232,22 +235,22 @@ namespace UnitTests.General
             }
 
             // verify parameter key
-            await VerifyKey(testKey, silos);
+            await VerifyKey(testKey, silos, cancellationToken);
             // verify some other keys as well, apart from the parameter key            
             // some random keys
             for (int i = 0; i < 3; i++)
             {
-                await VerifyKey((uint)Random.Shared.Next(), silos);
+                await VerifyKey((uint)Random.Shared.Next(), silos, cancellationToken);
             }
             // lowest key
             uint lowest = (uint)(silos.First().GetConsistentHashCode() - 1);
-            await VerifyKey(lowest, silos);
+            await VerifyKey(lowest, silos, cancellationToken);
             // highest key
             uint highest = (uint)(silos.Last().GetConsistentHashCode() + 1);
-            await VerifyKey(lowest, silos);
+            await VerifyKey(lowest, silos, cancellationToken);
         }
 
-        private async Task VerifyKey(uint key, List<SiloAddress> silos)
+        private async Task VerifyKey(uint key, List<SiloAddress> silos, CancellationToken cancellationToken)
         {
             var testHooks = this.Client.GetTestHooks(this.HostedCluster.Primary!);
             SiloAddress truth = testHooks.GetConsistentRingPrimaryTargetSilo(key).Result; //expected;
@@ -264,12 +267,12 @@ namespace UnitTests.General
             foreach (var siloHandle in this.HostedCluster.GetActiveSilos()) // do this for each silo
             {
                 testHooks = this.Client.GetTestHooks(siloHandle);
-                SiloAddress s = await testHooks.GetConsistentRingPrimaryTargetSilo((uint)key);
+                SiloAddress s = await testHooks.GetConsistentRingPrimaryTargetSilo((uint)key).WaitAsync(cancellationToken);
                 Assert.Equal(truth, s);
             }
         }
 
-        private async Task<List<SiloHandle>> getSilosToFail(Fail fail, int numOfFailures)
+        private async Task<List<SiloHandle>> getSilosToFail(Fail fail, int numOfFailures, CancellationToken cancellationToken)
         {
             List<SiloHandle> failures = new List<SiloHandle>();
             int count = 0;
@@ -279,10 +282,10 @@ namespace UnitTests.General
             var tableGrainId = ((GrainReference)tableGrain).GrainId;
 
             // Ping the grain to make sure it is active.
-            await tableGrain.ReadRows(tableGrainId);
+            await tableGrain.ReadRows(tableGrainId).WaitAsync(cancellationToken);
 
             (SiloAddress reminderTableGrainPrimaryDirectoryAddress, SiloAddress reminderGrainActivationSiloAddress) =
-                await GetReminderTableGrainAddresses(tableGrainId);
+                await GetReminderTableGrainAddresses(tableGrainId, cancellationToken);
 
             SortedList<int, SiloHandle> ids = new SortedList<int, SiloHandle>();
             foreach (var siloHandle in this.HostedCluster.GetActiveSilos())
@@ -343,7 +346,9 @@ namespace UnitTests.General
             return failures;
         }
 
-        private async Task<(SiloAddress DirectoryAddress, SiloAddress ActivationSiloAddress)> GetReminderTableGrainAddresses(GrainId tableGrainId)
+        private async Task<(SiloAddress DirectoryAddress, SiloAddress ActivationSiloAddress)> GetReminderTableGrainAddresses(
+            GrainId tableGrainId,
+            CancellationToken cancellationToken)
         {
             SiloAddress? directoryAddress = null;
             SiloAddress? activationSiloAddress = null;
@@ -353,7 +358,7 @@ namespace UnitTests.General
                 var primaryReport = await TestUtils.GetDetailedGrainReport(
                     this.HostedCluster.InternalGrainFactory!,
                     tableGrainId,
-                    this.HostedCluster.Primary!);
+                    this.HostedCluster.Primary!).WaitAsync(cancellationToken);
 
                 if (primaryReport.PrimaryForGrain is not { } primaryForGrain)
                 {
@@ -369,7 +374,7 @@ namespace UnitTests.General
                 var directoryReport = await TestUtils.GetDetailedGrainReport(
                     this.HostedCluster.InternalGrainFactory!,
                     tableGrainId,
-                    directorySilo);
+                    directorySilo).WaitAsync(cancellationToken);
 
                 if (directoryReport.LocalDirectoryActivationAddress is not { } activationAddress)
                 {
@@ -378,24 +383,29 @@ namespace UnitTests.General
 
                 directoryAddress = primaryForGrain;
                 activationSiloAddress = activationAddress.SiloAddress;
-            }, failureTimeout);
+            }, failureTimeout, cancellationToken);
 
             return (
                 directoryAddress ?? throw new XunitException($"No primary directory silo was reported for reminder table grain {tableGrainId}."),
                 activationSiloAddress ?? throw new XunitException($"No activation silo was reported for reminder table grain {tableGrainId}."));
         }
 
-        private static async Task AssertEventually(Func<Task> assertion, TimeSpan timeout)
+        private static async Task AssertEventually(Func<Task> assertion, TimeSpan timeout, CancellationToken cancellationToken)
         {
-            await AssertEventually(assertion, timeout, TimeSpan.FromMilliseconds(500));
+            await AssertEventually(assertion, timeout, TimeSpan.FromMilliseconds(500), cancellationToken);
         }
 
-        private static async Task AssertEventually(Func<Task> assertion, TimeSpan timeout, TimeSpan delayBetweenIterations)
+        private static async Task AssertEventually(
+            Func<Task> assertion,
+            TimeSpan timeout,
+            TimeSpan delayBetweenIterations,
+            CancellationToken cancellationToken)
         {
             var sw = Stopwatch.StartNew();
 
             while (true)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     await assertion();
@@ -411,7 +421,7 @@ namespace UnitTests.General
 
                 if (delayBetweenIterations > TimeSpan.Zero)
                 {
-                    Thread.Sleep(delayBetweenIterations);
+                    await Task.Delay(delayBetweenIterations, cancellationToken);
                 }
             }
         }

--- a/test/Orleans.Runtime.Internal.Tests/General/RequestContextTest.cs
+++ b/test/Orleans.Runtime.Internal.Tests/General/RequestContextTest.cs
@@ -346,32 +346,33 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
         public async Task Halo_RequestContextShouldBeMaintainedWhenThreadHoppingOccurs()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             int numTasks = 20;
             Task[] tasks = new Task[numTasks];
 
             for (int i = 0; i < numTasks; i++)
             {
                 var closureInt = i;
-                async Task func() { await ContextTester(closureInt); }
-                tasks[i] = Task.Run(func);
+                async Task func() { await ContextTester(closureInt, cancellationToken); }
+                tasks[i] = Task.Run(func, cancellationToken);
             }
 
             await Task.WhenAll(tasks);
         }
 
-        private async Task ContextTester(int i)
+        private async Task ContextTester(int i, CancellationToken cancellationToken)
         {
             RequestContext.Set("threadId", i);
             int contextId = (int)(RequestContext.Get("threadId") ?? -1);
             output.WriteLine("ExplicitId={0}, ContextId={2}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, contextId);
-            await FrameworkContextVerification(i).ConfigureAwait(false);
+            await FrameworkContextVerification(i, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task FrameworkContextVerification(int id)
+        private async Task FrameworkContextVerification(int id, CancellationToken cancellationToken)
         {
             for (int i = 0; i < 10; i++)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, cancellationToken);
                 int contextId = (int)(RequestContext.Get("threadId") ?? -1);
                 output.WriteLine("Inner, in loop {0}, Explicit Id={2}, ContextId={3}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, id, contextId);
                 Assert.Equal(id, contextId);
@@ -396,32 +397,33 @@ namespace UnitTests.General
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
         public async Task Halo_LogicalCallContextShouldBeMaintainedWhenThreadHoppingOccurs()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             int numTasks = 20;
             Task[] tasks = new Task[numTasks];
 
             for (int i = 0; i < numTasks; i++)
             {
                 var closureInt = i;
-                async Task func() { await ContextTester(closureInt); }
-                tasks[i] = Task.Run(func);
+                async Task func() { await ContextTester(closureInt, cancellationToken); }
+                tasks[i] = Task.Run(func, cancellationToken);
             }
 
             await Task.WhenAll(tasks);
         }
 
-        private async Task ContextTester(int i)
+        private async Task ContextTester(int i, CancellationToken cancellationToken)
         {
             threadId.Value = i;
             int contextId = threadId.Value;
             output.WriteLine("ExplicitId={0}, ContextId={2}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, contextId);
-            await FrameworkContextVerification(i).ConfigureAwait(false);
+            await FrameworkContextVerification(i, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task FrameworkContextVerification(int id)
+        private async Task FrameworkContextVerification(int id, CancellationToken cancellationToken)
         {
             for (int i = 0; i < 10; i++)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, cancellationToken);
                 int contextId = threadId.Value;
                 output.WriteLine("Inner, in loop {0}, Explicit Id={2}, ContextId={3}, ManagedThreadId={1}", i, Environment.CurrentManagedThreadId, id, contextId);
                 Assert.Equal(id, contextId);

--- a/test/Orleans.Runtime.Internal.Tests/GrainLocatorActivationResiliencyTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GrainLocatorActivationResiliencyTests.cs
@@ -54,6 +54,7 @@ namespace UnitTests
         [Fact, TestCategory("BVT")]
         public async Task ReactivateGrainWithPoisonGrainDirectoryEntry_LocalSilo()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var primarySilo = (InProcessSiloHandle)Fixture.HostedCluster.Primary!;
             var primarySiloAddress = primarySilo.SiloAddress;
             var grain = GrainFactory.GetGrain<IGuidTestGrain>(Guid.NewGuid());
@@ -64,7 +65,7 @@ namespace UnitTests
             // This simulates a stale entry from a crashed/deactivated grain
             var grainLocator = primarySilo.SiloHost.Services.GetRequiredService<GrainLocator>();
             var badAddress = GrainAddress.GetAddress(primarySiloAddress, grain.GetGrainId(), ActivationId.NewId());
-            await grainLocator.Register(badAddress, previousRegistration: null);
+            await grainLocator.Register(badAddress, previousRegistration: null, cancellationToken);
 
             {
                 // Force placement on the primary silo using placement hint
@@ -90,6 +91,7 @@ namespace UnitTests
         [Fact, TestCategory("BVT")]
         public async Task ReactivateGrainWithPoisonGrainDirectoryEntry_RemoteSilo()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var primarySilo = (InProcessSiloHandle)Fixture.HostedCluster.Primary!;
             var secondarySiloAddress = Fixture.HostedCluster.SecondarySilos.First().SiloAddress;
             var primarySiloAddress = primarySilo.SiloAddress;
@@ -100,7 +102,7 @@ namespace UnitTests
             // and forward the request to primary, where recovery will occur
             var grainLocator = primarySilo.SiloHost.Services.GetRequiredService<GrainLocator>();
             var badAddress = GrainAddress.GetAddress(primarySiloAddress, grain.GetGrainId(), ActivationId.NewId());
-            await grainLocator.Register(badAddress, previousRegistration: null);
+            await grainLocator.Register(badAddress, previousRegistration: null, cancellationToken);
 
             {
                 // Attempt placement on secondary silo, but the directory entry

--- a/test/Orleans.Runtime.Internal.Tests/Manifest/ClusterManifestStabilizationTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Manifest/ClusterManifestStabilizationTests.cs
@@ -14,7 +14,7 @@ public sealed class ClusterManifestStabilizationTests
     {
         var builder = new InProcessTestClusterBuilder(2);
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
         await cluster.WaitForClusterManifestToStabilizeAsync();
 
         await cluster.StartAdditionalSiloAsync();

--- a/test/Orleans.Runtime.Internal.Tests/MembershipTests/ClientIdPartitionDataRebuildTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/MembershipTests/ClientIdPartitionDataRebuildTests.cs
@@ -27,9 +27,9 @@ namespace UnitTests.MembershipTests
                 this.semaphore.Release();
             }
 
-            public async Task WaitForNotification(int expectedA, int expectedB, TimeSpan timeout)
+            public async Task WaitForNotification(int expectedA, int expectedB, TimeSpan timeout, CancellationToken cancellationToken)
             {
-                Assert.True(await this.semaphore.WaitAsync(timeout), "No notification received");
+                Assert.True(await this.semaphore.WaitAsync(timeout, cancellationToken), "No notification received");
                 Assert.Equal(expectedA, this.lastA);
                 Assert.Equal(expectedB, this.lastB);
             }
@@ -48,8 +48,9 @@ namespace UnitTests.MembershipTests
         //[Fact(typeof(SiloUnavailableException)), TestCategory("Functional")]
         public async Task ReconstructClientIdPartitionTest_Observer()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             // Ensure the client entry is on Silo2 partition and get a grain that live on Silo3
-            var grain = await SetupTestAndPickGrain<ISimpleObserverableGrain>(g => g.GetRuntimeInstanceId());
+            var grain = await SetupTestAndPickGrain<ISimpleObserverableGrain>(g => g.GetRuntimeInstanceId(), cancellationToken);
             var observer = new Observer();
             var reference = this.hostedCluster.GrainFactory!.CreateObjectReference<ISimpleGrainObserver>(observer);
 
@@ -57,44 +58,48 @@ namespace UnitTests.MembershipTests
 
             // Test first notification
             await grain.SetA(10);
-            await observer.WaitForNotification(10, 0, TimeSpan.FromSeconds(10));
+            await observer.WaitForNotification(10, 0, TimeSpan.FromSeconds(10), cancellationToken);
 
             // Kill the silo that hold directory client entry
-            await this.hostedCluster.SecondarySilos[0].StopSiloAsync(stopGracefully: false);
-            await Task.Delay(5000);
+            await this.hostedCluster.SecondarySilos[0].StopSiloAsync(stopGracefully: false, cancellationToken);
+            await Task.Delay(5000, cancellationToken);
 
             // Second notification should work since the directory was "rebuilt" when
             // silos in cluster detected the dead one
             await grain.SetB(20);
-            await observer.WaitForNotification(10, 20, TimeSpan.FromSeconds(10));
+            await observer.WaitForNotification(10, 20, TimeSpan.FromSeconds(10), cancellationToken);
         }
 
         [Fact(Skip = "Not reliable in PR build, skipping for now")]
         //[Fact(typeof(SiloUnavailableException)), TestCategory("Functional")]
         public async Task ReconstructClientIdPartitionTest_Request()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             // Ensure the client entry is on Silo2 partition and get a grain that live on Silo2
-            var grain = await SetupTestAndPickGrain<ITestGrain>(g => g.GetRuntimeInstanceId());
+            var grain = await SetupTestAndPickGrain<ITestGrain>(g => g.GetRuntimeInstanceId(), cancellationToken);
 
             // Launch a long task and kill the silo that hold directory client entry
             var promise = grain.DoLongAction(TimeSpan.FromSeconds(10), "LongAction");
-            await this.hostedCluster.SecondarySilos[0].StopSiloAsync(stopGracefully: false);
+            await this.hostedCluster.SecondarySilos[0].StopSiloAsync(stopGracefully: false, cancellationToken);
 
             // It should work since the directory was "rebuilt" when
             // silos in cluster detected the dead one
-            await promise;
+            await promise.WaitAsync(cancellationToken);
         }
 
-        private async Task<T> SetupTestAndPickGrain<T>(Func<T, Task<string>> getRuntimeInstanceId) where T : class, IGrainWithIntegerKey
+        private async Task<T> SetupTestAndPickGrain<T>(
+            Func<T, Task<string>> getRuntimeInstanceId,
+            CancellationToken cancellationToken) where T : class, IGrainWithIntegerKey
         {
             // Ensure the client entry is on Silo2 partition
             GrainId clientId = default;
             CreateAndDeployTestCluster();
             for (var i = 0; i < 100; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (this.hostedCluster.Client! == null)
                 {
-                    await this.hostedCluster.InitializeClientAsync();
+                    await this.hostedCluster.InitializeClientAsync(cancellationToken);
                 }
 
                 var client = this.hostedCluster.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
@@ -113,8 +118,9 @@ namespace UnitTests.MembershipTests
             T? grain = null;
             for (var i = 0; i < 100; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 grain = this.hostedCluster.GrainFactory!.GetGrain<T>(i);
-                var instanceId = await getRuntimeInstanceId(grain);
+                var instanceId = await getRuntimeInstanceId(grain).WaitAsync(cancellationToken);
                 if (instanceId.Contains(hostedCluster.SecondarySilos[1].SiloAddress.Endpoint.ToString()))
                 {
                     break;

--- a/test/Orleans.Runtime.Internal.Tests/MessageScheduling/ReentrancyTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/MessageScheduling/ReentrancyTests.cs
@@ -58,11 +58,12 @@ namespace UnitTests
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         public async Task ReentrantGrain()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var reentrant = this.fixture.GrainFactory.GetGrain<IReentrantGrain>(GetRandomGrainId());
             await reentrant.SetSelf(reentrant);
 
             // Should reenter
-            await reentrant.Two().WaitAsync(TimeSpan.FromSeconds(5));
+            await reentrant.Two().WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
             this.fixture.Logger.LogInformation("Reentrancy ReentrantGrain Test finished OK.");
         }
 
@@ -72,11 +73,12 @@ namespace UnitTests
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         public async Task NonReentrantGrain_WithMayInterleaveStaticPredicate_WhenPredicateReturnsTrue()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.fixture.GrainFactory.GetGrain<IMayInterleaveStaticPredicateGrain>(GetRandomGrainId());
             await grain.SetSelf(grain);
 
             // Should reenter since predicate should return true.
-            await grain.TwoReentrant().WaitAsync(TimeSpan.FromSeconds(5));
+            await grain.TwoReentrant().WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
             this.fixture.Logger.LogInformation("Reentrancy NonReentrantGrain_WithMayInterleaveStaticPredicate_WhenPredicateReturnsTrue Test finished OK.");
         }
 
@@ -88,15 +90,16 @@ namespace UnitTests
         [InlineData(false)]
         public async Task MayInterleavePredicate_AllowsInterleaving(bool mayInterleaveFirst)
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             // Create a unique grain per run
             var grainKey = $"grain-{mayInterleaveFirst}";
             var grain = this.fixture.GrainFactory.GetGrain<ICallOrderingGrain>(grainKey);
 
             Task first = mayInterleaveFirst ? grain.MethodA() : grain.MethodB();
-            await Task.Delay(250); // Stagger second call
+            await Task.Delay(250, cancellationToken); // Stagger second call
             Task second = mayInterleaveFirst ? grain.MethodB() : grain.MethodA();
 
-            await Task.Delay(500); // Let both methods reach entry point
+            await Task.Delay(500, cancellationToken); // Let both methods reach entry point
 
             await grain.Unblock();
             await Task.WhenAll(first, second);
@@ -118,11 +121,16 @@ namespace UnitTests
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         public async Task NonReentrantGrain_WithMayInterleaveStaticPredicate_WhenPredicateThrows()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.fixture.GrainFactory.GetGrain<IMayInterleaveStaticPredicateGrain>(GetRandomGrainId());
             await grain.SetSelf(grain);
             try
             {
-                await grain.Exceptional().WaitAsync(TimeSpan.FromSeconds(2));
+                await grain.Exceptional().WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -139,11 +147,12 @@ namespace UnitTests
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         public async Task NonReentrantGrain_WithMayInterleaveInstancedPredicate_WhenPredicateReturnsTrue()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.fixture.GrainFactory.GetGrain<IMayInterleaveInstancedPredicateGrain>(GetRandomGrainId());
             await grain.SetSelf(grain);
 
             // Grain should reenter when MayInterleave predicate returns true
-            await grain.TwoReentrant().WaitAsync(TimeSpan.FromSeconds(2));
+            await grain.TwoReentrant().WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
             this.fixture.Logger.LogInformation("Reentrancy NonReentrantGrain_WithMayInterleaveInstancedPredicate_WhenPredicateReturnsTrue Test finished OK.");
         }
 
@@ -153,11 +162,16 @@ namespace UnitTests
         [Fact, TestCategory("Functional"), TestCategory("Tasks"), TestCategory("Reentrancy")]
         public async Task NonReentrantGrain_WithMayInterleaveInstancedPredicate_WhenPredicateThrows()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var grain = this.fixture.GrainFactory.GetGrain<IMayInterleaveInstancedPredicateGrain>(GetRandomGrainId());
             await grain.SetSelf(grain);
             try
             {
-                await grain.Exceptional().WaitAsync(TimeSpan.FromSeconds(2));
+                await grain.Exceptional().WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -308,7 +322,7 @@ namespace UnitTests
             const int numLoops = 5;
             const int blockSize = 10;
             TimeSpan timeout = TimeSpan.FromSeconds(40);
-            await Do_FanOut_Stress(numLoops, blockSize, timeout, false, false);
+            await Do_FanOut_Stress(numLoops, blockSize, timeout, false, false, TestContext.Current.CancellationToken);
         }
 
         [TestSuite("Functional")]
@@ -319,7 +333,7 @@ namespace UnitTests
             const int numLoops = 5;
             const int blockSize = 10;
             TimeSpan timeout = TimeSpan.FromSeconds(40);
-            await Do_FanOut_Stress(numLoops, blockSize, timeout, true, false);
+            await Do_FanOut_Stress(numLoops, blockSize, timeout, true, false, TestContext.Current.CancellationToken);
         }
 
         [TestSuite("Functional")]
@@ -330,7 +344,7 @@ namespace UnitTests
             const int numLoops = 5;
             const int blockSize = 10;
             TimeSpan timeout = TimeSpan.FromSeconds(40);
-            await Do_FanOut_Stress(numLoops, blockSize, timeout, false, true);
+            await Do_FanOut_Stress(numLoops, blockSize, timeout, false, true, TestContext.Current.CancellationToken);
         }
 
         [TestSuite("Functional")]
@@ -341,7 +355,7 @@ namespace UnitTests
             const int numLoops = 5;
             const int blockSize = 10;
             TimeSpan timeout = TimeSpan.FromSeconds(40);
-            await Do_FanOut_Stress(numLoops, blockSize, timeout, true, true);
+            await Do_FanOut_Stress(numLoops, blockSize, timeout, true, true, TestContext.Current.CancellationToken);
         }
 
         // ---------- Utility methods ----------
@@ -409,7 +423,7 @@ namespace UnitTests
         private readonly TimeSpan MaxStressExecutionTime = TimeSpan.FromMinutes(2);
 
         private async Task Do_FanOut_Stress(int numLoops, int blockSize, TimeSpan timeout,
-            bool doNonReentrant, bool doAC)
+            bool doNonReentrant, bool doAC, CancellationToken cancellationToken)
         {
             Stopwatch totalTime = Stopwatch.StartNew();
             List<Task> promises = new List<Task>();
@@ -426,10 +440,10 @@ namespace UnitTests
                     {
                         return doAC ? Do_FanOut_AC_Join(offset, doNonReentrant, false)
                                     : Do_FanOut_Task_Join(offset, doNonReentrant, false);
-                    });
+                    }, cancellationToken);
                     promises.Add(promise);
                     output.WriteLine("Inner loop {0} - Created Tasks. Elapsed={1}", j, innerClock.Elapsed);
-                    await Task.WhenAll(promises).WaitAsync(timeout);
+                    await Task.WhenAll(promises).WaitAsync(timeout, cancellationToken);
                     output.WriteLine("Inner loop {0} - Finished Join. Elapsed={1}", j, innerClock.Elapsed);
                     promises.Clear();
                 }

--- a/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
@@ -57,21 +57,22 @@ namespace UnitTests.StuckGrainTests
         [Fact, TestCategory("Functional"), TestCategory("ActivationCollection")]
         public async Task StuckGrainTest_Basic()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var id = Guid.NewGuid();
             var stuckGrain = this.fixture.GrainFactory.GetGrain<IStuckGrain>(id);
             var task = stuckGrain.RunForever();
 
             // Should timeout
-            await Assert.ThrowsAsync<TimeoutException>(() => task.WaitAsync(TimeSpan.FromSeconds(1)));
+            await Assert.ThrowsAsync<TimeoutException>(() => task.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken));
 
             var cleaner = this.fixture.GrainFactory.GetGrain<IStuckCleanGrain>(id);
             await cleaner.Release(id);
 
             // Should complete now
-            await task.WaitAsync(TimeSpan.FromSeconds(1));
+            await task.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken);
 
             // wait for activation collection
-            await Task.Delay(TimeSpan.FromSeconds(6));
+            await Task.Delay(TimeSpan.FromSeconds(6), cancellationToken);
 
             Assert.False(await cleaner.IsActivated(id), "Grain activation is supposed be garbage collected, but it is still running.");
         }
@@ -79,34 +80,36 @@ namespace UnitTests.StuckGrainTests
         [Fact, TestCategory("Functional"), TestCategory("ActivationCollection")]
         public async Task StuckGrainTest_StuckDetectionAndForward()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var id = Guid.NewGuid();
             var stuckGrain = this.fixture.GrainFactory.GetGrain<IStuckGrain>(id);
             var task = stuckGrain.RunForever();
 
             // Should timeout
-            await Assert.ThrowsAsync<TimeoutException>(() => task.WaitAsync(TimeSpan.FromSeconds(1)));
+            await Assert.ThrowsAsync<TimeoutException>(() => task.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken));
 
             var calls = new Task[3];
             for (var i = 0; i < calls.Length; i++)
             {
                 var call = stuckGrain.NonBlockingCall();
                 calls[i] = call;
-                await Task.WhenAny(call, Task.Delay(TimeSpan.FromMilliseconds(500)));
+                await Task.WhenAny(call, Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken));
             }
 
             // Wait so the first task will reach with DefaultCollectionAge timeout
-            await Task.Delay(TimeSpan.FromSeconds(3));
+            await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
 
             // No issue on this one
             await stuckGrain.NonBlockingCall();
 
             // All otherwise stuck calls should have been forwarded to a new activation.
-            await Task.WhenAll(calls).WaitAsync(TimeSpan.FromSeconds(10));
+            await Task.WhenAll(calls).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("ActivationCollection")]
         public async Task StuckGrainTest_StuckDetectionOnDeactivation()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var id = Guid.NewGuid();
             var stuckGrain = this.fixture.GrainFactory.GetGrain<IStuckGrain>(id);
             await stuckGrain.BlockingDeactivation();
@@ -116,7 +119,7 @@ namespace UnitTests.StuckGrainTests
             for (var i = 0; i < 3; i++)
             {
                 var call = stuckGrain.NonBlockingCall();
-                await Task.WhenAny(call, Task.Delay(TimeSpan.FromMilliseconds(500)));
+                await Task.WhenAny(call, Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken));
             }
 
             await TestingUtils.WaitUntilAsync(
@@ -131,13 +134,14 @@ namespace UnitTests.StuckGrainTests
                     return count == 3;
                 },
                 TimeSpan.FromSeconds(10),
-                TimeSpan.FromMilliseconds(200));
+                TimeSpan.FromMilliseconds(200),
+                cancellationToken);
 
             // No issue on this one
             await stuckGrain.NonBlockingCall();
 
             // All 4 otherwise stuck calls should have been forwarded to a new activation
-            Assert.Equal(4, await stuckGrain.GetNonBlockingCallCounter());
+            Assert.Equal(4, await stuckGrain.GetNonBlockingCallCounter(cancellationToken));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("ActivationCollection")]

--- a/test/Orleans.Runtime.Internal.Tests/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/Orleans.Runtime.Internal.Tests/RemindersTest/ReminderTableTestsBase.cs
@@ -184,7 +184,8 @@ namespace UnitTests.RemindersTest
 
         [Fact, TestCategory("ModelBased")]
         public Task ReminderTable_ModelBasedGeneratedConformance()
-            => new ReminderTableModelBasedTestRunner(remindersTable, GetType().Name).RunGeneratedConformanceTests();
+            => new ReminderTableModelBasedTestRunner(remindersTable, GetType().Name)
+                .RunGeneratedConformanceTests(TestContext.Current.CancellationToken);
 
         private sealed class ProviderReminderTableTestRunner(IReminderTable table, string providerName)
             : ReminderTableTestRunner(table, providerName);

--- a/test/Orleans.Runtime.Internal.Tests/SiloMetadataTests/SiloMetadataTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/SiloMetadataTests/SiloMetadataTests.cs
@@ -108,7 +108,7 @@ public class SiloMetadataTests(SiloMetadataTests.Fixture fixture) : IClassFixtur
         Assert.NotNull(metadata);
         Assert.NotEmpty(metadata.Metadata);
 
-        await fixture.Cluster.StopSiloAsync(second);
+        await fixture.Cluster.StopSiloAsync(second, TestContext.Current.CancellationToken);
         metadata = firstSiloMetadataCache.GetSiloMetadata(second.SiloAddress);
         Assert.NotNull(metadata);
         Assert.Empty(metadata.Metadata);

--- a/test/Orleans.Runtime.Internal.Tests/StorageTests/PersistenceGrainTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/StorageTests/PersistenceGrainTests.cs
@@ -660,7 +660,7 @@ namespace UnitTests.StorageTests
             Assert.Equal(expectedVal, val); // Returned value
             await SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
 
-            await CheckStorageProviderErrors(grain.DoRead);
+            await CheckStorageProviderErrors(grain.DoRead, TestContext.Current.CancellationToken);
 
             await SetErrorInjection(providerName, ErrorInjectionPoint.None);
 
@@ -690,7 +690,7 @@ namespace UnitTests.StorageTests
             Assert.Equal(expectedVal, val); // Returned value
 
             await SetErrorInjection(providerName, ErrorInjectionPoint.AfterRead);
-            await CheckStorageProviderErrors(grain.DoRead);
+            await CheckStorageProviderErrors(grain.DoRead, TestContext.Current.CancellationToken);
 
             val = await grain.GetValue();
             Assert.Equal(expectedVal, val); // Returned value
@@ -728,7 +728,7 @@ namespace UnitTests.StorageTests
 
             const int attemptedVal3 = 63;
             await SetErrorInjection(providerName, ErrorInjectionPoint.BeforeWrite);
-            await CheckStorageProviderErrors(() => grain.DoWrite(attemptedVal3));
+            await CheckStorageProviderErrors(() => grain.DoWrite(attemptedVal3), TestContext.Current.CancellationToken);
 
             // Stored value unchanged
             providerState = GetStateForStorageProviderInUse<ErrorInjectionStorageProvider>(providerName);
@@ -770,7 +770,10 @@ namespace UnitTests.StorageTests
                 ErrorInjectionPoint = ErrorInjectionPoint.BeforeWrite,
                 ExceptionType = typeof(InconsistentStateException)
             });
-            await CheckStorageProviderErrors(() => grain.DoWrite(attemptedVal3), typeof(InconsistentStateException));
+            await CheckStorageProviderErrors(
+                () => grain.DoWrite(attemptedVal3),
+                TestContext.Current.CancellationToken,
+                typeof(InconsistentStateException));
 
             // Stored value unchanged
             providerState = GetStateForStorageProviderInUse<ErrorInjectionStorageProvider>(providerName);
@@ -811,7 +814,10 @@ namespace UnitTests.StorageTests
                 ErrorInjectionPoint = ErrorInjectionPoint.BeforeWrite,
                 ExceptionType = typeof(InconsistentStateException)
             });
-            await CheckStorageProviderErrors(() => proxy.DoWrite(63, target), typeof(InconsistentStateException));
+            await CheckStorageProviderErrors(
+                () => proxy.DoWrite(63, target),
+                TestContext.Current.CancellationToken,
+                typeof(InconsistentStateException));
 
             // The target should have been deactivated by the exception.
             Assert.NotEqual(targetActivationId, await target.GetActivationId());
@@ -839,7 +845,7 @@ namespace UnitTests.StorageTests
 
             const int attemptedVal4 = 83;
             await SetErrorInjection(providerName, ErrorInjectionPoint.AfterWrite);
-            await CheckStorageProviderErrors(() => grain.DoWrite(attemptedVal4));
+            await CheckStorageProviderErrors(() => grain.DoWrite(attemptedVal4), TestContext.Current.CancellationToken);
 
             // Stored value has changed
             expectedVal = attemptedVal4;
@@ -873,7 +879,7 @@ namespace UnitTests.StorageTests
             Assert.Equal(expectedVal, providerState.LastStoredGrainState!.Field1); // Store-Field1
 
             await SetErrorInjection(providerName, ErrorInjectionPoint.BeforeRead);
-            await CheckStorageProviderErrors(grain.DoRead);
+            await CheckStorageProviderErrors(grain.DoRead, TestContext.Current.CancellationToken);
 
             await SetErrorInjection(providerName, ErrorInjectionPoint.None);
             val = await grain.GetValue();
@@ -906,7 +912,7 @@ namespace UnitTests.StorageTests
             expectedVal = 94;
             SetStoredValue<ErrorInjectionStorageProvider>(providerName, DefaultGrainStateName, grain, "Field1", expectedVal);
             await SetErrorInjection(providerName, ErrorInjectionPoint.AfterRead);
-            await CheckStorageProviderErrors(grain.DoRead);
+            await CheckStorageProviderErrors(grain.DoRead, TestContext.Current.CancellationToken);
 
             await SetErrorInjection(providerName, ErrorInjectionPoint.None);
             val = await grain.GetValue();
@@ -1003,7 +1009,7 @@ namespace UnitTests.StorageTests
 
             int newVal = expectedVal + 1;
             await SetErrorInjection(providerName, ErrorInjectionPoint.BeforeWrite);
-            await CheckStorageProviderErrors(() => grain.DoWrite(newVal, false));
+            await CheckStorageProviderErrors(() => grain.DoWrite(newVal, false), TestContext.Current.CancellationToken);
 
             val = await grain.GetValue();
             // Stored value unchanged
@@ -1169,6 +1175,7 @@ namespace UnitTests.StorageTests
         [Fact, TestCategory("Persistence"), TestCategory("Serialization"), TestCategory("CorePerf"), TestCategory("Stress")]
         public async Task Serialize_GrainState_DeepCopy_Stress()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             int num = 100;
             int loops = num * 100;
             GrainStateContainingGrainReferences[] states = new GrainStateContainingGrainReferences[num];
@@ -1184,10 +1191,10 @@ namespace UnitTests.StorageTests
             for (int i = 0; i < loops; i++)
             {
                 int idx = Random.Shared.Next(num);
-                tasks.Add(Task.Run(() => { var copy = this.HostedCluster.DeepCopy(states[idx]); }));
-                tasks.Add(Task.Run(() => { var other = this.HostedCluster.RoundTripSerializationForTesting(states[idx]); }));
+                tasks.Add(Task.Run(() => { var copy = this.HostedCluster.DeepCopy(states[idx]); }, cancellationToken));
+                tasks.Add(Task.Run(() => { var other = this.HostedCluster.RoundTripSerializationForTesting(states[idx]); }, cancellationToken));
             }
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).WaitAsync(cancellationToken);
 
             //Task copyTask = Task.Run(() =>
             //{
@@ -1338,13 +1345,16 @@ namespace UnitTests.StorageTests
             await ErrorInjectionStorageProvider.SetErrorInjection(providerName, errorInjectionBehavior, this.HostedCluster.GrainFactory!);
         }
 
-        private async Task CheckStorageProviderErrors(Func<Task> taskFunc, Type? expectedException = null)
+        private async Task CheckStorageProviderErrors(
+            Func<Task> taskFunc,
+            CancellationToken cancellationToken,
+            Type? expectedException = null)
         {
             StackTrace at = new StackTrace();
             TimeSpan timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(15);
             try
             {
-                await taskFunc().WaitAsync(timeout);
+                await taskFunc().WaitAsync(timeout, cancellationToken);
 
                 if (ErrorInjectionStorageProvider.DoInjectErrors)
                 {
@@ -1352,6 +1362,10 @@ namespace UnitTests.StorageTests
                     output.WriteLine("Assertion failed: {0}", msg);
                     Assert.Fail(msg);
                 }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception e)
             {

--- a/test/Orleans.Runtime.Internal.Tests/TestRunners/GrainPersistenceTestRunner.cs
+++ b/test/Orleans.Runtime.Internal.Tests/TestRunners/GrainPersistenceTestRunner.cs
@@ -327,6 +327,7 @@ public abstract class GrainPersistenceTestsRunner : OrleansTestingBase
     [Fact, TestCategory("Functional")]
     public async Task Grain_GrainStorage_SiloRestart()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         if (!IsDurableStorage) 
         {
             throw Xunit.Sdk.SkipException.ForSkip("This provider does not persist state, so cannot survive a silo restart.");
@@ -364,7 +365,7 @@ public abstract class GrainPersistenceTestsRunner : OrleansTestingBase
             await HostedCluster.RestartSiloAsync(silo);
         }
 
-        await HostedCluster.InitializeClientAsync();
+        await HostedCluster.InitializeClientAsync(cancellationToken);
 
         output.WriteLine("Silos restarted");
 

--- a/test/Orleans.Runtime.Internal.Tests/TimeoutTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/TimeoutTests.cs
@@ -61,6 +61,7 @@ namespace UnitTests
         [Fact, TestCategory("Functional"), TestCategory("Timeout")]
         public async Task Timeout_LongMethod()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             bool finished = false;
             var grainName = typeof (ErrorGrain).FullName;
             IErrorGrain grain = this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId(), grainName);
@@ -79,9 +80,13 @@ namespace UnitTests
             stopwatch.Start();
             try
             {
-                await promise.WaitAsync(timeout.Multiply(3));
+                await promise.WaitAsync(timeout.Multiply(3), cancellationToken);
                 finished = true;
                 Assert.Fail("Should have thrown");
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception exc)
             {
@@ -139,6 +144,7 @@ namespace UnitTests
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/3995"), TestCategory("SlowBVT")]
         public async Task CallThatShouldHaveBeenDroppedNotExecutedTest()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             var responseTimeout = TimeSpan.FromSeconds(2);
             this.runtimeClient.SetResponseTimeout(responseTimeout);
 
@@ -147,7 +153,7 @@ namespace UnitTests
             // First call: Takes 5 seconds but client times out after 2 seconds
             var delay = TimeSpan.FromSeconds(5);
             var firstCall = target.LongRunningTask(1, responseTimeout + delay);
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
             // Second call: Should be dropped because grain is still busy with first call
             var secondCall = target.LongRunningTask(2, TimeSpan.Zero);
 
@@ -164,7 +170,7 @@ namespace UnitTests
             }
 
             // Wait for first call to complete on the silo
-            await Task.Delay(delay);
+            await Task.Delay(delay, cancellationToken);
 
             // Verify only the first call executed (value = 1), second call was dropped
             Assert.Equal(1, await target.GetLastValue());

--- a/test/Orleans.Runtime.Tests/ClientConnectionTests/ClientConnectionEventTests.cs
+++ b/test/Orleans.Runtime.Tests/ClientConnectionTests/ClientConnectionEventTests.cs
@@ -25,7 +25,7 @@ public class ClientConnectionEventTests
             c.AddClusterConnectionLostHandler((sender, args) => tcs.TrySetResult());
         });
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         // Burst lot of call, to be sure that we are connected to all silos
         for (int i = 0; i < 100; i++)
@@ -34,7 +34,7 @@ public class ClientConnectionEventTests
             await grain.SetLabel(i.ToString());
         }
 
-        await cluster.StopAllSilosAsync();
+        await cluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         await tcs.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
     }
 
@@ -60,10 +60,10 @@ public class ClientConnectionEventTests
             });
         });
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         var silo = cluster.Silos[0];
-        await silo.StopSiloAsync(true);
+        await silo.StopSiloAsync(true, TestContext.Current.CancellationToken);
 
         await lostGatewayTcs.Task.WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
 

--- a/test/Orleans.Runtime.Tests/ClientConnectionTests/ClientConnectionRegisteredServiceEventTests.cs
+++ b/test/Orleans.Runtime.Tests/ClientConnectionTests/ClientConnectionRegisteredServiceEventTests.cs
@@ -89,7 +89,7 @@ namespace Tester
                     await grain.SetLabel(i.ToString());
                 }
 
-                await this.HostedCluster.StopAllSilosAsync();
+                await this.HostedCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
 
                 Assert.True(await semaphore.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
             }
@@ -122,7 +122,7 @@ namespace Tester
             try
             {
                 var silo = this.HostedCluster.SecondarySilos[0];
-                await silo.StopSiloAsync(true);
+                await silo.StopSiloAsync(true, TestContext.Current.CancellationToken);
 
                 Assert.True(await lostGatewaySemaphore.WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken));
 

--- a/test/Orleans.Runtime.Tests/ClientConnectionTests/GatewayConnectionTests.cs
+++ b/test/Orleans.Runtime.Tests/ClientConnectionTests/GatewayConnectionTests.cs
@@ -189,7 +189,7 @@ namespace Tester
             }
 
             // Close current client connection
-            await this.HostedCluster.StopClusterClientAsync();
+            await this.HostedCluster.StopClusterClientAsync(TestContext.Current.CancellationToken);
             var hostBuilder = new HostBuilder().UseOrleansClient(
                 (ctx, clientBuilder) =>
                 {

--- a/test/Orleans.Runtime.Tests/ClientConnectionTests/StallConnectionTests.cs
+++ b/test/Orleans.Runtime.Tests/ClientConnectionTests/StallConnectionTests.cs
@@ -61,7 +61,7 @@ namespace Tester.ClientConnectionTests
 
                 // Try to reconnect to GW
                 var stopwatch = Stopwatch.StartNew();
-                await this.HostedCluster.InitializeClientAsync();
+                await this.HostedCluster.InitializeClientAsync(TestContext.Current.CancellationToken);
                 stopwatch.Stop();
 
                 // Check that we were able to connect before the first connection timeout

--- a/test/Orleans.Runtime.Tests/Directories/MultipleGrainDirectoriesTests.cs
+++ b/test/Orleans.Runtime.Tests/Directories/MultipleGrainDirectoriesTests.cs
@@ -36,7 +36,7 @@ namespace Tester.Directories
             await Task.Delay(5000, TestContext.Current.CancellationToken);
 
             // Shutdown the secondary silo
-            await this.HostedCluster.StopSecondarySilosAsync();
+            await this.HostedCluster.StopSecondarySilosAsync(TestContext.Current.CancellationToken);
 
             // Activation on the primary silo should still be there, another activation should be
             // created for the other one

--- a/test/Orleans.Runtime.Tests/Forwarding/ShutdownSiloTests.cs
+++ b/test/Orleans.Runtime.Tests/Forwarding/ShutdownSiloTests.cs
@@ -93,7 +93,7 @@ namespace Tester.Forwarding
 
             // Shutdown the silo where the grain is
             await Task.Delay(500, TestContext.Current.CancellationToken);
-            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First());
+            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First(), TestContext.Current.CancellationToken);
 
             var results = await Task.WhenAll(tasks);
             Assert.Equal(results[99], HostedCluster.Primary!.SiloAddress.ToString());
@@ -110,7 +110,7 @@ namespace Tester.Forwarding
             var promise = grain.StartAndWaitTimerTick(PendingRequestTimerDueTime);
 
             await timerCreated.Task.WaitAsync(TimerReadinessTimeout, TestContext.Current.CancellationToken);
-            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First());
+            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First(), TestContext.Current.CancellationToken);
 
             await promise;
         }
@@ -129,7 +129,7 @@ namespace Tester.Forwarding
 
             await timerStarted.Task.WaitAsync(TimerReadinessTimeout, TestContext.Current.CancellationToken);
             AssertTimerTickDidNotCompleteSuccessfully(timerStopped.Task);
-            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First());
+            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First(), TestContext.Current.CancellationToken);
             AssertTimerTickDidNotCompleteSuccessfully(timerStopped.Task);
         }
 
@@ -145,7 +145,7 @@ namespace Tester.Forwarding
 
             await timerCreated.Task.WaitAsync(TimerReadinessTimeout, TestContext.Current.CancellationToken);
             AssertTaskDidNotCompleteSuccessfully(promise);
-            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First());
+            await HostedCluster.StopSiloAsync(HostedCluster.SecondarySilos.First(), TestContext.Current.CancellationToken);
             AssertTaskDidNotCompleteSuccessfully(promise);
         }
 

--- a/test/Orleans.Runtime.Tests/InsideRuntimeClientTests.cs
+++ b/test/Orleans.Runtime.Tests/InsideRuntimeClientTests.cs
@@ -19,7 +19,7 @@ public class InsideRuntimeClientTests
         var builder = new InProcessTestClusterBuilder(1);
         builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         var silo = cluster.Silos[0];
         var runtimeClient = silo.ServiceProvider.GetRequiredService<InsideRuntimeClient>();

--- a/test/Orleans.Runtime.Tests/MembershipTests/SilosStopTests.cs
+++ b/test/Orleans.Runtime.Tests/MembershipTests/SilosStopTests.cs
@@ -56,7 +56,7 @@ namespace UnitTests.MembershipTests
             var promise = grain.CallOtherLongRunningTask(target, true, TimeSpan.FromSeconds(7));
 
             await Task.Delay(500, TestContext.Current.CancellationToken);
-            await HostedCluster.KillSiloAsync(HostedCluster.SecondarySilos[0]);
+            await HostedCluster.KillSiloAsync(HostedCluster.SecondarySilos[0], TestContext.Current.CancellationToken);
 
             await Assert.ThrowsAsync<SiloUnavailableException>(() => promise);
         }

--- a/test/Orleans.Serialization.UnitTests/ManualVersionToleranceTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ManualVersionToleranceTests.cs
@@ -258,7 +258,7 @@ namespace Orleans.Serialization.UnitTests
                 return (writer.Position, writer.Session.ReferencedObjects.CurrentReferenceId);
             }
 
-            _ = await pipe.Writer.FlushAsync();
+            _ = await pipe.Writer.FlushAsync(TestContext.Current.CancellationToken);
             pipe.Writer.Complete();
 
             _ = pipe.Reader.TryRead(out var readResult);
@@ -323,7 +323,7 @@ namespace Orleans.Serialization.UnitTests
                 return (writer.Position, writer.Session.ReferencedObjects.CurrentReferenceId);
             }
 
-            _ = await pipe.Writer.FlushAsync();
+            _ = await pipe.Writer.FlushAsync(TestContext.Current.CancellationToken);
             pipe.Writer.Complete();
 
             _ = pipe.Reader.TryRead(out var readResult);

--- a/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
@@ -445,8 +445,9 @@ public abstract class StreamQueueCheckpointerTests
 
         public async Task RunNext(CancellationToken cancellationToken)
         {
-            await _callbackPosted.WaitAsync(cancellationToken)
-                .WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            Assert.True(
+                await _callbackPosted.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken),
+                "Timed out waiting for a synchronization-context callback.");
             (SendOrPostCallback Callback, object? State) workItem;
             lock (_callbacks)
             {

--- a/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
@@ -161,8 +161,8 @@ public abstract class StreamQueueCheckpointerTests
 
         await store.WaitForWriteAttempts(1);
         firstWrite.SetResult();
-        await context.RunNext();
-        await context.RunNext();
+        await context.RunNext(TestContext.Current.CancellationToken);
+        await context.RunNext(TestContext.Current.CancellationToken);
         Assert.Equal(["20"], store.CompletedWrites);
 
         var secondWrite = store.BlockNextWrite();
@@ -172,15 +172,15 @@ public abstract class StreamQueueCheckpointerTests
         }
 
         await store.WaitForWriteAttempts(2);
-        await context.RunNext();
+        await context.RunNext(TestContext.Current.CancellationToken);
 
         Assert.False(flush.IsCompleted);
         Assert.Equal(["20", "30"], store.WriteAttempts);
         Assert.Single(store.CompletedWrites);
 
         secondWrite.SetResult();
-        await context.RunNext();
-        await context.RunNext();
+        await context.RunNext(TestContext.Current.CancellationToken);
+        await context.RunNext(TestContext.Current.CancellationToken);
         await flush;
 
         Assert.Equal(["20", "30"], store.WriteAttempts);
@@ -443,9 +443,10 @@ public abstract class StreamQueueCheckpointerTests
             return new DelegateDisposable(() => SetSynchronizationContext(previous));
         }
 
-        public async Task RunNext()
+        public async Task RunNext(CancellationToken cancellationToken)
         {
-            await _callbackPosted.WaitAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            await _callbackPosted.WaitAsync(cancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
             (SendOrPostCallback Callback, object? State) workItem;
             lock (_callbacks)
             {

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/LeaseBasedQueueBalancerTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/LeaseBasedQueueBalancerTests.cs
@@ -24,7 +24,7 @@ public class LeaseBasedQueueBalancerTests
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
         var membershipUpdates = Channel.CreateUnbounded<ClusterMembershipSnapshot>();
         var membership = Substitute.For<IClusterMembershipService>();
-        membership.MembershipUpdates.Returns(membershipUpdates.Reader.ReadAllAsync());
+        membership.MembershipUpdates.Returns(membershipUpdates.Reader.ReadAllAsync(TestContext.Current.CancellationToken));
         var localSiloDetails = Substitute.For<ILocalSiloDetails>();
         localSiloDetails.SiloAddress.Returns(siloAddress);
         using var services = new ServiceCollection()
@@ -61,14 +61,14 @@ public class LeaseBasedQueueBalancerTests
 
         await balancer.Initialize(queueMapper);
         balancer.NotifyClusterMembershipChange([siloAddress]);
-        var requests = await acquireStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var requests = await acquireStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
         var shutdownTask = balancer.Shutdown();
         var acquiredLease = new AcquiredLease(requests[0].ResourceKey, options.LeaseLength, "token", DateTime.UtcNow);
 
         try
         {
             await Assert.ThrowsAsync<TimeoutException>(
-                () => shutdownTask.WaitAsync(TimeSpan.FromMilliseconds(100)));
+                () => shutdownTask.WaitAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken));
         }
         finally
         {

--- a/test/Orleans.Streaming.Tests/StreamingTests/BroadcastChannels/BroadcastChannelTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/BroadcastChannels/BroadcastChannelTests.cs
@@ -60,30 +60,58 @@ namespace Tester.StreamingTests.BroadcastChannel
         }
 
         [Fact]
-        public async Task ClientPublishSingleChannelTest() => await ClientPublishSingleChannelTestImpl(_provider);
+        public async Task ClientPublishSingleChannelTest() =>
+            await ClientPublishSingleChannelTestImpl(
+                _provider,
+                cancellationToken: TestContext.Current.CancellationToken);
 
         [Fact]
-        public async Task ClientPublishSingleChannelMultipleConsumersTest() => await MultipleSubscribersChannelTestImpl(_provider);
+        public async Task ClientPublishSingleChannelMultipleConsumersTest() =>
+            await MultipleSubscribersChannelTestImpl(
+                _provider,
+                cancellationToken: TestContext.Current.CancellationToken);
 
         [Fact]
-        public async Task ClientPublishMultipleChannelTest() => await ClientPublishMultipleChannelTestImpl(_provider);
+        public async Task ClientPublishMultipleChannelTest() =>
+            await ClientPublishMultipleChannelTestImpl(_provider, TestContext.Current.CancellationToken);
 
         [Fact]
-        public async Task MultipleSubscribersOneBadActorChannelTest() => await MultipleSubscribersOneBadActorChannelTestImpl(_provider);
+        public async Task MultipleSubscribersOneBadActorChannelTest() =>
+            await MultipleSubscribersOneBadActorChannelTestImpl(
+                _provider,
+                cancellationToken: TestContext.Current.CancellationToken);
 
         [Fact]
-        public async Task NonFireAndForgetClientPublishSingleChannelTest() => await ClientPublishSingleChannelTestImpl(_providerNonFireAndForget, false);
+        public async Task NonFireAndForgetClientPublishSingleChannelTest() =>
+            await ClientPublishSingleChannelTestImpl(
+                _providerNonFireAndForget,
+                fireAndForget: false,
+                cancellationToken: TestContext.Current.CancellationToken);
 
         [Fact]
-        public async Task NonFireAndForgetClientPublishMultipleChannelTest() => await ClientPublishMultipleChannelTestImpl(_providerNonFireAndForget);
+        public async Task NonFireAndForgetClientPublishMultipleChannelTest() =>
+            await ClientPublishMultipleChannelTestImpl(
+                _providerNonFireAndForget,
+                TestContext.Current.CancellationToken);
 
         [Fact]
-        public async Task NonFireAndForgetClientPublishSingleChannelMultipleConsumersTest() => await MultipleSubscribersChannelTestImpl(_providerNonFireAndForget, false);
+        public async Task NonFireAndForgetClientPublishSingleChannelMultipleConsumersTest() =>
+            await MultipleSubscribersChannelTestImpl(
+                _providerNonFireAndForget,
+                fireAndForget: false,
+                cancellationToken: TestContext.Current.CancellationToken);
 
         [Fact]
-        public async Task NonFireAndForgetMultipleSubscribersOneBadActorChannelTest() => await MultipleSubscribersOneBadActorChannelTestImpl(_providerNonFireAndForget, false);
+        public async Task NonFireAndForgetMultipleSubscribersOneBadActorChannelTest() =>
+            await MultipleSubscribersOneBadActorChannelTestImpl(
+                _providerNonFireAndForget,
+                fireAndForget: false,
+                cancellationToken: TestContext.Current.CancellationToken);
 
-        private async Task ClientPublishSingleChannelTestImpl(IBroadcastChannelProvider provider, bool fireAndForget = true)
+        private async Task ClientPublishSingleChannelTestImpl(
+            IBroadcastChannelProvider provider,
+            bool fireAndForget = true,
+            CancellationToken cancellationToken = default)
         {
             var grainKey = Guid.NewGuid().ToString("N");
             var channelId = ChannelId.Create("some-namespace", grainKey);
@@ -95,7 +123,8 @@ namespace Tester.StreamingTests.BroadcastChannel
             await stream.Publish(2);
             await stream.Publish(3);
 
-            using var cts = new CancellationTokenSource(CallTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(CallTimeout);
             await observer.WaitForDeliveryCountAsync(channelId, 3, providerName: null, cancellationToken: cts.Token);
 
             var grain = _fixture.Client.GetGrain<ISimpleSubscriberGrain>(grainKey);
@@ -116,7 +145,9 @@ namespace Tester.StreamingTests.BroadcastChannel
             }
         }
 
-        private async Task ClientPublishMultipleChannelTestImpl(IBroadcastChannelProvider provider)
+        private async Task ClientPublishMultipleChannelTestImpl(
+            IBroadcastChannelProvider provider,
+            CancellationToken cancellationToken)
         {
             var grainKey = Guid.NewGuid().ToString("N");
 
@@ -137,7 +168,8 @@ namespace Tester.StreamingTests.BroadcastChannel
 
             foreach (var channel in channels)
             {
-                using var cts = new CancellationTokenSource(CallTimeout);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(CallTimeout);
                 await observer.WaitForDeliveryCountAsync(channel.ChannelId, 1, providerName: null, cancellationToken: cts.Token);
 
                 var values = await grain.GetValues(channel.ChannelId);
@@ -147,7 +179,10 @@ namespace Tester.StreamingTests.BroadcastChannel
             }
         }
 
-        private async Task MultipleSubscribersChannelTestImpl(IBroadcastChannelProvider provider, bool fireAndForget = true)
+        private async Task MultipleSubscribersChannelTestImpl(
+            IBroadcastChannelProvider provider,
+            bool fireAndForget = true,
+            CancellationToken cancellationToken = default)
         {
             var grainKey = Guid.NewGuid().ToString("N");
             var channelId = ChannelId.Create("multiple-namespaces-0", grainKey);
@@ -160,7 +195,8 @@ namespace Tester.StreamingTests.BroadcastChannel
             await stream.Publish(3);
 
             // 3 items × 2 subscribers = 6 deliveries
-            using var cts = new CancellationTokenSource(CallTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(CallTimeout);
             await observer.WaitForDeliveryCountAsync(channelId, 6, providerName: null, cancellationToken: cts.Token);
 
             var grains = new ISubscriberGrain[]
@@ -189,7 +225,10 @@ namespace Tester.StreamingTests.BroadcastChannel
             }
         }
 
-        private async Task MultipleSubscribersOneBadActorChannelTestImpl(IBroadcastChannelProvider provider, bool fireAndForget = true)
+        private async Task MultipleSubscribersOneBadActorChannelTestImpl(
+            IBroadcastChannelProvider provider,
+            bool fireAndForget = true,
+            CancellationToken cancellationToken = default)
         {
             var grainKey = Guid.NewGuid().ToString("N");
             var channelId = ChannelId.Create("multiple-namespaces-0", grainKey);
@@ -204,7 +243,8 @@ namespace Tester.StreamingTests.BroadcastChannel
             if (fireAndForget)
             {
                 // 1 item × 2 subscribers = 2 deliveries
-                using var cts1 = new CancellationTokenSource(CallTimeout);
+                using var cts1 = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts1.CancelAfter(CallTimeout);
                 await observer.WaitForDeliveryCountAsync(channelId, 2, providerName: null, cancellationToken: cts1.Token);
 
                 var values = await badGrain.GetValues(channelId);
@@ -215,18 +255,20 @@ namespace Tester.StreamingTests.BroadcastChannel
             {
                 await stream.Publish(2);
                 // Wait for good grain delivery (total: 3 successful deliveries)
-                using var cts2 = new CancellationTokenSource(CallTimeout);
+                using var cts2 = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts2.CancelAfter(CallTimeout);
                 await observer.WaitForDeliveryCountAsync(channelId, 3, providerName: null, cancellationToken: cts2.Token);
 
                 // Bad grain callback is still invoked (but throws), so emit doesn't fire.
                 // Poll for the counter as the diagnostic event can't observe failed deliveries.
                 var counter = 0;
-                using var cts = new CancellationTokenSource(CallTimeout);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(CallTimeout);
                 while (!cts.IsCancellationRequested)
                 {
                     counter = await badGrain.GetOnPublishedCounter();
                     if (counter == 2) break;
-                    await Task.Delay(10);
+                    await Task.Delay(10, cancellationToken);
                 }
                 Assert.Equal(2, counter);
             }
@@ -239,7 +281,8 @@ namespace Tester.StreamingTests.BroadcastChannel
             await stream.Publish(3);
 
             // Wait for all remaining deliveries: 5 total (good: 3, bad: 2)
-            using var ctsFinal = new CancellationTokenSource(CallTimeout);
+            using var ctsFinal = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            ctsFinal.CancelAfter(CallTimeout);
             await observer.WaitForDeliveryCountAsync(channelId, 5, providerName: null, cancellationToken: ctsFinal.Token);
 
             var goodValues = await goodGrain.GetValues(channelId);

--- a/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
@@ -38,7 +38,7 @@ namespace Tester.StreamingTests
             await WaitForDroppedClientsAsync(droppedClients, gatewayObserver, cancellationToken);
 
             // initialize new client
-            await testHost.InitializeClientAsync();
+            await testHost.InitializeClientAsync(cancellationToken);
 
             // run test again.
             await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced, cancellationToken);
@@ -69,7 +69,7 @@ namespace Tester.StreamingTests
             await WaitForDroppedClientsAsync(droppedClients, gatewayObserver, cancellationToken);
 
             // initialize new client
-            await testHost.InitializeClientAsync();
+            await testHost.InitializeClientAsync(cancellationToken);
 
             eventCount[0] = 0;
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
@@ -21,27 +21,36 @@ namespace Tester.StreamingTests
             this.testHost = testHost;
         }
 
-        public async Task StreamProducerOnDroppedClientTest(string streamProviderName, string streamNamespace)
+        public async Task StreamProducerOnDroppedClientTest(
+            string streamProviderName,
+            string streamNamespace,
+            CancellationToken cancellationToken = default)
         {
             const int eventsProduced = 10;
             Guid streamGuid = Guid.NewGuid();
 
-            await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced);
+            await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced, cancellationToken);
 
             // Hard kill client
             var droppedClients = GetConnectedClients();
             using var gatewayObserver = GatewayDiagnosticObserver.Create();
             await testHost.KillClientAsync();
-            await WaitForDroppedClientsAsync(droppedClients, gatewayObserver);
+            await WaitForDroppedClientsAsync(droppedClients, gatewayObserver, cancellationToken);
 
             // initialize new client
             await testHost.InitializeClientAsync();
 
             // run test again.
-            await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced);
+            await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced, cancellationToken);
         }
 
-        public async Task StreamConsumerOnDroppedClientTest(string streamProviderName, string streamNamespace, ITestOutputHelper? output, Func<Task<int>>? getDeliveryFailureCount = null, bool waitForRetryTimeouts = false)
+        public async Task StreamConsumerOnDroppedClientTest(
+            string streamProviderName,
+            string streamNamespace,
+            ITestOutputHelper? output,
+            Func<Task<int>>? getDeliveryFailureCount = null,
+            bool waitForRetryTimeouts = false,
+            CancellationToken cancellationToken = default)
         {
             var hasDeliveryFailureCounter = getDeliveryFailureCount is not null;
             getDeliveryFailureCount ??= DefaultDeliveryFailureCount;
@@ -50,26 +59,27 @@ namespace Tester.StreamingTests
             var streamId = StreamId.Create(streamNamespace, streamGuid);
             int[] eventCount = {0};
 
-            var droppedSubscriptionId = await ProduceEventsToClient(streamProviderName, streamGuid, streamNamespace, 10, eventCount);
+            var droppedSubscriptionId = await ProduceEventsToClient(streamProviderName, streamGuid, streamNamespace, 10, eventCount, cancellationToken);
 
             // Hard kill client
             var droppedClients = GetConnectedClients();
             using var gatewayObserver = GatewayDiagnosticObserver.Create();
             using var streamingObserver = StreamingDiagnosticObserver.Create();
             await testHost.KillClientAsync();
-            await WaitForDroppedClientsAsync(droppedClients, gatewayObserver);
+            await WaitForDroppedClientsAsync(droppedClients, gatewayObserver, cancellationToken);
 
             // initialize new client
             await testHost.InitializeClientAsync();
 
             eventCount[0] = 0;
 
-            await ProduceEventsToClient(streamProviderName, streamGuid, streamNamespace, 10, eventCount);
+            await ProduceEventsToClient(streamProviderName, streamGuid, streamNamespace, 10, eventCount, cancellationToken);
 
             // Wait for the dropped client's subscription to be removed after delivery fails.
             if (waitForRetryTimeouts && hasDeliveryFailureCounter)
             {
-                using var cts = new CancellationTokenSource(_timeout);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(_timeout);
                 await streamingObserver.WaitForSubscriptionUnregisteredAsync(streamId, droppedSubscriptionId, streamProviderName, cts.Token);
             }
 
@@ -85,17 +95,23 @@ namespace Tester.StreamingTests
             return stream.SubscribeAsync(onNextAsync);
         }
 
-        private async Task ProduceEventsFromClient(string streamProviderName, Guid streamGuid, string streamNamespace, int eventsProduced)
+        private async Task ProduceEventsFromClient(
+            string streamProviderName,
+            Guid streamGuid,
+            string streamNamespace,
+            int eventsProduced,
+            CancellationToken cancellationToken)
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(_timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(_timeout);
             var streamId = StreamId.Create(streamNamespace, streamGuid);
 
             // get reference to a consumer
             var consumer = this.testHost.GrainFactory!.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid()); // The runner deploys the client.
 
             // subscribe
-            await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
+            await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName, cts.Token);
             var subscription = await observer.WaitForSubscriptionRegisteredAsync(streamId, streamProviderName, cts.Token);
             try
             {
@@ -107,7 +123,9 @@ namespace Tester.StreamingTests
             }
             finally
             {
-                await consumer.StopConsuming();
+                using var cleanup = new CancellationTokenSource(_timeout);
+                await consumer.StopConsuming(cleanup.Token)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
             }
         }
 
@@ -121,10 +139,17 @@ namespace Tester.StreamingTests
             }
         }
 
-        private async Task<Guid> ProduceEventsToClient(string streamProviderName, Guid streamGuid, string streamNamespace, int eventsProduced, int[] eventCount)
+        private async Task<Guid> ProduceEventsToClient(
+            string streamProviderName,
+            Guid streamGuid,
+            string streamNamespace,
+            int eventsProduced,
+            int[] eventCount,
+            CancellationToken cancellationToken)
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(_timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(_timeout);
             var streamId = StreamId.Create(streamNamespace, streamGuid);
 
             var subscription = await SubscribeToStream(streamProviderName, streamGuid, streamNamespace,
@@ -135,9 +160,9 @@ namespace Tester.StreamingTests
                 });
 
             var producer = this.testHost.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid()); // The runner deploys the client.
-            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cts.Token);
 
-            await ProduceExactCountAsync(producer, eventsProduced);
+            await ProduceExactCountAsync(producer, eventsProduced, cts.Token);
             await observer.WaitForItemDeliveryCountAsync(streamId, eventsProduced, streamProviderName, cts.Token);
 
             Assert.Equal(eventsProduced, eventCount[0]);
@@ -145,14 +170,18 @@ namespace Tester.StreamingTests
             return subscription.HandleId;
         }
 
-        private async Task WaitForDroppedClientsAsync(HashSet<ConnectedClient> droppedClients, GatewayDiagnosticObserver observer)
+        private async Task WaitForDroppedClientsAsync(
+            HashSet<ConnectedClient> droppedClients,
+            GatewayDiagnosticObserver observer,
+            CancellationToken cancellationToken)
         {
             if (droppedClients.Count == 0)
             {
                 return;
             }
 
-            using var cts = new CancellationTokenSource(GetClientDropWaitTimeout());
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(GetClientDropWaitTimeout());
             await observer.WaitForClientsDroppedAsync(droppedClients.Select(client => (client.SiloAddress, client.ClientId)), cts.Token);
 
             var remainingClients = GetConnectedClients();
@@ -190,11 +219,14 @@ namespace Tester.StreamingTests
             return (maxDropTimeout * 2) + TimeSpan.FromSeconds(10);
         }
 
-        private static async Task ProduceExactCountAsync(ISampleStreaming_ProducerGrain producer, int count)
+        private static async Task ProduceExactCountAsync(
+            ISampleStreaming_ProducerGrain producer,
+            int count,
+            CancellationToken cancellationToken)
         {
             for (var i = 0; i < count; i++)
             {
-                await producer.Produce();
+                await producer.Produce(cancellationToken);
             }
         }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -64,18 +64,18 @@ namespace UnitTests.StreamingTests
         public async Task ValidateControllableGeneratedStreamsTest()
         {
             this.fixture.Logger.LogInformation("************************ ValidateControllableGeneratedStreamsTest *********************************");
-            await ValidateControllableGeneratedStreams();
+            await ValidateControllableGeneratedStreams(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task Validate2ControllableGeneratedStreamsTest()
         {
             this.fixture.Logger.LogInformation("************************ Validate2ControllableGeneratedStreamsTest *********************************");
-            await ValidateControllableGeneratedStreams();
-            await ValidateControllableGeneratedStreams();
+            await ValidateControllableGeneratedStreams(TestContext.Current.CancellationToken);
+            await ValidateControllableGeneratedStreams(TestContext.Current.CancellationToken);
         }
 
-        private async Task ValidateControllableGeneratedStreams()
+        private async Task ValidateControllableGeneratedStreams(CancellationToken cancellationToken)
         {
             var generatorConfig = new SimpleGeneratorOptions
             {
@@ -95,7 +95,10 @@ namespace UnitTests.StreamingTests
                     Assert.True(controlCommandResult);
                 }
 
-                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(generatorConfig, lastTry, cancellationToken), Timeout);
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, token) => CheckCounters(generatorConfig, lastTry, token),
+                    Timeout,
+                    cancellationToken: cancellationToken);
             }
             finally
             {
@@ -127,9 +130,13 @@ namespace UnitTests.StreamingTests
 
         private async Task ResetReporter(string streamNamespace)
         {
+            using var cleanup = new CancellationTokenSource(Timeout);
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
-            await reporter.Reset();
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckReporterIsEmpty(reporter, streamNamespace, lastTry, cancellationToken), Timeout);
+            await reporter.Reset(cleanup.Token);
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, token) => CheckReporterIsEmpty(reporter, streamNamespace, lastTry, token),
+                Timeout,
+                cancellationToken: cleanup.Token);
         }
 
         private static async Task<bool> CheckReporterIsEmpty(IGeneratedEventReporterGrain reporter, string streamNamespace, bool assertIsTrue, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/DeactivationTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/DeactivationTestRunner.cs
@@ -42,18 +42,22 @@ namespace UnitTests.StreamingTests
             this.client = client;
         }
 
-        public async Task DeactivationTest(Guid streamGuid, string streamNamespace)
+        public async Task DeactivationTest(
+            Guid streamGuid,
+            string streamNamespace,
+            CancellationToken cancellationToken = default)
         {
             // get producer and consumer
             var producer = this.client.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
             var consumer = this.client.GetGrain<IMultipleSubscriptionConsumerGrain>(Guid.NewGuid());
 
             // subscribe (PubSubRendezvousGrain will have one consumer)
+            cancellationToken.ThrowIfCancellationRequested();
             StreamSubscriptionHandle<int> subscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
 
             // produce one message (PubSubRendezvousGrain will have one consumer and one producer)
-            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
-            await producer.Produce();
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cancellationToken);
+            await producer.Produce(cancellationToken);
 
             var count = await consumer.GetNumberConsumed();
 
@@ -72,10 +76,11 @@ namespace UnitTests.StreamingTests
             // resume producing after the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain grains have been deactivated:
 
             // BecomeProducer is hung due to deactivation deadlock?
-            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName).WaitAsync(Timeout);
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cancellationToken)
+                .WaitAsync(Timeout, cancellationToken);
 
             // Produce is hung due to deactivation deadlock?
-            await producer.Produce().WaitAsync(Timeout);
+            await producer.Produce(cancellationToken).WaitAsync(Timeout, cancellationToken);
 
             // consumer grain should continue to receive stream messages:
             count = await consumer.GetNumberConsumed();
@@ -83,7 +88,10 @@ namespace UnitTests.StreamingTests
             Assert.True(count[subscriptionHandle].Item1 == 2, "Consumer did not receive stream messages after PubSubRendezvousGrain and SampleStreaming_ProducerGrain reactivation");
         }
 
-        public async Task DeactivationTest_ClientConsumer(Guid streamGuid, string streamNamespace)
+        public async Task DeactivationTest_ClientConsumer(
+            Guid streamGuid,
+            string streamNamespace,
+            CancellationToken cancellationToken = default)
         {
             // get producer and consumer
             var producer = this.client.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
@@ -95,8 +103,8 @@ namespace UnitTests.StreamingTests
             StreamSubscriptionHandle<int> subscriptionHandle = await stream.SubscribeAsync((e, t) => count.Increment());
 
             // produce one message (PubSubRendezvousGrain will have one consumer and one producer)
-            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
-            await producer.Produce();
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cancellationToken);
+            await producer.Produce(cancellationToken);
 
             Assert.Equal(1, count.Value);
 
@@ -112,10 +120,11 @@ namespace UnitTests.StreamingTests
             // resume producing after the PubSubRendezvousGrain and the SampleStreaming_ProducerGrain grains have been deactivated:
 
             // BecomeProducer is hung due to deactivation deadlock?
-            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName).WaitAsync(Timeout);
+            await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cancellationToken)
+                .WaitAsync(Timeout, cancellationToken);
 
             // Produce is hung due to deactivation deadlock?
-            await producer.Produce().WaitAsync(Timeout);
+            await producer.Produce(cancellationToken).WaitAsync(Timeout, cancellationToken);
 
             Assert.Equal(2, count.Value); // Client consumer grain did not receive stream messages after PubSubRendezvousGrain and SampleStreaming_ProducerGrain reactivation
         }

--- a/test/Orleans.Streaming.Tests/StreamingTests/Filtering/StreamFilteringTestsBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/Filtering/StreamFilteringTestsBase.cs
@@ -85,6 +85,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
 
     public virtual async Task IgnoreBadFilter()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         EnsureStreamFilterIsRegistered();
 
         const int numberOfEvents = 10;
@@ -93,6 +94,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await grain.BecomeConsumer(streamId, ProviderName, "throw");
 
             var stream = this.clusterClient.GetStreamProvider(ProviderName).GetStream<int>(streamId);
@@ -102,7 +104,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
                 await stream.OnNextAsync(i);
             }
 
-            var history = await WaitForReceivedItemsAsync(grain, numberOfEvents);
+            var history = await WaitForReceivedItemsAsync(grain, numberOfEvents, cancellationToken: cancellationToken);
 
             Assert.Equal(numberOfEvents, history.Count);
             for (var i = 0; i < numberOfEvents; i++)
@@ -118,6 +120,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
 
     public virtual async Task OnlyEvenItems()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         EnsureStreamFilterIsRegistered();
 
         const int numberOfEvents = 10;
@@ -126,6 +129,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await grain.BecomeConsumer(streamId, ProviderName, "even");
 
             var stream = this.clusterClient.GetStreamProvider(ProviderName).GetStream<int>(streamId);
@@ -135,7 +139,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
                 await stream.OnNextAsync(i);
             }
 
-            var history = await WaitForReceivedItemsAsync(grain, numberOfEvents / 2);
+            var history = await WaitForReceivedItemsAsync(grain, numberOfEvents / 2, cancellationToken: cancellationToken);
 
             var idx = 0;
             for (var i = 0; i < numberOfEvents; i++)
@@ -155,6 +159,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
 
     public virtual async Task MultipleSubscriptionsDifferentFilterData()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         EnsureStreamFilterIsRegistered();
 
         const int numberOfEvents = 10;
@@ -163,6 +168,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await grain.BecomeConsumer(streamId, ProviderName, "only3");
             await grain.BecomeConsumer(streamId, ProviderName, "only7");
 
@@ -173,7 +179,7 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
                 await stream.OnNextAsync(i);
             }
 
-            var history = await WaitForReceivedItemsAsync(grain, 2);
+            var history = await WaitForReceivedItemsAsync(grain, 2, cancellationToken: cancellationToken);
 
             Assert.Equal(2, history.Count);
             Assert.Contains(3, history);
@@ -185,10 +191,15 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
         }
     }
 
-    private static async Task<List<int>> WaitForReceivedItemsAsync(IStreamingHistoryGrain grain, int expectedCount, TimeSpan? timeout = null)
+    private static async Task<List<int>> WaitForReceivedItemsAsync(
+        IStreamingHistoryGrain grain,
+        int expectedCount,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
-        using var cts = new CancellationTokenSource(effectiveTimeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(effectiveTimeout);
 
         while (!cts.Token.IsCancellationRequested)
         {
@@ -202,12 +213,13 @@ public abstract class StreamFilteringTestsBase : OrleansTestingBase
             {
                 await Task.Delay(100, cts.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 break;
             }
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var finalHistory = await grain.GetReceivedItems();
         Assert.True(finalHistory.Count >= expectedCount,
             $"Expected at least {expectedCount} items but got {finalHistory.Count} after {effectiveTimeout}");

--- a/test/Orleans.Streaming.Tests/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -77,7 +77,8 @@ namespace UnitTests.StreamingTests
             await runner.Recoverable100EventStreamsWithTransientErrors(GenerateEvents,
                 ImplicitSubscription_TransientError_RecoverableStream_CollectorGrain.StreamNamespace,
                 TotalQueueCount,
-                100);
+                100,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
@@ -87,10 +88,15 @@ namespace UnitTests.StreamingTests
             await runner.Recoverable100EventStreamsWith1NonTransientError(GenerateEvents,
                 ImplicitSubscription_NonTransientError_RecoverableStream_CollectorGrain.StreamNamespace,
                 TotalQueueCount,
-                100);
+                100,
+                TestContext.Current.CancellationToken);
         }
 
-        private async Task GenerateEvents(string streamNamespace, int streamCount, int eventsInStream)
+        private async Task GenerateEvents(
+            string streamNamespace,
+            int streamCount,
+            int eventsInStream,
+            CancellationToken cancellationToken)
         {
             var generatorConfig = new SimpleGeneratorOptions
             {
@@ -99,7 +105,10 @@ namespace UnitTests.StreamingTests
             };
 
             var mgmt = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);
-            object?[] results = await mgmt.SendControlCommandToProvider<PersistentStreamProvider>(Fixture.StreamProviderName, (int)StreamGeneratorCommand.Configure, generatorConfig);
+            object?[] results = await mgmt.SendControlCommandToProvider<PersistentStreamProvider>(
+                Fixture.StreamProviderName,
+                (int)StreamGeneratorCommand.Configure,
+                generatorConfig);
             Assert.Equal(2, results.Length);
             bool[] bResults = results.Cast<bool>().ToArray();
             foreach (var result in bResults)

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
@@ -66,7 +66,10 @@ namespace UnitTests.StreamingTests
             await stream.OnNextAsync(value);
 
             var consumer = fixture.GrainFactory.GetGrain<IImplicitSubscriptionLongKeyGrain>(grainId);
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckValue(consumer, value, lastTry, cancellationToken), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, cancellationToken) => CheckValue(consumer, value, lastTry, cancellationToken),
+                TimeSpan.FromSeconds(30),
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         private async Task<bool> CheckValue(IImplicitSubscriptionKeyTypeGrain consumer, int expectedValue, bool assertIsTrue, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
@@ -16,34 +16,80 @@ namespace Tester.StreamingTests
             this.streamProviderName = streamProviderName;
         }
 
-        public async Task Recoverable100EventStreamsWithTransientErrors(Func<string, int, int, Task> generateFn, string streamNamespace, int streamCount, int eventsInStream)
+        public async Task Recoverable100EventStreamsWithTransientErrors(
+            Func<string, int, int, CancellationToken, Task> generateFn,
+            string streamNamespace,
+            int streamCount,
+            int eventsInStream,
+            CancellationToken cancellationToken)
         {
             try
             {
-                await generateFn(streamNamespace, streamCount, eventsInStream);
-                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => this.CheckCounters(streamNamespace, streamCount, eventsInStream, lastTry, cancellationToken), TimeSpan.FromSeconds(30));
+                await generateFn(streamNamespace, streamCount, eventsInStream, cancellationToken);
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, token) => this.CheckCounters(streamNamespace, streamCount, eventsInStream, lastTry, token),
+                    TimeSpan.FromSeconds(30),
+                    cancellationToken: cancellationToken);
             }
             finally
             {
                 var reporter = this.grainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
-                reporter.Reset().Ignore();
+                using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await reporter.Reset(cleanup.Token)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
             }
         }
 
-        public async Task Recoverable100EventStreamsWith1NonTransientError(Func<string, int, int, Task> generateFn, string streamNamespace, int streamCount, int eventsInStream)
+        public Task Recoverable100EventStreamsWithTransientErrors(
+            Func<string, int, int, Task> generateFn,
+            string streamNamespace,
+            int streamCount,
+            int eventsInStream) =>
+            Recoverable100EventStreamsWithTransientErrors(
+                (namespaceValue, count, eventCount, _) =>
+                    generateFn(namespaceValue, count, eventCount),
+                streamNamespace,
+                streamCount,
+                eventsInStream,
+                CancellationToken.None);
+
+        public async Task Recoverable100EventStreamsWith1NonTransientError(
+            Func<string, int, int, CancellationToken, Task> generateFn,
+            string streamNamespace,
+            int streamCount,
+            int eventsInStream,
+            CancellationToken cancellationToken)
         {
             try
             {
-                await generateFn(streamNamespace, streamCount, eventsInStream);
+                await generateFn(streamNamespace, streamCount, eventsInStream, cancellationToken);
                 // should eventually skip the faulted event, so event count should be one (faulted event) less that number of events in stream.
-                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, lastTry, cancellationToken), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, token) => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, lastTry, token),
+                    TimeSpan.FromSeconds(90),
+                    cancellationToken: cancellationToken);
             }
             finally
             {
                 var reporter = this.grainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
-                reporter.Reset().Ignore();
+                using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await reporter.Reset(cleanup.Token)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
             }
         }
+
+        public Task Recoverable100EventStreamsWith1NonTransientError(
+            Func<string, int, int, Task> generateFn,
+            string streamNamespace,
+            int streamCount,
+            int eventsInStream) =>
+            Recoverable100EventStreamsWith1NonTransientError(
+                (namespaceValue, count, eventCount, _) =>
+                    generateFn(namespaceValue, count, eventCount),
+                streamNamespace,
+                streamCount,
+                eventsInStream,
+                CancellationToken.None);
 
         private async Task<bool> CheckCounters(string streamNamespace, int streamCount, int eventsInStream, bool assertIsTrue, CancellationToken cancellationToken)
         {

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
@@ -61,15 +61,23 @@ namespace Tester.StreamingTests
         public async Task BatchedMemoryStreamProducerOnDroppedClientTest()
         {
             this.fixture.Logger.LogInformation("************************ BatchedMemoryStreamProducerOnDroppedClientTest *********************************");
-            await runner.StreamProducerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace);
+            await runner.StreamProducerOnDroppedClientTest(
+                Fixture.StreamProviderName,
+                Fixture.StreamNamespace,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming")]
         public async Task BatchedMemoryStreamConsumerOnDroppedClientTest()
         {
             this.fixture.Logger.LogInformation("************************ BatchedMemoryStreamConsumerOnDroppedClientTest *********************************");
-            await runner.StreamConsumerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace, output,
-                    null, true);
+            await runner.StreamConsumerOnDroppedClientTest(
+                Fixture.StreamProviderName,
+                Fixture.StreamNamespace,
+                output,
+                null,
+                true,
+                TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderClientTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderClientTests.cs
@@ -84,7 +84,10 @@ namespace Tester.StreamingTests
         public async Task MemoryStreamProducerOnDroppedClientTest()
         {
             this.fixture.Logger.LogInformation("************************ MemoryStreamProducerOnDroppedClientTest *********************************");
-            await runner.StreamProducerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace);
+            await runner.StreamProducerOnDroppedClientTest(
+                Fixture.StreamProviderName,
+                Fixture.StreamNamespace,
+                TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -98,8 +101,13 @@ namespace Tester.StreamingTests
         public async Task MemoryStreamConsumerOnDroppedClientTest()
         {
             this.fixture.Logger.LogInformation("************************ MemoryStreamConsumerOnDroppedClientTest *********************************");
-            await runner.StreamConsumerOnDroppedClientTest(Fixture.StreamProviderName, Fixture.StreamNamespace, output,
-                    null, true);
+            await runner.StreamConsumerOnDroppedClientTest(
+                Fixture.StreamProviderName,
+                Fixture.StreamNamespace,
+                output,
+                null,
+                true,
+                TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
@@ -43,7 +43,8 @@ namespace Tester.StreamingTests
         public async Task ActiveImplicitSubscriptionRejectsRewindAndContinuesForward()
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
             var key = Guid.NewGuid();
             var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
@@ -90,7 +91,8 @@ namespace Tester.StreamingTests
         public async Task ObserverReplacementDuringFirstDeliveryPreservesRewindRejection()
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
             var key = Guid.NewGuid();
             var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemorySubscriptionMultiplicityTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemorySubscriptionMultiplicityTests.cs
@@ -23,7 +23,10 @@ public sealed class MemorySubscriptionMultiplicityTests : IClassFixture<MemorySu
 
     [Fact]
     public Task MemoryMultipleSubscriptionTest_AddRemove()
-        => _runner.MultipleSubscriptionTest_AddRemove(Guid.NewGuid(), StreamNamespace);
+        => _runner.MultipleSubscriptionTest_AddRemove(
+            Guid.NewGuid(),
+            StreamNamespace,
+            TestContext.Current.CancellationToken);
 
     public sealed class Fixture : BaseTestClusterFixture
     {

--- a/test/Orleans.Streaming.Tests/StreamingTests/MultipleStreamsTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MultipleStreamsTestRunner.cs
@@ -31,7 +31,10 @@ namespace UnitTests.Streaming
             logger.LogInformation("\n\n************************ {StreamProviderName}_{TestNumber}_{TestName} ********************************* \n\n", streamProviderName, testNumber, testName);
         }
 
-        public async Task StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(Func<SiloHandle>? startSiloFunc = null, Action<SiloHandle>? stopSiloFunc = null)
+        public async Task StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
+            Func<SiloHandle>? startSiloFunc = null,
+            Action<SiloHandle>? stopSiloFunc = null,
+            CancellationToken cancellationToken = default)
         {
             Heading("MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains");
             List<SingleStreamTestRunner> runners = new List<SingleStreamTestRunner>();
@@ -42,7 +45,7 @@ namespace UnitTests.Streaming
             }
             foreach (var runner in runners)
             {
-                tasks.Add(runner.StreamTest_Create_OneProducerGrainOneConsumerGrain());
+                tasks.Add(runner.StreamTest_Create_OneProducerGrainOneConsumerGrain(cancellationToken));
             }
             await Task.WhenAll(tasks);
             tasks.Clear();
@@ -55,7 +58,7 @@ namespace UnitTests.Streaming
 
             foreach (var runner in runners)
             {
-                tasks.Add(runner.BasicTestAsync(runFullTest));
+                tasks.Add(runner.BasicTestAsync(runFullTest, cancellationToken));
             }
             await Task.WhenAll(tasks);
             tasks.Clear();
@@ -68,7 +71,7 @@ namespace UnitTests.Streaming
 
                 foreach (var runner in runners)
                 {
-                    tasks.Add(runner.BasicTestAsync(runFullTest));
+                    tasks.Add(runner.BasicTestAsync(runFullTest, cancellationToken));
                 }
                 await Task.WhenAll(tasks);
                 tasks.Clear();

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -219,7 +219,7 @@ namespace UnitTests.StreamingTests
             timeProvider.Advance(new StreamPullingAgentOptions().StreamInactivityPeriod + TimeSpan.FromTicks(1));
             await testAccessor.ReadFromQueue(queueId, receiver, 1);
 
-            await inactive.WaitAsync(TimeSpan.FromSeconds(5));
+            await inactive.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             Assert.Empty(await testAccessor.GetPubSubCache());
         }
 
@@ -283,7 +283,8 @@ namespace UnitTests.StreamingTests
             secondConsumerData.Cursor = queueCache.GetCacheCursor(streamId, firstToken);
 
             Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 10));
-            await Task.WhenAll(firstConsumer.Delivered.Task, secondConsumer.Delivered.Task).WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.WhenAll(firstConsumer.Delivered.Task, secondConsumer.Delivered.Task)
+                .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             Assert.False(await testAccessor.ReadFromQueue(queueId, receiver, 10));
             await receiver.DidNotReceive().MessagesDeliveredAsync(
@@ -291,25 +292,27 @@ namespace UnitTests.StreamingTests
                 Arg.Any<CancellationToken>());
 
             firstConsumer.ReleaseDelivery();
-            await WaitForInactive(firstConsumerData);
+            await WaitForInactive(firstConsumerData, TestContext.Current.CancellationToken);
             Assert.False(await testAccessor.ReadFromQueue(queueId, receiver, 10));
             await receiver.DidNotReceive().MessagesDeliveredAsync(
                 Arg.Any<IList<IBatchContainer>>(),
                 Arg.Any<CancellationToken>());
 
             secondConsumer.ReleaseDelivery();
-            await WaitForInactive(secondConsumerData);
+            await WaitForInactive(secondConsumerData, TestContext.Current.CancellationToken);
             Assert.False(await testAccessor.ReadFromQueue(queueId, receiver, 10));
             await receiver.Received(1).MessagesDeliveredAsync(
                 Arg.Is<IList<IBatchContainer>>(items => items.Count == messages.Count),
                 Arg.Any<CancellationToken>());
 
-            static async Task WaitForInactive(StreamConsumerData consumerData)
+            static async Task WaitForInactive(
+                StreamConsumerData consumerData,
+                CancellationToken cancellationToken)
             {
                 var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(5);
                 while (consumerData.State != StreamConsumerDataState.Inactive && DateTime.UtcNow < timeout)
                 {
-                    await Task.Delay(10);
+                    await Task.Delay(10, cancellationToken);
                 }
 
                 Assert.Equal(StreamConsumerDataState.Inactive, consumerData.State);
@@ -674,13 +677,13 @@ namespace UnitTests.StreamingTests
             queueCache.Purge();
 
             Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 1));
-            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             consumer.ReleaseDelivery();
 
             var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(5);
             while (consumerData.State != StreamConsumerDataState.Inactive && DateTime.UtcNow < timeout)
             {
-                await Task.Delay(10);
+                await Task.Delay(10, TestContext.Current.CancellationToken);
             }
 
             Assert.Equal(StreamConsumerDataState.Inactive, consumerData.State);
@@ -736,7 +739,7 @@ namespace UnitTests.StreamingTests
 
             queueCache.ClearDeliveryProgress();
             await testAccessor.ReadFromQueue(queueId, receiver, maxCacheAddCount: 1);
-            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             queueCache.ClearDeliveryProgress();
             await testAccessor.Shutdown();
@@ -1056,7 +1059,7 @@ namespace UnitTests.StreamingTests
 
             queueCache.ClearDeliveryProgress();
             var shutdownTask = testAccessor.Shutdown();
-            await receiverShutdownStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await receiverShutdownStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
             Assert.Empty(queueCache.DeliveryProgressTokens);
             Assert.Equal(0, queueCache.DeliveryProgressCallCount);

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -8,11 +8,19 @@ namespace Tester.StreamingTests
     public class PluggableQueueBalancerTestBase : OrleansTestingBase
     {
         private readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
-        public virtual async Task ShouldUseInjectedQueueBalancerAndBalanceCorrectly(BaseTestClusterFixture fixture, string streamProviderName, int siloCount, int totalQueueCount)
+        public virtual async Task ShouldUseInjectedQueueBalancerAndBalanceCorrectly(
+            BaseTestClusterFixture fixture,
+            string streamProviderName,
+            int siloCount,
+            int totalQueueCount,
+            CancellationToken cancellationToken = default)
         {
             var leaseManager = fixture.GrainFactory.GetGrain<ILeaseManagerGrain>(streamProviderName);
             var expectedResponsibilityPerBalancer = totalQueueCount / siloCount;
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, lastTry, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, token) => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, lastTry, token),
+                Timeout,
+                cancellationToken: cancellationToken);
         }
 
         private async Task<bool> CheckLeases(ILeaseManagerGrain leaseManager, int siloCount, int expectedResponsibilityPerBalancer, bool lastTry, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
@@ -66,7 +66,12 @@ namespace Tester.StreamingTests.PlugableQueueBalancerTests
         [Fact, TestCategory("BVT")]
         public Task PluggableQueueBalancerTest_ShouldUseInjectedQueueBalancerAndBalanceCorrectly()
         {
-            return base.ShouldUseInjectedQueueBalancerAndBalanceCorrectly(this.fixture, StreamProviderName, siloCount, totalQueueCount);
+            return base.ShouldUseInjectedQueueBalancerAndBalanceCorrectly(
+                this.fixture,
+                StreamProviderName,
+                siloCount,
+                totalQueueCount,
+                TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestsRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestsRunner.cs
@@ -45,7 +45,8 @@ public abstract class ProgrammaticSubscribeTestsRunner
     public async Task StreamingTests_Consumer_Producer_Subscribe()
     {
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(_timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(_timeout);
         var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
         var streamId = new FullStreamIdentity(Guid.NewGuid(), "EmptySpace", StreamProviderName);
         var rxStreamId = StreamId.Create(streamId.Namespace, streamId.Guid);
@@ -54,9 +55,10 @@ public abstract class ProgrammaticSubscribeTestsRunner
         var consumers = subscriptions.Select(sub => this.fixture.HostedCluster.GrainFactory!.GetGrain<IPassive_ConsumerGrain>(sub.GrainId)).ToList();
 
         var producer = this.fixture.HostedCluster.GrainFactory!.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+        cts.Token.ThrowIfCancellationRequested();
         await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
-        await ProduceExactCountAsync(producer, EventCountPerPhase);
+        await ProduceExactCountAsync(producer, EventCountPerPhase, cts.Token);
         await observer.WaitForItemDeliveryCountAsync(rxStreamId, EventCountPerPhase * consumers.Count, StreamProviderName, cts.Token);
         await AssertCountersAsync(new[] { producer }, consumers, this.fixture.Logger);
 
@@ -67,7 +69,8 @@ public abstract class ProgrammaticSubscribeTestsRunner
     [Fact(Skip = "https://github.com/dotnet/orleans/issues/5635")]
     public async Task StreamingTests_Consumer_Producer_UnSubscribe()
     {
-        using var cts = new CancellationTokenSource(_timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(_timeout);
         var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
         var streamId = new FullStreamIdentity(Guid.NewGuid(), "EmptySpace", StreamProviderName);
         var rxStreamId = StreamId.Create(streamId.Namespace, streamId.Guid);
@@ -75,11 +78,12 @@ public abstract class ProgrammaticSubscribeTestsRunner
         var subscriptions = await subscriptionManager.SetupStreamingSubscriptionForStream<IPassive_ConsumerGrain>(streamId, 2);
 
         var producer = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+        cts.Token.ThrowIfCancellationRequested();
         await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
         using (var phaseOneObserver = StreamingDiagnosticObserver.Create())
         {
-            await ProduceExactCountAsync(producer, EventCountPerPhase);
+            await ProduceExactCountAsync(producer, EventCountPerPhase, cts.Token);
             await phaseOneObserver.WaitForItemDeliveryCountAsync(rxStreamId, EventCountPerPhase * subscriptions.Count, StreamProviderName, cts.Token);
         }
 
@@ -99,7 +103,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
 
         using (var phaseTwoObserver = StreamingDiagnosticObserver.Create())
         {
-            await ProduceExactCountAsync(producer, EventCountPerPhase);
+            await ProduceExactCountAsync(producer, EventCountPerPhase, cts.Token);
             await phaseTwoObserver.WaitForItemDeliveryCountAsync(rxStreamId, EventCountPerPhase, StreamProviderName, cts.Token);
         }
 
@@ -152,13 +156,15 @@ public abstract class ProgrammaticSubscribeTestsRunner
         await subscriptionManager.SetupStreamingSubscriptionForStream<IJerk_ConsumerGrain>(streamId, 10);
 
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(_timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(_timeout);
 
         //producer start producing 
         var producer = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingInt>(Guid.NewGuid());
+        cts.Token.ThrowIfCancellationRequested();
         await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
-        await ProduceExactCountAsync(producer, 1);
+        await ProduceExactCountAsync(producer, 1, cts.Token);
 
         //wait for consumers to unsubscribe via diagnostic events
         var rxStreamId = StreamId.Create("EmptySpace", streamId.Guid);
@@ -174,7 +180,8 @@ public abstract class ProgrammaticSubscribeTestsRunner
     public async Task StreamingTests_Consumer_Producer_SubscribeToTwoStream_MessageWithPolymorphism()
     {
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(_timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(_timeout);
         var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
         var streamId = new FullStreamIdentity(Guid.NewGuid(), "EmptySpace", StreamProviderName);
         var rxStreamId = StreamId.Create(streamId.Namespace, streamId.Guid);
@@ -183,12 +190,14 @@ public abstract class ProgrammaticSubscribeTestsRunner
         var consumers = subscriptions.Select(sub => this.fixture.GrainFactory.GetGrain<IPassive_ConsumerGrain>(sub.GrainId)).ToList();
 
         var producer = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+        cts.Token.ThrowIfCancellationRequested();
         await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
         // set up the new stream to subscribe, which produce strings
         var streamId2 = new FullStreamIdentity(Guid.NewGuid(), "EmptySpace2", StreamProviderName);
         var rxStreamId2 = StreamId.Create(streamId2.Namespace, streamId2.Guid);
         var producer2 = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+        cts.Token.ThrowIfCancellationRequested();
         await producer2.BecomeProducer(streamId2.Guid, streamId2.Namespace, streamId2.ProviderName);
 
         //register the consumer grain to second stream
@@ -197,9 +206,11 @@ public abstract class ProgrammaticSubscribeTestsRunner
 
         for (var i = 0; i < EventCountPerPhase; i++)
         {
+            cts.Token.ThrowIfCancellationRequested();
             await producer.Produce();
             if (i < EventCountPerPhase - 2)
             {
+                cts.Token.ThrowIfCancellationRequested();
                 await producer2.Produce();
             }
         }
@@ -216,7 +227,8 @@ public abstract class ProgrammaticSubscribeTestsRunner
     public async Task StreamingTests_Consumer_Producer_SubscribeToStreamsHandledByDifferentStreamProvider()
     {
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(_timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(_timeout);
         var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
         var streamId = new FullStreamIdentity(Guid.NewGuid(), "EmptySpace", StreamProviderName);
         var rxStreamId = StreamId.Create(streamId.Namespace, streamId.Guid);
@@ -225,12 +237,14 @@ public abstract class ProgrammaticSubscribeTestsRunner
         var consumers = subscriptions.Select(sub => this.fixture.GrainFactory.GetGrain<IPassive_ConsumerGrain>(sub.GrainId)).ToList();
 
         var producer = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+        cts.Token.ThrowIfCancellationRequested();
         await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
         // set up the new stream to subscribe, which produce strings
         var streamId2 = new FullStreamIdentity(Guid.NewGuid(), "EmptySpace2", StreamProviderName2);
         var rxStreamId2 = StreamId.Create(streamId2.Namespace, streamId2.Guid);
         var producer2 = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+        cts.Token.ThrowIfCancellationRequested();
         await producer2.BecomeProducer(streamId2.Guid, streamId2.Namespace, streamId2.ProviderName);
 
         //register the consumer grain to second stream
@@ -239,9 +253,11 @@ public abstract class ProgrammaticSubscribeTestsRunner
 
         for (var i = 0; i < EventCountPerPhase; i++)
         {
+            cts.Token.ThrowIfCancellationRequested();
             await producer.Produce();
             if (i < EventCountPerPhase - 2)
             {
+                cts.Token.ThrowIfCancellationRequested();
                 await producer2.Produce();
             }
         }
@@ -257,10 +273,14 @@ public abstract class ProgrammaticSubscribeTestsRunner
     //test utilities and statics
     private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(30);
 
-    private static async Task ProduceExactCountAsync(ITypedProducerGrain producer, int count)
+    private static async Task ProduceExactCountAsync(
+        ITypedProducerGrain producer,
+        int count,
+        CancellationToken cancellationToken)
     {
         for (var i = 0; i < count; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await producer.Produce();
         }
     }

--- a/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestRunner.cs
@@ -31,14 +31,17 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
         public virtual async Task StreamingTests_Consumer_Producer_Subscribe()
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(_timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(_timeout);
             var streamId = new FullStreamIdentity(Guid.NewGuid(), ImplicitSubscribeGrain.StreamNameSpace, StreamProviderName);
             var rxStreamId = StreamId.Create(ImplicitSubscribeGrain.StreamNameSpace, streamId.Guid);
             var producer = this.fixture.HostedCluster.GrainFactory!.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+            cts.Token.ThrowIfCancellationRequested();
             await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
             for (var i = 0; i< 10; i++)
             {
+                cts.Token.ThrowIfCancellationRequested();
                 await producer.Produce();
             }
 
@@ -54,24 +57,29 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
         public virtual async Task StreamingTests_Consumer_Producer_SubscribeToTwoStream_MessageWithPolymorphism()
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(_timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(_timeout);
             var streamId = new FullStreamIdentity(Guid.NewGuid(), ImplicitSubscribeGrain.StreamNameSpace, StreamProviderName);
             var rxStreamId = StreamId.Create(ImplicitSubscribeGrain.StreamNameSpace, streamId.Guid);
             var producer = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+            cts.Token.ThrowIfCancellationRequested();
             await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
             // set up the new stream with the same guid, but different namespace, so it would invoke the same consumer grain
             var streamId2 = new FullStreamIdentity(streamId.Guid, ImplicitSubscribeGrain.StreamNameSpace2, StreamProviderName);
             var rxStreamId2 = StreamId.Create(ImplicitSubscribeGrain.StreamNameSpace2, streamId2.Guid);
             var producer2 = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+            cts.Token.ThrowIfCancellationRequested();
             await producer2.BecomeProducer(streamId2.Guid, streamId2.Namespace, streamId2.ProviderName);
 
             // Produce 10 events in streamId, 8 on streamId2
             for (var i = 0; i < 10; i++)
             {
+                cts.Token.ThrowIfCancellationRequested();
                 await producer.Produce();
                 if (i < 8)
                 {
+                    cts.Token.ThrowIfCancellationRequested();
                     await producer2.Produce();
                 }
             }
@@ -91,25 +99,30 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
         public virtual async Task StreamingTests_Consumer_Producer_SubscribeToStreamsHandledByDifferentStreamProvider()
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(_timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(_timeout);
             var streamId = new FullStreamIdentity(Guid.NewGuid(), ImplicitSubscribeGrain.StreamNameSpace, StreamProviderName);
             var rxStreamId = StreamId.Create(ImplicitSubscribeGrain.StreamNameSpace, streamId.Guid);
 
             var producer = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+            cts.Token.ThrowIfCancellationRequested();
             await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
             // set up the new stream with the same guid, but different namespace, so it would invoke the same consumer grain
             var streamId2 = new FullStreamIdentity(streamId.Guid, ImplicitSubscribeGrain.StreamNameSpace2, StreamProviderName2);
             var rxStreamId2 = StreamId.Create(ImplicitSubscribeGrain.StreamNameSpace2, streamId2.Guid);
             var producer2 = this.fixture.GrainFactory.GetGrain<ITypedProducerGrainProducingApple>(Guid.NewGuid());
+            cts.Token.ThrowIfCancellationRequested();
             await producer2.BecomeProducer(streamId2.Guid, streamId2.Namespace, streamId2.ProviderName);
 
             // Produce 10 events in streamId, 8 on streamId2
             for (var i = 0; i < 10; i++)
             {
+                cts.Token.ThrowIfCancellationRequested();
                 await producer.Produce();
                 if (i < 8)
                 {
+                    cts.Token.ThrowIfCancellationRequested();
                     await producer2.Produce();
                 }
             }

--- a/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
@@ -41,24 +41,43 @@ namespace UnitTests.StreamingTests
         /// - Messages are delivered once the producer starts
         /// - No messages are lost in the handoff
         /// </summary>
-        public async Task StreamingTests_Consumer_Producer(Guid streamId)
+        public async Task StreamingTests_Consumer_Producer(
+            Guid streamId,
+            CancellationToken cancellationToken = default)
         {
             // consumer joins first, producer later
             var consumer = this.cluster.GrainFactory!.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid());
-            await consumer.BecomeConsumer(streamId, StreamNamespace, streamProvider);
+            await consumer.BecomeConsumer(streamId, StreamNamespace, streamProvider, cancellationToken);
 
             var producer = this.cluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
-            await producer.BecomeProducer(streamId, StreamNamespace, streamProvider);
+            await producer.BecomeProducer(streamId, StreamNamespace, streamProvider, cancellationToken);
 
-            await producer.StartPeriodicProducing();
+            var producerStarted = false;
+            try
+            {
+                producerStarted = true;
+                await producer.StartPeriodicProducing(cancellationToken);
+                await Task.Delay(TimeSpan.FromMilliseconds(1000), cancellationToken);
+                await producer.StopPeriodicProducing(cancellationToken);
+                producerStarted = false;
 
-            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, token) => CheckCounters(producer, consumer, lastTry, token),
+                    _timeout,
+                    cancellationToken: cancellationToken);
+            }
+            finally
+            {
+                using var cleanup = new CancellationTokenSource(_timeout);
+                if (producerStarted)
+                {
+                    await producer.StopPeriodicProducing(cleanup.Token)
+                        .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+                }
 
-            await producer.StopPeriodicProducing();
-
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(producer, consumer, lastTry, cancellationToken), _timeout);
-
-            await consumer.StopConsuming();
+                await consumer.StopConsuming(cleanup.Token)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            }
         }
 
         /// <summary>
@@ -68,25 +87,43 @@ namespace UnitTests.StreamingTests
         /// - Late-joining consumers receive messages (depending on provider)
         /// - The system handles dynamic subscription scenarios
         /// </summary>
-        public async Task StreamingTests_Producer_Consumer(Guid streamId)
+        public async Task StreamingTests_Producer_Consumer(
+            Guid streamId,
+            CancellationToken cancellationToken = default)
         {
             // producer joins first, consumer later
             var producer = this.cluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
-            await producer.BecomeProducer(streamId, StreamNamespace, streamProvider);
+            await producer.BecomeProducer(streamId, StreamNamespace, streamProvider, cancellationToken);
 
             var consumer = this.cluster.GrainFactory!.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid());
-            await consumer.BecomeConsumer(streamId, StreamNamespace, streamProvider);
+            await consumer.BecomeConsumer(streamId, StreamNamespace, streamProvider, cancellationToken);
 
-            await producer.StartPeriodicProducing();
+            var producerStarted = false;
+            try
+            {
+                producerStarted = true;
+                await producer.StartPeriodicProducing(cancellationToken);
+                await Task.Delay(TimeSpan.FromMilliseconds(1000), cancellationToken);
+                await producer.StopPeriodicProducing(cancellationToken);
+                producerStarted = false;
 
-            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, token) => CheckCounters(producer, consumer, lastTry, token),
+                    _timeout,
+                    cancellationToken: cancellationToken);
+            }
+            finally
+            {
+                using var cleanup = new CancellationTokenSource(_timeout);
+                if (producerStarted)
+                {
+                    await producer.StopPeriodicProducing(cleanup.Token)
+                        .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+                }
 
-            await producer.StopPeriodicProducing();
-            //int numProduced = await producer.NumberProduced;
-
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(producer, consumer, lastTry, cancellationToken), _timeout);
-
-            await consumer.StopConsuming();
+                await consumer.StopConsuming(cleanup.Token)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            }
         }
 
         /// <summary>
@@ -96,25 +133,43 @@ namespace UnitTests.StreamingTests
         /// - Can provide lower latency but may impact throughput
         /// - Are useful for simple, fast message processing
         /// </summary>
-        public async Task StreamingTests_Producer_InlineConsumer(Guid streamId)
+        public async Task StreamingTests_Producer_InlineConsumer(
+            Guid streamId,
+            CancellationToken cancellationToken = default)
         {
             // producer joins first, consumer later
             var producer = this.cluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
-            await producer.BecomeProducer(streamId, StreamNamespace, streamProvider);
+            await producer.BecomeProducer(streamId, StreamNamespace, streamProvider, cancellationToken);
 
             var consumer = this.cluster.GrainFactory!.GetGrain<ISampleStreaming_InlineConsumerGrain>(Guid.NewGuid());
-            await consumer.BecomeConsumer(streamId, StreamNamespace, streamProvider);
+            await consumer.BecomeConsumer(streamId, StreamNamespace, streamProvider, cancellationToken);
 
-            await producer.StartPeriodicProducing();
+            var producerStarted = false;
+            try
+            {
+                producerStarted = true;
+                await producer.StartPeriodicProducing(cancellationToken);
+                await Task.Delay(TimeSpan.FromMilliseconds(1000), cancellationToken);
+                await producer.StopPeriodicProducing(cancellationToken);
+                producerStarted = false;
 
-            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+                await TestingUtils.WaitUntilAsync(
+                    (lastTry, token) => CheckCounters(producer, consumer, lastTry, token),
+                    _timeout,
+                    cancellationToken: cancellationToken);
+            }
+            finally
+            {
+                using var cleanup = new CancellationTokenSource(_timeout);
+                if (producerStarted)
+                {
+                    await producer.StopPeriodicProducing(cleanup.Token)
+                        .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+                }
 
-            await producer.StopPeriodicProducing();
-            //int numProduced = await producer.NumberProduced;
-
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(producer, consumer, lastTry, cancellationToken), _timeout);
-
-            await consumer.StopConsuming();
+                await consumer.StopConsuming(cleanup.Token)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            }
         }
 
         /// <summary>

--- a/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
@@ -45,117 +45,117 @@ public class SingleStreamTestRunner
     }
 
     //------------------------ One to One ----------------------//
-    public async Task StreamTest_01_OneProducerGrainOneConsumerGrain()
+    public async Task StreamTest_01_OneProducerGrainOneConsumerGrain(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_01_ConsumerJoinsFirstProducerLater");
         Guid streamId = Guid.NewGuid();
         // consumer joins first, producer later
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client);
-        await BasicTestAsync();
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, cancellationToken: cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
 
         streamId = Guid.NewGuid();
         // produce joins first, consumer later
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client);
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client);
-        await BasicTestAsync();
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, cancellationToken: cancellationToken);
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_02_OneProducerGrainOneConsumerClient()
+    public async Task StreamTest_02_OneProducerGrainOneConsumerClient(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_02_OneProducerGrainOneConsumerClient");
         Guid streamId = Guid.NewGuid();
-        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client);
-        await BasicTestAsync();
+        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, cancellationToken: cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
 
         streamId = Guid.NewGuid();
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client);
-        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client);
-        await BasicTestAsync();
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, cancellationToken: cancellationToken);
+        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_03_OneProducerClientOneConsumerGrain()
+    public async Task StreamTest_03_OneProducerClientOneConsumerGrain(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_03_OneProducerClientOneConsumerGrain");
         Guid streamId = Guid.NewGuid();
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client);
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client);
-        await BasicTestAsync();
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, cancellationToken: cancellationToken);
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
 
         streamId = Guid.NewGuid();
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client);
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client);
-        await BasicTestAsync();
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, cancellationToken: cancellationToken);
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_04_OneProducerClientOneConsumerClient()
+    public async Task StreamTest_04_OneProducerClientOneConsumerClient(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_04_OneProducerClientOneConsumerClient");
         Guid streamId = Guid.NewGuid();
-        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client);
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client);
-        await BasicTestAsync();
+        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, cancellationToken: cancellationToken);
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
 
         streamId = Guid.NewGuid();
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client);
-        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client);
-        await BasicTestAsync();
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, cancellationToken: cancellationToken);
+        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
     //------------------------ MANY to Many different grains ----------------------//
 
-    public async Task StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
+    public async Task StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains");
         Guid streamId = Guid.NewGuid();
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, null, Many);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, null, Many);
-        await BasicTestAsync();
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, null, Many, cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, null, Many, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
+    public async Task StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients");
         Guid streamId = Guid.NewGuid();
-        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, Many);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, null, Many);
-        await BasicTestAsync();
+        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, Many, cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, null, Many, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
+    public async Task StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains");
         Guid streamId = Guid.NewGuid();
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, null, Many);
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, Many);
-        await BasicTestAsync();
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, null, Many, cancellationToken);
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, Many, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
+    public async Task StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients");
         Guid streamId = Guid.NewGuid();
-        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, Many);
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, Many);
-        await BasicTestAsync();
+        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, Many, cancellationToken);
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, Many, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
     //------------------------ MANY to Many Same grains ----------------------//
 
-    public async Task StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains()
+    public async Task StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains");
         Guid streamId = Guid.NewGuid();
@@ -164,13 +164,13 @@ public class SingleStreamTestRunner
         Guid[] consumerGrainIds = new Guid[] { grain1, grain1, grain1 };
         Guid[] producerGrainIds = new Guid[] { grain2, grain2, grain2 };
         // producer joins first, consumer later
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds);
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds);
-        await BasicTestAsync();
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds, cancellationToken: cancellationToken);
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains()
+    public async Task StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains");
         Guid streamId = Guid.NewGuid();
@@ -179,96 +179,104 @@ public class SingleStreamTestRunner
         Guid[] consumerGrainIds = new Guid[] { grain1, grain1, grain1 };
         Guid[] producerGrainIds = new Guid[] { grain2, grain2, grain2 };
         // consumer joins first, producer later
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds);
-        await BasicTestAsync();
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds, cancellationToken: cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds, cancellationToken: cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients()
+    public async Task StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients");
         Guid streamId = Guid.NewGuid();
         Guid grain1 = Guid.NewGuid();
         Guid[] producerGrainIds = new Guid[] { grain1, grain1, grain1, grain1 };
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds);
-        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, Many);
-        await BasicTestAsync();
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds, cancellationToken: cancellationToken);
+        consumer = await ConsumerProxy.NewConsumerClientObjectsAsync(streamId, streamProviderName, logger, this.client, Many, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains()
+    public async Task StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains");
         Guid streamId = Guid.NewGuid();
         Guid grain1 = Guid.NewGuid();
         Guid[] consumerGrainIds = new Guid[] { grain1, grain1, grain1 };
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds);
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, Many);
-        await BasicTestAsync();
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds, cancellationToken: cancellationToken);
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamId, streamProviderName, null, logger, this.client, Many, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
     //------------------------ MANY to Many producer consumer same grain ----------------------//
 
-    public async Task StreamTest_13_SameGrain_ConsumerFirstProducerLater(bool useReentrantGrain)
+    public async Task StreamTest_13_SameGrain_ConsumerFirstProducerLater(
+        bool useReentrantGrain,
+        CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_13_SameGrain_ConsumerFirstProducerLater");
         Guid streamId = Guid.NewGuid();
         int grain1 = Random.Shared.Next();
         int[] grainIds = new int[] { grain1 };
         // consumer joins first, producer later
-        this.consumer = await ConsumerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client);
-        this.producer = await ProducerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client);
-        await BasicTestAsync();
+        this.consumer = await ConsumerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client, cancellationToken);
+        this.producer = await ProducerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    public async Task StreamTest_14_SameGrain_ProducerFirstConsumerLater(bool useReentrantGrain)
+    public async Task StreamTest_14_SameGrain_ProducerFirstConsumerLater(
+        bool useReentrantGrain,
+        CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_14_SameGrain_ProducerFirstConsumerLater");
         Guid streamId = Guid.NewGuid();
         int grain1 = Random.Shared.Next();
         int[] grainIds = new int[] { grain1 };
         // produce joins first, consumer later
-        this.producer = await ProducerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client);
-        this.consumer = await ConsumerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client);
-        await BasicTestAsync();
+        this.producer = await ProducerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client, cancellationToken);
+        this.consumer = await ConsumerProxy.NewProducerConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, grainIds, useReentrantGrain, this.client, cancellationToken);
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
     //----------------------------------------------//
 
-    public async Task StreamTest_15_ConsumeAtProducersRequest()
+    public async Task StreamTest_15_ConsumeAtProducersRequest(CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_15_ConsumeAtProducersRequest");
         Guid streamId = Guid.NewGuid();
         // this reproduces a scenario was discovered to not work (deadlock) by the Halo team. the scenario is that
         // where a producer calls a consumer, which subscribes to the calling producer.
 
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, cancellationToken: cancellationToken);
         Guid consumerGrainId = await producer.AddNewConsumerGrain();
 
         this.consumer = ConsumerProxy.NewConsumerGrainAsync_WithoutBecomeConsumer(consumerGrainId, this.logger, this.client);
-        await BasicTestAsync();
+        await BasicTestAsync(cancellationToken: cancellationToken);
         await StopProxies();
     }
 
-    internal async Task StreamTest_Create_OneProducerGrainOneConsumerGrain()
+    internal async Task StreamTest_Create_OneProducerGrainOneConsumerGrain(
+        CancellationToken cancellationToken = default)
     {
         Guid streamId = Guid.NewGuid();
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client);
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, cancellationToken: cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, cancellationToken: cancellationToken);
     }
 
-    private async Task ProducePhaseAndWaitForDeliveriesAsync(Func<Task> produce)
+    private async Task ProducePhaseAndWaitForDeliveriesAsync(
+        Func<Task> produce,
+        CancellationToken cancellationToken)
     {
         var consumerCount = await consumer.ConsumerCount;
         Assert.NotEqual(0, consumerCount);
 
         var producedBefore = await producer.ExpectedItemsProduced;
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(_timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_timeout);
 
         await produce();
 
@@ -279,16 +287,20 @@ public class SingleStreamTestRunner
         await observer.WaitForItemDeliveryCountAsync(producer.StreamId, producedThisPhase * consumerCount, producer.ProviderName, cts.Token);
     }
 
-    private async Task ProduceAndWaitForImplicitDeliveriesAsync(int count)
+    private async Task ProduceAndWaitForImplicitDeliveriesAsync(
+        int count,
+        CancellationToken cancellationToken)
     {
         using var observer = StreamingDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(_timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_timeout);
 
         await producer.ProduceSequentialSeries(count);
         await observer.WaitForItemDeliveryCountAsync(producer.StreamId, count, producer.ProviderName, cts.Token);
     }
 
-    public async Task StreamTest_16_Deactivation_OneProducerGrainOneConsumerGrain()
+    public async Task StreamTest_16_Deactivation_OneProducerGrainOneConsumerGrain(
+        CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_16_Deactivation_OneProducerGrainOneConsumerGrain");
         Guid streamId = Guid.NewGuid();
@@ -296,24 +308,32 @@ public class SingleStreamTestRunner
         Guid[] producerGrainIds = { Guid.NewGuid() };
 
         // consumer joins first, producer later
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds);
-        await BasicTestAsync(false);
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds, cancellationToken: cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds, cancellationToken: cancellationToken);
+        await BasicTestAsync(false, cancellationToken);
         //await consumer.StopBeingConsumer();
         await StopProxies();
 
         await consumer.DeactivateOnIdle();
         await producer.DeactivateOnIdle();
 
-        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckGrainsDeactivated(null, consumer, lastTry, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
-        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckGrainsDeactivated(producer, null, lastTry, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
+        await TestingUtils.WaitUntilAsync(
+            (lastTry, token) => CheckGrainsDeactivated(null, consumer, lastTry, token),
+            _timeout,
+            delayOnFail: TimeSpan.FromMilliseconds(100),
+            cancellationToken: cancellationToken);
+        await TestingUtils.WaitUntilAsync(
+            (lastTry, token) => CheckGrainsDeactivated(producer, null, lastTry, token),
+            _timeout,
+            delayOnFail: TimeSpan.FromMilliseconds(100),
+            cancellationToken: cancellationToken);
 
         logger.LogInformation("\n\n\n*******************************************************************\n\n\n");
 
-        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds);
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds);
+        this.consumer = await ConsumerProxy.NewConsumerGrainsAsync(streamId, this.streamProviderName, this.logger, this.client, consumerGrainIds, cancellationToken: cancellationToken);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamId, this.streamProviderName, null, this.logger, this.client, producerGrainIds, cancellationToken: cancellationToken);
 
-        await BasicTestAsync(false);
+        await BasicTestAsync(false, cancellationToken);
         await StopProxies();
     }
 
@@ -337,12 +357,13 @@ public class SingleStreamTestRunner
     //    //await StopProxies();
     //}
 
-    public async Task StreamTest_19_ConsumerImplicitlySubscribedToProducerClient()
+    public async Task StreamTest_19_ConsumerImplicitlySubscribedToProducerClient(
+        CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_19_ConsumerImplicitlySubscribedToProducerClient");
         string consumerTypeName = typeof(Streaming_ImplicitlySubscribedConsumerGrain).FullName!;
         Guid streamGuid = Guid.NewGuid();
-        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamGuid, streamProviderName, "TestNamespace1", logger, this.client);
+        producer = await ProducerProxy.NewProducerClientObjectsAsync(streamGuid, streamProviderName, "TestNamespace1", logger, this.client, cancellationToken: cancellationToken);
         this.consumer = ConsumerProxy.NewConsumerGrainAsync_WithoutBecomeConsumer(streamGuid, this.logger, this.client, consumerTypeName);
 
         logger.LogInformation("\n** Starting Test {TestNumber}.\n", testNumber);
@@ -350,17 +371,18 @@ public class SingleStreamTestRunner
         logger.LogInformation("\n** Test {TestNumber} BasicTestAsync: producerCount={ProducerCount}.\n", testNumber, producerCount);
 
         _ = consumerTypeName;
-        await ProduceAndWaitForImplicitDeliveriesAsync(ItemCount);
+        await ProduceAndWaitForImplicitDeliveriesAsync(ItemCount, cancellationToken);
         await CheckCounters(producer, consumer);
         await StopProxies();
     }
 
-    public async Task StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain()
+    public async Task StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain(
+        CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain");
         string consumerTypeName = typeof(Streaming_ImplicitlySubscribedConsumerGrain).FullName!;
         Guid streamGuid = Guid.NewGuid();
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamGuid, this.streamProviderName, "TestNamespace1", this.logger, this.client);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamGuid, this.streamProviderName, "TestNamespace1", this.logger, this.client, cancellationToken: cancellationToken);
         this.consumer = ConsumerProxy.NewConsumerGrainAsync_WithoutBecomeConsumer(streamGuid, this.logger, this.client, consumerTypeName);
 
         logger.LogInformation("\n** Starting Test {TestNumber}.\n", testNumber);
@@ -368,18 +390,19 @@ public class SingleStreamTestRunner
         logger.LogInformation("\n** Test {TestNumber} BasicTestAsync: producerCount={ProducerCount}.\n", testNumber, producerCount);
 
         _ = consumerTypeName;
-        await ProduceAndWaitForImplicitDeliveriesAsync(ItemCount);
+        await ProduceAndWaitForImplicitDeliveriesAsync(ItemCount, cancellationToken);
         await CheckCounters(producer, consumer);
         await StopProxies();
     }
 
-    public async Task StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain()
+    public async Task StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain(
+        CancellationToken cancellationToken = default)
     {
         Heading("StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain");
         //ToDo in migrate: the following consumer grain is not implemented in VSO and all tests depend on it fail.
         string consumerTypeName = "UnitTests.Grains.Streaming_ImplicitlySubscribedGenericConsumerGrain";//typeof(Streaming_ImplicitlySubscribedGenericConsumerGrain).FullName;
         Guid streamGuid = Guid.NewGuid();
-        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamGuid, this.streamProviderName, "TestNamespace1", this.logger, this.client);
+        this.producer = await ProducerProxy.NewProducerGrainsAsync(streamGuid, this.streamProviderName, "TestNamespace1", this.logger, this.client, cancellationToken: cancellationToken);
         this.consumer = ConsumerProxy.NewConsumerGrainAsync_WithoutBecomeConsumer(streamGuid, this.logger, this.client, consumerTypeName);
 
         logger.LogInformation("\n** Starting Test {TestNumber}.\n", testNumber);
@@ -387,7 +410,7 @@ public class SingleStreamTestRunner
         logger.LogInformation("\n** Test {TestNumber} BasicTestAsync: producerCount={ProducerCount}.\n", testNumber, producerCount);
 
         _ = consumerTypeName;
-        await ProduceAndWaitForImplicitDeliveriesAsync(ItemCount);
+        await ProduceAndWaitForImplicitDeliveriesAsync(ItemCount, cancellationToken);
         await CheckCounters(producer, consumer);
         await StopProxies();
     }
@@ -444,7 +467,9 @@ public class SingleStreamTestRunner
 
     //-----------------------------------------------------------------------------//
 
-    public async Task BasicTestAsync(bool fullTest = true)
+    public async Task BasicTestAsync(
+        bool fullTest = true,
+        CancellationToken cancellationToken = default)
     {
         logger.LogInformation("\n** Starting Test {TestNumber} BasicTestAsync.\n", testNumber);
         var producerCount = await producer.ProducerCount;
@@ -455,14 +480,14 @@ public class SingleStreamTestRunner
             producerCount,
             consumerCount);
 
-        await ProducePhaseAndWaitForDeliveriesAsync(() => producer.ProduceSequentialSeries(ItemCount));
+        await ProducePhaseAndWaitForDeliveriesAsync(() => producer.ProduceSequentialSeries(ItemCount), cancellationToken);
         await CheckCounters(producer, consumer);
         if (runFullTest)
         {
-            await ProducePhaseAndWaitForDeliveriesAsync(() => producer.ProduceParallelSeries(ItemCount));
+            await ProducePhaseAndWaitForDeliveriesAsync(() => producer.ProduceParallelSeries(ItemCount), cancellationToken);
             await CheckCounters(producer, consumer);
 
-            await ProducePhaseAndWaitForDeliveriesAsync(() => producer.ProducePeriodicSeries(ItemCount));
+            await ProducePhaseAndWaitForDeliveriesAsync(() => producer.ProducePeriodicSeries(ItemCount), cancellationToken);
             await CheckCounters(producer, consumer);
         }
         await ValidatePubSub(producer.StreamId, producer.ProviderName);

--- a/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StatelessWorkersStreamTests.cs
@@ -126,7 +126,8 @@ namespace UnitTests.StreamingTests
             finally
             {
                 await run.ReleaseDeliveriesAsync(Timeout);
-                await Task.WhenAll(streamIds.Select(streamId => consumer.StopConsuming(streamId, StreamProvider)));
+                await Task.WhenAll(streamIds.Select(streamId =>
+                    consumer.StopConsuming(streamId, StreamProvider)));
             }
 
             Assert.Equal(PartitionCount, run.DeliveryCount);

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
@@ -74,7 +74,10 @@ namespace UnitTests.StreamingTests
         public async Task ValidateGeneratedStreamsTest()
         {
             this.fixture.Logger.LogInformation("************************ ValidateGeneratedStreamsTest *********************************");
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(lastTry, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, cancellationToken) => CheckCounters(lastTry, cancellationToken),
+                Timeout,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         private async Task<bool> CheckCounters(bool assertIsTrue, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamProvidersTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamProvidersTests.cs
@@ -66,7 +66,10 @@ namespace UnitTests.Streaming
             var grainFullName = typeof(Streaming_ConsumerGrain).FullName;
             // consumer joins first, producer later
             IStreaming_ConsumerGrain consumer = this.HostedCluster.GrainFactory!.GetGrain<IStreaming_ConsumerGrain>(Guid.NewGuid(), grainFullName);
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => consumer.BecomeConsumer(streamId, STREAM_PROVIDER_NAME, null!));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => consumer.BecomeConsumer(
+                streamId,
+                STREAM_PROVIDER_NAME,
+                null!));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Config"), TestCategory("ServiceId"), TestCategory("Providers")]

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -81,7 +81,7 @@ namespace UnitTests.StreamingTests
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
         public async Task PubSub_Store_Baseline()
         {
-            await Test_PubSub_Stream(StreamProviderName, StreamId);
+            await Test_PubSub_Stream(StreamProviderName, StreamId, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
@@ -97,7 +97,7 @@ namespace UnitTests.StreamingTests
 
             // TODO: expect StorageProviderInjectedError directly instead of OrleansException
             await Assert.ThrowsAsync<StorageProviderInjectedError>(() =>
-                Test_PubSub_Stream(StreamProviderName, StreamId));
+                Test_PubSub_Stream(StreamProviderName, StreamId, TestContext.Current.CancellationToken));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
@@ -106,7 +106,7 @@ namespace UnitTests.StreamingTests
             await SetErrorInjection(PubSubStoreProviderName, ErrorInjectionPoint.BeforeWrite);
 
             var exception = await Assert.ThrowsAsync<StorageProviderInjectedError>(() =>
-                Test_PubSub_Stream(StreamProviderName, StreamId));
+                Test_PubSub_Stream(StreamProviderName, StreamId, TestContext.Current.CancellationToken));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Streaming"), TestCategory("PubSub")]
@@ -123,7 +123,8 @@ namespace UnitTests.StreamingTests
             var timeout = TimeSpan.FromSeconds(30);
             using var streamObserver = StreamingDiagnosticObserver.Create();
             using var grainObserver = GrainDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(timeout);
             var deliveryTask = streamObserver.WaitForItemDeliveryCountAsync(producedStreamId, 1, StreamProviderName, cts.Token);
             var deactivationTask = grainObserver.WaitForDeactivatedAsync(deactivatingConsumer, timeout);
 
@@ -134,22 +135,28 @@ namespace UnitTests.StreamingTests
             Assert.Equal(1, await receivingConsumer.GetReceivedCount());
         }
 
-        private async Task Test_PubSub_Stream(string streamProviderName, Guid streamId)
+        private async Task Test_PubSub_Stream(
+            string streamProviderName,
+            Guid streamId,
+            CancellationToken cancellationToken)
         {
             using var observer = StreamingDiagnosticObserver.Create();
 
             // Consumer
             IStreamLifecycleConsumerGrain consumer = this.GrainFactory.GetGrain<IStreamLifecycleConsumerGrain>(Guid.NewGuid());
+            cancellationToken.ThrowIfCancellationRequested();
             await consumer.BecomeConsumer(streamId, this.StreamNamespace, streamProviderName);
 
             // Producer
             IStreamLifecycleProducerGrain producer = this.GrainFactory.GetGrain<IStreamLifecycleProducerGrain>(Guid.NewGuid());
+            cancellationToken.ThrowIfCancellationRequested();
             await producer.BecomeProducer(StreamId, this.StreamNamespace, streamProviderName);
 
             await producer.SendItem(1);
 
             int received1 = 0;
-            using var cts = new CancellationTokenSource(1000);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(1000);
             do
             {
                 received1 = await consumer.GetReceivedCount();
@@ -162,7 +169,8 @@ namespace UnitTests.StreamingTests
 
             // Wait for subscription removal to propagate
             var rxStreamId = Orleans.Runtime.StreamId.Create(this.StreamNamespace, streamId);
-            using var subCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var subCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            subCts.CancelAfter(TimeSpan.FromSeconds(5));
             await observer.WaitForSubscriptionRemovedAsync(rxStreamId, streamProviderName, subCts.Token);
 
             // Send one more message

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamTestHelperClasses.cs
@@ -40,17 +40,32 @@ namespace UnitTests.StreamingTests
             return _consumer.OnErrorAsync(ex);
         }
 
-        public Task BecomeConsumer(Guid streamId, string providerToUse)
+        public Task BecomeConsumer(
+            Guid streamId,
+            string providerToUse,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _providerToUse = providerToUse;
             return _consumer.BecomeConsumer(streamId, this.client.GetStreamProvider(providerToUse), null!);
         }
+
+        public Task BecomeConsumer(Guid streamId, string providerToUse) =>
+            BecomeConsumer(streamId, providerToUse, CancellationToken.None);
         
-        public Task BecomeConsumer(Guid streamId, string providerToUse, string? streamNamespace)
+        public Task BecomeConsumer(
+            Guid streamId,
+            string providerToUse,
+            string? streamNamespace,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _providerToUse = providerToUse;
             return _consumer.BecomeConsumer(streamId, this.client.GetStreamProvider(providerToUse), streamNamespace!);
         }
+
+        public Task BecomeConsumer(Guid streamId, string providerToUse, string? streamNamespace) =>
+            BecomeConsumer(streamId, providerToUse, streamNamespace, CancellationToken.None);
 
         public Task StopBeingConsumer()
         {
@@ -90,11 +105,19 @@ namespace UnitTests.StreamingTests
             return new Streaming_ProducerClientObject(logger, client);
         }
 
-        public Task BecomeProducer(Guid streamId, string providerToUse, string? streamNamespace)
+        public Task BecomeProducer(
+            Guid streamId,
+            string providerToUse,
+            string? streamNamespace,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             this.producer.BecomeProducer(streamId, this.client.GetStreamProvider(providerToUse), streamNamespace!);
             return Task.CompletedTask;
         }
+
+        public Task BecomeProducer(Guid streamId, string providerToUse, string? streamNamespace) =>
+            BecomeProducer(streamId, providerToUse, streamNamespace, CancellationToken.None);
 
         public Task ProduceSequentialSeries(int count)
         {
@@ -188,7 +211,13 @@ namespace UnitTests.StreamingTests
             this.grainFactory = grainFactory;
         }
 
-        private static async Task<ConsumerProxy> NewConsumerProxy(Guid streamId, string streamProvider, IStreaming_ConsumerGrain[] targets, ILogger logger, IInternalGrainFactory grainFactory)
+        private static async Task<ConsumerProxy> NewConsumerProxy(
+            Guid streamId,
+            string streamProvider,
+            IStreaming_ConsumerGrain[] targets,
+            ILogger logger,
+            IInternalGrainFactory grainFactory,
+            CancellationToken cancellationToken)
         {
             if (targets == null)
                 throw new ArgumentNullException(nameof(targets));
@@ -200,11 +229,18 @@ namespace UnitTests.StreamingTests
                 throw new ArgumentNullException(nameof(logger));
 
             ConsumerProxy newObj = new ConsumerProxy(targets, logger, grainFactory);
-            await newObj.BecomeConsumer(streamId, streamProvider);
+            await newObj.BecomeConsumer(streamId, streamProvider, cancellationToken);
             return newObj;
         }
 
-        public static Task<ConsumerProxy> NewConsumerGrainsAsync(Guid streamId, string streamProvider, ILogger logger, IInternalGrainFactory grainFactory, Guid[]? grainIds = null, int grainCount = 1)
+        public static Task<ConsumerProxy> NewConsumerGrainsAsync(
+            Guid streamId,
+            string streamProvider,
+            ILogger logger,
+            IInternalGrainFactory grainFactory,
+            Guid[]? grainIds = null,
+            int grainCount = 1,
+            CancellationToken cancellationToken = default)
         {
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
@@ -232,10 +268,17 @@ namespace UnitTests.StreamingTests
                     grains[i] = grainFactory.GetGrain<IStreaming_ConsumerGrain>(Guid.NewGuid(), grainFullName);
                 }
             }
-            return NewConsumerProxy(streamId, streamProvider, grains, logger, grainFactory);
+            return NewConsumerProxy(streamId, streamProvider, grains, logger, grainFactory, cancellationToken);
         }
 
-        public static Task<ConsumerProxy> NewProducerConsumerGrainsAsync(Guid streamId, string streamProvider, ILogger logger, int[] grainIds, bool useReentrantGrain, IInternalGrainFactory grainFactory)
+        public static Task<ConsumerProxy> NewProducerConsumerGrainsAsync(
+            Guid streamId,
+            string streamProvider,
+            ILogger logger,
+            int[] grainIds,
+            bool useReentrantGrain,
+            IInternalGrainFactory grainFactory,
+            CancellationToken cancellationToken = default)
         {
             int grainCount = grainIds.Length;
             if (grainCount < 1)
@@ -262,10 +305,16 @@ namespace UnitTests.StreamingTests
                         dedup[grainIds[i]] = grains[i];
                     }
                     }
-            return NewConsumerProxy(streamId, streamProvider, grains, logger, grainFactory);
+            return NewConsumerProxy(streamId, streamProvider, grains, logger, grainFactory, cancellationToken);
         }
 
-        public static Task<ConsumerProxy> NewConsumerClientObjectsAsync(Guid streamId, string streamProvider, ILogger logger, IInternalClusterClient client, int consumerCount = 1)
+        public static Task<ConsumerProxy> NewConsumerClientObjectsAsync(
+            Guid streamId,
+            string streamProvider,
+            ILogger logger,
+            IInternalClusterClient client,
+            int consumerCount = 1,
+            CancellationToken cancellationToken = default)
         {
             if (consumerCount < 1)
                 throw new ArgumentOutOfRangeException(nameof(consumerCount), "argument must be 1 or greater");
@@ -273,7 +322,7 @@ namespace UnitTests.StreamingTests
             var objs = new IStreaming_ConsumerGrain[consumerCount];
             for (var i = 0; i < consumerCount; ++i)
                 objs[i] = Streaming_ConsumerClientObject.NewObserver(logger, client);
-            return NewConsumerProxy(streamId, streamProvider, objs, logger, client);
+            return NewConsumerProxy(streamId, streamProvider, objs, logger, client, cancellationToken);
         }
 
         public static ConsumerProxy NewConsumerGrainAsync_WithoutBecomeConsumer(Guid consumerGrainId, ILogger logger, IInternalGrainFactory grainFactory, string grainClassName = "")
@@ -292,11 +341,15 @@ namespace UnitTests.StreamingTests
             return newObj;
         }
 
-        private async Task BecomeConsumer(Guid streamId, string providerToUse)
+        private async Task BecomeConsumer(
+            Guid streamId,
+            string providerToUse,
+            CancellationToken cancellationToken)
         {
             List<Task> tasks = new List<Task>();
             foreach (var target in _targets)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 Task t = target.BecomeConsumer(streamId, providerToUse, null!);
                 // Consider: remove this await, let the calls go in parallel. 
                 // Have to do it for now to prevent multithreaded scheduler bug from happening.
@@ -386,7 +439,13 @@ namespace UnitTests.StreamingTests
             StreamId = StreamId.Create(streamNamespace!, streamId);
         }
 
-        private static async Task<ProducerProxy> NewProducerProxy(IStreaming_ProducerGrain[] targets, Guid streamId, string streamProvider, string? streamNamespace, ILogger logger)
+        private static async Task<ProducerProxy> NewProducerProxy(
+            IStreaming_ProducerGrain[] targets,
+            Guid streamId,
+            string streamProvider,
+            string? streamNamespace,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             if (targets == null)
                 throw new ArgumentNullException(nameof(targets));
@@ -396,11 +455,19 @@ namespace UnitTests.StreamingTests
                 throw new ArgumentNullException(nameof(logger));
 
             ProducerProxy newObj = new ProducerProxy(targets, streamId, streamProvider, streamNamespace, logger);
-            await newObj.BecomeProducer(streamId, streamProvider, streamNamespace);
+            await newObj.BecomeProducer(streamId, streamProvider, streamNamespace, cancellationToken);
             return newObj;
         }
 
-        public static Task<ProducerProxy> NewProducerGrainsAsync(Guid streamId, string streamProvider, string? streamNamespace, ILogger logger, IInternalGrainFactory grainFactory, Guid[]? grainIds = null, int grainCount = 1)
+        public static Task<ProducerProxy> NewProducerGrainsAsync(
+            Guid streamId,
+            string streamProvider,
+            string? streamNamespace,
+            ILogger logger,
+            IInternalGrainFactory grainFactory,
+            Guid[]? grainIds = null,
+            int grainCount = 1,
+            CancellationToken cancellationToken = default)
         {
             grainCount = grainIds != null ? grainIds.Length : grainCount;
             if (grainCount < 1)
@@ -428,10 +495,17 @@ namespace UnitTests.StreamingTests
                     grains[i] = grainFactory.GetGrain<IStreaming_ProducerGrain>(Guid.NewGuid(), producerGrainFullName);
                 }
             }
-            return NewProducerProxy(grains, streamId, streamProvider, streamNamespace, logger);
+            return NewProducerProxy(grains, streamId, streamProvider, streamNamespace, logger, cancellationToken);
         }
 
-        public static Task<ProducerProxy> NewProducerConsumerGrainsAsync(Guid streamId, string streamProvider, ILogger logger, int[] grainIds, bool useReentrantGrain, IInternalGrainFactory grainFactory)
+        public static Task<ProducerProxy> NewProducerConsumerGrainsAsync(
+            Guid streamId,
+            string streamProvider,
+            ILogger logger,
+            int[] grainIds,
+            bool useReentrantGrain,
+            IInternalGrainFactory grainFactory,
+            CancellationToken cancellationToken = default)
         {
             int grainCount = grainIds.Length;
             if (grainCount < 1)
@@ -458,10 +532,17 @@ namespace UnitTests.StreamingTests
                         dedup[grainIds[i]] = grains[i];
                     }                    
                 }
-            return NewProducerProxy(grains, streamId, streamProvider, null, logger);
+            return NewProducerProxy(grains, streamId, streamProvider, null, logger, cancellationToken);
         }
 
-        public static Task<ProducerProxy> NewProducerClientObjectsAsync(Guid streamId, string streamProvider, string? streamNamespace, ILogger logger, IClusterClient client, int producersCount = 1)
+        public static Task<ProducerProxy> NewProducerClientObjectsAsync(
+            Guid streamId,
+            string streamProvider,
+            string? streamNamespace,
+            ILogger logger,
+            IClusterClient client,
+            int producersCount = 1,
+            CancellationToken cancellationToken = default)
         {            
             if (producersCount < 1)
                 throw new ArgumentOutOfRangeException(nameof(producersCount), "The producer count must be at least one");
@@ -469,16 +550,23 @@ namespace UnitTests.StreamingTests
             for (var i = 0; i < producersCount; ++i)
                 producers[i] = Streaming_ProducerClientObject.NewObserver(logger, client);
             logger.LogInformation("ProducerProxy.NewProducerClientObjectsAsync: multiplexing {ProducerCount} producer client objects for stream {StreamId}.", producersCount, streamId);
-            return NewProducerProxy(producers, streamId, streamProvider, streamNamespace, logger);
+            return NewProducerProxy(producers, streamId, streamProvider, streamNamespace, logger, cancellationToken);
         }
 
-        private Task BecomeProducer(Guid streamId, string providerToUse, string? streamNamespace)
+        private Task BecomeProducer(
+            Guid streamId,
+            string providerToUse,
+            string? streamNamespace,
+            CancellationToken cancellationToken)
         {
             _cleanedUpFlag.ThrowNotInitializedIfSet();
 
             return Task.WhenAll(_targets.Select(
                 target => 
-                    target.BecomeProducer(streamId, providerToUse, streamNamespace!)).ToArray());
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return target.BecomeProducer(streamId, providerToUse, streamNamespace!);
+                }).ToArray());
         }
 
         public async Task ProduceSequentialSeries(int count)

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
@@ -60,7 +60,8 @@ namespace Tester.StreamingTests
         public virtual async Task PreviousEventEvictedFromCacheTest()
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
 
             // Tested stream and corresponding grain
@@ -84,7 +85,7 @@ namespace Tester.StreamingTests
 
             // Wait for cache expiration time to pass
             // Then send events to other streams to trigger cache cleaning/eviction
-            await Task.Delay(DataMaxAgeInCache + TimeSpan.FromSeconds(1));
+            await Task.Delay(DataMaxAgeInCache + TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
             await Task.WhenAll(otherStreams.Select(s => s.OnNextAsync(interestingData)));
 
             // Should be delivered
@@ -93,7 +94,7 @@ namespace Tester.StreamingTests
             await WaitForEventCounterAsync(grain, 2);
 
             Assert.Equal(0, await grain.GetErrorCounter());
-            Assert.Equal(2, await grain.GetEventCounter());
+            Assert.Equal(2, await grain.GetEventCounter(TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -107,7 +108,8 @@ namespace Tester.StreamingTests
         public virtual async Task PreviousEventEvictedFromCacheWithFilterTest()
         {
             using var observer = StreamingDiagnosticObserver.Create();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
 
             // Tested stream and corresponding grain
@@ -135,7 +137,7 @@ namespace Tester.StreamingTests
 
             // Wait for cache expiration and trigger eviction with more filtered events
             // This tests that filtered events in cache don't affect delivery guarantees
-            await Task.Delay(DataMaxAgeInCache + TimeSpan.FromSeconds(1));
+            await Task.Delay(DataMaxAgeInCache + TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
             await Task.WhenAll(otherStreams.Select(s => s.OnNextAsync(skippedData)));
 
             // Should be delivered
@@ -144,7 +146,7 @@ namespace Tester.StreamingTests
             await WaitForEventCounterAsync(grain, 1);
 
             Assert.Equal(0, await grain.GetErrorCounter());
-            Assert.Equal(1, await grain.GetEventCounter());
+            Assert.Equal(1, await grain.GetEventCounter(TestContext.Current.CancellationToken));
         }
 
         private static Task WaitForEventCounterAsync(IImplicitSubscriptionCounterGrain grain, int expected)

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -206,10 +206,18 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var slowGrain = this.Client.GetGrain<ISlowImplicitSubscriptionCounterGrain>(key);
 
         await stream.OnNextAsync([1]);
-        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckFastCounter(1, lastTry, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync(
+            (lastTry, cancellationToken) => CheckFastCounter(1, lastTry, cancellationToken),
+            TimeSpan.FromSeconds(30),
+            delayOnFail: PollInterval,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await stream.OnNextAsync([2]);
-        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckFastCounter(2, lastTry, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync(
+            (lastTry, cancellationToken) => CheckFastCounter(2, lastTry, cancellationToken),
+            TimeSpan.FromSeconds(30),
+            delayOnFail: PollInterval,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         async Task<bool> CheckFastCounter(int expected, bool lastTry, CancellationToken cancellationToken)
         {

--- a/test/Orleans.Streaming.Tests/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -165,9 +165,13 @@ public class SubscriptionMultiplicityTestRunner
         this.testCluster = testCluster;
     }
 
-    public async Task MultipleParallelSubscriptionTest(Guid streamGuid, string streamNamespace)
+    public async Task MultipleParallelSubscriptionTest(
+        Guid streamGuid,
+        string streamNamespace,
+        CancellationToken cancellationToken = default)
     {
-        using var cts = new CancellationTokenSource(Timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(Timeout);
 
         // get producer and consumer
         var producer = this.testCluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
@@ -180,7 +184,7 @@ public class SubscriptionMultiplicityTestRunner
         StreamSubscriptionHandle<int> secondSubscriptionHandle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId, async () => secondSubscriptionHandle = await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName), cts.Token);
         // produce some messages
-        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cts.Token);
         await WarmUpColdStreamAsync(
             producer,
             this.testCluster.Client!,
@@ -203,16 +207,20 @@ public class SubscriptionMultiplicityTestRunner
         await consumer.StopConsuming(secondSubscriptionHandle);
     }
 
-    public async Task MultipleLinearSubscriptionTest(Guid streamGuid, string streamNamespace)
+    public async Task MultipleLinearSubscriptionTest(
+        Guid streamGuid,
+        string streamNamespace,
+        CancellationToken cancellationToken = default)
     {
-        using var cts = new CancellationTokenSource(Timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(Timeout);
 
         // get producer and consumer
         var producer = this.testCluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
         var consumer = this.testCluster.GrainFactory!.GetGrain<IMultipleSubscriptionConsumerGrain>(Guid.NewGuid());
         var streamId = StreamId.Create(streamNamespace, streamGuid);
 
-        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cts.Token);
 
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
@@ -238,16 +246,20 @@ public class SubscriptionMultiplicityTestRunner
         await consumer.StopConsuming(secondSubscriptionHandle);
     }
 
-    public async Task MultipleSubscriptionTest_AddRemove(Guid streamGuid, string streamNamespace)
+    public async Task MultipleSubscriptionTest_AddRemove(
+        Guid streamGuid,
+        string streamNamespace,
+        CancellationToken cancellationToken = default)
     {
-        using var cts = new CancellationTokenSource(Timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(Timeout);
 
         // get producer and consumer
         var producer = this.testCluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
         var consumer = this.testCluster.GrainFactory!.GetGrain<IMultipleSubscriptionConsumerGrain>(Guid.NewGuid());
         var streamId = StreamId.Create(streamNamespace, streamGuid);
 
-        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cts.Token);
 
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
@@ -294,16 +306,20 @@ public class SubscriptionMultiplicityTestRunner
         await consumer.StopConsuming(secondSubscriptionHandle);
     }
 
-    public async Task ResubscriptionTest(Guid streamGuid, string streamNamespace)
+    public async Task ResubscriptionTest(
+        Guid streamGuid,
+        string streamNamespace,
+        CancellationToken cancellationToken = default)
     {
-        using var cts = new CancellationTokenSource(Timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(Timeout);
 
         // get producer and consumer
         var producer = this.testCluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
         var consumer = this.testCluster.GrainFactory!.GetGrain<IMultipleSubscriptionConsumerGrain>(Guid.NewGuid());
         var streamId = StreamId.Create(streamNamespace, streamGuid);
 
-        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cts.Token);
 
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
@@ -325,17 +341,21 @@ public class SubscriptionMultiplicityTestRunner
         await consumer.StopConsuming(resumeHandle);
     }
 
-    public async Task ResubscriptionAfterDeactivationTest(Guid streamGuid, string streamNamespace)
+    public async Task ResubscriptionAfterDeactivationTest(
+        Guid streamGuid,
+        string streamNamespace,
+        CancellationToken cancellationToken = default)
     {
         using var grainObserver = GrainDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(Timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(Timeout);
 
         // get producer and consumer
         var producer = this.testCluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
         var consumer = this.testCluster.GrainFactory!.GetGrain<IMultipleSubscriptionConsumerGrain>(Guid.NewGuid());
         var streamId = StreamId.Create(streamNamespace, streamGuid);
 
-        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cts.Token);
 
         // setup one subscription and send messsages
         StreamSubscriptionHandle<int> firstSubscriptionHandle = null!;
@@ -364,7 +384,10 @@ public class SubscriptionMultiplicityTestRunner
         await consumer.StopConsuming(resumeHandle);
     }
 
-    public async Task ActiveSubscriptionTest(Guid streamGuid, string streamNamespace)
+    public async Task ActiveSubscriptionTest(
+        Guid streamGuid,
+        string streamNamespace,
+        CancellationToken cancellationToken = default)
     {
         const int subscriptionCount = 10;
 
@@ -374,7 +397,11 @@ public class SubscriptionMultiplicityTestRunner
         // create expected subscriptions
         IEnumerable<Task<StreamSubscriptionHandle<int>>> subscriptionTasks =
             Enumerable.Range(0, subscriptionCount)
-                .Select(async i => await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName));
+                .Select(async i =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
+                });
         List<StreamSubscriptionHandle<int>> expectedSubscriptions = (await Task.WhenAll(subscriptionTasks)).ToList();
 
         // query actuall subscriptions
@@ -390,6 +417,7 @@ public class SubscriptionMultiplicityTestRunner
 
         // unsubscribe from one of the subscriptions
         StreamSubscriptionHandle<int> firstHandle = expectedSubscriptions.First();
+        cancellationToken.ThrowIfCancellationRequested();
         await consumer.StopConsuming(firstHandle);
         expectedSubscriptions.Remove(firstHandle);
 
@@ -405,6 +433,7 @@ public class SubscriptionMultiplicityTestRunner
         }
 
         // unsubscribe from the rest of the subscriptions
+        cancellationToken.ThrowIfCancellationRequested();
         await Task.WhenAll(expectedSubscriptions.Select(h => consumer.StopConsuming(h)));
 
         // query actuall subscriptions again
@@ -414,18 +443,21 @@ public class SubscriptionMultiplicityTestRunner
         Assert.Empty(actualSubscriptions);
     }
 
-    public async Task TwoIntermittentStreamTest(Guid streamGuid)
+    public async Task TwoIntermittentStreamTest(
+        Guid streamGuid,
+        CancellationToken cancellationToken = default)
     {
         const string streamNamespace1 = "streamNamespace1";
         const string streamNamespace2 = "streamNamespace2";
-        using var cts = new CancellationTokenSource(Timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(Timeout);
 
         // send events on first stream /////////////////////////////
         var producer = this.testCluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
         var consumer = this.testCluster.GrainFactory!.GetGrain<IMultipleSubscriptionConsumerGrain>(Guid.NewGuid());
         var streamId1 = StreamId.Create(streamNamespace1, streamGuid);
 
-        await producer.BecomeProducer(streamGuid, streamNamespace1, streamProviderName);
+        await producer.BecomeProducer(streamGuid, streamNamespace1, streamProviderName, cts.Token);
 
         StreamSubscriptionHandle<int> handle = null!;
         await WaitForSubscriptionRegisteredAsync(streamId1, async () => handle = await consumer.BecomeConsumer(streamGuid, streamNamespace1, streamProviderName), cts.Token);
@@ -438,7 +470,7 @@ public class SubscriptionMultiplicityTestRunner
         var consumer2 = this.testCluster.GrainFactory!.GetGrain<IMultipleSubscriptionConsumerGrain>(Guid.NewGuid());
         var streamId2 = StreamId.Create(streamNamespace2, streamGuid);
 
-        await producer2.BecomeProducer(streamGuid, streamNamespace2, streamProviderName);
+        await producer2.BecomeProducer(streamGuid, streamNamespace2, streamProviderName, cts.Token);
 
         StreamSubscriptionHandle<int> handle2 = null!;
         await WaitForSubscriptionRegisteredAsync(streamId2, async () => handle2 = await consumer2.BecomeConsumer(streamGuid, streamNamespace2, streamProviderName), cts.Token);
@@ -454,9 +486,13 @@ public class SubscriptionMultiplicityTestRunner
         await consumer2.StopConsuming(handle2);
     }
 
-    public async Task SubscribeFromClientTest(Guid streamGuid, string streamNamespace)
+    public async Task SubscribeFromClientTest(
+        Guid streamGuid,
+        string streamNamespace,
+        CancellationToken cancellationToken = default)
     {
-        using var cts = new CancellationTokenSource(Timeout);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(Timeout);
 
         // get producer and consumer
         var producer = this.testCluster.GrainFactory!.GetGrain<ISampleStreaming_ProducerGrain>(Guid.NewGuid());
@@ -480,7 +516,7 @@ public class SubscriptionMultiplicityTestRunner
             cts.Token);
 
         // produce some messages
-        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName);
+        await producer.BecomeProducer(streamGuid, streamNamespace, streamProviderName, cts.Token);
         await WarmUpColdClientStreamAsync(producer, cts.Token, eventCount);
         var produced = await ProduceUntilClientConsumedAsync(producer, cts.Token, eventCount, EventCountPerPhase);
         await AssertCountersAsync(producer, () => eventCount.CurrentCount, produced);
@@ -489,11 +525,14 @@ public class SubscriptionMultiplicityTestRunner
         await handle.UnsubscribeAsync();
     }
 
-    private static async Task ProduceExactCountAsync(ISampleStreaming_ProducerGrain producer, int count)
+    private static async Task ProduceExactCountAsync(
+        ISampleStreaming_ProducerGrain producer,
+        int count,
+        CancellationToken cancellationToken)
     {
         for (var i = 0; i < count; i++)
         {
-            await producer.Produce();
+            await producer.Produce(cancellationToken);
         }
     }
 
@@ -528,6 +567,7 @@ public class SubscriptionMultiplicityTestRunner
             }
             catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
             {
+                TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
                 var snapshots = new List<string>(waits.Length);
                 foreach (var wait in waits)
                 {
@@ -574,7 +614,7 @@ public class SubscriptionMultiplicityTestRunner
         }
 
         using var deliveryObserver = StreamingDiagnosticObserver.Create();
-        await ProduceExactCountAsync(producer, target);
+        await ProduceExactCountAsync(producer, target, cancellationToken);
         var produced = await producer.GetNumberProduced();
 
         try
@@ -606,6 +646,7 @@ public class SubscriptionMultiplicityTestRunner
         }
         catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {
+            TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
             var currentProduced = await producer.GetNumberProduced();
             throw new TimeoutException(
                 $"Timed out waiting for client consumer count to reach {expectedCount}. Current produced={currentProduced}, current client count={countObserver.CurrentCount}.",
@@ -621,7 +662,7 @@ public class SubscriptionMultiplicityTestRunner
     {
         countObserver.Reset();
         await producer.ClearNumberProduced();
-        await ProduceExactCountAsync(producer, target);
+        await ProduceExactCountAsync(producer, target, cancellationToken);
         var produced = await producer.GetNumberProduced();
         await WaitForClientCountAsync(producer, cancellationToken, countObserver, produced);
 
@@ -679,14 +720,16 @@ public class SubscriptionMultiplicityTestRunner
 
         await producer.ClearNumberProduced();
         using var deliveryObserver = StreamingDiagnosticObserver.Create();
-        await producer.StartPeriodicProducing();
         try
         {
+            await producer.StartPeriodicProducing(cancellationToken);
             await WaitForConsumerCountsAsync(grainFactory, cancellationToken, 1, waits);
         }
         finally
         {
-            await producer.StopPeriodicProducing().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            using var cleanup = new CancellationTokenSource(Timeout);
+            await producer.StopPeriodicProducing(cleanup.Token)
+                .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
         }
 
         var produced = await WaitForConsumersToCatchUpAsync(producer, grainFactory, cancellationToken, waits);
@@ -720,14 +763,16 @@ public class SubscriptionMultiplicityTestRunner
     {
         countObserver.Reset();
         await producer.ClearNumberProduced();
-        await producer.StartPeriodicProducing();
         try
         {
+            await producer.StartPeriodicProducing(cancellationToken);
             await WaitForClientCountAsync(producer, cancellationToken, countObserver, 1);
         }
         finally
         {
-            await producer.StopPeriodicProducing().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            using var cleanup = new CancellationTokenSource(Timeout);
+            await producer.StopPeriodicProducing(cleanup.Token)
+                .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
         }
 
         await WaitForClientToCatchUpAsync(producer, cancellationToken, countObserver);

--- a/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
@@ -81,17 +81,38 @@ namespace Tester.StreamingTests
                 .ToList();
 
             // become producers
-            await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].BecomeProducer(streamIds[i], null!, Fixture.StreamProviderName)));
+            await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].BecomeProducer(
+                streamIds[i],
+                null!,
+                Fixture.StreamProviderName,
+                TestContext.Current.CancellationToken)));
 
             // produce some events
-            await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].StartPeriodicProducing()));
-            await Task.Delay(TimeSpan.FromMilliseconds(1000));
-            await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].StopPeriodicProducing()));
+            var periodicProducingStarted = true;
+            try
+            {
+                await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].StartPeriodicProducing(TestContext.Current.CancellationToken)));
+                await Task.Delay(TimeSpan.FromMilliseconds(1000), TestContext.Current.CancellationToken);
+                await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].StopPeriodicProducing(TestContext.Current.CancellationToken)));
+                periodicProducingStarted = false;
+            }
+            finally
+            {
+                if (periodicProducingStarted)
+                {
+                    using var cleanup = new CancellationTokenSource(Timeout);
+                    await Task.WhenAll(producers.Select(producer => producer.StopPeriodicProducing(cleanup.Token)))
+                        .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+                }
+            }
 
             int[] counts = await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].GetNumberProduced()));
 
             // make sure all went well
-            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(counts.Sum(), lastTry, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, cancellationToken) => CheckCounters(counts.Sum(), lastTry, cancellationToken),
+                Timeout,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
 
         private Task OnNextAsync(int e, StreamSequenceToken? token)

--- a/test/Orleans.Testing.Reminders/ReminderTestClock.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTestClock.cs
@@ -96,7 +96,7 @@ public sealed class ReminderTestClock : IDisposable
     /// </summary>
     /// <param name="amount">The amount of time to advance.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    public async Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
+    public async Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken = default)
     {
         if (amount < TimeSpan.Zero)
         {
@@ -122,7 +122,7 @@ public sealed class ReminderTestClock : IDisposable
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>An async-disposable handle which resumes clock advances when disposed.</returns>
-    public async Task<IAsyncDisposable> FreezeAsync(CancellationToken cancellationToken)
+    public async Task<IAsyncDisposable> FreezeAsync(CancellationToken cancellationToken = default)
     {
         await _advanceLock.WaitAsync(cancellationToken);
         try

--- a/test/Orleans.Testing.Reminders/ReminderTestClock.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTestClock.cs
@@ -96,7 +96,7 @@ public sealed class ReminderTestClock : IDisposable
     /// </summary>
     /// <param name="amount">The amount of time to advance.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    public async Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken = default)
+    public async Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
     {
         if (amount < TimeSpan.Zero)
         {
@@ -122,7 +122,7 @@ public sealed class ReminderTestClock : IDisposable
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>An async-disposable handle which resumes clock advances when disposed.</returns>
-    public async Task<IAsyncDisposable> FreezeAsync(CancellationToken cancellationToken = default)
+    public async Task<IAsyncDisposable> FreezeAsync(CancellationToken cancellationToken)
     {
         await _advanceLock.WaitAsync(cancellationToken);
         try

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/ClientLifecycleTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/ClientLifecycleTests.cs
@@ -21,11 +21,11 @@ public class ClientLifecycleTests
         AssertClientUnavailable(() => cluster.Client);
         AssertClientUnavailable(() => cluster.GrainFactory);
 
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         Assert.Same(cluster.Client, cluster.GrainFactory);
 
-        await cluster.StopClusterClientAsync();
+        await cluster.StopClusterClientAsync(TestContext.Current.CancellationToken);
 
         AssertClientUnavailable(() => cluster.Client);
         AssertClientUnavailable(() => cluster.GrainFactory);
@@ -42,12 +42,12 @@ public class ClientLifecycleTests
 
         AssertClientUnavailable(() => cluster.Client);
 
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         var client = cluster.Client;
         Assert.Same(client, cluster.Client);
 
-        await cluster.StopClusterClientAsync();
+        await cluster.StopClusterClientAsync(TestContext.Current.CancellationToken);
 
         AssertClientUnavailable(() => cluster.Client);
     }
@@ -63,7 +63,7 @@ public class ClientLifecycleTests
         builder.AddClientBuilderConfigurator<FailingClientConfigurator>();
         await using var cluster = builder.Build();
 
-        await Assert.ThrowsAsync<TimeoutException>(() => cluster.DeployAsync());
+        await Assert.ThrowsAsync<TimeoutException>(() => cluster.DeployAsync(TestContext.Current.CancellationToken));
 
         AssertClientUnavailable(() => cluster.Client);
         AssertClientUnavailable(() => cluster.GrainFactory);
@@ -79,7 +79,7 @@ public class ClientLifecycleTests
         builder.ConfigureClientHost(hostBuilder => hostBuilder.Services.AddSingleton<IHostedService, FailingHostedService>());
         await using var cluster = builder.Build();
 
-        await Assert.ThrowsAsync<TimeoutException>(() => cluster.DeployAsync());
+        await Assert.ThrowsAsync<TimeoutException>(() => cluster.DeployAsync(TestContext.Current.CancellationToken));
 
         AssertClientUnavailable(() => cluster.Client);
     }

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
@@ -41,7 +41,11 @@ namespace Orleans.TestingHost.Tests.Grains
 
         public static void Release(Guid key) => GetState(key).Release.TrySetResult();
 
-        public static Task<bool> WaitForEntered(Guid key, TimeSpan timeout) => GetState(key).Entered.WaitAsync(timeout);
+        public static Task<bool> WaitForEntered(Guid key, TimeSpan timeout)
+            => WaitForEntered(key, timeout, CancellationToken.None);
+
+        public static Task<bool> WaitForEntered(Guid key, TimeSpan timeout, CancellationToken cancellationToken)
+            => GetState(key).Entered.WaitAsync(timeout, cancellationToken);
 
         public Task<string> GetSiloIdentity() =>
             Task.FromResult(this.ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
@@ -26,7 +26,7 @@ namespace Orleans.TestingHost.Tests
             var builder = new InProcessTestClusterBuilder(1);
             builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
             await using var cluster = builder.Build();
-            await cluster.DeployAsync();
+            await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
             var key = Guid.NewGuid();
             var blocker = cluster.Client.GetGrain<IRemoteBlockerGrain>(key);
@@ -34,10 +34,15 @@ namespace Orleans.TestingHost.Tests
             // Start (but do not await) a call to a grain that blocks and never responds.
             var pending = blocker.BlockUntilReleased();
             var followUp = RetryAfterFailure(pending, blocker);
-            Assert.True(await RemoteBlockerGrain.WaitForEntered(key, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
+            Assert.True(
+                await RemoteBlockerGrain.WaitForEntered(
+                    key,
+                    TimeSpan.FromSeconds(30),
+                    TestContext.Current.CancellationToken),
+                "The blocking call was never entered.");
 
             // Stop the client while the call is in-flight.
-            await cluster.StopClusterClientAsync();
+            await cluster.StopClusterClientAsync(TestContext.Current.CancellationToken);
 
             // The pending call must fault promptly instead of hanging.
             var faulted = await Task.WhenAny(pending, Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken));

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterDirectoryTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterDirectoryTests.cs
@@ -15,7 +15,7 @@ public sealed class InProcessTestClusterDirectoryTests
         var builder = new InProcessTestClusterBuilder(1);
 
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal("InProcessGrainDirectory", GetDefaultDirectory(cluster).GetType().Name);
     }
@@ -31,7 +31,7 @@ public sealed class InProcessTestClusterDirectoryTests
 #pragma warning restore ORLEANSEXP003
 
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal("DistributedGrainDirectory", GetDefaultDirectory(cluster).GetType().Name);
     }
@@ -48,7 +48,7 @@ public sealed class InProcessTestClusterDirectoryTests
 #pragma warning restore ORLEANSEXP003
 
         await using var cluster = builder.Build();
-        await cluster.DeployAsync();
+        await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
         var defaultDirectory = GetDefaultDirectory(cluster);
         var namedDirectory = cluster.Silos[0].ServiceProvider.GetRequiredKeyedService<IGrainDirectory>("named");

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
@@ -30,7 +30,7 @@ namespace Orleans.TestingHost.Tests
             var builder = new InProcessTestClusterBuilder(1);
             builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
             var cluster = builder.Build();
-            await cluster.DeployAsync();
+            await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
             var serviceProvider = cluster.Silos[0].ServiceProvider;
 
@@ -38,7 +38,7 @@ namespace Orleans.TestingHost.Tests
             Assert.NotNull(serviceProvider.GetService<ILocalSiloDetails>());
 
             // The pattern from the issue: stop the silos first, then dispose the cluster.
-            await cluster.StopAllSilosAsync();
+            await cluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
             await cluster.DisposeAsync();
 
             // If the host was disposed, its service provider is disposed too and resolving throws.
@@ -53,14 +53,16 @@ namespace Orleans.TestingHost.Tests
             var builder = new InProcessTestClusterBuilder(1);
             builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
             var cluster = builder.Build();
-            await cluster.DeployAsync();
+            await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
             var handle = cluster.Silos[0];
             var serviceProvider = handle.ServiceProvider;
 
             // Stop the silo, then dispose the handle directly. Disposal must dispose the host even
             // though the handle is no longer active.
-            await handle.StopSiloAsync(stopGracefully: true);
+            await handle.StopSiloAsync(
+                stopGracefully: true,
+                TestContext.Current.CancellationToken);
             await handle.DisposeAsync();
 
             Assert.Throws<ObjectDisposedException>(() => serviceProvider.GetService<ILocalSiloDetails>());
@@ -101,7 +103,7 @@ namespace Orleans.TestingHost.Tests
             var builder = new InProcessTestClusterBuilder(2);
             builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
             await using var cluster = builder.Build();
-            await cluster.DeployAsync();
+            await cluster.DeployAsync(TestContext.Current.CancellationToken);
 
             var client = cluster.Client;
             var launcherHandle = cluster.Silos[0];
@@ -142,12 +144,19 @@ namespace Orleans.TestingHost.Tests
                 // Trigger the outbound call from a stateless worker co-located on the launcher's silo.
                 var worker = client.GetGrain<ILocalWorkerGrain>(Guid.NewGuid());
                 await launcher.StartBlockingCall(worker, remote);
-                Assert.True(await RemoteBlockerGrain.WaitForEntered(remoteKey, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
+                Assert.True(
+                    await RemoteBlockerGrain.WaitForEntered(
+                        remoteKey,
+                        TimeSpan.FromSeconds(30),
+                        TestContext.Current.CancellationToken),
+                    "The blocking call was never entered.");
             }
 
             // Kill the launcher's silo (ungraceful) and dispose its host. Prior to the fix this can hang
             // if cancellation interrupts callback timer shutdown before the callbacks are faulted.
-            var killAndDispose = cluster.KillSiloAsync(launcherHandle);
+            var killAndDispose = cluster.KillSiloAsync(
+                launcherHandle,
+                TestContext.Current.CancellationToken);
             var completed = await Task.WhenAny(killAndDispose, Task.Delay(TimeSpan.FromSeconds(60), TestContext.Current.CancellationToken));
             Assert.True(completed == killAndDispose, "Killing a silo with an in-flight outbound call should not hang host disposal.");
             await killAndDispose;
@@ -182,9 +191,9 @@ namespace Orleans.TestingHost.Tests
         private static WeakReference DeployStopAndDispose()
         {
             var cluster = BuildCluster();
-            cluster.DeployAsync().GetAwaiter().GetResult();
+            cluster.DeployAsync(TestContext.Current.CancellationToken).GetAwaiter().GetResult();
             var weakRef = new WeakReference(cluster.Silos[0].ServiceProvider);
-            cluster.StopAllSilosAsync().GetAwaiter().GetResult();
+            cluster.StopAllSilosAsync(TestContext.Current.CancellationToken).GetAwaiter().GetResult();
             cluster.DisposeAsync().AsTask().GetAwaiter().GetResult();
             return weakRef;
         }
@@ -193,9 +202,9 @@ namespace Orleans.TestingHost.Tests
         private static WeakReference DeployKillAndDispose()
         {
             var cluster = BuildCluster();
-            cluster.DeployAsync().GetAwaiter().GetResult();
+            cluster.DeployAsync(TestContext.Current.CancellationToken).GetAwaiter().GetResult();
             var weakRef = new WeakReference(cluster.Silos[0].ServiceProvider);
-            cluster.KillSiloAsync(cluster.Silos[0]).GetAwaiter().GetResult();
+            cluster.KillSiloAsync(cluster.Silos[0], TestContext.Current.CancellationToken).GetAwaiter().GetResult();
             cluster.DisposeAsync().AsTask().GetAwaiter().GetResult();
             return weakRef;
         }

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestClusterTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestClusterTests.cs
@@ -37,7 +37,7 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
             var primary = Assert.IsType<InProcessSiloHandle>(testCluster.Primary);
             Assert.Equal("TestClusterFatalErrorHandler", primary.ServiceProvider.GetRequiredService<IFatalErrorHandler>().GetType().Name);
         }
@@ -49,7 +49,7 @@ namespace Orleans.TestingHost.Tests
             builder.Options.ServiceId = Guid.NewGuid().ToString();
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
-            await testCluster.DeployAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
 
             var primary = Assert.IsType<InProcessSiloHandle>(testCluster.Primary);
             var applicationLifetime = primary.ServiceProvider.GetRequiredService<IHostApplicationLifetime>();
@@ -75,7 +75,7 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -92,7 +92,7 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -109,8 +109,8 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -127,8 +127,8 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -145,8 +145,8 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -163,8 +163,8 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -181,8 +181,8 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -199,8 +199,8 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -217,8 +217,8 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             await using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
         }
     }
 
@@ -255,8 +255,8 @@ namespace Orleans.TestingHost.Tests
             builder.AddClientBuilderConfigurator<TConfigurator>();
             using var testCluster = builder.Build();
 
-            await testCluster.DeployAsync();
-            await testCluster.StopAllSilosAsync();
+            await testCluster.DeployAsync(TestContext.Current.CancellationToken);
+            await testCluster.StopAllSilosAsync(TestContext.Current.CancellationToken);
 
             _hostWasInvoked.Should().Be(hostInvoked);
             _clientWasInvoked.Should().Be(clientInvoked);
@@ -320,7 +320,7 @@ namespace Orleans.TestingHost.Tests
             builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
             _testCluster = builder.Build();
 
-            await _testCluster.DeployAsync();
+            await _testCluster.DeployAsync(TestContext.Current.CancellationToken);
 
             var grain = _testCluster.Client.GetGrain<ISimpleGrain>(1);
 
@@ -341,7 +341,7 @@ namespace Orleans.TestingHost.Tests
             builder.AddSiloBuilderConfigurator<SiloConfigurator>();
             _testCluster = builder.Build();
 
-            await _testCluster.DeployAsync();
+            await _testCluster.DeployAsync(TestContext.Current.CancellationToken);
 
             var grain = _testCluster.Client.GetGrain<ISimpleGrain>(1);
 

--- a/test/TestInfrastructure/TestExtensions/BaseClusterFixture.cs
+++ b/test/TestInfrastructure/TestExtensions/BaseClusterFixture.cs
@@ -89,7 +89,7 @@ namespace TestExtensions
             var testCluster = builder.Build();
             if (testCluster.Primary == null)
             {
-                await testCluster.DeployAsync().ConfigureAwait(false);
+                await testCluster.DeployAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
             }
 
             this.HostedCluster = testCluster;
@@ -103,7 +103,7 @@ namespace TestExtensions
 
             try
             {
-                await cluster.StopAllSilosAsync().ConfigureAwait(false);
+                await cluster.StopAllSilosAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
+++ b/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
@@ -90,7 +90,7 @@ public abstract class BaseInProcessTestClusterFixture : Xunit.IAsyncLifetime
         ConfigureTestCluster(builder);
 
         var testCluster = builder.Build();
-        await testCluster.DeployAsync().ConfigureAwait(false);
+        await testCluster.DeployAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
 
         HostedCluster = testCluster;
         Logger = Client.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Application");
@@ -103,7 +103,7 @@ public abstract class BaseInProcessTestClusterFixture : Xunit.IAsyncLifetime
 
         try
         {
-            await cluster.StopAllSilosAsync().ConfigureAwait(false);
+            await cluster.StopAllSilosAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/test/TestInfrastructure/TestExtensions/DefaultClusterFixture.cs
+++ b/test/TestInfrastructure/TestExtensions/DefaultClusterFixture.cs
@@ -29,7 +29,7 @@ namespace TestExtensions
             var testCluster = builder.Build();
             if (testCluster.Primary == null)
             {
-                await testCluster.DeployAsync().ConfigureAwait(false);
+                await testCluster.DeployAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
             }
 
             this.HostedCluster = testCluster;
@@ -43,7 +43,7 @@ namespace TestExtensions
 
             try
             {
-                await cluster.StopAllSilosAsync().ConfigureAwait(false);
+                await cluster.StopAllSilosAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/test/TestInfrastructure/TestExtensions/TestClusterPerTest.cs
+++ b/test/TestInfrastructure/TestExtensions/TestClusterPerTest.cs
@@ -68,7 +68,7 @@ namespace TestExtensions
             var testCluster = builder.Build();
             if (testCluster.Primary == null)
             {
-                await testCluster.DeployAsync().ConfigureAwait(false);
+                await testCluster.DeployAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
             }
 
             this.HostedCluster = testCluster;
@@ -82,7 +82,7 @@ namespace TestExtensions
 
             try
             {
-                await cluster.StopAllSilosAsync().ConfigureAwait(false);
+                await cluster.StopAllSilosAsync(Xunit.TestContext.Current.CancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/test/TesterInternal/ActivationsLifeCycleTests/ActivationCancellationTests.cs
+++ b/test/TesterInternal/ActivationsLifeCycleTests/ActivationCancellationTests.cs
@@ -148,12 +148,12 @@ public class ActivationCancellationLoggingTests : OrleansTestingBase, IClassFixt
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
-            await grain.IsActivated().WaitAsync(TimeSpan.FromSeconds(5));
+            await grain.IsActivated().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         });
 
         RequestContext.Clear();
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var (errorLogs, warningLogs, infoLogs) = GetActivationLogs();
 
@@ -190,7 +190,7 @@ public class ActivationCancellationLoggingTests : OrleansTestingBase, IClassFixt
 
         RequestContext.Clear();
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var (errorLogs, warningLogs, infoLogs) = GetActivationLogs();
 
@@ -221,12 +221,12 @@ public class ActivationCancellationLoggingTests : OrleansTestingBase, IClassFixt
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
-            await grain.IsActivated().WaitAsync(TimeSpan.FromSeconds(5));
+            await grain.IsActivated().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         });
 
         RequestContext.Clear();
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var (errorLogs, warningLogs, infoLogs) = GetActivationLogs();
 
@@ -263,7 +263,7 @@ public class ActivationCancellationLoggingTests : OrleansTestingBase, IClassFixt
 
         RequestContext.Clear();
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var (errorLogs, _, infoLogs) = GetActivationLogs();
 
@@ -291,7 +291,7 @@ public class ActivationCancellationLoggingTests : OrleansTestingBase, IClassFixt
 
         RequestContext.Clear();
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var (errorLogs, _, infoLogs) = GetActivationLogs();
 
@@ -319,7 +319,7 @@ public class ActivationCancellationLoggingTests : OrleansTestingBase, IClassFixt
 
         RequestContext.Clear();
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var (errorLogs, _, infoLogs) = GetActivationLogs();
 
@@ -346,7 +346,7 @@ public class ActivationCancellationLoggingTests : OrleansTestingBase, IClassFixt
 
         var isActivated = await grain.IsActivated();
 
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         var (errorLogs, warningLogs, infoLogs) = GetActivationLogs();
 

--- a/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/TransactionRecoveryTests.cs
@@ -56,7 +56,10 @@ namespace Orleans.Transactions.AzureStorage.Tests
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, 20)]
         public Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(string transactionTestGrainClassName, int concurrent)
         {
-            return this.testRunner.TransactionWillRecoverAfterRandomSiloGracefulShutdown(transactionTestGrainClassName, concurrent);
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloGracefulShutdown(
+                transactionTestGrainClassName,
+                concurrent,
+                TestContext.Current.CancellationToken);
         }
 
         [Theory]
@@ -64,7 +67,10 @@ namespace Orleans.Transactions.AzureStorage.Tests
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, 20)]
         public Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(string transactionTestGrainClassName, int concurrent)
         {
-            return this.testRunner.TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(transactionTestGrainClassName, concurrent);
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(
+                transactionTestGrainClassName,
+                concurrent,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact]

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
@@ -287,6 +287,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
         [Fact]
         public async Task TransactWriteItems_ExplicitClientRequestToken_ReplaysIdenticalRequest()
         {
+            var cancellationToken = TestContext.Current.CancellationToken;
             _ = await InitTableAsync(NullLogger.Instance);
             using var client = CreateDynamoDBClient();
             var partitionKey = $"{partition}-{Guid.NewGuid():N}";
@@ -313,8 +314,8 @@ namespace Orleans.Transactions.DynamoDB.Tests
                 ]
             };
 
-            await client.TransactWriteItemsAsync(request);
-            await client.TransactWriteItemsAsync(request);
+            await client.TransactWriteItemsAsync(request, cancellationToken);
+            await client.TransactWriteItemsAsync(request, cancellationToken);
 
             var response = await client.GetItemAsync(new GetItemRequest
             {
@@ -325,7 +326,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
                     [DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME] = new AttributeValue { S = partitionKey },
                     [DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME] = new AttributeValue { S = "idempotency" }
                 }
-            });
+            }, cancellationToken);
             Assert.Equal("1", response.Item["Value"].N);
         }
 

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/TransactionRecoveryTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/TransactionRecoveryTests.cs
@@ -59,7 +59,10 @@ namespace Orleans.Transactions.DynamoDB.Tests
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, 20)]
         public Task TransactionWillRecoverAfterRandomSiloGracefulShutdown(string transactionTestGrainClassName, int concurrent)
         {
-            return this.testRunner.TransactionWillRecoverAfterRandomSiloGracefulShutdown(transactionTestGrainClassName, concurrent);
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloGracefulShutdown(
+                transactionTestGrainClassName,
+                concurrent,
+                TestContext.Current.CancellationToken);
         }
 
         [Theory]
@@ -67,7 +70,10 @@ namespace Orleans.Transactions.DynamoDB.Tests
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, 20)]
         public Task TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(string transactionTestGrainClassName, int concurrent)
         {
-            return this.testRunner.TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(transactionTestGrainClassName, concurrent);
+            return this.testRunner.TransactionWillRecoverAfterRandomSiloUnGracefulShutdown(
+                transactionTestGrainClassName,
+                concurrent,
+                TestContext.Current.CancellationToken);
         }
 
         [Fact]

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/TransactionQueueRecoveryPolicyFixture.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/TransactionQueueRecoveryPolicyFixture.cs
@@ -187,14 +187,22 @@ internal sealed class TransactionQueueRecoveryPolicyActivationTracker
         }
     }
 
-    public Task WaitForActivationCountAsync(GrainId grainId, int expectedCount, TimeSpan? timeout = null)
+    public Task WaitForActivationCountAsync(
+        GrainId grainId,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        TimeSpan? timeout = null)
     {
-        return this.WaitForCountAsync(grainId, WaiterKind.Activation, expectedCount, timeout);
+        return this.WaitForCountAsync(grainId, WaiterKind.Activation, expectedCount, cancellationToken, timeout);
     }
 
-    public Task WaitForDeactivationCountAsync(GrainId grainId, int expectedCount, TimeSpan? timeout = null)
+    public Task WaitForDeactivationCountAsync(
+        GrainId grainId,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        TimeSpan? timeout = null)
     {
-        return this.WaitForCountAsync(grainId, WaiterKind.Deactivation, expectedCount, timeout);
+        return this.WaitForCountAsync(grainId, WaiterKind.Deactivation, expectedCount, cancellationToken, timeout);
     }
 
     public void RecordActivated(GrainId grainId)
@@ -207,7 +215,12 @@ internal sealed class TransactionQueueRecoveryPolicyActivationTracker
         this.Record(grainId, WaiterKind.Deactivation, this.deactivations);
     }
 
-    private Task WaitForCountAsync(GrainId grainId, WaiterKind kind, int expectedCount, TimeSpan? timeout)
+    private Task WaitForCountAsync(
+        GrainId grainId,
+        WaiterKind kind,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        TimeSpan? timeout)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(expectedCount, 1);
 
@@ -224,7 +237,7 @@ internal sealed class TransactionQueueRecoveryPolicyActivationTracker
             task = completion.Task;
         }
 
-        return task.WaitAsync(timeout ?? TimeSpan.FromSeconds(30));
+        return task.WaitAsync(timeout ?? TimeSpan.FromSeconds(30), cancellationToken);
     }
 
     private void Record(GrainId grainId, WaiterKind kind, Dictionary<GrainId, int> counts)
@@ -277,13 +290,13 @@ public sealed class TransactionQueueRecoveryPolicyState
 
 public interface ITransactionQueueRecoveryPolicyGrain : IGrainWithStringKey
 {
-    Task<Guid> GetActivationId();
+    Task<Guid> GetActivationId(CancellationToken cancellationToken);
 
     [Transaction(TransactionOption.CreateOrJoin)]
-    Task<int> Add(int delta);
+    Task<int> Add(int delta, CancellationToken cancellationToken);
 
     [Transaction(TransactionOption.CreateOrJoin)]
-    Task<int> GetValue();
+    Task<int> GetValue(CancellationToken cancellationToken);
 }
 
 internal sealed class TransactionQueueRecoveryPolicyGrain(
@@ -305,10 +318,15 @@ internal sealed class TransactionQueueRecoveryPolicyGrain(
         return base.OnDeactivateAsync(reason, cancellationToken);
     }
 
-    public Task<Guid> GetActivationId() => Task.FromResult(this.activationId);
-
-    public Task<int> Add(int delta)
+    public Task<Guid> GetActivationId(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(this.activationId);
+    }
+
+    public Task<int> Add(int delta, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
         return state.PerformUpdate(currentState =>
         {
             currentState.Value += delta;
@@ -316,5 +334,9 @@ internal sealed class TransactionQueueRecoveryPolicyGrain(
         });
     }
 
-    public Task<int> GetValue() => state.PerformRead(currentState => currentState.Value);
+    public Task<int> GetValue(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return state.PerformRead(currentState => currentState.Value);
+    }
 }

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/TransactionQueueRecoveryPolicyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/TransactionQueueRecoveryPolicyTests.cs
@@ -23,72 +23,92 @@ public sealed class TransactionQueueRecoveryPolicyTests : IClassFixture<Transact
     [Fact]
     public async Task StorageConflict_DeactivatesImmediately()
     {
-        var (grain, grainId, activationId) = await this.CreateGrainAsync(nameof(StorageConflict_DeactivatesImmediately));
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var (grain, grainId, activationId) = await this.CreateGrainAsync(
+            nameof(StorageConflict_DeactivatesImmediately),
+            cancellationToken);
         this.fixture.StorageController.EnqueueWriteFault(grainId, new InconsistentStateException("Simulated storage conflict."));
 
-        var deactivated = this.fixture.ActivationTracker.WaitForDeactivationCountAsync(grainId, expectedCount: 1);
-        await Assert.ThrowsAnyAsync<Exception>(async () => await grain.Add(1));
-        await deactivated;
+        var deactivated = this.fixture.ActivationTracker.WaitForDeactivationCountAsync(
+            grainId,
+            expectedCount: 1,
+            cancellationToken);
+        await Assert.ThrowsAnyAsync<Exception>(async () => await grain.Add(1, cancellationToken));
+        await deactivated.WaitAsync(cancellationToken);
 
         this.fixture.ActivationTracker.GetDeactivationCount(grainId).Should().Be(1);
 
-        var activated = this.fixture.ActivationTracker.WaitForActivationCountAsync(grainId, expectedCount: 2);
-        var newActivationId = await grain.GetActivationId();
-        await activated;
+        var activated = this.fixture.ActivationTracker.WaitForActivationCountAsync(
+            grainId,
+            expectedCount: 2,
+            cancellationToken);
+        var newActivationId = await grain.GetActivationId(cancellationToken);
+        await activated.WaitAsync(cancellationToken);
 
         newActivationId.Should().NotBe(activationId);
-        (await grain.GetValue()).Should().Be(1);
+        (await grain.GetValue(cancellationToken)).Should().Be(1);
     }
 
     [Fact]
     public async Task LaterRequests_RecoverAfterTransientStoreAndRecoveryFailures()
     {
-        var (grain, grainId, activationId) = await this.CreateGrainAsync(nameof(LaterRequests_RecoverAfterTransientStoreAndRecoveryFailures));
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var (grain, grainId, activationId) = await this.CreateGrainAsync(
+            nameof(LaterRequests_RecoverAfterTransientStoreAndRecoveryFailures),
+            cancellationToken);
         this.QueueFailedStoreAndRecoveryWave(grainId, readFailureCount: 4);
 
-        await this.AssertFailureWithoutDeactivationAsync(grain, grainId, activationId, async () => await grain.Add(1));
+        await this.AssertFailureWithoutDeactivationAsync(
+            grain,
+            grainId,
+            activationId,
+            async () => await grain.Add(1, cancellationToken),
+            cancellationToken);
 
         var recovered = false;
         for (var attempt = 0; attempt < 4; attempt++)
         {
             try
             {
-                (await grain.Add(10)).Should().Be(11);
+                (await grain.Add(10, cancellationToken)).Should().Be(11);
                 recovered = true;
                 break;
             }
             catch
             {
                 this.fixture.ActivationTracker.GetDeactivationCount(grainId).Should().Be(0);
-                (await grain.GetActivationId()).Should().Be(activationId);
+                (await grain.GetActivationId(cancellationToken)).Should().Be(activationId);
             }
         }
 
         recovered.Should().BeTrue();
         this.fixture.ActivationTracker.GetDeactivationCount(grainId).Should().Be(0);
-        (await grain.GetValue()).Should().Be(11);
+        (await grain.GetValue(cancellationToken)).Should().Be(11);
     }
 
-    private async Task<(ITransactionQueueRecoveryPolicyGrain Grain, GrainId GrainId, Guid ActivationId)> CreateGrainAsync(string key)
+    private async Task<(ITransactionQueueRecoveryPolicyGrain Grain, GrainId GrainId, Guid ActivationId)> CreateGrainAsync(
+        string key,
+        CancellationToken cancellationToken)
     {
         this.fixture.StorageController.Reset();
         this.fixture.ActivationTracker.Reset();
 
         var grain = this.fixture.GrainFactory.GetGrain<ITransactionQueueRecoveryPolicyGrain>(key);
-        (await grain.Add(1)).Should().Be(1);
+        (await grain.Add(1, cancellationToken)).Should().Be(1);
 
-        return (grain, grain.GetGrainId(), await grain.GetActivationId());
+        return (grain, grain.GetGrainId(), await grain.GetActivationId(cancellationToken));
     }
 
     private async Task AssertFailureWithoutDeactivationAsync(
         ITransactionQueueRecoveryPolicyGrain grain,
         GrainId grainId,
         Guid expectedActivationId,
-        Func<Task> operation)
+        Func<Task> operation,
+        CancellationToken cancellationToken)
     {
         await Assert.ThrowsAnyAsync<Exception>(operation);
         this.fixture.ActivationTracker.GetDeactivationCount(grainId).Should().Be(0);
-        (await grain.GetActivationId()).Should().Be(expectedActivationId);
+        (await grain.GetActivationId(cancellationToken)).Should().Be(expectedActivationId);
     }
 
     private void QueueFailedStoreAndRecoveryWave(GrainId grainId, int readFailureCount)

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
@@ -695,7 +695,9 @@ public class TransactionDiagnosticEventsTests
             waitCount: 2,
             deadline: timeStamp.AddSeconds(10),
             identity));
-        var transition = await gate.WaitAsync(GetDeadline(RecoveryObservationTimeout));
+        var transition = await gate.WaitAsync(
+            GetDeadline(RecoveryObservationTimeout),
+            TestContext.Current.CancellationToken);
 
         Assert.False(emission.IsCompleted);
         Assert.Equal(transactionId, transition.TransactionId);
@@ -718,7 +720,9 @@ public class TransactionDiagnosticEventsTests
         using var gate = observer.GateNextTransition(transition =>
             transition.Kind == TransactionRecoveryEventObserver.RecoveryTransitionKind.TransactionConfirmCompleted
             && transition.TransactionId == committedTransactionId);
-        var wait = gate.WaitAsync(GetDeadline(RecoveryObservationTimeout));
+        var wait = gate.WaitAsync(
+            GetDeadline(RecoveryObservationTimeout),
+            TestContext.Current.CancellationToken);
 
         TransactionDiagnosticEvents.EmitTransactionConfirmCompleted(
             resource,

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryFailureObservationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryFailureObservationTests.cs
@@ -46,7 +46,8 @@ public class TransactionRecoveryFailureObservationTests
             failure.Task,
             stopProducing,
             responseWindow,
-            schedulingMargin);
+            schedulingMargin,
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(TransactionRecoveryFailureObservation.OutcomeKind.AttemptTimedOut, outcome.Kind);
         Assert.Null(outcome.Failure);
@@ -81,7 +82,8 @@ public class TransactionRecoveryFailureObservationTests
             failure.Task,
             stopProducing,
             observationWindow: TimeSpan.Zero,
-            producerDrainTimeout: TimeSpan.FromSeconds(1));
+            producerDrainTimeout: TimeSpan.FromSeconds(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(TransactionRecoveryFailureObservation.OutcomeKind.FailureObserved, outcome.Kind);
         Assert.Same(expectedFailure, outcome.Failure);
@@ -113,27 +115,28 @@ public class TransactionRecoveryFailureObservationTests
                 maximumActiveAttempts = Math.Max(maximumActiveAttempts, active);
                 Interlocked.Increment(ref attemptCount);
                 firstAttemptStarted.TrySetResult();
-                await finishFirstAttempt.Task;
+                await finishFirstAttempt.Task.WaitAsync(TestContext.Current.CancellationToken);
                 Interlocked.Decrement(ref activeAttempts);
 
                 betweenAttempts.TrySetResult();
-                await cancellationObserved.Task;
+                await cancellationObserved.Task.WaitAsync(TestContext.Current.CancellationToken);
             }
 
             return attemptCount;
         }
 
         var producer = ProduceAsync();
-        await firstAttemptStarted.Task;
+        await firstAttemptStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
         finishFirstAttempt.TrySetResult();
-        await betweenAttempts.Task;
+        await betweenAttempts.Task.WaitAsync(TestContext.Current.CancellationToken);
 
         var outcome = await TransactionRecoveryFailureObservation.DetectAsync(
             producer,
             failure.Task,
             stopProducing,
             observationWindow: TimeSpan.Zero,
-            producerDrainTimeout: TimeSpan.FromSeconds(1));
+            producerDrainTimeout: TimeSpan.FromSeconds(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(TransactionRecoveryFailureObservation.OutcomeKind.StoppedWithoutFailure, outcome.Kind);
         Assert.Null(outcome.Failure);
@@ -156,11 +159,11 @@ public class TransactionRecoveryFailureObservationTests
             (_, observedAt) => observedFailure.TrySetResult(observedAt));
 
         inFlight.TrySetResult();
-        await inFlight.Task;
+        await inFlight.Task.WaitAsync(TestContext.Current.CancellationToken);
         mutation.TrySetException(new InvalidOperationException("Pre-shutdown transaction fault"));
-        var observedAt = await observedFailure.Task;
+        var observedAt = await observedFailure.Task.WaitAsync(TestContext.Current.CancellationToken);
         var shutdownRequestedAt = Stopwatch.GetTimestamp();
-        await observation;
+        await observation.WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.True(TransactionRecoveryFailureObservation.IsPremature(observedAt, shutdownRequestedAt));
     }

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -168,7 +168,9 @@ public class TransactionRecoveryLatencyTests
         var observer = new RecordingObserver(transactionId);
         using var subscription = TransactionDiagnosticEvents.AllEvents.Subscribe(observer);
 
-        var resolution = Task.Run(async () => await agent.Resolve(transaction));
+        var resolution = Task.Run(
+            async () => await agent.Resolve(transaction),
+            TestContext.Current.CancellationToken);
         await queue.WaitForCancelInvocationAsync(TestContext.Current.CancellationToken);
 
         var promise = Assert.IsType<TaskCompletionSource<TransactionalStatus>>(protocol.ManagerPromise);
@@ -199,8 +201,9 @@ public class TransactionRecoveryLatencyTests
 
         remoteTwoGate.TrySetResult();
         remoteOneGate.TrySetResult();
-        await Task.WhenAll(queue.CancelInvocations.Select(send => send.SendTask));
-        await managerFanOut;
+        await Task.WhenAll(queue.CancelInvocations.Select(send => send.SendTask))
+            .WaitAsync(TestContext.Current.CancellationToken);
+        await managerFanOut.WaitAsync(TestContext.Current.CancellationToken);
         Assert.True(managerFanOut.IsCompletedSuccessfully);
         Assert.Equal(
             new[] { remoteOne.Name, remoteTwo.Name },
@@ -244,16 +247,16 @@ public class TransactionRecoveryLatencyTests
         transaction.RecordWrite(selfResource, timeStamp);
 
         var resolution = agent.Resolve(transaction);
-        Assert.True(SpinWait.SpinUntil(
-            () => queue.CancelSendCount == 2
-                && protocol.ManagerPromise is not null
-                && protocol.ManagerPromise.Task.IsCompleted,
-            TimeSpan.FromSeconds(1)));
-        var (status, exception) = await resolution.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        var (status, exception) = await resolution.WaitAsync(
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(TransactionalStatus.PrepareTimeout, status);
         Assert.Null(exception);
-        Assert.Equal(TransactionalStatus.PrepareTimeout, await protocol.ManagerPromise!.Task);
+        Assert.Equal(2, queue.CancelSendCount);
+        Assert.Equal(
+            TransactionalStatus.PrepareTimeout,
+            await protocol.ManagerPromise!.Task.WaitAsync(TestContext.Current.CancellationToken));
         Assert.True(protocol.ManagerFanOutTask!.IsCompletedSuccessfully);
         Assert.Equal(2, queue.CancelSendCount);
         Assert.Equal(1, queue.CancelInvocations.Count(send => send.Target.Equals(remote)));
@@ -303,7 +306,7 @@ public class TransactionRecoveryLatencyTests
         Assert.False(notification.IsCompleted);
 
         lifetime.Cancel();
-        await notification;
+        await notification.WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.False(send.SendTask.IsCompleted);
         Assert.Equal(TransactionalStatus.PrepareTimeout, send.Status);
@@ -320,7 +323,7 @@ public class TransactionRecoveryLatencyTests
         Assert.IsType<TransactionDiagnosticEvents.CancelFanOutFailed>(observer.Events[^1]);
 
         remoteGate.TrySetResult();
-        await send.SendTask;
+        await send.SendTask.WaitAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -348,24 +351,20 @@ public class TransactionRecoveryLatencyTests
         var outerDeadline = TimeSpan.FromSeconds(2);
 
         var resolution = agent.Resolve(transaction);
-
-        Assert.True(SpinWait.SpinUntil(
-            () => protocol.ManagerPromise is not null
-                && protocol.ManagerFanOutTask is not null
-                && queue.CancelSendCount == 1
-                && protocol.ManagerPromise.Task.IsCompleted
-                && resolution.IsCompleted,
-            TimeSpan.FromSeconds(1)));
+        var (status, exception) = await resolution.WaitAsync(
+            outerDeadline,
+            TestContext.Current.CancellationToken);
 
         Assert.False(protocol.ManagerFanOutTask!.IsCompleted);
-        var (status, exception) = await resolution.WaitAsync(outerDeadline, TestContext.Current.CancellationToken);
 
         Assert.Equal(TransactionalStatus.PrepareTimeout, status);
         Assert.Null(exception);
         Assert.Equal(1, queue.CancelSendCount);
         Assert.Equal(1, protocol.ManagerFanOutCount);
         Assert.Equal(0, protocol.TransactionAgentCancelCount);
-        Assert.Equal(TransactionalStatus.PrepareTimeout, await protocol.ManagerPromise!.Task);
+        Assert.Equal(
+            TransactionalStatus.PrepareTimeout,
+            await protocol.ManagerPromise!.Task.WaitAsync(TestContext.Current.CancellationToken));
         var send = Assert.Single(queue.CancelInvocations);
         Assert.False(send.SendTask.IsCompleted);
         Assert.Equal(TransactionalStatus.PrepareTimeout, send.Status);
@@ -436,7 +435,7 @@ public class TransactionRecoveryLatencyTests
         Assert.IsType<TransactionDiagnosticEvents.CancelFanOutFailed>(observer.Events[^1]);
 
         selfGate.TrySetResult();
-        await send.SendTask;
+        await send.SendTask.WaitAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -459,13 +458,9 @@ public class TransactionRecoveryLatencyTests
         transaction.RecordWrite(remote, timeStamp);
 
         var resolution = agent.Resolve(transaction);
-        Assert.True(SpinWait.SpinUntil(
-            () => protocol.ManagerPromise is not null
-                && protocol.ManagerFanOutTask is not null
-                && queue.CancelSendCount == 1
-                && protocol.ManagerPromise.Task.IsCompleted
-                && resolution.IsCompleted,
-            TimeSpan.FromSeconds(1)));
+        var (status, exception) = await resolution.WaitAsync(
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
 
         var promise = Assert.IsType<TaskCompletionSource<TransactionalStatus>>(protocol.ManagerPromise);
         var managerFanOut = Assert.IsAssignableFrom<Task>(protocol.ManagerFanOutTask);
@@ -474,17 +469,17 @@ public class TransactionRecoveryLatencyTests
         Assert.Equal(1, queue.CancelSendCount);
         Assert.Equal(0, protocol.TransactionAgentCancelCount);
 
-        var (status, exception) = await resolution;
-
         Assert.Equal(TransactionalStatus.PrepareTimeout, status);
         Assert.Null(exception);
-        Assert.Equal(TransactionalStatus.PrepareTimeout, await promise.Task);
+        Assert.Equal(
+            TransactionalStatus.PrepareTimeout,
+            await promise.Task.WaitAsync(TestContext.Current.CancellationToken));
         Assert.Equal(1, protocol.ManagerFanOutCount);
         Assert.Equal(1, queue.CancelSendCount);
         Assert.Equal(0, protocol.TransactionAgentCancelCount);
 
         cancelGate.TrySetResult();
-        await managerFanOut;
+        await managerFanOut.WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.True(managerFanOut.IsCompletedSuccessfully);
     }
@@ -500,8 +495,10 @@ public class TransactionRecoveryLatencyTests
         var observer = new RecordingObserver(transactionId);
         using var subscription = TransactionDiagnosticEvents.AllEvents.Subscribe(observer);
 
-        await queue.NotifyOfPing(transactionId, timeStamp, remote);
-        await queue.NotifyOfPing(transactionId, timeStamp, remote);
+        await queue.NotifyOfPing(transactionId, timeStamp, remote)
+            .WaitAsync(TestContext.Current.CancellationToken);
+        await queue.NotifyOfPing(transactionId, timeStamp, remote)
+            .WaitAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, observer.Events.OfType<TransactionDiagnosticEvents.CancelSendStarted>().Count());
         Assert.Equal(2, observer.Events.OfType<TransactionDiagnosticEvents.CancelSendCompleted>().Count());


### PR DESCRIPTION
## Problem

The test build globally suppressed xUnit1051, so Microsoft Testing Platform and xUnit cancellation did not consistently reach long-running waits, lifecycle operations, storage calls, streams, reminders, transactions, and provider test helpers.

## Solution

- remove the xUnit1051 suppression and propagate `TestContext.Current.CancellationToken` throughout the test suites
- add cancellation-aware TestingHost, persistence, reminder, transaction, durable-job, streaming, and test-grain helper APIs
- pass cancellation through cluster lifecycle and provider operations, including file storage async I/O
- update the generated TestingHost API surface for the new overloads

## Rationale

Cooperative cancellation now reaches the operation performing the work, allowing stopped or timed-out test runs to terminate promptly while preserving existing timeout and cleanup behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10845)