### PR TITLE
test(reminders): harden lifecycle synchronization

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
@@ -98,13 +98,9 @@ namespace Tester.AdoNet.Reminders
 
         public async ValueTask InitializeAsync()
         {
-            // ReminderTable.Clear() cannot be called from a non-Orleans thread,
-            // so we must proxy the call through a grain.
-            var controlProxy = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            await controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken);
+            await ClearReminderTableAsync(TestContext.Current.CancellationToken)
+                .WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken);
         }
-
-        ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
         
         // Basic tests
 

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -67,21 +67,10 @@ namespace Tester.AzureUtils.TimerTests
 
                 var silos = HostedCluster.Silos.ToArray();
                 _initialSilos = silos.Select(silo => silo.SiloAddress).ToArray();
-                using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                _startedReminderServices = await _startupHarness.WaitForServicesReadyAsync(
+                    silos,
+                    ReminderServiceStartupTimeout,
                     TestContext.Current.CancellationToken);
-                cancellation.CancelAfter(ReminderServiceStartupTimeout);
-                try
-                {
-                    _startedReminderServices = await _startupHarness.WaitForServicesReadyAsync(
-                        silos,
-                        cancellation.Token);
-                }
-                catch (TimeoutException exception)
-                {
-                    throw new TimeoutException(
-                        $"Azure reminder services did not start within {ReminderServiceStartupTimeout}. {exception.Message}",
-                        exception);
-                }
             }
 
             public override async ValueTask DisposeAsync()

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -29,7 +29,7 @@ namespace Tester.AzureUtils.TimerTests
         {
             private static readonly TimeSpan ReminderServiceStartupTimeout = TimeSpan.FromMinutes(5);
             private ReminderTestClock? _reminderClock;
-            private readonly ReminderDiagnosticObserver _startupObserver = ReminderDiagnosticObserver.Create();
+            private readonly ReminderLifecycleHarness _startupHarness = new();
             private IReadOnlyList<SiloAddress>? _initialSilos;
             private IReadOnlyList<SiloAddress>? _startedReminderServices;
             internal ReminderTestClock ReminderClock
@@ -70,25 +70,17 @@ namespace Tester.AzureUtils.TimerTests
                 using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
                     TestContext.Current.CancellationToken);
                 cancellation.CancelAfter(ReminderServiceStartupTimeout);
-                var startedTasks = silos
-                    .Select(silo => _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress))
-                    .ToArray();
-
                 try
                 {
-                    _startedReminderServices = (await Task.WhenAll(startedTasks))
-                        .Select(started => started.SiloAddress!)
-                        .ToArray();
+                    _startedReminderServices = await _startupHarness.WaitForServicesReadyAsync(
+                        silos,
+                        cancellation.Token);
                 }
-                catch (OperationCanceledException) when (
-                    cancellation.IsCancellationRequested
-                    && !TestContext.Current.CancellationToken.IsCancellationRequested)
+                catch (TimeoutException exception)
                 {
-                    var missing = silos
-                        .Where((_, index) => !startedTasks[index].IsCompletedSuccessfully)
-                        .Select(silo => silo.SiloAddress);
                     throw new TimeoutException(
-                        $"Azure reminder services did not start within {ReminderServiceStartupTimeout}. Missing silos: {string.Join(", ", missing)}.");
+                        $"Azure reminder services did not start within {ReminderServiceStartupTimeout}. {exception.Message}",
+                        exception);
                 }
             }
 
@@ -101,7 +93,7 @@ namespace Tester.AzureUtils.TimerTests
                 finally
                 {
                     _reminderClock?.Dispose();
-                    _startupObserver.Dispose();
+                    _startupHarness.Dispose();
                 }
             }
         }

--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -198,6 +198,45 @@ public class ReminderEventsTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task ReminderDiagnosticObserver_GlobalQuiescenceIgnoresUnrelatedSilos()
+    {
+        using var observer = ReminderDiagnosticObserver.Create();
+        var grainId = GrainId.Create("test", "grain");
+        const string reminderName = "reminder";
+        var clusterIdentity = new object();
+        var unrelatedIdentity = new object();
+        var clusterSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14015), 16);
+        var unrelatedSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14016), 17);
+
+        ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, clusterIdentity, clusterSilo);
+        ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, unrelatedIdentity, unrelatedSilo);
+        var waitTask = observer.WaitForGlobalQuiescenceAsync(
+            new HashSet<SiloAddress> { clusterSilo },
+            TestContext.Current.CancellationToken);
+
+        Assert.False(waitTask.IsCompleted);
+        ReminderEvents.EmitLocalReminderStopped(
+            grainId,
+            reminderName,
+            clusterIdentity,
+            ReminderEvents.LocalReminderStopReason.RemovedFromTable,
+            clusterSilo);
+
+        Assert.True(waitTask.IsCompletedSuccessfully);
+        await waitTask;
+        Assert.Equal(1, observer.GetActiveReminderCount(grainId, reminderName));
+
+        ReminderEvents.EmitLocalReminderStopped(
+            grainId,
+            reminderName,
+            unrelatedIdentity,
+            ReminderEvents.LocalReminderStopReason.RemovedFromTable,
+            unrelatedSilo);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_CanceledQuiescenceWait_RemainsCanceled()
     {
         using var observer = ReminderDiagnosticObserver.Create();

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -244,9 +244,9 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
 
-        var started = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
+        var started = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
 
-        Assert.Equal(silo.SiloAddress, started.SiloAddress);
+        Assert.Equal([silo.SiloAddress], started);
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         Assert.True(reminderTable.RangeReadCount > 0);
     }
@@ -259,7 +259,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
@@ -298,12 +298,96 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task RangeChangeBarrier_PropagatesCurrentProviderReadFailure()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
+        var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
+        var readGate = reminderTable.BlockNextRangeRead(cancellation.Token);
+        var failure = new ControlledRangeReadException();
+        try
+        {
+            var rangeChangeTask = reminderService.TestOnlyChangeRange(oldRange, newRange, increased: false);
+            await readGate.WaitUntilBlockedAsync(cancellation.Token);
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+
+            readGate.Fail(failure);
+
+            var rangeChangeException = await Assert.ThrowsAsync<ControlledRangeReadException>(
+                () => rangeChangeTask.WaitAsync(cancellation.Token));
+            var reconciliationException = await Assert.ThrowsAsync<ControlledRangeReadException>(
+                () => reconciliationTask.WaitAsync(cancellation.Token));
+            Assert.Same(failure, rangeChangeException);
+            Assert.Same(failure, reconciliationException);
+
+            await reminderService.TestOnlyChangeRange(newRange, oldRange, increased: true)
+                .WaitAsync(cancellation.Token);
+            await reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+        }
+        finally
+        {
+            readGate.Release();
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task RangeChangeBarrier_IgnoresObsoleteProviderReadFailure()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
+        var intermediateRange = RangeFactory.CreateRange(0, uint.MaxValue / 3);
+        var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
+        var obsoleteRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+        RangeReadGate? currentRead = null;
+        var failure = new ControlledRangeReadException();
+        try
+        {
+            var obsoleteRangeChange = reminderService.TestOnlyChangeRange(oldRange, intermediateRange, increased: false);
+            await obsoleteRead.WaitUntilBlockedAsync(cancellation.Token);
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+
+            currentRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+            var currentRangeChange = reminderService.TestOnlyChangeRange(intermediateRange, newRange, increased: false);
+            await currentRead.WaitUntilBlockedAsync(cancellation.Token);
+            currentRead.Release();
+            await Task.WhenAll(currentRangeChange, reconciliationTask).WaitAsync(cancellation.Token);
+
+            obsoleteRead.Fail(failure);
+            var obsoleteException = await Assert.ThrowsAsync<ControlledRangeReadException>(
+                () => obsoleteRangeChange.WaitAsync(cancellation.Token));
+            Assert.Same(failure, obsoleteException);
+            Assert.True(reconciliationTask.IsCompletedSuccessfully);
+        }
+        finally
+        {
+            obsoleteRead.Release();
+            currentRead?.Release();
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task RangeChangeBarrier_StopsWaitingWhenCanceled()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
@@ -339,7 +423,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
 
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
         await reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
@@ -369,7 +453,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
 
     public sealed class Fixture : BaseInProcessTestClusterFixture
     {
-        public ReminderDiagnosticObserver ReminderObserver { get; } = ReminderDiagnosticObserver.Create();
+        public ReminderLifecycleHarness ReminderHarness { get; } = new();
 
         protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
         {
@@ -395,7 +479,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             }
             finally
             {
-                ReminderObserver.Dispose();
+                ReminderHarness.Dispose();
             }
         }
     }
@@ -456,5 +540,9 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         public Task WaitForReleaseAsync() => release.Task.WaitAsync(cancellationToken);
 
         public void Release() => release.TrySetResult();
+
+        public void Fail(Exception exception) => release.TrySetException(exception);
     }
