### PR TITLE
test(testing): cover TestingHost failure diagnostics

### DIFF
--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitDiagnosticsTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitDiagnosticsTests.cs
@@ -1,4 +1,5 @@
 using Orleans.Reminders.TestKit;
+using TestExtensions;
 using Xunit;
 
 namespace Orleans.Reminders.TestKit.Tests;

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitDiagnosticsTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitDiagnosticsTests.cs
@@ -1,0 +1,60 @@
+using Orleans.Reminders.TestKit;
+using Xunit;
+
+namespace Orleans.Reminders.TestKit.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Reminders")]
+[TestCategory("BVT"), TestCategory("Reminders")]
+public sealed class ReminderTestKitDiagnosticsTests
+{
+    [Fact]
+    public void Build_BlankNamesAndNullDetails_UsesExactPlaceholders()
+    {
+        var report = ReminderFailureReport.Create(string.Empty, "\r\n", " \t")
+            .WithDetail("observation", null);
+
+        var expected =
+            "Reminder conformance failure [provider=<unnamed-provider>, guarantee=<unnamed-guarantee>, operation=<unnamed-operation>]" + Environment.NewLine +
+            "  observation: <null>";
+
+        Assert.Equal(expected, report.Build());
+    }
+
+    [Fact]
+    public void ToException_PreservesExactReportAndInnerException()
+    {
+        var report = ReminderFailureReport.Create("InMemory", "ETag rotation", "UpsertRow")
+            .WithDetail("attempt", "second write");
+        var innerException = new InvalidOperationException("write failed");
+        var expected =
+            "Reminder conformance failure [provider=InMemory, guarantee=ETag rotation, operation=UpsertRow]" + Environment.NewLine +
+            "  attempt: 'second write'";
+
+        var exception = report.ToException(innerException);
+
+        Assert.IsType<ReminderConformanceException>(exception);
+        Assert.Equal(expected, report.Build());
+        Assert.Equal(expected, exception.Message);
+        Assert.Same(innerException, exception.InnerException);
+    }
+
+    [Fact]
+    public void Throw_PreservesExactReportAndInnerException()
+    {
+        var report = ReminderFailureReport.Create("AzureTable", "Remove semantics", "RemoveRow")
+            .WithDetail("observation", "row remained");
+        var innerException = new InvalidOperationException("conditional delete failed");
+        var expected =
+            "Reminder conformance failure [provider=AzureTable, guarantee=Remove semantics, operation=RemoveRow]" + Environment.NewLine +
+            "  observation: 'row remained'";
+
+        var exception = Assert.Throws<ReminderConformanceException>(() => report.Throw(innerException));
+
+        Assert.IsType<ReminderConformanceException>(exception);
+        Assert.Equal(expected, report.Build());
+        Assert.Equal(expected, exception.Message);
+        Assert.Same(innerException, exception.InnerException);
+    }
+}

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/DiagnosticEventCollectorTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/DiagnosticEventCollectorTests.cs
@@ -1,0 +1,267 @@
+using System.Diagnostics;
+using Orleans.TestingHost.Diagnostics;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("TestingHost")]
+public sealed class DiagnosticEventCollectorTests
+{
+    [Fact]
+    public async Task ListenerPrefixes_CaptureMatchingListenerAndExcludeUnrelatedListener()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var listenerPrefix = CreateListenerName("Matching");
+        var matchingListenerName = $"{listenerPrefix}.Listener";
+        var unrelatedListenerName = CreateListenerName("Unrelated");
+        var matchingEventName = $"{matchingListenerName}.Captured";
+        var unrelatedEventName = $"{unrelatedListenerName}.Excluded";
+        var matchingPayload = new object();
+        var unrelatedPayload = new object();
+        using var collector = new DiagnosticEventCollector(listenerPrefix);
+        using var matchingListener = new DiagnosticListener(matchingListenerName);
+        using var unrelatedListener = new DiagnosticListener(unrelatedListenerName);
+        var matchingWaiter = collector.WaitForEventAsync(
+            matchingEventName,
+            Timeout.InfiniteTimeSpan,
+            cancellationToken);
+        var unrelatedWaiter = collector.CreateEventAwaiter(unrelatedEventName).Task;
+
+        matchingListener.Write(matchingEventName, matchingPayload);
+        unrelatedListener.Write(unrelatedEventName, unrelatedPayload);
+
+        var captured = await matchingWaiter;
+        Assert.Equal(matchingListenerName, matchingListener.Name);
+        Assert.Equal(unrelatedListenerName, unrelatedListener.Name);
+        Assert.Equal(matchingEventName, captured.Name);
+        Assert.Same(matchingPayload, captured.Payload);
+        Assert.NotEqual(default, captured.Timestamp);
+        Assert.Equal(captured, Assert.Single(collector.Events));
+        Assert.Equal(1, collector.GetEventCount(matchingEventName));
+        Assert.Equal(0, collector.GetEventCount(unrelatedEventName));
+        await AssertNotCompletedAsync(unrelatedWaiter, cancellationToken);
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => collector.WaitForEventAsync(unrelatedEventName, TimeSpan.Zero, cancellationToken));
+    }
+
+    [Fact]
+    public async Task WaitForEventAsync_WhenEventAlreadyExists_ReturnsExactCapturedEvent()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var listenerName = CreateListenerName("Historical");
+        var eventName = $"{listenerName}.Existing";
+        var payload = new object();
+        using var collector = new DiagnosticEventCollector(listenerName);
+        using var listener = new DiagnosticListener(listenerName);
+        var captureBarrier = collector.CreateEventAwaiter(eventName).Task;
+
+        listener.Write(eventName, payload);
+
+        var captured = await captureBarrier.WaitAsync(cancellationToken);
+        var historical = await collector.WaitForEventAsync(
+            eventName,
+            Timeout.InfiniteTimeSpan,
+            cancellationToken);
+        Assert.Equal(listenerName, listener.Name);
+        Assert.Equal(eventName, historical.Name);
+        Assert.Same(payload, historical.Payload);
+        Assert.NotEqual(default, historical.Timestamp);
+        Assert.Equal(captured, historical);
+        Assert.Equal(historical, Assert.Single(collector.Events));
+    }
+
+    [Fact]
+    public async Task WaitForEventAsync_Predicate_CompletesOnlyMatchingArmedWaiter()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var listenerName = CreateListenerName("Predicate");
+        var eventName = $"{listenerName}.Value";
+        var firstPayload = new object();
+        var matchingPayload = new object();
+        var neverMatchingPayload = new object();
+        using var collector = new DiagnosticEventCollector(listenerName);
+        using var listener = new DiagnosticListener(listenerName);
+        var matchingWaiter = collector.WaitForEventAsync(
+            eventName,
+            evt => ReferenceEquals(evt.Payload, matchingPayload),
+            Timeout.InfiniteTimeSpan,
+            cancellationToken);
+        var nonmatchingWaiter = collector.WaitForEventAsync(
+            eventName,
+            evt => ReferenceEquals(evt.Payload, neverMatchingPayload),
+            Timeout.InfiniteTimeSpan,
+            cancellationToken);
+
+        listener.Write(eventName, firstPayload);
+
+        await AssertNotCompletedAsync(matchingWaiter, cancellationToken);
+        await AssertNotCompletedAsync(nonmatchingWaiter, cancellationToken);
+
+        listener.Write(eventName, matchingPayload);
+
+        var captured = await matchingWaiter;
+        Assert.Equal(eventName, captured.Name);
+        Assert.Same(matchingPayload, captured.Payload);
+        Assert.NotEqual(default, captured.Timestamp);
+        await AssertNotCompletedAsync(nonmatchingWaiter, cancellationToken);
+        Assert.Equal(2, collector.GetEventCount(eventName));
+        Assert.Equal(
+            [firstPayload, matchingPayload],
+            collector.GetEvents(eventName).Select(static evt => evt.Payload));
+    }
+
+    [Fact]
+    public async Task CreateEventAwaiter_IgnoresHistoricalEventAndCompletesForNextEvent()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var listenerName = CreateListenerName("Future");
+        var eventName = $"{listenerName}.Value";
+        var historicalPayload = new object();
+        var nextPayload = new object();
+        using var collector = new DiagnosticEventCollector(listenerName);
+        using var listener = new DiagnosticListener(listenerName);
+        var historicalBarrier = collector.CreateEventAwaiter(eventName).Task;
+
+        listener.Write(eventName, historicalPayload);
+
+        var historical = await historicalBarrier.WaitAsync(cancellationToken);
+        var futureAwaiter = collector.CreateEventAwaiter(eventName).Task;
+        await AssertNotCompletedAsync(futureAwaiter, cancellationToken);
+
+        listener.Write(eventName, nextPayload);
+
+        var next = await futureAwaiter.WaitAsync(cancellationToken);
+        Assert.Equal(eventName, next.Name);
+        Assert.Same(nextPayload, next.Payload);
+        Assert.NotEqual(default, next.Timestamp);
+        Assert.NotEqual(historical, next);
+        Assert.Same(historicalPayload, historical.Payload);
+        Assert.Equal(
+            [historicalPayload, nextPayload],
+            collector.GetEvents(eventName).Select(static evt => evt.Payload));
+        Assert.Equal(2, collector.GetEventCount(eventName));
+    }
+
+    [Fact]
+    public async Task WaitForEventCountAsync_TimeoutReportsExpectedAndActualCountsExactly()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var listenerName = CreateListenerName("Count");
+        var eventName = $"{listenerName}.Counted";
+        var firstPayload = new object();
+        var secondPayload = new object();
+        using var collector = new DiagnosticEventCollector(listenerName);
+        using var listener = new DiagnosticListener(listenerName);
+        var countBarrier = collector.WaitForEventCountAsync(
+            eventName,
+            2,
+            Timeout.InfiniteTimeSpan,
+            cancellationToken);
+
+        listener.Write(eventName, firstPayload);
+        listener.Write(eventName, secondPayload);
+
+        var captured = await countBarrier;
+        Assert.Equal(2, captured.Count);
+        Assert.Equal([firstPayload, secondPayload], captured.Select(static evt => evt.Payload));
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(
+            () => collector.WaitForEventCountAsync(eventName, 3, TimeSpan.Zero, cancellationToken));
+
+        Assert.Equal(
+            $"Timed out waiting for 3 '{eventName}' events after 00:00:00. Got 2 events.",
+            exception.Message);
+        Assert.Contains(listenerName, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(eventName, exception.Message, StringComparison.Ordinal);
+        Assert.Equal(2, collector.GetEventCount(eventName));
+    }
+
+    [Fact]
+    public async Task Clear_RemovesCapturedEventsWithoutBreakingSubsequentWaits()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var listenerName = CreateListenerName("Clear");
+        var eventName = $"{listenerName}.Value";
+        var initialPayload = new object();
+        var subsequentPayload = new object();
+        using var collector = new DiagnosticEventCollector(listenerName);
+        using var listener = new DiagnosticListener(listenerName);
+        var initialBarrier = collector.CreateEventAwaiter(eventName).Task;
+
+        listener.Write(eventName, initialPayload);
+
+        var initial = await initialBarrier.WaitAsync(cancellationToken);
+        Assert.Equal(eventName, initial.Name);
+        Assert.Same(initialPayload, initial.Payload);
+        Assert.Equal(initial, Assert.Single(collector.Events));
+        Assert.Equal(1, collector.GetEventCount(eventName));
+
+        collector.Clear();
+
+        Assert.Empty(collector.Events);
+        Assert.Empty(collector.GetEvents(eventName));
+        Assert.Equal(0, collector.GetEventCount(eventName));
+        var subsequentWaiter = collector.WaitForEventAsync(
+            eventName,
+            Timeout.InfiniteTimeSpan,
+            cancellationToken);
+
+        listener.Write(eventName, subsequentPayload);
+
+        var subsequent = await subsequentWaiter;
+        Assert.Equal(eventName, subsequent.Name);
+        Assert.Same(subsequentPayload, subsequent.Payload);
+        Assert.NotEqual(initial, subsequent);
+        Assert.Equal(subsequent, Assert.Single(collector.Events));
+        Assert.Equal(1, collector.GetEventCount(eventName));
+    }
+
+    [Fact]
+    public async Task Dispose_UnsubscribesAndIsIdempotent()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var listenerName = CreateListenerName("Dispose");
+        var capturedEventName = $"{listenerName}.BeforeDispose";
+        var excludedEventName = $"{listenerName}.AfterDispose";
+        var capturedPayload = new object();
+        var excludedPayload = new object();
+        var collector = new DiagnosticEventCollector(listenerName);
+        using var listener = new DiagnosticListener(listenerName);
+        var captureBarrier = collector.CreateEventAwaiter(capturedEventName).Task;
+        var excludedWaiter = collector.CreateEventAwaiter(excludedEventName).Task;
+
+        listener.Write(capturedEventName, capturedPayload);
+
+        var captured = await captureBarrier.WaitAsync(cancellationToken);
+        var evidenceBeforeDispose = collector.Events;
+
+        var firstDisposeException = Record.Exception(collector.Dispose);
+        var secondDisposeException = Record.Exception(collector.Dispose);
+        listener.Write(excludedEventName, excludedPayload);
+
+        Assert.Null(firstDisposeException);
+        Assert.Null(secondDisposeException);
+        Assert.Equal(evidenceBeforeDispose, collector.Events);
+        Assert.Equal(captured, Assert.Single(collector.Events));
+        Assert.Same(capturedPayload, captured.Payload);
+        Assert.Equal(1, collector.GetEventCount(capturedEventName));
+        Assert.Equal(0, collector.GetEventCount(excludedEventName));
+        await AssertNotCompletedAsync(excludedWaiter, cancellationToken);
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => collector.WaitForEventAsync(excludedEventName, TimeSpan.Zero, cancellationToken));
+    }
+
+    private static string CreateListenerName(string scenario) =>
+        $"Orleans.TestingHost.Tests.DiagnosticEventCollector.{scenario}.{Guid.NewGuid():N}";
+
+    private static async Task AssertNotCompletedAsync(Task task, CancellationToken cancellationToken)
+    {
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => task.WaitAsync(TimeSpan.Zero, cancellationToken));
+        Assert.False(task.IsCompleted);
+    }
+}

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InMemoryLoggerProviderTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InMemoryLoggerProviderTests.cs
@@ -1,0 +1,331 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Orleans.TestingHost.Logging;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("TestingHost")]
+public sealed class InMemoryLoggerProviderTests
+{
+    [Fact]
+    public void FormatAllEntries_NestedException_FormatsMetadataAndEveryLevelExactly()
+    {
+        var inner = new FormatException("inner failure");
+        var middle = new ArgumentException("middle failure", inner);
+        var outer = new InvalidOperationException("outer failure", middle);
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Nested.Category");
+
+        logger.Log(
+            LogLevel.Error,
+            new EventId(101, "NestedEvent"),
+            "nested message",
+            outer,
+            static (state, _) => state);
+
+        var entry = Assert.Single(buffer.AllEntries);
+        var exceptionText =
+            FormatException(0, outer)
+            + FormatException(1, middle)
+            + FormatException(2, inner);
+        var expected = FormatEntry(entry, exceptionText) + Environment.NewLine;
+
+        Assert.Equal(expected, buffer.FormatAllEntries());
+    }
+
+    [Fact]
+    public void FormatAllEntries_AggregateException_FormatsAllInnerExceptionsAtSameDepth()
+    {
+        var first = new InvalidOperationException("first failure");
+        var second = new ArgumentException("second failure");
+        var aggregate = new AggregateException("aggregate failure", first, second);
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Aggregate.Category");
+
+        logger.Log(
+            LogLevel.Warning,
+            new EventId(102, "AggregateEvent"),
+            "aggregate message",
+            aggregate,
+            static (state, _) => state);
+
+        var entry = Assert.Single(buffer.AllEntries);
+        var exceptionText =
+            FormatException(0, aggregate)
+            + FormatException(1, first)
+            + FormatException(1, second);
+        var expected = FormatEntry(entry, exceptionText) + Environment.NewLine;
+
+        Assert.Equal(expected, buffer.FormatAllEntries());
+    }
+
+    [Fact]
+    public void FormatAllEntries_ReflectionTypeLoadException_FormatsLoaderExceptionDiagnostics()
+    {
+        var first = new TypeLoadException("loader one");
+        var second = new FileNotFoundException("loader two");
+        var exception = new ReflectionTypeLoadException([], [first, second]);
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Loader.Category");
+
+        logger.Log(
+            LogLevel.Critical,
+            new EventId(103, "LoaderEvent"),
+            "loader message",
+            exception,
+            static (state, _) => state);
+
+        var entry = Assert.Single(buffer.AllEntries);
+        var exceptionText =
+            FormatException(0, exception)
+            + FormatException(1, first)
+            + FormatException(1, second);
+        var expected = FormatEntry(entry, exceptionText) + Environment.NewLine;
+
+        Assert.Equal(expected, buffer.FormatAllEntries());
+    }
+
+    [Fact]
+    public void Log_NoneAndMinimumLevelFiltering_ReturnsOnlyExpectedEntries()
+    {
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Filter.Category");
+        var levels = new[]
+        {
+            LogLevel.Trace,
+            LogLevel.Debug,
+            LogLevel.Information,
+            LogLevel.Warning,
+            LogLevel.Error,
+            LogLevel.Critical,
+            LogLevel.None,
+        };
+
+        foreach (var level in levels)
+        {
+            logger.Log(
+                level,
+                new EventId(200 + (int)level, $"Event-{level}"),
+                $"message-{level}",
+                exception: null,
+                static (state, _) => state);
+        }
+
+        Assert.All(levels[..^1], level => Assert.True(logger.IsEnabled(level)));
+        Assert.False(logger.IsEnabled(LogLevel.None));
+        Assert.Equal(
+            [
+                "Trace|200|Event-Trace|Filter.Category|message-Trace",
+                "Debug|201|Event-Debug|Filter.Category|message-Debug",
+                "Information|202|Event-Information|Filter.Category|message-Information",
+                "Warning|203|Event-Warning|Filter.Category|message-Warning",
+                "Error|204|Event-Error|Filter.Category|message-Error",
+                "Critical|205|Event-Critical|Filter.Category|message-Critical",
+            ],
+            buffer.AllEntries.Select(DescribeEntry));
+        Assert.Equal(
+            [
+                "Warning|203|Event-Warning|Filter.Category|message-Warning",
+                "Error|204|Event-Error|Filter.Category|message-Error",
+                "Critical|205|Event-Critical|Filter.Category|message-Critical",
+            ],
+            buffer.GetEntries(LogLevel.Warning).Select(DescribeEntry));
+    }
+
+    [Fact]
+    public void BeginScope_IsNoOpAndDoesNotSuppressFollowingLogEntry()
+    {
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Scope.Category");
+
+        var outer = Assert.IsAssignableFrom<IDisposable>(logger.BeginScope("outer-scope"));
+        var inner = Assert.IsAssignableFrom<IDisposable>(logger.BeginScope("inner-scope"));
+        Assert.Same(outer, inner);
+        inner.Dispose();
+        outer.Dispose();
+        logger.Log(
+            LogLevel.Information,
+            new EventId(301, "AfterScopes"),
+            "scope-free message",
+            exception: null,
+            static (state, _) => state);
+
+        var entry = Assert.Single(buffer.AllEntries);
+        Assert.Equal("Information|301|AfterScopes|Scope.Category|scope-free message", DescribeEntry(entry));
+        Assert.Null(entry.Exception);
+    }
+
+    [Fact]
+    public async Task ConcurrentLog_AllEntriesAreCollectedExactlyOnce()
+    {
+        const int workerCount = 16;
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var armed = Enumerable.Range(0, workerCount)
+            .Select(_ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+
+        var workers = Enumerable.Range(0, workerCount)
+            .Select(LogAfterReleaseAsync)
+            .ToArray();
+        await Task.WhenAll(armed.Select(static signal => signal.Task))
+            .WaitAsync(TestContext.Current.CancellationToken);
+        release.SetResult();
+        await Task.WhenAll(workers).WaitAsync(TestContext.Current.CancellationToken);
+
+        var entries = buffer.AllEntries;
+        Assert.Equal(workerCount, entries.Count);
+        Assert.Equal(
+            Enumerable.Range(0, workerCount).Select(static index =>
+                $"Concurrent.Category.{index:D2}|{400 + index}:ConcurrentEvent{index:D2}|concurrent-message-{index:D2}"),
+            entries
+                .Select(static entry =>
+                    $"{entry.Category}|{entry.EventId.Id}:{entry.EventId.Name}|{entry.Message}")
+                .Order());
+
+        async Task LogAfterReleaseAsync(int index)
+        {
+            var logger = provider.CreateLogger($"Concurrent.Category.{index:D2}");
+            armed[index].SetResult();
+            await release.Task;
+            logger.Log(
+                LogLevel.Information,
+                new EventId(400 + index, $"ConcurrentEvent{index:D2}"),
+                $"concurrent-message-{index:D2}",
+                exception: null,
+                static (state, _) => state);
+        }
+    }
+
+    [Fact]
+    public void Dispose_ClearsOwnedBufferButPreservesSharedBuffer()
+    {
+        var ownedProvider = new InMemoryLoggerProvider();
+        var ownedLogger = ownedProvider.CreateLogger("Owned.Category");
+        LogMessage(ownedLogger, 501, "owned-before-dispose");
+
+        ownedProvider.Dispose();
+
+        Assert.Empty(ownedProvider.Buffer.AllEntries);
+        LogMessage(ownedLogger, 502, "owned-after-first-dispose");
+        ownedProvider.Dispose();
+        Assert.Equal(["owned-after-first-dispose"], ownedProvider.Buffer.AllEntries.Select(static entry => entry.Message));
+
+        var sharedBuffer = new InMemoryLogBuffer();
+        var sharedProvider = new InMemoryLoggerProvider(sharedBuffer);
+        var sharedLogger = sharedProvider.CreateLogger("Shared.Category");
+        LogMessage(sharedLogger, 503, "shared-before-dispose");
+
+        sharedProvider.Dispose();
+
+        Assert.Equal(["shared-before-dispose"], sharedBuffer.AllEntries.Select(static entry => entry.Message));
+        LogMessage(sharedLogger, 504, "shared-after-first-dispose");
+        sharedProvider.Dispose();
+        Assert.Equal(
+            ["shared-before-dispose", "shared-after-first-dispose"],
+            sharedBuffer.AllEntries.Select(static entry => entry.Message));
+    }
+
+    [Fact]
+    public void AssertNoWarningsOrErrors_ReportsFirstTenEntriesAndRemainderExactly()
+    {
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Diagnostics.Category");
+        LogMessage(logger, 600, "ignored-information", LogLevel.Information);
+        for (var index = 0; index < 12; index++)
+        {
+            LogMessage(
+                logger,
+                601 + index,
+                $"issue-{index:D2}",
+                index % 2 == 0 ? LogLevel.Warning : LogLevel.Error);
+        }
+
+        var issues = buffer.GetEntries(LogLevel.Warning).ToArray();
+        var expected = new StringBuilder()
+            .AppendLine("Found 12 warnings/errors:");
+        foreach (var entry in issues.Take(10))
+        {
+            expected.AppendLine(FormatEntry(entry));
+        }
+
+        expected.AppendLine("... and 2 more.");
+
+        var exception = Assert.Throws<InvalidOperationException>(buffer.AssertNoWarningsOrErrors);
+
+        Assert.Equal(expected.ToString(), exception.Message);
+    }
+
+    [Fact]
+    public void FormatEntriesWithSize_ReturnsExactUtf8ByteCount()
+    {
+        var buffer = new InMemoryLogBuffer();
+        using var provider = new InMemoryLoggerProvider(buffer);
+        var logger = provider.CreateLogger("Size.Category");
+        LogMessage(logger, 701, "excluded café", LogLevel.Information);
+        LogMessage(logger, 702, "naïve 東京 ☕", LogLevel.Warning);
+
+        var included = Assert.Single(buffer.GetEntries(LogLevel.Warning));
+        var expectedContent = FormatEntry(included) + Environment.NewLine;
+
+        var (content, sizeBytes) = buffer.FormatEntriesWithSize(LogLevel.Warning);
+
+        Assert.Equal(expectedContent, content);
+        Assert.Equal(Encoding.UTF8.GetByteCount(expectedContent), sizeBytes);
+        Assert.True(sizeBytes > content.Length);
+    }
+
+    private static void LogMessage(
+        ILogger logger,
+        int eventId,
+        string message,
+        LogLevel level = LogLevel.Information) =>
+        logger.Log(
+            level,
+            new EventId(eventId, $"Event-{eventId}"),
+            message,
+            exception: null,
+            static (state, _) => state);
+
+    private static string DescribeEntry(LogEntry entry) =>
+        $"{entry.LogLevel}|{entry.EventId.Id}|{entry.EventId.Name}|{entry.Category}|{entry.Message}";
+
+    private static string FormatException(int level, Exception exception) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"Exc level {level}: {exception.GetType()}: {exception.Message}");
+
+    private static string FormatEntry(LogEntry entry, string? exceptionText = null)
+    {
+        var level = entry.LogLevel switch
+        {
+            LogLevel.Trace => "TRCE",
+            LogLevel.Debug => "DBUG",
+            LogLevel.Information => "INFO",
+            LogLevel.Warning => "WARN",
+            LogLevel.Error => "FAIL",
+            LogLevel.Critical => "CRIT",
+            _ => "NONE",
+        };
+        var prefix = entry.LogLevel == LogLevel.Error ? "!!!!!!!!!! " : "";
+        var exception = exceptionText is null ? "" : $"\n{exceptionText}";
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"[{entry.Timestamp:yyyy-MM-dd HH:mm:ss.fff} {entry.ThreadId}\t{level}\t{entry.EventId}\t{entry.Category}]\t{prefix}{entry.Message}{exception}");
+    }
+}

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
@@ -1,0 +1,433 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Orleans.TestingHost.Logging;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests;
+
+[TestSuite("Functional")]
+[TestProvider("None")]
+[TestArea("TestingHost")]
+[TestCategory("Functional")]
+public sealed class InProcessTestClusterLifecycleTests
+{
+    private const string DiagnosticCategory = "Orleans.TestingHost.Tests.LifecycleFailureProbe";
+    private static readonly EventId SiloStartupFailureEvent = new(7101, "SiloStartupFailed");
+    private static readonly EventId ClientStartupFailureEvent = new(7102, "ClientStartupFailed");
+    private static readonly EventId SiloStopFailureEvent = new(7103, "SiloStopFailed");
+
+    [Fact]
+    public async Task DeployAsync_WhenOneSiloStartupFails_DisposesEveryBuiltHostAndReportsRootFailure()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var expectedFailure = new InvalidOperationException("Controlled Silo_1 startup failure.");
+        var coordinator = new SiloStartupCoordinator(expectedStarts: 2);
+        var startedSilo = new LifecycleControl("Silo_0", coordinator);
+        var failedSilo = new LifecycleControl("Silo_1", coordinator)
+        {
+            StartFailure = expectedFailure
+        };
+        var startedSiloDisposal = new DisposalTracker();
+        var failedSiloDisposal = new DisposalTracker();
+        var logBuffer = new InMemoryLogBuffer();
+        var allocator = new FixedPortAllocator();
+        var builder = CreateBuilder(initialSilosCount: 2, initializeClientOnDeploy: false);
+        builder.ConfigureSiloHost((options, hostBuilder) =>
+        {
+            if (options.SiloName == startedSilo.Name)
+            {
+                AddControlledLifecycle(hostBuilder.Services, startedSilo, startedSiloDisposal, logBuffer);
+            }
+            else
+            {
+                Assert.Equal(failedSilo.Name, options.SiloName);
+                AddControlledLifecycle(hostBuilder.Services, failedSilo, failedSiloDisposal, logBuffer);
+            }
+        });
+
+        var cluster = new InProcessTestCluster(builder.Options, allocator);
+        try
+        {
+            var deployment = cluster.DeployAsync(cancellationToken);
+            await coordinator.BothStartsObserved.Task.WaitAsync(cancellationToken);
+            await coordinator.SuccessfulSiloStarted.Task.WaitAsync(cancellationToken);
+
+            coordinator.ReleaseFailure.TrySetResult();
+            await startedSilo.StopEntered.Task.WaitAsync(cancellationToken);
+            var startedHandle = Assert.Single(cluster.Silos);
+            startedSilo.ReleaseStop.TrySetResult();
+
+            var actualFailure = await Assert.ThrowsAsync<InvalidOperationException>(() => deployment);
+
+            Assert.Same(expectedFailure, actualFailure);
+            Assert.Equal("Controlled Silo_1 startup failure.", actualFailure.Message);
+            Assert.False(startedHandle.IsActive);
+            Assert.Empty(cluster.Silos);
+            AssertClientUnavailable(cluster);
+            Assert.Equal(1, startedSiloDisposal.DisposeCount);
+            Assert.Equal(1, failedSiloDisposal.DisposeCount);
+            Assert.Equal([1, 1], allocator.AllocationRequests.Order());
+            Assert.Equal(0, allocator.DisposeCount);
+            AssertProviderDisposed(startedHandle.ServiceProvider);
+            AssertProviderDisposed(failedSilo.ServiceProvider);
+
+            var diagnostic = Assert.Single(
+                logBuffer.AllEntries,
+                entry => entry.Category == DiagnosticCategory && entry.EventId == SiloStartupFailureEvent);
+            Assert.Equal(LogLevel.Error, diagnostic.LogLevel);
+            Assert.Equal("Silo Silo_1 startup failed by test control.", diagnostic.Message);
+            Assert.Same(expectedFailure, diagnostic.Exception);
+            Assert.DoesNotContain("Done initializing cluster", cluster.GetLog(), StringComparison.Ordinal);
+
+            await cluster.DisposeAsync();
+            await cluster.DisposeAsync();
+
+            Assert.Equal(1, startedSiloDisposal.DisposeCount);
+            Assert.Equal(1, failedSiloDisposal.DisposeCount);
+            Assert.Equal(1, allocator.DisposeCount);
+            Assert.Same(expectedFailure, diagnostic.Exception);
+        }
+        finally
+        {
+            coordinator.ReleaseFailure.TrySetResult();
+            startedSilo.ReleaseStop.TrySetResult();
+            await cluster.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task DeployAsync_WhenClientStartupFails_DisposesClientAndSilosAndRetainsDiagnostics()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var expectedFailure = new InvalidOperationException("Controlled cluster client startup failure.");
+        var silo = new LifecycleControl("Silo_0");
+        var client = new LifecycleControl("TestClusterClient")
+        {
+            RequiredPredecessor = silo.Started.Task,
+            StartFailure = expectedFailure
+        };
+        var siloDisposal = new DisposalTracker();
+        var clientDisposal = new DisposalTracker();
+        var logBuffer = new InMemoryLogBuffer();
+        var allocator = new FixedPortAllocator();
+        var builder = CreateBuilder(initialSilosCount: 1, initializeClientOnDeploy: true);
+        builder.ConfigureSiloHost((options, hostBuilder) =>
+        {
+            Assert.Equal(silo.Name, options.SiloName);
+            AddControlledLifecycle(hostBuilder.Services, silo, siloDisposal, logBuffer);
+        });
+        builder.ConfigureClientHost(hostBuilder =>
+            AddControlledLifecycle(hostBuilder.Services, client, clientDisposal, logBuffer));
+
+        var cluster = new InProcessTestCluster(builder.Options, allocator);
+        try
+        {
+            var deployment = cluster.DeployAsync(cancellationToken);
+            await silo.Started.Task.WaitAsync(cancellationToken);
+            await client.StartEntered.Task.WaitAsync(cancellationToken);
+            Assert.True(silo.Started.Task.IsCompletedSuccessfully);
+
+            client.ReleaseStart.TrySetResult();
+            await silo.StopEntered.Task.WaitAsync(cancellationToken);
+            var siloHandle = Assert.Single(cluster.Silos);
+            silo.ReleaseStop.TrySetResult();
+
+            var actualFailure = await Assert.ThrowsAsync<InvalidOperationException>(() => deployment);
+
+            Assert.Same(expectedFailure, actualFailure);
+            Assert.Equal("Controlled cluster client startup failure.", actualFailure.Message);
+            Assert.False(siloHandle.IsActive);
+            Assert.Empty(cluster.Silos);
+            Assert.Null(cluster.ClientHost);
+            AssertClientUnavailable(cluster);
+            Assert.Equal(1, siloDisposal.DisposeCount);
+            Assert.Equal(1, clientDisposal.DisposeCount);
+            Assert.Equal([1], allocator.AllocationRequests);
+            Assert.Equal(0, allocator.DisposeCount);
+            AssertProviderDisposed(siloHandle.ServiceProvider);
+            AssertProviderDisposed(client.ServiceProvider);
+
+            var clusterLog = cluster.GetLog();
+            var doneIndex = clusterLog.IndexOf("Done initializing cluster", StringComparison.Ordinal);
+            var clientIndex = clusterLog.IndexOf("Initializing Cluster Client", StringComparison.Ordinal);
+            Assert.True(doneIndex >= 0);
+            Assert.True(clientIndex > doneIndex);
+
+            var diagnostic = Assert.Single(
+                logBuffer.AllEntries,
+                entry => entry.Category == DiagnosticCategory && entry.EventId == ClientStartupFailureEvent);
+            Assert.Equal(LogLevel.Error, diagnostic.LogLevel);
+            Assert.Equal("Client TestClusterClient startup failed by test control.", diagnostic.Message);
+            Assert.Same(expectedFailure, diagnostic.Exception);
+
+            await cluster.DisposeAsync();
+            await cluster.DisposeAsync();
+
+            Assert.Equal(1, siloDisposal.DisposeCount);
+            Assert.Equal(1, clientDisposal.DisposeCount);
+            Assert.Equal(1, allocator.DisposeCount);
+            Assert.Same(expectedFailure, diagnostic.Exception);
+            Assert.Contains(diagnostic, logBuffer.AllEntries);
+        }
+        finally
+        {
+            client.ReleaseStart.TrySetResult();
+            silo.ReleaseStop.TrySetResult();
+            await cluster.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task StopSiloAsync_WhenHostStopFails_RemovesAndDisposesHandle()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var expectedFailure = new InvalidOperationException("Controlled Silo_0 stop failure.");
+        var silo = new LifecycleControl("Silo_0")
+        {
+            StopFailure = expectedFailure
+        };
+        var siloDisposal = new DisposalTracker();
+        var logBuffer = new InMemoryLogBuffer();
+        var allocator = new FixedPortAllocator();
+        var builder = CreateBuilder(initialSilosCount: 1, initializeClientOnDeploy: false);
+        builder.ConfigureSiloHost((options, hostBuilder) =>
+        {
+            Assert.Equal(silo.Name, options.SiloName);
+            AddControlledLifecycle(hostBuilder.Services, silo, siloDisposal, logBuffer);
+        });
+
+        var cluster = new InProcessTestCluster(builder.Options, allocator);
+        try
+        {
+            await cluster.DeployAsync(cancellationToken);
+            await silo.Started.Task.WaitAsync(cancellationToken);
+            var handle = Assert.Single(cluster.Silos);
+
+            var stopping = cluster.StopSiloAsync(handle, cancellationToken);
+            await silo.StopEntered.Task.WaitAsync(cancellationToken);
+            silo.ReleaseStop.TrySetResult();
+
+            var actualFailure = await Assert.ThrowsAsync<InvalidOperationException>(() => stopping);
+
+            Assert.Same(expectedFailure, actualFailure);
+            Assert.Equal("Controlled Silo_0 stop failure.", actualFailure.Message);
+            Assert.False(handle.IsActive);
+            Assert.Empty(cluster.Silos);
+            Assert.Equal(1, siloDisposal.DisposeCount);
+            Assert.Equal([1], allocator.AllocationRequests);
+            Assert.Equal(0, allocator.DisposeCount);
+            AssertProviderDisposed(handle.ServiceProvider);
+
+            var diagnostic = Assert.Single(
+                logBuffer.AllEntries,
+                entry => entry.Category == DiagnosticCategory && entry.EventId == SiloStopFailureEvent);
+            Assert.Equal(LogLevel.Error, diagnostic.LogLevel);
+            Assert.Equal("Silo Silo_0 stop failed by test control.", diagnostic.Message);
+            Assert.Same(expectedFailure, diagnostic.Exception);
+
+            await cluster.StopAllSilosAsync(cancellationToken);
+            await cluster.DisposeAsync();
+            await cluster.DisposeAsync();
+
+            Assert.Equal(1, siloDisposal.DisposeCount);
+            Assert.Equal(1, allocator.DisposeCount);
+            Assert.Same(expectedFailure, diagnostic.Exception);
+        }
+        finally
+        {
+            silo.ReleaseStop.TrySetResult();
+            await DisposeClusterAfterStopFailureAsync(cluster, expectedFailure);
+        }
+    }
+
+    private static InProcessTestClusterBuilder CreateBuilder(short initialSilosCount, bool initializeClientOnDeploy)
+    {
+        var builder = new InProcessTestClusterBuilder(initialSilosCount);
+        builder.Options.ConfigureFileLogging = false;
+        builder.Options.InitializeClientOnDeploy = initializeClientOnDeploy;
+        return builder;
+    }
+
+    private static void AddControlledLifecycle(
+        IServiceCollection services,
+        LifecycleControl control,
+        DisposalTracker disposalTracker,
+        InMemoryLogBuffer logBuffer)
+    {
+        services.AddLogging(logging => logging.AddProvider(new InMemoryLoggerProvider(logBuffer)));
+        services.AddSingleton(_ => disposalTracker);
+        services.AddSingleton<IHostedService>(serviceProvider =>
+            new ControlledHostedService(
+                control,
+                serviceProvider,
+                serviceProvider.GetRequiredService<DisposalTracker>(),
+                serviceProvider.GetRequiredService<ILoggerFactory>()));
+    }
+
+    private static void AssertClientUnavailable(InProcessTestCluster cluster)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => cluster.Client);
+        Assert.Equal(
+            "The test cluster client is unavailable because the cluster has not been deployed or has been stopped.",
+            exception.Message);
+    }
+
+    private static void AssertProviderDisposed(IServiceProvider serviceProvider) =>
+        Assert.Throws<ObjectDisposedException>(() => serviceProvider.GetRequiredService<DisposalTracker>());
+
+    private static async Task DisposeClusterAfterStopFailureAsync(
+        InProcessTestCluster cluster,
+        InvalidOperationException expectedFailure)
+    {
+        try
+        {
+            await cluster.DisposeAsync();
+        }
+        catch (InvalidOperationException exception) when (ReferenceEquals(exception, expectedFailure))
+        {
+            await cluster.DisposeAsync();
+        }
+    }
+
+    private sealed class ControlledHostedService(
+        LifecycleControl control,
+        IServiceProvider serviceProvider,
+        DisposalTracker disposalTracker,
+        ILoggerFactory loggerFactory) : IHostedLifecycleService
+    {
+        private readonly ILogger _logger = loggerFactory.CreateLogger(DiagnosticCategory);
+
+        public Task StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            _ = disposalTracker;
+            control.ServiceProvider = serviceProvider;
+            control.StartCoordinator?.ObserveStart();
+            control.StartEntered.TrySetResult();
+
+            if (control.RequiredPredecessor is { } predecessor)
+            {
+                await predecessor.WaitAsync(cancellationToken);
+            }
+
+            if (control.StartFailure is { } failure)
+            {
+                if (control.StartCoordinator is { } coordinator)
+                {
+                    await coordinator.SuccessfulSiloStarted.Task.WaitAsync(cancellationToken);
+                    await coordinator.ReleaseFailure.Task.WaitAsync(cancellationToken);
+                }
+                else
+                {
+                    await control.ReleaseStart.Task.WaitAsync(cancellationToken);
+                }
+
+                var eventId = control.Name == "TestClusterClient"
+                    ? ClientStartupFailureEvent
+                    : SiloStartupFailureEvent;
+                var role = control.Name == "TestClusterClient" ? "Client" : "Silo";
+                _logger.LogError(
+                    eventId,
+                    failure,
+                    "{Role} {Name} startup failed by test control.",
+                    role,
+                    control.Name);
+                throw failure;
+            }
+        }
+
+        public Task StartedAsync(CancellationToken cancellationToken)
+        {
+            control.Started.TrySetResult();
+            control.StartCoordinator?.SuccessfulSiloStarted.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            control.StopEntered.TrySetResult();
+            await control.ReleaseStop.Task.WaitAsync(cancellationToken);
+
+            if (control.StopFailure is { } failure)
+            {
+                _logger.LogError(
+                    SiloStopFailureEvent,
+                    failure,
+                    "Silo {Name} stop failed by test control.",
+                    control.Name);
+                throw failure;
+            }
+        }
+
+        public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class LifecycleControl(string name, SiloStartupCoordinator? startCoordinator = null)
+    {
+        public string Name { get; } = name;
+        public SiloStartupCoordinator? StartCoordinator { get; } = startCoordinator;
+        public Exception? StartFailure { get; init; }
+        public Exception? StopFailure { get; init; }
+        public Task? RequiredPredecessor { get; init; }
+        public IServiceProvider ServiceProvider { get; set; } = null!;
+        public TaskCompletionSource StartEntered { get; } = CreateCompletionSource();
+        public TaskCompletionSource Started { get; } = CreateCompletionSource();
+        public TaskCompletionSource ReleaseStart { get; } = CreateCompletionSource();
+        public TaskCompletionSource StopEntered { get; } = CreateCompletionSource();
+        public TaskCompletionSource ReleaseStop { get; } = CreateCompletionSource();
+    }
+
+    private sealed class SiloStartupCoordinator(int expectedStarts)
+    {
+        private int _remainingStarts = expectedStarts;
+
+        public TaskCompletionSource BothStartsObserved { get; } = CreateCompletionSource();
+        public TaskCompletionSource SuccessfulSiloStarted { get; } = CreateCompletionSource();
+        public TaskCompletionSource ReleaseFailure { get; } = CreateCompletionSource();
+
+        public void ObserveStart()
+        {
+            if (Interlocked.Decrement(ref _remainingStarts) == 0)
+            {
+                BothStartsObserved.TrySetResult();
+            }
+        }
+    }
+
+    private sealed class DisposalTracker : IDisposable
+    {
+        private int _disposeCount;
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public void Dispose() => Interlocked.Increment(ref _disposeCount);
+    }
+
+    private sealed class FixedPortAllocator : ITestClusterPortAllocator
+    {
+        private readonly ConcurrentQueue<int> _allocationRequests = new();
+        private int _nextPortPair;
+        private int _disposeCount;
+
+        public IReadOnlyList<int> AllocationRequests => [.. _allocationRequests];
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public (int, int) AllocateConsecutivePortPairs(int numPorts)
+        {
+            _allocationRequests.Enqueue(numPorts);
+            var pair = Interlocked.Increment(ref _nextPortPair);
+            return (20_000 + pair, 30_000 + pair);
+        }
+
+        public void Dispose() => Interlocked.Increment(ref _disposeCount);
+    }
+
+    private static TaskCompletionSource CreateCompletionSource() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}


