### PR TITLE
fix(codegen): suppress warnings in generated source

### DIFF
--- a/src/Orleans.CodeGenerator/GeneratedSourceOutput.cs
+++ b/src/Orleans.CodeGenerator/GeneratedSourceOutput.cs
@@ -11,8 +11,8 @@ namespace Orleans.CodeGenerator;
 
 internal static class GeneratedSourceOutput
 {
-    private const string GeneratedCodeWarningDisable = "#pragma warning disable CS1591, RS0016, RS0041";
-    private const string GeneratedCodeWarningRestore = "#pragma warning restore CS1591, RS0016, RS0041";
+    private const string GeneratedCodeWarningDisable = "#pragma warning disable";
+    private const string GeneratedCodeWarningRestore = "#pragma warning restore";
 
     internal static void EmitSourceOutputResult(SourceProductionContext context, SourceOutputResult result)
     {
@@ -379,5 +379,4 @@ internal static class GeneratedSourceOutput
         return result.Length > 0 ? result : "generated";
     }
 }
-
 

--- a/test/Orleans.CodeGenerator.Tests/GeneratedWarningSuppressionTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/GeneratedWarningSuppressionTests.cs
@@ -6,6 +6,8 @@ namespace Orleans.CodeGenerator.Tests;
 
 public sealed class GeneratedWarningSuppressionTests
 {
+    private const string ObsoleteWithoutMessageDiagnosticId = "CS0612";
+    private const string ObsoleteWithMessageDiagnosticId = "CS0618";
     private const string MissingXmlCommentDiagnosticId = "CS1591";
     private const string PublicApiAnalyzerDiagnosticId = "RS0016";
     private const string CompilerApiAnalyzerDiagnosticId = "RS0041";
@@ -46,7 +48,7 @@ public sealed class GeneratedWarningSuppressionTests
             }
             """;
 
-        var compilation = await CreateCompilationWithDocumentationDiagnostics(source);
+        var compilation = await CreateCompilationWithStrictDiagnostics(source);
         var result = RunGenerator(compilation);
 
         Assert.Empty(result.Diagnostics.Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
@@ -72,7 +74,65 @@ public sealed class GeneratedWarningSuppressionTests
     }
 
     [Fact]
-    public async Task GeneratedSources_CompileCleanlyUnderStrictDiagnosticsForMixedSourceAndReferences()
+    public async Task GeneratedProxySourcesSuppressObsoleteMemberWarnings()
+    {
+        const string source = """
+            using Orleans;
+            using System;
+            using System.Threading.Tasks;
+
+            namespace TestProject;
+
+            public interface IWarningGrain : IGrainWithIntegerKey
+            {
+                [Obsolete]
+                Task OldMethodWithoutMessage();
+
+                [Obsolete("Use NewMethod instead.")]
+                Task OldMethodWithMessage();
+
+                Task NewMethod();
+            }
+
+            public static class WarningCaller
+            {
+                public static async Task CallObsoleteMethods(IWarningGrain grain)
+                {
+                    await grain.OldMethodWithoutMessage();
+                    await grain.OldMethodWithMessage();
+                }
+            }
+            """;
+
+        var compilation = await CreateCompilationWithStrictDiagnostics(source);
+        var result = RunGenerator(compilation);
+
+        Assert.Empty(result.Diagnostics.Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.Contains(result.GeneratedSources, static source => source.HintName.Contains(".orleans.proxy.", StringComparison.Ordinal));
+
+        var generatedCompilation = compilation.AddSyntaxTrees(CreateGeneratedSyntaxTrees(result));
+        var generatedTreePaths = result.GeneratedSources
+            .Select(static source => source.HintName)
+            .ToHashSet(StringComparer.Ordinal);
+        var obsoleteErrors = generatedCompilation.GetDiagnostics()
+            .Where(static diagnostic => (diagnostic.Id is ObsoleteWithoutMessageDiagnosticId or ObsoleteWithMessageDiagnosticId)
+                && diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { ObsoleteWithoutMessageDiagnosticId, ObsoleteWithMessageDiagnosticId },
+            obsoleteErrors
+                .Where(diagnostic => diagnostic.Location.SourceTree is { } tree && !generatedTreePaths.Contains(tree.FilePath))
+                .Select(static diagnostic => diagnostic.Id)
+                .OrderBy(static id => id, StringComparer.Ordinal)
+                .ToArray());
+        Assert.DoesNotContain(
+            obsoleteErrors,
+            diagnostic => diagnostic.Location.SourceTree is { } tree && generatedTreePaths.Contains(tree.FilePath));
+    }
+
+    [Fact]
+    public async Task GeneratedSourcesCompileCleanlyWhenWarningsAreErrorsForMixedSourceAndReferences()
     {
         const string librarySource = """
             using Orleans;
