### PR TITLE
test(codegen): pass cancellation token to diagnostics

### DIFF
--- a/test/Orleans.CodeGenerator.Tests/GeneratedWarningSuppressionTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/GeneratedWarningSuppressionTests.cs
@@ -114,7 +114,7 @@ public sealed class GeneratedWarningSuppressionTests
         var generatedTreePaths = result.GeneratedSources
             .Select(static source => source.HintName)
             .ToHashSet(StringComparer.Ordinal);
-        var obsoleteErrors = generatedCompilation.GetDiagnostics()
+        var obsoleteErrors = generatedCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
             .Where(static diagnostic => (diagnostic.Id is ObsoleteWithoutMessageDiagnosticId or ObsoleteWithMessageDiagnosticId)
                 && diagnostic.Severity == DiagnosticSeverity.Error)
             .ToArray();


### PR DESCRIPTION
Fixes #10856.

Passes `TestContext.Current.CancellationToken` to Roslyn diagnostic collection in `GeneratedWarningSuppressionTests`, satisfying xUnit1051 and restoring warning-as-error builds for the test project.

This keeps cancellation flowing through the potentially long-running diagnostic operation without changing the test's assertions or generated-code behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10878)