### PR TITLE
test(adonet): raise relational provider coverage above 90%

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Orleans.AdoNet.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(SourceRoot)src\Orleans.Runtime\Orleans.Runtime.csproj" />
   </ItemGroup>
 

--- a/src/AdoNet/Shared/Storage/DbExtensions.cs
+++ b/src/AdoNet/Shared/Storage/DbExtensions.cs
@@ -109,7 +109,7 @@ namespace Orleans.Tests.SqlUtils
         /// <param name="dbType">the <see cref="DbType"/> of the parameter.</param>
         public static void AddParameter<T>(this IDbCommand command, string parameterName, T? value, ParameterDirection direction = ParameterDirection.Input, int? size = null, DbType? dbType = null)
         {
-            command.Parameters.Add(command.CreateParameter(direction, parameterName, value, size));
+            command.Parameters.Add(command.CreateParameter(direction, parameterName, value, size, dbType));
         }
 
         /// <summary>

--- a/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
+++ b/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
@@ -76,7 +76,7 @@ namespace Orleans.Tests.SqlUtils
         internal static Task<RelationalOrleansQueries> CreateInstance(string invariantName, string? connectionString, DbDataSource? dataSource) =>
             CreateInstance(RelationalStorage.CreateInstance(invariantName, connectionString, dataSource));
 