+
+    private sealed class ControlledRangeReadException : Exception;
 }

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -244,7 +244,10 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
 
-        var started = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+        var started = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
 
         Assert.Equal([silo.SiloAddress], started);
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
@@ -259,7 +262,10 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
@@ -303,7 +309,10 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
@@ -344,7 +353,10 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
@@ -387,7 +399,10 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
 
         var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
@@ -423,7 +438,10 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var silo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync([silo], cancellation.Token);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
 
         var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
         await reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarness.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarness.cs
@@ -35,40 +35,57 @@ public sealed class ReminderLifecycleHarness : IDisposable
 
     public async Task<IReadOnlyList<SiloAddress>> WaitForServicesReadyAsync(
         IEnumerable<InProcessSiloHandle> silos,
+        TimeSpan timeout,
         CancellationToken cancellationToken)
     {
         var siloArray = silos.ToArray();
-        var startedTasks = siloArray
-            .Select(silo => _diagnostics.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress))
-            .ToArray();
-        try
-        {
-            return (await Task.WhenAll(startedTasks)).Select(started => started.SiloAddress!).ToArray();
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            var missing = siloArray
-                .Where((_, index) => !startedTasks[index].IsCompletedSuccessfully)
-                .Select(silo => silo.SiloAddress);
-            throw new TimeoutException(
-                $"Reminder services did not become ready. Missing silos: {string.Join(", ", missing)}.");
-        }
+        Task<Orleans.Reminders.Diagnostics.ReminderEvents.ReminderServiceStarted>[]? startedTasks = null;
+        using var timeoutCancellation = new CancellationTokenSource(timeout);
+        return await WaitForPhaseAsync(
+            async phaseCancellation =>
+            {
+                startedTasks = siloArray
+                    .Select(silo => _diagnostics.WaitForReminderServiceStartedAsync(phaseCancellation, silo.SiloAddress))
+                    .ToArray();
+                return (await Task.WhenAll(startedTasks)).Select(started => started.SiloAddress!).ToArray();
+            },
+            timeoutCancellation.Token,
+            cancellationToken,
+            () =>
+            {
+                var missing = siloArray
+                    .Where((_, index) => startedTasks is null || !startedTasks[index].IsCompletedSuccessfully)
+                    .Select(silo => silo.SiloAddress);
+                return new TimeoutException(
+                    $"Reminder services did not become ready within {timeout}. Missing silos: {string.Join(", ", missing)}.");
+            });
     }
 
     public async Task WaitForTopologyReconciledAsync(
         Task topologyConverged,
         IEnumerable<InProcessSiloHandle> addedSilos,
+        TimeSpan timeout,
         CancellationToken cancellationToken)
     {
-        var serviceReady = WaitForServicesReadyAsync(addedSilos, cancellationToken);
-        await Task.WhenAll(topologyConverged.WaitAsync(cancellationToken), serviceReady);
+        var addedSiloArray = addedSilos.ToArray();
+        using var timeoutCancellation = new CancellationTokenSource(timeout);
+        await WaitForPhaseAsync(
+            async phaseCancellation =>
+            {
+                var serviceReady = WaitForServicesReadyCoreAsync(addedSiloArray, phaseCancellation);
+                await Task.WhenAll(topologyConverged.WaitAsync(phaseCancellation), serviceReady);
 
-        foreach (var silo in GetCluster().GetActiveSilos())
-        {
-            await silo.ServiceProvider
-                .GetRequiredService<LocalReminderService>()
-                .TestOnlyWaitForRangeChangeReconciliation(cancellationToken);
-        }
+                foreach (var silo in GetCluster().GetActiveSilos())
+                {
+                    await silo.ServiceProvider
+                        .GetRequiredService<LocalReminderService>()
+                        .TestOnlyWaitForRangeChangeReconciliation(phaseCancellation);
+                }
+            },
+            timeoutCancellation.Token,
+            cancellationToken,
+            () => new TimeoutException(
+                $"Reminder topology did not reconcile within {timeout}. Added silos: {string.Join(", ", addedSiloArray.Select(static silo => silo.SiloAddress))}."));
     }
 
     public async Task RefreshActiveServicesAsync(CancellationToken cancellationToken)
@@ -128,7 +145,9 @@ public sealed class ReminderLifecycleHarness : IDisposable
         => Task.WhenAll(phase.Entries.Select(entry => entry.Completion));
 
     public Task WaitForGlobalQuiescenceAsync(CancellationToken cancellationToken)
-        => _diagnostics.WaitForGlobalQuiescenceAsync(cancellationToken);
+        => _diagnostics.WaitForGlobalQuiescenceAsync(
+            GetCluster().GetActiveSilos().Select(static silo => silo.SiloAddress).ToHashSet(),
+            cancellationToken);
 
     public Task WaitForReminderQuiescenceAsync(
         IAddressable grain,
@@ -234,15 +253,16 @@ public sealed class ReminderLifecycleHarness : IDisposable
         Func<T, Task> stopResource,
         Func<Task> waitForTopology,
         ILogger logger,
-        CancellationToken startupWaitCancellationToken,
+        CancellationTokenSource startupCancellation,
         CancellationToken cleanupCancellationToken)
         where T : notnull
     {
+        await startupCancellation.CancelAsync();
         try
         {
-            await startupTask.WaitAsync(startupWaitCancellationToken);
+            await startupTask.WaitAsync(cleanupCancellationToken);
         }
-        catch (Exception exception)
+        catch (Exception exception) when (!cleanupCancellationToken.IsCancellationRequested)
         {
             logger.LogInformation(exception, "Additional resource startup did not complete successfully before cleanup.");
         }
@@ -260,6 +280,53 @@ public sealed class ReminderLifecycleHarness : IDisposable
     }
 
     public void Dispose() => _diagnostics.Dispose();
