### PR TITLE
test(reminders): enable provider failover coverage

### DIFF
--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -410,6 +410,49 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         }
     }
 
+    internal async Task WaitForTopologyToConvergeAsync(
+        CancellationToken cancellationToken,
+        bool didKill = false)
+    {
+        var clusterMembershipOptions = Client!.ServiceProvider
+            .GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
+        var timeout = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
+        var activeSilos = GetActiveSilos().ToArray();
+        var expectedSilos = string.Join(", ", activeSilos.Select(static silo => silo.SiloAddress));
+        var testHooks = activeSilos
+            .Select(static silo => (ITestHooks)silo.ServiceProvider.GetRequiredService<TestHooksSystemTarget>())
+            .ToArray();
+        var gatewayManager = Client.ServiceProvider.GetRequiredService<GatewayManager>();
+        if (!GrainDirectoryObserver.CanObserve(activeSilos))
+        {
+            throw new InvalidOperationException(
+                $"The grain directory cannot report convergence for the expected topology: {expectedSilos}.");
+        }
+
+        var topologyConverged = await LivenessStabilizationHelper
+            .WaitForExpectedActiveSilosAndGatewaysAsync(
+                activeSilos,
+                testHooks,
+                gatewayManager,
+                timeout,
+                remaining => _grainDirectoryObserver.WaitForConvergenceAsync(activeSilos, remaining))
+            .WaitAsync(cancellationToken);
+        if (!topologyConverged)
+        {
+            throw new TimeoutException(
+                $"Membership, gateway, and grain-directory views did not converge within {timeout}. Expected active silos: {expectedSilos}.");
+        }
+
+        var manifestConverged = await ClusterManifestStabilizationHelper
+            .WaitForExpectedClusterManifestAsync(activeSilos, testHooks, timeout)
+            .WaitAsync(cancellationToken);
+        if (!manifestConverged)
+        {
+            throw new TimeoutException(
+                $"Cluster manifests did not converge within {timeout}. Expected active silos: {expectedSilos}.");
+        }
+    }
+
     /// <summary>
     /// Get the timeout value to use to wait for the silo liveness sub-system to detect and act on any recent cluster membership changes.
     /// <seealso cref="WaitForLivenessToStabilizeAsync"/>

--- a/src/Orleans.TestingHost/Orleans.TestingHost.csproj
+++ b/src/Orleans.TestingHost/Orleans.TestingHost.csproj
@@ -26,6 +26,7 @@
     <InternalsVisibleTo Include="Orleans.Placement.Tests" />
     <InternalsVisibleTo Include="Orleans.Runtime.Internal.Tests" />
     <InternalsVisibleTo Include="Orleans.Persistence.Firestore.Tests" />
+    <InternalsVisibleTo Include="Orleans.Reminders.Tests" />
     <InternalsVisibleTo Include="Orleans.Streaming.Tests" />
     <InternalsVisibleTo Include="Orleans.Streaming.Kinesis.Tests" />
     <InternalsVisibleTo Include="Orleans.TestingHost.Tests" />

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -339,31 +339,10 @@ namespace Tester.AzureUtils.TimerTests
             await StopReminderAndWaitForQuiescenceAsync(g2, DR, g2.StopReminder, cts.Token);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/4319"), TestCategory("Functional")]
+        [Fact, TestCategory("Functional")]
         public async Task Rem_Azure_GT_1F1J_MultiGrain()
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
-                TestContext.Current.CancellationToken);
-            cts.CancelAfter(ENDWAIT);
-            _ = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
-
-            IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            IReminderTestCopyGrain g3 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-            IReminderTestCopyGrain g4 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-
-            IAddressable[] grains = [g1, g2, g3, g4];
-            await PrepareForGrainFailureAsync(cts.Token, grains);
-
-            var siloToKill = this.GetReminderOwner(g1, DR);
-            // stop a silo and join a new one in parallel
-            await using (await PauseReminderTimeAsync(cts.Token))
-            {
-                log.LogInformation("Stopping a silo and joining a silo");
-                await this.StopSiloAndStartAdditionalSiloAsync(siloToKill, cts.Token);
-            }
-
-            await CompleteGrainFailureTestAsync(cts.Token, grains);
+            await Test_Reminders_GT_1F1J_MultiGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -21,7 +21,9 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
 {
     public class Fixture : BaseInProcessTestClusterFixture
     {
+        private static readonly TimeSpan ReminderServiceStartupTimeout = TimeSpan.FromMinutes(5);
         private ReminderTestClock? _reminderClock;
+        private readonly ReminderDiagnosticObserver _startupObserver = ReminderDiagnosticObserver.Create();
         internal ReminderTestClock ReminderClock
         {
             get
@@ -45,6 +47,38 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
             });
         }
 
