### PR TITLE
test(transactions): verify consistency histories

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
@@ -11,7 +11,7 @@ namespace Orleans.Transactions.TestKit.Consistency
     public class ConsistencyTestHarness
     {
         private readonly ConsistencyTestOptions options;
-        private Action<string> output = null!;
+        private Action<string> output = _ => { };
 
         private readonly Dictionary<int,       // Grain
                           SortedDictionary<int, // SeqNo
@@ -66,6 +66,68 @@ namespace Orleans.Transactions.TestKit.Consistency
 
         public int NumAborted => aborted.Count;
 
+        internal void RecordSucceeded(params Observation[] result)
+        {
+            if (result.Length == 0)
+            {
+                return;
+            }
+
+            var id = result[0].ExecutingTx;
+
+            lock (succeeded)
+            {
+                succeeded.Add(id);
+            }
+
+            foreach (var tuple in result)
+            {
+                tuple.ExecutingTx.Should().BeEquivalentTo(id);
+                RecordObservation(tuple);
+            }
+        }
+
+        internal void RecordObservation(Observation tuple)
+        {
+            lock (tuples)
+            {
+                if (!tuples.TryGetValue(tuple.Grain, out var versions))
+                {
+                    tuples.Add(tuple.Grain, versions = new SortedDictionary<int, Dictionary<string, HashSet<string>>>());
+                }
+
+                if (!versions.TryGetValue(tuple.SeqNo, out var writers))
+                {
+                    versions.Add(tuple.SeqNo, writers = new Dictionary<string, HashSet<string>>());
+                }
+
+                if (!writers.TryGetValue(tuple.WriterTx, out var readers))
+                {
+                    writers.Add(tuple.WriterTx, readers = new HashSet<string>());
+                }
+
+                readers.Add(tuple.ExecutingTx);
+            }
+        }
+
+        internal void RecordAborted(string transactionId)
+        {
+            lock (aborted)
+            {
+                aborted.Add(transactionId);
+            }
+        }
+
+        internal void RecordInDoubt(string transactionId, string message)
+        {
+            lock (indoubt)
+            {
+                indoubt.Add(transactionId, message);
+            }
+        }
+
+        internal void RecordTimeout() => timeoutsOccurred = true;
+
         public async Task RunRandomTransactionSequence(int partition, int count, IGrainFactory grainFactory, Action<string> output)
         {
             this.output = output;
@@ -84,52 +146,25 @@ namespace Orleans.Transactions.TestKit.Consistency
 
                     if (result.Length > 0)
                     {
-                        var id = result[0].ExecutingTx;
-
-                        lock (succeeded)
-                            succeeded.Add(id);                           
-
                         output($"{partition}.{i} g{target} -> {result.Length} tuples");
-
-                        foreach (var tuple in result)
-                        {
-                            tuple.ExecutingTx.Should().BeEquivalentTo(id); // all effects of this transaction must have same id
-                            lock (tuples)
-                            {
-                                if (!tuples.TryGetValue(tuple.Grain, out var versions))
-                                {
-                                    tuples.Add(tuple.Grain, versions = new SortedDictionary<int, Dictionary<string, HashSet<string>>>());
-                                }
-                                if (!versions.TryGetValue(tuple.SeqNo, out var writers))
-                                {
-                                    versions.Add(tuple.SeqNo, writers = new Dictionary<string, HashSet<string>>());
-                                }
-                                if (!writers.TryGetValue(tuple.WriterTx, out var readers))
-                                {
-                                    writers.Add(tuple.WriterTx, readers = new HashSet<string>());
-                                }
-                                readers.Add(tuple.ExecutingTx);
-                            }
-                        }
+                        RecordSucceeded(result);
                     }
 
                 }
                 catch (OrleansTransactionAbortedException e)
                 {
                     output($"{partition}.{i} g{target} -> aborted {e.GetType().Name} {e.InnerException} {e.TransactionId}");
-                    lock (aborted)
-                        aborted.Add(e.TransactionId);
+                    RecordAborted(e.TransactionId);
                 }
                 catch (OrleansTransactionInDoubtException f)
                 {
                     output($"{partition}.{i} g{target} -> in doubt {f.TransactionId}");
-                    lock (indoubt)
-                        indoubt.Add(f.TransactionId, f.Message);
+                    RecordInDoubt(f.TransactionId, f.Message);
                 }
                 catch (System.TimeoutException)
                 {
                     output($"{partition}.{i} g{target} -> timeout");
-                    timeoutsOccurred = true;
+                    RecordTimeout();
                 }
                 catch (OrleansException o)
                 {
@@ -145,83 +180,164 @@ namespace Orleans.Transactions.TestKit.Consistency
         {
             foreach (var grainKvp in tuples)
             {
-                var pos = 0;
-                void fail(string msg)
-                {
-                    foreach (var kvp1 in grainKvp.Value)
-                        foreach (var kvp2 in kvp1.Value)
-                            foreach (var r in kvp2.Value)
-                                output($"g{grainKvp.Key} v{kvp1.Key} w:{kvp2.Key} a:{r}");
-                    true.Should().BeFalse(msg);
-                }
-
-                HashSet<string> readersOfPreviousVersion = new HashSet<string>();
-                
-                foreach (var seqnoKvp in grainKvp.Value)
-                {
-                    var seqno = seqnoKvp.Key;
-
-                    if (pos++ != seqno && indoubt.Count == 0 && !timeoutsOccurred)
-                        fail($"g{grainKvp.Key} is missing version v{pos - 1}, found v{seqno} instead");
-
-                    var writers = seqnoKvp.Value;
-                    if (writers.Count != 1)
-                        fail($"g{grainKvp.Key} v{seqno} has multiple writers {string.Join(",", writers.Keys)}");
-
-                    var writer = writers.First().Key;
-                    var readers = writers.First().Value;
- 
-                    if (seqno == 0)
-                    {
-                        if (writer != InitialTx)
-                            fail($"g{grainKvp.Key} v{seqno} not written by {InitialTx}");
-                    }
-                    else
-                    {
-                        if (aborted.Contains(writer))
-                            fail($"g{grainKvp.Key} v{seqno} written by aborted transaction {writer}");
-                        if (!timeoutsOccurred && !(succeeded.Contains(writer) || indoubt.ContainsKey(writer)))
-                            fail($"g{grainKvp.Key} v{seqno} written by unknown transaction {writer}");
-                        if (indoubt.Count == 0 && !timeoutsOccurred && !readers.Contains(writer))
-                            fail($"g{grainKvp.Key} v{seqno} writer {writer} missing");
-                    }
-
-                    // add edges from previous readers to this write
-                    foreach (var r in readersOfPreviousVersion)
-                        if (r != writer)
-                        {
-                            if (!orderEdges.TryGetValue(r, out var readedges))
-                                orderEdges[r] = readedges = new HashSet<string>();
-                            readedges.Add(writer);
-                        }
-
-                    if (!orderEdges.TryGetValue(writer, out var writeedges))
-                        orderEdges[writer] = writeedges = new HashSet<string>();
-
-                    foreach (var r in readers)
-                        if (r != writer)
-                        {
-                            if (!succeeded.Contains(r))
-                                fail($"g{grainKvp.Key} v{seqno} read by aborted transaction {r}");
-                            writeedges.Add(r);
-                        }
-
-                    readersOfPreviousVersion = readers;
-                }
+                CheckGrainConsistency(grainKvp.Key, grainKvp.Value);
             }
 
             // due a DFS to find cycles in the ordered-before graph (= violation of serializability)
-            DFS();             
+            DFS();
 
             // report unknown exceptions
             if (!tolerateUnknownExceptions)
-            foreach (var kvp in indoubt)
-                if (kvp.Value.Contains("failure during transaction commit"))
-                    true.Should().BeFalse($"exception during commit {kvp.Key} {kvp.Value}");
+            {
+                ReportInDoubtCommitFailures();
+            }
 
-            // report timeout exceptions          
+            // report timeout exceptions
             if (!tolerateGenericTimeouts && timeoutsOccurred)
+            {
                 true.Should().BeFalse($"generic timeout exception caught");
+            }
+        }
+
+        private void CheckGrainConsistency(
+            int grain,
+            SortedDictionary<int, Dictionary<string, HashSet<string>>> versions)
+        {
+            var pos = 0;
+            var readersOfPreviousVersion = new HashSet<string>();
+
+            foreach (var seqnoKvp in versions)
+            {
+                var seqno = seqnoKvp.Key;
+
+                if (pos++ != seqno && indoubt.Count == 0 && !timeoutsOccurred)
+                {
+                    Fail(grain, versions, $"g{grain} is missing version v{pos - 1}, found v{seqno} instead");
+                }
+
+                var writers = seqnoKvp.Value;
+                if (writers.Count != 1)
+                {
+                    Fail(grain, versions, $"g{grain} v{seqno} has multiple writers {string.Join(",", writers.Keys)}");
+                }
+
+                var writer = writers.First().Key;
+                var readers = writers.First().Value;
+
+                CheckWriter(grain, seqno, writer, readers, versions);
+                AddPreviousVersionEdges(readersOfPreviousVersion, writer);
+                AddCurrentVersionEdges(grain, seqno, writer, readers, versions);
+                readersOfPreviousVersion = readers;
+            }
+        }
+
+        private void CheckWriter(
+            int grain,
+            int seqno,
+            string writer,
+            HashSet<string> readers,
+            SortedDictionary<int, Dictionary<string, HashSet<string>>> versions)
+        {
+            if (seqno == 0)
+            {
+                if (writer != InitialTx)
+                {
+                    Fail(grain, versions, $"g{grain} v{seqno} not written by {InitialTx}");
+                }
+
+                return;
+            }
+
+            if (aborted.Contains(writer))
+            {
+                Fail(grain, versions, $"g{grain} v{seqno} written by aborted transaction {writer}");
+            }
+
+            if (!timeoutsOccurred && !(succeeded.Contains(writer) || indoubt.ContainsKey(writer)))
+            {
+                Fail(grain, versions, $"g{grain} v{seqno} written by unknown transaction {writer}");
+            }
+
+            if (indoubt.Count == 0 && !timeoutsOccurred && !readers.Contains(writer))
+            {
+                Fail(grain, versions, $"g{grain} v{seqno} writer {writer} missing");
+            }
+        }
+
+        private void AddPreviousVersionEdges(HashSet<string> readersOfPreviousVersion, string writer)
+        {
+            foreach (var reader in readersOfPreviousVersion)
+            {
+                if (reader == writer)
+                {
+                    continue;
+                }
+
+                if (!orderEdges.TryGetValue(reader, out var readEdges))
+                {
+                    orderEdges[reader] = readEdges = new HashSet<string>();
+                }
+
+                readEdges.Add(writer);
+            }
+        }
+
+        private void AddCurrentVersionEdges(
+            int grain,
+            int seqno,
+            string writer,
+            HashSet<string> readers,
+            SortedDictionary<int, Dictionary<string, HashSet<string>>> versions)
+        {
+            if (!orderEdges.TryGetValue(writer, out var writeEdges))
+            {
+                orderEdges[writer] = writeEdges = new HashSet<string>();
+            }
+
+            foreach (var reader in readers)
+            {
+                if (reader == writer)
+                {
+                    continue;
+                }
+
+                if (!succeeded.Contains(reader))
+                {
+                    Fail(grain, versions, $"g{grain} v{seqno} read by aborted transaction {reader}");
+                }
+
+                writeEdges.Add(reader);
+            }
+        }
+
+        private void Fail(
+            int grain,
+            SortedDictionary<int, Dictionary<string, HashSet<string>>> versions,
+            string message)
+        {
+            foreach (var version in versions)
+            {
+                foreach (var writer in version.Value)
+                {
+                    foreach (var reader in writer.Value)
+                    {
+                        output($"g{grain} v{version.Key} w:{writer.Key} a:{reader}");
+                    }
+                }
+            }
+
+            true.Should().BeFalse(message);
+        }
+
+        private void ReportInDoubtCommitFailures()
+        {
+            foreach (var transaction in indoubt)
+            {
+                if (transaction.Value.Contains("failure during transaction commit"))
+                {
+                    true.Should().BeFalse($"exception during commit {transaction.Key} {transaction.Value}");
+                }
+            }
         }
 
 

--- a/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
@@ -75,6 +75,11 @@ namespace Orleans.Transactions.TestKit.Consistency
 
             var id = result[0].ExecutingTx;
 
+            foreach (var tuple in result)
+            {
+                tuple.ExecutingTx.Should().BeEquivalentTo(id);
+            }
+
             lock (succeeded)
             {
                 succeeded.Add(id);
@@ -82,7 +87,6 @@ namespace Orleans.Transactions.TestKit.Consistency
 
             foreach (var tuple in result)
             {
-                tuple.ExecutingTx.Should().BeEquivalentTo(id);
                 RecordObservation(tuple);
             }
         }
@@ -178,6 +182,9 @@ namespace Orleans.Transactions.TestKit.Consistency
 
         public void CheckConsistency(bool tolerateGenericTimeouts = false, bool tolerateUnknownExceptions = false)
         {
+            orderEdges.Clear();
+            marks.Clear();
+
             foreach (var grainKvp in tuples)
             {
                 CheckGrainConsistency(grainKvp.Key, grainKvp.Value);

--- a/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestHarnessTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestHarnessTests.cs
@@ -1,0 +1,201 @@
+using Orleans.Transactions.TestKit.Consistency;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class ConsistencyTestHarnessTests
+{
+    [Fact]
+    public void ValidHistory_PreservesVersionOrderingAndSerializableDependencies()
+    {
+        var harness = CreateHarness();
+
+        harness.RecordSucceeded(
+            Observe(grain: 0, version: 0, writer: ConsistencyTestHarness.InitialTx, transaction: "tx1"),
+            Observe(grain: 0, version: 1, writer: "tx1", transaction: "tx1"),
+            Observe(grain: 1, version: 0, writer: ConsistencyTestHarness.InitialTx, transaction: "tx1"));
+        harness.RecordSucceeded(
+            Observe(grain: 0, version: 1, writer: "tx1", transaction: "tx2"),
+            Observe(grain: 0, version: 2, writer: "tx2", transaction: "tx2"),
+            Observe(grain: 1, version: 0, writer: ConsistencyTestHarness.InitialTx, transaction: "tx2"),
+            Observe(grain: 1, version: 1, writer: "tx2", transaction: "tx2"));
+
+        Assert.Equal(0, harness.NumAborted);
+        harness.CheckConsistency();
+    }
+
+    [Fact]
+    public void MissingVersion_IsRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(
+            Observe(0, 0, ConsistencyTestHarness.InitialTx, "tx1"),
+            Observe(0, 2, "tx1", "tx1"));
+
+        AssertInconsistent(harness, "is missing version v1, found v2 instead");
+    }
+
+    [Fact]
+    public void MultipleWritersForVersion_AreRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(Observe(0, 0, ConsistencyTestHarness.InitialTx, "reader"));
+        harness.RecordObservation(Observe(0, 1, "tx1", "tx1"));
+        harness.RecordObservation(Observe(0, 1, "tx2", "tx2"));
+
+        AssertInconsistent(harness, "v1 has multiple writers");
+    }
+
+    [Fact]
+    public void InitialVersionFromTransaction_IsRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(Observe(0, 0, "tx1", "tx1"));
+
+        AssertInconsistent(harness, $"v0 not written by {ConsistencyTestHarness.InitialTx}");
+    }
+
+    [Fact]
+    public void AbortedWriter_IsRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(Observe(0, 0, ConsistencyTestHarness.InitialTx, "reader"));
+        harness.RecordObservation(Observe(0, 1, "tx1", "tx1"));
+        harness.RecordAborted("tx1");
+
+        Assert.Equal(1, harness.NumAborted);
+        AssertInconsistent(harness, "v1 written by aborted transaction tx1");
+    }
+
+    [Fact]
+    public void UnknownWriter_IsRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(Observe(0, 0, ConsistencyTestHarness.InitialTx, "reader"));
+        harness.RecordObservation(Observe(0, 1, "unknown", "unknown"));
+
+        AssertInconsistent(harness, "v1 written by unknown transaction unknown");
+    }
+
+    [Fact]
+    public void WriterMissingFromVersionReaders_IsRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(Observe(0, 0, ConsistencyTestHarness.InitialTx, "writer"));
+        harness.RecordSucceeded(
+            Observe(1, 0, ConsistencyTestHarness.InitialTx, "reader"),
+            Observe(1, 1, "writer", "reader"));
+
+        AssertInconsistent(harness, "v1 writer writer missing");
+    }
+
+    [Fact]
+    public void ReaderWithoutSuccessfulOutcome_IsRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordObservation(Observe(0, 0, ConsistencyTestHarness.InitialTx, "aborted-reader"));
+        harness.RecordAborted("aborted-reader");
+
+        AssertInconsistent(harness, "v0 read by aborted transaction aborted-reader");
+    }
+
+    [Fact]
+    public void CyclicDependency_IsRejected()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(
+            Observe(0, 0, ConsistencyTestHarness.InitialTx, "tx1"),
+            Observe(1, 1, "tx1", "tx1"));
+        harness.RecordSucceeded(
+            Observe(1, 0, ConsistencyTestHarness.InitialTx, "tx2"),
+            Observe(0, 1, "tx2", "tx2"));
+
+        AssertInconsistent(harness, "found serializability violation");
+    }
+
+    [Fact]
+    public void InDoubtCommitFailure_IsRejectedByDefault()
+    {
+        var harness = CreateHarness();
+        harness.RecordInDoubt("tx1", "failure during transaction commit");
+
+        AssertInconsistent(harness, "exception during commit tx1");
+    }
+
+    [Fact]
+    public void InDoubtCommitFailure_CanBeTolerated()
+    {
+        var harness = CreateHarness();
+        harness.RecordInDoubt("tx1", "failure during transaction commit");
+
+        harness.CheckConsistency(tolerateUnknownExceptions: true);
+    }
+
+    [Fact]
+    public void InDoubtOutcome_AllowsRecoverableHistoryGaps()
+    {
+        var harness = CreateHarness();
+        harness.RecordInDoubt("tx1", "transaction outcome is not yet known");
+        harness.RecordSucceeded(Observe(0, 2, "tx1", "reader"));
+
+        harness.CheckConsistency();
+    }
+
+    [Fact]
+    public void GenericTimeout_IsRejectedByDefault()
+    {
+        var harness = CreateHarness();
+        harness.RecordTimeout();
+
+        AssertInconsistent(harness, "generic timeout exception caught");
+    }
+
+    [Fact]
+    public void GenericTimeout_CanBeTolerated()
+    {
+        var harness = CreateHarness();
+        harness.RecordTimeout();
+
+        harness.CheckConsistency(tolerateGenericTimeouts: true);
+    }
+
+    [Fact]
+    public void GenericTimeout_AllowsIncompleteHistory()
+    {
+        var harness = CreateHarness();
+        harness.RecordTimeout();
+        harness.RecordSucceeded(Observe(0, 2, "unknown", "reader"));
+
+        harness.CheckConsistency(tolerateGenericTimeouts: true);
+    }
+
+    private static ConsistencyTestHarness CreateHarness() =>
+        new(
+            grainFactory: null!,
+            numGrains: 2,
+            seed: 0,
+            avoidDeadlocks: true,
+            avoidTimeouts: true,
+            readWrite: ReadWriteDetermination.PerGrain,
+            tolerateUnknownExceptions: false);
+
+    private static Observation Observe(int grain, int version, string writer, string transaction) =>
+        new()
+        {
+            Grain = grain,
+            SeqNo = version,
+            WriterTx = writer,
+            ExecutingTx = transaction,
+        };
+
+    private static void AssertInconsistent(ConsistencyTestHarness harness, string expectedMessage)
+    {
+        var exception = Assert.ThrowsAny<Exception>(() => harness.CheckConsistency());
+        Assert.Contains(expectedMessage, exception.Message);
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestHarnessTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestHarnessTests.cs
@@ -30,6 +30,33 @@ public class ConsistencyTestHarnessTests
     }
 
     [Fact]