+
+    internal static async Task WaitForPhaseAsync(
+        Func<CancellationToken, Task> phase,
+        CancellationToken timeoutCancellationToken,
+        CancellationToken cancellationToken,
+        Func<TimeoutException> createTimeoutException)
+    {
+        await WaitForPhaseAsync(
+            async phaseCancellation =>
+            {
+                await phase(phaseCancellation);
+                return true;
+            },
+            timeoutCancellationToken,
+            cancellationToken,
+            createTimeoutException);
+    }
+
+    private async Task<IReadOnlyList<SiloAddress>> WaitForServicesReadyCoreAsync(
+        IEnumerable<InProcessSiloHandle> silos,
+        CancellationToken cancellationToken)
+    {
+        var startedTasks = silos
+            .Select(silo => _diagnostics.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress));
+        return (await Task.WhenAll(startedTasks)).Select(started => started.SiloAddress!).ToArray();
+    }
+
+    private static async Task<T> WaitForPhaseAsync<T>(
+        Func<CancellationToken, Task<T>> phase,
+        CancellationToken timeoutCancellationToken,
+        CancellationToken cancellationToken,
+        Func<TimeoutException> createTimeoutException)
+    {
+        using var phaseCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutCancellationToken,
+            cancellationToken);
+        try
+        {
+            return await phase(phaseCancellation.Token);
+        }
+        catch (OperationCanceledException) when (
+            timeoutCancellationToken.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested)
+        {
+            throw createTimeoutException();
+        }
+    }
 
     private InProcessTestCluster GetCluster()
         => _cluster ?? throw new InvalidOperationException("This reminder harness is not attached to a test cluster.");

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarness.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarness.cs
@@ -1,0 +1,285 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.Runtime.ReminderService;
+using Orleans.Testing.Reminders;
+using Orleans.TestingHost;
+
+namespace UnitTests.TimerTests;
+
+/// <summary>
+/// Coordinates the observable phases of reminder lifecycle tests.
+/// </summary>
+public sealed class ReminderLifecycleHarness : IDisposable
+{
+    private readonly ReminderDiagnosticObserver _diagnostics;
+    private readonly InProcessTestCluster? _cluster;
+
+    public ReminderLifecycleHarness()
+        : this(ReminderDiagnosticObserver.Create(), cluster: null)
+    {
+    }
+
+    public ReminderLifecycleHarness(InProcessTestCluster cluster)
+        : this(ReminderDiagnosticObserver.Create(), cluster)
+    {
+    }
+
+    private ReminderLifecycleHarness(ReminderDiagnosticObserver diagnostics, InProcessTestCluster? cluster)
+    {
+        _diagnostics = diagnostics;
+        _cluster = cluster;
+    }
+
+    public async Task<IReadOnlyList<SiloAddress>> WaitForServicesReadyAsync(
+        IEnumerable<InProcessSiloHandle> silos,
+        CancellationToken cancellationToken)
+    {
+        var siloArray = silos.ToArray();
+        var startedTasks = siloArray
+            .Select(silo => _diagnostics.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress))
+            .ToArray();
+        try
+        {
+            return (await Task.WhenAll(startedTasks)).Select(started => started.SiloAddress!).ToArray();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            var missing = siloArray
+                .Where((_, index) => !startedTasks[index].IsCompletedSuccessfully)
+                .Select(silo => silo.SiloAddress);
+            throw new TimeoutException(
+                $"Reminder services did not become ready. Missing silos: {string.Join(", ", missing)}.");
+        }
+    }
+
+    public async Task WaitForTopologyReconciledAsync(
+        Task topologyConverged,
+        IEnumerable<InProcessSiloHandle> addedSilos,
+        CancellationToken cancellationToken)
+    {
+        var serviceReady = WaitForServicesReadyAsync(addedSilos, cancellationToken);
+        await Task.WhenAll(topologyConverged.WaitAsync(cancellationToken), serviceReady);
+
+        foreach (var silo in GetCluster().GetActiveSilos())
+        {
+            await silo.ServiceProvider
+                .GetRequiredService<LocalReminderService>()
+                .TestOnlyWaitForRangeChangeReconciliation(cancellationToken);
+        }
+    }
+
+    public async Task RefreshActiveServicesAsync(CancellationToken cancellationToken)
+    {
+        foreach (var silo in GetCluster().GetActiveSilos())
+        {
+            await silo.ServiceProvider
+                .GetRequiredService<LocalReminderService>()
+                .TestOnlyRefresh()
+                .WaitAsync(cancellationToken);
+        }
+    }
+
+    public async Task WaitForSchedulesArmedAsync(
+        CancellationToken cancellationToken,
+        params (IAddressable Grain, string ReminderName)[] reminders)
+    {
+        await RefreshActiveServicesAsync(cancellationToken);
+        await Task.WhenAll(reminders.Select(async reminder =>
+        {
+            await _diagnostics.WaitForActiveReminderCountAsync(
+                reminder.Grain,
+                1,
+                cancellationToken,
+                reminder.ReminderName);
+            await _diagnostics.WaitForLocalReminderScheduleAsync(
+                reminder.Grain,
+                reminder.ReminderName,
+                cancellationToken);
+        }));
+    }
+
+    public TickCompletionPhase ArmTickCompletion(
+        CancellationToken cancellationToken,
+        params (IAddressable Grain, string ReminderName)[] reminders)
+    {
+        var entries = new TickCompletionEntry[reminders.Length];
+        for (var i = 0; i < reminders.Length; i++)
+        {
+            var reminder = reminders[i];
+            var previousCount = GetTickCount(reminder.Grain.GetGrainId(), reminder.ReminderName);
+            entries[i] = new(
+                reminder.Grain.GetGrainId(),
+                reminder.ReminderName,
+                previousCount,
+                _diagnostics.WaitForTickCountAsync(
+                    reminder.Grain,
+                    previousCount + 1,
+                    cancellationToken,
+                    reminder.ReminderName));
+        }
+
+        return new TickCompletionPhase(entries);
+    }
+
+    public Task WaitForTickCompletedAsync(TickCompletionPhase phase)
+        => Task.WhenAll(phase.Entries.Select(entry => entry.Completion));
+
+    public Task WaitForGlobalQuiescenceAsync(CancellationToken cancellationToken)
+        => _diagnostics.WaitForGlobalQuiescenceAsync(cancellationToken);
+
+    public Task WaitForReminderQuiescenceAsync(
+        IAddressable grain,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForReminderQuiescenceAsync(grain, reminderName, cancellationToken);
+
+    public Task WaitForReminderQuiescenceAsync(
+        GrainId grainId,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForReminderQuiescenceAsync(grainId, reminderName, cancellationToken);
+
+    public Task WaitForReminderRegisteredAsync(
+        IAddressable grain,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForReminderRegisteredAsync(grain, reminderName, cancellationToken);
+
+    public Task WaitForReminderRegisteredAsync(
+        GrainId grainId,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForReminderRegisteredAsync(grainId, reminderName, cancellationToken);
+
+    public Task WaitForReminderUnregisteredAsync(
+        IAddressable grain,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForReminderUnregisteredAsync(grain, reminderName, cancellationToken);
+
+    public Task WaitForReminderUnregisteredAsync(
+        GrainId grainId,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForReminderUnregisteredAsync(grainId, reminderName, cancellationToken);
+
+    public Task WaitForActiveReminderCountAsync(
+        IAddressable grain,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        string reminderName)
+        => _diagnostics.WaitForActiveReminderCountAsync(grain, expectedCount, cancellationToken, reminderName);
+
+    public Task WaitForActiveReminderCountAsync(
+        GrainId grainId,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        string reminderName)
+        => _diagnostics.WaitForActiveReminderCountAsync(grainId, expectedCount, cancellationToken, reminderName);
+
+    public Task WaitForLocalReminderScheduleAsync(
+        IAddressable grain,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForLocalReminderScheduleAsync(grain, reminderName, cancellationToken);
+
+    public Task WaitForLocalReminderScheduleAsync(
+        GrainId grainId,
+        string reminderName,
+        CancellationToken cancellationToken)
+        => _diagnostics.WaitForLocalReminderScheduleAsync(grainId, reminderName, cancellationToken);
+
+    public Task<Orleans.Reminders.Diagnostics.ReminderEvents.TickCompleted> WaitForReminderTickAsync(
+        IAddressable grain,
+        CancellationToken cancellationToken,
+        string reminderName)
+        => _diagnostics.WaitForReminderTickAsync(grain, cancellationToken, reminderName);
+
+    public Task<Orleans.Reminders.Diagnostics.ReminderEvents.TickCompleted> WaitForReminderTickAsync(
+        GrainId grainId,
+        CancellationToken cancellationToken,
+        string reminderName)
+        => _diagnostics.WaitForReminderTickAsync(grainId, cancellationToken, reminderName);
+
+    public Task WaitForTickCountAsync(
+        IAddressable grain,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        string reminderName)
+        => _diagnostics.WaitForTickCountAsync(grain, expectedCount, cancellationToken, reminderName);
+
+    public Task WaitForTickCountAsync(
+        GrainId grainId,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        string reminderName)
+        => _diagnostics.WaitForTickCountAsync(grainId, expectedCount, cancellationToken, reminderName);
+
+    public int GetTickCount(GrainId grainId, string reminderName)
+        => _diagnostics.GetTickCount(grainId, reminderName);
+
+    public int GetActiveReminderCount(GrainId grainId, string reminderName)
+        => _diagnostics.GetActiveReminderCount(grainId, reminderName);
+
+    public SiloAddress[] GetActiveReminderSilos(GrainId grainId, string reminderName)
+        => _diagnostics.GetActiveReminderSilos(grainId, reminderName);
+
+    internal static async Task CleanupPartialStartupAsync<T>(
+        IReadOnlySet<T> initialResources,
+        Task startupTask,
+        Func<IReadOnlyList<T>> getActiveResources,
+        Func<T, Task> stopResource,
+        Func<Task> waitForTopology,
+        ILogger logger,
+        CancellationToken startupWaitCancellationToken,
+        CancellationToken cleanupCancellationToken)
+        where T : notnull
+    {
+        try
+        {
+            await startupTask.WaitAsync(startupWaitCancellationToken);
+        }
+        catch (Exception exception)
+        {
+            logger.LogInformation(exception, "Additional resource startup did not complete successfully before cleanup.");
+        }
+
+        var additionalResources = getActiveResources()
+            .Where(resource => !initialResources.Contains(resource))
+            .ToArray();
+        if (additionalResources.Length == 0)
+        {
+            return;
+        }
+
+        await Task.WhenAll(additionalResources.Select(stopResource)).WaitAsync(cleanupCancellationToken);
+        await waitForTopology().WaitAsync(cleanupCancellationToken);
+    }
+
+    public void Dispose() => _diagnostics.Dispose();
+
+    private InProcessTestCluster GetCluster()
+        => _cluster ?? throw new InvalidOperationException("This reminder harness is not attached to a test cluster.");
+
+    public sealed class TickCompletionPhase
+    {
+        internal TickCompletionPhase(IReadOnlyList<TickCompletionEntry> entries)
+        {
+            Entries = entries;
+        }
+
+        internal IReadOnlyList<TickCompletionEntry> Entries { get; }
+
+        public IReadOnlyList<(GrainId GrainId, string ReminderName, int PreviousCount)> Snapshot
+            => Entries.Select(entry => (entry.GrainId, entry.ReminderName, entry.PreviousCount)).ToArray();
+    }
+
+    internal sealed record TickCompletionEntry(
+        GrainId GrainId,
+        string ReminderName,
+        int PreviousCount,
+        Task Completion);
+}

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarnessTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarnessTests.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Runtime;
+using Orleans.TestingHost;
 using TestExtensions;
 using Xunit;
 
@@ -43,35 +46,151 @@ public class ReminderLifecycleHarnessTests
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task PartialStartupCleanupStopsDiscoveredResourcesWhenStartupStalls()
+    public async Task CleanupDoesNotStartAnotherPhaseAfterBudgetExpires()
     {
-        var initialResources = new HashSet<string> { "initial" };
-        IReadOnlyList<string> activeResources = ["initial", "partially-started"];
-        var stoppedResources = new List<string>();
-        var topologyReconciled = false;
-        var stalledStartup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var startupWaitCancellation = new CancellationTokenSource();
-        startupWaitCancellation.Cancel();
+        var phases = new List<string>();
 
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ReminderTestsBase.ExecuteCleanupAsync(
+                async cancellationToken =>
+                {
+                    phases.Add("clear");
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                },
+                _ =>
+                {
+                    phases.Add("refresh");
+                    return Task.CompletedTask;
+                },
+                _ =>
+                {
+                    phases.Add("quiescence");
+                    return Task.CompletedTask;
+                },
+                TimeSpan.Zero));
+
+        Assert.Equal(["clear"], phases);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task PhaseWaitPreservesExternalCancellation()
+    {
+        using var timeoutCancellation = new CancellationTokenSource();
+        using var externalCancellation = new CancellationTokenSource();
+        externalCancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ReminderLifecycleHarness.WaitForPhaseAsync(
+                cancellationToken => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken),
+                timeoutCancellation.Token,
+                externalCancellation.Token,
+                () => new TimeoutException("dedicated timeout")));
+
+        Assert.IsNotType<TimeoutException>(exception);
+        Assert.True(exception.CancellationToken.IsCancellationRequested);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task PhaseWaitTranslatesDedicatedTimeout()
+    {
+        using var timeoutCancellation = new CancellationTokenSource();
+        timeoutCancellation.Cancel();
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() =>
+            ReminderLifecycleHarness.WaitForPhaseAsync(
+                cancellationToken => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken),
+                timeoutCancellation.Token,
+                TestContext.Current.CancellationToken,
+                () => new TimeoutException("dedicated timeout")));
+
+        Assert.Equal("dedicated timeout", exception.Message);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task PartialStartupCannotPublishSiloAfterCleanupReturns()
+    {
+        var controller = new ControlledSiloStartup();
+        var builder = new InProcessTestClusterBuilder(1);
+        builder.ConfigureSilo((siloOptions, siloBuilder) =>
+            siloBuilder.Services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>>(
+                new ControlledSiloStartupParticipant(siloOptions.SiloName, controller)));
+        await using var cluster = builder.Build();
+        using var testCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        testCancellation.CancelAfter(TestConstants.InitTimeout);
+        await cluster.DeployAsync(testCancellation.Token);
+
+        var initialSilos = cluster.GetActiveSilos().ToHashSet();
+        using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellation.Token);
+        var startupBlocked = controller.BlockNextStartup("Silo_2");
+        var startupTask = cluster.StartSilosAsync(2, startupCancellation.Token);
+        await startupBlocked.WaitAsync(testCancellation.Token);
+
+        using var cleanupCancellation = new CancellationTokenSource(TestConstants.InitTimeout);
         await ReminderLifecycleHarness.CleanupPartialStartupAsync(
-            initialResources,
-            stalledStartup.Task,
-            () => activeResources,
-            resource =>
-            {
-                stoppedResources.Add(resource);
-                return Task.CompletedTask;
-            },
-            () =>
-            {
-                topologyReconciled = true;
-                return Task.CompletedTask;
-            },
+            initialSilos,
+            startupTask,
+            () => cluster.GetActiveSilos().ToArray(),
+            cluster.StopSiloAsync,
+            () => cluster.WaitForLivenessToStabilizeAsync(didKill: true),
             NullLogger.Instance,
-            startupWaitCancellation.Token,
-            TestContext.Current.CancellationToken);
+            startupCancellation,
+            cleanupCancellation.Token);
 
-        Assert.Equal(["partially-started"], stoppedResources);
-        Assert.True(topologyReconciled);
+        Assert.True(startupTask.IsCompleted);
+        Assert.Equal(initialSilos, cluster.GetActiveSilos().ToHashSet());
+    }
+
+    private sealed class ControlledSiloStartup
+    {
+        private readonly object _lock = new();
+        private string? _siloName;
+        private TaskCompletionSource? _blocked;
+
+        public Task BlockNextStartup(string siloName)
+        {
+            lock (_lock)
+            {
+                if (_siloName is not null)
+                {
+                    throw new InvalidOperationException($"Startup for {_siloName} is already blocked.");
+                }
+
+                _siloName = siloName;
+                _blocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                return _blocked.Task;
+            }
+        }
+
+        public async Task OnStartAsync(string siloName, CancellationToken cancellationToken)
+        {
+            TaskCompletionSource? blocked;
+            lock (_lock)
+            {
+                if (_siloName != siloName)
+                {
+                    return;
+                }
+
+                _siloName = null;
+                blocked = _blocked;
+                _blocked = null;
+            }
+
+            blocked!.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+    }
+
+    private sealed class ControlledSiloStartupParticipant(
+        string siloName,
+        ControlledSiloStartup controller) : ILifecycleParticipant<ISiloLifecycle>
+    {
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+            lifecycle.Subscribe(
+                nameof(ControlledSiloStartupParticipant),
+                ServiceLifecycleStage.Active,
+                cancellationToken => controller.OnStartAsync(siloName, cancellationToken));
+        }
     }
 }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarnessTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarnessTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.TimerTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+public class ReminderLifecycleHarnessTests
+{
+    [Fact, TestCategory("BVT")]
+    public async Task CleanupUsesIndependentTokenAfterTestCancellation()
+    {
+        using var testCancellation = new CancellationTokenSource();
+        testCancellation.Cancel();
+        var phases = new List<string>();
+
+        await ReminderTestsBase.ExecuteCleanupAsync(
+            cancellationToken =>
+            {
+                Assert.NotEqual(testCancellation.Token, cancellationToken);
+                Assert.False(cancellationToken.IsCancellationRequested);
+                phases.Add("clear");
+                return Task.CompletedTask;
+            },
+            cancellationToken =>
+            {
+                Assert.NotEqual(testCancellation.Token, cancellationToken);
+                Assert.False(cancellationToken.IsCancellationRequested);
+                phases.Add("refresh");
+                return Task.CompletedTask;
+            },
+            cancellationToken =>
+            {
+                Assert.NotEqual(testCancellation.Token, cancellationToken);
+                Assert.False(cancellationToken.IsCancellationRequested);
+                phases.Add("quiescence");
+                return Task.CompletedTask;
+            },
+            TimeSpan.FromSeconds(1));
+
+        Assert.Equal(["clear", "refresh", "quiescence"], phases);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task PartialStartupCleanupStopsDiscoveredResourcesWhenStartupStalls()
+    {
+        var initialResources = new HashSet<string> { "initial" };
+        IReadOnlyList<string> activeResources = ["initial", "partially-started"];
+        var stoppedResources = new List<string>();
+        var topologyReconciled = false;
+        var stalledStartup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var startupWaitCancellation = new CancellationTokenSource();
+        startupWaitCancellation.Cancel();
+
+        await ReminderLifecycleHarness.CleanupPartialStartupAsync(
+            initialResources,
+            stalledStartup.Task,
+            () => activeResources,
+            resource =>
+            {
+                stoppedResources.Add(resource);
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                topologyReconciled = true;
+                return Task.CompletedTask;
+            },
+            NullLogger.Instance,
+            startupWaitCancellation.Token,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(["partially-started"], stoppedResources);
+        Assert.True(topologyReconciled);
+    }
+}

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -1,13 +1,12 @@
 #nullable enable
 
 using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
 using System.Text;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Runtime.Messaging;
-using Orleans.Runtime.ReminderService;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
@@ -26,7 +25,7 @@ namespace UnitTests.TimerTests;
 /// Base class for reminder tests providing common test operations and utilities.
 /// Uses <see cref="ReminderDiagnosticObserver"/> for event-driven waiting instead of Task.Delay.
 /// </summary>
-public class ReminderTestsBase : OrleansTestingBase, IDisposable
+public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
 {
     protected InProcessTestCluster HostedCluster { get; }
     protected static readonly TimeSpan LEEWAY = TimeSpan.FromMilliseconds(500);
@@ -42,7 +41,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
     protected const long failAfter = 2;
     protected const long failCheckAfter = 6;
     protected ILogger log;
-    protected ReminderDiagnosticObserver observer;
+    protected ReminderLifecycleHarness observer { get; }
     private ReminderTestClock ReminderClock { get; }
 
     public ReminderTestsBase(ReminderTestClock reminderClock, InProcessTestCluster hostedCluster)
@@ -67,21 +66,70 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 #endif
 
         log = TestingUtils.CreateDefaultLoggerFactory(TestingUtils.CreateTraceFileName("client", DateTime.Now.ToString("yyyyMMdd_hhmmss")), filters).CreateLogger<ReminderTestsBase>();
-        observer = ReminderDiagnosticObserver.Create();
+        observer = new ReminderLifecycleHarness(hostedCluster);
     }
 
     public IGrainFactory GrainFactory { get; }
 
     protected DateTimeOffset ReminderUtcNow => ReminderClock.UtcNow;
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        observer.Dispose();
+        try
+        {
+            await ExecuteCleanupAsync(
+                ClearReminderTableAsync,
+                observer.RefreshActiveServicesAsync,
+                observer.WaitForGlobalQuiescenceAsync,
+                TestConstants.InitTimeout);
+        }
+        finally
+        {
+            observer.Dispose();
+        }
+    }
 
+    protected Task ClearReminderTableAsync(CancellationToken cancellationToken)
+    {
         // ReminderTable.Clear() cannot be called from a non-Orleans thread,
-        // so we must proxy the call through a grain.
-        var controlProxy = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout).Wait();
+        // so proxy the call through a grain.
+        var controlProxy = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+        return controlProxy.EraseReminderTable().WaitAsync(cancellationToken);
+    }
+
+    internal static async Task ExecuteCleanupAsync(
+        Func<CancellationToken, Task> clearReminderTable,
+        Func<CancellationToken, Task> refreshReminderServices,
+        Func<CancellationToken, Task> waitForGlobalQuiescence,
+        TimeSpan timeout)
+    {
+        using var cleanupCancellation = new CancellationTokenSource(timeout);
+        List<Exception>? exceptions = null;
+        await RunPhase(clearReminderTable);
+        await RunPhase(refreshReminderServices);
+        await RunPhase(waitForGlobalQuiescence);
+
+        if (exceptions is [var exception])
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+        }
+
+        if (exceptions is { Count: > 1 })
+        {
+            throw new AggregateException("Reminder test cleanup failed.", exceptions);
+        }
+
+        async Task RunPhase(Func<CancellationToken, Task> phase)
+        {
+            try
+            {
+                await phase(cleanupCancellation.Token);
+            }
+            catch (Exception exception)
+            {
+                (exceptions ??= []).Add(exception);
+            }
+        }
     }
 
     public Task Test_Reminders_Basic_StopByRef()