+        public override async ValueTask InitializeAsync()
+        {
+            await base.InitializeAsync();
+            if (!PreconditionsMet)
+            {
+                return;
+            }
+
+            var silos = HostedCluster.Silos.ToArray();
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(ReminderServiceStartupTimeout);
+            var startedTasks = silos
+                .Select(silo => _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress))
+                .ToArray();
+
+            try
+            {
+                await Task.WhenAll(startedTasks);
+            }
+            catch (OperationCanceledException) when (
+                cancellation.IsCancellationRequested
+                && !TestContext.Current.CancellationToken.IsCancellationRequested)
+            {
+                var missing = silos
+                    .Where((_, index) => !startedTasks[index].IsCompletedSuccessfully)
+                    .Select(silo => silo.SiloAddress);
+                throw new TimeoutException(
+                    $"Cosmos reminder services did not start within {ReminderServiceStartupTimeout}. Missing silos: {string.Join(", ", missing)}.");
+            }
+        }
+
         public override async ValueTask DisposeAsync()
         {
             try
@@ -54,6 +88,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
             finally
             {
                 _reminderClock?.Dispose();
+                _startupObserver.Dispose();
             }
         }
     }
@@ -316,30 +351,10 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     }
 
     [TestSuite("Functional")]
-    [Fact(Skip = "https://github.com/dotnet/orleans/issues/4319"), TestCategory("Functional")]
+    [Fact, TestCategory("Functional")]
     public async Task Rem_Azure_GT_1F1J_MultiGrain()
     {
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-        cts.CancelAfter(ENDWAIT);
-        _ = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
-
-        IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        IReminderTestGrain2 g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        IReminderTestCopyGrain g3 = GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-        IReminderTestCopyGrain g4 = GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-
-        IAddressable[] grains = [g1, g2, g3, g4];
-        await PrepareForGrainFailureAsync(cts.Token, grains);
-
-        var siloToKill = GetReminderOwner(g1, DR);
-        // stop a silo and join a new one in parallel
-        await using (await PauseReminderTimeAsync(cts.Token))
-        {
-            log.LogInformation("Stopping a silo and joining a silo");
-            await StopSiloAndStartAdditionalSiloAsync(siloToKill, cts.Token);
-        }
-
-        await CompleteGrainFailureTestAsync(cts.Token, grains);
+        await Test_Reminders_GT_1F1J_MultiGrain(TestContext.Current.CancellationToken);
     }
 
     [TestSuite("Functional")]

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -384,8 +384,13 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
                 failoverJoinTask = StartAdditionalSilosAsync(1, startupCancellation.Token);
                 await Task.WhenAll(stopTask, failoverJoinTask).WaitAsync(cts.Token);
                 _ = Assert.Single(
-                    await WaitForAdditionalSilosAndReminderServicesAsync(failoverJoinTask, cts.Token));
-                await WaitForGrainsReachableAsync(cts.Token, grains);
+                    await WaitForReminderServicesStartedAsync(failoverJoinTask, cts.Token));
+                await InvokeGrainCallsAfterTopologyConvergenceAsync(
+                    cts.Token,
+                    [.. grains.Select(grain => new Func<Task>(async () =>
+                    {
+                        _ = await GetReminderPeriodAsync(grain, DR).WaitAsync(cts.Token);
+                    }))]);
                 await AssertReminderOwnershipAndSchedulesAsync(reminders, failAfter, cts.Token);
                 await AssertReminderCountersAsync(grains, cts.Token, (DR, failAfter));
                 Assert.DoesNotContain(
@@ -394,7 +399,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
                         observer.GetActiveReminderSilos(reminder.Grain.GetGrainId(), reminder.ReminderName)));
             }
 
