### PR TITLE
test(serialization): cover multidimensional array copying

### DIFF
--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -36,16 +36,12 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [System.Diagnostics.CodeAnalysis.AllowNull] Type expectedType, [System.Diagnostics.CodeAnalysis.AllowNull] object? value) where TBufferWriter : IBufferWriter<byte>
         {
-            if (value is Array input)
-            {
-                EnsureZeroLowerBounds(input);
-            }
-
             if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value!))
             {
                 return;
             }
 
+            EnsureZeroLowerBounds((Array)value);
             writer.WriteFieldHeader(fieldIdDelta, expectedType, value!.GetType(), WireType.TagDelimited);
 
             var array = (Array)value;

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -36,6 +36,11 @@ namespace Orleans.Serialization.Codecs
         /// <inheritdoc/>
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [System.Diagnostics.CodeAnalysis.AllowNull] Type expectedType, [System.Diagnostics.CodeAnalysis.AllowNull] object? value) where TBufferWriter : IBufferWriter<byte>
         {
+            if (value is Array input)
+            {
+                EnsureZeroLowerBounds(input);
+            }
+
             if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value!))
             {
                 return;
@@ -186,6 +191,22 @@ namespace Orleans.Serialization.Codecs
             $"Declared dimensions [{string.Join(", ", lengths)}] require more elements than the remaining length of the input, {remaining}.");
 
         private static void ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
+
+        private static void EnsureZeroLowerBounds(Array array)
+        {
+            for (var i = 0; i < array.Rank; i++)
+            {
+                if (array.GetLowerBound(i) != 0)
+                {
+                    ThrowNonZeroLowerBoundsNotSupported();
+                }
+            }
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowNonZeroLowerBoundsNotSupported() => throw new NotSupportedException(
+            "Serialization of multi-dimensional arrays with non-zero lower bounds is not supported.");
     }
 
     /// <summary>
@@ -208,33 +229,39 @@ namespace Orleans.Serialization.Codecs
             var elementType = type.GetElementType();
             if (ShallowCopyableTypes.Contains(elementType!))
             {
-                return originalArray.Clone();
+                result = (Array)originalArray.Clone();
+                context.RecordCopy(original, result);
+                return result;
             }
 
-            // We assume that all arrays have lower bound 0. In .NET 4.0, it's hard to create an array with a non-zero lower bound.
             var rank = originalArray.Rank;
             var lengths = new int[rank];
+            var lowerBounds = new int[rank];
             for (var i = 0; i < rank; i++)
             {
                 lengths[i] = originalArray.GetLength(i);
+                lowerBounds[i] = originalArray.GetLowerBound(i);
             }
 
