### PR TITLE
fix(test): remove activation-local reminder waits

### DIFF
--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -26,7 +26,6 @@ namespace UnitTests.Grains
         private readonly IOptions<ReminderOptions> reminderOptions;
 
         private readonly ILogger logger;
-        private readonly ReminderCounterWaiter counterWaiter = new();
         private string _id = null!; // used to distinguish during debugging between multiple activations of the same grain
 
         private string filePrefix = null!;
@@ -53,7 +52,6 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this.logger.LogInformation("OnDeactivateAsync");
-            counterWaiter.Deactivate(this.GrainId);
             return Task.CompletedTask;
         }
 
@@ -87,7 +85,6 @@ namespace UnitTests.Grains
 
             string fileName = GetFileName(reminderName);
             File.Delete(fileName); // if successfully started, then remove any old data
-            counterWaiter.Reset(reminderName);
             this.logger.LogInformation("Started reminder {Reminder}", r);
             return r;
         }
@@ -139,7 +136,6 @@ namespace UnitTests.Grains
             string fileName = GetFileName(reminderName);
             string counterValue = this.sequence[reminderName].ToString(CultureInfo.InvariantCulture);
             File.WriteAllText(fileName, counterValue);
-            counterWaiter.Signal(reminderName, sequenceNumber);
 
             return;
         }
@@ -217,9 +213,6 @@ namespace UnitTests.Grains
             return Task.FromResult(counterValue);
         }
 
-        public Task<bool> WaitForCounterForTestAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
-            => counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
-
         public Task<IGrainReminder?> GetReminderObject(string reminderName)
         {
             return this.GetReminder(reminderName);
@@ -263,7 +256,6 @@ namespace UnitTests.Grains
         private static readonly long aCCURACY = 50 * TimeSpan.TicksPerMillisecond; // when we use ticks to compute sequence numbers, we might get wrong results as timeouts don't happen with precision of ticks  ... we keep this as a leeway
 
         private readonly ILogger logger;
-        private readonly ReminderCounterWaiter counterWaiter = new();
         private long myId; // used to distinguish during debugging between multiple activations of the same grain
 
         private string filePrefix = null!;
@@ -288,7 +280,6 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this.logger.LogInformation("OnDeactivateAsync.");
-            counterWaiter.Deactivate(this.GrainId);
             return Task.CompletedTask;
         }
 
@@ -315,9 +306,7 @@ namespace UnitTests.Grains
                 this.allReminders.Add(reminderName, r);
                 this.sequence.Add(reminderName, 0);
             }
-
             File.Delete(GetFileName(reminderName)); // if successfully started, then remove any old data
-            counterWaiter.Reset(reminderName);
             this.logger.LogInformation("Started reminder {Reminder}.", r);
             return r;
         }
@@ -366,9 +355,7 @@ namespace UnitTests.Grains
 
             this.sequence[reminderName] = sequenceNumber;
             this.logger.LogInformation("{ReminderName} Sequence # {SequenceNumber} with status {Status}.", reminderName, this.sequence[reminderName], status);
-
             File.WriteAllText(GetFileName(reminderName), this.sequence[reminderName].ToString());
-            counterWaiter.Signal(reminderName, sequenceNumber);
 
             return;
         }
@@ -421,9 +408,6 @@ namespace UnitTests.Grains
             return Task.FromResult(long.Parse(File.ReadAllText(GetFileName(name))));
         }
 