-            await CompleteGrainFailureTestAsync(cts.Token, grains);
+            await CompleteGrainFailureTestWithoutReachabilityRetriesAsync(cts.Token, grains);
             AssertRemindersStopped(reminders, failCheckAfter);
         }
         finally
@@ -436,9 +441,17 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         Task<List<InProcessSiloHandle>> startSilosTask,
         CancellationToken cancellationToken)
     {
+        var result = await WaitForReminderServicesStartedAsync(startSilosTask, cancellationToken);
+        await WaitForTopologyConvergenceAsync(cancellationToken);
+        return result;
+    }
+
+    private async Task<List<InProcessSiloHandle>> WaitForReminderServicesStartedAsync(
+        Task<List<InProcessSiloHandle>> startSilosTask,
+        CancellationToken cancellationToken)
+    {
         var result = await startSilosTask.WaitAsync(cancellationToken);
-        await observer.WaitForTopologyReconciledAsync(
-            WaitForLivenessToStabilizeAsync(),
+        await observer.WaitForServicesReadyAsync(
             result,
             CHURN_ENDWAIT,
             cancellationToken);
@@ -590,6 +603,13 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         Assert.NotEmpty(grains);
 
         await WaitForGrainsReachableAsync(cancellationToken, grains);
+        await CompleteGrainFailureTestWithoutReachabilityRetriesAsync(cancellationToken, grains);
+    }
+
+    private async Task CompleteGrainFailureTestWithoutReachabilityRetriesAsync(
+        CancellationToken cancellationToken,
+        params IAddressable[] grains)
+    {
         await AdvanceRemindersByTicksAsync((int)(failCheckAfter - failAfter), cancellationToken, GetReminderIdentities(grains, DR));
         await AssertReminderCountersAsync(grains, cancellationToken, (DR, failCheckAfter));
 
@@ -644,14 +664,43 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         for (var attempt = 0; attempt < maximumAttempts; attempt++)
         {
             var grain = GrainFactory.GetGrain<TGrainInterface>(Guid.NewGuid());
-            await StartReminderAsync(grain, DR).WaitAsync(cancellationToken);
-            await SynchronizeReminderSchedulesAsync(cancellationToken, (grain, DR));
-            if (GetReminderOwner(grain, DR).SiloAddress == owner.SiloAddress)
+            var reminderStarted = false;
+            var selected = false;
+            Exception? selectionException = null;
+            try
             {
-                return grain;
+                await StartReminderAsync(grain, DR).WaitAsync(cancellationToken);
+                reminderStarted = true;
+                await SynchronizeReminderSchedulesAsync(cancellationToken, (grain, DR));
+                if (GetReminderOwner(grain, DR).SiloAddress == owner.SiloAddress)
+                {
+                    selected = true;
+                    return grain;
+                }
             }
-
-            await StopRemindersAsync([grain], DR, cancellationToken);
+            catch (Exception exception)
+            {
+                selectionException = exception;
+                throw;
+            }
+            finally
+            {
+                if (reminderStarted && !selected)
+                {
+                    using var cleanupCts = new CancellationTokenSource(ENDWAIT);
+                    try
+                    {
+                        await StopRemindersAsync([grain], DR, cleanupCts.Token);
+                    }
+                    catch (Exception cleanupException) when (selectionException is not null)
+                    {
+                        log.LogWarning(
+                            cleanupException,
+                            "Failed to clean up reminder candidate {GrainId} after selection failed",
+                            grain.GetGrainId());
+                    }
+                }
+            }
         }
 
         throw new InvalidOperationException(
@@ -665,6 +714,24 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
             silo.ServiceProvider.GetRequiredService<LocalReminderService>()
                 .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
         await Task.WhenAll(rangeChangeReconciliations);
+    }
+
+    protected async Task InvokeGrainCallsAfterTopologyConvergenceAsync(
+        CancellationToken cancellationToken,
+        params Func<Task>[] grainCalls)
+    {
+        await WaitForTopologyConvergenceAsync(cancellationToken);
+
+        var callTasks = grainCalls.Select(static grainCall => grainCall()).ToArray();
+        await Task.WhenAll(callTasks).WaitAsync(cancellationToken);
+    }
+
+    private async Task WaitForTopologyConvergenceAsync(CancellationToken cancellationToken)
+    {
+        // Liveness stabilization covers membership, client gateways, and the in-process grain directory.
+        await WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+        await HostedCluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken);
+        await WaitForReminderRangeReconciliationAsync(cancellationToken);
     }
 
     private async Task WaitForGrainsReachableAsync(CancellationToken cancellationToken, params IAddressable[] grains)

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -707,15 +707,6 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
             $"Could not select a {typeof(TGrainInterface).Name} reminder grain owned by {owner.SiloAddress} after {maximumAttempts} attempts.");
     }
 