@@ -313,15 +361,10 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         CancellationToken cancellationToken)
     {
         var result = await startSilosTask.WaitAsync(cancellationToken);
-        var reminderServicesStarted = result.Select(silo =>
-            observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress));
-        await Task.WhenAll(
-            Task.WhenAll(reminderServicesStarted),
-            WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
-        // Membership convergence does not await the reminder services' queued range-change reconciliation.
-        var rangeChangeReconciliations = HostedCluster.GetActiveSilos().Select(silo =>
-            silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
-        await Task.WhenAll(rangeChangeReconciliations);
+        await observer.WaitForTopologyReconciledAsync(
+            WaitForLivenessToStabilizeAsync(),
+            result,
+            cancellationToken);
         return result;
     }
 
@@ -334,27 +377,17 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             return;
         }
 
-        try
-        {
-            using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
-            await startSilosTask.WaitAsync(startupCompletionCts.Token);
-        }
-        catch (Exception exception)
-        {
-            log.LogInformation(exception, "Additional silo startup did not complete successfully before cleanup.");
-        }
-
-        var additionalSilos = HostedCluster.GetActiveSilos()
-            .Where(silo => !initialSilos.Contains(silo))
-            .ToArray();
-        if (additionalSilos.Length == 0)
-        {
-            return;
-        }
-
+        using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
         using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
