### PR TITLE
test(azure): cover queue JSON validation

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -1,6 +1,7 @@
 #pragma warning disable StreamingJsonSerializationExperimental // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Buffers.Text;
+using JsonValueKind = System.Text.Json.JsonValueKind;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -19,6 +20,7 @@ using Xunit;
 namespace Tester.AzureUtils.Streaming
 {
     [Collection(TestEnvironmentFixture.DefaultCollection)]
+    [TestCategory("AzureStorage"), TestCategory("Streaming")]
     [TestSuite("BVT")]
     [TestProvider("AzureStorage")]
     [TestArea("Streaming")]
@@ -51,7 +53,10 @@ namespace Tester.AzureUtils.Streaming
         {
             var serializer = this.fixture.Services.GetRequiredService<Serializer>();
             var azureQueueDataAdapterV2 = new AzureQueueDataAdapterV2(serializer);
-            var jsonOptions = this.fixture.Services.GetRequiredService<IOptions<OrleansJsonSerializerOptions>>();
+            var jsonOptions = Options.Create(new OrleansJsonSerializerOptions
+            {
+                JsonSerializerSettings = OrleansJsonSerializerSettings.GetDefaultSerializerSettings(this.fixture.Services)
+            });
             var jsonOrleansSerializer = new OrleansJsonSerializer(jsonOptions);
 
             return new AzureQueueJsonDataAdapter(
@@ -209,19 +214,24 @@ namespace Tester.AzureUtils.Streaming
             var exception = Assert.Throws<InvalidDataException>(
                 () => jsonAdapter.FromQueueMessage($"{{\"version\":{version}}}", sequenceId: 0));
 
-            Assert.Equal($"Unsupported Azure Queue JSON envelope version: {version}.", exception.Message);
+            Assert.Contains("Unsupported Azure Queue JSON envelope version", exception.Message);
+            Assert.Contains(version, exception.Message);
         }
 
         [Theory, TestCategory("BVT")]
         [MemberData(nameof(MalformedCompactEnvelopeCases))]
-        public void JsonAdapter_RejectsMalformedCompactEnvelope(string message, string expectedMessage)
+        public void JsonAdapter_RejectsMalformedCompactEnvelope(
+            string message,
+            string expectedProperty,
+            string expectedKind)
         {
             var jsonAdapter = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { EnableFallback = false });
 
             var exception = Assert.Throws<InvalidDataException>(
                 () => jsonAdapter.FromQueueMessage(message, sequenceId: 0));
 
-            Assert.Equal(expectedMessage, exception.Message);
+            Assert.Contains($"property '{expectedProperty}'", exception.Message);
+            Assert.Contains(expectedKind, exception.Message);
         }
 
         [Fact, TestCategory("BVT")]
@@ -413,47 +423,57 @@ namespace Tester.AzureUtils.Streaming
             Assert.True(IsValidJson(jsonMessage));
         }
 