-    private async Task WaitForReminderRangeReconciliationAsync(CancellationToken cancellationToken)
-    {
-        // Membership convergence does not await the reminder services' queued range-change reconciliation.
-        var rangeChangeReconciliations = HostedCluster.GetActiveSilos().Select(silo =>
-            silo.ServiceProvider.GetRequiredService<LocalReminderService>()
-                .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
-        await Task.WhenAll(rangeChangeReconciliations);
-    }
-
     protected async Task InvokeGrainCallsAfterTopologyConvergenceAsync(
         CancellationToken cancellationToken,
         params Func<Task>[] grainCalls)
@@ -738,7 +729,11 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
     private async Task WaitForTopologyConvergenceAsync(CancellationToken cancellationToken)
     {
         await HostedCluster.WaitForTopologyToConvergeAsync(cancellationToken);
-        await WaitForReminderRangeReconciliationAsync(cancellationToken);
+        await observer.WaitForTopologyReconciledAsync(
+            Task.CompletedTask,
+            [],
+            CHURN_ENDWAIT,
+            cancellationToken);
     }
 
     private async Task WaitForGrainsReachableAsync(CancellationToken cancellationToken, params IAddressable[] grains)

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -353,7 +353,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
     {
         var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(ENDWAIT);
+        cts.CancelAfter(CHURN_ENDWAIT);
         using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
         Task<List<InProcessSiloHandle>>? setupJoinTask = null;
         Task<List<InProcessSiloHandle>>? failoverJoinTask = null;

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -257,7 +257,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, startupCancellation);
+            await CleanupAdditionalSilosAsync(initialSilos, startupCancellation, startSilosTask);
         }
     }
 
@@ -300,7 +300,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         }
         finally
         {
-            await CleanupAdditionalSilosAsync(initialSilos, startSilosTask, startupCancellation);
+            await CleanupAdditionalSilosAsync(initialSilos, startupCancellation, startSilosTask);
         }
     }
 
@@ -349,6 +349,64 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         Assert.Equal(0, observer.GetActiveReminderCount(grainId, DR));
     }
 