-        await Task.WhenAll(additionalSilos.Select(StopSiloAsync)).WaitAsync(cleanupCts.Token);
-        await WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCts.Token);
+        await ReminderLifecycleHarness.CleanupPartialStartupAsync(
+            initialSilos,
+            startSilosTask,
+            () => HostedCluster.GetActiveSilos().ToArray(),
+            StopSiloAsync,
+            () => WaitForLivenessToStabilizeAsync(),
+            log,
+            startupCompletionCts.Token,
+            cleanupCts.Token);
     }
 
     protected async Task<InProcessSiloHandle> StopSiloAndStartAdditionalSiloAsync(
@@ -367,9 +400,10 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         await Task.WhenAll(stopTask, startTask).WaitAsync(cancellationToken);
 
         var silo = Assert.Single(await startTask);
-        await Task.WhenAll(
-            observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress),
-            WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
+        await observer.WaitForTopologyReconciledAsync(
+            WaitForLivenessToStabilizeAsync(),
+            [silo],
+            cancellationToken);
         return silo;
     }
 
@@ -538,25 +572,16 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             await SynchronizeReminderSchedulesAsync(cancellationToken, reminders);
 
             var previousCounters = new long[reminders.Length];
-            var previousTickCounts = new int[reminders.Length];
-            var tickTasks = new Task[reminders.Length];
             for (var reminderIndex = 0; reminderIndex < reminders.Length; reminderIndex++)
             {
                 var reminder = reminders[reminderIndex];
-                previousTickCounts[reminderIndex] = observer.GetTickCount(
-                    reminder.Grain.GetGrainId(),
-                    reminder.ReminderName);
-                tickTasks[reminderIndex] = observer.WaitForTickCountAsync(
-                    reminder.Grain,
-                    previousTickCounts[reminderIndex] + 1,
-                    cancellationToken,
-                    reminder.ReminderName);
                 previousCounters[reminderIndex] = await GetReminderCounterOrZeroAsync(
                     reminder.Grain,
                     reminder.ReminderName,
                     cancellationToken);
             }
 