-        public Task<bool> WaitForCounterForTestAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
-            => counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
-
         public async Task<IGrainReminder?> GetReminderObject(string reminderName)
         {
             return await this.GetReminder(reminderName);
@@ -436,131 +420,6 @@ namespace UnitTests.Grains
         private string GetFileName(string reminderName)
         {
             return string.Format("{0}{1}", this.filePrefix, reminderName);
-        }
-    }
-
-    internal sealed class ReminderCounterWaiter
-    {
-        private readonly object lockObject = new();
-        private readonly Dictionary<string, long> counters = new();
-        private readonly Dictionary<string, List<(long Target, TaskCompletionSource<bool> Completion)>> waiters = new();
-        private bool deactivated;
-
-        public async Task<bool> WaitAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
-        {
-            TaskCompletionSource<bool> completion;
-            lock (lockObject)
-            {
-                if (deactivated)
-                {
-                    return false;
-                }
-
-                current = Math.Max(current, counters.GetValueOrDefault(reminderName));
-                if (current >= target)
-                {
-                    return true;
-                }
-
-                if (!waiters.TryGetValue(reminderName, out var reminderWaiters))
-                {
-                    reminderWaiters = [];
-                    waiters.Add(reminderName, reminderWaiters);
-                }
-
-                completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
-                reminderWaiters.Add((target, completion));
-            }
-
-            using var registration = cancellationToken.Register(
-                static state =>
-                {
-                    var (source, token) = ((TaskCompletionSource<bool> Source, CancellationToken Token))state!;
-                    source.TrySetCanceled(token);
-                },
-                (completion, cancellationToken));
-            try
-            {
-                return await completion.Task.ConfigureAwait(false);
-            }
-            finally
-            {
-                lock (lockObject)
-                {
-                    if (waiters.TryGetValue(reminderName, out var reminderWaiters))
-                    {
-                        reminderWaiters.RemoveAll(waiter => ReferenceEquals(waiter.Completion, completion));
-                        if (reminderWaiters.Count == 0)
-                        {
-                            waiters.Remove(reminderName);
-                        }
-                    }
-                }
-            }
-        }
-
-        public void Signal(string reminderName, long current)
-        {
-            List<TaskCompletionSource<bool>>? completed = null;
-            lock (lockObject)
-            {
-                counters[reminderName] = current;
-                if (!waiters.TryGetValue(reminderName, out var reminderWaiters))
-                {
-                    return;
-                }
-
-                for (var i = reminderWaiters.Count - 1; i >= 0; i--)
-                {
-                    var waiter = reminderWaiters[i];
-                    if (waiter.Completion.Task.IsCompleted || current >= waiter.Target)
-                    {
-                        reminderWaiters.RemoveAt(i);
-                        if (!waiter.Completion.Task.IsCompleted)
-                        {
-                            (completed ??= []).Add(waiter.Completion);
-                        }
-                    }
-                }
-
-                if (reminderWaiters.Count == 0)
-                {
-                    waiters.Remove(reminderName);
-                }
-            }
-
-            if (completed is not null)
-            {
-                foreach (var completion in completed)
-                {
-                    completion.TrySetResult(true);
-                }
-            }
-        }
-
-        public void Reset(string reminderName)
-        {
-            lock (lockObject)
-            {
-                counters[reminderName] = 0;
-            }
-        }
-
-        public void Deactivate(GrainId grainId)
-        {
-            List<TaskCompletionSource<bool>> pending;
-            lock (lockObject)
-            {
-                deactivated = true;
-                pending = waiters.Values.SelectMany(static value => value.Select(static waiter => waiter.Completion)).ToList();
-                waiters.Clear();
-                counters.Clear();
-            }
-
-            foreach (var completion in pending)
-            {
-                completion.TrySetResult(false);
-            }
         }
     }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -537,7 +537,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             await SynchronizeReminderSchedulesAsync(cancellationToken, reminders);
 
-            var counterWaitTasks = new List<Task>(reminders.Length);
+            var previousCounters = new long[reminders.Length];
             var previousTickCounts = new int[reminders.Length];
             var tickTasks = new Task[reminders.Length];
             for (var reminderIndex = 0; reminderIndex < reminders.Length; reminderIndex++)
@@ -551,19 +551,10 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                     previousTickCounts[reminderIndex] + 1,
                     cancellationToken,
                     reminder.ReminderName);