@@ -132,7 +192,7 @@ public sealed class GeneratedWarningSuppressionTests
         var libraryCompilation = await TestCompilationHelper.CreateCompilation(librarySource, "LibraryProject");
         Assert.Empty(libraryCompilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
 
-        var compilation = await CreateCompilationWithDocumentationDiagnostics(
+        var compilation = await CreateCompilationWithStrictDiagnostics(
             consumerSource,
             libraryCompilation.ToMetadataReference());
         var result = RunGenerator(compilation);
@@ -158,7 +218,7 @@ public sealed class GeneratedWarningSuppressionTests
             string.Join(Environment.NewLine, generatedErrors));
     }
 
-    private static async Task<CSharpCompilation> CreateCompilationWithDocumentationDiagnostics(
+    private static async Task<CSharpCompilation> CreateCompilationWithStrictDiagnostics(
         string source,
         params MetadataReference[] additionalReferences)
     {
@@ -168,11 +228,15 @@ public sealed class GeneratedWarningSuppressionTests
             DocumentationParseOptions,
             path: "WarningSuppressionInput.cs",
             encoding: Encoding.UTF8);
-        var options = compilation.Options.WithSpecificDiagnosticOptions(
-            compilation.Options.SpecificDiagnosticOptions
-                .SetItem(MissingXmlCommentDiagnosticId, ReportDiagnostic.Error)
-                .SetItem(PublicApiAnalyzerDiagnosticId, ReportDiagnostic.Error)
-                .SetItem(CompilerApiAnalyzerDiagnosticId, ReportDiagnostic.Error));
+        var options = compilation.Options
+            .WithGeneralDiagnosticOption(ReportDiagnostic.Error)
+            .WithSpecificDiagnosticOptions(
+                compilation.Options.SpecificDiagnosticOptions
+                    .SetItem(ObsoleteWithoutMessageDiagnosticId, ReportDiagnostic.Error)
+                    .SetItem(ObsoleteWithMessageDiagnosticId, ReportDiagnostic.Error)
+                    .SetItem(MissingXmlCommentDiagnosticId, ReportDiagnostic.Error)
+                    .SetItem(PublicApiAnalyzerDiagnosticId, ReportDiagnostic.Error)
+                    .SetItem(CompilerApiAnalyzerDiagnosticId, ReportDiagnostic.Error));
 
         return compilation
             .ReplaceSyntaxTree(compilation.SyntaxTrees.Single(), syntaxTree)

--- a/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/OrleansSourceGeneratorTests.cs
@@ -1869,7 +1869,7 @@ public class DemoClass
         resultText = resultText.Replace(".Add(typeof(int));", ".Add(typeof( int ));", StringComparison.Ordinal);
         if (assemblyAttributes.Count > 0)
         {
-            resultText += $"{Environment.NewLine}#pragma warning restore CS1591, RS0016, RS0041";
+            resultText += $"{Environment.NewLine}#pragma warning restore";
         }
 
         return resultText;

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestAlias.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestAlias.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -75,4 +75,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClass.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClass.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -118,4 +118,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithAnnotatedFields.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithAnnotatedFields.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -142,4 +142,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithDifferentAccessModifiers.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithDifferentAccessModifiers.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -218,4 +218,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithFields.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithFields.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -142,4 +142,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithInheritance.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithInheritance.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -183,4 +183,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithInitOnlyProperty.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithInitOnlyProperty.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -120,4 +120,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithoutNamespace.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicClassWithoutNamespace.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -124,4 +124,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicGrain.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicGrain.verified.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -264,4 +264,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicStruct.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestBasicStruct.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -74,4 +74,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassNestedTypes.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassNestedTypes.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -163,4 +163,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassPrimitiveTypes.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassPrimitiveTypes.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -318,4 +318,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassPrimitiveTypesUsingFullName.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassPrimitiveTypesUsingFullName.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -318,4 +318,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassReferenceProperties.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassReferenceProperties.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -158,4 +158,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithConstructorParameters.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithConstructorParameters.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -138,4 +138,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithFieldAndNoSetters.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithFieldAndNoSetters.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -146,4 +146,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithGenerateMethodSerializersAnnotation.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithGenerateMethodSerializersAnnotation.verified.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -171,4 +171,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithGenerateSerializerAnnotation.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithGenerateSerializerAnnotation.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -150,4 +150,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithInterfaceConstructorParameter.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithInterfaceConstructorParameter.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -132,4 +132,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithNoPublicConstructors.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithNoPublicConstructors.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -123,4 +123,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithOptionalConstructorParameters.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithOptionalConstructorParameters.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -142,4 +142,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithParameterizedConstructor.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassWithParameterizedConstructor.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -236,4 +236,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassesWithGeneratedActivatorConstructorAnnotation.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestClassesWithGeneratedActivatorConstructorAnnotation.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -129,4 +129,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestCompoundTypeAlias.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestCompoundTypeAlias.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -250,4 +250,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGenericClass.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGenericClass.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -271,4 +271,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGenericClassWithConstructorParameters.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGenericClassWithConstructorParameters.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -260,4 +260,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainComplexGrain.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainComplexGrain.verified.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -460,4 +460,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainMethodAnnotatedWithInvokableBaseType.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainMethodAnnotatedWithInvokableBaseType.verified.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -269,4 +269,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainMethodAnnotatedWithResponseTimeout.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainMethodAnnotatedWithResponseTimeout.verified.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -168,4 +168,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainWithDifferentKeyTypes.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainWithDifferentKeyTypes.verified.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -812,4 +812,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainWithMultipleInterfaces.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestGrainWithMultipleInterfaces.verified.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -311,4 +311,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestRecords.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestRecords.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -312,4 +312,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestRecordsWithParameterIdAttributes.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestRecordsWithParameterIdAttributes.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -361,4 +361,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithOmitDefaultMemberValuesAnnotation.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithOmitDefaultMemberValuesAnnotation.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -123,4 +123,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithSerializerTransparentAnnotation.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithSerializerTransparentAnnotation.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -18,4 +18,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithSuppressReferenceTrackingAttribute.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithSuppressReferenceTrackingAttribute.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -122,4 +122,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore

--- a/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithUseActivatorAnnotation.verified.cs
+++ b/test/Orleans.CodeGenerator.Tests/snapshots/OrleansSourceGeneratorTests.TestWithUseActivatorAnnotation.verified.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591, RS0016, RS0041
+﻿#pragma warning disable
 [assembly: global::Orleans.ApplicationPartAttribute("TestProject")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Core.Abstractions")]
 [assembly: global::Orleans.ApplicationPartAttribute("Orleans.Serialization")]
@@ -19,4 +19,4 @@ namespace OrleansCodeGen.TestProject
         }
     }
 }
-#pragma warning restore CS1591, RS0016, RS0041
+#pragma warning restore


### PR DESCRIPTION
Generated Orleans source can reference obsolete members or trigger compiler and analyzer warnings that user projects promote to errors. Maintaining a fixed warning list leaves generated code vulnerable to new diagnostics.

This wraps each generated compilation unit in `#pragma warning disable` and `#pragma warning restore`, suppressing warning-severity diagnostics only within generated source while preserving compiler errors and diagnostics in user-authored code. Regression coverage promotes all warnings to errors and verifies that obsolete user calls remain errors.

Closes #10851
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10854)