+            var tickCompletion = observer.ArmTickCompletion(cancellationToken, reminders);
             var periods = await Task.WhenAll(reminders.Select(reminder =>
                 GetReminderPeriodAsync(reminder.Grain, reminder.ReminderName))).WaitAsync(cancellationToken);
             var period = Assert.Single(periods.Distinct());
@@ -568,8 +593,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                 tickCount,
                 reminders.Length);
             await AdvanceReminderTimeAsync(period, cancellationToken);
-            // TickCompleted is emitted after ReceiveReminder returns, so the counter is already persisted.
-            await Task.WhenAll(tickTasks).WaitAsync(cancellationToken);
+            // TickCompleted is emitted after ReceiveReminder returns, so counters are already persisted.
+            await observer.WaitForTickCompletedAsync(tickCompletion).WaitAsync(cancellationToken);
 
             await SynchronizeReminderSchedulesAsync(cancellationToken, reminders);
             for (var reminderIndex = 0; reminderIndex < reminders.Length; reminderIndex++)
@@ -583,8 +608,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                     observer.GetActiveReminderCount(
                         reminder.Grain.GetGrainId(),
                         reminder.ReminderName));
+                var tickSnapshot = tickCompletion.Snapshot[reminderIndex];
                 Assert.Equal(
-                    previousTickCounts[reminderIndex] + 1,
+                    tickSnapshot.PreviousCount + 1,
                     observer.GetTickCount(
                         reminder.Grain.GetGrainId(),
                         reminder.ReminderName));
@@ -902,11 +928,11 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             if (observer.GetActiveReminderCount(grain.GetGrainId(), reminderName) > 0)
             {
                 var quiescenceTask = observer.WaitForReminderQuiescenceAsync(grain, reminderName, cancellationToken);
-                await RefreshReminderServicesAsync(cancellationToken);
+                await observer.RefreshActiveServicesAsync(cancellationToken);
                 await quiescenceTask;
             }
 
-            await RefreshReminderServicesAsync(cancellationToken);
+            await observer.RefreshActiveServicesAsync(cancellationToken);
             if (observer.GetActiveReminderCount(grain.GetGrainId(), reminderName) == 0)
             {
                 return;
@@ -914,35 +940,13 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
     }
 
-    private async Task RefreshReminderServicesAsync(CancellationToken cancellationToken)
-    {
-        // Each refresh scans the backing reminder table. Serialize this test-only barrier so that
-        // constrained provider emulators observe the same completed-refresh invariant without an artificial query burst.
-        foreach (var silo in HostedCluster.GetActiveSilos())
-        {
-            await silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyRefresh().WaitAsync(cancellationToken);
-        }
-    }
-
     private async Task SynchronizeReminderSchedulesAsync(
         CancellationToken cancellationToken,
         params (IAddressable Grain, string ReminderName)[] reminders)
     {
-        await RefreshReminderServicesAsync(cancellationToken);
         try
         {
-            await Task.WhenAll(reminders.Select(async reminder =>
-            {
-                await observer.WaitForActiveReminderCountAsync(
-                    reminder.Grain,
-                    1,
-                    cancellationToken,
-                    reminder.ReminderName);
-                await observer.WaitForLocalReminderScheduleAsync(
-                    reminder.Grain,
-                    reminder.ReminderName,
-                    cancellationToken);
-            }));
+            await observer.WaitForSchedulesArmedAsync(cancellationToken, reminders);
         }
         catch (OperationCanceledException exception) when (
             cancellationToken.IsCancellationRequested

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -41,7 +41,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
     protected const long failAfter = 2;
     protected const long failCheckAfter = 6;
     protected ILogger log;
-    protected ReminderLifecycleHarness observer { get; }
+    protected readonly ReminderLifecycleHarness observer;
     private ReminderTestClock ReminderClock { get; }
 
     public ReminderTestsBase(ReminderTestClock reminderClock, InProcessTestCluster hostedCluster)
@@ -105,9 +105,11 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
     {
         using var cleanupCancellation = new CancellationTokenSource(timeout);
         List<Exception>? exceptions = null;
-        await RunPhase(clearReminderTable);
-        await RunPhase(refreshReminderServices);
-        await RunPhase(waitForGlobalQuiescence);
+        if (await RunPhase(clearReminderTable)
+            && await RunPhase(refreshReminderServices))
+        {
+            await RunPhase(waitForGlobalQuiescence);
+        }
 
         if (exceptions is [var exception])
         {
@@ -119,7 +121,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
             throw new AggregateException("Reminder test cleanup failed.", exceptions);
         }
 
-        async Task RunPhase(Func<CancellationToken, Task> phase)
+        async Task<bool> RunPhase(Func<CancellationToken, Task> phase)
         {
             try
             {
@@ -129,6 +131,8 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
             {
                 (exceptions ??= []).Add(exception);
             }
+
+            return !cleanupCancellation.IsCancellationRequested;
         }
     }
 
@@ -226,6 +230,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(CHURN_ENDWAIT);
+        using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
         Task<List<InProcessSiloHandle>>? startSilosTask = null;
         try
         {
@@ -235,7 +240,10 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
                     await using (await PauseReminderTimeAsync(cancellationToken))
                     {
                         log.LogInformation("Starting another silo");
-                        startSilosTask = StartAdditionalSilosAsync(1, startAdditionalSiloOnNewPort: true);
+                        startSilosTask = StartAdditionalSilosAsync(
+                            1,
+                            startupCancellation.Token,
+                            startAdditionalSiloOnNewPort: true);
                         var additionalSilos = await WaitForAdditionalSilosAndReminderServicesAsync(startSilosTask, cancellationToken);
                         _ = Assert.Single(additionalSilos);
                     }
@@ -249,7 +257,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, startupCancellation);
         }
     }
 
@@ -266,6 +274,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(CHURN_ENDWAIT);
+        using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
         Task<List<InProcessSiloHandle>>? startSilosTask = null;
         try
         {
@@ -275,7 +284,10 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
                     await using (await PauseReminderTimeAsync(cancellationToken))
                     {
                         log.LogInformation("Starting 2 extra silos");
-                        startSilosTask = StartAdditionalSilosAsync(2, startAdditionalSiloOnNewPort: true);
+                        startSilosTask = StartAdditionalSilosAsync(
+                            2,
+                            startupCancellation.Token,
+                            startAdditionalSiloOnNewPort: true);
                         await WaitForAdditionalSilosAndReminderServicesAsync(startSilosTask, cancellationToken);
                     }
                 },
@@ -288,7 +300,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask);
+            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, startupCancellation);
         }
     }
 