+    public async Task Test_Reminders_GT_1F1J_MultiGrain(CancellationToken cancellationToken)
+    {
+        var initialSilos = HostedCluster.GetActiveSilos().ToHashSet();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(ENDWAIT);
+        using var startupCancellation = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        Task<List<InProcessSiloHandle>>? setupJoinTask = null;
+        Task<List<InProcessSiloHandle>>? failoverJoinTask = null;
+
+        try
+        {
+            setupJoinTask = StartAdditionalSilosAsync(1, startupCancellation.Token);
+            var failedSilo = Assert.Single(
+                await WaitForAdditionalSilosAndReminderServicesAsync(setupJoinTask, cts.Token));
+
+            var g1 = await GetGrainOwnedBySiloAsync<IReminderTestGrain2>(failedSilo, cts.Token);
+            var g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+            var g3 = GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
+            var g4 = GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
+            IAddressable[] grains = [g1, g2, g3, g4];
+            var reminders = GetReminderIdentities(grains, DR);
+
+            await PrepareForGrainFailureAsync(cts.Token, grains);
+            await AssertReminderOwnershipAndSchedulesAsync(reminders, failAfter, cts.Token);
+            Assert.Equal(failedSilo.SiloAddress, GetReminderOwner(g1, DR).SiloAddress);
+
+            await using (await PauseReminderTimeAsync(cts.Token))
+            {
+                log.LogInformation(
+                    "Stopping reminder owner {SiloAddress} while joining a replacement silo",
+                    failedSilo.SiloAddress);
+                var stopTask = StopSiloAsync(failedSilo);
+                failoverJoinTask = StartAdditionalSilosAsync(1, startupCancellation.Token);
+                await Task.WhenAll(stopTask, failoverJoinTask).WaitAsync(cts.Token);
+                _ = Assert.Single(
+                    await WaitForAdditionalSilosAndReminderServicesAsync(failoverJoinTask, cts.Token));
+                await WaitForGrainsReachableAsync(cts.Token, grains);
+                await AssertReminderOwnershipAndSchedulesAsync(reminders, failAfter, cts.Token);
+                await AssertReminderCountersAsync(grains, cts.Token, (DR, failAfter));
+                Assert.DoesNotContain(
+                    failedSilo.SiloAddress,
+                    reminders.SelectMany(reminder =>
+                        observer.GetActiveReminderSilos(reminder.Grain.GetGrainId(), reminder.ReminderName)));
+            }
+
+            await CompleteGrainFailureTestAsync(cts.Token, grains);
+            AssertRemindersStopped(reminders, failCheckAfter);
+        }
+        finally
+        {
+            await CleanupAdditionalSilosAsync(
+                initialSilos,
+                startupCancellation,
+                setupJoinTask,
+                failoverJoinTask);
+        }
+    }
+
     protected Task<List<InProcessSiloHandle>> StartAdditionalSilosAsync(
         int silosToStart,
         CancellationToken cancellationToken,
@@ -389,10 +447,10 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
 
     private async Task CleanupAdditionalSilosAsync(
         HashSet<InProcessSiloHandle> initialSilos,
-        Task<List<InProcessSiloHandle>>? startSilosTask,
-        CancellationTokenSource startupCancellation)
+        CancellationTokenSource startupCancellation,
+        params Task<List<InProcessSiloHandle>>?[] startSilosTasks)
     {
-        if (startSilosTask is null)
+        if (startSilosTasks.All(static task => task is null))
         {
             return;
         }
@@ -400,13 +458,22 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
         using var cleanupCts = new CancellationTokenSource(CHURN_ENDWAIT);
         await ReminderLifecycleHarness.CleanupPartialStartupAsync(
             initialSilos,
-            startSilosTask,
+            Task.WhenAll(startSilosTasks.OfType<Task<List<InProcessSiloHandle>>>()),
             () => HostedCluster.GetActiveSilos().ToArray(),
             StopSiloAsync,
-            () => WaitForLivenessToStabilizeAsync(didKill: true),
+            () => observer.WaitForTopologyReconciledAsync(
+                WaitForLivenessToStabilizeAsync(didKill: true),
+                [],
+                CHURN_ENDWAIT,
+                cleanupCts.Token),
             log,
             startupCancellation,
             cleanupCts.Token);
+
+        var activeSilos = HostedCluster.GetActiveSilos().ToHashSet();
+        Assert.True(
+            initialSilos.SetEquals(activeSilos),
+            $"Reminder test did not restore its baseline topology. Expected: {string.Join(", ", initialSilos.Select(static silo => silo.SiloAddress))}; actual: {string.Join(", ", activeSilos.Select(static silo => silo.SiloAddress))}.");
     }
 
     protected async Task<InProcessSiloHandle> StopSiloAndStartAdditionalSiloAsync(
@@ -531,6 +598,73 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
             await GetReminderPeriodAsync(grains[0], DR).WaitAsync(cancellationToken),
             cancellationToken);
         await AssertReminderCountersAsync(grains, cancellationToken, (DR, failCheckAfter));