-        private static async Task<RelationalOrleansQueries> CreateInstance(IRelationalStorage storage)
+        internal static async Task<RelationalOrleansQueries> CreateInstance(IRelationalStorage storage)
         {
             var queries = await storage.ReadAsync(DbStoredQueries.GetQueriesKey, DbStoredQueries.Converters.GetQueryKeyAndValue, null);
 

--- a/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
@@ -38,6 +38,7 @@ namespace Orleans.Tests.SqlUtils
         /// <returns></returns>
         public static Task<IEnumerable<TResult>> ReadAsync<TResult>(this IRelationalStorage storage, string query, Func<IDataRecord, TResult> selector, Action<IDbCommand>? parameterProvider)
         {
+            ArgumentNullException.ThrowIfNull(selector);
             return storage.ReadAsync(query, parameterProvider, (record, i, cancellationToken) => Task.FromResult(selector(record)));
         }
 

--- a/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorageExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,126 +27,6 @@ namespace Orleans.Tests.SqlUtils
     /// </summary>
     internal static class RelationalStorageExtensions
     {
-        /// <summary>
-        /// Used to format .NET objects suitable to relational database format.
-        /// </summary>
-        private static readonly AdoNetFormatProvider adoNetFormatProvider = new AdoNetFormatProvider();
-
-        /// <summary>
-        /// This is a template to produce query parameters that are indexed.
-        /// </summary>
-        private const string indexedParameterTemplate = "@p{0}";
-
-        /// <summary>
-        /// Executes a multi-record insert query clause with <em>SELECT UNION ALL</em>.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="storage">The storage to use.</param>
-        /// <param name="tableName">The table name to against which to execute the query.</param>
-        /// <param name="parameters">The parameters to insert.</param>
-        /// <param name="nameMap">If provided, maps property names from <typeparamref name="T"/> to ones provided in the map.</param>
-        /// <param name="onlyOnceColumns">If given, SQL parameter values for the given <typeparamref name="T"/> property types are generated only once. Effective only when <paramref name="useSqlParams"/> is <em>TRUE</em>.</param>
-        /// <param name="useSqlParams"><em>TRUE</em> if the query should be in parameterized form. <em>FALSE</em> otherwise.</param>
-        /// <param name="cancellationToken">The cancellation token. Defaults to <see cref="CancellationToken.None"/>.</param>
-        /// <returns>The rows affected.</returns>
-        public static Task<int> ExecuteMultipleInsertIntoAsync<T>(this IRelationalStorage storage, string tableName, IEnumerable<T> parameters, IReadOnlyDictionary<string, string>? nameMap = null, IEnumerable<string>? onlyOnceColumns = null, bool useSqlParams = true, CancellationToken cancellationToken = default)
-        {
-            if(string.IsNullOrWhiteSpace(tableName))
-            {
-                throw new ArgumentException("The name must be a legal SQL table name", nameof(tableName));
-            }
-
-            if(parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-
-            var storageConsts = DbConstantsStore.GetDbConstants(storage.InvariantName);
-
-            var startEscapeIndicator = storageConsts.StartEscapeIndicator;
-            var endEscapeIndicator = storageConsts.EndEscapeIndicator;
-
-            //SqlParameters map is needed in case the query needs to be parameterized in order to avoid two
-            //reflection passes as first a query needs to be constructed and after that when a database
-            //command object has been created, parameters need to be provided to them.
-            var sqlParameters = new Dictionary<string, object?>();
-            const string insertIntoValuesTemplate = "INSERT INTO {0} ({1}) SELECT {2};";
-            var columns = string.Empty;
-            var values = new List<string>();
-            if(parameters.Any())
-            {
-                //Type and property information are the same for all of the objects.
-                //The following assumes the property names will be retrieved in the same
-                //order as is the index iteration done.
-                var onlyOnceRow = new List<string>();
-                var properties = parameters.First()!.GetType().GetProperties();
-                columns = string.Join(",", nameMap == null ? properties.Select(pn => string.Format("{0}{1}{2}", startEscapeIndicator, pn.Name, endEscapeIndicator)) : properties.Select(pn => string.Format("{0}{1}{2}", startEscapeIndicator, (nameMap.TryGetValue(pn.Name, out var pnName) ? pnName : pn.Name), endEscapeIndicator)));
-                if (onlyOnceColumns != null && onlyOnceColumns.Any())
-                {
-                    var onlyOnceProperties = properties.Where(pn => onlyOnceColumns.Contains(pn.Name)).Select(pn => pn).ToArray();
-                    var onlyOnceData = parameters.First();
-                    for(int i = 0; i < onlyOnceProperties.Length; ++i)
-                    {
-                        var currentProperty = onlyOnceProperties[i];
-                        var parameterValue = currentProperty.GetValue(onlyOnceData, null);
-                        if(useSqlParams)
-                        {
-                            var parameterName = string.Format("@{0}", (nameMap!.TryGetValue(onlyOnceProperties[i].Name, out var parameter) ? parameter : onlyOnceProperties[i].Name));
-                            onlyOnceRow.Add(parameterName);
-                            sqlParameters.Add(parameterName, parameterValue);
-                        }
-                        else
-                        {
-                            onlyOnceRow.Add(string.Format(adoNetFormatProvider, "{0}", parameterValue));
-                        }
-                    }
-                }
-
-                var dataRows = new List<string>();
-                var multiProperties = onlyOnceColumns == null ? properties : properties.Where(pn => !onlyOnceColumns.Contains(pn.Name)).Select(pn => pn).ToArray();
-                int parameterCount = 0;
-                foreach(var row in parameters)
-                {
-                    for(int i = 0; i < multiProperties.Length; ++i)
-                    {
-                        var currentProperty = multiProperties[i];
-                        var parameterValue = currentProperty.GetValue(row, null);
-                        if(useSqlParams)
-                        {
-                            var parameterName = string.Format(indexedParameterTemplate, parameterCount);
-                            dataRows.Add(parameterName);
-                            sqlParameters.Add(parameterName, parameterValue);
-                            ++parameterCount;
-                        }
-                        else
-                        {
-                            dataRows.Add(string.Format(adoNetFormatProvider, "{0}", parameterValue));
-                        }
-                    }
-
-                    values.Add(string.Format("{0}", string.Join(",", onlyOnceRow.Concat(dataRows))));
-                    dataRows.Clear();
-                }
-            }
-
-            var query = string.Format(insertIntoValuesTemplate, tableName, columns, string.Join(storageConsts.UnionAllSelectTemplate, values));
-            return storage.ExecuteAsync(query, command =>
-            {
-                if (useSqlParams)
-                {
-                    foreach (var sp in sqlParameters)
-                    {
-                        var p = command.CreateParameter();
-                        p.ParameterName = sp.Key;
-                        p.Value = sp.Value ?? DBNull.Value;
-                        p.Direction = ParameterDirection.Input;
-                        command.Parameters.Add(p);
-                    }
-                }
-            }, cancellationToken: cancellationToken);
-        }
-
-
         /// <summary>
         /// A simplified version of <see cref="IRelationalStorage.ReadAsync{TResult}"/>
         /// </summary>

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/DbExtensionsTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/DbExtensionsTests.cs
@@ -1,0 +1,501 @@
+using System.Data;
+using System.Data.Common;
+using NSubstitute;
+using Orleans.Persistence.AdoNet.Storage;
+using UnitTests.StorageTests.Relational.Fakes;
+
+namespace UnitTests.StorageTests.Relational;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Persistence")]
+public sealed class DbExtensionsTests
+{
+    [Fact]
+    public void AddParameter_PreservesExplicitDbType()
+    {
+        using var command = new RecordingDbCommand();
+
+        command.AddParameter("@amount", 42, dbType: DbType.Currency);
+
+        var parameter = Assert.IsType<RecordingDbParameter>(Assert.Single(command.Parameters.Cast<object>()));
+        Assert.Equal("@amount", parameter.ParameterName);
+        Assert.Equal(42, parameter.Value);
+        Assert.Equal(DbType.Currency, parameter.DbType);
+    }
+
+    [Fact]
+    public void AddParameter_CapturesNameValueTypeAndSize()
+    {
+        using var command = new RecordingDbCommand();
+
+        command.AddParameter(
+            "@customer",
+            "customer-42",
+            ParameterDirection.InputOutput,
+            size: 64,
+            dbType: DbType.AnsiString);
+
+        var parameter = AssertParameter(command);
+        Assert.Equal("@customer", parameter.ParameterName);
+        Assert.Equal("customer-42", parameter.Value);
+        Assert.Equal(DbType.AnsiString, parameter.DbType);
+        Assert.Equal(64, parameter.Size);
+        Assert.Equal(ParameterDirection.InputOutput, parameter.Direction);
+    }
+
+    [Fact]
+    public void AddParameter_MapsNullToDbNull()
+    {
+        using var command = new RecordingDbCommand();
+
+        command.AddParameter<string>("@optional", null);
+
+        var parameter = AssertParameter(command);
+        Assert.Same(DBNull.Value, parameter.Value);
+        Assert.Equal(DbType.String, parameter.DbType);
+        Assert.Equal(ParameterDirection.Input, parameter.Direction);
+    }
+
+    [Fact]
+    public void AddParameter_UsesDefaultsWhenOptionalMetadataIsOmitted()
+    {
+        using var command = new RecordingDbCommand();
+        var value = Guid.Parse("a13da96c-8b25-4df6-8248-94f38975af81");
+
+        command.AddParameter("@id", value);
+
+        var parameter = AssertParameter(command);
+        Assert.Equal(Guid.Parse("a13da96c-8b25-4df6-8248-94f38975af81"), parameter.Value);
+        Assert.Equal(DbType.Guid, parameter.DbType);
+        Assert.Equal(ParameterDirection.Input, parameter.Direction);
+        Assert.Equal(0, parameter.Size);
+    }
+
+    [Fact]
+    public void GetValue_ByNameThrowsDataExceptionWhenFieldIsMissing()
+    {
+        var record = Substitute.For<IDataRecord>();
+        record.GetOrdinal("Missing").Returns(_ => throw new IndexOutOfRangeException("Missing"));
+
+        var exception = Assert.Throws<DataException>(
+            () => record.GetValue<int>("Missing"));
+
+        Assert.Equal("Field 'Missing' not found in data record.", exception.Message);
+        Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void GetValue_ReturnsUtcDateTime()
+    {
+        var source = new DateTime(2026, 8, 27, 14, 15, 16, DateTimeKind.Unspecified);
+        using var reader = CreateReader(
+            ("Required", typeof(DateTime), source),
+            ("Optional", typeof(DateTime), DBNull.Value));
+
+        var required = reader.GetDateTimeValue("Required");
+        var optional = reader.GetDateTimeValueOrDefault(
+            "Optional",
+            new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc));
+
+        Assert.Equal(source, required);
+        Assert.Equal(DateTimeKind.Utc, required.Kind);
+        Assert.Equal(new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc), optional);
+    }
+
+    [Fact]
+    public void GetValue_ConvertsIntAndLongForOracleCompatibility()
+    {
+        using var intReader = CreateReader(("Value", typeof(int), 1_234_567));
+        using var longReader = CreateReader(("Value", typeof(long), 9_876_543_210L));
+
+        var fromInt = ((IDataRecord)intReader).GetInt64("Value");
+        var fromLong = ((IDataRecord)longReader).GetInt64("Value");
+
+        Assert.Equal(1_234_567L, fromInt);
+        Assert.Equal(9_876_543_210L, fromLong);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_ReturnsConfiguredDefaultsForDbNull()
+    {
+        using var reader = CreateReader(
+            ("Name", typeof(string), DBNull.Value),
+            ("Count", typeof(int), DBNull.Value));
+
+        var name = reader.GetValueOrDefault("Name", "fallback");
+        var count = reader.GetValueOrDefault(1, 17);
+        var nullableCount = reader.GetNullableInt32("Count");
+
+        Assert.Equal("fallback", name);
+        Assert.Equal(17, count);
+        Assert.Null(nullableCount);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_ReturnsTypedValue()
+    {
+        using var reader = CreateReader(("MessageId", typeof(long), 4_294_967_300L));
+
+        var byName = await reader.GetValueAsync<long>(
+            "MessageId",
+            TestContext.Current.CancellationToken);
+        var byOrdinal = await reader.GetValueOrDefaultAsync(0, -1L);
+
+        Assert.Equal(4_294_967_300L, byName);
+        Assert.Equal(byName, byOrdinal);
+    }
+
+    [Fact]
+    public async Task GetValueAsync_PropagatesCancellation()
+    {
+        using var reader = Substitute.For<DbDataReader>();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+        reader.GetOrdinal("MessageId").Returns(3);
+        reader.GetFieldValueAsync<long>(3, cancellation.Token)
+            .Returns(Task.FromCanceled<long>(cancellation.Token));
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => reader.GetValueAsync<long>("MessageId", cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        reader.Received(1).GetOrdinal("MessageId");
+        _ = reader.Received(1).GetFieldValueAsync<long>(3, cancellation.Token);
+    }
+
+    [Fact]
+    public void ReflectionParameterProvider_MapsMembersAndDbNull()
+    {
+        using var command = new RecordingDbCommand();
+        var values = new ParameterClass
+        {
+            Tenant = "north",
+            Count = 23,
+            Optional = null,
+        };
+
+        command.ReflectionParameterProvider(
+            values,
+            new Dictionary<string, string> { [nameof(ParameterClass.Tenant)] = "@tenant_id" });
+
+        var parameters = command.Parameters.Cast<RecordingDbParameter>().ToArray();
+        Assert.Collection(
+            parameters,
+            parameter =>
+            {
+                Assert.Equal("@tenant_id", parameter.ParameterName);
+                Assert.Equal("north", parameter.Value);
+                Assert.Equal(DbType.String, parameter.DbType);
+            },
+            parameter =>
+            {
+                Assert.Equal(nameof(ParameterClass.Count), parameter.ParameterName);
+                Assert.Equal(23, parameter.Value);
+                Assert.Equal(DbType.Int32, parameter.DbType);
+            },
+            parameter =>
+            {
+                Assert.Equal(nameof(ParameterClass.Optional), parameter.ParameterName);
+                Assert.Same(DBNull.Value, parameter.Value);
+                Assert.Equal(DbType.String, parameter.DbType);
+            });
+        Assert.All(parameters, parameter => Assert.Equal(ParameterDirection.Input, parameter.Direction));
+    }
+
+    [Fact]
+    public void ReflectionParameterProvider_HandlesStructAndClassInputs()
+    {
+        using var structCommand = new RecordingDbCommand();
+        using var classCommand = new RecordingDbCommand();
+
+        structCommand.ReflectionParameterProvider(new ParameterStruct { Sequence = 91L });
+        classCommand.ReflectionParameterProvider(new ParameterClass { Tenant = "west", Count = 8 });
+
+        var structParameter = AssertParameter(structCommand);
+        Assert.Equal(nameof(ParameterStruct.Sequence), structParameter.ParameterName);
+        Assert.Equal(91L, structParameter.Value);
+        Assert.Equal(DbType.Int64, structParameter.DbType);
+        Assert.Equal(3, classCommand.Parameters.Count);
+        Assert.Equal(
+            ["west", 8, DBNull.Value],
+            classCommand.Parameters.Cast<RecordingDbParameter>().Select(parameter => parameter.Value));
+    }
+
+    [Fact]
+    public void ReflectionSelector_MapsRecordToClassAndStruct()
+    {
+        using var classReader = CreateReader(
+            (nameof(ClassProjection.Name), typeof(string), "alpha"),
+            (nameof(ClassProjection.Count), typeof(int), 12));
+        using var structReader = CreateReader(
+            (nameof(StructProjection.Id), typeof(Guid), Guid.Parse("035704b9-e17f-421d-a7b5-038527ec74a3")),
+            (nameof(StructProjection.Optional), typeof(string), DBNull.Value));
+
+        var classResult = classReader.ReflectionSelector<ClassProjection>();
+        var structResult = structReader.ReflectionSelector<StructProjection>();
+
+        Assert.Equal("alpha", classResult.Name);
+        Assert.Equal(12, classResult.Count);
+        Assert.Equal(Guid.Parse("035704b9-e17f-421d-a7b5-038527ec74a3"), structResult.Id);
+        Assert.Null(structResult.Optional);
+    }
+
+    [Fact]
+    public void ReflectionSelector_ThrowsForInvalidMapping()
+    {
+        using var reader = CreateReader((nameof(ClassProjection.Count), typeof(string), "not-an-int"));
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => reader.ReflectionSelector<CountOnlyProjection>());
+
+        Assert.Contains(typeof(string).FullName!, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(int).FullName!, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_ByName_ReturnsTypedValue()
+    {
+        using var reader = CreateReader(
+            ("Decoy", typeof(int), -17),
+            ("Attempts", typeof(int), 42));
+
+        var actual = reader.GetValueOrDefault("Attempts", -1);
+
+        Assert.Equal(42, actual);
+        Assert.Equal(1, reader.GetOrdinal("Attempts"));
+    }
+
+    [Fact]
+    public void GetValueOrDefault_ByName_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'RetryCount'.";
+        var record = Substitute.For<IDataRecord>();
+        record.GetOrdinal("RetryCount").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = Assert.Throws<DataException>(
+            () => record.GetValueOrDefault("RetryCount", -1));
+
+        Assert.Equal("Field 'RetryCount' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        record.Received(1).GetOrdinal("RetryCount");
+    }
+
+    [Fact]
+    public void GetDateTimeValueOrDefault_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'CreatedUtc'.";
+        var record = Substitute.For<IDataRecord>();
+        record.GetOrdinal("CreatedUtc").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = Assert.Throws<DataException>(
+            () => record.GetDateTimeValueOrDefault("CreatedUtc"));
+
+        Assert.Equal("Field 'CreatedUtc' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        record.Received(1).GetOrdinal("CreatedUtc");
+    }
+
+    [Fact]
+    public async Task GetValueOrDefaultAsync_ByName_ReturnsTypedValue()
+    {
+        var expected = Guid.Parse("a1937343-6067-444a-b4ec-9c92364e0ed4");
+        using var reader = CreateReader(
+            ("Decoy", typeof(Guid), Guid.Parse("d4580117-318d-4052-83d0-2f6dc427f62f")),
+            ("CorrelationId", typeof(Guid), expected));
+
+        var actual = await reader.GetValueOrDefaultAsync("CorrelationId", Guid.Empty);
+
+        Assert.Equal(expected, actual);
+        Assert.Equal(1, reader.GetOrdinal("CorrelationId"));
+    }
+
+    [Fact]
+    public async Task GetValueOrDefaultAsync_ByName_ReturnsDefaultForDbNull()
+    {
+        using var reader = CreateReader(
+            ("Decoy", typeof(string), "not-selected"),
+            ("DisplayName", typeof(string), DBNull.Value));
+
+        var actual = await reader.GetValueOrDefaultAsync("DisplayName", "anonymous");
+
+        Assert.Equal("anonymous", actual);
+        Assert.True(reader.IsDBNull(reader.GetOrdinal("DisplayName")));
+    }
+
+    [Fact]
+    public async Task GetValueOrDefaultAsync_ByName_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'SequenceNumber'.";
+        using var reader = Substitute.For<DbDataReader>();
+        reader.GetOrdinal("SequenceNumber").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = await Assert.ThrowsAsync<DataException>(
+            () => reader.GetValueOrDefaultAsync("SequenceNumber", -1L));
+
+        Assert.Equal("Field 'SequenceNumber' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        reader.Received(1).GetOrdinal("SequenceNumber");
+    }
+
+    [Fact]
+    public void GetValueOrDefault_ByOrdinal_ReturnsTypedValue()
+    {
+        using var reader = CreateReader(
+            ("Decoy", typeof(string), "not-selected"),
+            ("Region", typeof(string), "northwest"));
+
+        var actual = reader.GetValueOrDefault(1, "unknown");
+
+        Assert.Equal("northwest", actual);
+        Assert.Equal("Region", reader.GetName(1));
+    }
+
+    [Fact]
+    public void GetDateTimeValue_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'ModifiedUtc'.";
+        var record = Substitute.For<IDataRecord>();
+        record.GetOrdinal("ModifiedUtc").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = Assert.Throws<DataException>(
+            () => record.GetDateTimeValue("ModifiedUtc"));
+
+        Assert.Equal("Field 'ModifiedUtc' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        record.Received(1).GetOrdinal("ModifiedUtc");
+    }
+
+    [Fact]
+    public void GetInt32_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'AttemptCount'.";
+        var record = Substitute.For<IDataRecord>();
+        record.GetOrdinal("AttemptCount").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = Assert.Throws<DataException>(
+            () => record.GetInt32("AttemptCount"));
+
+        Assert.Equal("Field 'AttemptCount' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        record.Received(1).GetOrdinal("AttemptCount");
+    }
+
+    [Fact]
+    public void GetInt64_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'MessageId'.";
+        var record = Substitute.For<IDataRecord>();
+        record.GetOrdinal("MessageId").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = Assert.Throws<DataException>(
+            () => record.GetInt64("MessageId"));
+
+        Assert.Equal("Field 'MessageId' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        record.Received(1).GetOrdinal("MessageId");
+    }
+
+    [Fact]
+    public void GetNullableInt32_ConvertsNonNullValue()
+    {
+        using var reader = CreateReader(
+            ("Decoy", typeof(short), (short)-9),
+            ("Priority", typeof(short), (short)32123));
+
+        var actual = reader.GetNullableInt32("Priority");
+
+        Assert.Equal(32123, actual);
+        Assert.Equal(typeof(short), reader.GetFieldType(reader.GetOrdinal("Priority")));
+    }
+
+    [Fact]
+    public void GetNullableInt32_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'Priority'.";
+        var record = Substitute.For<IDataRecord>();
+        record.GetOrdinal("Priority").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = Assert.Throws<DataException>(
+            () => record.GetNullableInt32("Priority"));
+
+        Assert.Equal("Field 'Priority' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        record.Received(1).GetOrdinal("Priority");
+    }
+
+    [Fact]
+    public async Task GetValueAsync_ThrowsDataExceptionWhenFieldIsMissing()
+    {
+        const string providerMessage = "Provider could not find column 'Payload'.";
+        using var reader = Substitute.For<DbDataReader>();
+        reader.GetOrdinal("Payload").Returns(_ => throw new IndexOutOfRangeException(providerMessage));
+
+        var exception = await Assert.ThrowsAsync<DataException>(
+            () => reader.GetValueAsync<byte[]>("Payload", TestContext.Current.CancellationToken));
+
+        Assert.Equal("Field 'Payload' not found in data record.", exception.Message);
+        var innerException = Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+        Assert.Equal(providerMessage, innerException.Message);
+        reader.Received(1).GetOrdinal("Payload");
+    }
+
+    private static RecordingDbParameter AssertParameter(RecordingDbCommand command) =>
+        Assert.IsType<RecordingDbParameter>(Assert.Single(command.Parameters.Cast<object>()));
+
+    private static DataTableReader CreateReader(
+        params (string Name, Type Type, object Value)[] columns)
+    {
+        var table = new DataTable();
+        foreach (var column in columns)
+        {
+            table.Columns.Add(column.Name, column.Type);
+        }
+
+        table.Rows.Add(columns.Select(column => column.Value).ToArray());
+        var reader = table.CreateDataReader();
+        Assert.True(reader.Read());
+        return reader;
+    }
+
+    private sealed class ParameterClass
+    {
+        public string Tenant { get; init; } = string.Empty;
+
+        public int Count { get; init; }
+
+        public string? Optional { get; init; }
+    }
+
+    private struct ParameterStruct
+    {
+        public long Sequence { get; init; }
+    }
+
+    private sealed class ClassProjection
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int Count { get; set; }
+    }
+
+    private struct StructProjection
+    {
+        public Guid Id { get; set; }
+
+        public string? Optional { get; set; }
+    }
+
+    private sealed class CountOnlyProjection
+    {
+        public int Count { get; set; }
+    }
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/Fakes/ScriptedRelationalStorage.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/Fakes/ScriptedRelationalStorage.cs
@@ -1,0 +1,325 @@
+using System.Collections;
+using System.Data;
+using Orleans.Persistence.AdoNet.Storage;
+
+namespace UnitTests.StorageTests.Relational.Fakes;
+
+internal sealed class ScriptedRelationalStorage(
+    string invariantName = "Scripted.Provider",
+    string connectionString = "scripted") :
+    IRelationalStorage,
+    Orleans.Clustering.AdoNet.Storage.IRelationalStorage,
+    Orleans.Reminders.AdoNet.Storage.IRelationalStorage,
+    Orleans.Streaming.AdoNet.Storage.IRelationalStorage,
+    Orleans.GrainDirectory.AdoNet.Storage.IRelationalStorage
+{
+    private readonly Queue<ExpectedCall> _expectedCalls = [];
+    private readonly List<RecordedStorageCall> _calls = [];
+
+    public string InvariantName { get; } = invariantName;
+
+    public string ConnectionString { get; } = connectionString;
+
+    public IReadOnlyList<RecordedStorageCall> Calls => _calls;
+
+    public ScriptedRelationalStorage ExpectRead(string query, params DataTable[] resultSets)
+    {
+        _expectedCalls.Enqueue(new(ExpectedCallKind.Read, query, resultSets, 0, null));
+        return this;
+    }
+
+    public ScriptedRelationalStorage ExpectReadException(string query, Exception exception)
+    {
+        _expectedCalls.Enqueue(new(ExpectedCallKind.Read, query, [], 0, exception));
+        return this;
+    }
+
+    public ScriptedRelationalStorage ExpectExecute(string query, int affectedRows)
+    {
+        _expectedCalls.Enqueue(new(ExpectedCallKind.Execute, query, [], affectedRows, null));
+        return this;
+    }
+
+    public ScriptedRelationalStorage ExpectExecuteException(string query, Exception exception)
+    {
+        _expectedCalls.Enqueue(new(ExpectedCallKind.Execute, query, [], 0, exception));
+        return this;
+    }
+
+    public void VerifyComplete()
+    {
+        if (_expectedCalls.TryPeek(out var expected))
+        {
+            throw new InvalidOperationException(
+                $"Missing scripted {expected.Kind} call for query '{expected.Query}'.");
+        }
+    }
+
+    public async Task<IEnumerable<TResult>> ReadAsync<TResult>(
+        string query,
+        Action<IDbCommand>? parameterProvider,
+        Func<IDataRecord, int, CancellationToken, Task<TResult>> selector,
+        CommandBehavior commandBehavior = CommandBehavior.Default,
+        CancellationToken cancellationToken = default)
+    {
+        var expected = TakeExpected(ExpectedCallKind.Read, query);
+        var command = RecordCall(ExpectedCallKind.Read, query, parameterProvider, commandBehavior, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (expected.Exception is not null)
+        {
+            throw expected.Exception;
+        }
+
+        if (expected.ResultSets.Length == 0)
+        {
+            return [];
+        }
+
+        var results = new List<TResult>();
+        using var reader = new DataTableReader(expected.ResultSets);
+        var resultSet = 0;
+        do
+        {
+            while (reader.Read())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                results.Add(await selector(reader, resultSet, cancellationToken));
+            }
+
+            resultSet++;
+        }
+        while (reader.NextResult());
+
+        _ = command;
+        return results;
+    }
+
+    public Task<int> ExecuteAsync(
+        string query,
+        Action<IDbCommand>? parameterProvider,
+        CommandBehavior commandBehavior = CommandBehavior.Default,
+        CancellationToken cancellationToken = default)
+    {
+        var expected = TakeExpected(ExpectedCallKind.Execute, query);
+        _ = RecordCall(ExpectedCallKind.Execute, query, parameterProvider, commandBehavior, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return expected.Exception is not null
+            ? Task.FromException<int>(expected.Exception)
+            : Task.FromResult(expected.AffectedRows);
+    }
+
+    private ExpectedCall TakeExpected(ExpectedCallKind kind, string query)
+    {
+        if (!_expectedCalls.TryDequeue(out var expected))
+        {
+            throw new InvalidOperationException($"Unexpected {kind} call for query '{query}'.");
+        }
+
+        if (expected.Kind != kind || !string.Equals(expected.Query, query, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Expected {expected.Kind} call for query '{expected.Query}', but received {kind} call for query '{query}'.");
+        }
+
+        return expected;
+    }
+
+    private RecordingDbCommand RecordCall(
+        ExpectedCallKind kind,
+        string query,
+        Action<IDbCommand>? parameterProvider,
+        CommandBehavior commandBehavior,
+        CancellationToken cancellationToken)
+    {
+        var command = new RecordingDbCommand { CommandText = query };
+        var call = new RecordedStorageCall(kind, query, commandBehavior, cancellationToken, command);
+        _calls.Add(call);
+        parameterProvider?.Invoke(command);
+        return command;
+    }
+
+    private sealed record ExpectedCall(
+        ExpectedCallKind Kind,
+        string Query,
+        DataTable[] ResultSets,
+        int AffectedRows,
+        Exception? Exception);
+}
+
+internal enum ExpectedCallKind
+{
+    Read,
+    Execute,
+}
+
+internal sealed record RecordedStorageCall(
+    ExpectedCallKind Kind,
+    string Query,
+    CommandBehavior CommandBehavior,
+    CancellationToken CancellationToken,
+    RecordingDbCommand Command);
+
+internal sealed class RecordingDbCommand : IDbCommand
+{
+    private readonly RecordingDbParameterCollection _parameters = new();
+
+    [AllowNull]
+    public string CommandText { get; set; } = string.Empty;
+
+    public int CommandTimeout { get; set; }
+
+    public CommandType CommandType { get; set; } = CommandType.Text;
+
+    public IDbConnection? Connection { get; set; }
+
+    public IDataParameterCollection Parameters => _parameters;
+
+    public IDbTransaction? Transaction { get; set; }
+
+    public UpdateRowSource UpdatedRowSource { get; set; }
+
+    public void Cancel() => throw new NotSupportedException();
+
+    public IDbDataParameter CreateParameter() => new RecordingDbParameter();
+
+    public void Dispose()
+    {
+    }
+
+    public int ExecuteNonQuery() => throw new NotSupportedException();
+
+    public IDataReader ExecuteReader() => throw new NotSupportedException();
+
+    public IDataReader ExecuteReader(CommandBehavior behavior) => throw new NotSupportedException();
+
+    public object? ExecuteScalar() => throw new NotSupportedException();
+
+    public void Prepare() => throw new NotSupportedException();
+}
+
+internal sealed class RecordingDbParameter : IDbDataParameter
+{
+    public DbType DbType { get; set; }
+
+    public ParameterDirection Direction { get; set; } = ParameterDirection.Input;
+
+    public bool IsNullable => true;
+
+    [AllowNull]
+    public string ParameterName { get; set; } = string.Empty;
+
+    [AllowNull]
+    public string SourceColumn { get; set; } = string.Empty;
+
+    public DataRowVersion SourceVersion { get; set; } = DataRowVersion.Current;
+
+    public object? Value { get; set; }
+
+    public byte Precision { get; set; }
+
+    public byte Scale { get; set; }
+
+    public int Size { get; set; }
+}
+
+internal sealed class RecordingDbParameterCollection : IDataParameterCollection
+{
+    private readonly List<object?> _items = [];
+
+    [AllowNull]
+    public object this[string parameterName]
+    {
+        get => Find(parameterName)!;
+        set
+        {
+            var index = IndexOf(parameterName);
+            if (index < 0)
+            {
+                Add(value);
+            }
+            else
+            {
+                this[index] = value;
+            }
+        }
+    }
+
+    public object? this[int index]
+    {
+        get => _items[index];
+        set
+        {
+            EnsureParameter(value);
+            _items[index] = value;
+        }
+    }
+
+    public bool IsFixedSize => false;
+
+    public bool IsReadOnly => false;
+
+    public int Count => _items.Count;
+
+    public bool IsSynchronized => false;
+
+    public object SyncRoot => ((ICollection)_items).SyncRoot;
+
+    public int Add(object? value)
+    {
+        EnsureParameter(value);
+        _items.Add(value);
+        return _items.Count - 1;
+    }
+
+    public void Clear() => _items.Clear();
+
+    public bool Contains(string parameterName) => IndexOf(parameterName) >= 0;
+
+    public bool Contains(object? value) => _items.Contains(value);
+
+    public void CopyTo(Array array, int index) => ((ICollection)_items).CopyTo(array, index);
+
+    public IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+    public int IndexOf(string parameterName) =>
+        _items.FindIndex(item =>
+            item is IDataParameter parameter
+            && string.Equals(parameter.ParameterName, parameterName, StringComparison.Ordinal));
+
+    public int IndexOf(object? value) => _items.IndexOf(value);
+
+    public void Insert(int index, object? value)
+    {
+        EnsureParameter(value);
+        _items.Insert(index, value);
+    }
+
+    public void Remove(object? value) => _items.Remove(value);
+
+    public void RemoveAt(string parameterName)
+    {
+        var index = IndexOf(parameterName);
+        if (index >= 0)
+        {
+            _items.RemoveAt(index);
+        }
+    }
+
+    public void RemoveAt(int index) => _items.RemoveAt(index);
+
+    private object? Find(string parameterName)
+    {
+        var index = IndexOf(parameterName);
+        return index >= 0 ? _items[index] : null;
+    }
+
+    private static void EnsureParameter(object? value)
+    {
+        if (value is not IDbDataParameter)
+        {
+            throw new ArgumentException("Only IDbDataParameter instances can be added.", nameof(value));
+        }
+    }
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/Orleans3CompatibleHasherTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/Orleans3CompatibleHasherTests.cs
@@ -1,0 +1,180 @@
+using System.Text;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace UnitTests.StorageTests.Relational;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Persistence")]
+public sealed class Orleans3CompatibleHasherTests
+{
+    [Theory]
+    [InlineData(0, "BD49D10D")]
+    [InlineData(1, "6DDFB8C9")]
+    [InlineData(2, "D1AF6F8A")]
+    [InlineData(3, "C643A2B0")]
+    [InlineData(4, "821CC2DB")]
+    [InlineData(5, "641B59C9")]
+    [InlineData(6, "E44BDCB2")]
+    [InlineData(7, "D074CE9C")]
+    [InlineData(8, "A491F494")]
+    [InlineData(9, "9CAC434C")]
+    [InlineData(10, "AD3B7804")]
+    [InlineData(11, "F189C885")]
+    [InlineData(12, "99BDD9EF")]
+    [InlineData(13, "ECAD9B0D")]
+    public void ComputeHash_ProducesOrleans3CompatibleVector(int length, string expectedHex)
+    {
+        var input = Enumerable.Range(0, length).Select(static value => (byte)value).ToArray();
+
+        var actual = JenkinsHash.ComputeHash(input);
+
+        Assert.Equal(expectedHex, actual.ToString("X8"));
+    }
+
+    [Fact]
+    public void ComputeHash_ProducesIndependentMultiBlockVector()
+    {
+        var input = Enumerable.Range(0, 32).Select(static value => (byte)value).ToArray();
+
+        var actual = JenkinsHash.ComputeHash(input);
+
+        Assert.Equal(0x9E867842u, actual);
+    }
+
+    [Fact]
+    public void Hash_ByteArrayAndSpanProduceSameValue()
+    {
+        var sut = new Orleans3CompatibleHasher();
+        var input = Enumerable.Range(0, 13).Select(static value => (byte)value).ToArray();
+
+        var arrayHash = sut.Hash(input);
+        var spanHash = sut.Hash(input.AsSpan());
+
+        Assert.Equal(unchecked((int)0xECAD9B0D), arrayHash);
+        Assert.Equal(arrayHash, spanHash);
+    }
+
+    [Fact]
+    public void Description_IdentifiesOrleans3Compatibility()
+    {
+        var sut = new Orleans3CompatibleHasher();
+
+        Assert.Equal("Orleans v3 hash function (JenkinsHash).", sut.Description);
+    }
+
+    [Fact]
+    public void HashProviders_ContainsSharedCompatibleHasher()
+    {
+        var sut = new Orleans3CompatibleStorageHashPicker();
+
+        var hasher = Assert.Single(sut.HashProviders);
+
+        Assert.IsType<Orleans3CompatibleHasher>(hasher);
+        Assert.Equal("Orleans v3 hash function (JenkinsHash).", hasher.Description);
+    }
+
+    [Fact]
+    public void PickHasher_ReturnsSharedHasher_ForIntegerAndGuidKeys()
+    {
+        var sut = new Orleans3CompatibleStorageHashPicker();
+        var state = new GrainState<object> { State = new() };
+        var integerId = GrainId.Create(
+            GrainType.Create("integer-grain"),
+            GrainIdKeyExtensions.CreateIntegerKey(0x1234_5678));
+        var guidId = GrainId.Create(
+            GrainType.Create("guid-grain"),
+            GrainIdKeyExtensions.CreateGuidKey(Guid.Parse("751D8030-9C84-4A91-816E-E95F64CE7588")));
+
+        var integerHasher = sut.PickHasher("service", "provider", "integer-grain", integerId, state);
+        var guidHasher = sut.PickHasher("service", "provider", "guid-grain", guidId, state);
+
+        Assert.Same(Assert.Single(sut.HashProviders), integerHasher);
+        Assert.Same(integerHasher, guidHasher);
+    }
+
+    [Fact]
+    public void PickHasher_ReturnsContentAwareHasher_ForStringKey()
+    {
+        var sut = new Orleans3CompatibleStorageHashPicker();
+        var state = new GrainState<object> { State = new() };
+        var grainId = GrainId.Create("customer-grain", "customer/key");
+
+        var first = sut.PickHasher("service", "provider", "customer-grain", grainId, state);
+        var second = sut.PickHasher("service", "provider", "customer-grain", grainId, state);
+
+        Assert.IsType<Orleans3CompatibleStringKeyHasher>(first);
+        Assert.NotSame(Assert.Single(sut.HashProviders), first);
+        Assert.NotSame(first, second);
+        Assert.Equal(unchecked((int)0xE82B5CEF), first.Hash(Encoding.UTF8.GetBytes("customer/key")));
+    }
+
+    [Fact]
+    public void StringHasher_ExtendsKeyWithEightZeroBytes()
+    {
+        var sut = CreateStringHasher("Contoso.CustomerGrain");
+        var key = Encoding.UTF8.GetBytes("customer-42");
+
+        var actual = sut.Hash(key);
+
+        Assert.Equal(unchecked((int)0xB49371FE), actual);
+        Assert.NotEqual(unchecked((int)0x6F645A72), actual);
+    }
+
+    [Fact]
+    public void StringHasher_DoesNotExtendGrainType()
+    {
+        const string GrainType = "Contoso.CustomerGrain";
+        var sut = CreateStringHasher(GrainType);
+
+        var actual = sut.Hash(Encoding.UTF8.GetBytes(GrainType));
+
+        Assert.Equal(unchecked((int)0xFA04865B), actual);
+        Assert.NotEqual(0x42D641BA, actual);
+    }
+
+    [Fact]
+    public void StringHasher_UsesUtf8ForNonAsciiContent()
+    {
+        const string GrainType = "Gräin.東京";
+        var sut = CreateStringHasher(GrainType);
+        var utf8GrainType = Encoding.UTF8.GetBytes(GrainType);
+
+        var actual = sut.Hash(utf8GrainType);
+
+        Assert.Equal(13, utf8GrainType.Length);
+        Assert.Equal(unchecked((int)0xE9A22DAF), actual);
+        Assert.NotEqual(unchecked((int)0xC0B7345C), actual);
+    }
+
+    [Theory]
+    [InlineData(248, 0x2DE3D3DD)]
+    [InlineData(249, 0x113CC853)]
+    public void StringHasher_HandlesStackAndPooledBufferBoundary(int keyLength, int expected)
+    {
+        var sut = CreateStringHasher("T");
+        var key = Enumerable.Range(0, keyLength)
+            .Select(static value => (byte)((value * 37 + 11) % 256))
+            .ToArray();
+
+        var actual = sut.Hash(key);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void StringHasher_PreservesDocumentedEqualContentAmbiguity()
+    {
+        var sut = CreateStringHasher("orders");
+        var contentSharedByKeyAndType = Encoding.UTF8.GetBytes("orders");
+
+        var actual = sut.Hash(contentSharedByKeyAndType);
+
+        Assert.Equal(0x01F833FC, actual);
+        Assert.NotEqual(0x27342C9B, actual);
+    }
+
+    private static Orleans3CompatibleStringKeyHasher CreateStringHasher(string grainType) =>
+        new(new Orleans3CompatibleHasher(), grainType);
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalOrleansQueriesUnitTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalOrleansQueriesUnitTests.cs
@@ -1,0 +1,1402 @@
+using System.Data;
+using System.Net;
+using Orleans;
+using Orleans.GrainDirectory.AdoNet;
+using Orleans.Runtime;
+using Orleans.Streaming.AdoNet;
+using UnitTests.StorageTests.Relational.Fakes;
+using ClusteringQueries = Orleans.Clustering.AdoNet.Storage.RelationalOrleansQueries;
+using DirectoryQueries = Orleans.GrainDirectory.AdoNet.Storage.RelationalOrleansQueries;
+using PersistenceQueries = Orleans.Persistence.AdoNet.Storage.RelationalOrleansQueries;
+using ReminderQueries = Orleans.Reminders.AdoNet.Storage.RelationalOrleansQueries;
+using StreamingQueries = Orleans.Streaming.AdoNet.Storage.RelationalOrleansQueries;
+
+namespace UnitTests.StorageTests.Relational;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Persistence")]
+public sealed class RelationalOrleansQueriesUnitTests
+{
+    private const string GetQueriesSql = "SELECT QueryKey, QueryText FROM OrleansQuery";
+
+    private static readonly string[] ReminderQueryKeys =
+    [
+        "ReadReminderRowsKey",
+        "ReadRangeRows1Key",
+        "ReadRangeRows2Key",
+        "ReadReminderRowKey",
+        "UpsertReminderRowKey",
+        "DeleteReminderRowKey",
+        "DeleteReminderRowsKey",
+    ];
+
+    private static readonly string[] MembershipQueryKeys =
+    [
+        "GatewaysQueryKey",
+        "MembershipReadRowKey",
+        "MembershipReadAllKey",
+        "InsertMembershipVersionKey",
+        "UpdateIAmAlivetimeKey",
+        "InsertMembershipKey",
+        "UpdateMembershipKey",
+        "DeleteMembershipTableEntriesKey",
+        "CleanupDefunctSiloEntriesKey",
+    ];
+
+    private static readonly string[] StreamingQueryKeys =
+    [
+        "QueueStreamMessageKey",
+        "GetStreamMessagesKey",
+        "ConfirmStreamMessagesKey",
+        "FailStreamMessageKey",
+        "EvictStreamMessagesKey",
+        "EvictStreamDeadLettersKey",
+    ];
+
+    private static readonly string[] DirectoryQueryKeys =
+    [
+        "RegisterGrainActivationKey",
+        "UnregisterGrainActivationKey",
+        "LookupGrainActivationKey",
+        "UnregisterGrainActivationsKey",
+    ];
+
+    [Fact]
+    public async Task CreateInstance_LoadsQueriesUsingDbStoredQueriesKey()
+    {
+        var storage = new ScriptedRelationalStorage().ExpectRead(GetQueriesSql, CreateQueryTable());
+
+        _ = await PersistenceQueries.CreateInstance(storage);
+
+        var call = Assert.Single(storage.Calls);
+        Assert.Equal(GetQueriesSql, call.Query);
+        Assert.Empty(call.Command.Parameters);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task CreateInstance_ThrowsWhenStoredQueryIsMissing()
+    {
+        var suppliedKeys = ReminderQueryKeys.Where(key => key != "DeleteReminderRowsKey").ToArray();
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), suppliedKeys);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => ReminderQueries.CreateInstance(storage));
+
+        Assert.Contains("DeleteReminderRowsKey", exception.Message, StringComparison.Ordinal);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task CreateInstance_ThrowsWhenStoredQueryIsDuplicated()
+    {
+        var storage = new ScriptedRelationalStorage().ExpectRead(
+            GetQueriesSql,
+            CreateQueryTable(
+                ("DuplicateKey", "first"),
+                ("DuplicateKey", "second")));
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => PersistenceQueries.CreateInstance(storage));
+
+        Assert.Contains("same key", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task CreateInstance_AcceptsCompleteStoredQuerySet()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys);
+
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        Assert.NotNull(queries);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReminderRange_UsesSignedNonWrappingQueryAndExpectedParameters()
+    {
+        const uint BeginHash = 0x8000_0000;
+        const uint EndHash = 0;
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectRead(Sql("ReadRangeRows1Key"));
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        var result = await queries.ReadReminderRowsAsync("service-a", BeginHash, EndHash);
+
+        Assert.Empty(result.Reminders);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("ReadRangeRows1Key")),
+            ("ServiceId", "service-a"),
+            ("BeginHash", int.MinValue),
+            ("EndHash", 0));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReminderRange_UsesSignedWrapQueryAndExpectedParameters()
+    {
+        const uint BeginHash = 0;
+        const uint EndHash = 0x8000_0000;
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectRead(Sql("ReadRangeRows2Key"));
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        var result = await queries.ReadReminderRowsAsync("service-b", BeginHash, EndHash);
+
+        Assert.Empty(result.Reminders);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("ReadRangeRows2Key")),
+            ("ServiceId", "service-b"),
+            ("BeginHash", 0),
+            ("EndHash", int.MinValue));
+        Assert.False(ReminderQueries.IsReminderRangeNonWrappingInSignedOrder(BeginHash, BeginHash));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadReminderRow_ReturnsNullWhenNoRowsExist()
+    {
+        var grainId = GrainId.Create("reminder-type", "grain-7");
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectRead(Sql("ReadReminderRowKey"));
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        var result = await queries.ReadReminderRowAsync("service-c", grainId, "wake-up");
+
+        Assert.Null(result);
+        var call = AssertOperationCall(storage, Sql("ReadReminderRowKey"));
+        AssertParameters(
+            call,
+            ("ServiceId", "service-c"),
+            ("GrainId", grainId.ToString()),
+            ("ReminderName", "wake-up"));
+        Assert.Equal(DbType.AnsiString, Parameter(call, "GrainId").DbType);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadReminderRow_AggregatesTheReturnedRow()
+    {
+        var grainId = GrainId.Create("reminder-type", "grain-8");
+        var startAt = new DateTime(2026, 8, 27, 12, 30, 0, DateTimeKind.Utc);
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectRead(
+                Sql("ReadReminderRowKey"),
+                CreateTable(
+                    [
+                        ("GrainId", typeof(string)),
+                        ("ReminderName", typeof(string)),
+                        ("StartTime", typeof(DateTime)),
+                        ("Period", typeof(long)),
+                        ("Version", typeof(long)),
+                    ],
+                    [grainId.ToString(), "refresh", startAt, 90_000L, 23L]));
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        var result = await queries.ReadReminderRowAsync("service-d", grainId, "refresh");
+
+        Assert.NotNull(result);
+        Assert.Equal(grainId, result.GrainId);
+        Assert.Equal("refresh", result.ReminderName);
+        Assert.Equal(startAt, result.StartAt);
+        Assert.Equal(TimeSpan.FromSeconds(90), result.Period);
+        Assert.Equal("23", result.ETag);
+        AssertOperationCall(storage, Sql("ReadReminderRowKey"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAllMembershipRows_ReturnsVersionOnlyWhenRowsAreEmpty()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectRead(
+                Sql("MembershipReadAllKey"),
+                CreateTable(
+                    [("StartTime", typeof(DateTime)), ("Version", typeof(long))],
+                    [DBNull.Value, 17L]));
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        var result = await queries.MembershipReadAllAsync("cluster-a");
+
+        Assert.Empty(result.Members);
+        Assert.Equal(17, result.Version.Version);
+        Assert.Equal("17", result.Version.VersionEtag);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("MembershipReadAllKey")),
+            ("DeploymentId", "cluster-a"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAllMembershipRows_ConvertsRowsAndVersion()
+    {
+        var startTime = new DateTime(2026, 8, 27, 10, 0, 0, DateTimeKind.Utc);
+        var aliveTime = startTime.AddMinutes(5);
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectRead(
+                Sql("MembershipReadAllKey"),
+                CreateTable(
+                    [
+                        ("StartTime", typeof(DateTime)),
+                        ("Port", typeof(int)),
+                        ("Generation", typeof(int)),
+                        ("Address", typeof(string)),
+                        ("SiloName", typeof(string)),
+                        ("HostName", typeof(string)),
+                        ("Status", typeof(int)),
+                        ("ProxyPort", typeof(int)),
+                        ("IAmAliveTime", typeof(DateTime)),
+                        ("SuspectTimes", typeof(string)),
+                        ("Version", typeof(long)),
+                    ],
+                    [startTime, 11_111, 9, "127.0.0.1", "silo-a", "host-a", (int)SiloStatus.Active, 30_000, aliveTime, DBNull.Value, 42L]));
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        var result = await queries.MembershipReadAllAsync("cluster-b");
+
+        var member = Assert.Single(result.Members).Item1;
+        Assert.Equal(SiloAddress.New(IPAddress.Loopback, 11_111, 9), member.SiloAddress);
+        Assert.Equal("silo-a", member.SiloName);
+        Assert.Equal("host-a", member.HostName);
+        Assert.Equal(SiloStatus.Active, member.Status);
+        Assert.Equal(30_000, member.ProxyPort);
+        Assert.Equal(startTime, member.StartTime);
+        Assert.Equal(aliveTime, member.IAmAliveTime);
+        Assert.Null(member.SuspectTimes);
+        Assert.Equal(42, result.Version.Version);
+        Assert.Equal("42", result.Version.VersionEtag);
+        AssertOperationCall(storage, Sql("MembershipReadAllKey"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task MembershipMutation_ReturnsResultAndCapturesAllParameters()
+    {
+        var startTime = new DateTime(2026, 8, 27, 8, 0, 0, DateTimeKind.Utc);
+        var aliveTime = startTime.AddMinutes(1);
+        var address = SiloAddress.New(IPAddress.Parse("10.20.30.40"), 12_345, 7);
+        var entry = new MembershipEntry
+        {
+            SiloAddress = address,
+            SiloName = "silo-mutation",
+            HostName = "host-mutation",
+            Status = SiloStatus.Joining,
+            ProxyPort = 30_001,
+            StartTime = startTime,
+            IAmAliveTime = aliveTime,
+        };
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectRead(
+                Sql("InsertMembershipKey"),
+                CreateTable([("Result", typeof(int))], [1]));
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        var result = await queries.InsertMembershipRowAsync("cluster-c", entry, "73");
+
+        Assert.True(result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("InsertMembershipKey")),
+            ("DeploymentId", "cluster-c"),
+            ("IAmAliveTime", aliveTime),
+            ("SiloName", "silo-mutation"),
+            ("HostName", "host-mutation"),
+            ("Address", "10.20.30.40"),
+            ("Port", 12_345),
+            ("Generation", 7),
+            ("StartTime", startTime),
+            ("Status", (int)SiloStatus.Joining),
+            ("ProxyPort", 30_001),
+            ("Version", 73));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task GetStreamMessages_ReturnsRowsSortedByQueueAndSequence()
+    {
+        var now = new DateTime(2026, 8, 27, 16, 0, 0, DateTimeKind.Utc);
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectRead(
+                Sql("GetStreamMessagesKey"),
+                CreateTable(
+                    StreamMessageColumns,
+                    ["service-e", "provider-a", "queue-a", 20L, 2, now, now.AddHours(1), now.AddMinutes(-2), now.AddMinutes(-1), new byte[] { 2, 0 }],
+                    ["service-e", "provider-a", "queue-a", 3L, 1, now, now.AddHours(2), now.AddMinutes(-4), now.AddMinutes(-3), new byte[] { 0, 3 }]));
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var result = await queries.GetStreamMessagesAsync("service-e", "provider-a", "queue-a", 25, 4, 30, 60, 90, 10);
+
+        Assert.Equal([3L, 20L], result.Select(message => message.MessageId));
+        Assert.Equal([0, 3], result[0].Payload);
+        Assert.Equal(2, result[1].Dequeued);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("GetStreamMessagesKey")),
+            ("ServiceId", "service-e"),
+            ("ProviderId", "provider-a"),
+            ("QueueId", "queue-a"),
+            ("MaxCount", 25),
+            ("MaxAttempts", 4),
+            ("VisibilityTimeout", 30),
+            ("RemovalTimeout", 60),
+            ("EvictionInterval", 90),
+            ("EvictionBatchSize", 10));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task GetStreamMessages_ReturnsEmptyWhenNoRowsExist()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectRead(Sql("GetStreamMessagesKey"));
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var result = await queries.GetStreamMessagesAsync("service-f", "provider-b", "queue-b", 5, 2, 10, 20, 30, 4);
+
+        Assert.Empty(result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("GetStreamMessagesKey")),
+            ("ServiceId", "service-f"),
+            ("ProviderId", "provider-b"),
+            ("QueueId", "queue-b"),
+            ("MaxCount", 5),
+            ("MaxAttempts", 2),
+            ("VisibilityTimeout", 10),
+            ("RemovalTimeout", 20),
+            ("EvictionInterval", 30),
+            ("EvictionBatchSize", 4));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ConfirmStreamMessages_EmptySet_DoesNotExecuteMutation()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys);
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var result = await queries.ConfirmStreamMessagesAsync("service-g", "provider-c", "queue-c", []);
+
+        Assert.Empty(result);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ConfirmStreamMessages_CapturesReceiptParameters()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectRead(
+                Sql("ConfirmStreamMessagesKey"),
+                CreateTable(
+                    StreamConfirmationColumns,
+                    ["service-g", "provider-c", "queue-c", 11L],
+                    ["service-g", "provider-c", "queue-c", 12L]));
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var result = await queries.ConfirmStreamMessagesAsync(
+            "service-g",
+            "provider-c",
+            "queue-c",
+            [new(11, 3), new(12, 4)]);
+
+        Assert.Equal([11L, 12L], result.Select(ack => ack.MessageId));
+        Assert.All(result, ack => Assert.Equal("queue-c", ack.QueueId));
+        AssertParameters(
+            AssertOperationCall(storage, Sql("ConfirmStreamMessagesKey")),
+            ("ServiceId", "service-g"),
+            ("ProviderId", "provider-c"),
+            ("QueueId", "queue-c"),
+            ("Items", "11:3|12:4"));
+        storage.VerifyComplete();
+
+        var singletonStorage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectRead(
+                Sql("ConfirmStreamMessagesKey"),
+                CreateTable(StreamConfirmationColumns, ["service-g", "provider-c", "queue-c", 13L]));
+        var singletonQueries = await StreamingQueries.CreateInstance(singletonStorage);
+
+        var singletonResult = await singletonQueries.ConfirmStreamMessagesAsync(
+            "service-g",
+            "provider-c",
+            "queue-c",
+            [new(13, 5)]);
+
+        Assert.Equal([13L], singletonResult.Select(ack => ack.MessageId));
+        AssertParameters(
+            AssertOperationCall(singletonStorage, Sql("ConfirmStreamMessagesKey")),
+            ("ServiceId", "service-g"),
+            ("ProviderId", "provider-c"),
+            ("QueueId", "queue-c"),
+            ("Items", "13:5"));
+        singletonStorage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReleaseStreamMessages_EmptySet_DoesNotExecuteMutation()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys);
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var result = await queries.ReleaseStreamMessagesAsync("service-h", "provider-d", "queue-d", []);
+
+        Assert.Empty(result);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReleaseStreamMessages_CapturesReceiptParameters()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectRead(
+                Sql("ConfirmStreamMessagesKey"),
+                CreateTable(
+                    StreamConfirmationColumns,
+                    ["service-h", "provider-d", "queue-d", 21L],
+                    ["service-h", "provider-d", "queue-d", 22L]));
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var result = await queries.ReleaseStreamMessagesAsync(
+            "service-h",
+            "provider-d",
+            "queue-d",
+            [new(21, 5), new(22, 6)]);
+
+        Assert.Equal([21L, 22L], result.Select(ack => ack.MessageId));
+        AssertParameters(
+            AssertOperationCall(storage, Sql("ConfirmStreamMessagesKey")),
+            ("ServiceId", "service-h"),
+            ("ProviderId", "provider-d"),
+            ("QueueId", "queue-d"),
+            ("Items", "21:-5|22:-6"));
+        storage.VerifyComplete();
+
+        var singletonStorage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectRead(
+                Sql("ConfirmStreamMessagesKey"),
+                CreateTable(StreamConfirmationColumns, ["service-h", "provider-d", "queue-d", 23L]));
+        var singletonQueries = await StreamingQueries.CreateInstance(singletonStorage);
+
+        var singletonResult = await singletonQueries.ReleaseStreamMessagesAsync(
+            "service-h",
+            "provider-d",
+            "queue-d",
+            [new(23, 7)]);
+
+        Assert.Equal([23L], singletonResult.Select(ack => ack.MessageId));
+        AssertParameters(
+            AssertOperationCall(singletonStorage, Sql("ConfirmStreamMessagesKey")),
+            ("ServiceId", "service-h"),
+            ("ProviderId", "provider-d"),
+            ("QueueId", "queue-d"),
+            ("Items", "23:-7"));
+        singletonStorage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task GrainDirectoryLookup_ReturnsSingleEntry()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys)
+            .ExpectRead(
+                Sql("LookupGrainActivationKey"),
+                CreateTable(
+                    DirectoryEntryColumns,
+                    ["cluster-d", "directory-a", "type/key", "127.0.0.1:11111@9", "activation-1"]));
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var result = await queries.LookupGrainActivationAsync("cluster-d", "directory-a", "type/key");
+
+        Assert.Equal(
+            new AdoNetGrainDirectoryEntry("cluster-d", "directory-a", "type/key", "127.0.0.1:11111@9", "activation-1"),
+            result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("LookupGrainActivationKey")),
+            ("ClusterId", "cluster-d"),
+            ("ProviderId", "directory-a"),
+            ("GrainId", "type/key"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task GrainDirectoryLookup_ReturnsDefaultWhenNoRowsExist()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys)
+            .ExpectRead(Sql("LookupGrainActivationKey"));
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var result = await queries.LookupGrainActivationAsync("cluster-e", "directory-b", "type/missing");
+
+        Assert.Null(result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("LookupGrainActivationKey")),
+            ("ClusterId", "cluster-e"),
+            ("ProviderId", "directory-b"),
+            ("GrainId", "type/missing"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task GrainDirectoryLookup_ThrowsWhenMultipleRowsAreReturned()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys)
+            .ExpectRead(
+                Sql("LookupGrainActivationKey"),
+                CreateTable(
+                    DirectoryEntryColumns,
+                    ["cluster-f", "directory-c", "type/duplicate", "127.0.0.1:11111@1", "activation-1"],
+                    ["cluster-f", "directory-c", "type/duplicate", "127.0.0.1:11112@2", "activation-2"]));
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => queries.LookupGrainActivationAsync("cluster-f", "directory-c", "type/duplicate"));
+
+        AssertParameters(
+            AssertOperationCall(storage, Sql("LookupGrainActivationKey")),
+            ("ClusterId", "cluster-f"),
+            ("ProviderId", "directory-c"),
+            ("GrainId", "type/duplicate"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task Operation_PropagatesStorageErrorAcrossProductionCopies()
+    {
+        var expected = new InvalidOperationException("scripted storage failure");
+        var reminderStorage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectReadException(Sql("ReadReminderRowKey"), expected);
+        var reminderQueries = await ReminderQueries.CreateInstance(reminderStorage);
+        var reminderError = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reminderQueries.ReadReminderRowAsync("service-error", GrainId.Create("type", "key"), "name"));
+        Assert.Same(expected, reminderError);
+        AssertOperationCall(reminderStorage, Sql("ReadReminderRowKey"));
+        reminderStorage.VerifyComplete();
+
+        var membershipStorage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectReadException(Sql("MembershipReadAllKey"), expected);
+        var membershipQueries = await ClusteringQueries.CreateInstance(membershipStorage);
+        var membershipError = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => membershipQueries.MembershipReadAllAsync("cluster-error"));
+        Assert.Same(expected, membershipError);
+        AssertOperationCall(membershipStorage, Sql("MembershipReadAllKey"));
+        membershipStorage.VerifyComplete();
+
+        var streamingStorage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectReadException(Sql("GetStreamMessagesKey"), expected);
+        var streamingQueries = await StreamingQueries.CreateInstance(streamingStorage);
+        var streamingError = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => streamingQueries.GetStreamMessagesAsync("service-error", "provider-error", "queue-error", 5, 2, 10, 20, 30, 4));
+        Assert.Same(expected, streamingError);
+        AssertOperationCall(streamingStorage, Sql("GetStreamMessagesKey"));
+        streamingStorage.VerifyComplete();
+
+        var directoryStorage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys)
+            .ExpectReadException(Sql("LookupGrainActivationKey"), expected);
+        var directoryQueries = await DirectoryQueries.CreateInstance(directoryStorage);
+        var directoryError = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => directoryQueries.LookupGrainActivationAsync("cluster-error", "provider-error", "grain-error"));
+        Assert.Same(expected, directoryError);
+        AssertOperationCall(directoryStorage, Sql("LookupGrainActivationKey"));
+        directoryStorage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task RegisterGrainActivationAsync_ReturnsEntryAndCapturesParameters()
+    {
+        var expected = new AdoNetGrainDirectoryEntry(
+            "cluster-register",
+            "directory-register",
+            "registered/type/key",
+            "10.10.20.30:11111@17",
+            "activation-register");
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys)
+            .ExpectRead(
+                Sql("RegisterGrainActivationKey"),
+                CreateTable(
+                    DirectoryEntryColumns,
+                    [expected.ClusterId, expected.ProviderId, expected.GrainId, expected.SiloAddress, expected.ActivationId]));
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var result = await queries.RegisterGrainActivationAsync(
+            expected.ClusterId,
+            expected.ProviderId,
+            expected.GrainId,
+            expected.SiloAddress,
+            expected.ActivationId);
+
+        Assert.Equal(expected, result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("RegisterGrainActivationKey")),
+            ("ClusterId", "cluster-register"),
+            ("ProviderId", "directory-register"),
+            ("GrainId", "registered/type/key"),
+            ("SiloAddress", "10.10.20.30:11111@17"),
+            ("ActivationId", "activation-register"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task UnregisterGrainActivationAsync_ReturnsResultAndCapturesParameters()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys)
+            .ExpectRead(
+                Sql("UnregisterGrainActivationKey"),
+                CreateTable([("Result", typeof(int))], [3]));
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var result = await queries.UnregisterGrainActivationAsync(
+            "cluster-unregister",
+            "directory-unregister",
+            "unregistered/type/key",
+            "activation-unregister");
+
+        Assert.Equal(3, result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("UnregisterGrainActivationKey")),
+            ("ClusterId", "cluster-unregister"),
+            ("ProviderId", "directory-unregister"),
+            ("GrainId", "unregistered/type/key"),
+            ("ActivationId", "activation-unregister"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task UnregisterGrainActivationsAsync_ReturnsCountAndCapturesParameters()
+    {
+        const string SiloAddresses = "10.0.0.1:11111@3|10.0.0.2:11112@4";
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys)
+            .ExpectRead(
+                Sql("UnregisterGrainActivationsKey"),
+                CreateTable([("Result", typeof(int))], [5]));
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var result = await queries.UnregisterGrainActivationsAsync(
+            "cluster-unregister-all",
+            "directory-unregister-all",
+            SiloAddresses);
+
+        Assert.Equal(5, result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("UnregisterGrainActivationsKey")),
+            ("ClusterId", "cluster-unregister-all"),
+            ("ProviderId", "directory-unregister-all"),
+            ("SiloAddresses", SiloAddresses));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task QueueStreamMessageAsync_ReturnsAcknowledgementAndCapturesParameters()
+    {
+        byte[] payload = [0, 1, 127, 255];
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectRead(
+                Sql("QueueStreamMessageKey"),
+                CreateTable(
+                    StreamConfirmationColumns,
+                    ["service-queue", "provider-queue", "queue-queue", 9_876_543_210L]));
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var result = await queries.QueueStreamMessageAsync(
+            "service-queue",
+            "provider-queue",
+            "queue-queue",
+            payload,
+            3_600);
+
+        Assert.Equal(
+            new AdoNetStreamMessageAck("service-queue", "provider-queue", "queue-queue", 9_876_543_210L),
+            result);
+        var call = AssertOperationCall(storage, Sql("QueueStreamMessageKey"));
+        AssertParameters(
+            call,
+            ("ServiceId", "service-queue"),
+            ("ProviderId", "provider-queue"),
+            ("QueueId", "queue-queue"),
+            ("Payload", payload),
+            ("ExpiryTimeout", 3_600));
+        Assert.Equal(payload, Assert.IsType<byte[]>(Parameter(call, "Payload").Value));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task UpsertReminderRowAsync_ReturnsVersionAndCapturesParameters()
+    {
+        var grainId = GrainId.Create("reminder-upsert-type", "grain-upsert");
+        var startTime = new DateTime(2026, 8, 27, 20, 15, 30, DateTimeKind.Utc);
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectRead(
+                Sql("UpsertReminderRowKey"),
+                CreateTable([("Version", typeof(long))], [81L]));
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        var result = await queries.UpsertReminderRowAsync(
+            "service-upsert",
+            grainId,
+            "reminder-upsert",
+            startTime,
+            TimeSpan.FromMilliseconds(123_456));
+
+        Assert.Equal("81", result);
+        var call = AssertOperationCall(storage, Sql("UpsertReminderRowKey"));
+        AssertParameters(
+            call,
+            ("ServiceId", "service-upsert"),
+            ("GrainHash", unchecked((int)grainId.GetUniformHashCode())),
+            ("GrainId", grainId.ToString()),
+            ("ReminderName", "reminder-upsert"),
+            ("StartTime", startTime),
+            ("Period", 123_456));
+        Assert.Equal(DbType.AnsiString, Parameter(call, "GrainId").DbType);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task DeleteReminderRowAsync_ReturnsResultAndCapturesParameters()
+    {
+        var grainId = GrainId.Create("reminder-delete-type", "grain-delete");
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectRead(
+                Sql("DeleteReminderRowKey"),
+                CreateTable([("Result", typeof(int))], [1]));
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        var result = await queries.DeleteReminderRowAsync(
+            "service-delete",
+            grainId,
+            "reminder-delete",
+            "44");
+
+        Assert.True(result);
+        var call = AssertOperationCall(storage, Sql("DeleteReminderRowKey"));
+        AssertParameters(
+            call,
+            ("ServiceId", "service-delete"),
+            ("GrainId", grainId.ToString()),
+            ("ReminderName", "reminder-delete"),
+            ("Version", 44));
+        Assert.Equal(DbType.AnsiString, Parameter(call, "GrainId").DbType);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadReminderRowsAsync_ForGrain_ReturnsEntriesAndCapturesParameters()
+    {
+        var grainId = GrainId.Create("reminder-read-type", "grain-read");
+        var firstStart = new DateTime(2026, 8, 27, 18, 0, 0, DateTimeKind.Utc);
+        var secondStart = firstStart.AddMinutes(15);
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectRead(
+                Sql("ReadReminderRowsKey"),
+                CreateTable(
+                    [
+                        ("GrainId", typeof(string)),
+                        ("ReminderName", typeof(string)),
+                        ("StartTime", typeof(DateTime)),
+                        ("Period", typeof(long)),
+                        ("Version", typeof(long)),
+                    ],
+                    [grainId.ToString(), "first-reminder", firstStart, 45_000L, 91L],
+                    [grainId.ToString(), "second-reminder", secondStart, 120_000L, 92L]));
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        var result = await queries.ReadReminderRowsAsync("service-read", grainId);
+
+        Assert.Collection(
+            result.Reminders,
+            reminder =>
+            {
+                Assert.Equal(grainId, reminder.GrainId);
+                Assert.Equal("first-reminder", reminder.ReminderName);
+                Assert.Equal(firstStart, reminder.StartAt);
+                Assert.Equal(TimeSpan.FromSeconds(45), reminder.Period);
+                Assert.Equal("91", reminder.ETag);
+            },
+            reminder =>
+            {
+                Assert.Equal(grainId, reminder.GrainId);
+                Assert.Equal("second-reminder", reminder.ReminderName);
+                Assert.Equal(secondStart, reminder.StartAt);
+                Assert.Equal(TimeSpan.FromMinutes(2), reminder.Period);
+                Assert.Equal("92", reminder.ETag);
+            });
+        var call = AssertOperationCall(storage, Sql("ReadReminderRowsKey"));
+        AssertParameters(
+            call,
+            ("ServiceId", "service-read"),
+            ("GrainId", grainId.ToString()));
+        Assert.Equal(DbType.AnsiString, Parameter(call, "GrainId").DbType);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public void GetReminderEntry_WithDbNullGrainId_ReturnsNull()
+    {
+        using var reader = new DataTableReader(
+            CreateTable([("GrainId", typeof(string))], [DBNull.Value]));
+        Assert.True(reader.Read());
+
+        var result = ReminderQueries.GetReminderEntry(reader);
+
+        Assert.Null(result);
+        Assert.False(reader.Read());
+    }
+
+    [Fact]
+    public async Task UpdateMembershipRowAsync_ReturnsResultAndCapturesParameters()
+    {
+        var address = SiloAddress.New(IPAddress.Parse("10.30.40.50"), 12_345, 6);
+        var aliveTime = new DateTime(2026, 8, 27, 21, 5, 0, DateTimeKind.Utc);
+        var suspectTime1 = new DateTime(2026, 8, 27, 20, 1, 2, 345, DateTimeKind.Utc);
+        var suspectTime2 = new DateTime(2026, 8, 27, 20, 2, 3, 456, DateTimeKind.Utc);
+        var entry = new MembershipEntry
+        {
+            SiloAddress = address,
+            IAmAliveTime = aliveTime,
+            Status = SiloStatus.Active,
+            SuspectTimes =
+            [
+                Tuple.Create(SiloAddress.New(IPAddress.Parse("10.30.40.60"), 12_346, 7), suspectTime1),
+                Tuple.Create(SiloAddress.New(IPAddress.Parse("10.30.40.70"), 12_347, 8), suspectTime2),
+            ],
+        };
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectRead(
+                Sql("UpdateMembershipKey"),
+                CreateTable([("Result", typeof(int))], [1]));
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        var result = await queries.UpdateMembershipRowAsync("cluster-update", entry, "105");
+
+        Assert.True(result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("UpdateMembershipKey")),
+            ("DeploymentId", "cluster-update"),
+            ("Address", "10.30.40.50"),
+            ("Port", 12_345),
+            ("Generation", 6),
+            ("IAmAliveTime", aliveTime),
+            ("Status", (int)SiloStatus.Active),
+            ("SuspectTimes", "10.30.40.60:12346@7,2026-08-27 20:01:02.345 GMT|10.30.40.70:12347@8,2026-08-27 20:02:03.456 GMT"),
+            ("Version", 105));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ActiveGatewaysAsync_ReturnsUrisAndCapturesStatus()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectRead(
+                Sql("GatewaysQueryKey"),
+                CreateTable(
+                    [("ProxyPort", typeof(int)), ("Generation", typeof(int)), ("Address", typeof(string))],
+                    [30_002, 12, "10.2.3.4"],
+                    [30_003, 13, "10.2.3.5"]));
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        var result = await queries.ActiveGatewaysAsync("cluster-gateways");
+
+        Assert.Equal(
+            [new Uri("gwy.tcp://10.2.3.4:30002/12"), new Uri("gwy.tcp://10.2.3.5:30003/13")],
+            result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("GatewaysQueryKey")),
+            ("DeploymentId", "cluster-gateways"),
+            ("Status", (int)SiloStatus.Active));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task MembershipReadRowAsync_ReturnsEntryAndCapturesParameters()
+    {
+        var address = SiloAddress.New(IPAddress.Parse("10.4.5.6"), 11_222, 14);
+        var startTime = new DateTime(2026, 8, 27, 17, 30, 0, DateTimeKind.Utc);
+        var aliveTime = startTime.AddMinutes(7);
+        var suspectTime = startTime.AddMinutes(3);
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectRead(
+                Sql("MembershipReadRowKey"),
+                CreateTable(
+                    [
+                        ("StartTime", typeof(DateTime)),
+                        ("Port", typeof(int)),
+                        ("Generation", typeof(int)),
+                        ("Address", typeof(string)),
+                        ("SiloName", typeof(string)),
+                        ("HostName", typeof(string)),
+                        ("Status", typeof(int)),
+                        ("ProxyPort", typeof(int)),
+                        ("IAmAliveTime", typeof(DateTime)),
+                        ("SuspectTimes", typeof(string)),
+                        ("Version", typeof(long)),
+                    ],
+                    [
+                        startTime,
+                        11_222,
+                        14,
+                        "10.4.5.6",
+                        "silo-read-row",
+                        "host-read-row",
+                        (int)SiloStatus.Active,
+                        30_004,
+                        aliveTime,
+                        "10.4.5.7:11223@15,2026-08-27 17:33:00.000 GMT",
+                        106L,
+                    ]));
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        var result = await queries.MembershipReadRowAsync("cluster-read-row", address);
+
+        var memberAndEtag = Assert.Single(result.Members);
+        var member = memberAndEtag.Item1;
+        Assert.Equal(string.Empty, memberAndEtag.Item2);
+        Assert.Equal(address, member.SiloAddress);
+        Assert.Equal("silo-read-row", member.SiloName);
+        Assert.Equal("host-read-row", member.HostName);
+        Assert.Equal(SiloStatus.Active, member.Status);
+        Assert.Equal(30_004, member.ProxyPort);
+        Assert.Equal(startTime, member.StartTime);
+        Assert.Equal(aliveTime, member.IAmAliveTime);
+        Assert.NotNull(member.SuspectTimes);
+        var suspect = Assert.Single(member.SuspectTimes);
+        Assert.Equal(SiloAddress.New(IPAddress.Parse("10.4.5.7"), 11_223, 15), suspect.Item1);
+        Assert.Equal(suspectTime, suspect.Item2);
+        Assert.Equal(106, result.Version.Version);
+        Assert.Equal("106", result.Version.VersionEtag);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("MembershipReadRowKey")),
+            ("DeploymentId", "cluster-read-row"),
+            ("Address", "10.4.5.6"),
+            ("Port", 11_222),
+            ("Generation", 14));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task InsertMembershipVersionRowAsync_ReturnsResultAndCapturesDeployment()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectRead(
+                Sql("InsertMembershipVersionKey"),
+                CreateTable([("Result", typeof(int))], [1]));
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        var result = await queries.InsertMembershipVersionRowAsync("cluster-version");
+
+        Assert.True(result);
+        AssertParameters(
+            AssertOperationCall(storage, Sql("InsertMembershipVersionKey")),
+            ("DeploymentId", "cluster-version"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task FailStreamMessageAsync_ExecutesSentinelQueryAndCapturesParameters()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectExecute(Sql("FailStreamMessageKey"), affectedRows: 1);
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        await queries.FailStreamMessageAsync(
+            "service-fail",
+            "provider-fail",
+            "queue-fail",
+            4_294_967_297L,
+            8,
+            7_200);
+
+        AssertParameters(
+            AssertOperationCall(storage, Sql("FailStreamMessageKey"), ExpectedCallKind.Execute),
+            ("ServiceId", "service-fail"),
+            ("ProviderId", "provider-fail"),
+            ("QueueId", "queue-fail"),
+            ("MessageId", 4_294_967_297L),
+            ("MaxAttempts", 8),
+            ("RemovalTimeout", 7_200));
+        storage.VerifyComplete();
+    }
+
+    [Theory]
+    [InlineData(0, "serviceId")]
+    [InlineData(1, "providerId")]
+    [InlineData(2, "queueId")]
+    public async Task QueueStreamMessageAsync_WithNullRequiredArgument_ThrowsArgumentNullException(
+        int nullIndex,
+        string expectedParameterName)
+    {
+        var arguments = new string?[] { "service-null", "provider-null", "queue-null" };
+        arguments[nullIndex] = null;
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys);
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => queries.QueueStreamMessageAsync(
+                arguments[0]!,
+                arguments[1]!,
+                arguments[2]!,
+                [1, 2, 3],
+                60));
+
+        Assert.Equal(expectedParameterName, exception.ParamName);
+        AssertOnlyQueryLoadCall(storage);
+        storage.VerifyComplete();
+    }
+
+    [Theory]
+    [InlineData(0, "clusterId")]
+    [InlineData(1, "providerId")]
+    [InlineData(2, "grainId")]
+    [InlineData(3, "siloAddress")]
+    [InlineData(4, "activationId")]
+    public async Task RegisterGrainActivationAsync_WithNullRequiredArgument_ThrowsArgumentNullException(
+        int nullIndex,
+        string expectedParameterName)
+    {
+        var arguments = new string?[]
+        {
+            "cluster-null",
+            "provider-null",
+            "grain-null",
+            "silo-null",
+            "activation-null",
+        };
+        arguments[nullIndex] = null;
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys);
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => queries.RegisterGrainActivationAsync(
+                arguments[0]!,
+                arguments[1]!,
+                arguments[2]!,
+                arguments[3]!,
+                arguments[4]!));
+
+        Assert.Equal(expectedParameterName, exception.ParamName);
+        AssertOnlyQueryLoadCall(storage);
+        storage.VerifyComplete();
+    }
+
+    [Theory]
+    [InlineData(0, "clusterId")]
+    [InlineData(1, "providerId")]
+    [InlineData(2, "grainId")]
+    [InlineData(3, "activationId")]
+    public async Task UnregisterGrainActivationAsync_WithNullRequiredArgument_ThrowsArgumentNullException(
+        int nullIndex,
+        string expectedParameterName)
+    {
+        var arguments = new string?[]
+        {
+            "cluster-null",
+            "provider-null",
+            "grain-null",
+            "activation-null",
+        };
+        arguments[nullIndex] = null;
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys);
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => queries.UnregisterGrainActivationAsync(
+                arguments[0]!,
+                arguments[1]!,
+                arguments[2]!,
+                arguments[3]!));
+
+        Assert.Equal(expectedParameterName, exception.ParamName);
+        AssertOnlyQueryLoadCall(storage);
+        storage.VerifyComplete();
+    }
+
+    [Theory]
+    [InlineData(0, "clusterId")]
+    [InlineData(1, "providerId")]
+    [InlineData(2, "siloAddresses")]
+    public async Task UnregisterGrainActivationsAsync_WithNullRequiredArgument_ThrowsArgumentNullException(
+        int nullIndex,
+        string expectedParameterName)
+    {
+        var arguments = new string?[]
+        {
+            "cluster-null",
+            "provider-null",
+            "silos-null",
+        };
+        arguments[nullIndex] = null;
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), DirectoryQueryKeys);
+        var queries = await DirectoryQueries.CreateInstance(storage);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => queries.UnregisterGrainActivationsAsync(
+                arguments[0]!,
+                arguments[1]!,
+                arguments[2]!));
+
+        Assert.Equal(expectedParameterName, exception.ParamName);
+        AssertOnlyQueryLoadCall(storage);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task EvictStreamMessagesAsync_ExecutesSentinelQueryAndCapturesParameters()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectExecute(Sql("EvictStreamMessagesKey"), affectedRows: 37);
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        await queries.EvictStreamMessagesAsync(
+            "service-evict",
+            "provider-evict",
+            "queue-evict",
+            37,
+            8,
+            7_200);
+
+        AssertParameters(
+            AssertOperationCall(storage, Sql("EvictStreamMessagesKey"), ExpectedCallKind.Execute),
+            ("ServiceId", "service-evict"),
+            ("ProviderId", "provider-evict"),
+            ("QueueId", "queue-evict"),
+            ("MaxCount", 37),
+            ("MaxAttempts", 8),
+            ("RemovalTimeout", 7_200));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task EvictStreamDeadLettersAsync_ExecutesSentinelQueryAndCapturesParameters()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), StreamingQueryKeys)
+            .ExpectExecute(Sql("EvictStreamDeadLettersKey"), affectedRows: 43);
+        var queries = await StreamingQueries.CreateInstance(storage);
+
+        await queries.EvictStreamDeadLettersAsync(
+            "service-dead-letter",
+            "provider-dead-letter",
+            "queue-dead-letter",
+            43);
+
+        AssertParameters(
+            AssertOperationCall(storage, Sql("EvictStreamDeadLettersKey"), ExpectedCallKind.Execute),
+            ("ServiceId", "service-dead-letter"),
+            ("ProviderId", "provider-dead-letter"),
+            ("QueueId", "queue-dead-letter"),
+            ("MaxCount", 43));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task UpdateIAmAliveTimeAsync_ExecutesSentinelQueryAndCapturesUtcValue()
+    {
+        var address = SiloAddress.New(IPAddress.Parse("10.50.60.70"), 12_345, 9);
+        var aliveTime = new DateTime(2026, 8, 27, 22, 31, 45, DateTimeKind.Utc);
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectExecute(Sql("UpdateIAmAlivetimeKey"), affectedRows: 1);
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        await queries.UpdateIAmAliveTimeAsync("cluster-alive", address, aliveTime);
+
+        var call = AssertOperationCall(storage, Sql("UpdateIAmAlivetimeKey"), ExpectedCallKind.Execute);
+        AssertParameters(
+            call,
+            ("DeploymentId", "cluster-alive"),
+            ("Address", "10.50.60.70"),
+            ("Port", 12_345),
+            ("Generation", 9),
+            ("IAmAliveTime", aliveTime));
+        Assert.Equal(DateTimeKind.Utc, Assert.IsType<DateTime>(Parameter(call, "IAmAliveTime").Value).Kind);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task DeleteReminderRowsAsync_ExecutesSentinelQueryAndCapturesServiceId()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), ReminderQueryKeys)
+            .ExpectExecute(Sql("DeleteReminderRowsKey"), affectedRows: 12);
+        var queries = await ReminderQueries.CreateInstance(storage);
+
+        await queries.DeleteReminderRowsAsync("service-delete-all");
+
+        AssertParameters(
+            AssertOperationCall(storage, Sql("DeleteReminderRowsKey"), ExpectedCallKind.Execute),
+            ("ServiceId", "service-delete-all"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task DeleteMembershipTableEntriesAsync_ExecutesSentinelQueryAndCapturesDeploymentId()
+    {
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectExecute(Sql("DeleteMembershipTableEntriesKey"), affectedRows: 17);
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        await queries.DeleteMembershipTableEntriesAsync("cluster-delete-all");
+
+        AssertParameters(
+            AssertOperationCall(storage, Sql("DeleteMembershipTableEntriesKey"), ExpectedCallKind.Execute),
+            ("DeploymentId", "cluster-delete-all"));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task CleanupDefunctSiloEntriesAsync_ExecutesSentinelQueryAndCapturesUtcDateTime()
+    {
+        var beforeDate = new DateTimeOffset(2026, 8, 28, 4, 15, 30, TimeSpan.FromHours(5.5));
+        var storage = ExpectQueryLoad(new ScriptedRelationalStorage(), MembershipQueryKeys)
+            .ExpectExecute(Sql("CleanupDefunctSiloEntriesKey"), affectedRows: 5);
+        var queries = await ClusteringQueries.CreateInstance(storage);
+
+        await queries.CleanupDefunctSiloEntriesAsync(beforeDate, "cluster-cleanup");
+
+        var call = AssertOperationCall(storage, Sql("CleanupDefunctSiloEntriesKey"), ExpectedCallKind.Execute);
+        AssertParameters(
+            call,
+            ("DeploymentId", "cluster-cleanup"),
+            ("IAmAliveTime", new DateTime(2026, 8, 27, 22, 45, 30, DateTimeKind.Utc)));
+        Assert.Equal(DateTimeKind.Utc, Assert.IsType<DateTime>(Parameter(call, "IAmAliveTime").Value).Kind);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task CreateInstance_WithInvalidInvariantName_DelegatesThroughTwoArgumentFactory()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => PersistenceQueries.CreateInstance("   ", "Data Source=:memory:"));
+
+        Assert.Equal("invariantName", exception.ParamName);
+        Assert.Equal(
+            "The name of invariant must contain characters (Parameter 'invariantName')",
+            exception.Message);
+    }
+
+    [Fact]
+    public void GetQueryKeyAndValue_WithDuplicateColumns_ReturnsExpectedPair()
+    {
+        using var reader = new DataTableReader(
+            CreateTable(
+                [("QueryKey", typeof(string)), ("QueryText", typeof(string))],
+                ["duplicate-query-key", "/* duplicate converter sentinel */ SELECT 42"]));
+        Assert.True(reader.Read());
+        IDataRecord record = reader;
+
+        var result = ReminderQueries.GetQueryKeyAndValue(record);
+
+        Assert.Equal("duplicate-query-key", result.Key);
+        Assert.Equal("/* duplicate converter sentinel */ SELECT 42", result.Value);
+        Assert.False(reader.Read());
+    }
+
+    private static readonly (string Name, Type Type)[] StreamMessageColumns =
+    [
+        ("ServiceId", typeof(string)),
+        ("ProviderId", typeof(string)),
+        ("QueueId", typeof(string)),
+        ("MessageId", typeof(long)),
+        ("Dequeued", typeof(int)),
+        ("VisibleOn", typeof(DateTime)),
+        ("ExpiresOn", typeof(DateTime)),
+        ("CreatedOn", typeof(DateTime)),
+        ("ModifiedOn", typeof(DateTime)),
+        ("Payload", typeof(byte[])),
+    ];
+
+    private static readonly (string Name, Type Type)[] StreamConfirmationColumns =
+    [
+        ("ServiceId", typeof(string)),
+        ("ProviderId", typeof(string)),
+        ("QueueId", typeof(string)),
+        ("MessageId", typeof(long)),
+    ];
+
+    private static readonly (string Name, Type Type)[] DirectoryEntryColumns =
+    [
+        ("ClusterId", typeof(string)),
+        ("ProviderId", typeof(string)),
+        ("GrainId", typeof(string)),
+        ("SiloAddress", typeof(string)),
+        ("ActivationId", typeof(string)),
+    ];
+
+    private static ScriptedRelationalStorage ExpectQueryLoad(
+        ScriptedRelationalStorage storage,
+        IEnumerable<string> keys) =>
+        storage.ExpectRead(
+            GetQueriesSql,
+            CreateQueryTable(keys.Select(key => (key, Sql(key))).ToArray()));
+
+    private static DataTable CreateQueryTable(params (string Key, string Query)[] queries) =>
+        CreateTable(
+            [("QueryKey", typeof(string)), ("QueryText", typeof(string))],
+            queries.Select(query => new object?[] { query.Key, query.Query }).ToArray());
+
+    private static DataTable CreateTable(
+        (string Name, Type Type)[] columns,
+        params object?[][] rows)
+    {
+        var table = new DataTable();
+        foreach (var (name, type) in columns)
+        {
+            table.Columns.Add(name, type);
+        }
+
+        foreach (var row in rows)
+        {
+            table.Rows.Add(row.Select(value => value ?? DBNull.Value).ToArray());
+        }
+
+        return table;
+    }
+
+    private static string Sql(string key) => $"/* sentinel:{key} */ SELECT 1";
+
+    private static RecordedStorageCall AssertOperationCall(
+        ScriptedRelationalStorage storage,
+        string expectedQuery)
+    {
+        Assert.Equal(2, storage.Calls.Count);
+        var call = storage.Calls[1];
+        Assert.Equal(ExpectedCallKind.Read, call.Kind);
+        Assert.Equal(expectedQuery, call.Query);
+        return call;
+    }
+
+    private static void AssertParameters(
+        RecordedStorageCall call,
+        params (string Name, object? Value)[] expected)
+    {
+        var parameters = call.Command.Parameters
+            .Cast<RecordingDbParameter>()
+            .ToDictionary(parameter => parameter.ParameterName, StringComparer.Ordinal);
+        Assert.Equal(expected.Length, parameters.Count);
+        foreach (var (name, value) in expected)
+        {
+            Assert.Equal(value, parameters[name].Value);
+        }
+    }
+
+    private static RecordingDbParameter Parameter(RecordedStorageCall call, string name) =>
+        Assert.IsType<RecordingDbParameter>(call.Command.Parameters[name]);
+
+    private static RecordedStorageCall AssertOperationCall(
+        ScriptedRelationalStorage storage,
+        string expectedQuery,
+        ExpectedCallKind expectedKind)
+    {
+        Assert.Equal(2, storage.Calls.Count);
+        var call = storage.Calls[1];
+        Assert.Equal(expectedKind, call.Kind);
+        Assert.Equal(expectedQuery, call.Query);
+        return call;
+    }
+
+    private static void AssertOnlyQueryLoadCall(ScriptedRelationalStorage storage)
+    {
+        var call = Assert.Single(storage.Calls);
+        Assert.Equal(ExpectedCallKind.Read, call.Kind);
+        Assert.Equal(GetQueriesSql, call.Query);
+        Assert.Empty(call.Command.Parameters);
+    }
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Data.Sqlite;
 using MySql.Data.MySqlClient;
 using Npgsql;
 using Orleans.Tests.SqlUtils;
+using PersistenceRelationalStorage = Orleans.Persistence.AdoNet.Storage.RelationalStorage;
 
 namespace UnitTests.StorageTests.Relational;
 
@@ -93,7 +94,7 @@ public sealed class RelationalStorageDataSourceTests
         var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNamePostgreSql, dataSource);
 
         Assert.Equal(AdoNetInvariants.InvariantNamePostgreSql, storage.InvariantName);
-        Assert.Equal(dataSource.ConnectionString, storage.ConnectionString);
+        Assert.Equal("Host=127.0.0.1;Port=1;Database=unused;Username=unused", storage.ConnectionString);
     }
 
     [Fact]