@@ -337,9 +349,12 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         Assert.Equal(0, observer.GetActiveReminderCount(grainId, DR));
     }
 
-    protected Task<List<InProcessSiloHandle>> StartAdditionalSilosAsync(int silosToStart, bool startAdditionalSiloOnNewPort = false)
+    protected Task<List<InProcessSiloHandle>> StartAdditionalSilosAsync(
+        int silosToStart,
+        CancellationToken cancellationToken,
+        bool startAdditionalSiloOnNewPort = false)
     {
-        return HostedCluster.StartSilosAsync(silosToStart);
+        return HostedCluster.StartSilosAsync(silosToStart, cancellationToken);
     }
 
     protected Task WaitForLivenessToStabilizeAsync(bool didKill = false)
@@ -352,7 +367,10 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         CancellationToken cancellationToken,
         bool startAdditionalSiloOnNewPort = false)
     {
-        var startSilosTask = StartAdditionalSilosAsync(silosToStart, startAdditionalSiloOnNewPort);
+        var startSilosTask = StartAdditionalSilosAsync(
+            silosToStart,
+            cancellationToken,
+            startAdditionalSiloOnNewPort);
         return await WaitForAdditionalSilosAndReminderServicesAsync(startSilosTask, cancellationToken);
     }
 
@@ -364,29 +382,30 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         await observer.WaitForTopologyReconciledAsync(
             WaitForLivenessToStabilizeAsync(),
             result,
+            CHURN_ENDWAIT,
             cancellationToken);
         return result;
     }
 
     private async Task CleanupAdditionalSilosAsync(
         HashSet<InProcessSiloHandle> initialSilos,
-        Task<List<InProcessSiloHandle>>? startSilosTask)
+        Task<List<InProcessSiloHandle>>? startSilosTask,
+        CancellationTokenSource startupCancellation)
     {
         if (startSilosTask is null)
         {
             return;
         }
 
-        using var startupCompletionCts = new CancellationTokenSource(CHURN_ENDWAIT);
         using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
         await ReminderLifecycleHarness.CleanupPartialStartupAsync(
             initialSilos,
             startSilosTask,
             () => HostedCluster.GetActiveSilos().ToArray(),
             StopSiloAsync,
-            () => WaitForLivenessToStabilizeAsync(),
+            () => WaitForLivenessToStabilizeAsync(didKill: true),
             log,
-            startupCompletionCts.Token,
+            startupCancellation,
             cleanupCts.Token);
     }
 
@@ -396,13 +415,17 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         bool startAdditionalSiloOnNewPort = false)
     {
         var stopTask = StopSiloAsync(siloToStop);
-        var startTask = StartAdditionalSilosAsync(1, startAdditionalSiloOnNewPort);
+        var startTask = StartAdditionalSilosAsync(
+            1,
+            cancellationToken,
+            startAdditionalSiloOnNewPort);
         await Task.WhenAll(stopTask, startTask).WaitAsync(cancellationToken);
 
         var silo = Assert.Single(await startTask);
         await observer.WaitForTopologyReconciledAsync(
             WaitForLivenessToStabilizeAsync(),
             [silo],
+            CHURN_ENDWAIT,
             cancellationToken);
         return silo;
     }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -36,7 +36,7 @@ namespace UnitTests.TimerTests
         public class Fixture : BaseInProcessTestClusterFixture
         {
             private ReminderTestClock? _reminderClock;
-            private readonly ReminderDiagnosticObserver _startupObserver = ReminderDiagnosticObserver.Create();
+            private readonly ReminderLifecycleHarness _startupHarness = new();
             private IReadOnlyList<SiloAddress>? _startedReminderServices;
             internal ReminderTestClock ReminderClock => _reminderClock ?? throw new InvalidOperationException($"{nameof(ReminderTestClock)} has not been configured.");
             internal ReminderTableReadController ReadController { get; } = new();
@@ -73,9 +73,9 @@ namespace UnitTests.TimerTests
 
                 using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
                 cancellation.CancelAfter(TestConstants.InitTimeout);
-                var started = HostedCluster.Silos.Select(silo =>
-                    _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress));
-                _startedReminderServices = (await Task.WhenAll(started)).Select(e => e.SiloAddress!).ToArray();
+                _startedReminderServices = await _startupHarness.WaitForServicesReadyAsync(
+                    HostedCluster.Silos,
+                    cancellation.Token);
             }
 
             public override async ValueTask DisposeAsync()
@@ -88,7 +88,7 @@ namespace UnitTests.TimerTests
                 finally
                 {
                     _reminderClock?.Dispose();
-                    _startupObserver.Dispose();
+                    _startupHarness.Dispose();
                 }
             }
         }
@@ -104,13 +104,9 @@ namespace UnitTests.TimerTests
 
         public async ValueTask InitializeAsync()
         {
-            // ReminderTable.Clear() cannot be called from a non-Orleans thread,
-            // so we must proxy the call through a grain.
-            var controlProxy = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            await controlProxy.EraseReminderTable().WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken);
+            await ClearReminderTableAsync(TestContext.Current.CancellationToken)
+                .WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken);
         }
-
-        ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
 
         // Basic tests
 
@@ -182,6 +178,32 @@ namespace UnitTests.TimerTests
             await AdvanceRemindersByTicksAsync(1, cts.Token, GetReminderIdentities(grains, DR));
             await AssertReminderCountersAsync(grains, cts.Token, (DR, 1));
             await StopRemindersAsync(grains, DR, cts.Token);
+        }
+
+        [Fact]
+        public async Task Rem_Grain_TickCompletionSurvivesActivationReplacement()
+        {
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TestConstants.InitTimeout);
+            var grain = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+            var grainId = grain.GetGrainId();
+
+            await grain.StartReminder(DR).WaitAsync(cancellation.Token);
+            await observer.WaitForSchedulesArmedAsync(cancellation.Token, (grain, DR));
+            await Assert.ThrowsAsync<FileNotFoundException>(
+                () => grain.GetCounter(DR).WaitAsync(cancellation.Token));
+            var period = await grain.GetReminderPeriod(DR).WaitAsync(cancellation.Token);
+
+            var tickCompletion = observer.ArmTickCompletion(cancellation.Token, (grain, DR));
+            await HostedCluster.DeactivateAsync(grainId).WaitAsync(cancellation.Token);
+            Assert.False(HostedCluster.TryGetGrainContext(grainId, out _));
+
+            await AdvanceReminderTimeAsync(period, cancellation.Token);
+            await observer.WaitForTickCompletedAsync(tickCompletion).WaitAsync(cancellation.Token);
+
+            Assert.Equal(1, await grain.GetCounter(DR).WaitAsync(cancellation.Token));
+            Assert.Equal(1, observer.GetTickCount(grainId, DR));
+            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, cancellation.Token);
         }
 
         [Fact]
@@ -277,8 +299,7 @@ namespace UnitTests.TimerTests
             Assert.Equal(firstTickTime, firstTick.Status.CurrentTickTime);
             Assert.Equal(1, observer.GetTickCount(grainId, reminderName));
 