+    }
+
+    private async Task AssertReminderOwnershipAndSchedulesAsync(
+        (IAddressable Grain, string ReminderName)[] reminders,
+        long expectedTickCount,
+        CancellationToken cancellationToken)
+    {
+        await SynchronizeReminderSchedulesAsync(cancellationToken, reminders);
+        var activeSilos = HostedCluster.GetActiveSilos();
+
+        foreach (var reminder in reminders)
+        {
+            var grainId = reminder.Grain.GetGrainId();
+            var actualOwner = Assert.Single(observer.GetActiveReminderSilos(grainId, reminder.ReminderName));
+
+            Assert.Equal(1, observer.GetActiveReminderCount(grainId, reminder.ReminderName));
+            Assert.Contains(activeSilos, silo => silo.SiloAddress == actualOwner);
+            Assert.Equal(expectedTickCount, (long)observer.GetTickCount(grainId, reminder.ReminderName));
+        }
+    }
+
+    private void AssertRemindersStopped(
+        (IAddressable Grain, string ReminderName)[] reminders,
+        long expectedTickCount)
+    {
+        foreach (var reminder in reminders)
+        {
+            var grainId = reminder.Grain.GetGrainId();
+            Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminder.ReminderName));
+            Assert.Empty(observer.GetActiveReminderSilos(grainId, reminder.ReminderName));
+            Assert.Equal(expectedTickCount, (long)observer.GetTickCount(grainId, reminder.ReminderName));
+        }
+    }
+
+    private async Task<TGrainInterface> GetGrainOwnedBySiloAsync<TGrainInterface>(
+        InProcessSiloHandle owner,
+        CancellationToken cancellationToken)
+        where TGrainInterface : IGrainWithGuidKey
+    {
+        const int maximumAttempts = 1_000;
+
+        // Select a key in the joined silo's range so the test always removes a real reminder owner
+        // while leaving every baseline silo available for subsequent shared-fixture tests.
+        for (var attempt = 0; attempt < maximumAttempts; attempt++)
+        {
+            var grain = GrainFactory.GetGrain<TGrainInterface>(Guid.NewGuid());
+            await StartReminderAsync(grain, DR).WaitAsync(cancellationToken);
+            await SynchronizeReminderSchedulesAsync(cancellationToken, (grain, DR));
+            if (GetReminderOwner(grain, DR).SiloAddress == owner.SiloAddress)
+            {
+                return grain;
+            }
+
+            await StopRemindersAsync([grain], DR, cancellationToken);
+        }
+
+        throw new InvalidOperationException(
+            $"Could not select a {typeof(TGrainInterface).Name} reminder grain owned by {owner.SiloAddress} after {maximumAttempts} attempts.");
+    }
+
+    private async Task WaitForReminderRangeReconciliationAsync(CancellationToken cancellationToken)
+    {
+        // Membership convergence does not await the reminder services' queued range-change reconciliation.
+        var rangeChangeReconciliations = HostedCluster.GetActiveSilos().Select(silo =>
+            silo.ServiceProvider.GetRequiredService<LocalReminderService>()
+                .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
+        await Task.WhenAll(rangeChangeReconciliations);
     }
 
     private async Task WaitForGrainsReachableAsync(CancellationToken cancellationToken, params IAddressable[] grains)

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -719,8 +719,17 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
     protected async Task InvokeGrainCallsAfterTopologyConvergenceAsync(
         CancellationToken cancellationToken,
         params Func<Task>[] grainCalls)
+        => await InvokeGrainCallsAfterTopologyConvergenceAsync(
+            WaitForTopologyConvergenceAsync,
+            cancellationToken,
+            grainCalls);
+
+    protected static async Task InvokeGrainCallsAfterTopologyConvergenceAsync(
+        Func<CancellationToken, Task> topologyConvergence,
+        CancellationToken cancellationToken,
+        params Func<Task>[] grainCalls)
     {
-        await WaitForTopologyConvergenceAsync(cancellationToken);
+        await topologyConvergence(cancellationToken);
 
         var callTasks = grainCalls.Select(static grainCall => grainCall()).ToArray();
         await Task.WhenAll(callTasks).WaitAsync(cancellationToken);
@@ -728,9 +737,7 @@ public class ReminderTestsBase : OrleansTestingBase, IAsyncDisposable
 
     private async Task WaitForTopologyConvergenceAsync(CancellationToken cancellationToken)
     {
-        // Liveness stabilization covers membership, client gateways, and the in-process grain directory.
-        await WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
-        await HostedCluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken);
+        await HostedCluster.WaitForTopologyToConvergeAsync(cancellationToken);
         await WaitForReminderRangeReconciliationAsync(cancellationToken);
     }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -7,6 +7,7 @@ using System.Reactive.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Internal;
 using Orleans.Reminders;
+using Orleans.Runtime;
 using Orleans.Runtime.ReminderService;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
@@ -210,6 +211,33 @@ namespace UnitTests.TimerTests
         public async Task Rem_Grain_GT_1F1J_MultiGrain()
         {
             await Test_Reminders_GT_1F1J_MultiGrain(TestContext.Current.CancellationToken);
+        }
+
+        [Fact]
+        public async Task Rem_Grain_PostTopologyConvergence_DoesNotSuppressMessageRejection()
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
+            var rejection = (OrleansMessageRejectionException)System.Runtime.CompilerServices.RuntimeHelpers
+                .GetUninitializedObject(typeof(OrleansMessageRejectionException));
+            var callCounts = new int[4];
+
+            var actual = await Assert.ThrowsAsync<OrleansMessageRejectionException>(() =>
+                InvokeGrainCallsAfterTopologyConvergenceAsync(
+                    cts.Token,
+                    CreateCall(0),
+                    CreateCall(1),
+                    CreateCall(2, rejection),
+                    CreateCall(3)));
+
+            Assert.Same(rejection, actual);
+            Assert.All(callCounts, count => Assert.Equal(1, count));
+
+            Func<Task> CreateCall(int index, Exception? exception = null) => () =>
+            {
+                callCounts[index]++;
+                return exception is null ? Task.CompletedTask : Task.FromException(exception);
+            };
         }
 
         [Fact]

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -207,6 +207,12 @@ namespace UnitTests.TimerTests
         }
 
         [Fact]