@@ -107,7 +108,7 @@ public sealed class RelationalStorageDataSourceTests
         var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlServer, dataSource);
 
         Assert.Equal(AdoNetInvariants.InvariantNameSqlServer, storage.InvariantName);
-        Assert.Equal(dataSource.ConnectionString, storage.ConnectionString);
+        Assert.Equal(connectionString, storage.ConnectionString);
     }
 
     [Fact]
@@ -121,7 +122,486 @@ public sealed class RelationalStorageDataSourceTests
         var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameMySql, dataSource);
 
         Assert.Equal(AdoNetInvariants.InvariantNameMySql, storage.InvariantName);
-        Assert.Equal(dataSource.ConnectionString, storage.ConnectionString);
+        Assert.Equal(connectionString, storage.ConnectionString);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReturnsResultSetsInRequestedIndexOrder()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+        var observedTokens = new List<CancellationToken>();
+
+        var results = await fixture.Storage.ReadAsync(
+            "SELECT 'first-a' AS Value UNION ALL SELECT 'first-b'; SELECT 'second' AS Value;",
+            parameterProvider: null,
+            (record, resultSetIndex, cancellationToken) =>
+            {
+                observedTokens.Add(cancellationToken);
+                return Task.FromResult($"{resultSetIndex}:{record.GetString(0)}");
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(["0:first-a", "0:first-b", "1:second"], results);
+        Assert.Equal(3, observedTokens.Count);
+        Assert.All(observedTokens, token => Assert.Equal(TestContext.Current.CancellationToken, token));
+        AssertOperationDisposed(fixture.DataSource, expectReader: true);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReportsRecordsAffected()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+        fixture.ExecuteSetup(
+            """
+            CREATE TABLE Items(Id INTEGER PRIMARY KEY, Value TEXT NOT NULL);
+            INSERT INTO Items(Id, Value) VALUES (1, 'one'), (2, 'two'), (3, 'three');
+            """);
+        var observations = new List<(int ResultSetIndex, int RecordsAffected)>();
+
+        var results = await fixture.Storage.ReadAsync(
+            "UPDATE Items SET Value = Value || '-updated' WHERE Id <= 2; SELECT Id, Value FROM Items ORDER BY Id;",
+            parameterProvider: null,
+            (record, resultSetIndex, _) =>
+            {
+                observations.Add((resultSetIndex, ((DbDataReader)record).RecordsAffected));
+                return Task.FromResult($"{record.GetInt64(0)}:{record.GetString(1)}");
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(["1:one-updated", "2:two-updated", "3:three"], results);
+        Assert.Equal([(0, 2), (0, 2), (0, 2)], observations);
+        Assert.Equal(2L, fixture.ExecuteScalar<long>("SELECT COUNT(*) FROM Items WHERE Value LIKE '%-updated';"));
+        AssertOperationDisposed(fixture.DataSource, expectReader: true);
+    }
+
+    [Fact]
+    public async Task ReadAsync_DisposesResourcesAfterSuccess()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+
+        var results = await fixture.Storage.ReadAsync(
+            "SELECT 17 AS Value UNION ALL SELECT 29;",
+            parameterProvider: null,
+            (record, resultSetIndex, _) => Task.FromResult((resultSetIndex, record.GetInt32(0))),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal([(0, 17), (0, 29)], results);
+        AssertOperationDisposed(fixture.DataSource, expectReader: true);
+        Assert.False(fixture.DataSource.IsDisposed);
+    }
+
+    [Fact]
+    public async Task ReadAsync_DisposesResourcesWhenOpenFails()
+    {
+        var expected = new InvalidOperationException("Simulated open failure.");
+        using var fixture = new RelationalStorageLifecycleFixture(expected);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Storage.ReadAsync(
+            "SELECT 1;",
+            parameterProvider: null,
+            (record, _, _) => Task.FromResult(record.GetInt32(0)),
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Same(expected, exception);
+        Assert.Equal(1, fixture.DataSource.OpenConnectionAsyncCallCount);
+        Assert.Equal(2, fixture.DataSource.Connections.Count);
+        Assert.All(fixture.DataSource.Connections, connection => Assert.True(connection.IsDisposed));
+        var failedConnection = fixture.DataSource.Connections[1];
+        Assert.True(failedConnection.OpenAttempted);
+        Assert.Empty(failedConnection.Commands);
+        Assert.False(fixture.DataSource.IsDisposed);
+    }
+
+    [Fact]
+    public async Task ReadAsync_DisposesResourcesWhenExecuteFails()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+
+        var exception = await Assert.ThrowsAsync<SqliteException>(() => fixture.Storage.ReadAsync(
+            "SELECT MissingColumn FROM MissingTable;",
+            parameterProvider: null,
+            (record, _, _) => Task.FromResult(record.GetInt32(0)),
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("no such table", exception.Message, StringComparison.OrdinalIgnoreCase);
+        var command = AssertOperationDisposed(fixture.DataSource, expectReader: false);
+        Assert.Equal(1, command.ExecuteReaderAsyncCallCount);
+    }
+
+    [Fact]
+    public async Task ReadAsync_DisposesResourcesWhenSelectorFails()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+        var expected = new InvalidOperationException("Selector failure.");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Storage.ReadAsync<int>(
+            "SELECT 11;",
+            parameterProvider: null,
+            (_, _, _) => throw expected,
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Same(expected, exception);
+        var command = AssertOperationDisposed(fixture.DataSource, expectReader: true);
+        Assert.Equal(1, command.ExecuteReaderAsyncCallCount);
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsInvalidResultSetIndex()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => fixture.Storage.ReadAsync<string>(
+            "SELECT 'accepted'; SELECT 'unexpected';",
+            parameterProvider: null,
+            (record, resultSetIndex, _) => resultSetIndex switch
+            {
+                0 => Task.FromResult(record.GetString(0)),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(resultSetIndex),
+                    resultSetIndex,
+                    "Only the first result set is valid for this selector.")
+            },
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("resultSetIndex", exception.ParamName);
+        Assert.Equal(1, exception.ActualValue);
+        AssertOperationDisposed(fixture.DataSource, expectReader: true);
+    }
+
+    [Fact]
+    public async Task ReadAsync_PropagatesCancellationWhenProviderSupportsIt()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var selectorCallCount = 0;
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fixture.Storage.ReadAsync<int>(
+            "SELECT 5 UNION ALL SELECT 8;",
+            parameterProvider: null,
+            (record, resultSetIndex, cancellationToken) =>
+            {
+                Assert.Equal(0, resultSetIndex);
+                Assert.Equal(5, record.GetInt32(0));
+                Assert.Equal(cancellation.Token, cancellationToken);
+                selectorCallCount++;
+                cancellation.Cancel();
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(0);
+            },
+            cancellationToken: cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Equal(1, selectorCallCount);
+        var command = AssertOperationDisposed(fixture.DataSource, expectReader: true);
+        Assert.Equal(1, command.CancelCallCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsAffectedRowsAndDisposesResources()
+    {
+        using var fixture = new RelationalStorageLifecycleFixture();
+        fixture.ExecuteSetup(
+            """
+            CREATE TABLE Items(Id INTEGER PRIMARY KEY, Value TEXT NOT NULL);
+            INSERT INTO Items(Id, Value) VALUES (1, 'one'), (2, 'two'), (3, 'three');
+            """);
+
+        var affectedRows = await fixture.Storage.ExecuteAsync(
+            "UPDATE Items SET Value = upper(Value) WHERE Id <> 2;",
+            parameterProvider: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, affectedRows);
+        Assert.Equal("ONE,two,THREE", fixture.ExecuteScalar<string>(
+            "SELECT group_concat(Value, ',') FROM (SELECT Value FROM Items ORDER BY Id);"));
+        var command = AssertOperationDisposed(fixture.DataSource, expectReader: true);
+        Assert.Equal(1, command.ExecuteReaderAsyncCallCount);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateInstance_WithInvalidInvariantName_ThrowsArgumentException(string? invariantName)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            RelationalStorage.CreateInstance(invariantName!, "Data Source=:memory:"));
+
+        Assert.Equal("invariantName", exception.ParamName);
+        Assert.Equal(
+            "The name of invariant must contain characters (Parameter 'invariantName')",
+            exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateInstance_WithInvalidConnectionString_ThrowsArgumentException(string? connectionString)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlLite, connectionString!));
+
+        Assert.Equal("connectionString", exception.ParamName);
+        Assert.Equal(
+            "Connection string must contain characters (Parameter 'connectionString')",
+            exception.Message);
+    }
+
+    [Fact]
+    public void CreateInstance_WithConnectionString_ReturnsConfiguredStorage()
+    {
+        const string connectionString = "Data Source=:memory:";
+
+        var storage = RelationalStorage.CreateInstance(
+            AdoNetInvariants.InvariantNameSqlLite,
+            connectionString);
+
+        Assert.Equal(AdoNetInvariants.InvariantNameSqlLite, storage.InvariantName);
+        Assert.Equal(connectionString, storage.ConnectionString);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateInstance_WithDataSourceAndInvalidInvariantName_ValidatesBeforeOpening(string? invariantName)
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            RelationalStorage.CreateInstance(invariantName!, dataSource));
+
+        Assert.Equal("invariantName", exception.ParamName);
+        Assert.Empty(dataSource.Connections);
+        Assert.Equal(0, dataSource.OpenConnectionAsyncCallCount);
+        Assert.False(dataSource.IsDisposed);
+    }
+
+    [Fact]
+    public void CreateInstance_WithConnectionStringAndNullDataSource_UsesConnectionString()
+    {
+        const string connectionString = "Data Source=:memory:";
+
+        var storage = RelationalStorage.CreateInstance(
+            AdoNetInvariants.InvariantNameSqlLite,
+            connectionString,
+            dataSource: null);
+
+        Assert.Equal(AdoNetInvariants.InvariantNameSqlLite, storage.InvariantName);
+        Assert.Equal(connectionString, storage.ConnectionString);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WithNullQuery_ThrowsArgumentNullExceptionBeforeOpening()
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+        var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlLite, dataSource);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => storage.ReadAsync<int>(
+            query: null!,
+            parameterProvider: null,
+            (record, _, _) => Task.FromResult(record.GetInt32(0)),
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("query", exception.ParamName);
+        AssertNoConnectionOpened(dataSource);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WithNullSelector_ThrowsArgumentNullExceptionBeforeOpening()
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+        var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlLite, dataSource);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => storage.ReadAsync<int>(
+            "SELECT 1;",
+            parameterProvider: null,
+            selector: null!,
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("selector", exception.ParamName);
+        AssertNoConnectionOpened(dataSource);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNullQuery_ThrowsArgumentNullExceptionBeforeOpening()
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+        var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlLite, dataSource);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => storage.ExecuteAsync(
+            query: null!,
+            parameterProvider: null,
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("query", exception.ParamName);
+        AssertNoConnectionOpened(dataSource);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WithConnectionStringAndParameterProvider_ReturnsExpectedValue()
+    {
+        const string connectionString = "Data Source=:memory:";
+        var storage = RelationalStorage.CreateInstance(
+            AdoNetInvariants.InvariantNameSqlLite,
+            connectionString);
+        System.Data.IDbDataParameter? capturedParameter = null;
+        var parameterProviderCallCount = 0;
+        var selectorCallCount = 0;
+        var observedResultSetIndex = -1;
+        var observedCancellationToken = CancellationToken.None;
+
+        var results = await storage.ReadAsync(
+            "SELECT (@value * 3) + 2;",
+            command =>
+            {
+                parameterProviderCallCount++;
+                capturedParameter = command.CreateParameter();
+                capturedParameter.ParameterName = "@value";
+                capturedParameter.DbType = System.Data.DbType.Int32;
+                capturedParameter.Direction = System.Data.ParameterDirection.Input;
+                capturedParameter.Value = 13;
+                command.Parameters.Add(capturedParameter);
+            },
+            (record, resultSetIndex, cancellationToken) =>
+            {
+                selectorCallCount++;
+                observedResultSetIndex = resultSetIndex;
+                observedCancellationToken = cancellationToken;
+                return Task.FromResult(record.GetInt64(0));
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal([41L], results);
+        Assert.Equal(1, parameterProviderCallCount);
+        Assert.Equal(1, selectorCallCount);
+        Assert.Equal(0, observedResultSetIndex);
+        Assert.Equal(TestContext.Current.CancellationToken, observedCancellationToken);
+        Assert.NotNull(capturedParameter);
+        Assert.Equal("@value", capturedParameter.ParameterName);
+        Assert.Equal(13, capturedParameter.Value);
+        Assert.Equal(System.Data.DbType.Int32, capturedParameter.DbType);
+        Assert.Equal(System.Data.ParameterDirection.Input, capturedParameter.Direction);
+        Assert.Equal(connectionString, storage.ConnectionString);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithConnectionString_ReturnsAffectedRows()
+    {
+        var databaseName = $"relational-storage-connection-string-{Guid.NewGuid():N}";
+        var connectionString = $"Data Source={databaseName};Mode=Memory;Cache=Shared";
+        using var keeper = new SqliteConnection(connectionString);
+        await keeper.OpenAsync(TestContext.Current.CancellationToken);
+        using (var setup = keeper.CreateCommand())
+        {
+            setup.CommandText =
+                """
+                CREATE TABLE Items(Id INTEGER PRIMARY KEY, Value TEXT NOT NULL);
+                INSERT INTO Items(Id, Value) VALUES (1, 'one'), (2, 'two'), (3, 'three');
+                """;
+            Assert.Equal(3, await setup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken));
+        }
+
+        var storage = RelationalStorage.CreateInstance(
+            AdoNetInvariants.InvariantNameSqlLite,
+            connectionString);
+
+        var affectedRows = await storage.ExecuteAsync(
+            "UPDATE Items SET Value = upper(Value) WHERE Id <> 2;",
+            parameterProvider: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, affectedRows);
+        using var verification = keeper.CreateCommand();
+        verification.CommandText =
+            "SELECT group_concat(Value, ',') FROM (SELECT Value FROM Items ORDER BY Id);";
+        Assert.Equal("ONE,two,THREE", await verification.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(connectionString, storage.ConnectionString);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenConnectionStringOpenFails_PropagatesProviderException()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"orleans-relational-storage-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var databasePath = Path.Combine(directory, "missing.db");
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false
+        }.ToString();
+
+        try
+        {
+            var storage = RelationalStorage.CreateInstance(
+                AdoNetInvariants.InvariantNameSqlLite,
+                connectionString);
+            Assert.False(File.Exists(databasePath));
+
+            var exception = await Assert.ThrowsAsync<SqliteException>(() => storage.ReadAsync<int>(
+                "SELECT 1;",
+                parameterProvider: null,
+                (record, _, _) => Task.FromResult(record.GetInt32(0)),
+                cancellationToken: TestContext.Current.CancellationToken));
+
+            Assert.Equal(14, exception.SqliteErrorCode);
+            Assert.Equal(14, exception.SqliteExtendedErrorCode);
+            Assert.Contains("unable to open database file", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(databasePath));
+            Directory.Delete(directory);
+            Assert.False(Directory.Exists(directory));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    private static LifecycleTrackingSqliteCommand AssertOperationDisposed(
+        LifecycleTrackingSqliteDataSource dataSource,
+        bool expectReader)
+    {
+        Assert.Equal(1, dataSource.OpenConnectionAsyncCallCount);
+        Assert.Equal(2, dataSource.Connections.Count);
+        var validationConnection = dataSource.Connections[0];
+        Assert.False(validationConnection.OpenAttempted);
+        Assert.True(validationConnection.IsDisposed);
+        Assert.Empty(validationConnection.Commands);
+
+        var operationConnection = dataSource.Connections[1];
+        Assert.True(operationConnection.OpenAttempted);
+        Assert.True(operationConnection.IsDisposed);
+        Assert.Equal(System.Data.ConnectionState.Closed, operationConnection.State);
+        var command = Assert.Single(operationConnection.Commands);
+        Assert.True(command.IsDisposed);
+        if (expectReader)
+        {
+            var reader = Assert.Single(command.Readers);
+            Assert.True(reader.IsClosed);
+        }
+        else
+        {
+            Assert.Empty(command.Readers);
+        }
+
+        Assert.False(dataSource.IsDisposed);
+        return command;
+    }
+
+    private static void AssertNoConnectionOpened(TrackingSqliteDataSource dataSource)
+    {
+        Assert.Equal(0, dataSource.OpenConnectionAsyncCallCount);
+        var validationConnection = Assert.Single(dataSource.Connections);
+        Assert.True(validationConnection.IsDisposed);
+        Assert.Equal(System.Data.ConnectionState.Closed, validationConnection.Connection.State);
+        Assert.False(dataSource.IsDisposed);
     }
 }
 
@@ -188,4 +668,172 @@ internal sealed class ProviderDbDataSource(string connectionString, Func<DbConne
     public override string ConnectionString { get; } = connectionString;
 
     protected override DbConnection CreateDbConnection() => createConnection();
+}
+
+internal sealed class RelationalStorageLifecycleFixture : IDisposable
+{
+    private readonly SqliteConnection _keeper;
+
+    public RelationalStorageLifecycleFixture(Exception? openException = null)
+    {
+        var databaseName = $"relational-storage-{Guid.NewGuid():N}";
+        var connectionString = $"Data Source={databaseName};Mode=Memory;Cache=Shared";
+        _keeper = new SqliteConnection(connectionString);
+        _keeper.Open();
+        DataSource = new LifecycleTrackingSqliteDataSource(connectionString, openException);
+        Storage = PersistenceRelationalStorage.CreateInstance(
+            AdoNetInvariants.InvariantNameSqlLite,
+            DataSource);
+    }
+
+    public LifecycleTrackingSqliteDataSource DataSource { get; }
+
+    public Orleans.Persistence.AdoNet.Storage.IRelationalStorage Storage { get; }
+
+    public void ExecuteSetup(string sql)
+    {
+        using var command = _keeper.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    public T ExecuteScalar<T>(string sql)
+    {
+        using var command = _keeper.CreateCommand();
+        command.CommandText = sql;
+        return (T)command.ExecuteScalar()!;
+    }
+
+    public void Dispose()
+    {
+        DataSource.Dispose();
+        _keeper.Dispose();
+    }
+}
+
+internal sealed class LifecycleTrackingSqliteDataSource(
+    string connectionString,
+    Exception? openException) : DbDataSource
+{
+    private readonly List<LifecycleTrackingSqliteConnection> _connections = [];
+
+    public override string ConnectionString { get; } = connectionString;
+
+    public IReadOnlyList<LifecycleTrackingSqliteConnection> Connections => _connections;
+
+    public int OpenConnectionAsyncCallCount { get; private set; }
+
+    public bool IsDisposed { get; private set; }
+
+    protected override DbConnection CreateDbConnection()
+    {
+        var connection = new LifecycleTrackingSqliteConnection(ConnectionString, openException);
+        _connections.Add(connection);
+        return connection;
+    }
+
+    protected override async ValueTask<DbConnection> OpenDbConnectionAsync(CancellationToken cancellationToken)
+    {
+        OpenConnectionAsyncCallCount++;
+        var connection = CreateDbConnection();
+        try
+        {
+            await connection.OpenAsync(cancellationToken);
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            IsDisposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+}
+
+internal sealed class LifecycleTrackingSqliteConnection(
+    string connectionString,
+    Exception? openException) : SqliteConnection(connectionString)
+{
+    private readonly List<LifecycleTrackingSqliteCommand> _commands = [];
+
+    public IReadOnlyList<LifecycleTrackingSqliteCommand> Commands => _commands;
+
+    public bool OpenAttempted { get; private set; }
+
+    public bool IsDisposed { get; private set; }
+
+    public override Task OpenAsync(CancellationToken cancellationToken)
+    {
+        OpenAttempted = true;
+        return openException is null
+            ? base.OpenAsync(cancellationToken)
+            : Task.FromException(openException);
+    }
+
+    protected override DbCommand CreateDbCommand()
+    {
+        var command = new LifecycleTrackingSqliteCommand(string.Empty, this);
+        _commands.Add(command);
+        return command;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            IsDisposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+}
+
+internal sealed class LifecycleTrackingSqliteCommand(
+    string commandText,
+    SqliteConnection connection) : SqliteCommand(commandText, connection)
+{
+    private readonly List<DbDataReader> _readers = [];
+
+    public IReadOnlyList<DbDataReader> Readers => _readers;
+
+    public int ExecuteReaderAsyncCallCount { get; private set; }
+
+    public int CancelCallCount { get; private set; }
+
+    public bool IsDisposed { get; private set; }
+
+    public override void Cancel()
+    {
+        CancelCallCount++;
+        base.Cancel();
+    }
+
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
+        System.Data.CommandBehavior behavior,
+        CancellationToken cancellationToken)
+    {
+        ExecuteReaderAsyncCallCount++;
+        var reader = await base.ExecuteDbDataReaderAsync(behavior, cancellationToken);
+        _readers.Add(reader);
+        return reader;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            IsDisposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
@@ -94,7 +94,7 @@ public sealed class RelationalStorageDataSourceTests
         var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNamePostgreSql, dataSource);
 
         Assert.Equal(AdoNetInvariants.InvariantNamePostgreSql, storage.InvariantName);
-        Assert.Equal("Host=127.0.0.1;Port=1;Database=unused;Username=unused", storage.ConnectionString);
+        Assert.Equal(dataSource.ConnectionString, storage.ConnectionString);
     }
 
     [Fact]
@@ -156,20 +156,20 @@ public sealed class RelationalStorageDataSourceTests
             CREATE TABLE Items(Id INTEGER PRIMARY KEY, Value TEXT NOT NULL);
             INSERT INTO Items(Id, Value) VALUES (1, 'one'), (2, 'two'), (3, 'three');
             """);
-        var observations = new List<(int ResultSetIndex, int RecordsAffected)>();
+        var recordsAffected = new List<int>();
 
         var results = await fixture.Storage.ReadAsync(
             "UPDATE Items SET Value = Value || '-updated' WHERE Id <= 2; SELECT Id, Value FROM Items ORDER BY Id;",
             parameterProvider: null,
-            (record, resultSetIndex, _) =>
+            (record, _, _) =>
             {
-                observations.Add((resultSetIndex, ((DbDataReader)record).RecordsAffected));
+                recordsAffected.Add(((DbDataReader)record).RecordsAffected);
                 return Task.FromResult($"{record.GetInt64(0)}:{record.GetString(1)}");
             },
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(["1:one-updated", "2:two-updated", "3:three"], results);
-        Assert.Equal([(0, 2), (0, 2), (0, 2)], observations);
+        Assert.Equal([2, 2, 2], recordsAffected);
         Assert.Equal(2L, fixture.ExecuteScalar<long>("SELECT COUNT(*) FROM Items WHERE Value LIKE '%-updated';"));
         AssertOperationDisposed(fixture.DataSource, expectReader: true);
     }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageExtensionsTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageExtensionsTests.cs
@@ -1,0 +1,329 @@
+using System.Data;
+using System.Data.Common;
+using Orleans.Persistence.AdoNet.Storage;
+using UnitTests.StorageTests.Relational.Fakes;
+
+namespace UnitTests.StorageTests.Relational;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Persistence")]
+public sealed class RelationalStorageExtensionsTests
+{
+    [Fact]
+    public async Task ReadAsync_DelegatesSqlParametersAndSelector()
+    {
+        const string Sql = "SELECT Value FROM Sample WHERE Tenant = @tenant";
+        var storage = new ScriptedRelationalStorage().ExpectRead(
+            Sql,
+            CreateTable(("Value", typeof(int), 42)));
+
+        var results = await storage.ReadAsync(
+            Sql,
+            record => record.GetInt32(0) * 2,
+            command => command.AddParameter(
+                "@tenant",
+                "north",
+                size: 32,
+                dbType: DbType.AnsiString));
+
+        Assert.Equal([84], results);
+        var call = Assert.Single(storage.Calls);
+        Assert.Equal(Sql, call.Query);
+        Assert.Equal(CommandBehavior.Default, call.CommandBehavior);
+        var parameter = AssertParameter(call);
+        Assert.Equal("@tenant", parameter.ParameterName);
+        Assert.Equal("north", parameter.Value);
+        Assert.Equal(DbType.AnsiString, parameter.DbType);
+        Assert.Equal(32, parameter.Size);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_FlowsAcrossResultSetsInOrder()
+    {
+        const string Sql = "SELECT 10 AS Value; SELECT 30 AS Value;";
+        var storage = new ScriptedRelationalStorage().ExpectRead(
+            Sql,
+            CreateTable(("Value", typeof(int), 10), ("Value", typeof(int), 20)),
+            CreateTable(("Value", typeof(int), 30)));
+
+        var results = await storage.ReadAsync(Sql, record => record.GetInt32(0), parameterProvider: null);
+
+        Assert.Equal([10, 20, 30], results);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_UsesReflectionParameterProvider()
+    {
+        const string Sql = "SELECT Name, Count FROM Sample WHERE Tenant = @Tenant AND Optional = @Optional";
+        var storage = new ScriptedRelationalStorage().ExpectRead(
+            Sql,
+            CreateTable(
+                (nameof(ReadProjection.Name), typeof(string), "record-a"),
+                (nameof(ReadProjection.Count), typeof(int), 7)));
+
+        var results = await storage.ReadAsync<ReadProjection>(
+            Sql,
+            new { Tenant = "east", Optional = (string?)null },
+            TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(results);
+        Assert.Equal("record-a", result.Name);
+        Assert.Equal(7, result.Count);
+        var parameters = Assert.Single(storage.Calls).Command.Parameters.Cast<RecordingDbParameter>().ToArray();
+        Assert.Collection(
+            parameters,
+            parameter =>
+            {
+                Assert.Equal("Tenant", parameter.ParameterName);
+                Assert.Equal("east", parameter.Value);
+                Assert.Equal(DbType.String, parameter.DbType);
+            },
+            parameter =>
+            {
+                Assert.Equal("Optional", parameter.ParameterName);
+                Assert.Same(DBNull.Value, parameter.Value);
+                Assert.Equal(DbType.String, parameter.DbType);
+            });
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReturnsEmptyCollectionWhenNoRowsExist()
+    {
+        const string Sql = "SELECT Value FROM EmptySample";
+        var storage = new ScriptedRelationalStorage().ExpectRead(Sql);
+
+        var results = await storage.ReadAsync<int>(Sql, TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+        Assert.Empty(Assert.Single(storage.Calls).Command.Parameters.Cast<object>());
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsNullSelector()
+    {
+        const string Sql = "SELECT Value FROM Sample";
+        var storage = new ScriptedRelationalStorage().ExpectRead(
+            Sql,
+            CreateTable(("Value", typeof(int), 42)));
+
+        var exception = await Assert.ThrowsAsync<NullReferenceException>(
+            () => storage.ReadAsync(Sql, (Func<IDataRecord, int>)null!, parameterProvider: null));
+
+        var call = Assert.Single(storage.Calls);
+        Assert.Equal(Sql, call.Query);
+        Assert.Null(exception.InnerException);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_PropagatesStorageException()
+    {
+        const string Sql = "SELECT Value FROM BrokenSample";
+        var expected = new DataException("scripted read failure");
+        var storage = new ScriptedRelationalStorage().ExpectReadException(Sql, expected);
+
+        var actual = await Assert.ThrowsAsync<DataException>(
+            () => storage.ReadAsync<int>(Sql, TestContext.Current.CancellationToken));
+
+        Assert.Same(expected, actual);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_PropagatesCancellation()
+    {
+        const string Sql = "SELECT Value FROM SlowSample";
+        var storage = new ScriptedRelationalStorage().ExpectRead(Sql);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => storage.ReadAsync<int>(Sql, cancellation.Token));
+
+        var call = Assert.Single(storage.Calls);
+        Assert.Equal(cancellation.Token, call.CancellationToken);
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DelegatesSqlParametersAndReturnsAffectedRows()
+    {
+        const string Sql = "UPDATE Sample SET Value = @Value WHERE Id = @Id";
+        var storage = new ScriptedRelationalStorage().ExpectExecute(Sql, 3);
+
+        var affectedRows = await storage.ExecuteAsync(
+            Sql,
+            new { Value = "updated", Id = 17 },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, affectedRows);
+        var call = Assert.Single(storage.Calls);
+        Assert.Equal(Sql, call.Query);
+        Assert.Equal(CommandBehavior.Default, call.CommandBehavior);
+        Assert.Equal(TestContext.Current.CancellationToken, call.CancellationToken);
+        Assert.Equal(
+            ["updated", 17],
+            call.Command.Parameters.Cast<RecordingDbParameter>().Select(parameter => parameter.Value));
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UsesReflectionParameterProvider()
+    {
+        const string Sql = "DELETE FROM Sample WHERE Tenant = @Tenant AND Sequence = @Sequence";
+        var storage = new ScriptedRelationalStorage().ExpectExecute(Sql, 1);
+
+        var affectedRows = await storage.ExecuteAsync(
+            Sql,
+            new ExecuteParameters { Tenant = "south", Sequence = 99L },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, affectedRows);
+        var parameters = Assert.Single(storage.Calls).Command.Parameters.Cast<RecordingDbParameter>().ToArray();
+        Assert.Collection(
+            parameters,
+            parameter =>
+            {
+                Assert.Equal(nameof(ExecuteParameters.Tenant), parameter.ParameterName);
+                Assert.Equal("south", parameter.Value);
+                Assert.Equal(DbType.String, parameter.DbType);
+            },
+            parameter =>
+            {
+                Assert.Equal(nameof(ExecuteParameters.Sequence), parameter.ParameterName);
+                Assert.Equal(99L, parameter.Value);
+                Assert.Equal(DbType.Int64, parameter.DbType);
+            });
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MapsNullParametersToDbNull()
+    {
+        const string Sql = "UPDATE Sample SET Optional = @Optional";
+        var storage = new ScriptedRelationalStorage().ExpectExecute(Sql, 5);
+
+        var affectedRows = await storage.ExecuteAsync(
+            Sql,
+            new { Optional = (byte[]?)null },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(5, affectedRows);
+        var parameter = AssertParameter(Assert.Single(storage.Calls));
+        Assert.Equal("Optional", parameter.ParameterName);
+        Assert.Same(DBNull.Value, parameter.Value);
+        Assert.Equal(DbType.Binary, parameter.DbType);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PropagatesStorageException()
+    {
+        const string Sql = "DELETE FROM BrokenSample";
+        var expected = new InvalidOperationException("scripted execute failure");
+        var storage = new ScriptedRelationalStorage().ExpectExecuteException(Sql, expected);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.ExecuteAsync(Sql, TestContext.Current.CancellationToken));
+
+        Assert.Same(expected, actual);
+        Assert.Single(storage.Calls);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PropagatesCancellation()
+    {
+        const string Sql = "DELETE FROM SlowSample";
+        var storage = new ScriptedRelationalStorage().ExpectExecute(Sql, 2);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => storage.ExecuteAsync(Sql, cancellation.Token));
+
+        var call = Assert.Single(storage.Calls);
+        Assert.Equal(cancellation.Token, call.CancellationToken);
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        storage.VerifyComplete();
+    }
+
+    [Fact]
+    public async Task GetStream_UsesNativeProviderStream()
+    {
+        var payload = new byte[] { 1, 3, 5, 7, 9 };
+        using var reader = CreateTable(("Payload", typeof(byte[]), payload)).CreateDataReader();
+        Assert.True(reader.Read());
+        var storage = new ScriptedRelationalStorage(AdoNetInvariants.InvariantNameSqlServer);
+
+        await using var stream = reader.GetStream(0, storage);
+
+        Assert.IsNotType<OrleansRelationalDownloadStream>(stream);
+        Assert.Equal(payload, await ReadAllBytesAsync(stream));
+    }
+
+    [Fact]
+    public async Task GetStream_FallsBackToChunkedProviderStream()
+    {
+        var payload = Enumerable.Range(0, 4_500).Select(value => (byte)(value % 251)).ToArray();
+        using var reader = CreateTable(("Payload", typeof(byte[]), payload)).CreateDataReader();
+        Assert.True(reader.Read());
+        var storage = new ScriptedRelationalStorage(AdoNetInvariants.InvariantNameSqlLite);
+
+        await using var stream = reader.GetStream(0, storage);
+
+        Assert.IsType<OrleansRelationalDownloadStream>(stream);
+        Assert.Equal(payload, await ReadAllBytesAsync(stream));
+    }
+
+    private static RecordingDbParameter AssertParameter(RecordedStorageCall call) =>
+        Assert.IsType<RecordingDbParameter>(Assert.Single(call.Command.Parameters.Cast<object>()));
+
+    private static DataTable CreateTable(
+        params (string Name, Type Type, object Value)[] values)
+    {
+        var table = new DataTable();
+        foreach (var group in values.GroupBy(value => value.Name))
+        {
+            table.Columns.Add(group.Key, group.First().Type);
+        }
+
+        foreach (var row in values.Chunk(table.Columns.Count))
+        {
+            table.Rows.Add(row.Select(value => value.Value).ToArray());
+        }
+
+        return table;
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsync(Stream stream)
+    {
+        using var destination = new MemoryStream();
+        await stream.CopyToAsync(destination, TestContext.Current.CancellationToken);
+        return destination.ToArray();
+    }
+
+    private sealed class ReadProjection
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int Count { get; set; }
+    }
+
+    private sealed class ExecuteParameters
+    {
+        public string Tenant { get; init; } = string.Empty;
+
+        public long Sequence { get; init; }
+    }
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageExtensionsTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageExtensionsTests.cs
@@ -108,17 +108,13 @@ public sealed class RelationalStorageExtensionsTests
     public async Task ReadAsync_RejectsNullSelector()
     {
         const string Sql = "SELECT Value FROM Sample";
-        var storage = new ScriptedRelationalStorage().ExpectRead(
-            Sql,
-            CreateTable(("Value", typeof(int), 42)));
+        var storage = new ScriptedRelationalStorage();
 
-        var exception = await Assert.ThrowsAsync<NullReferenceException>(
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
             () => storage.ReadAsync(Sql, (Func<IDataRecord, int>)null!, parameterProvider: null));
 
-        var call = Assert.Single(storage.Calls);
-        Assert.Equal(Sql, call.Query);
-        Assert.Null(exception.InnerException);
-        storage.VerifyComplete();
+        Assert.Equal("selector", exception.ParamName);
+        Assert.Empty(storage.Calls);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #10860

Raises deterministic coverage for shared ADO.NET relational behavior and Orleans 3-compatible hashing using fake ADO.NET infrastructure plus in-memory SQLite lifecycle tests.

The new tests pin stored-query loading, membership/reminder/stream/directory mutations, parameter metadata, cancellation and failure propagation, resource disposal, result-set ordering, and legacy Jenkins hash vectors. Physical linked-source coverage reaches 98.90% line / 96.51% branch for retained relational code and 99.16% line / 95.24% branch for the compatibility hash scope.

Also forwards explicit `DbType` metadata when creating parameters. Removes `ExecuteMultipleInsertIntoAsync` after repository/API/history review found no callers and identified incompatible SQL behavior across supported dialects, including Oracle's required `FROM DUAL`; no replacement dialect contract is introduced.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10892)