+    public void RecordSucceeded_WithMixedTransactionIds_DoesNotMutateHistory()
+    {
+        var harness = CreateHarness();
+
+        Assert.ThrowsAny<Exception>(() => harness.RecordSucceeded(
+            Observe(0, 1, "tx1", "tx1"),
+            Observe(0, 2, "tx1", "tx2")));
+
+        harness.CheckConsistency();
+    }
+
+    [Fact]
+    public void CheckConsistency_AfterRecordingMoreHistory_RebuildsDependencyGraph()
+    {
+        var harness = CreateHarness();
+        harness.RecordSucceeded(Observe(0, 0, ConsistencyTestHarness.InitialTx, "tx1"));
+        harness.RecordSucceeded(Observe(0, 1, "tx2", "tx2"));
+
+        harness.CheckConsistency();
+
+        harness.RecordSucceeded(Observe(1, 0, ConsistencyTestHarness.InitialTx, "tx2"));
+        harness.RecordSucceeded(Observe(1, 1, "tx1", "tx1"));
+
+        AssertInconsistent(harness, "found serializability violation");
+    }
+
+    [Fact]
     public void MissingVersion_IsRejected()
     {
         var harness = CreateHarness();


### PR DESCRIPTION
## Problem

The transaction TestKit consistency verifier had no deterministic coverage despite carrying the highest measured state-testing risk: `CheckConsistency` was uncovered with cyclomatic complexity 54 and CRAP 2970. Its rejection rules were exercised primarily through randomized and stress-oriented tests.

## Solution

Add deterministic BVT tests for valid serialized histories, missing versions, multiple and invalid writers, invalid readers, dependency cycles, in-doubt outcomes, and timeout tolerance. Factor history recording and consistency checks into invariant-specific helpers so runtime collection and deterministic verification use the same paths.

## Rationale

The focused suite verifies persisted version observations, ordering, serializability, abort state, corruption-shaped histories, and recoverable incomplete outcomes without cloud dependencies. The extraction lowers `CheckConsistency` complexity from 54 to 8 while focused coverage reaches 93.3% line and 100% branch for that method.

Progress toward #10863.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10875)