+        public async Task Rem_Grain_GT_1F1J_MultiGrain()
+        {
+            await Test_Reminders_GT_1F1J_MultiGrain(TestContext.Current.CancellationToken);
+        }
+
+        [Fact]
         public async Task Rem_Grain_CanRestartBeforeRemovedReminderIsPurged()
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -241,6 +241,28 @@ namespace UnitTests.TimerTests
         }
 
         [Fact]
+        public async Task Rem_Grain_TopologyConvergenceTimeout_PreventsGrainCalls()
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cts.CancelAfter(TestConstants.InitTimeout);
+            var timeout = new TimeoutException("Controlled topology convergence timeout.");
+            var callCount = 0;
+
+            var actual = await Assert.ThrowsAsync<TimeoutException>(() =>
+                InvokeGrainCallsAfterTopologyConvergenceAsync(
+                    _ => Task.FromException(timeout),
+                    cts.Token,
+                    () =>
+                    {
+                        callCount++;
+                        return Task.CompletedTask;
+                    }));
+
+            Assert.Same(timeout, actual);
+            Assert.Equal(0, callCount);
+        }
+
+        [Fact]
         public async Task Rem_Grain_CanRestartBeforeRemovedReminderIsPurged()
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -218,8 +218,12 @@ namespace UnitTests.TimerTests
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(TestConstants.InitTimeout);
-            var rejection = (OrleansMessageRejectionException)System.Runtime.CompilerServices.RuntimeHelpers
-                .GetUninitializedObject(typeof(OrleansMessageRejectionException));
+            var rejection = (OrleansMessageRejectionException)Activator.CreateInstance(
+                typeof(OrleansMessageRejectionException),
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                args: ["Controlled post-convergence rejection."],
+                culture: null)!;
             var callCounts = new int[4];
 
             var actual = await Assert.ThrowsAsync<OrleansMessageRejectionException>(() =>


### PR DESCRIPTION
Closes #4319

## Problem
The Azure Table and Cosmos generic-type reminder failover tests remained skipped because their original worker tasks kept calling grains while a silo was shutting down. The tests also raced reminder-service startup, membership convergence, and ownership reconciliation, then left joined silos in their shared fixtures.

## Solution
Move the scenario into `ReminderTestsBase` with one fake-time driver and explicit startup, ownership, schedule, tick, and counter barriers. Add a fail-closed TestingHost barrier which requires the expected membership, gateway, grain-directory, and manifest views before reminder reconciliation; a timeout throws before any grain call runs. After convergence, invoke each grain exactly once and propagate any rejection. Select a reminder actually owned by the disposable joined silo, replace that silo during failover, and restore the exact baseline topology in `finally`. Enable the Azure Table and Cosmos cases, add the in-memory equivalent, and cover rejection and timeout propagation directly.

## Rationale
This preserves the intended one-failure/one-join topology while removing shutdown-call races without hiding the original failure mode. The scenario validates real ownership recovery across both grain implementations without weakening assertions or contaminating later fixture tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10895)