-            }
-
-            foreach (var reminder in reminders)
-            {
-                var current = await GetReminderCounterOrZeroAsync(
+                previousCounters[reminderIndex] = await GetReminderCounterOrZeroAsync(
                     reminder.Grain,
                     reminder.ReminderName,
                     cancellationToken);
-                counterWaitTasks.Add(GetReminderCounterWaitTask(
-                    reminder.Grain,
-                    reminder.ReminderName,
-                    current + 1,
-                    cancellationToken));
             }
 
             var periods = await Task.WhenAll(reminders.Select(reminder =>
@@ -577,12 +568,16 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                 tickCount,
                 reminders.Length);
             await AdvanceReminderTimeAsync(period, cancellationToken);
-            await Task.WhenAll(Task.WhenAll(counterWaitTasks), Task.WhenAll(tickTasks));
+            // TickCompleted is emitted after ReceiveReminder returns, so the counter is already persisted.
+            await Task.WhenAll(tickTasks).WaitAsync(cancellationToken);
 
             await SynchronizeReminderSchedulesAsync(cancellationToken, reminders);
             for (var reminderIndex = 0; reminderIndex < reminders.Length; reminderIndex++)
             {
                 var reminder = reminders[reminderIndex];
+                Assert.Equal(
+                    previousCounters[reminderIndex] + 1,
+                    await GetReminderCounterAsync(reminder.Grain, reminder.ReminderName).WaitAsync(cancellationToken));
                 Assert.Equal(
                     1,
                     observer.GetActiveReminderCount(
@@ -1026,53 +1021,6 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         catch (FileNotFoundException)
         {
             return 0;
-        }
-    }
-
-    private async Task GetReminderCounterWaitTask(
-        IAddressable grain,
-        string reminderName,
-        long target,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var current = await GetReminderCounterOrZeroAsync(grain, reminderName, cancellationToken);
-                if (!HostedCluster.TryGetGrainContext(grain.GetGrainId(), out var grainContext))
-                {
-                    await Task.Yield();
-                    continue;
-                }
-
-                var completed = grainContext.GrainInstance switch
-                {
-                    ReminderTestGrain2 reminderTestGrain => await reminderTestGrain.WaitForCounterForTestAsync(reminderName, target, current, cancellationToken),
-                    ReminderTestCopyGrain reminderTestCopyGrain => await reminderTestCopyGrain.WaitForCounterForTestAsync(reminderName, target, current, cancellationToken),
-                    { } instance => throw new InvalidOperationException($"Unexpected grain instance type {instance.GetType()} for grain {grain.GetGrainId()}."),
-                    null => false
-                };
-                if (completed)
-                {
-                    return;
-                }
-            }
-        }
-        catch (OperationCanceledException exception) when (
-            cancellationToken.IsCancellationRequested
-            && !TestContext.Current.CancellationToken.IsCancellationRequested)
-        {
-            using var diagnosticsCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            var current = await GetReminderCounterOrZeroAsync(
-                grain,
-                reminderName,
-                diagnosticsCancellation.Token);
-            var activeOwners = observer.GetActiveReminderCount(grain.GetGrainId(), reminderName);
-            throw new InvalidOperationException(
-                $"Timed out waiting for reminder '{reminderName}' on grain {grain.GetGrainId()} to reach counter {target}. Current counter: {current}. Active owners: {activeOwners}.",
-                exception);
         }
     }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -170,7 +170,7 @@ namespace UnitTests.TimerTests
         }
 
         [Fact]
-        public async Task Rem_Grain_ConcurrentCounterWaitersUseSingleClockDriver()
+        public async Task Rem_Grain_ConcurrentRemindersUseSingleClockDriver()
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(TestConstants.InitTimeout);


### PR DESCRIPTION
## Problem

The reminder test clock driver waited for persisted counters through a waiter attached to whichever grain activation TryGetGrainContext found. During activation churn, a reminder tick could run on another activation: the callback persisted the target counter and emitted TickCompleted, while the waiter on the stale activation remained blocked until the suite timeout.

## Solution

Remove the activation-local counter waiter and its test-grain hooks. The clock driver now arms reminder diagnostic waits before advancing time, awaits TickCompleted, and then verifies that each persisted counter advanced exactly once.

## Rationale

TickCompleted is emitted only after ReceiveReminder returns, and the test grains persist their counters before returning. This gives the tests an activation-independent completion barrier which remains valid across ownership changes and grain reactivation.

Fixes #10499
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10855)