### PR DESCRIPTION
## Problem

`Orleans.TestingHost` lifecycle, logging, and diagnostic infrastructure has significant uncovered failure paths, making regressions in cleanup and failure evidence difficult to detect.

## Solution

- Add deterministic in-process cluster tests for silo startup, client startup, and silo stop failures, including exact cleanup and retained diagnostics.
- Cover in-memory logging across nested, aggregate, and loader exceptions; filtering, scopes, concurrent collection, disposal, truncation, and UTF-8 sizing.
- Cover diagnostic event filtering, historical and future waits, predicates, timeout messages, clearing, and disposal.
- Pin Reminder TestKit failure-report placeholders and exception propagation.

## Coverage impact

| Target | Before | After |
|---|---:|---:|
| `Orleans.TestingHost` | 30.70% line / 24.20% branch | 48.39% line / 39.63% branch |
| `InProcTestCluster.cs` | 0% / 0% | 50.41% / 40.67% |
| `InMemoryLoggerProvider.cs` | 0% / 0% | 80.86% / 71.93% |
| `PrintException` | 0% / 0% | 84.44% / 80.77% |
| `DiagnosticEventCollector.cs` | 0% / 0% | 90.34% / 75.00% |
| `ReminderTestKitDiagnostics.cs` | 87.76% line / 75.00% branch | 87.76% line / 100.00% branch |

This is a mergeable first slice toward #10864. Storage emulator modernization and the remaining package-wide coverage gap remain follow-up work.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10883)