-        public static TheoryData<string, string> MalformedCompactEnvelopeCases => new()
+        public static TheoryData<string, string, string> MalformedCompactEnvelopeCases => new()
         {
             {
                 """{"version":1,"events":[],"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'stream' must be a Object."
+                "stream",
+                nameof(JsonValueKind.Object)
             },
             {
                 """{"version":1,"stream":[],"events":[],"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'stream' must be a Object."
+                "stream",
+                nameof(JsonValueKind.Object)
             },
             {
                 """{"version":1,"stream":{"key":"key"},"events":[],"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'namespace' must be a String or Null."
+                "namespace",
+                $"{nameof(JsonValueKind.String)} or {nameof(JsonValueKind.Null)}"
             },
             {
                 """{"version":1,"stream":{"namespace":1,"key":"key"},"events":[],"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'namespace' must be a String or Null."
+                "namespace",
+                $"{nameof(JsonValueKind.String)} or {nameof(JsonValueKind.Null)}"
             },
             {
                 """{"version":1,"stream":{"namespace":"namespace"},"events":[],"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'key' must be a String."
+                "key",
+                nameof(JsonValueKind.String)
             },
             {
                 """{"version":1,"stream":{"namespace":"namespace","key":null},"events":[],"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'key' must be a String."
+                "key",
+                nameof(JsonValueKind.String)
             },
             {
                 """{"version":1,"stream":{"namespace":"namespace","key":"key"},"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'events' must be a Array."
+                "events",
+                nameof(JsonValueKind.Array)
             },
             {
                 """{"version":1,"stream":{"namespace":"namespace","key":"key"},"events":{},"requestContext":{}}""",
-                "The Azure Queue JSON envelope property 'events' must be a Array."
+                "events",
+                nameof(JsonValueKind.Array)
             },
             {
                 """{"version":1,"stream":{"namespace":"namespace","key":"key"},"events":[]}""",
-                "The Azure Queue JSON envelope property 'requestContext' must be a Object."
+                "requestContext",
+                nameof(JsonValueKind.Object)
             },
             {
                 """{"version":1,"stream":{"namespace":"namespace","key":"key"},"events":[],"requestContext":[]}""",
-                "The Azure Queue JSON envelope property 'requestContext' must be a Object."
+                "requestContext",
+                nameof(JsonValueKind.Object)
             }
         };
 

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueJsonDataAdapterTests.cs
@@ -19,7 +19,9 @@ using Xunit;
 namespace Tester.AzureUtils.Streaming
 {
     [Collection(TestEnvironmentFixture.DefaultCollection)]
-    [TestCategory("AzureStorage"), TestCategory("Streaming")]
+    [TestSuite("BVT")]
+    [TestProvider("AzureStorage")]
+    [TestArea("Streaming")]
     public class AzureQueueJsonDataAdapterTests
     {
         private const string CompactOrleans3JsonMessage =
@@ -194,6 +196,41 @@ namespace Tester.AzureUtils.Streaming
             Assert.Equal(
                 StreamId.Create("test-namespace", Guid.Parse("00112233-4455-6677-8899-aabbccddeeff")),
                 batchContainer.StreamId);
+        }
+
+        [Theory, TestCategory("BVT")]
+        [InlineData("\"1\"")]
+        [InlineData("2147483648")]
+        [InlineData("2")]
+        public void JsonAdapter_RejectsUnsupportedCompactEnvelopeVersion(string version)
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { EnableFallback = false });
+
+            var exception = Assert.Throws<InvalidDataException>(
+                () => jsonAdapter.FromQueueMessage($"{{\"version\":{version}}}", sequenceId: 0));
+
+            Assert.Equal($"Unsupported Azure Queue JSON envelope version: {version}.", exception.Message);
+        }
+
+        [Theory, TestCategory("BVT")]
+        [MemberData(nameof(MalformedCompactEnvelopeCases))]
+        public void JsonAdapter_RejectsMalformedCompactEnvelope(string message, string expectedMessage)
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { EnableFallback = false });
+
+            var exception = Assert.Throws<InvalidDataException>(
+                () => jsonAdapter.FromQueueMessage(message, sequenceId: 0));
+
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact, TestCategory("BVT")]
+        public void JsonAdapter_RejectsInvalidJson()
+        {
+            var jsonAdapter = InitializeQueueJsonDataAdapter(new AzureQueueJsonDataAdapterOptions { EnableFallback = false });
+
+            Assert.ThrowsAny<System.Text.Json.JsonException>(
+                () => jsonAdapter.FromQueueMessage("{\"version\":1", sequenceId: 0));
         }
 
         [Fact, TestCategory("BVT")]
@@ -375,6 +412,50 @@ namespace Tester.AzureUtils.Streaming
             Assert.False(IsValidJson(binaryMessage));
             Assert.True(IsValidJson(jsonMessage));
         }
+
+        public static TheoryData<string, string> MalformedCompactEnvelopeCases => new()
+        {
+            {
+                """{"version":1,"events":[],"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'stream' must be a Object."
+            },
+            {
+                """{"version":1,"stream":[],"events":[],"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'stream' must be a Object."
+            },
+            {
+                """{"version":1,"stream":{"key":"key"},"events":[],"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'namespace' must be a String or Null."
+            },
+            {
+                """{"version":1,"stream":{"namespace":1,"key":"key"},"events":[],"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'namespace' must be a String or Null."
+            },
+            {
+                """{"version":1,"stream":{"namespace":"namespace"},"events":[],"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'key' must be a String."
+            },
+            {
+                """{"version":1,"stream":{"namespace":"namespace","key":null},"events":[],"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'key' must be a String."
+            },
+            {
+                """{"version":1,"stream":{"namespace":"namespace","key":"key"},"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'events' must be a Array."
+            },
+            {
+                """{"version":1,"stream":{"namespace":"namespace","key":"key"},"events":{},"requestContext":{}}""",
+                "The Azure Queue JSON envelope property 'events' must be a Array."
+            },
+            {
+                """{"version":1,"stream":{"namespace":"namespace","key":"key"},"events":[]}""",
+                "The Azure Queue JSON envelope property 'requestContext' must be a Object."
+            },
+            {
+                """{"version":1,"stream":{"namespace":"namespace","key":"key"},"events":[],"requestContext":[]}""",
+                "The Azure Queue JSON envelope property 'requestContext' must be a Object."
+            }
+        };
 
         [GenerateSerializer]
         public sealed class EventData : IEquatable<EventData>


### PR DESCRIPTION
Part of #10861.

The Azure Queue JSON adapter tests used legacy category traits, so the Azure Storage coverage partition selected none of them. This change adds first-class suite, provider, and area traits so the existing credential-free tests contribute to provider coverage, then covers unsupported envelope versions, malformed required fields and types, and invalid JSON.

Targeted coverage impact for `AzureQueueJsonDataAdapter`:

| Scope | Before | After |
| --- | ---: | ---: |
| Class line coverage | 90.95% | 93.97% |
| Class branch coverage | 78.41% | 86.36% |
| `TryDeserializeCompactJson` line coverage | 87.50% | 100% |
| `TryDeserializeCompactJson` branch coverage | 62.50% | 83.33% |
| `GetRequiredProperty` line coverage | 66.67% | 100% |
| `GetRequiredProperty` branch coverage | 50% | 100% |

The canonical Azure Storage CI query now selects all 29 adapter test cases instead of zero. These tests run without credentials or Azurite.

Remaining #10861 scope includes DynamoDB mutation/configuration and reminder parsing, Azure table/blob/queue error paths, and focused Google, Redis, and Cassandra gaps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10876)