### PR TITLE
ci: add reminder reliability audit

### DIFF
--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -5,6 +5,10 @@ inputs:
   name:
     description: Artifact name.
     required: true
+  retention-days:
+    description: Number of days to retain the artifact.
+    required: false
+    default: '1'
 
 runs:
   using: composite
@@ -15,7 +19,7 @@ runs:
     with:
       name: ${{ inputs.name }}
       if-no-files-found: warn
-      retention-days: 1
+      retention-days: ${{ inputs.retention-days }}
       path: |
         **/TestResults/*
         !TestResults/*.cobertura.xml
@@ -31,7 +35,7 @@ runs:
     with:
       name: ${{ inputs.name }}
       if-no-files-found: warn
-      retention-days: 1
+      retention-days: ${{ inputs.retention-days }}
       overwrite: true
       path: |
         **/TestResults/*

--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Number of days to retain the artifact.
     required: false
     default: '1'
+  fail-on-upload-error:
+    description: Fail if both test result upload attempts fail.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -30,7 +34,7 @@ runs:
     run: Start-Sleep -Seconds 30
   - name: Retry test result upload
     if: steps.archive-test-results.outcome == 'failure'
-    continue-on-error: true
+    continue-on-error: ${{ inputs.fail-on-upload-error != 'true' }}
     uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     with:
       name: ${{ inputs.name }}

--- a/.github/scripts/run-reminder-reliability.ps1
+++ b/.github/scripts/run-reminder-reliability.ps1
@@ -1,0 +1,153 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('None', 'AzureStorage', 'SqlServer', 'Cosmos')]
+    [string] $Provider,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('net8.0', 'net10.0')]
+    [string] $Framework,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateRange(1, 20)]
+    [int] $Iterations,
+
+    [Parameter(Mandatory = $true)]
+    [string] $FilterQuery,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Topology,
+
+    [Parameter(Mandatory = $true)]
+    [string] $Commit
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+$repositoryRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$logsDirectory = Join-Path $repositoryRoot 'logs'
+$testResultsDirectory = Join-Path $repositoryRoot 'TestResults'
+New-Item -ItemType Directory -Force $logsDirectory, $testResultsDirectory | Out-Null
+
+Push-Location $repositoryRoot
+try
+{
+    for ($iteration = 1; $iteration -le $Iterations; $iteration++)
+    {
+        $runId = "reminders_$($Provider.ToLowerInvariant())_${Framework}_iteration_$iteration"
+        $metadataPath = Join-Path $logsDirectory "$runId.json"
+        $consoleLogPath = Join-Path $logsDirectory "$runId.console.log"
+        $startedAt = [DateTimeOffset]::UtcNow
+        $metadata = [ordered]@{
+            iteration = $iteration
+            iterations = $Iterations
+            framework = $Framework
+            provider = $Provider
+            commit = $Commit
+            topology = $Topology
+            filter = $FilterQuery
+            startedUtc = $startedAt.ToString('O')
+            status = 'running'
+        }
+        $metadata | ConvertTo-Json | Set-Content -Path $metadataPath
+
+        Write-Host "::group::Reminder reliability: provider=$Provider framework=$Framework iteration=$iteration/$Iterations"
+        Write-Host "Commit: $Commit"
+        Write-Host "Topology: $Topology"
+
+        $arguments = @(
+            'test'
+            '--solution'
+            'Orleans.slnx'
+            '--framework'
+            $Framework
+            '--filter-query'
+            $FilterQuery
+            '--minimum-expected-tests'
+            '1'
+            '--hangdump'
+            '--hangdump-timeout'
+            '10m'
+            '--crashdump'
+            '--crashdump-type'
+            'Full'
+            '--hangdump-type'
+            'Full'
+            '--report-trx'
+            '--report-trx-filename'
+            "$runId`_{asm}_{tfm}_{arch}.trx"
+            '--max-parallel-test-modules'
+            '1'
+        )
+
+        & dotnet @arguments 2>&1 | Tee-Object -FilePath $consoleLogPath
+        $exitCode = $LASTEXITCODE
+        Write-Host '::endgroup::'
+
+        $metadata.completedUtc = [DateTimeOffset]::UtcNow.ToString('O')
+        if ($exitCode -eq 0)
+        {
+            $metadata.status = 'passed'
+            $metadata | ConvertTo-Json | Set-Content -Path $metadataPath
+            continue
+        }
+
+        $failedTests = @(
+            Get-ChildItem -Path $repositoryRoot -Filter "$runId*.trx" -Recurse -ErrorAction SilentlyContinue |
+                ForEach-Object {
+                    try
+                    {
+                        $trx = [xml](Get-Content -Raw -Path $_.FullName)
+                        $trx.SelectNodes("//*[local-name()='UnitTestResult' and @outcome='Failed']") |
+                            ForEach-Object { $_.testName }
+                    }
+                    catch
+                    {
+                        Write-Warning "Could not read failed tests from $($_.FullName): $_"
+                    }
+                } |
+                Sort-Object -Unique
+        )
+        if ($failedTests.Count -eq 0)
+        {
+            $failedTests = @("<not reported; dotnet test exited with code $exitCode>")
+        }
+
+        $metadata.status = 'failed'
+        $metadata.exitCode = $exitCode
+        $metadata.failingTests = $failedTests
+        $metadata | ConvertTo-Json -Depth 3 | Set-Content -Path $metadataPath
+
+        $failureContext = @(
+            "iteration=$iteration/$Iterations"
+            "framework=$Framework"
+            "provider=$Provider"
+            "commit=$Commit"
+            "topology=$Topology"
+            "failingTests=$($failedTests -join '; ')"
+        )
+        $failureContextPath = Join-Path $logsDirectory 'failure-context.txt'
+        $failureContext | Set-Content -Path $failureContextPath
+
+        if ($env:GITHUB_STEP_SUMMARY)
+        {
+            @(
+                '## Reminder reliability failure'
+                ''
+                "- Iteration: $iteration/$Iterations"
+                "- Framework: $Framework"
+                "- Provider: $Provider"
+                "- Commit: ``$Commit``"
+                "- Topology: $Topology"
+                "- Failing test(s): $($failedTests -join ', ')"
+            ) | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+        }
+
+        Write-Host "::error title=Reminder reliability failure::provider=$Provider framework=$Framework iteration=$iteration/$Iterations failingTests=$($failedTests -join '; ')"
+        exit $exitCode
+    }
+}
+finally
+{
+    Pop-Location
+}

--- a/.github/scripts/run-reminder-reliability.ps1
+++ b/.github/scripts/run-reminder-reliability.ps1
@@ -79,6 +79,10 @@ try
             '--max-parallel-test-modules'
             '1'
         )
+        if ($iteration -gt 1)
+        {
+            $arguments += '--no-build'
+        }
 
         & dotnet @arguments 2>&1 | Tee-Object -FilePath $consoleLogPath
         $exitCode = $LASTEXITCODE

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -479,11 +479,11 @@ exit 0
         Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'run: Start-Sleep -Seconds 30')).Count 'Artifact upload retry delay count differs.'
         Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact upload retries must replace partial artifacts.'
         Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Both coverage upload attempts must require the report.'
-        Assert-Equal 3 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only the final coverage upload attempt may gate the job.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only the final coverage upload and an explicitly strict test result retry may gate the job.'
         Assert-Matches `
             $archiveTestResultsAction `
-            "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Retry test result upload\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
-            'Test result upload attempts must remain non-gating and retry with overwrite.'
+            "(?ms)^  fail-on-upload-error:\r?\n    description:.*?\r?\n    required: false\r?\n    default: 'false'\r?\n.*?^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Retry test result upload\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    continue-on-error: \$\{\{ inputs\.fail-on-upload-error != 'true' \}\}\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
+            'Test result upload must remain non-gating by default, retry with overwrite, and support strict opt-in.'
         Assert-Matches `
             $archiveTestResultsAction `
             "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: github\.event_name == 'pull_request'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n.*?^  - name: Retry coverage upload\r?\n    if: github\.event_name == 'pull_request' && steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `

--- a/.github/workflows/reminder-reliability.yml
+++ b/.github/workflows/reminder-reliability.yml
@@ -1,0 +1,225 @@
+name: Reminder reliability
+
+on:
+  schedule:
+    # Five repetitions weekly catch 23-83% of 5-30% flakes per run and 64-99.9% over four runs.
+    - cron: '17 5 * * 4'
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Reminder provider to exercise
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - in-memory
+          - azure-storage
+          - sql-server
+          - cosmos
+      framework:
+        description: Target framework to exercise
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - net8.0
+          - net10.0
+      iterations:
+        description: Sequential repetitions per provider/framework (1-20)
+        required: true
+        default: '5'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reminder-reliability-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  BuildExternalAssets: 'false'
+  AZURITE_IMAGE: mcr.microsoft.com/azure-storage/azurite:3.35.0@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37
+  COSMOSDB_EMULATOR_IMAGE: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview@sha256:bf3bd3cbe3fae2005a0745f77b01d1fc8cd04112193f3ee32289ee15ee9ae5fa
+  MSSQL_IMAGE: mcr.microsoft.com/mssql/server:2022-CU20-ubuntu-22.04@sha256:7c29dfbac885ad7519e219c7fe4aee0e67283e21a10e9c252d13b0fbde1866f8
+  TESTCONTAINERS_RYUK_IMAGE: testcontainers/ryuk:0.14.0@sha256:7c1a8a9a47c780ed0f983770a662f80deb115d95cce3e2daa3d12115b8cd28f0
+
+jobs:
+  prepare:
+    name: Prepare reliability matrix
+    runs-on: ubuntu-latest
+    outputs:
+      iterations: ${{ steps.matrix.outputs.iterations }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+    - name: Build requested matrix
+      id: matrix
+      shell: pwsh
+      env:
+        REQUESTED_FRAMEWORK: ${{ inputs.framework || 'all' }}
+        REQUESTED_ITERATIONS: ${{ inputs.iterations || '5' }}
+        REQUESTED_PROVIDER: ${{ inputs.provider || 'all' }}
+      run: |
+        $iterations = 0
+        if (-not [int]::TryParse($env:REQUESTED_ITERATIONS, [ref]$iterations) -or $iterations -lt 1 -or $iterations -gt 20) {
+          throw "iterations must be an integer from 1 through 20"
+        }
+
+        $providers = @(
+          [ordered]@{ input = 'in-memory'; id = 'None'; artifact = 'in-memory'; topology = 'in-process cluster; in-memory reminder table; suite-managed silo failover' }
+          [ordered]@{ input = 'azure-storage'; id = 'AzureStorage'; artifact = 'azure-storage'; topology = 'in-process cluster; Azurite table service; suite-managed silo failover' }
+          [ordered]@{ input = 'sql-server'; id = 'SqlServer'; artifact = 'sql-server'; topology = 'in-process cluster; SQL Server 2022 container; suite-managed silo failover' }
+          [ordered]@{ input = 'cosmos'; id = 'Cosmos'; artifact = 'cosmos'; topology = 'in-process cluster; Cosmos DB Linux emulator; suite-managed silo failover' }
+        )
+        if ($env:REQUESTED_PROVIDER -ne 'all') {
+          $providers = @($providers | Where-Object input -eq $env:REQUESTED_PROVIDER)
+        }
+
+        $frameworks = if ($env:REQUESTED_FRAMEWORK -eq 'all') { @('net8.0', 'net10.0') } else { @($env:REQUESTED_FRAMEWORK) }
+        $include = foreach ($provider in $providers) {
+          foreach ($framework in $frameworks) {
+            [ordered]@{
+              provider = $provider.id
+              artifact = $provider.artifact
+              topology = $provider.topology
+              framework = $framework
+              filter = $(if ($provider.id -eq 'None') {
+                '/[(Provider=None)&(Category=Reminders)&(Category!=Performance)]'
+              } else {
+                "/[(Provider=$($provider.id))&(Area=Reminders)&(Category!=Performance)]"
+              })
+            }
+          }
+        }
+
+        "iterations=$iterations" >> $env:GITHUB_OUTPUT
+        "matrix=$(@{ include = @($include) } | ConvertTo-Json -Compress -Depth 4)" >> $env:GITHUB_OUTPUT
+
+  test-reminders:
+    name: ${{ matrix.artifact }} / ${{ matrix.framework }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    env:
+      ACCEPT_EULA: 'Y'
+      MSSQL_PID: Developer
+# [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Local emulator credential")]
+      SA_PASSWORD: 'yourWeak(!)Password'
+    steps:
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    - uses: ./.github/actions/setup-test-environment
+    - name: Record run context
+      shell: pwsh
+      env:
+        ITERATIONS: ${{ needs.prepare.outputs.iterations }}
+        PROVIDER: ${{ matrix.provider }}
+        TARGET_FRAMEWORK: ${{ matrix.framework }}
+        TOPOLOGY: ${{ matrix.topology }}
+      run: |
+        New-Item -ItemType Directory -Force logs | Out-Null
+        [ordered]@{
+          iterations = $env:ITERATIONS
+          framework = $env:TARGET_FRAMEWORK
+          provider = $env:PROVIDER
+          commit = '${{ github.sha }}'
+          topology = $env:TOPOLOGY
+          workflowRun = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        } | ConvertTo-Json | Set-Content logs/run-context.json
+    - name: Start reminder provider
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        case "${{ matrix.provider }}" in
+          None)
+            ;;
+          AzureStorage)
+            echo "REMINDER_CONTAINER=azurite" >> "$GITHUB_ENV"
+            bash .github/scripts/docker-pull-with-retry.sh "$AZURITE_IMAGE"
+            docker run -d --pull=never --name azurite \
+              -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+              "$AZURITE_IMAGE" \
+              azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
+            timeout 60 bash -c 'until nc -z localhost 10000 && nc -z localhost 10001 && nc -z localhost 10002; do sleep 1; done'
+            # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Well-known Azurite emulator credential")]
+            echo "ORLEANSDATACONNECTIONSTRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;" >> "$GITHUB_ENV"
+            ;;
+          SqlServer)
+            echo "REMINDER_CONTAINER=mssql" >> "$GITHUB_ENV"
+            bash .github/scripts/docker-pull-with-retry.sh "$MSSQL_IMAGE"
+            docker run -d --pull=never --name mssql \
+              -p 1433:1433 \
+              -e ACCEPT_EULA="$ACCEPT_EULA" \
+              -e MSSQL_PID="$MSSQL_PID" \
+              -e MSSQL_SA_PASSWORD="$SA_PASSWORD" \
+              --health-cmd '/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -Q "SELECT 1" -b -o /dev/null' \
+              --health-interval 2s \
+              --health-timeout 5s \
+              --health-retries 60 \
+              "$MSSQL_IMAGE"
+            bash .github/scripts/docker-wait-for-health.sh mssql 120
+            echo "ORLEANSMSSQLCONNECTIONSTRING=Server=127.0.0.1,1433;User Id=SA;Password=$SA_PASSWORD;TrustServerCertificate=True;" >> "$GITHUB_ENV"
+            ;;
+          Cosmos)
+            echo "REMINDER_CONTAINER=cosmosdb-emulator" >> "$GITHUB_ENV"
+            bash .github/scripts/docker-pull-with-retry.sh "$COSMOSDB_EMULATOR_IMAGE"
+            docker run -d --pull=never --name cosmosdb-emulator \
+              -p 8081:8081 \
+              -e PROTOCOL=https \
+              -e ENABLE_EXPLORER=false \
+              -e ENABLE_TELEMETRY=false \
+              -e LOG_LEVEL=warn \
+              "$COSMOSDB_EMULATOR_IMAGE"
+            endpoint="https://localhost:8081/"
+            for attempt in {1..60}; do
+              if curl --silent --show-error --insecure "$endpoint" > /dev/null; then
+                echo "ORLEANSCOSMOSDBACCOUNTENDPOINT=$endpoint" >> "$GITHUB_ENV"
+                break
+              fi
+              if [[ "$attempt" -eq 60 ]]; then
+                echo "Azure Cosmos DB emulator did not become ready in time."
+                exit 1
+              fi
+              sleep 2
+            done
+            # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Well-known Cosmos emulator credential")]
+            echo "ORLEANSCOSMOSDBACCOUNTKEY=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" >> "$GITHUB_ENV"
+            ;;
+        esac
+    - name: Run reminder reliability repetitions
+      shell: pwsh
+      run: >-
+        ./.github/scripts/run-reminder-reliability.ps1
+        -Provider '${{ matrix.provider }}'
+        -Framework '${{ matrix.framework }}'
+        -Iterations '${{ needs.prepare.outputs.iterations }}'
+        -FilterQuery '${{ matrix.filter }}'
+        -Topology '${{ matrix.topology }}'
+        -Commit '${{ github.sha }}'
+    - name: Capture provider diagnostics
+      if: always()
+      shell: bash
+      run: |
+        mkdir -p logs
+        if [[ -n "${REMINDER_CONTAINER:-}" ]]; then
+          docker inspect "$REMINDER_CONTAINER" > "logs/${REMINDER_CONTAINER}-inspect.json" 2>&1 || true
+          docker logs --timestamps "$REMINDER_CONTAINER" > "logs/${REMINDER_CONTAINER}.log" 2>&1 || true
+        fi
+    - name: Archive reliability diagnostics
+      if: always()
+      uses: ./.github/actions/archive-test-results
+      with:
+        name: reminder-reliability_${{ matrix.artifact }}_${{ matrix.framework }}_${{ github.run_attempt }}
+        retention-days: '14'
+    - name: Clean up reminder provider
+      if: always() && env.REMINDER_CONTAINER != ''
+      shell: bash
+      run: docker rm -f "$REMINDER_CONTAINER" || true

--- a/.github/workflows/reminder-reliability.yml
+++ b/.github/workflows/reminder-reliability.yml
@@ -88,7 +88,7 @@ jobs:
               topology = $provider.topology
               framework = $framework
               filter = $(if ($provider.id -eq 'None') {
-                '/[(Provider=None)&(Category=Reminders)&(Category!=Performance)]'
+                '/[(Provider=None)&((Area=Reminders)|(Category=Reminders))&(Category!=Performance)]'
               } else {
                 "/[(Provider=$($provider.id))&(Area=Reminders)&(Category!=Performance)]"
               })
@@ -195,6 +195,7 @@ jobs:
             ;;
         esac
     - name: Run reminder reliability repetitions
+      timeout-minutes: 90
       shell: pwsh
       run: >-
         ./.github/scripts/run-reminder-reliability.ps1
@@ -219,6 +220,7 @@ jobs:
       with:
         name: reminder-reliability_${{ matrix.artifact }}_${{ matrix.framework }}_${{ github.run_attempt }}
         retention-days: '14'
+        fail-on-upload-error: 'true'
     - name: Clean up reminder provider
       if: always() && env.REMINDER_CONTAINER != ''
       shell: bash


### PR DESCRIPTION
## Problem

Reminder provider regressions can be intermittent and the regular CI lane only exercises each provider partition once, so 5-30% recurrence failures can escape detection.

## Solution

- Add a weekly and manually dispatchable reminder reliability workflow covering in-memory, Azurite-backed Azure Table, SQL Server, and the Cosmos emulator on .NET 8 and .NET 10.
- Run each complete reminder provider suite sequentially five times by default, stop at the first failed repetition, and permit bounded provider/framework/iteration overrides for investigation.
- Reuse the repository test setup/archive actions and container retry/health scripts, pin all service images, and retain TRX, Orleans logs, dumps/traces, console output, metadata, and container diagnostics for 14 days.
- Record iteration, framework, provider, commit, topology, and failing test names in machine-readable artifacts and the workflow summary.

## Rationale

A Thursday weekly cadence with five repetitions gives a 23-83% chance of catching a 5-30% flake in one run and approximately 64-99.9% over four runs. Keeping this lane off pull request events avoids adding routine PR cost, while an eight-job bounded matrix and a maximum of 20 manual repetitions keep scheduled and investigative spend controlled.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10890)