### PR TITLE
Enable DefaultDeny network isolation for CI

### DIFF
--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -76,6 +76,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: DefaultDeny
     sdl:
       autobaseline:
         enableForGitHub: true


### PR DESCRIPTION
Configure the Orleans Azure DevOps CI pipeline to use the DefaultDeny network isolation policy, as required by SFI-ES4.2.4.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10850)