-            var reminderService = HostedCluster.Silos.Single().ServiceProvider.GetRequiredService<LocalReminderService>();
-            await reminderService.TestOnlyRefresh().WaitAsync(cts.Token);
+            await observer.RefreshActiveServicesAsync(cts.Token);
 
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
             Assert.Equal(1, observer.GetTickCount(grainId, reminderName));

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -71,11 +71,10 @@ namespace UnitTests.TimerTests
                     return;
                 }
 
-                using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-                cancellation.CancelAfter(TestConstants.InitTimeout);
                 _startedReminderServices = await _startupHarness.WaitForServicesReadyAsync(
                     HostedCluster.Silos,
-                    cancellation.Token);
+                    TestConstants.InitTimeout,
+                    TestContext.Current.CancellationToken);
             }
 
             public override async ValueTask DisposeAsync()
@@ -90,6 +89,7 @@ namespace UnitTests.TimerTests
                     _reminderClock?.Dispose();
                     _startupHarness.Dispose();
                 }
+
             }
         }
 

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -33,6 +33,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     private readonly List<TickCountWaiter> _tickCountWaiters = [];
     private readonly List<ActiveReminderCountWaiter> _activeReminderCountWaiters = [];
     private readonly List<LocalReminderScheduleWaiter> _localReminderScheduleWaiters = [];
+    private readonly List<GlobalQuiescenceWaiter> _globalQuiescenceWaiters = [];
 
     /// <summary>
     /// Creates a new instance of the observer and starts listening for reminder diagnostic events.
@@ -109,6 +110,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
 
                     ReleaseReadyActiveReminderWaiters(ready);
                     ReleaseReadyLocalReminderScheduleWaiters(ready);
+                    ReleaseReadyGlobalQuiescenceWaiters(ready);
                     break;
                 case ReminderEvents.LocalReminderScheduleChanged localReminderScheduleChanged:
                     var changedKey = new ReminderTickKey(localReminderScheduleChanged.GrainId, localReminderScheduleChanged.ReminderName);
@@ -297,6 +299,32 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     {
         ArgumentException.ThrowIfNullOrEmpty(reminderName);
         return WaitForActiveReminderCountCoreAsync(grainId, 0, reminderName, cancellationToken);
+    }
+
+    /// <summary>
+    /// Waits until there are no active local reminders on any observed silo.
+    /// </summary>
+    public Task WaitForGlobalQuiescenceAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        GlobalQuiescenceWaiter waiter;
+        lock (_lock)
+        {
+            if (_activeLocalReminders.Count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            waiter = new();
+            _globalQuiescenceWaiters.Add(waiter);
+            RegisterCancellation(waiter, _globalQuiescenceWaiters, cancellationToken);
+        }
+
+        return waiter.TaskSource.Task;
     }
 
     private static bool MatchesReminder(ReminderEvents.ReminderEvent evt, GrainId grainId, string? reminderName)
@@ -492,6 +520,17 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         }
     }
 
+    private void ReleaseReadyGlobalQuiescenceWaiters(List<Waiter> ready)
+    {
+        if (_activeLocalReminders.Count != 0)
+        {
+            return;
+        }
+
+        ready.AddRange(_globalQuiescenceWaiters);
+        _globalQuiescenceWaiters.Clear();
+    }
+
     private readonly record struct ReminderTickKey(GrainId GrainId, string ReminderName);
     private readonly record struct LocalReminderInstanceKey(object Identity)
     {
@@ -540,6 +579,8 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         public GrainId GrainId { get; } = grainId;
         public string ReminderName { get; } = reminderName;
     }
+
+    private sealed class GlobalQuiescenceWaiter : Waiter;
 
     /// <inheritdoc/>
     public void Dispose()

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -302,10 +302,13 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     }
 
     /// <summary>
-    /// Waits until there are no active local reminders on any observed silo.
+    /// Waits until there are no active local reminders on the specified silos.
     /// </summary>
-    public Task WaitForGlobalQuiescenceAsync(CancellationToken cancellationToken)
+    public Task WaitForGlobalQuiescenceAsync(
+        IReadOnlySet<SiloAddress> siloAddresses,
+        CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(siloAddresses);
         if (cancellationToken.IsCancellationRequested)
         {
             return Task.FromCanceled(cancellationToken);
@@ -314,12 +317,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         GlobalQuiescenceWaiter waiter;
         lock (_lock)
         {
-            if (_activeLocalReminders.Count == 0)
+            if (IsGloballyQuiescentCore(siloAddresses))
             {
                 return Task.CompletedTask;
             }
 
-            waiter = new();
+            waiter = new(siloAddresses);
             _globalQuiescenceWaiters.Add(waiter);
             RegisterCancellation(waiter, _globalQuiescenceWaiters, cancellationToken);
         }
@@ -522,13 +525,24 @@ public sealed class ReminderDiagnosticObserver : IDisposable
 
     private void ReleaseReadyGlobalQuiescenceWaiters(List<Waiter> ready)
     {
-        if (_activeLocalReminders.Count != 0)
+        for (var i = _globalQuiescenceWaiters.Count - 1; i >= 0; i--)
         {
-            return;
-        }
+            var waiter = _globalQuiescenceWaiters[i];
+            if (!IsGloballyQuiescentCore(waiter.SiloAddresses))
+            {
+                continue;
+            }
 
-        ready.AddRange(_globalQuiescenceWaiters);
-        _globalQuiescenceWaiters.Clear();
+            _globalQuiescenceWaiters.RemoveAt(i);
+            ready.Add(waiter);
+        }
+    }
+
+    private bool IsGloballyQuiescentCore(IReadOnlySet<SiloAddress> siloAddresses)
+    {
+        return !_activeLocalReminders.Values
+            .SelectMany(static instances => instances.Values)
+            .Any(instance => instance.SiloAddress is { } address && siloAddresses.Contains(address));
     }
 
     private readonly record struct ReminderTickKey(GrainId GrainId, string ReminderName);
@@ -580,7 +594,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         public string ReminderName { get; } = reminderName;
     }
 
-    private sealed class GlobalQuiescenceWaiter : Waiter;
+    private sealed class GlobalQuiescenceWaiter(IReadOnlySet<SiloAddress> siloAddresses) : Waiter
+    {
+        public IReadOnlySet<SiloAddress> SiloAddresses { get; } = siloAddresses.ToHashSet();
+    }
 
     /// <inheritdoc/>
     public void Dispose()


### PR DESCRIPTION
## Problem

Reminder provider suites rely on several independently composed diagnostic waits and test-only service hooks. Their synchronous per-test cleanup is tied to test cancellation, can leave local reminder state behind, and activation-local counter waits can strand a clock driver when an activation is replaced. Lifecycle edge cases around partial startup and failed or superseded range reads also lack focused regression coverage.

## Solution

Introduce a cohesive reminder lifecycle harness for service readiness, topology reconciliation, schedule arming, activation-independent tick completion, sequential refresh, and global quiescence. Convert the shared reminder suite base to asynchronous disposal using an independent bounded cleanup token, clear storage through the grain proxy, refresh every active service in order, and always dispose diagnostics. Preserve the in-memory and SQL Server pre-clear behavior and route Azure Table startup synchronization through the same harness.

Add controlled regressions for activation replacement, current and obsolete reconciliation failures, stalled partial startup cleanup, and cleanup after test cancellation.

## Rationale

Centralizing phase barriers makes provider tests express lifecycle intent without rebuilding synchronization from low-level hooks. Cleanup now establishes both persistent and local-state isolation even when the test token is canceled. Tick completion uses the activation-independent diagnostic event emitted after reminder delivery, matching the approach in #10855 without copying its test-grain cleanup; whichever PR merges second can resolve the small shared-base overlap while retaining this harness.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10891)