-            result = Array.CreateInstance(elementType!, lengths);
-            context.RecordCopy(original, result); 
+            result = Array.CreateInstance(elementType!, lengths, lowerBounds);
+            context.RecordCopy(original, result);
 
             if (rank == 1)
             {
-                for (var i = 0; i < lengths[0]; i++)
+                for (var offset = 0; offset < lengths[0]; offset++)
                 {
+                    var i = lowerBounds[0] + offset;
                     result.SetValue(ObjectCopier.DeepCopy(originalArray.GetValue(i), context), i);
                 }
             }
             else if (rank == 2)
             {
-                for (var i = 0; i < lengths[0]; i++)
+                for (var iOffset = 0; iOffset < lengths[0]; iOffset++)
                 {
-                    for (var j = 0; j < lengths[1]; j++)
+                    var i = lowerBounds[0] + iOffset;
+                    for (var jOffset = 0; jOffset < lengths[1]; jOffset++)
                     {
+                        var j = lowerBounds[1] + jOffset;
                         result.SetValue(ObjectCopier.DeepCopy(originalArray.GetValue(i, j), context), i, j);
                     }
                 }
@@ -256,7 +283,7 @@ namespace Orleans.Serialization.Codecs
                     {
                         int offset = k / sizes[n];
                         k -= offset * sizes[n];
-                        index[n] = offset;
+                        index[n] = offset + lowerBounds[n];
                     }
 
                     result.SetValue(ObjectCopier.DeepCopy(originalArray.GetValue(index), context), index);

--- a/test/Orleans.Serialization.UnitTests/MultiDimensionalArrayTests.cs
+++ b/test/Orleans.Serialization.UnitTests/MultiDimensionalArrayTests.cs
@@ -1,0 +1,242 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+[Trait("Suite", "BVT")]
+[Trait("Provider", "None")]
+[Trait("Area", "Serialization")]
+public sealed class MultiDimensionalArrayTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly DeepCopier _deepCopier;
+    private readonly Serializer _serializer;
+
+    public MultiDimensionalArrayTests()
+    {
+        _serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        _deepCopier = _serviceProvider.GetRequiredService<DeepCopier>();
+        _serializer = _serviceProvider.GetRequiredService<Serializer>();
+    }
+
+    [Fact]
+    public void DeepCopy_ShallowCopyableArray_ClonesStorage()
+    {
+        var original = new[,] { { 1, 2 }, { 3, 4 } };
+
+        var result = _deepCopier.Copy(original)!;
+
+        Assert.NotSame(original, result);
+        Assert.Equal(2, result.GetLength(0));
+        Assert.Equal(2, result.GetLength(1));
+        Assert.Equal(1, result[0, 0]);
+        Assert.Equal(2, result[0, 1]);
+        Assert.Equal(3, result[1, 0]);
+        Assert.Equal(4, result[1, 1]);
+
+        result[0, 0] = 10;
+        original[1, 1] = 40;
+        Assert.Equal(1, original[0, 0]);
+        Assert.Equal(4, result[1, 1]);
+    }
+
+    [Fact]
+    public void DeepCopy_RankOneReferenceArray_PreservesAliasesAndCopiesElements()
+    {
+        var shared = new MyValue(10);
+        var original = Array.CreateInstance(typeof(MyValue), [3], [1]);
+        original.SetValue(shared, 1);
+        original.SetValue(new MyValue(20), 2);
+        original.SetValue(shared, 3);
+
+        var result = Copy(original);
+
+        Assert.NotSame(original, result);
+        Assert.Equal(original.GetType(), result.GetType());
+        Assert.Equal(1, result.GetLowerBound(0));
+        Assert.Equal(3, result.GetUpperBound(0));
+        var first = Assert.IsType<MyValue>(result.GetValue(1));
+        Assert.Equal(10, first.Value);
+        Assert.Equal(20, Assert.IsType<MyValue>(result.GetValue(2)).Value);
+        Assert.Same(first, result.GetValue(3));
+        Assert.NotSame(shared, first);
+
+        first.Value = 100;
+        Assert.Equal(10, shared.Value);
+    }
+
+    [Fact]
+    public void DeepCopy_RankTwoReferenceArray_PreservesBoundsAliasesAndIndependence()
+    {
+        var shared = new MyValue(30);
+        var original = Array.CreateInstance(typeof(MyValue), [2, 2], [2, -1]);
+        original.SetValue(shared, 2, -1);
+        original.SetValue(new MyValue(40), 2, 0);
+        original.SetValue(new MyValue(50), 3, -1);
+        original.SetValue(shared, 3, 0);
+
+        var result = Copy(original);
+
+        Assert.NotSame(original, result);
+        Assert.Equal(original.GetType(), result.GetType());
+        Assert.Equal(2, result.GetLowerBound(0));
+        Assert.Equal(3, result.GetUpperBound(0));
+        Assert.Equal(-1, result.GetLowerBound(1));
+        Assert.Equal(0, result.GetUpperBound(1));
+        var first = Assert.IsType<MyValue>(result.GetValue(2, -1));
+        Assert.Equal(30, first.Value);
+        Assert.Equal(40, Assert.IsType<MyValue>(result.GetValue(2, 0)).Value);
+        Assert.Equal(50, Assert.IsType<MyValue>(result.GetValue(3, -1)).Value);
+        Assert.Same(first, result.GetValue(3, 0));
+        Assert.NotSame(shared, first);
+
+        first.Value = 300;
+        shared.Value = 31;
+        Assert.Equal(31, Assert.IsType<MyValue>(original.GetValue(3, 0)).Value);
+        Assert.Equal(300, Assert.IsType<MyValue>(result.GetValue(2, -1)).Value);
+    }
+
+    [Fact]
+    public void DeepCopy_RankThreeReferenceArray_PreservesCyclesAndAliases()
+    {
+        var shared = new MyValue(60);
+        var original = new object[1, 2, 2];
+        original[0, 0, 0] = original;
+        original[0, 0, 1] = shared;
+        original[0, 1, 0] = "immutable";
+        original[0, 1, 1] = shared;
+
+        var result = Assert.IsType<object[,,]>(Copy(original));
+
+        Assert.NotSame(original, result);
+        Assert.Same(result, result[0, 0, 0]);
+        var first = Assert.IsType<MyValue>(result[0, 0, 1]);
+        Assert.Equal(60, first.Value);
+        Assert.Same(first, result[0, 1, 1]);
+        Assert.NotSame(shared, first);
+        Assert.Same(original[0, 1, 0], result[0, 1, 0]);
+    }
+
+    [Fact]
+    public void DeepCopy_EmptyHigherRankArray_PreservesDimensions()
+    {
+        var original = new MyValue[2, 0, 3, 4];
+
+        var result = Assert.IsType<MyValue[,,,]>(Copy(original));
+
+        Assert.NotSame(original, result);
+        Assert.Empty(result);
+        Assert.Equal(2, result.GetLength(0));
+        Assert.Equal(0, result.GetLength(1));
+        Assert.Equal(3, result.GetLength(2));
+        Assert.Equal(4, result.GetLength(3));
+    }
+
+    [Fact]
+    public void DeepCopy_ExtremeBounds_PreservesBoundsWithoutOverflow()
+    {
+        var rankOne = Array.CreateInstance(typeof(MyValue), [1], [int.MaxValue]);
+        rankOne.SetValue(new MyValue(65), int.MaxValue);
+        var rankTwoEmpty = Array.CreateInstance(typeof(MyValue), [1, 0], [int.MaxValue, int.MinValue]);
+
+        var rankOneResult = Copy(rankOne);
+        var rankTwoResult = Copy(rankTwoEmpty);
+
+        Assert.Equal(int.MaxValue, rankOneResult.GetLowerBound(0));
+        Assert.Equal(int.MaxValue, rankOneResult.GetUpperBound(0));
+        Assert.Equal(65, Assert.IsType<MyValue>(rankOneResult.GetValue(int.MaxValue)).Value);
+        Assert.Equal(int.MaxValue, rankTwoResult.GetLowerBound(0));
+        Assert.Equal(int.MaxValue, rankTwoResult.GetUpperBound(0));
+        Assert.Equal(int.MinValue, rankTwoResult.GetLowerBound(1));
+        Assert.Empty(rankTwoResult);
+    }
+
+    [Fact]
+    public void DeepCopy_RepeatedArrayInSameContext_ReturnsRecordedCopy()
+    {
+        var original = new MyValue[,] { { new(70) } };
+        var copier = new MultiDimensionalArrayCopier<MyValue>();
+        using var context = _serviceProvider.GetRequiredService<CopyContextPool>().GetContext();
+
+        var first = copier.DeepCopy(original, context);
+        var second = copier.DeepCopy(original, context);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void DeepCopy_RepeatedShallowArrayInSameContext_ReturnsRecordedCopy()
+    {
+        var original = new[,] { { 71 } };
+        var copier = new MultiDimensionalArrayCopier<int>();
+        using var context = _serviceProvider.GetRequiredService<CopyContextPool>().GetContext();
+
+        var first = copier.DeepCopy(original, context);
+        var second = copier.DeepCopy(original, context);
+
+        Assert.NotSame(original, first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void RoundTrip_RankThreeReferenceArray_PreservesAliasesAndCopyIndependence()
+    {
+        var shared = new MyValue(80);
+        var original = new MyValue[2, 1, 2];
+        original[0, 0, 0] = shared;
+        original[0, 0, 1] = new MyValue(90);
+        original[1, 0, 0] = new MyValue(100);
+        original[1, 0, 1] = shared;
+
+        var payload = _serializer.SerializeToArray(original);
+        var result = _serializer.Deserialize<MyValue[,,]>(payload)!;
+
+        Assert.NotEmpty(payload);
+        Assert.NotSame(original, result);
+        Assert.Equal(2, result.GetLength(0));
+        Assert.Equal(1, result.GetLength(1));
+        Assert.Equal(2, result.GetLength(2));
+        var first = result[0, 0, 0];
+        Assert.Equal(80, first.Value);
+        Assert.Equal(90, result[0, 0, 1].Value);
+        Assert.Equal(100, result[1, 0, 0].Value);
+        Assert.Same(first, result[1, 0, 1]);
+        Assert.NotSame(shared, first);
+
+        first.Value = 800;
+        shared.Value = 81;
+        Assert.Equal(81, original[1, 0, 1].Value);
+        Assert.Equal(800, result[0, 0, 0].Value);
+    }
+
+    [Fact]
+    public void Serialize_NonZeroLowerBoundArray_ThrowsNotSupportedException()
+    {
+        var original = Array.CreateInstance(typeof(int), [2, 2], [1, -1]);
+
+        var exception = Assert.Throws<NotSupportedException>(() => _serializer.SerializeToArray((object)original));
+
+        Assert.Equal(
+            "Serialization of multi-dimensional arrays with non-zero lower bounds is not supported.",
+            exception.Message);
+    }
+
+    [Fact]
+    public void IsSupportedType_RequiresNonVectorArray()
+    {
+        var copier = new MultiDimensionalArrayCopier<int>();
+
+        Assert.True(copier.IsSupportedType(typeof(int[,])));
+        Assert.True(copier.IsSupportedType(typeof(int).MakeArrayType(1)));
+        Assert.False(copier.IsSupportedType(typeof(int[])));
+        Assert.False(copier.IsSupportedType(typeof(int)));
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    private Array Copy(Array original) => Assert.IsAssignableFrom<Array>(_deepCopier.Copy((object)original));
+}

--- a/test/Orleans.Serialization.UnitTests/MultiDimensionalArrayTests.cs
+++ b/test/Orleans.Serialization.UnitTests/MultiDimensionalArrayTests.cs
@@ -141,10 +141,11 @@ public sealed class MultiDimensionalArrayTests : IDisposable
     {
         var rankOne = Array.CreateInstance(typeof(MyValue), [1], [int.MaxValue]);
         rankOne.SetValue(new MyValue(65), int.MaxValue);
-        var rankTwoEmpty = Array.CreateInstance(typeof(MyValue), [1, 0], [int.MaxValue, int.MinValue]);
+        var rankTwo = Array.CreateInstance(typeof(MyValue), [1, 1], [int.MaxValue, int.MinValue]);
+        rankTwo.SetValue(new MyValue(66), int.MaxValue, int.MinValue);
 
         var rankOneResult = Copy(rankOne);
-        var rankTwoResult = Copy(rankTwoEmpty);
+        var rankTwoResult = Copy(rankTwo);
 
         Assert.Equal(int.MaxValue, rankOneResult.GetLowerBound(0));
         Assert.Equal(int.MaxValue, rankOneResult.GetUpperBound(0));
@@ -152,7 +153,8 @@ public sealed class MultiDimensionalArrayTests : IDisposable
         Assert.Equal(int.MaxValue, rankTwoResult.GetLowerBound(0));
         Assert.Equal(int.MaxValue, rankTwoResult.GetUpperBound(0));
         Assert.Equal(int.MinValue, rankTwoResult.GetLowerBound(1));
-        Assert.Empty(rankTwoResult);
+        Assert.Equal(int.MinValue, rankTwoResult.GetUpperBound(1));
+        Assert.Equal(66, Assert.IsType<MyValue>(rankTwoResult.GetValue(int.MaxValue, int.MinValue)).Value);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`MultiDimensionalArrayCopier<T>.DeepCopy` had no coverage despite complexity 22 and a reported CRAP score of 506. Its lower-bound handling also assumed zero-based arrays, and shallow-copyable arrays were not recorded in the copy context.

## Solution

Add focused multidimensional array tests covering ranks 1, 2, and 3+, shallow and reference elements, repeated aliases, cycles, empty dimensions, extreme CLR bounds, round-trip independence, supported-type boundaries, and the non-zero-lower-bound serialization failure contract.

Preserve lower bounds during deep copy, record shallow array copies so aliases remain stable, use offset-based loops which remain correct at `int.MinValue`/`int.MaxValue`, and reject non-zero lower bounds during serialization explicitly because the wire format records lengths only.

The targeted coverage run raises `MultiDimensionalArrayCopier<T>` and `DeepCopy` from 0% line / 0% branch coverage to 100% line / 100% branch coverage, reducing the method CRAP score from 506 to 22.

This is a mergeable first slice of #10859. The repository-wide build currently encounters the independent main-branch failure tracked by #10856; #10878 contains that fix.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10880)