### PR TITLE
test(reminders): add lifecycle conformance scenarios

### DIFF
--- a/src/Orleans.Reminders.TestKit/README.md
+++ b/src/Orleans.Reminders.TestKit/README.md
@@ -213,7 +213,15 @@ public sealed class MyLifecycleTests : ReminderServiceLifecycleTestRunner
 ```
 
 Do not replace harness barriers with delays, retry loops, longer timeouts, or provider-specific skips. Scenario cleanup
-unregisters only deterministic scenario identities and verifies their absence; it never clears unrelated provider rows.
+uses its own bounded token, unregisters only deterministic scenario identities, and verifies their absence; it never
+clears unrelated provider rows or replaces the original scenario failure. Ownership assertions count local reminder
+instance identities, including duplicate instances on one silo, rather than counting distinct silo addresses.
+
+The built-in in-memory, Azure Table, Cosmos DB, ADO.NET SQL Server, PostgreSQL, MySQL, Redis, DynamoDB, and Firestore
+providers all expose these same inherited facts. Their adapters contain only backend precondition/setup and provider
+registration. External-service availability can skip fixture construction, but no provider disables individual
+lifecycle guarantees. Add a documented capability boundary here before omitting a future provider which cannot host
+the Orleans reminder service or participate in in-process silo churn.
 
 ## Deterministic oracle and cluster testing
 
@@ -242,7 +250,9 @@ The oracle exposes:
 - `FreezeReads` for stale-read convergence scenarios; and
 - lifecycle cancellation and invariant checks.
 
-The TestKit cluster integration suite uses these controls to cover exact-due delivery, exact-due storage recovery,
+`ReminderTestClock` creates its lifecycle observer before the cluster is built, allowing startup conformance to await
+one `ReminderServiceStarted` event for every silo before liveness and range-reconciliation barriers. The TestKit
+cluster integration suite uses these controls to cover exact-due delivery, exact-due storage recovery,
 due times beyond the platform timer limit, stale-refresh suppression after unregister, and single-owner delivery in a
 multi-silo cluster.
 

--- a/src/Orleans.Reminders.TestKit/README.md
+++ b/src/Orleans.Reminders.TestKit/README.md
@@ -12,6 +12,8 @@ cardinality setup and cleanup, bounded retries, diagnostics, and failure message
 | --- | --- |
 | `ReminderTableTestRunner` | Direct conformance facts for every documented table guarantee. |
 | `ReminderServiceTestRunner` | Cluster-level registration, replacement, lookup, enumeration, and removal conformance. |
+| `ReminderServiceLifecycleTestRunner` | Deterministic startup, ownership, exact-due, reconciliation, churn, and cleanup-isolation conformance. |
+| `IReminderServiceLifecycleHarness` | Adapter contract for one cluster, one reminder clock, diagnostics, and explicit topology barriers. |
 | `ReminderTableModelBasedTestRunner` | Generated sequential conformance against the same full contract. |
 | `IdealizedReminderTable` | Deterministic, strongly consistent reference implementation and fault-injection oracle. |
 | `ReminderTableTestFixture` | In-process cluster fixture which deploys and resolves a provider. |
@@ -172,6 +174,46 @@ public sealed class MyReminderServiceTests
         => base.ReminderService_UpdateReplacesScheduleAndETagWithoutDuplicate();
 }
 ```
+
+### Run lifecycle and churn conformance
+
+`ReminderServiceLifecycleTestRunner` adds the shared service-level contract. The same eight scenarios run for every
+service provider: startup readiness, single registration ownership, in-place schedule update, removal quiescence,
+exact-due recovery, stale-owner registration reconciliation, one-silo join/leave transfer, and cleanup isolation.
+
+Use `ReminderTestClock` as the sole time driver and `ReminderDiagnosticObserver` as the lifecycle/tick source. The
+`ReminderServiceLifecycleHarness` adapter for `InProcessTestCluster` supplies explicit membership and reminder-range
+reconciliation barriers:
+
+```csharp
+var observer = ReminderDiagnosticObserver.Create(); // create before deployment
+var clock = builder.AddReminderTestClock();
+var cluster = builder.Build();
+await cluster.DeployAsync();
+
+var options = cluster.Silos[0].ServiceProvider
+    .GetRequiredService<IOptions<ReminderOptions>>().Value;
+var harness = new ReminderServiceLifecycleHarness(
+    cluster,
+    clock,
+    observer,
+    options.ReminderLoadingWindow);
+
+public sealed class MyLifecycleTests : ReminderServiceLifecycleTestRunner
+{
+    public MyLifecycleTests(IReminderServiceLifecycleHarness harness)
+        : base(harness, "MyProvider", seed: 42)
+    {
+    }
+
+    [Fact]
+    public override Task ReminderService_OneSiloJoinLeaveTransfersOwnership()
+        => base.ReminderService_OneSiloJoinLeaveTransfersOwnership();
+}
+```
+
+Do not replace harness barriers with delays, retry loops, longer timeouts, or provider-specific skips. Scenario cleanup
+unregisters only deterministic scenario identities and verifies their absence; it never clears unrelated provider rows.
 
 ## Deterministic oracle and cluster testing
 

--- a/src/Orleans.Reminders.TestKit/README.md
+++ b/src/Orleans.Reminders.TestKit/README.md
@@ -213,9 +213,10 @@ public sealed class MyLifecycleTests : ReminderServiceLifecycleTestRunner
 ```
 
 Do not replace harness barriers with delays, retry loops, longer timeouts, or provider-specific skips. Scenario cleanup
-uses its own bounded token, unregisters only deterministic scenario identities, and verifies their absence; it never
-clears unrelated provider rows or replaces the original scenario failure. Ownership assertions count local reminder
-instance identities, including duplicate instances on one silo, rather than counting distinct silo addresses.
+uses its own bounded token, removes only deterministic scenario rows using their current ETags, advances one explicit
+refresh for owner quiescence, and verifies their absence; it never clears unrelated provider rows or replaces the
+original scenario failure. Ownership assertions count local reminder instance identities, including duplicate
+instances on one silo, rather than counting distinct silo addresses.
 
 The built-in in-memory, Azure Table, Cosmos DB, ADO.NET SQL Server, PostgreSQL, MySQL, Redis, DynamoDB, and Firestore
 providers all expose these same inherited facts. Their adapters contain only backend precondition/setup and provider

--- a/src/Orleans.Reminders.TestKit/README.md
+++ b/src/Orleans.Reminders.TestKit/README.md
@@ -186,7 +186,6 @@ Use `ReminderTestClock` as the sole time driver and `ReminderDiagnosticObserver`
 reconciliation barriers:
 
 ```csharp
-var observer = ReminderDiagnosticObserver.Create(); // create before deployment
 var clock = builder.AddReminderTestClock();
 var cluster = builder.Build();
 await cluster.DeployAsync();
@@ -196,7 +195,7 @@ var options = cluster.Silos[0].ServiceProvider
 var harness = new ReminderServiceLifecycleHarness(
     cluster,
     clock,
-    observer,
+    clock.DiagnosticObserver,
     options.ReminderLoadingWindow);
 
 public sealed class MyLifecycleTests : ReminderServiceLifecycleTestRunner

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -302,9 +302,11 @@ public abstract class ReminderServiceLifecycleTestRunner
                 var owner = _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
                 await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
                 await owner;
+                await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
                 var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-                await _harness.AdvanceAsync(_harness.ReminderLoadingWindow, cancellationToken);
+                await _harness.AdvanceAsync(expectedStart - _harness.UtcNow.UtcDateTime, cancellationToken);
                 await tick;
                 await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
                 AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
@@ -347,6 +349,13 @@ public abstract class ReminderServiceLifecycleTestRunner
                         .ToArray();
                     await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
                     await Task.WhenAll(ownerWaits);
+                    await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                    await Task.WhenAll(reminders.Select(item =>
+                        _harness.WaitForOwnerCountAsync(
+                            item.Grain.GetGrainId(),
+                            item.Name,
+                            1,
+                            cancellationToken)));
                     foreach (var (grain, name) in reminders)
                     {
                         phase = $"schedule reconciliation for {grain.GetGrainId()}/{name}";
@@ -414,6 +423,13 @@ public abstract class ReminderServiceLifecycleTestRunner
                         item.Name,
                         1,
                         cancellationToken)));
+                await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                await Task.WhenAll(reminders.Select(item =>
+                    _harness.WaitForOwnerCountAsync(
+                        item.Grain.GetGrainId(),
+                        item.Name,
+                        1,
+                        cancellationToken)));
                 var transferred = 0;
                 (IReminderServiceTestGrain Grain, string Name)? transferredReminder = null;
                 foreach (var (grain, name) in reminders)
@@ -436,6 +452,13 @@ public abstract class ReminderServiceLifecycleTestRunner
 
                 await _harness.LeaveSiloAsync(joined, cancellationToken);
                 joined = null;
+                await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                await Task.WhenAll(reminders.Select(item =>
+                    _harness.WaitForOwnerCountAsync(
+                        item.Grain.GetGrainId(),
+                        item.Name,
+                        1,
+                        cancellationToken)));
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
                 await Task.WhenAll(reminders.Select(item =>
                     _harness.WaitForOwnerCountAsync(

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -159,7 +159,7 @@ public abstract class ReminderServiceLifecycleTestRunner
             {
                 var expectedStart = _harness.UtcNow.UtcDateTime + due;
                 await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
-                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await WaitForOwnersAfterRefreshAsync([(grain, Name)], cancellationToken);
                 if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 1)
                 {
                     OwnershipFailure(Guarantee, grain.GetGrainId(), Name, 1).Throw();
@@ -190,7 +190,7 @@ public abstract class ReminderServiceLifecycleTestRunner
             async () =>
             {
                 await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await WaitForOwnersAfterRefreshAsync([(grain, Name)], cancellationToken);
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
                 var original = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
                 var owners = _harness.GetOwners(grain.GetGrainId(), Name).ToArray();
@@ -246,7 +246,7 @@ public abstract class ReminderServiceLifecycleTestRunner
             async () =>
             {
                 await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await WaitForOwnersAfterRefreshAsync([(grain, Name)], cancellationToken);
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
 
                 if (!await grain.UnregisterAsync(Name).WaitAsync(cancellationToken))
@@ -396,12 +396,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                 await Task.WhenAll(reminders.Select(item =>
                     item.Grain.RegisterOrUpdateAsync(item.Name, TimeSpan.FromSeconds(3), Period)
                         .WaitAsync(cancellationToken)));
-                await Task.WhenAll(reminders.Select(item =>
-                    _harness.WaitForOwnerCountAsync(
-                        item.Grain.GetGrainId(),
-                        item.Name,
-                        1,
-                        cancellationToken)));
+                await WaitForOwnersAfterRefreshAsync(reminders, cancellationToken);
                 foreach (var (grain, name) in reminders)
                 {
                     initialOwners[grain.GetGrainId()] = _harness.GetOwners(grain.GetGrainId(), name).Single();
@@ -578,6 +573,21 @@ public abstract class ReminderServiceLifecycleTestRunner
                 .WithObserved($"{cleanupFailure.GetType().FullName}: {cleanupFailure.Message}")
                 .Throw(cleanupFailure);
         }
+    }
+
+    private async Task WaitForOwnersAfterRefreshAsync(
+        IReadOnlyList<(IReminderServiceTestGrain Grain, string Name)> reminders,
+        CancellationToken cancellationToken)
+    {
+        var ownerWaits = reminders
+            .Select(item => _harness.WaitForOwnerCountAsync(
+                item.Grain.GetGrainId(),
+                item.Name,
+                1,
+                cancellationToken))
+            .ToArray();
+        await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+        await Task.WhenAll(ownerWaits);
     }
 
     private async Task CleanupAsync(

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -52,13 +52,13 @@ public interface IReminderServiceLifecycleHarness
     /// <summary>Waits until the current owner has armed its persisted schedule.</summary>
     Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken);
 
-    /// <summary>Gets the number of local reminder instances started for an identity.</summary>
+    /// <summary>Gets the number of local reminder instances started for a reminder.</summary>
     int GetLocalStartCount(GrainId grainId, string reminderName);
 
-    /// <summary>Gets the number of local reminder instances stopped for an identity.</summary>
+    /// <summary>Gets the number of local reminder instances stopped for a reminder.</summary>
     int GetLocalStopCount(GrainId grainId, string reminderName);
 
-    /// <summary>Gets the number of local schedule changes for an identity.</summary>
+    /// <summary>Gets the number of local schedule changes for a reminder.</summary>
     int GetScheduleChangeCount(GrainId grainId, string reminderName);
 
     /// <summary>Waits for the local schedule-change count.</summary>

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -39,6 +39,9 @@ public interface IReminderServiceLifecycleHarness
     /// <summary>Advances the one reminder clock driver.</summary>
     Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken);
 
+    /// <summary>Refreshes every active reminder service without advancing time.</summary>
+    Task RefreshAsync(CancellationToken cancellationToken);
+
     /// <summary>Waits for exactly <paramref name="count"/> local owners.</summary>
     Task WaitForOwnerCountAsync(
         GrainId grainId,
@@ -206,7 +209,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                     scheduleChanges + 1,
                     cancellationToken);
                 await grain.RegisterOrUpdateAsync(Name, due, Period + TimeSpan.FromMinutes(1)).WaitAsync(cancellationToken);
-                await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+                await _harness.RefreshAsync(cancellationToken);
                 await changed;
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
                 var updated = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
@@ -260,7 +263,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                 }
 
                 var quiescence = _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 0, cancellationToken);
-                await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+                await _harness.RefreshAsync(cancellationToken);
                 await quiescence;
                 await AssertAbsentAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
                 await _harness.AdvanceAsync(Period, cancellationToken);
@@ -288,7 +291,8 @@ public abstract class ReminderServiceLifecycleTestRunner
             {
                 var expectedStart = _harness.UtcNow.UtcDateTime + due;
                 await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
-                var preWindowAdvance = due - _harness.ReminderLoadingWindow - _harness.ReminderRefreshPeriod;
+                var boundaryStep = TimeSpan.FromTicks(1);
+                var preWindowAdvance = due - _harness.ReminderLoadingWindow - boundaryStep;
                 await _harness.AdvanceAsync(preWindowAdvance, cancellationToken);
                 if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 0)
                 {
@@ -300,7 +304,8 @@ public abstract class ReminderServiceLifecycleTestRunner
                 }
 
                 var owner = _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-                await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+                await _harness.AdvanceAsync(boundaryStep, cancellationToken);
+                await _harness.RefreshAsync(cancellationToken);
                 await owner;
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
                 await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
@@ -347,7 +352,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                             1,
                             cancellationToken))
                         .ToArray();
-                    await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+                    await _harness.RefreshAsync(cancellationToken);
                     await Task.WhenAll(ownerWaits);
                     await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
                     await Task.WhenAll(reminders.Select(item =>
@@ -619,7 +624,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                 1,
                 cancellationToken))
             .ToArray();
-        await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+        await _harness.RefreshAsync(cancellationToken);
         await Task.WhenAll(ownerWaits);
     }
 
@@ -637,7 +642,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                 0,
                 cancellationToken))
             .ToArray();
-        await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+        await _harness.RefreshAsync(cancellationToken);
         await Task.WhenAll(quiescence);
         await Task.WhenAll(reminders.Select(item =>
             AssertAbsentAsync(guarantee, item.Grain.GetGrainId(), item.Name, cancellationToken)));

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Runtime;
@@ -125,14 +126,20 @@ public abstract class ReminderServiceLifecycleTestRunner
     public async Task RunReminderService_StartupReadiness(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderService_StartupReadiness);
-        await _harness.WaitForStartupReadinessAsync(cancellationToken);
-        if (_harness.ActiveSilos.Count == 0)
-        {
-            Fail(Guarantee, "startup")
-                .WithExpected("at least one ready initial silo")
-                .WithObserved($"activeSilos=[{string.Join(", ", _harness.ActiveSilos)}]")
-                .Throw();
-        }
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
+            {
+                await _harness.WaitForStartupReadinessAsync(cancellationToken);
+                if (_harness.ActiveSilos.Count == 0)
+                {
+                    Fail(Guarantee, "startup")
+                        .WithExpected("at least one ready initial silo")
+                        .WithObserved($"activeSilos=[{string.Join(", ", _harness.ActiveSilos)}]")
+                        .Throw();
+                }
+            },
+            _ => Task.CompletedTask);
     }
 
     /// <summary>Guarantee: a registration has one owner and one exact delivery.</summary>
@@ -146,27 +153,26 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Name = "registration-owner";
         var grain = CreateGrain(Guarantee);
         var due = TimeSpan.FromSeconds(3);
-        try
-        {
-            var expectedStart = _harness.UtcNow.UtcDateTime + due;
-            await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
-            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
-            await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
-            if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 1)
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
             {
-                OwnershipFailure(Guarantee, grain.GetGrainId(), Name, 1).Throw();
-            }
+                var expectedStart = _harness.UtcNow.UtcDateTime + due;
+                await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
+                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 1)
+                {
+                    OwnershipFailure(Guarantee, grain.GetGrainId(), Name, 1).Throw();
+                }
 
-            var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-            await _harness.AdvanceAsync(due, cancellationToken);
-            await tick;
-            AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
-        }
-        finally
-        {
-            await CleanupAsync(Guarantee, grain, Name, cancellationToken);
-        }
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+                await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
+                var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await _harness.AdvanceAsync(due, cancellationToken);
+                await tick;
+                AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
+            },
+            cleanupToken => CleanupAsync(Guarantee, grain, Name, cleanupToken));
     }
 
     /// <summary>Guarantee: updating a reminder changes its schedule without restarting its local owner.</summary>
@@ -179,51 +185,50 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_UpdateDoesNotRestartLocalOwner);
         const string Name = "in-place-update";
         var grain = CreateGrain(Guarantee);
-        try
-        {
-            await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
-            var original = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
-            var owners = _harness.GetOwners(grain.GetGrainId(), Name).ToArray();
-            var starts = _harness.GetLocalStartCount(grain.GetGrainId(), Name);
-            var stops = _harness.GetLocalStopCount(grain.GetGrainId(), Name);
-            var scheduleChanges = _harness.GetScheduleChangeCount(grain.GetGrainId(), Name);
-            var due = TimeSpan.FromSeconds(4);
-            var expectedStart = _harness.UtcNow.UtcDateTime + due;
-
-            var changed = _harness.WaitForScheduleChangeCountAsync(
-                grain.GetGrainId(),
-                Name,
-                scheduleChanges + 1,
-                cancellationToken);
-            await grain.RegisterOrUpdateAsync(Name, due, Period + TimeSpan.FromMinutes(1)).WaitAsync(cancellationToken);
-            await changed;
-            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
-            var updated = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
-
-            if (!owners.SequenceEqual(_harness.GetOwners(grain.GetGrainId(), Name))
-                || starts != _harness.GetLocalStartCount(grain.GetGrainId(), Name)
-                || stops != _harness.GetLocalStopCount(grain.GetGrainId(), Name)
-                || string.Equals(original.ETag, updated.ETag, StringComparison.Ordinal)
-                || updated.StartAt != expectedStart
-                || updated.Period != Period + TimeSpan.FromMinutes(1))
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
             {
-                Fail(Guarantee, "RegisterOrUpdateReminder")
-                    .WithIdentity(grain.GetGrainId(), Name)
-                    .WithExpected($"same single owner, starts={starts}, stops={stops}, rotated ETag, StartAt={expectedStart:O}")
-                    .WithObserved(
-                        $"owners=[{string.Join(", ", _harness.GetOwners(grain.GetGrainId(), Name))}], "
-                        + $"starts={_harness.GetLocalStartCount(grain.GetGrainId(), Name)}, "
-                        + $"stops={_harness.GetLocalStopCount(grain.GetGrainId(), Name)}, row={Describe(updated)}")
-                    .WithETags(updated.ETag, original.ETag)
-                    .Throw();
-            }
-        }
-        finally
-        {
-            await CleanupAsync(Guarantee, grain, Name, cancellationToken);
-        }
+                await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+                var original = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
+                var owners = _harness.GetOwners(grain.GetGrainId(), Name).ToArray();
+                var starts = _harness.GetLocalStartCount(grain.GetGrainId(), Name);
+                var stops = _harness.GetLocalStopCount(grain.GetGrainId(), Name);
+                var scheduleChanges = _harness.GetScheduleChangeCount(grain.GetGrainId(), Name);
+                var due = TimeSpan.FromSeconds(4);
+                var expectedStart = _harness.UtcNow.UtcDateTime + due;
+
+                var changed = _harness.WaitForScheduleChangeCountAsync(
+                    grain.GetGrainId(),
+                    Name,
+                    scheduleChanges + 1,
+                    cancellationToken);
+                await grain.RegisterOrUpdateAsync(Name, due, Period + TimeSpan.FromMinutes(1)).WaitAsync(cancellationToken);
+                await changed;
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+                var updated = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
+
+                if (!owners.SequenceEqual(_harness.GetOwners(grain.GetGrainId(), Name))
+                    || starts != _harness.GetLocalStartCount(grain.GetGrainId(), Name)
+                    || stops != _harness.GetLocalStopCount(grain.GetGrainId(), Name)
+                    || string.Equals(original.ETag, updated.ETag, StringComparison.Ordinal)
+                    || updated.StartAt != expectedStart
+                    || updated.Period != Period + TimeSpan.FromMinutes(1))
+                {
+                    Fail(Guarantee, "RegisterOrUpdateReminder")
+                        .WithIdentity(grain.GetGrainId(), Name)
+                        .WithExpected($"same single owner, starts={starts}, stops={stops}, rotated ETag, StartAt={expectedStart:O}")
+                        .WithObserved(
+                            $"owners=[{string.Join(", ", _harness.GetOwners(grain.GetGrainId(), Name))}], "
+                            + $"starts={_harness.GetLocalStartCount(grain.GetGrainId(), Name)}, "
+                            + $"stops={_harness.GetLocalStopCount(grain.GetGrainId(), Name)}, row={Describe(updated)}")
+                        .WithETags(updated.ETag, original.ETag)
+                        .Throw();
+                }
+            },
+            cleanupToken => CleanupAsync(Guarantee, grain, Name, cleanupToken));
     }
 
     /// <summary>Guarantee: removal reaches quiescence and cannot deliver a later occurrence.</summary>
@@ -236,23 +241,29 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_RemovalReachesQuiescence);
         const string Name = "removal-quiescence";
         var grain = CreateGrain(Guarantee);
-        await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-        await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-        await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
+            {
+                await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
 
-        if (!await grain.UnregisterAsync(Name).WaitAsync(cancellationToken))
-        {
-            Fail(Guarantee, "UnregisterReminder")
-                .WithIdentity(grain.GetGrainId(), Name)
-                .WithExpected("successful removal")
-                .WithObserved("removal returned false")
-                .Throw();
-        }
+                if (!await grain.UnregisterAsync(Name).WaitAsync(cancellationToken))
+                {
+                    Fail(Guarantee, "UnregisterReminder")
+                        .WithIdentity(grain.GetGrainId(), Name)
+                        .WithExpected("successful removal")
+                        .WithObserved("removal returned false")
+                        .Throw();
+                }
 
-        await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 0, cancellationToken);
-        await AssertAbsentAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
-        await _harness.AdvanceAsync(Period, cancellationToken);
-        AssertCounts(Guarantee, grain, Name, owners: 0, ticks: 0);
+                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 0, cancellationToken);
+                await AssertAbsentAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
+                await _harness.AdvanceAsync(Period, cancellationToken);
+                AssertCounts(Guarantee, grain, Name, owners: 0, ticks: 0);
+            },
+            cleanupToken => CleanupAsync(Guarantee, grain, Name, cleanupToken));
     }
 
     /// <summary>Guarantee: a persisted reminder entering the loading window fires at its exact due time.</summary>
@@ -265,33 +276,37 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_ExactDueRecovery);
         const string Name = "exact-due-recovery";
         var grain = CreateGrain(Guarantee);
-        var due = _harness.ReminderLoadingWindow + TimeSpan.FromSeconds(10);
-        try
-        {
-            var expectedStart = _harness.UtcNow.UtcDateTime + due;
-            await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
-            if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 0)
+        var due = _harness.ReminderLoadingWindow
+            + _harness.ReminderRefreshPeriod
+            + _harness.ReminderRefreshPeriod;
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
             {
-                Fail(Guarantee, "initial loading window")
-                    .WithIdentity(grain.GetGrainId(), Name)
-                    .WithExpected("no local owner before entering the loading window")
-                    .WithObserved($"owners=[{string.Join(", ", _harness.GetOwners(grain.GetGrainId(), Name))}]")
-                    .Throw();
-            }
+                var expectedStart = _harness.UtcNow.UtcDateTime + due;
+                await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
+                var preWindowAdvance = due - _harness.ReminderLoadingWindow - _harness.ReminderRefreshPeriod;
+                await _harness.AdvanceAsync(preWindowAdvance, cancellationToken);
+                if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 0)
+                {
+                    Fail(Guarantee, "before loading window")
+                        .WithIdentity(grain.GetGrainId(), Name)
+                        .WithExpected("no local owner immediately before entering the loading window")
+                        .WithObserved($"owners=[{string.Join(", ", _harness.GetOwners(grain.GetGrainId(), Name))}]")
+                        .Throw();
+                }
 
-            await _harness.AdvanceAsync(due - _harness.ReminderLoadingWindow, cancellationToken);
-            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
-            var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-            await _harness.AdvanceAsync(_harness.ReminderLoadingWindow, cancellationToken);
-            await tick;
-            await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
-            AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
-        }
-        finally
-        {
-            await CleanupAsync(Guarantee, grain, Name, cancellationToken);
-        }
+                var owner = _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+                await owner;
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+                var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+                await _harness.AdvanceAsync(_harness.ReminderLoadingWindow, cancellationToken);
+                await tick;
+                await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
+                AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
+            },
+            cleanupToken => CleanupAsync(Guarantee, grain, Name, cleanupToken));
     }
 
     /// <summary>Guarantee: registration and ownership reconcile to one owner after a silo joins.</summary>
@@ -304,58 +319,64 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_StaleOwnerRegistrationReconciles);
         var reminders = CreateGrains(Guarantee, 16);
         var phase = "join";
-        var joined = await _harness.JoinOneSiloAsync(cancellationToken);
-        try
-        {
-            phase = "registration";
-            foreach (var (grain, name) in reminders)
+        SiloAddress? joined = null;
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
             {
-                await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-            }
-
-            phase = "topology reconciliation";
-            await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-            phase = "owner reconciliation";
-            var ownerWaits = reminders
-                .Select(item => _harness.WaitForOwnerCountAsync(
-                    item.Grain.GetGrainId(),
-                    item.Name,
-                    1,
-                    cancellationToken))
-                .ToArray();
-            await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
-            await Task.WhenAll(ownerWaits);
-            foreach (var (grain, name) in reminders)
-            {
-                phase = $"schedule reconciliation for {grain.GetGrainId()}/{name}";
-                await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
-                if (_harness.GetOwners(grain.GetGrainId(), name).Count != 1)
+                try
                 {
-                    OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1).Throw();
+                    joined = await _harness.JoinOneSiloAsync(cancellationToken);
+                    phase = "registration";
+                    foreach (var (grain, name) in reminders)
+                    {
+                        await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+                    }
+
+                    phase = "topology reconciliation";
+                    await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                    phase = "owner reconciliation";
+                    var ownerWaits = reminders
+                        .Select(item => _harness.WaitForOwnerCountAsync(
+                            item.Grain.GetGrainId(),
+                            item.Name,
+                            1,
+                            cancellationToken))
+                        .ToArray();
+                    await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+                    await Task.WhenAll(ownerWaits);
+                    foreach (var (grain, name) in reminders)
+                    {
+                        phase = $"schedule reconciliation for {grain.GetGrainId()}/{name}";
+                        await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
+                        if (_harness.GetOwners(grain.GetGrainId(), name).Count != 1)
+                        {
+                            OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1).Throw();
+                        }
+                    }
                 }
-            }
-        }
-        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
-        {
-            Fail(Guarantee, phase)
-                .WithExpected("all registrations reconcile to one current owner with an armed schedule")
-                .WithObserved(string.Join(
-                    "; ",
-                    reminders.Select(item =>
-                        $"{item.Grain.GetGrainId()}/{item.Name}="
-                        + $"[{string.Join(", ", _harness.GetOwners(item.Grain.GetGrainId(), item.Name))}]")))
-                .Throw(exception);
-        }
-        finally
-        {
-            using var cleanupCancellation = cancellationToken.IsCancellationRequested
-                ? new CancellationTokenSource(TimeSpan.FromSeconds(30))
-                : null;
-            var cleanupToken = cleanupCancellation?.Token ?? cancellationToken;
-            await _harness.LeaveSiloAsync(joined, cleanupToken);
-            await _harness.WaitForTopologyReconciliationAsync(cleanupToken);
-            await CleanupAsync(Guarantee, reminders, cleanupToken);
-        }
+                catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+                {
+                    Fail(Guarantee, phase)
+                        .WithExpected("all registrations reconcile to one current owner with an armed schedule")
+                        .WithObserved(string.Join(
+                            "; ",
+                            reminders.Select(item =>
+                                $"{item.Grain.GetGrainId()}/{item.Name}="
+                                + $"[{string.Join(", ", _harness.GetOwners(item.Grain.GetGrainId(), item.Name))}]")))
+                        .Throw(exception);
+                }
+            },
+            async cleanupToken =>
+            {
+                if (joined is not null && _harness.ActiveSilos.Contains(joined))
+                {
+                    await _harness.LeaveSiloAsync(joined, cleanupToken);
+                    await _harness.WaitForTopologyReconciliationAsync(cleanupToken);
+                }
+
+                await CleanupAsync(Guarantee, reminders, cleanupToken);
+            });
     }
 
     /// <summary>Guarantee: one-silo join/leave transfers ownership without duplicates or missed delivery.</summary>
@@ -368,75 +389,79 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_OneSiloJoinLeaveTransfersOwnership);
         var reminders = CreateGrains(Guarantee, 32);
         var initialOwners = new Dictionary<GrainId, SiloAddress>();
-        foreach (var (grain, name) in reminders)
-        {
-            await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
-            initialOwners[grain.GetGrainId()] = _harness.GetOwners(grain.GetGrainId(), name).Single();
-        }
-
-        var joined = await _harness.JoinOneSiloAsync(cancellationToken);
-        try
-        {
-            await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-            var transferred = 0;
-            foreach (var (grain, name) in reminders)
+        SiloAddress? joined = null;
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
             {
-                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
-                var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
-                transferred += owner.Equals(joined) ? 1 : 0;
-            }
-
-            if (transferred == 0)
-            {
-                Fail(Guarantee, "join reconciliation")
-                    .WithExpected($"at least one of {reminders.Count} deterministic reminders transferred to {joined}")
-                    .WithObserved("all reminders remained on the initial silo")
-                    .Throw();
-            }
-
-            await _harness.LeaveSiloAsync(joined, cancellationToken);
-            await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-            foreach (var (grain, name) in reminders)
-            {
-                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
-                var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
-                var expectedOwner = initialOwners[grain.GetGrainId()];
-                if (!owner.Equals(expectedOwner))
+                foreach (var (grain, name) in reminders)
                 {
-                    OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1)
-                        .WithExpected($"owner={expectedOwner} after joined silo leaves")
-                        .WithObserved($"owner={owner}")
+                    await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+                    await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
+                    initialOwners[grain.GetGrainId()] = _harness.GetOwners(grain.GetGrainId(), name).Single();
+                }
+
+                joined = await _harness.JoinOneSiloAsync(cancellationToken);
+                await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                var transferred = 0;
+                foreach (var (grain, name) in reminders)
+                {
+                    await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
+                    var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
+                    transferred += owner.Equals(joined) ? 1 : 0;
+                }
+
+                if (transferred == 0)
+                {
+                    Fail(Guarantee, "join reconciliation")
+                        .WithExpected($"at least one of {reminders.Count} deterministic reminders transferred to {joined}")
+                        .WithObserved("all reminders remained on the initial silos")
                         .Throw();
                 }
 
-                await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
-            }
-
-            var tickWaits = reminders
-                .Select(item => _harness.WaitForTickCountAsync(
-                    item.Grain.GetGrainId(),
-                    item.Name,
-                    1,
-                    cancellationToken))
-                .ToArray();
-            await _harness.AdvanceAsync(TimeSpan.FromSeconds(3), cancellationToken);
-            await Task.WhenAll(tickWaits);
-            foreach (var (grain, name) in reminders)
-            {
-                AssertCounts(Guarantee, grain, name, owners: null, ticks: 1);
-            }
-        }
-        finally
-        {
-            if (_harness.ActiveSilos.Contains(joined))
-            {
                 await _harness.LeaveSiloAsync(joined, cancellationToken);
+                joined = null;
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-            }
+                foreach (var (grain, name) in reminders)
+                {
+                    await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
+                    var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
+                    var expectedOwner = initialOwners[grain.GetGrainId()];
+                    if (!owner.Equals(expectedOwner))
+                    {
+                        OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1)
+                            .WithExpected($"owner={expectedOwner} after joined silo leaves")
+                            .WithObserved($"owner={owner}")
+                            .Throw();
+                    }
 
-            await CleanupAsync(Guarantee, reminders, cancellationToken);
-        }
+                    await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
+                }
+
+                var tickWaits = reminders
+                    .Select(item => _harness.WaitForTickCountAsync(
+                        item.Grain.GetGrainId(),
+                        item.Name,
+                        1,
+                        cancellationToken))
+                    .ToArray();
+                await _harness.AdvanceAsync(TimeSpan.FromSeconds(3), cancellationToken);
+                await Task.WhenAll(tickWaits);
+                foreach (var (grain, name) in reminders)
+                {
+                    AssertCounts(Guarantee, grain, name, owners: null, ticks: 1);
+                }
+            },
+            async cleanupToken =>
+            {
+                if (joined is not null && _harness.ActiveSilos.Contains(joined))
+                {
+                    await _harness.LeaveSiloAsync(joined, cleanupToken);
+                    await _harness.WaitForTopologyReconciliationAsync(cleanupToken);
+                }
+
+                await CleanupAsync(Guarantee, reminders, cleanupToken);
+            });
     }
 
     /// <summary>Guarantee: scenario cleanup removes only rows owned by that scenario.</summary>
@@ -451,26 +476,28 @@ public abstract class ReminderServiceLifecycleTestRunner
         var subject = CreateGrain($"{Guarantee}/subject");
         const string SentinelName = "unrelated-sentinel";
         const string SubjectName = "scenario-owned";
-        try
-        {
-            await sentinel.RegisterOrUpdateAsync(SentinelName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
-            await subject.RegisterOrUpdateAsync(SubjectName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
-            await CleanupAsync(Guarantee, subject, SubjectName, cancellationToken);
-            var sentinelRow = await _harness.ReminderTable.ReadRow(sentinel.GetGrainId(), SentinelName).WaitAsync(cancellationToken);
-            if (sentinelRow is null)
+        await ExecuteWithCleanupAsync(
+            Guarantee,
+            async () =>
             {
-                Fail(Guarantee, "cleanup")
-                    .WithIdentity(sentinel.GetGrainId(), SentinelName)
-                    .WithExpected("unrelated sentinel remains registered")
-                    .WithObserved("sentinel row was removed")
-                    .Throw();
-            }
-        }
-        finally
-        {
-            await CleanupAsync(Guarantee, sentinel, SentinelName, cancellationToken);
-            await CleanupAsync(Guarantee, subject, SubjectName, cancellationToken);
-        }
+                await sentinel.RegisterOrUpdateAsync(SentinelName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
+                await subject.RegisterOrUpdateAsync(SubjectName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
+                await CleanupAsync(Guarantee, subject, SubjectName, cancellationToken);
+                var sentinelRow = await _harness.ReminderTable.ReadRow(sentinel.GetGrainId(), SentinelName).WaitAsync(cancellationToken);
+                if (sentinelRow is null)
+                {
+                    Fail(Guarantee, "cleanup")
+                        .WithIdentity(sentinel.GetGrainId(), SentinelName)
+                        .WithExpected("unrelated sentinel remains registered")
+                        .WithObserved("sentinel row was removed")
+                        .Throw();
+                }
+            },
+            async cleanupToken =>
+            {
+                await CleanupAsync(Guarantee, sentinel, SentinelName, cleanupToken);
+                await CleanupAsync(Guarantee, subject, SubjectName, cleanupToken);
+            });
     }
 
     private List<(IReminderServiceTestGrain Grain, string Name)> CreateGrains(string guarantee, int count)
@@ -483,6 +510,53 @@ public abstract class ReminderServiceLifecycleTestRunner
         var ordinal = Interlocked.Increment(ref _grainCounter);
         var key = ReminderTestData.CreateGuid(_seed, $"{ProviderName}/{label}/{ordinal}");
         return _harness.GrainFactory.GetGrain<IReminderServiceTestGrain>(key);
+    }
+
+    private async Task ExecuteWithCleanupAsync(
+        string guarantee,
+        Func<Task> scenario,
+        Func<CancellationToken, Task> cleanup)
+    {
+        ExceptionDispatchInfo? scenarioFailure = null;
+        try
+        {
+            await scenario();
+        }
+        catch (Exception exception)
+        {
+            scenarioFailure = ExceptionDispatchInfo.Capture(exception);
+        }
+
+        Exception? cleanupFailure = null;
+        using (var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+        {
+            try
+            {
+                await cleanup(cleanupCancellation.Token);
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure = exception;
+            }
+        }
+
+        if (scenarioFailure is not null)
+        {
+            if (cleanupFailure is not null)
+            {
+                scenarioFailure.SourceException.Data["ReminderServiceLifecycleCleanupFailure"] = cleanupFailure.ToString();
+            }
+
+            scenarioFailure.Throw();
+        }
+
+        if (cleanupFailure is not null)
+        {
+            Fail(guarantee, "scenario cleanup")
+                .WithExpected("all scenario-owned reminders absent and all temporary topology restored")
+                .WithObserved($"{cleanupFailure.GetType().FullName}: {cleanupFailure.Message}")
+                .Throw(cleanupFailure);
+        }
     }
 
     private async Task CleanupAsync(

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -1,0 +1,608 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace Orleans.Reminders.TestKit;
+
+/// <summary>
+/// Supplies deterministic clock, diagnostics, and topology controls to
+/// <see cref="ReminderServiceLifecycleTestRunner"/>.
+/// </summary>
+public interface IReminderServiceLifecycleHarness
+{
+    /// <summary>Gets the deployed cluster's grain factory.</summary>
+    IGrainFactory GrainFactory { get; }
+
+    /// <summary>Gets the provider table used by the reminder service.</summary>
+    IReminderTable ReminderTable { get; }
+
+    /// <summary>Gets the deterministic reminder clock time.</summary>
+    DateTimeOffset UtcNow { get; }
+
+    /// <summary>Gets the configured reminder loading window.</summary>
+    TimeSpan ReminderLoadingWindow { get; }
+
+    /// <summary>Gets the configured reminder-table refresh period.</summary>
+    TimeSpan ReminderRefreshPeriod { get; }
+
+    /// <summary>Gets the currently active silos.</summary>
+    IReadOnlyList<SiloAddress> ActiveSilos { get; }
+
+    /// <summary>Waits until every active reminder service is ready.</summary>
+    Task WaitForStartupReadinessAsync(CancellationToken cancellationToken);
+
+    /// <summary>Advances the one reminder clock driver.</summary>
+    Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken);
+
+    /// <summary>Waits for exactly <paramref name="count"/> local owners.</summary>
+    Task WaitForOwnerCountAsync(
+        GrainId grainId,
+        string reminderName,
+        int count,
+        CancellationToken cancellationToken);
+
+    /// <summary>Gets the current local owners.</summary>
+    IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName);
+
+    /// <summary>Waits until the current owner has armed its persisted schedule.</summary>
+    Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken);
+
+    /// <summary>Gets the number of local reminder instances started for an identity.</summary>
+    int GetLocalStartCount(GrainId grainId, string reminderName);
+
+    /// <summary>Gets the number of local reminder instances stopped for an identity.</summary>
+    int GetLocalStopCount(GrainId grainId, string reminderName);
+
+    /// <summary>Gets the number of local schedule changes for an identity.</summary>
+    int GetScheduleChangeCount(GrainId grainId, string reminderName);
+
+    /// <summary>Waits for the local schedule-change count.</summary>
+    Task WaitForScheduleChangeCountAsync(
+        GrainId grainId,
+        string reminderName,
+        int count,
+        CancellationToken cancellationToken);
+
+    /// <summary>Waits for exactly the requested completed tick count.</summary>
+    Task WaitForTickCountAsync(
+        GrainId grainId,
+        string reminderName,
+        int count,
+        CancellationToken cancellationToken);
+
+    /// <summary>Gets the current completed tick count.</summary>
+    int GetTickCount(GrainId grainId, string reminderName);
+
+    /// <summary>Starts one silo and waits for its reminder service to become ready.</summary>
+    Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken);
+
+    /// <summary>Stops the specified silo.</summary>
+    Task LeaveSiloAsync(SiloAddress siloAddress, CancellationToken cancellationToken);
+
+    /// <summary>Waits for membership and reminder-range reconciliation on all active silos.</summary>
+    Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Shared deterministic conformance scenarios for reminder service lifecycle, ownership, and churn.
+/// </summary>
+/// <remarks>
+/// Provider suites supply only an <see cref="IReminderServiceLifecycleHarness"/>. The runner owns identities,
+/// schedules, topology transitions, exact assertions, and cleanup. Each scenario cleans only the reminders which
+/// it created and verifies their absence, so unrelated rows and concurrently running provider suites are isolated.
+/// </remarks>
+public abstract class ReminderServiceLifecycleTestRunner
+{
+    private static readonly TimeSpan Period = TimeSpan.FromMinutes(2);
+    private readonly IReminderServiceLifecycleHarness _harness;
+    private readonly int _seed;
+    private int _grainCounter;
+
+    /// <summary>Initializes the runner.</summary>
+    protected ReminderServiceLifecycleTestRunner(
+        IReminderServiceLifecycleHarness harness,
+        string providerName,
+        int seed = 0)
+    {
+        _harness = harness ?? throw new ArgumentNullException(nameof(harness));
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+        ProviderName = providerName;
+        _seed = seed;
+    }
+
+    /// <summary>Gets the provider name used in diagnostics.</summary>
+    protected string ProviderName { get; }
+
+    /// <summary>Guarantee: every active silo reports reminder-service readiness before operations begin.</summary>
+    public virtual Task ReminderService_StartupReadiness()
+        => RunReminderService_StartupReadiness(CancellationToken.None);
+
+    /// <summary>Runs the startup-readiness scenario.</summary>
+    public async Task RunReminderService_StartupReadiness(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_StartupReadiness);
+        await _harness.WaitForStartupReadinessAsync(cancellationToken);
+        if (_harness.ActiveSilos.Count == 0)
+        {
+            Fail(Guarantee, "startup")
+                .WithExpected("at least one ready initial silo")
+                .WithObserved($"activeSilos=[{string.Join(", ", _harness.ActiveSilos)}]")
+                .Throw();
+        }
+    }
+
+    /// <summary>Guarantee: a registration has one owner and one exact delivery.</summary>
+    public virtual Task ReminderService_RegistrationHasSingleOwner()
+        => RunReminderService_RegistrationHasSingleOwner(CancellationToken.None);
+
+    /// <summary>Runs the registration-ownership scenario.</summary>
+    public async Task RunReminderService_RegistrationHasSingleOwner(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_RegistrationHasSingleOwner);
+        const string Name = "registration-owner";
+        var grain = CreateGrain(Guarantee);
+        var due = TimeSpan.FromSeconds(3);
+        try
+        {
+            var expectedStart = _harness.UtcNow.UtcDateTime + due;
+            await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
+            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+            await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
+            if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 1)
+            {
+                OwnershipFailure(Guarantee, grain.GetGrainId(), Name, 1).Throw();
+            }
+
+            var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+            await _harness.AdvanceAsync(due, cancellationToken);
+            await tick;
+            AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
+        }
+        finally
+        {
+            await CleanupAsync(Guarantee, grain, Name, cancellationToken);
+        }
+    }
+
+    /// <summary>Guarantee: updating a reminder changes its schedule without restarting its local owner.</summary>
+    public virtual Task ReminderService_UpdateDoesNotRestartLocalOwner()
+        => RunReminderService_UpdateDoesNotRestartLocalOwner(CancellationToken.None);
+
+    /// <summary>Runs the in-place update scenario.</summary>
+    public async Task RunReminderService_UpdateDoesNotRestartLocalOwner(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_UpdateDoesNotRestartLocalOwner);
+        const string Name = "in-place-update";
+        var grain = CreateGrain(Guarantee);
+        try
+        {
+            await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+            var original = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
+            var owners = _harness.GetOwners(grain.GetGrainId(), Name).ToArray();
+            var starts = _harness.GetLocalStartCount(grain.GetGrainId(), Name);
+            var stops = _harness.GetLocalStopCount(grain.GetGrainId(), Name);
+            var scheduleChanges = _harness.GetScheduleChangeCount(grain.GetGrainId(), Name);
+            var due = TimeSpan.FromSeconds(4);
+            var expectedStart = _harness.UtcNow.UtcDateTime + due;
+
+            var changed = _harness.WaitForScheduleChangeCountAsync(
+                grain.GetGrainId(),
+                Name,
+                scheduleChanges + 1,
+                cancellationToken);
+            await grain.RegisterOrUpdateAsync(Name, due, Period + TimeSpan.FromMinutes(1)).WaitAsync(cancellationToken);
+            await changed;
+            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+            var updated = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
+
+            if (!owners.SequenceEqual(_harness.GetOwners(grain.GetGrainId(), Name))
+                || starts != _harness.GetLocalStartCount(grain.GetGrainId(), Name)
+                || stops != _harness.GetLocalStopCount(grain.GetGrainId(), Name)
+                || string.Equals(original.ETag, updated.ETag, StringComparison.Ordinal)
+                || updated.StartAt != expectedStart
+                || updated.Period != Period + TimeSpan.FromMinutes(1))
+            {
+                Fail(Guarantee, "RegisterOrUpdateReminder")
+                    .WithIdentity(grain.GetGrainId(), Name)
+                    .WithExpected($"same single owner, starts={starts}, stops={stops}, rotated ETag, StartAt={expectedStart:O}")
+                    .WithObserved(
+                        $"owners=[{string.Join(", ", _harness.GetOwners(grain.GetGrainId(), Name))}], "
+                        + $"starts={_harness.GetLocalStartCount(grain.GetGrainId(), Name)}, "
+                        + $"stops={_harness.GetLocalStopCount(grain.GetGrainId(), Name)}, row={Describe(updated)}")
+                    .WithETags(updated.ETag, original.ETag)
+                    .Throw();
+            }
+        }
+        finally
+        {
+            await CleanupAsync(Guarantee, grain, Name, cancellationToken);
+        }
+    }
+
+    /// <summary>Guarantee: removal reaches quiescence and cannot deliver a later occurrence.</summary>
+    public virtual Task ReminderService_RemovalReachesQuiescence()
+        => RunReminderService_RemovalReachesQuiescence(CancellationToken.None);
+
+    /// <summary>Runs the removal/quiescence scenario.</summary>
+    public async Task RunReminderService_RemovalReachesQuiescence(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_RemovalReachesQuiescence);
+        const string Name = "removal-quiescence";
+        var grain = CreateGrain(Guarantee);
+        await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+        await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+        await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+
+        if (!await grain.UnregisterAsync(Name).WaitAsync(cancellationToken))
+        {
+            Fail(Guarantee, "UnregisterReminder")
+                .WithIdentity(grain.GetGrainId(), Name)
+                .WithExpected("successful removal")
+                .WithObserved("removal returned false")
+                .Throw();
+        }
+
+        await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 0, cancellationToken);
+        await AssertAbsentAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
+        await _harness.AdvanceAsync(Period, cancellationToken);
+        AssertCounts(Guarantee, grain, Name, owners: 0, ticks: 0);
+    }
+
+    /// <summary>Guarantee: a persisted reminder entering the loading window fires at its exact due time.</summary>
+    public virtual Task ReminderService_ExactDueRecovery()
+        => RunReminderService_ExactDueRecovery(CancellationToken.None);
+
+    /// <summary>Runs the exact-due recovery scenario.</summary>
+    public async Task RunReminderService_ExactDueRecovery(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_ExactDueRecovery);
+        const string Name = "exact-due-recovery";
+        var grain = CreateGrain(Guarantee);
+        var due = _harness.ReminderLoadingWindow + TimeSpan.FromSeconds(10);
+        try
+        {
+            var expectedStart = _harness.UtcNow.UtcDateTime + due;
+            await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
+            if (_harness.GetOwners(grain.GetGrainId(), Name).Count != 0)
+            {
+                Fail(Guarantee, "initial loading window")
+                    .WithIdentity(grain.GetGrainId(), Name)
+                    .WithExpected("no local owner before entering the loading window")
+                    .WithObserved($"owners=[{string.Join(", ", _harness.GetOwners(grain.GetGrainId(), Name))}]")
+                    .Throw();
+            }
+
+            await _harness.AdvanceAsync(due - _harness.ReminderLoadingWindow, cancellationToken);
+            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+            await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
+            var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
+            await _harness.AdvanceAsync(_harness.ReminderLoadingWindow, cancellationToken);
+            await tick;
+            await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
+            AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
+        }
+        finally
+        {
+            await CleanupAsync(Guarantee, grain, Name, cancellationToken);
+        }
+    }
+
+    /// <summary>Guarantee: registration and ownership reconcile to one owner after a silo joins.</summary>
+    public virtual Task ReminderService_StaleOwnerRegistrationReconciles()
+        => RunReminderService_StaleOwnerRegistrationReconciles(CancellationToken.None);
+
+    /// <summary>Runs stale-owner registration reconciliation.</summary>
+    public async Task RunReminderService_StaleOwnerRegistrationReconciles(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_StaleOwnerRegistrationReconciles);
+        var reminders = CreateGrains(Guarantee, 16);
+        var phase = "join";
+        var joined = await _harness.JoinOneSiloAsync(cancellationToken);
+        try
+        {
+            phase = "registration";
+            foreach (var (grain, name) in reminders)
+            {
+                await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+            }
+
+            phase = "topology reconciliation";
+            await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+            phase = "owner reconciliation";
+            var ownerWaits = reminders
+                .Select(item => _harness.WaitForOwnerCountAsync(
+                    item.Grain.GetGrainId(),
+                    item.Name,
+                    1,
+                    cancellationToken))
+                .ToArray();
+            await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+            await Task.WhenAll(ownerWaits);
+            foreach (var (grain, name) in reminders)
+            {
+                phase = $"schedule reconciliation for {grain.GetGrainId()}/{name}";
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
+                if (_harness.GetOwners(grain.GetGrainId(), name).Count != 1)
+                {
+                    OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1).Throw();
+                }
+            }
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            Fail(Guarantee, phase)
+                .WithExpected("all registrations reconcile to one current owner with an armed schedule")
+                .WithObserved(string.Join(
+                    "; ",
+                    reminders.Select(item =>
+                        $"{item.Grain.GetGrainId()}/{item.Name}="
+                        + $"[{string.Join(", ", _harness.GetOwners(item.Grain.GetGrainId(), item.Name))}]")))
+                .Throw(exception);
+        }
+        finally
+        {
+            using var cleanupCancellation = cancellationToken.IsCancellationRequested
+                ? new CancellationTokenSource(TimeSpan.FromSeconds(30))
+                : null;
+            var cleanupToken = cleanupCancellation?.Token ?? cancellationToken;
+            await _harness.LeaveSiloAsync(joined, cleanupToken);
+            await _harness.WaitForTopologyReconciliationAsync(cleanupToken);
+            await CleanupAsync(Guarantee, reminders, cleanupToken);
+        }
+    }
+
+    /// <summary>Guarantee: one-silo join/leave transfers ownership without duplicates or missed delivery.</summary>
+    public virtual Task ReminderService_OneSiloJoinLeaveTransfersOwnership()
+        => RunReminderService_OneSiloJoinLeaveTransfersOwnership(CancellationToken.None);
+
+    /// <summary>Runs the one-silo join/leave ownership-transfer scenario.</summary>
+    public async Task RunReminderService_OneSiloJoinLeaveTransfersOwnership(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_OneSiloJoinLeaveTransfersOwnership);
+        var reminders = CreateGrains(Guarantee, 32);
+        var initialOwners = new Dictionary<GrainId, SiloAddress>();
+        foreach (var (grain, name) in reminders)
+        {
+            await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
+            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
+            initialOwners[grain.GetGrainId()] = _harness.GetOwners(grain.GetGrainId(), name).Single();
+        }
+
+        var joined = await _harness.JoinOneSiloAsync(cancellationToken);
+        try
+        {
+            await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+            var transferred = 0;
+            foreach (var (grain, name) in reminders)
+            {
+                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
+                var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
+                transferred += owner.Equals(joined) ? 1 : 0;
+            }
+
+            if (transferred == 0)
+            {
+                Fail(Guarantee, "join reconciliation")
+                    .WithExpected($"at least one of {reminders.Count} deterministic reminders transferred to {joined}")
+                    .WithObserved("all reminders remained on the initial silo")
+                    .Throw();
+            }
+
+            await _harness.LeaveSiloAsync(joined, cancellationToken);
+            await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+            foreach (var (grain, name) in reminders)
+            {
+                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
+                var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
+                var expectedOwner = initialOwners[grain.GetGrainId()];
+                if (!owner.Equals(expectedOwner))
+                {
+                    OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1)
+                        .WithExpected($"owner={expectedOwner} after joined silo leaves")
+                        .WithObserved($"owner={owner}")
+                        .Throw();
+                }
+
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
+            }
+
+            var tickWaits = reminders
+                .Select(item => _harness.WaitForTickCountAsync(
+                    item.Grain.GetGrainId(),
+                    item.Name,
+                    1,
+                    cancellationToken))
+                .ToArray();
+            await _harness.AdvanceAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            await Task.WhenAll(tickWaits);
+            foreach (var (grain, name) in reminders)
+            {
+                AssertCounts(Guarantee, grain, name, owners: null, ticks: 1);
+            }
+        }
+        finally
+        {
+            if (_harness.ActiveSilos.Contains(joined))
+            {
+                await _harness.LeaveSiloAsync(joined, cancellationToken);
+                await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+            }
+
+            await CleanupAsync(Guarantee, reminders, cancellationToken);
+        }
+    }
+
+    /// <summary>Guarantee: scenario cleanup removes only rows owned by that scenario.</summary>
+    public virtual Task ReminderService_CleanupIsIsolated()
+        => RunReminderService_CleanupIsIsolated(CancellationToken.None);
+
+    /// <summary>Runs cleanup isolation.</summary>
+    public async Task RunReminderService_CleanupIsIsolated(CancellationToken cancellationToken)
+    {
+        const string Guarantee = nameof(ReminderService_CleanupIsIsolated);
+        var sentinel = CreateGrain($"{Guarantee}/sentinel");
+        var subject = CreateGrain($"{Guarantee}/subject");
+        const string SentinelName = "unrelated-sentinel";
+        const string SubjectName = "scenario-owned";
+        try
+        {
+            await sentinel.RegisterOrUpdateAsync(SentinelName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
+            await subject.RegisterOrUpdateAsync(SubjectName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
+            await CleanupAsync(Guarantee, subject, SubjectName, cancellationToken);
+            var sentinelRow = await _harness.ReminderTable.ReadRow(sentinel.GetGrainId(), SentinelName).WaitAsync(cancellationToken);
+            if (sentinelRow is null)
+            {
+                Fail(Guarantee, "cleanup")
+                    .WithIdentity(sentinel.GetGrainId(), SentinelName)
+                    .WithExpected("unrelated sentinel remains registered")
+                    .WithObserved("sentinel row was removed")
+                    .Throw();
+            }
+        }
+        finally
+        {
+            await CleanupAsync(Guarantee, sentinel, SentinelName, cancellationToken);
+            await CleanupAsync(Guarantee, subject, SubjectName, cancellationToken);
+        }
+    }
+
+    private List<(IReminderServiceTestGrain Grain, string Name)> CreateGrains(string guarantee, int count)
+        => Enumerable.Range(0, count)
+            .Select(index => (CreateGrain($"{guarantee}/{index}"), $"churn-{index.ToString("D2", CultureInfo.InvariantCulture)}"))
+            .ToList();
+
+    private IReminderServiceTestGrain CreateGrain(string label)
+    {
+        var ordinal = Interlocked.Increment(ref _grainCounter);
+        var key = ReminderTestData.CreateGuid(_seed, $"{ProviderName}/{label}/{ordinal}");
+        return _harness.GrainFactory.GetGrain<IReminderServiceTestGrain>(key);
+    }
+
+    private async Task CleanupAsync(
+        string guarantee,
+        IReadOnlyList<(IReminderServiceTestGrain Grain, string Name)> reminders,
+        CancellationToken cancellationToken)
+    {
+        foreach (var (grain, name) in reminders)
+        {
+            await CleanupAsync(guarantee, grain, name, cancellationToken);
+        }
+    }
+
+    private async Task CleanupAsync(
+        string guarantee,
+        IReminderServiceTestGrain grain,
+        string name,
+        CancellationToken cancellationToken)
+    {
+        if (await grain.UnregisterAsync(name).WaitAsync(cancellationToken))
+        {
+            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 0, cancellationToken);
+        }
+
+        await AssertAbsentAsync(guarantee, grain.GetGrainId(), name, cancellationToken);
+    }
+
+    private async Task AssertPersistedAsync(
+        string guarantee,
+        GrainId grainId,
+        string name,
+        DateTime expectedStart,
+        TimeSpan expectedPeriod,
+        CancellationToken cancellationToken)
+    {
+        var row = await ReadRequiredAsync(guarantee, grainId, name, cancellationToken);
+        if (row.StartAt != expectedStart || row.Period != expectedPeriod || string.IsNullOrEmpty(row.ETag))
+        {
+            Fail(guarantee, "ReadRow")
+                .WithIdentity(grainId, name)
+                .WithExpected($"StartAt={expectedStart:O}, Period={expectedPeriod}, non-empty ETag")
+                .WithObserved(Describe(row))
+                .WithSchedule(row.StartAt, row.Period)
+                .WithETags(row.ETag)
+                .Throw();
+        }
+    }
+
+    private async Task<ReminderEntry> ReadRequiredAsync(
+        string guarantee,
+        GrainId grainId,
+        string name,
+        CancellationToken cancellationToken)
+    {
+        var row = await _harness.ReminderTable.ReadRow(grainId, name).WaitAsync(cancellationToken);
+        if (row is null)
+        {
+            Fail(guarantee, "ReadRow")
+                .WithIdentity(grainId, name)
+                .WithExpected("one persisted row")
+                .WithObserved("<null>")
+                .Throw();
+        }
+
+        return row!;
+    }
+
+    private async Task AssertAbsentAsync(
+        string guarantee,
+        GrainId grainId,
+        string name,
+        CancellationToken cancellationToken)
+    {
+        var row = await _harness.ReminderTable.ReadRow(grainId, name).WaitAsync(cancellationToken);
+        if (row is not null)
+        {
+            Fail(guarantee, "cleanup")
+                .WithIdentity(grainId, name)
+                .WithExpected("row absent")
+                .WithObserved(Describe(row))
+                .WithETags(row.ETag)
+                .Throw();
+        }
+    }
+
+    private void AssertCounts(
+        string guarantee,
+        IReminderServiceTestGrain grain,
+        string name,
+        int? owners,
+        int ticks)
+    {
+        var diagnosticTicks = _harness.GetTickCount(grain.GetGrainId(), name);
+        var actualOwners = _harness.GetOwners(grain.GetGrainId(), name);
+        if ((owners is { } expectedOwners && actualOwners.Count != expectedOwners)
+            || diagnosticTicks != ticks)
+        {
+            Fail(guarantee, "exact counters")
+                .WithIdentity(grain.GetGrainId(), name)
+                .WithExpected($"owners={(owners?.ToString(CultureInfo.InvariantCulture) ?? "<not-asserted>")}, completedTicks={ticks}")
+                .WithObserved(
+                    $"owners={actualOwners.Count} [{string.Join(", ", actualOwners)}], "
+                    + $"completedTicks={diagnosticTicks}")
+                .Throw();
+        }
+    }
+
+    private ReminderFailureReport OwnershipFailure(string guarantee, GrainId grainId, string name, int expected)
+        => Fail(guarantee, "ownership reconciliation")
+            .WithIdentity(grainId, name)
+            .WithExpected($"exactly {expected} local owner(s)")
+            .WithObserved($"owners=[{string.Join(", ", _harness.GetOwners(grainId, name))}]");
+
+    private ReminderFailureReport Fail(string guarantee, string operation)
+        => ReminderFailureReport.Create(ProviderName, guarantee, operation)
+            .WithDetail("seed", _seed.ToString(CultureInfo.InvariantCulture))
+            .WithDetail("clock", _harness.UtcNow.ToString("O", CultureInfo.InvariantCulture))
+            .WithDetail("activeSilos", string.Join(", ", _harness.ActiveSilos));
+
+    private static string Describe(ReminderEntry row)
+        => $"(GrainId={row.GrainId}, ReminderName='{row.ReminderName}', StartAt={row.StartAt:O}, "
+            + $"Period={row.Period}, ETag='{row.ETag}')";
+}

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -586,21 +586,48 @@ public abstract class ReminderServiceLifecycleTestRunner
         CancellationToken cancellationToken)
     {
         await Task.WhenAll(reminders.Select(item =>
-            CleanupAsync(guarantee, item.Grain, item.Name, cancellationToken)));
+            RemovePersistedRowAsync(guarantee, item.Grain.GetGrainId(), item.Name, cancellationToken)));
+        var quiescence = reminders
+            .Select(item => _harness.WaitForOwnerCountAsync(
+                item.Grain.GetGrainId(),
+                item.Name,
+                0,
+                cancellationToken))
+            .ToArray();
+        await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+        await Task.WhenAll(quiescence);
+        await Task.WhenAll(reminders.Select(item =>
+            AssertAbsentAsync(guarantee, item.Grain.GetGrainId(), item.Name, cancellationToken)));
     }
 
-    private async Task CleanupAsync(
+    private Task CleanupAsync(
         string guarantee,
         IReminderServiceTestGrain grain,
         string name,
         CancellationToken cancellationToken)
+        => CleanupAsync(guarantee, [(grain, name)], cancellationToken);
+
+    private async Task RemovePersistedRowAsync(
+        string guarantee,
+        GrainId grainId,
+        string name,
+        CancellationToken cancellationToken)
     {
-        if (await grain.UnregisterAsync(name).WaitAsync(cancellationToken))
+        var row = await _harness.ReminderTable.ReadRow(grainId, name).WaitAsync(cancellationToken);
+        if (row is null)
         {
-            await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 0, cancellationToken);
+            return;
         }
 
-        await AssertAbsentAsync(guarantee, grain.GetGrainId(), name, cancellationToken);
+        if (!await _harness.ReminderTable.RemoveRow(grainId, name, row.ETag!).WaitAsync(cancellationToken))
+        {
+            Fail(guarantee, "scenario cleanup remove")
+                .WithIdentity(grainId, name)
+                .WithExpected("scenario-owned row removed using its current ETag")
+                .WithObserved(Describe(row))
+                .WithETags(row.ETag, supplied: row.ETag)
+                .Throw();
+        }
     }
 
     private async Task AssertPersistedAsync(

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -328,10 +328,9 @@ public abstract class ReminderServiceLifecycleTestRunner
                 {
                     joined = await _harness.JoinOneSiloAsync(cancellationToken);
                     phase = "registration";
-                    foreach (var (grain, name) in reminders)
-                    {
-                        await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-                    }
+                    await Task.WhenAll(reminders.Select(item =>
+                        item.Grain.RegisterOrUpdateAsync(item.Name, TimeSpan.FromSeconds(3), Period)
+                            .WaitAsync(cancellationToken)));
 
                     phase = "topology reconciliation";
                     await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
@@ -394,19 +393,31 @@ public abstract class ReminderServiceLifecycleTestRunner
             Guarantee,
             async () =>
             {
+                await Task.WhenAll(reminders.Select(item =>
+                    item.Grain.RegisterOrUpdateAsync(item.Name, TimeSpan.FromSeconds(3), Period)
+                        .WaitAsync(cancellationToken)));
+                await Task.WhenAll(reminders.Select(item =>
+                    _harness.WaitForOwnerCountAsync(
+                        item.Grain.GetGrainId(),
+                        item.Name,
+                        1,
+                        cancellationToken)));
                 foreach (var (grain, name) in reminders)
                 {
-                    await grain.RegisterOrUpdateAsync(name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
-                    await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
                     initialOwners[grain.GetGrainId()] = _harness.GetOwners(grain.GetGrainId(), name).Single();
                 }
 
                 joined = await _harness.JoinOneSiloAsync(cancellationToken);
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                await Task.WhenAll(reminders.Select(item =>
+                    _harness.WaitForOwnerCountAsync(
+                        item.Grain.GetGrainId(),
+                        item.Name,
+                        1,
+                        cancellationToken)));
                 var transferred = 0;
                 foreach (var (grain, name) in reminders)
                 {
-                    await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
                     var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
                     transferred += owner.Equals(joined) ? 1 : 0;
                 }
@@ -422,9 +433,14 @@ public abstract class ReminderServiceLifecycleTestRunner
                 await _harness.LeaveSiloAsync(joined, cancellationToken);
                 joined = null;
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
+                await Task.WhenAll(reminders.Select(item =>
+                    _harness.WaitForOwnerCountAsync(
+                        item.Grain.GetGrainId(),
+                        item.Name,
+                        1,
+                        cancellationToken)));
                 foreach (var (grain, name) in reminders)
                 {
-                    await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), name, 1, cancellationToken);
                     var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
                     var expectedOwner = initialOwners[grain.GetGrainId()];
                     if (!owner.Equals(expectedOwner))
@@ -435,9 +451,13 @@ public abstract class ReminderServiceLifecycleTestRunner
                             .Throw();
                     }
 
-                    await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
                 }
 
+                await Task.WhenAll(reminders.Select(item =>
+                    _harness.WaitForScheduleAsync(
+                        item.Grain.GetGrainId(),
+                        item.Name,
+                        cancellationToken)));
                 var tickWaits = reminders
                     .Select(item => _harness.WaitForTickCountAsync(
                         item.Grain.GetGrainId(),
@@ -480,8 +500,9 @@ public abstract class ReminderServiceLifecycleTestRunner
             Guarantee,
             async () =>
             {
-                await sentinel.RegisterOrUpdateAsync(SentinelName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
-                await subject.RegisterOrUpdateAsync(SubjectName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken);
+                await Task.WhenAll(
+                    sentinel.RegisterOrUpdateAsync(SentinelName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken),
+                    subject.RegisterOrUpdateAsync(SubjectName, TimeSpan.FromMinutes(1), Period).WaitAsync(cancellationToken));
                 await CleanupAsync(Guarantee, subject, SubjectName, cancellationToken);
                 var sentinelRow = await _harness.ReminderTable.ReadRow(sentinel.GetGrainId(), SentinelName).WaitAsync(cancellationToken);
                 if (sentinelRow is null)
@@ -564,10 +585,8 @@ public abstract class ReminderServiceLifecycleTestRunner
         IReadOnlyList<(IReminderServiceTestGrain Grain, string Name)> reminders,
         CancellationToken cancellationToken)
     {
-        foreach (var (grain, name) in reminders)
-        {
-            await CleanupAsync(guarantee, grain, name, cancellationToken);
-        }
+        await Task.WhenAll(reminders.Select(item =>
+            CleanupAsync(guarantee, item.Grain, item.Name, cancellationToken)));
     }
 
     private async Task CleanupAsync(

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -52,6 +52,9 @@ public interface IReminderServiceLifecycleHarness
     /// <summary>Gets the current local owners.</summary>
     IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName);
 
+    /// <summary>Returns whether a silo's current ring range owns a grain identity.</summary>
+    bool IsOwner(SiloAddress siloAddress, GrainId grainId);
+
     /// <summary>Waits until the current owner has armed its persisted schedule.</summary>
     Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken);
 
@@ -131,6 +134,7 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_StartupReadiness);
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
                 await _harness.WaitForStartupReadinessAsync(cancellationToken);
@@ -155,9 +159,10 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_RegistrationHasSingleOwner);
         const string Name = "registration-owner";
         var grain = CreateGrain(Guarantee);
-        var due = TimeSpan.FromSeconds(3);
+        var due = GetNonRefreshAlignedDueTime();
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
                 var expectedStart = _harness.UtcNow.UtcDateTime + due;
@@ -190,6 +195,7 @@ public abstract class ReminderServiceLifecycleTestRunner
         var grain = CreateGrain(Guarantee);
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
                 await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
@@ -247,6 +253,7 @@ public abstract class ReminderServiceLifecycleTestRunner
         var grain = CreateGrain(Guarantee);
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
                 await grain.RegisterOrUpdateAsync(Name, TimeSpan.FromSeconds(3), Period).WaitAsync(cancellationToken);
@@ -282,11 +289,14 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_ExactDueRecovery);
         const string Name = "exact-due-recovery";
         var grain = CreateGrain(Guarantee);
+        var refreshSkew = TimeSpan.FromTicks(_harness.ReminderRefreshPeriod.Ticks / 2);
         var due = _harness.ReminderLoadingWindow
             + _harness.ReminderRefreshPeriod
-            + _harness.ReminderRefreshPeriod;
+            + _harness.ReminderRefreshPeriod
+            + refreshSkew;
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
                 var expectedStart = _harness.UtcNow.UtcDateTime + due;
@@ -332,6 +342,7 @@ public abstract class ReminderServiceLifecycleTestRunner
         SiloAddress? joined = null;
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
                 try
@@ -403,105 +414,58 @@ public abstract class ReminderServiceLifecycleTestRunner
     public async Task RunReminderService_OneSiloJoinLeaveTransfersOwnership(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderService_OneSiloJoinLeaveTransfersOwnership);
-        var reminders = CreateGrains(Guarantee, 32);
-        var firstTickTime = _harness.UtcNow.UtcDateTime + TimeSpan.FromSeconds(3);
-        var initialOwners = new Dictionary<GrainId, SiloAddress>();
+        var reminders = new List<(IReminderServiceTestGrain Grain, string Name)>();
         SiloAddress? joined = null;
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
-                await Task.WhenAll(reminders.Select(item =>
-                    item.Grain.RegisterOrUpdateAsync(item.Name, TimeSpan.FromSeconds(3), Period)
-                        .WaitAsync(cancellationToken)));
-                await WaitForOwnersAfterRefreshAsync(reminders, cancellationToken);
-                foreach (var (grain, name) in reminders)
-                {
-                    initialOwners[grain.GetGrainId()] = _harness.GetOwners(grain.GetGrainId(), name).Single();
-                }
-
                 joined = await _harness.JoinOneSiloAsync(cancellationToken);
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-                await Task.WhenAll(reminders.Select(item =>
-                    _harness.WaitForOwnerCountAsync(
-                        item.Grain.GetGrainId(),
-                        item.Name,
-                        1,
-                        cancellationToken)));
-                await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-                await Task.WhenAll(reminders.Select(item =>
-                    _harness.WaitForOwnerCountAsync(
-                        item.Grain.GetGrainId(),
-                        item.Name,
-                        1,
-                        cancellationToken)));
-                var transferred = 0;
-                (IReminderServiceTestGrain Grain, string Name)? transferredReminder = null;
-                foreach (var (grain, name) in reminders)
-                {
-                    var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
-                    if (owner.Equals(joined))
-                    {
-                        transferred++;
-                        transferredReminder ??= (grain, name);
-                    }
-                }
+                var grain = CreateGrainOwnedBy(joined, Guarantee);
+                const string Name = "join-leave-owner";
+                reminders.Add((grain, Name));
+                var due = GetNonRefreshAlignedDueTime();
+                var firstTickTime = _harness.UtcNow.UtcDateTime + due;
 
-                if (transferred == 0)
+                await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
+                await WaitForOwnersAfterRefreshAsync(reminders, cancellationToken);
+                var joinedOwner = _harness.GetOwners(grain.GetGrainId(), Name);
+                if (joinedOwner.Count != 1 || !joinedOwner[0].Equals(joined))
                 {
-                    Fail(Guarantee, "join reconciliation")
-                        .WithExpected($"at least one of {reminders.Count} deterministic reminders transferred to {joined}")
-                        .WithObserved("all reminders remained on the initial silos")
+                    OwnershipFailure(Guarantee, grain.GetGrainId(), Name, 1)
+                        .WithExpected($"the joined silo {joined} owns the selected reminder")
+                        .WithObserved($"owners=[{string.Join(", ", joinedOwner)}]")
                         .Throw();
                 }
 
                 await _harness.LeaveSiloAsync(joined, cancellationToken);
                 joined = null;
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-                await Task.WhenAll(reminders.Select(item =>
-                    _harness.WaitForOwnerCountAsync(
-                        item.Grain.GetGrainId(),
-                        item.Name,
-                        1,
-                        cancellationToken)));
+                await _harness.WaitForOwnerCountAsync(
+                    grain.GetGrainId(),
+                    Name,
+                    1,
+                    cancellationToken);
                 await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-                await Task.WhenAll(reminders.Select(item =>
-                    _harness.WaitForOwnerCountAsync(
-                        item.Grain.GetGrainId(),
-                        item.Name,
-                        1,
-                        cancellationToken)));
-                foreach (var (grain, name) in reminders)
-                {
-                    var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
-                    var expectedOwner = initialOwners[grain.GetGrainId()];
-                    if (!owner.Equals(expectedOwner))
-                    {
-                        OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1)
-                            .WithExpected($"owner={expectedOwner} after joined silo leaves")
-                            .WithObserved($"owner={owner}")
-                            .Throw();
-                    }
-
-                }
-
-                await Task.WhenAll(reminders.Select(item =>
-                    _harness.WaitForScheduleAsync(
-                        item.Grain.GetGrainId(),
-                        item.Name,
-                        cancellationToken)));
-                var transferredItem = transferredReminder!.Value;
+                await _harness.WaitForOwnerCountAsync(
+                    grain.GetGrainId(),
+                    Name,
+                    1,
+                    cancellationToken);
+                await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
                 var tick = _harness.WaitForTickCountAsync(
-                    transferredItem.Grain.GetGrainId(),
-                    transferredItem.Name,
+                    grain.GetGrainId(),
+                    Name,
                     1,
                     cancellationToken);
                 await _harness.AdvanceAsync(firstTickTime - _harness.UtcNow.UtcDateTime, cancellationToken);
                 await tick;
                 AssertCounts(
                     Guarantee,
-                    transferredItem.Grain,
-                    transferredItem.Name,
+                    grain,
+                    Name,
                     owners: null,
                     ticks: 1);
             },
@@ -531,6 +495,7 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string SubjectName = "scenario-owned";
         await ExecuteWithCleanupAsync(
             Guarantee,
+            cancellationToken,
             async () =>
             {
                 await Task.WhenAll(
@@ -566,14 +531,44 @@ public abstract class ReminderServiceLifecycleTestRunner
         return _harness.GrainFactory.GetGrain<IReminderServiceTestGrain>(key);
     }
 
+    private IReminderServiceTestGrain CreateGrainOwnedBy(SiloAddress owner, string label)
+    {
+        var ordinal = Interlocked.Increment(ref _grainCounter);
+        for (var candidate = 0; candidate < ushort.MaxValue; candidate++)
+        {
+            var key = ReminderTestData.CreateGuid(
+                _seed,
+                $"{ProviderName}/{label}/{ordinal}/{candidate.ToString(CultureInfo.InvariantCulture)}");
+            var grain = _harness.GrainFactory.GetGrain<IReminderServiceTestGrain>(key);
+            if (_harness.IsOwner(owner, grain.GetGrainId()))
+            {
+                return grain;
+            }
+        }
+
+        Fail(label, "identity selection")
+            .WithExpected($"a deterministic grain identity owned by {owner}")
+            .WithObserved("no owned identity in 65,535 deterministic candidates")
+            .Throw();
+        return null!;
+    }
+
+    private TimeSpan GetNonRefreshAlignedDueTime()
+        => _harness.ReminderRefreshPeriod
+            + _harness.ReminderRefreshPeriod
+            + _harness.ReminderRefreshPeriod
+            + TimeSpan.FromTicks(_harness.ReminderRefreshPeriod.Ticks / 2);
+
     private async Task ExecuteWithCleanupAsync(
         string guarantee,
+        CancellationToken scenarioCancellationToken,
         Func<Task> scenario,
         Func<CancellationToken, Task> cleanup)
     {
         ExceptionDispatchInfo? scenarioFailure = null;
         try
         {
+            await _harness.WaitForStartupReadinessAsync(scenarioCancellationToken);
             await scenario();
         }
         catch (Exception exception)

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -159,7 +159,7 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_RegistrationHasSingleOwner);
         const string Name = "registration-owner";
         var grain = CreateGrain(Guarantee);
-        var due = GetNonRefreshAlignedDueTime();
+        var due = TimeSpan.FromSeconds(3);
         await ExecuteWithCleanupAsync(
             Guarantee,
             cancellationToken,
@@ -289,11 +289,9 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_ExactDueRecovery);
         const string Name = "exact-due-recovery";
         var grain = CreateGrain(Guarantee);
-        var refreshSkew = TimeSpan.FromTicks(_harness.ReminderRefreshPeriod.Ticks / 2);
         var due = _harness.ReminderLoadingWindow
             + _harness.ReminderRefreshPeriod
-            + _harness.ReminderRefreshPeriod
-            + refreshSkew;
+            + _harness.ReminderRefreshPeriod;
         await ExecuteWithCleanupAsync(
             Guarantee,
             cancellationToken,
@@ -426,7 +424,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                 var grain = CreateGrainOwnedBy(joined, Guarantee);
                 const string Name = "join-leave-owner";
                 reminders.Add((grain, Name));
-                var due = GetNonRefreshAlignedDueTime();
+                var due = TimeSpan.FromSeconds(3);
                 var firstTickTime = _harness.UtcNow.UtcDateTime + due;
 
                 await grain.RegisterOrUpdateAsync(Name, due, Period).WaitAsync(cancellationToken);
@@ -552,12 +550,6 @@ public abstract class ReminderServiceLifecycleTestRunner
             .Throw();
         return null!;
     }
-
-    private TimeSpan GetNonRefreshAlignedDueTime()
-        => _harness.ReminderRefreshPeriod
-            + _harness.ReminderRefreshPeriod
-            + _harness.ReminderRefreshPeriod
-            + TimeSpan.FromTicks(_harness.ReminderRefreshPeriod.Ticks / 2);
 
     private async Task ExecuteWithCleanupAsync(
         string guarantee,

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -168,7 +168,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
                 await AssertPersistedAsync(Guarantee, grain.GetGrainId(), Name, expectedStart, Period, cancellationToken);
                 var tick = _harness.WaitForTickCountAsync(grain.GetGrainId(), Name, 1, cancellationToken);
-                await _harness.AdvanceAsync(due, cancellationToken);
+                await _harness.AdvanceAsync(expectedStart - _harness.UtcNow.UtcDateTime, cancellationToken);
                 await tick;
                 AssertCounts(Guarantee, grain, Name, owners: null, ticks: 1);
             },
@@ -206,6 +206,7 @@ public abstract class ReminderServiceLifecycleTestRunner
                     scheduleChanges + 1,
                     cancellationToken);
                 await grain.RegisterOrUpdateAsync(Name, due, Period + TimeSpan.FromMinutes(1)).WaitAsync(cancellationToken);
+                await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
                 await changed;
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
                 var updated = await ReadRequiredAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
@@ -258,7 +259,9 @@ public abstract class ReminderServiceLifecycleTestRunner
                         .Throw();
                 }
 
-                await _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 0, cancellationToken);
+                var quiescence = _harness.WaitForOwnerCountAsync(grain.GetGrainId(), Name, 0, cancellationToken);
+                await _harness.AdvanceAsync(_harness.ReminderRefreshPeriod, cancellationToken);
+                await quiescence;
                 await AssertAbsentAsync(Guarantee, grain.GetGrainId(), Name, cancellationToken);
                 await _harness.AdvanceAsync(Period, cancellationToken);
                 AssertCounts(Guarantee, grain, Name, owners: 0, ticks: 0);
@@ -387,6 +390,7 @@ public abstract class ReminderServiceLifecycleTestRunner
     {
         const string Guarantee = nameof(ReminderService_OneSiloJoinLeaveTransfersOwnership);
         var reminders = CreateGrains(Guarantee, 32);
+        var firstTickTime = _harness.UtcNow.UtcDateTime + TimeSpan.FromSeconds(3);
         var initialOwners = new Dictionary<GrainId, SiloAddress>();
         SiloAddress? joined = null;
         await ExecuteWithCleanupAsync(
@@ -411,10 +415,15 @@ public abstract class ReminderServiceLifecycleTestRunner
                         1,
                         cancellationToken)));
                 var transferred = 0;
+                (IReminderServiceTestGrain Grain, string Name)? transferredReminder = null;
                 foreach (var (grain, name) in reminders)
                 {
                     var owner = _harness.GetOwners(grain.GetGrainId(), name).Single();
-                    transferred += owner.Equals(joined) ? 1 : 0;
+                    if (owner.Equals(joined))
+                    {
+                        transferred++;
+                        transferredReminder ??= (grain, name);
+                    }
                 }
 
                 if (transferred == 0)
@@ -453,19 +462,20 @@ public abstract class ReminderServiceLifecycleTestRunner
                         item.Grain.GetGrainId(),
                         item.Name,
                         cancellationToken)));
-                var tickWaits = reminders
-                    .Select(item => _harness.WaitForTickCountAsync(
-                        item.Grain.GetGrainId(),
-                        item.Name,
-                        1,
-                        cancellationToken))
-                    .ToArray();
-                await _harness.AdvanceAsync(TimeSpan.FromSeconds(3), cancellationToken);
-                await Task.WhenAll(tickWaits);
-                foreach (var (grain, name) in reminders)
-                {
-                    AssertCounts(Guarantee, grain, name, owners: null, ticks: 1);
-                }
+                var transferredItem = transferredReminder!.Value;
+                var tick = _harness.WaitForTickCountAsync(
+                    transferredItem.Grain.GetGrainId(),
+                    transferredItem.Name,
+                    1,
+                    cancellationToken);
+                await _harness.AdvanceAsync(firstTickTime - _harness.UtcNow.UtcDateTime, cancellationToken);
+                await tick;
+                AssertCounts(
+                    Guarantee,
+                    transferredItem.Grain,
+                    transferredItem.Name,
+                    owners: null,
+                    ticks: 1);
             },
             async cleanupToken =>
             {

--- a/src/Orleans.Reminders/Orleans.Reminders.csproj
+++ b/src/Orleans.Reminders/Orleans.Reminders.csproj
@@ -21,9 +21,9 @@
     <InternalsVisibleTo Include="Orleans.Azure.Tests" />
     <InternalsVisibleTo Include="Orleans.Core.Tests" />
     <InternalsVisibleTo Include="Orleans.Reminders.Tests" />
+    <InternalsVisibleTo Include="Orleans.Testing.Reminders" />
     <InternalsVisibleTo Include="Orleans.Runtime" />
     <InternalsVisibleTo Include="Orleans.Runtime.Internal.Tests" />
     <InternalsVisibleTo Include="TestInternalGrains" />
   </ItemGroup>
 </Project>
-

--- a/src/Orleans.Runtime/Orleans.Runtime.csproj
+++ b/src/Orleans.Runtime/Orleans.Runtime.csproj
@@ -40,6 +40,7 @@
     <InternalsVisibleTo Include="Orleans.Streaming" />
     <InternalsVisibleTo Include="Orleans.Streaming.Tests" />
     <InternalsVisibleTo Include="Orleans.TestingHost" />
+    <InternalsVisibleTo Include="Orleans.Testing.Reminders" />
     <InternalsVisibleTo Include="TestInternalGrains" />
   </ItemGroup>
 </Project>

--- a/test/Extensions/Orleans.AWS.Tests/Orleans.AWS.Tests.csproj
+++ b/test/Extensions/Orleans.AWS.Tests/Orleans.AWS.Tests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Persistence.TestKit\Orleans.Persistence.TestKit.csproj" PrivateAssets="all" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Reminders.TestKit\Orleans.Reminders.TestKit.csproj" PrivateAssets="all" />
     <ProjectReference Include="$(SourceRoot)test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj" />
+    <ProjectReference Include="$(SourceRoot)test\Orleans.Reminders.Tests\Orleans.Reminders.Tests.csproj" />
     <ProjectReference Include="$(SourceRoot)test\Orleans.Streaming.Tests\Orleans.Streaming.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Extensions/Orleans.AWS.Tests/Reminder/DynamoDBRemindersTableTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Reminder/DynamoDBRemindersTableTests.cs
@@ -2,14 +2,75 @@ using AWSUtils.Tests.StorageTests;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Reminders.DynamoDB;
+using Orleans.Testing.Reminders;
+using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests;
 using UnitTests.RemindersTest;
+using UnitTests.TimerTests;
 using Xunit;
 
 namespace AWSUtils.Tests.RemindersTest
 {
+    public sealed class DynamoDBReminderServiceLifecycleFixture : BaseInProcessTestClusterFixture
+    {
+        private ReminderTestClock? _clock;
+
+        public ReminderTestClock Clock
+        {
+            get
+            {
+                EnsurePreconditionsMet();
+                return _clock ?? throw new InvalidOperationException("The reminder clock has not been configured.");
+            }
+        }
+
+        protected override void CheckPreconditionsOrThrow()
+        {
+            if (!AWSTestConstants.IsDynamoDbAvailable)
+            {
+                throw Xunit.Sdk.SkipException.ForSkip("Unable to connect to AWS DynamoDB simulator");
+            }
+        }
+
+        protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
+        {
+            _clock = builder.AddReminderTestClock();
+            builder.ConfigureSilo((_, siloBuilder) =>
+                siloBuilder.UseDynamoDBReminderService(options =>
+                    options.ParseConnectionString($"Service={AWSTestConstants.DynamoDbService}")));
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await base.DisposeAsync();
+            }
+            finally
+            {
+                _clock?.Dispose();
+            }
+        }
+    }
+
+    [TestCategory("Reminders"), TestCategory("AWS"), TestCategory("DynamoDb")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    [TestSuite("Functional")]
+    [TestProvider("DynamoDB")]
+    [TestArea("Reminders")]
+    public sealed class DynamoDBReminderServiceLifecycleTests
+        : ReminderServiceLifecycleTestsBase, IClassFixture<DynamoDBReminderServiceLifecycleFixture>
+    {
+        public DynamoDBReminderServiceLifecycleTests(DynamoDBReminderServiceLifecycleFixture fixture)
+            : base(fixture.Clock, fixture.HostedCluster, "DynamoDB")
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+    }
+
     /// <summary>
     /// Tests DynamoDB implementation of the Orleans reminders table for storing and retrieving grain reminders.
     /// </summary>

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderServiceLifecycleTests_AdoNet.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderServiceLifecycleTests_AdoNet.cs
@@ -26,7 +26,7 @@ public abstract class AdoNetReminderServiceLifecycleFixture : BaseInProcessTestC
     }
 
     protected override void CheckPreconditionsOrThrow()
-        => RelationalStorageForTesting.CheckPreconditionsOrThrow(Invariant);
+        => UnitTests.General.RelationalStorageForTesting.CheckPreconditionsOrThrow(Invariant);
 
     public override async ValueTask InitializeAsync()
     {
@@ -35,7 +35,7 @@ public abstract class AdoNetReminderServiceLifecycleFixture : BaseInProcessTestC
             return;
         }
 
-        var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+        var relationalStorage = await UnitTests.General.RelationalStorageForTesting.SetupInstance(
             Invariant,
             DatabaseName,
             cancellationToken: TestContext.Current.CancellationToken);

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderServiceLifecycleTests_AdoNet.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderServiceLifecycleTests_AdoNet.cs
@@ -3,7 +3,6 @@ using Orleans.Tests.SqlUtils;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
 using TestExtensions;
-using UnitTests.General;
 using UnitTests.TimerTests;
 
 namespace Tester.AdoNet.Reminders;

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderServiceLifecycleTests_AdoNet.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderServiceLifecycleTests_AdoNet.cs
@@ -1,0 +1,111 @@
+using Orleans.Hosting;
+using Orleans.Tests.SqlUtils;
+using Orleans.Testing.Reminders;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.General;
+using UnitTests.TimerTests;
+
+namespace Tester.AdoNet.Reminders;
+
+public abstract class AdoNetReminderServiceLifecycleFixture : BaseInProcessTestClusterFixture
+{
+    private string _connectionString = null!;
+    private ReminderTestClock? _clock;
+
+    protected abstract string Invariant { get; }
+
+    protected abstract string DatabaseName { get; }
+
+    public ReminderTestClock Clock
+    {
+        get
+        {
+            EnsurePreconditionsMet();
+            return _clock ?? throw new InvalidOperationException("The reminder clock has not been configured.");
+        }
+    }
+
+    protected override void CheckPreconditionsOrThrow()
+        => RelationalStorageForTesting.CheckPreconditionsOrThrow(Invariant);
+
+    public override async ValueTask InitializeAsync()
+    {
+        if (!PreconditionsMet)
+        {
+            return;
+        }
+
+        var relationalStorage = await RelationalStorageForTesting.SetupInstance(
+            Invariant,
+            DatabaseName,
+            cancellationToken: TestContext.Current.CancellationToken);
+        _connectionString = relationalStorage.CurrentConnectionString;
+        await base.InitializeAsync();
+    }
+
+    protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
+    {
+        _clock = builder.AddReminderTestClock();
+        builder.ConfigureSilo((_, siloBuilder) =>
+            siloBuilder.UseAdoNetReminderService(options =>
+            {
+                options.ConnectionString = _connectionString;
+                options.Invariant = Invariant;
+            }));
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await base.DisposeAsync();
+        }
+        finally
+        {
+            _clock?.Dispose();
+        }
+    }
+}
+
+public sealed class PostgreSqlReminderServiceLifecycleFixture : AdoNetReminderServiceLifecycleFixture
+{
+    protected override string Invariant => AdoNetInvariants.InvariantNamePostgreSql;
+
+    protected override string DatabaseName => "OrleansTest_PostgreSql_ReminderLifecycle";
+}
+
+public sealed class MySqlReminderServiceLifecycleFixture : AdoNetReminderServiceLifecycleFixture
+{
+    protected override string Invariant => AdoNetInvariants.InvariantNameMySql;
+
+    protected override string DatabaseName => "OrleansTest_MySql_ReminderLifecycle";
+}
+
+[TestSuite("Functional")]
+[TestProvider("PostgreSql")]
+[TestArea("Reminders")]
+[TestCategory("Functional"), TestCategory("Reminders"), TestCategory("AdoNet"), TestCategory("PostgreSql")]
+public sealed class PostgreSqlReminderServiceLifecycleTests
+    : ReminderServiceLifecycleTestsBase, IClassFixture<PostgreSqlReminderServiceLifecycleFixture>
+{
+    public PostgreSqlReminderServiceLifecycleTests(PostgreSqlReminderServiceLifecycleFixture fixture)
+        : base(fixture.Clock, fixture.HostedCluster, "AdoNet.PostgreSql")
+    {
+        fixture.EnsurePreconditionsMet();
+    }
+}
+
+[TestSuite("Functional")]
+[TestProvider("MySql")]
+[TestArea("Reminders")]
+[TestCategory("Functional"), TestCategory("Reminders"), TestCategory("AdoNet"), TestCategory("MySql")]
+public sealed class MySqlReminderServiceLifecycleTests
+    : ReminderServiceLifecycleTestsBase, IClassFixture<MySqlReminderServiceLifecycleFixture>
+{
+    public MySqlReminderServiceLifecycleTests(MySqlReminderServiceLifecycleFixture fixture)
+        : base(fixture.Clock, fixture.HostedCluster, "AdoNet.MySql")
+    {
+        fixture.EnsurePreconditionsMet();
+    }
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Reminders/ReminderTests_AdoNet_SqlServer.cs
@@ -17,6 +17,20 @@ using Xunit;
 
 namespace Tester.AdoNet.Reminders
 {
+    [TestSuite("Functional")]
+    [TestProvider("SqlServer")]
+    [TestArea("Reminders")]
+    [TestCategory("Reminders"), TestCategory("AdoNet"), TestCategory("SqlServer")]
+    public sealed class ReminderServiceLifecycleTests_AdoNet_SqlServer
+        : ReminderServiceLifecycleTestsBase, IClassFixture<ReminderTests_AdoNet_SqlServer.Fixture>
+    {
+        public ReminderServiceLifecycleTests_AdoNet_SqlServer(ReminderTests_AdoNet_SqlServer.Fixture fixture)
+            : base(fixture.ReminderClock, fixture.HostedCluster, "AdoNet.SqlServer")
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+    }
+
     /// <summary>
     /// Integration tests for Orleans reminders functionality using SQL Server as the reminder service backend.
     /// </summary>
@@ -101,7 +115,7 @@ namespace Tester.AdoNet.Reminders
             await ClearReminderTableAsync(TestContext.Current.CancellationToken)
                 .WaitAsync(TestConstants.InitTimeout, TestContext.Current.CancellationToken);
         }
-        
+
         // Basic tests
 
         [Fact]

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -14,6 +14,20 @@ using Orleans.Internal;
 
 namespace Tester.AzureUtils.TimerTests
 {
+    [TestSuite("Functional")]
+    [TestProvider("AzureStorage")]
+    [TestArea("Reminders")]
+    [TestCategory("Reminders"), TestCategory("AzureStorage")]
+    public sealed class ReminderServiceLifecycleTests_AzureTable
+        : ReminderServiceLifecycleTestsBase, IClassFixture<ReminderTests_AzureTable.Fixture>
+    {
+        public ReminderServiceLifecycleTests_AzureTable(ReminderTests_AzureTable.Fixture fixture)
+            : base(fixture.ReminderClock, fixture.HostedCluster, "AzureStorage")
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+    }
+
     /// <summary>
     /// Tests for Azure Table Storage-based reminder service, including basic operations, failover, and multi-grain scenarios.
     /// </summary>

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -11,6 +11,20 @@ using UnitTests.GrainInterfaces;
 
 namespace Tester.Cosmos.Reminders;
 
+[TestSuite("Functional")]
+[TestProvider("Cosmos")]
+[TestArea("Reminders")]
+[TestCategory("Reminders"), TestCategory("Cosmos")]
+public sealed class ReminderServiceLifecycleTests_Cosmos
+    : ReminderServiceLifecycleTestsBase, IClassFixture<ReminderTests_Cosmos.Fixture>
+{
+    public ReminderServiceLifecycleTests_Cosmos(ReminderTests_Cosmos.Fixture fixture)
+        : base(fixture.ReminderClock, fixture.HostedCluster, "Cosmos")
+    {
+        fixture.EnsurePreconditionsMet();
+    }
+}
+
 /// <summary>
 /// Tests for Orleans reminders functionality using Azure Cosmos DB as the reminder service backing store.
 /// </summary>

--- a/test/Extensions/Orleans.Redis.Tests/Orleans.Redis.Tests.csproj
+++ b/test/Extensions/Orleans.Redis.Tests/Orleans.Redis.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Persistence.TestKit\Orleans.Persistence.TestKit.csproj" PrivateAssets="all" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Reminders.TestKit\Orleans.Reminders.TestKit.csproj" PrivateAssets="all" />
     <ProjectReference Include="$(SourceRoot)test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj" />
+    <ProjectReference Include="$(SourceRoot)test\Orleans.Reminders.Tests\Orleans.Reminders.Tests.csproj" />
     <ProjectReference Include="$(SourceRoot)test\Orleans.Streaming.Tests\Orleans.Streaming.Tests.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Redis\Orleans.Journaling.Redis\Orleans.Journaling.Redis.csproj" />
   </ItemGroup>

--- a/test/Extensions/Orleans.Redis.Tests/Reminders/RedisReminderTableTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Reminders/RedisReminderTableTests.cs
@@ -3,16 +3,75 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Orleans.Configuration;
+using Orleans.Hosting;
 using Orleans.Reminders.Redis;
 using Orleans.Runtime;
+using Orleans.Testing.Reminders;
+using Orleans.TestingHost;
 using StackExchange.Redis;
 using TestExtensions;
 using UnitTests;
 using UnitTests.RemindersTest;
+using UnitTests.TimerTests;
 using Xunit;
 
 namespace Tester.Redis.Reminders
 {
+    public sealed class RedisReminderServiceLifecycleFixture : BaseInProcessTestClusterFixture
+    {
+        private ReminderTestClock? _clock;
+
+        public ReminderTestClock Clock
+        {
+            get
+            {
+                EnsurePreconditionsMet();
+                return _clock ?? throw new InvalidOperationException("The reminder clock has not been configured.");
+            }
+        }
+
+        protected override void CheckPreconditionsOrThrow() => TestUtils.CheckForRedis();
+
+        protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
+        {
+            _clock = builder.AddReminderTestClock();
+            builder.ConfigureSilo((_, siloBuilder) =>
+                siloBuilder.UseRedisReminderService(options =>
+                {
+                    options.ConfigurationOptions = ConfigurationOptions.Parse(
+                        TestDefaultConfiguration.RedisConnectionString!);
+                    options.EntryExpiry = TimeSpan.FromHours(1);
+                }));
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await base.DisposeAsync();
+            }
+            finally
+            {
+                _clock?.Dispose();
+            }
+        }
+    }
+
+    [TestCategory("Redis"), TestCategory("Reminders"), TestCategory("Functional")]
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    [TestSuite("Functional")]
+    [TestProvider("Redis")]
+    [TestArea("Reminders")]
+    public sealed class RedisReminderServiceLifecycleTests
+        : ReminderServiceLifecycleTestsBase, IClassFixture<RedisReminderServiceLifecycleFixture>
+    {
+        public RedisReminderServiceLifecycleTests(RedisReminderServiceLifecycleFixture fixture)
+            : base(fixture.Clock, fixture.HostedCluster, "Redis")
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+    }
+
     /// <summary>
     /// Tests for Redis reminder table implementation.
     /// </summary>
@@ -23,7 +82,7 @@ namespace Tester.Redis.Reminders
     [TestArea("Reminders")]
     public class RedisRemindersTableTests : ReminderTableTestsBase
     {
-        public RedisRemindersTableTests(ConnectionStringFixture fixture, CommonFixture clusterFixture) : base (fixture, clusterFixture, CreateFilters())
+        public RedisRemindersTableTests(ConnectionStringFixture fixture, CommonFixture clusterFixture) : base(fixture, clusterFixture, CreateFilters())
         {
             TestUtils.CheckForRedis();
         }
@@ -46,7 +105,7 @@ namespace Tester.Redis.Reminders
                 {
                     ConfigurationOptions = ConfigurationOptions.Parse(GetConnectionString().Result),
                     EntryExpiry = TimeSpan.FromHours(1)
-                })); 
+                }));
 
             if (reminderTable == null)
             {

--- a/test/Extensions/Orleans.Reminders.Firestore.Tests/FirestoreRemindersTests.cs
+++ b/test/Extensions/Orleans.Reminders.Firestore.Tests/FirestoreRemindersTests.cs
@@ -1,13 +1,70 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using UnitTests;
-using TestExtensions;
-using UnitTests.RemindersTest;
+using Orleans.Hosting;
 using Orleans.Reminders.Firestore;
 using Orleans.Runtime;
-
+using Orleans.Testing.Reminders;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests;
+using UnitTests.RemindersTest;
+using UnitTests.TimerTests;
 
 namespace Orleans.Reminders.Firestore.Tests;
+
+public sealed class FirestoreReminderServiceLifecycleFixture : BaseInProcessTestClusterFixture
+{
+    private ReminderTestClock? _clock;
+
+    public ReminderTestClock Clock
+    {
+        get
+        {
+            EnsurePreconditionsMet();
+            return _clock ?? throw new InvalidOperationException("The reminder clock has not been configured.");
+        }
+    }
+
+    protected override void CheckPreconditionsOrThrow() => _ = GoogleEmulatorHost.FirestoreEndpoint;
+
+    protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
+    {
+        _clock = builder.AddReminderTestClock();
+        builder.ConfigureSilo((_, siloBuilder) =>
+            siloBuilder.UseFirestoreReminderService(options =>
+            {
+                options.ProjectId = GoogleEmulatorHost.ProjectId;
+                options.EmulatorHost = GoogleEmulatorHost.FirestoreEndpoint;
+            }));
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await base.DisposeAsync();
+        }
+        finally
+        {
+            _clock?.Dispose();
+        }
+    }
+}
+
+[TestSuite("Functional")]
+[TestProvider("GoogleCloud")]
+[TestArea("Reminders")]
+[TestCategory("Reminders"), TestCategory("Firestore"), TestCategory("GoogleCloud"), TestCategory("Functional")]
+[Collection(TestEnvironmentFixture.DefaultCollection)]
+public sealed class FirestoreReminderServiceLifecycleTests
+    : ReminderServiceLifecycleTestsBase, IClassFixture<FirestoreReminderServiceLifecycleFixture>
+{
+    public FirestoreReminderServiceLifecycleTests(FirestoreReminderServiceLifecycleFixture fixture)
+        : base(fixture.Clock, fixture.HostedCluster, "Firestore")
+    {
+        fixture.EnsurePreconditionsMet();
+    }
+}
 
 [TestSuite("Functional")]
 [TestProvider("GoogleCloud")]

--- a/test/Extensions/Orleans.Reminders.Firestore.Tests/Orleans.Reminders.Firestore.Tests.csproj
+++ b/test/Extensions/Orleans.Reminders.Firestore.Tests/Orleans.Reminders.Firestore.Tests.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="$(SourceRoot)src\Google\Orleans.Reminders.Firestore\Orleans.Reminders.Firestore.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Reminders.TestKit\Orleans.Reminders.TestKit.csproj" PrivateAssets="all" />
     <ProjectReference Include="$(SourceRoot)test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj" />
+    <ProjectReference Include="$(SourceRoot)test\Orleans.Reminders.Tests\Orleans.Reminders.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -19,7 +19,6 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
     private static readonly TimeSpan LoadingWindow = TimeSpan.FromSeconds(5);
     private InProcessTestCluster? _cluster;
     private ReminderTestClock? _clock;
-    private ReminderDiagnosticObserver? _observer;
 
     public ReminderServiceLifecycleHarness Harness { get; private set; } = null!;
 
@@ -34,10 +33,13 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
             builder,
             minimumReminderPeriod: TimeSpan.FromSeconds(1),
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
-        _observer = ReminderDiagnosticObserver.Create();
         _cluster = builder.Build();
         await _cluster.DeployAsync(TestContext.Current.CancellationToken);
-        Harness = new ReminderServiceLifecycleHarness(_cluster, _clock, _observer, LoadingWindow);
+        Harness = new ReminderServiceLifecycleHarness(
+            _cluster,
+            _clock,
+            _clock.DiagnosticObserver,
+            LoadingWindow);
     }
 
     public async ValueTask DisposeAsync()
@@ -56,7 +58,6 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
         {
             using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
             await cluster.DisposeAsync().AsTask().WaitAsync(cancellation.Token);
-            _observer?.Dispose();
             _clock?.Dispose();
         }
     }
@@ -156,6 +157,30 @@ public sealed class FaultyReminderServiceLifecycleTests
                 Assert.Contains("starts=2", exception.Message, StringComparison.Ordinal);
             });
 
+    [Fact]
+    public async Task CanceledScenarioPreservesCancellationAndStillCleansItsRows()
+    {
+        var fixture = new ReminderServiceLifecycleFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            var runner = new LifecycleRunner(new BlockingScheduleHarness(fixture.Harness), "CanceledScenario");
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => runner.RunReminderService_RegistrationHasSingleOwner(cancellation.Token));
+
+            var table = Assert.IsType<IdealizedReminderTable>(fixture.Harness.ReminderTable);
+            Assert.Empty(table.Snapshot());
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
     private static async Task RunFaultAsync(
         Func<IReminderServiceLifecycleHarness, LifecycleRunner> createRunner,
         Func<LifecycleRunner, CancellationToken, Task> scenario)
@@ -190,9 +215,9 @@ public sealed class FaultyReminderServiceLifecycleTests
         public IReadOnlyList<SiloAddress> ActiveSilos => Inner.ActiveSilos;
         public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => Inner.WaitForStartupReadinessAsync(cancellationToken);
         public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => Inner.AdvanceAsync(amount, cancellationToken);
-        public Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
+        public virtual Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
         public virtual IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName) => Inner.GetOwners(grainId, reminderName);
-        public Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => Inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
+        public virtual Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => Inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
         public virtual int GetLocalStartCount(GrainId grainId, string reminderName) => Inner.GetLocalStartCount(grainId, reminderName);
         public int GetLocalStopCount(GrainId grainId, string reminderName) => Inner.GetLocalStopCount(grainId, reminderName);
         public int GetScheduleChangeCount(GrainId grainId, string reminderName) => Inner.GetScheduleChangeCount(grainId, reminderName);
@@ -206,10 +231,26 @@ public sealed class FaultyReminderServiceLifecycleTests
 
     private sealed class DuplicateOwnerHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)
     {
-        public override IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName)
+        private object? _duplicateIdentity;
+
+        public override async Task WaitForOwnerCountAsync(
+            GrainId grainId,
+            string reminderName,
+            int count,
+            CancellationToken cancellationToken)
         {
-            var owners = base.GetOwners(grainId, reminderName);
-            return owners.Count == 1 ? [owners[0], owners[0]] : owners;
+            var harness = Assert.IsType<ReminderServiceLifecycleHarness>(Inner);
+            if (count == 0 && _duplicateIdentity is { } identity)
+            {
+                harness.RemoveDuplicateOwnerForTesting(grainId, reminderName, identity);
+                _duplicateIdentity = null;
+            }
+
+            await base.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
+            if (count == 1 && _duplicateIdentity is null)
+            {
+                _duplicateIdentity = harness.AddDuplicateOwnerForTesting(grainId, reminderName);
+            }
         }
     }
 
@@ -229,5 +270,14 @@ public sealed class FaultyReminderServiceLifecycleTests
             await base.WaitForScheduleChangeCountAsync(grainId, reminderName, count, cancellationToken);
             _updated = true;
         }
+    }
+
+    private sealed class BlockingScheduleHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)
+    {
+        public override Task WaitForScheduleAsync(
+            GrainId grainId,
+            string reminderName,
+            CancellationToken cancellationToken)
+            => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 }

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -258,7 +258,14 @@ public sealed class FaultyReminderServiceLifecycleTests
             {
                 await runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership(token);
                 Assert.NotNull(recordingHarness);
-                Assert.Equal([TimeSpan.FromSeconds(3)], recordingHarness.Advances);
+                Assert.Equal(
+                    [
+                        recordingHarness.ReminderRefreshPeriod
+                            + recordingHarness.ReminderRefreshPeriod
+                            + recordingHarness.ReminderRefreshPeriod
+                            + TimeSpan.FromTicks(recordingHarness.ReminderRefreshPeriod.Ticks / 2)
+                    ],
+                    recordingHarness.Advances);
             });
     }
 
@@ -299,6 +306,7 @@ public sealed class FaultyReminderServiceLifecycleTests
         public virtual Task RefreshAsync(CancellationToken cancellationToken) => Inner.RefreshAsync(cancellationToken);
         public virtual Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
         public virtual IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName) => Inner.GetOwners(grainId, reminderName);
+        public bool IsOwner(SiloAddress siloAddress, GrainId grainId) => Inner.IsOwner(siloAddress, grainId);
         public virtual Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => Inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
         public virtual int GetLocalStartCount(GrainId grainId, string reminderName) => Inner.GetLocalStartCount(grainId, reminderName);
         public int GetLocalStopCount(GrainId grainId, string reminderName) => Inner.GetLocalStopCount(grainId, reminderName);

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -20,6 +20,15 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
     private InProcessTestCluster? _cluster;
     private ReminderTestClock? _clock;
 
+    public ReminderServiceLifecycleFixture()
+    {
+    }
+
+    internal ReminderServiceLifecycleFixture(ReminderTestClock clock)
+    {
+        _clock = clock;
+    }
+
     public ReminderServiceLifecycleHarness Harness { get; private set; } = null!;
 
     public async ValueTask InitializeAsync()
@@ -44,21 +53,33 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        if (_cluster is not { } cluster)
-        {
-            return;
-        }
+        var cluster = _cluster;
+        var clock = _clock;
+        _cluster = null;
+        _clock = null;
 
         try
         {
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            await cluster.StopAllSilosAsync(cancellation.Token);
+            if (cluster is not null)
+            {
+                using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                await cluster.StopAllSilosAsync(cancellation.Token);
+            }
         }
         finally
         {
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-            await cluster.DisposeAsync().AsTask().WaitAsync(cancellation.Token);
-            _clock?.Dispose();
+            try
+            {
+                if (cluster is not null)
+                {
+                    using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                    await cluster.DisposeAsync().AsTask().WaitAsync(cancellation.Token);
+                }
+            }
+            finally
+            {
+                clock?.Dispose();
+            }
         }
     }
 }
@@ -133,6 +154,18 @@ public sealed class ReminderServiceLifecycleConformanceTests
 [Collection(ReminderServiceLifecycleCollection.Name)]
 public sealed class FaultyReminderServiceLifecycleTests
 {
+    [Fact]
+    public async Task PartiallyInitializedFixtureDisposesClock()
+    {
+        var clock = ReminderTestClock.Attach(new InProcessTestClusterBuilder(1));
+        var fixture = new ReminderServiceLifecycleFixture(clock);
+
+        await fixture.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => clock.AdvanceAsync(TimeSpan.Zero, TestContext.Current.CancellationToken));
+    }
+
     [Fact]
     public Task DuplicateOwnerImplementationIsRejected()
         => RunFaultAsync(
@@ -209,13 +242,7 @@ public sealed class FaultyReminderServiceLifecycleTests
             {
                 await runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership(token);
                 Assert.NotNull(recordingHarness);
-                Assert.Equal(
-                    [
-                        recordingHarness.ReminderRefreshPeriod,
-                        TimeSpan.FromSeconds(3) - recordingHarness.ReminderRefreshPeriod,
-                        recordingHarness.ReminderRefreshPeriod
-                    ],
-                    recordingHarness.Advances);
+                Assert.Equal([TimeSpan.FromSeconds(3)], recordingHarness.Advances);
             });
     }
 
@@ -253,6 +280,7 @@ public sealed class FaultyReminderServiceLifecycleTests
         public IReadOnlyList<SiloAddress> ActiveSilos => Inner.ActiveSilos;
         public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => Inner.WaitForStartupReadinessAsync(cancellationToken);
         public virtual Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => Inner.AdvanceAsync(amount, cancellationToken);
+        public virtual Task RefreshAsync(CancellationToken cancellationToken) => Inner.RefreshAsync(cancellationToken);
         public virtual Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
         public virtual IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName) => Inner.GetOwners(grainId, reminderName);
         public virtual Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => Inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
@@ -342,9 +370,9 @@ public sealed class FaultyReminderServiceLifecycleTests
             ReleasedByRefresh = true;
         }
 
-        public override async Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
+        public override async Task RefreshAsync(CancellationToken cancellationToken)
         {
-            await base.AdvanceAsync(amount, cancellationToken);
+            await base.RefreshAsync(cancellationToken);
             Interlocked.Exchange(ref _refreshGate, null)?.TrySetResult();
         }
     }

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -181,6 +181,44 @@ public sealed class FaultyReminderServiceLifecycleTests
         }
     }
 
+    [Fact]
+    public Task UpdateWaitsForRefreshBeforeExpectingScheduleReconciliation()
+    {
+        RefreshGatedScheduleHarness? gatedHarness = null;
+        return RunFaultAsync(
+            harness => new LifecycleRunner(
+                gatedHarness = new RefreshGatedScheduleHarness(harness),
+                "RefreshGatedUpdate"),
+            async (runner, token) =>
+            {
+                await runner.RunReminderService_UpdateDoesNotRestartLocalOwner(token);
+                Assert.NotNull(gatedHarness);
+                Assert.True(gatedHarness.ReleasedByRefresh);
+            });
+    }
+
+    [Fact]
+    public Task JoinLeaveAdvancesToTheExactRemainingDueTime()
+    {
+        RecordingAdvanceHarness? recordingHarness = null;
+        return RunFaultAsync(
+            harness => new LifecycleRunner(
+                recordingHarness = new RecordingAdvanceHarness(harness),
+                "ExactJoinLeaveDue"),
+            async (runner, token) =>
+            {
+                await runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership(token);
+                Assert.NotNull(recordingHarness);
+                Assert.Equal(
+                    [
+                        recordingHarness.ReminderRefreshPeriod,
+                        TimeSpan.FromSeconds(3) - recordingHarness.ReminderRefreshPeriod,
+                        recordingHarness.ReminderRefreshPeriod
+                    ],
+                    recordingHarness.Advances);
+            });
+    }
+
     private static async Task RunFaultAsync(
         Func<IReminderServiceLifecycleHarness, LifecycleRunner> createRunner,
         Func<LifecycleRunner, CancellationToken, Task> scenario)
@@ -214,7 +252,7 @@ public sealed class FaultyReminderServiceLifecycleTests
         public TimeSpan ReminderRefreshPeriod => Inner.ReminderRefreshPeriod;
         public IReadOnlyList<SiloAddress> ActiveSilos => Inner.ActiveSilos;
         public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => Inner.WaitForStartupReadinessAsync(cancellationToken);
-        public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => Inner.AdvanceAsync(amount, cancellationToken);
+        public virtual Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => Inner.AdvanceAsync(amount, cancellationToken);
         public virtual Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
         public virtual IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName) => Inner.GetOwners(grainId, reminderName);
         public virtual Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => Inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
@@ -279,5 +317,46 @@ public sealed class FaultyReminderServiceLifecycleTests
             string reminderName,
             CancellationToken cancellationToken)
             => Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    private sealed class RefreshGatedScheduleHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)
+    {
+        private TaskCompletionSource? _refreshGate;
+
+        public bool ReleasedByRefresh { get; private set; }
+
+        public override async Task WaitForScheduleChangeCountAsync(
+            GrainId grainId,
+            string reminderName,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            var innerWait = base.WaitForScheduleChangeCountAsync(
+                grainId,
+                reminderName,
+                count,
+                cancellationToken);
+            var refreshGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _refreshGate = refreshGate;
+            await Task.WhenAll(innerWait, refreshGate.Task.WaitAsync(cancellationToken));
+            ReleasedByRefresh = true;
+        }
+
+        public override async Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
+        {
+            await base.AdvanceAsync(amount, cancellationToken);
+            Interlocked.Exchange(ref _refreshGate, null)?.TrySetResult();
+        }
+    }
+
+    private sealed class RecordingAdvanceHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)
+    {
+        public List<TimeSpan> Advances { get; } = [];
+
+        public override async Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
+        {
+            Advances.Add(amount);
+            await base.AdvanceAsync(amount, cancellationToken);
+        }
     }
 }

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -1,0 +1,233 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
+using Orleans.Reminders.TestKit;
+using Orleans.Runtime;
+using Orleans.Testing.Reminders;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace Orleans.Reminders.TestKit.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ReminderServiceLifecycleCollection
+{
+    public const string Name = "Reminder service lifecycle conformance";
+}
+
+public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
+{
+    private static readonly TimeSpan LoadingWindow = TimeSpan.FromSeconds(5);
+    private InProcessTestCluster? _cluster;
+    private ReminderTestClock? _clock;
+    private ReminderDiagnosticObserver? _observer;
+
+    public ReminderServiceLifecycleHarness Harness { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = new InProcessTestClusterBuilder(1);
+        builder.ConfigureSilo((_, siloBuilder) =>
+            siloBuilder.Configure<ConsistentRingOptions>(options => options.UseVirtualBucketsConsistentRing = false));
+        builder.UseIdealizedReminderTable(
+            configureReminderOptions: options => options.ReminderLoadingWindow = LoadingWindow);
+        _clock = ReminderTestClock.Attach(
+            builder,
+            minimumReminderPeriod: TimeSpan.FromSeconds(1),
+            refreshReminderListPeriod: TimeSpan.FromSeconds(1));
+        _observer = ReminderDiagnosticObserver.Create();
+        _cluster = builder.Build();
+        await _cluster.DeployAsync(TestContext.Current.CancellationToken);
+        Harness = new ReminderServiceLifecycleHarness(_cluster, _clock, _observer, LoadingWindow);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_cluster is not { } cluster)
+        {
+            return;
+        }
+
+        try
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.StopAllSilosAsync(cancellation.Token);
+        }
+        finally
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            await cluster.DisposeAsync().AsTask().WaitAsync(cancellation.Token);
+            _observer?.Dispose();
+            _clock?.Dispose();
+        }
+    }
+}
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Reminders")]
+[TestCategory("BVT"), TestCategory("Reminders"), TestCategory("ReminderTestKit")]
+[Collection(ReminderServiceLifecycleCollection.Name)]
+public sealed class ReminderServiceLifecycleConformanceTests
+{
+    [Fact]
+    public Task ReminderService_StartupReadiness()
+        => RunAsync((runner, token) => runner.RunReminderService_StartupReadiness(token));
+
+    [Fact]
+    public Task ReminderService_RegistrationHasSingleOwner()
+        => RunAsync((runner, token) => runner.RunReminderService_RegistrationHasSingleOwner(token));
+
+    [Fact]
+    public Task ReminderService_UpdateDoesNotRestartLocalOwner()
+        => RunAsync((runner, token) => runner.RunReminderService_UpdateDoesNotRestartLocalOwner(token));
+
+    [Fact]
+    public Task ReminderService_RemovalReachesQuiescence()
+        => RunAsync((runner, token) => runner.RunReminderService_RemovalReachesQuiescence(token));
+
+    [Fact]
+    public Task ReminderService_ExactDueRecovery()
+        => RunAsync((runner, token) => runner.RunReminderService_ExactDueRecovery(token));
+
+    [Fact]
+    public Task ReminderService_StaleOwnerRegistrationReconciles()
+        => RunAsync((runner, token) => runner.RunReminderService_StaleOwnerRegistrationReconciles(token));
+
+    [Fact]
+    public Task ReminderService_OneSiloJoinLeaveTransfersOwnership()
+        => RunAsync((runner, token) => runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership(token));
+
+    [Fact]
+    public Task ReminderService_CleanupIsIsolated()
+        => RunAsync((runner, token) => runner.RunReminderService_CleanupIsIsolated(token));
+
+    private static async Task RunAsync(
+        Func<ReminderServiceLifecycleTestRunner, CancellationToken, Task> scenario)
+    {
+        var fixture = new ReminderServiceLifecycleFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromMinutes(2));
+            await scenario(
+                new LifecycleRunner(fixture.Harness, "IdealizedReminderTable"),
+                cancellation.Token);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    private sealed class LifecycleRunner(IReminderServiceLifecycleHarness harness, string providerName)
+        : ReminderServiceLifecycleTestRunner(harness, providerName, seed: 42);
+}
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Reminders")]
+[TestCategory("BVT"), TestCategory("Reminders"), TestCategory("ReminderTestKit")]
+[Collection(ReminderServiceLifecycleCollection.Name)]
+public sealed class FaultyReminderServiceLifecycleTests
+{
+    [Fact]
+    public Task DuplicateOwnerImplementationIsRejected()
+        => RunFaultAsync(
+            harness => new LifecycleRunner(new DuplicateOwnerHarness(harness), "DuplicateOwner"),
+            async (runner, token) =>
+            {
+                var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+                    () => runner.RunReminderService_RegistrationHasSingleOwner(token));
+                Assert.Contains("exactly 1 local owner", exception.Message, StringComparison.Ordinal);
+                Assert.Contains("owners=[", exception.Message, StringComparison.Ordinal);
+            });
+
+    [Fact]
+    public Task RestartingUpdateImplementationIsRejected()
+        => RunFaultAsync(
+            harness => new LifecycleRunner(new RestartingUpdateHarness(harness), "RestartingUpdate"),
+            async (runner, token) =>
+            {
+                var exception = await Assert.ThrowsAsync<ReminderConformanceException>(
+                    () => runner.RunReminderService_UpdateDoesNotRestartLocalOwner(token));
+                Assert.Contains("same single owner", exception.Message, StringComparison.Ordinal);
+                Assert.Contains("starts=2", exception.Message, StringComparison.Ordinal);
+            });
+
+    private static async Task RunFaultAsync(
+        Func<IReminderServiceLifecycleHarness, LifecycleRunner> createRunner,
+        Func<LifecycleRunner, CancellationToken, Task> scenario)
+    {
+        var fixture = new ReminderServiceLifecycleFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromMinutes(2));
+            await scenario(createRunner(fixture.Harness), cancellation.Token);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    private sealed class LifecycleRunner(IReminderServiceLifecycleHarness harness, string providerName)
+        : ReminderServiceLifecycleTestRunner(harness, providerName);
+
+    private class DelegatingHarness(IReminderServiceLifecycleHarness inner) : IReminderServiceLifecycleHarness
+    {
+        protected IReminderServiceLifecycleHarness Inner { get; } = inner;
+
+        public IGrainFactory GrainFactory => Inner.GrainFactory;
+        public IReminderTable ReminderTable => Inner.ReminderTable;
+        public DateTimeOffset UtcNow => Inner.UtcNow;
+        public TimeSpan ReminderLoadingWindow => Inner.ReminderLoadingWindow;
+        public TimeSpan ReminderRefreshPeriod => Inner.ReminderRefreshPeriod;
+        public IReadOnlyList<SiloAddress> ActiveSilos => Inner.ActiveSilos;
+        public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => Inner.WaitForStartupReadinessAsync(cancellationToken);
+        public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => Inner.AdvanceAsync(amount, cancellationToken);
+        public Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
+        public virtual IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName) => Inner.GetOwners(grainId, reminderName);
+        public Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => Inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
+        public virtual int GetLocalStartCount(GrainId grainId, string reminderName) => Inner.GetLocalStartCount(grainId, reminderName);
+        public int GetLocalStopCount(GrainId grainId, string reminderName) => Inner.GetLocalStopCount(grainId, reminderName);
+        public int GetScheduleChangeCount(GrainId grainId, string reminderName) => Inner.GetScheduleChangeCount(grainId, reminderName);
+        public virtual Task WaitForScheduleChangeCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForScheduleChangeCountAsync(grainId, reminderName, count, cancellationToken);
+        public Task WaitForTickCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForTickCountAsync(grainId, reminderName, count, cancellationToken);
+        public int GetTickCount(GrainId grainId, string reminderName) => Inner.GetTickCount(grainId, reminderName);
+        public Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken) => Inner.JoinOneSiloAsync(cancellationToken);
+        public Task LeaveSiloAsync(SiloAddress siloAddress, CancellationToken cancellationToken) => Inner.LeaveSiloAsync(siloAddress, cancellationToken);
+        public Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken) => Inner.WaitForTopologyReconciliationAsync(cancellationToken);
+    }
+
+    private sealed class DuplicateOwnerHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)
+    {
+        public override IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName)
+        {
+            var owners = base.GetOwners(grainId, reminderName);
+            return owners.Count == 1 ? [owners[0], owners[0]] : owners;
+        }
+    }
+
+    private sealed class RestartingUpdateHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)
+    {
+        private bool _updated;
+
+        public override int GetLocalStartCount(GrainId grainId, string reminderName)
+            => base.GetLocalStartCount(grainId, reminderName) + (_updated ? 1 : 0);
+
+        public override async Task WaitForScheduleChangeCountAsync(
+            GrainId grainId,
+            string reminderName,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            await base.WaitForScheduleChangeCountAsync(grainId, reminderName, count, cancellationToken);
+            _updated = true;
+        }
+    }
+}

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -33,22 +33,38 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        var builder = new InProcessTestClusterBuilder(1);
-        builder.ConfigureSilo((_, siloBuilder) =>
-            siloBuilder.Configure<ConsistentRingOptions>(options => options.UseVirtualBucketsConsistentRing = false));
-        builder.UseIdealizedReminderTable(
-            configureReminderOptions: options => options.ReminderLoadingWindow = LoadingWindow);
-        _clock = ReminderTestClock.Attach(
-            builder,
-            minimumReminderPeriod: TimeSpan.FromSeconds(1),
-            refreshReminderListPeriod: TimeSpan.FromSeconds(1));
-        _cluster = builder.Build();
-        await _cluster.DeployAsync(TestContext.Current.CancellationToken);
-        Harness = new ReminderServiceLifecycleHarness(
-            _cluster,
-            _clock,
-            _clock.DiagnosticObserver,
-            LoadingWindow);
+        try
+        {
+            var builder = new InProcessTestClusterBuilder(1);
+            builder.ConfigureSilo((_, siloBuilder) =>
+                siloBuilder.Configure<ConsistentRingOptions>(options => options.UseVirtualBucketsConsistentRing = false));
+            builder.UseIdealizedReminderTable(
+                configureReminderOptions: options => options.ReminderLoadingWindow = LoadingWindow);
+            _clock = ReminderTestClock.Attach(
+                builder,
+                minimumReminderPeriod: TimeSpan.FromSeconds(1),
+                refreshReminderListPeriod: TimeSpan.FromSeconds(1));
+            _cluster = builder.Build();
+            await _cluster.DeployAsync(TestContext.Current.CancellationToken);
+            Harness = new ReminderServiceLifecycleHarness(
+                _cluster,
+                _clock,
+                _clock.DiagnosticObserver,
+                LoadingWindow);
+        }
+        catch (Exception initializationException)
+        {
+            try
+            {
+                await DisposeAsync();
+            }
+            catch (Exception cleanupException)
+            {
+                initializationException.Data["ReminderServiceLifecycleFixture.CleanupException"] = cleanupException;
+            }
+
+            throw;
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -258,14 +258,7 @@ public sealed class FaultyReminderServiceLifecycleTests
             {
                 await runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership(token);
                 Assert.NotNull(recordingHarness);
-                Assert.Equal(
-                    [
-                        recordingHarness.ReminderRefreshPeriod
-                            + recordingHarness.ReminderRefreshPeriod
-                            + recordingHarness.ReminderRefreshPeriod
-                            + TimeSpan.FromTicks(recordingHarness.ReminderRefreshPeriod.Ticks / 2)
-                    ],
-                    recordingHarness.Advances);
+                Assert.Equal([TimeSpan.FromSeconds(3)], recordingHarness.Advances);
             });
     }
 

--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -237,6 +237,47 @@ public class ReminderEventsTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task ReminderDiagnosticObserver_CountsDuplicateInstancesOnOneSilo()
+    {
+        using var observer = ReminderDiagnosticObserver.Create();
+        var grainId = GrainId.Create("test", "duplicate-owner");
+        const string reminderName = "reminder";
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14010), 11);
+        var firstIdentity = new object();
+        var secondIdentity = new object();
+
+        var twoOwners = observer.WaitForActiveReminderCountAsync(
+            grainId,
+            2,
+            TestContext.Current.CancellationToken,
+            reminderName,
+            [siloAddress]);
+        ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, firstIdentity, siloAddress);
+        ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, secondIdentity, siloAddress);
+
+        await twoOwners;
+        Assert.Equal(
+            [siloAddress, siloAddress],
+            observer.GetActiveReminderOwnerSilos(grainId, reminderName));
+        Assert.Single(observer.GetActiveReminderSilos(grainId, reminderName));
+
+        ReminderEvents.EmitLocalReminderStopped(
+            grainId,
+            reminderName,
+            firstIdentity,
+            ReminderEvents.LocalReminderStopReason.Unregistered,
+            siloAddress);
+        ReminderEvents.EmitLocalReminderStopped(
+            grainId,
+            reminderName,
+            secondIdentity,
+            ReminderEvents.LocalReminderStopReason.Unregistered,
+            siloAddress);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_CanceledQuiescenceWait_RemainsCanceled()
     {
         using var observer = ReminderDiagnosticObserver.Create();

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Reminders.TestKit;
+using Orleans.Testing.Reminders;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace UnitTests.TimerTests;
+
+/// <summary>
+/// Exposes the shared reminder-service lifecycle contract without inheriting provider whole-table cleanup.
+/// </summary>
+public abstract class ReminderServiceLifecycleTestsBase
+{
+    private readonly ReminderServiceLifecycleTestRunner _runner;
+
+    protected ReminderServiceLifecycleTestsBase(
+        ReminderTestClock reminderClock,
+        InProcessTestCluster cluster,
+        string providerName)
+    {
+        ArgumentNullException.ThrowIfNull(reminderClock);
+        ArgumentNullException.ThrowIfNull(cluster);
+        var services = cluster.GetActiveSilos().First().ServiceProvider;
+        var options = services.GetRequiredService<IOptions<ReminderOptions>>().Value;
+        var harness = new ReminderServiceLifecycleHarness(
+            cluster,
+            reminderClock,
+            reminderClock.DiagnosticObserver,
+            options.ReminderLoadingWindow);
+        _runner = new ProviderRunner(harness, providerName);
+    }
+
+    [Fact]
+    public Task ReminderService_StartupReadiness()
+        => _runner.RunReminderService_StartupReadiness(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public Task ReminderService_RegistrationHasSingleOwner()
+        => _runner.RunReminderService_RegistrationHasSingleOwner(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public Task ReminderService_UpdateDoesNotRestartLocalOwner()
+        => _runner.RunReminderService_UpdateDoesNotRestartLocalOwner(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public Task ReminderService_RemovalReachesQuiescence()
+        => _runner.RunReminderService_RemovalReachesQuiescence(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public Task ReminderService_ExactDueRecovery()
+        => _runner.RunReminderService_ExactDueRecovery(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public Task ReminderService_StaleOwnerRegistrationReconciles()
+        => _runner.RunReminderService_StaleOwnerRegistrationReconciles(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public Task ReminderService_OneSiloJoinLeaveTransfersOwnership()
+        => _runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public Task ReminderService_CleanupIsIsolated()
+        => _runner.RunReminderService_CleanupIsIsolated(TestContext.Current.CancellationToken);
+
+    private sealed class ProviderRunner(IReminderServiceLifecycleHarness harness, string providerName)
+        : ReminderServiceLifecycleTestRunner(harness, providerName);
+}

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
@@ -12,6 +12,7 @@ namespace UnitTests.TimerTests;
 /// </summary>
 public abstract class ReminderServiceLifecycleTestsBase
 {
+    private static readonly TimeSpan ScenarioTimeout = TimeSpan.FromMinutes(2);
     private readonly ReminderServiceLifecycleTestRunner _runner;
 
     protected ReminderServiceLifecycleTestsBase(
@@ -33,35 +34,43 @@ public abstract class ReminderServiceLifecycleTestsBase
 
     [Fact]
     public Task ReminderService_StartupReadiness()
-        => _runner.RunReminderService_StartupReadiness(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_StartupReadiness);
 
     [Fact]
     public Task ReminderService_RegistrationHasSingleOwner()
-        => _runner.RunReminderService_RegistrationHasSingleOwner(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_RegistrationHasSingleOwner);
 
     [Fact]
     public Task ReminderService_UpdateDoesNotRestartLocalOwner()
-        => _runner.RunReminderService_UpdateDoesNotRestartLocalOwner(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_UpdateDoesNotRestartLocalOwner);
 
     [Fact]
     public Task ReminderService_RemovalReachesQuiescence()
-        => _runner.RunReminderService_RemovalReachesQuiescence(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_RemovalReachesQuiescence);
 
     [Fact]
     public Task ReminderService_ExactDueRecovery()
-        => _runner.RunReminderService_ExactDueRecovery(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_ExactDueRecovery);
 
     [Fact]
     public Task ReminderService_StaleOwnerRegistrationReconciles()
-        => _runner.RunReminderService_StaleOwnerRegistrationReconciles(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_StaleOwnerRegistrationReconciles);
 
     [Fact]
     public Task ReminderService_OneSiloJoinLeaveTransfersOwnership()
-        => _runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_OneSiloJoinLeaveTransfersOwnership);
 
     [Fact]
     public Task ReminderService_CleanupIsIsolated()
-        => _runner.RunReminderService_CleanupIsIsolated(TestContext.Current.CancellationToken);
+        => RunAsync(_runner.RunReminderService_CleanupIsIsolated);
+
+    private static async Task RunAsync(Func<CancellationToken, Task> scenario)
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(ScenarioTimeout);
+        await scenario(cancellation.Token);
+    }
 
     private sealed class ProviderRunner(IReminderServiceLifecycleHarness harness, string providerName)
         : ReminderServiceLifecycleTestRunner(harness, providerName);

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Reminders.TestKit;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
+using TestExtensions;
 using Xunit;
 
 namespace UnitTests.TimerTests;
@@ -10,6 +11,7 @@ namespace UnitTests.TimerTests;
 /// <summary>
 /// Exposes the shared reminder-service lifecycle contract without inheriting provider whole-table cleanup.
 /// </summary>
+[Collection(TestEnvironmentFixture.DefaultCollection)]
 public abstract class ReminderServiceLifecycleTestsBase
 {
     private static readonly TimeSpan ScenarioTimeout = TimeSpan.FromMinutes(2);

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderServiceLifecycleTestsBase.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Reminders.TestKit;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -20,6 +20,19 @@ using ReminderEvents = Orleans.Reminders.Diagnostics.ReminderEvents;
 
 namespace UnitTests.TimerTests
 {
+    [TestSuite("Functional")]
+    [TestProvider("None")]
+    [TestArea("Reminders")]
+    [TestCategory("Functional"), TestCategory("Reminders")]
+    public sealed class ReminderServiceLifecycleTests_TableGrain
+        : ReminderServiceLifecycleTestsBase, IClassFixture<ReminderTests_TableGrain.Fixture>
+    {
+        public ReminderServiceLifecycleTests_TableGrain(ReminderTests_TableGrain.Fixture fixture)
+            : base(fixture.ReminderClock, fixture.HostedCluster, "InMemory")
+        {
+        }
+    }
+
     /// <summary>
     /// Tests for grain-based reminder functionality using in-memory reminder service as table storage.
     /// </summary>

--- a/test/Orleans.Testing.Reminders/Orleans.Testing.Reminders.csproj
+++ b/test/Orleans.Testing.Reminders/Orleans.Testing.Reminders.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(SourceRoot)src\Orleans.Reminders.TestKit\Orleans.Reminders.TestKit.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Reminders\Orleans.Reminders.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
   </ItemGroup>

--- a/test/Orleans.Testing.Reminders/Orleans.Testing.Reminders.csproj
+++ b/test/Orleans.Testing.Reminders/Orleans.Testing.Reminders.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Reminders\Orleans.Reminders.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Orleans.Reminders.TestKit.Tests" />
+  </ItemGroup>
 </Project>

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -29,11 +29,15 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     private readonly IDisposable _storageSubscription;
     private readonly Dictionary<GrainId, int> _tickCountsByGrain = [];
     private readonly Dictionary<ReminderTickKey, int> _tickCountsByReminder = [];
+    private readonly Dictionary<ReminderTickKey, int> _localStartCounts = [];
+    private readonly Dictionary<ReminderTickKey, int> _localStopCounts = [];
+    private readonly Dictionary<ReminderTickKey, int> _scheduleChangeCounts = [];
     private readonly Dictionary<ReminderTickKey, Dictionary<LocalReminderInstanceKey, LocalReminderInstanceState>> _activeLocalReminders = [];
     private readonly List<TickCountWaiter> _tickCountWaiters = [];
     private readonly List<ActiveReminderCountWaiter> _activeReminderCountWaiters = [];
     private readonly List<LocalReminderScheduleWaiter> _localReminderScheduleWaiters = [];
     private readonly List<GlobalQuiescenceWaiter> _globalQuiescenceWaiters = [];
+    private readonly List<ScheduleChangeCountWaiter> _scheduleChangeCountWaiters = [];
 
     /// <summary>
     /// Creates a new instance of the observer and starts listening for reminder diagnostic events.
@@ -84,6 +88,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                     break;
                 case ReminderEvents.LocalReminderStarted localReminderStarted:
                     var startedKey = new ReminderTickKey(localReminderStarted.GrainId, localReminderStarted.ReminderName);
+                    _localStartCounts[startedKey] = _localStartCounts.GetValueOrDefault(startedKey) + 1;
                     if (!_activeLocalReminders.TryGetValue(startedKey, out var startedInstances))
                     {
                         startedInstances = new Dictionary<LocalReminderInstanceKey, LocalReminderInstanceState>();
@@ -97,6 +102,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                     break;
                 case ReminderEvents.LocalReminderStopped localReminderStopped:
                     var stoppedKey = new ReminderTickKey(localReminderStopped.GrainId, localReminderStopped.ReminderName);
+                    _localStopCounts[stoppedKey] = _localStopCounts.GetValueOrDefault(stoppedKey) + 1;
                     if (_activeLocalReminders.TryGetValue(stoppedKey, out var stoppedInstances))
                     {
                         stoppedInstances.Remove(new LocalReminderInstanceKey(
@@ -114,6 +120,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                     break;
                 case ReminderEvents.LocalReminderScheduleChanged localReminderScheduleChanged:
                     var changedKey = new ReminderTickKey(localReminderScheduleChanged.GrainId, localReminderScheduleChanged.ReminderName);
+                    _scheduleChangeCounts[changedKey] = _scheduleChangeCounts.GetValueOrDefault(changedKey) + 1;
                     if (TryGetLocalReminderInstance(changedKey, localReminderScheduleChanged.Identity, out var changedInstance))
                     {
                         changedInstance.ScheduleVersion = Math.Max(
@@ -121,6 +128,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                             localReminderScheduleChanged.ScheduleVersion);
                     }
 
+                    ReleaseReadyScheduleChangeWaiters(ready);
                     break;
                 case ReminderEvents.LocalReminderTickWaitArmed localReminderTickWaitArmed:
                     var tickWaitArmedKey = new ReminderTickKey(localReminderTickWaitArmed.GrainId, localReminderTickWaitArmed.ReminderName);
@@ -243,6 +251,63 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         {
             return GetTickCountCore(grainId, reminderName);
         }
+    }
+
+    /// <summary>Gets the number of local reminder instances started for an identity.</summary>
+    public int GetLocalStartCount(GrainId grainId, string reminderName)
+    {
+        lock (_lock)
+        {
+            return _localStartCounts.GetValueOrDefault(new ReminderTickKey(grainId, reminderName));
+        }
+    }
+
+    /// <summary>Gets the number of local reminder instances stopped for an identity.</summary>
+    public int GetLocalStopCount(GrainId grainId, string reminderName)
+    {
+        lock (_lock)
+        {
+            return _localStopCounts.GetValueOrDefault(new ReminderTickKey(grainId, reminderName));
+        }
+    }
+
+    /// <summary>Gets the number of local schedule changes for an identity.</summary>
+    public int GetScheduleChangeCount(GrainId grainId, string reminderName)
+    {
+        lock (_lock)
+        {
+            return _scheduleChangeCounts.GetValueOrDefault(new ReminderTickKey(grainId, reminderName));
+        }
+    }
+
+    /// <summary>Waits for the requested number of local schedule changes for an identity.</summary>
+    public Task WaitForScheduleChangeCountAsync(
+        GrainId grainId,
+        string reminderName,
+        int expectedCount,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(expectedCount);
+        ArgumentException.ThrowIfNullOrEmpty(reminderName);
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        ScheduleChangeCountWaiter waiter;
+        lock (_lock)
+        {
+            if (_scheduleChangeCounts.GetValueOrDefault(new ReminderTickKey(grainId, reminderName)) >= expectedCount)
+            {
+                return Task.CompletedTask;
+            }
+
+            waiter = new ScheduleChangeCountWaiter(grainId, reminderName, expectedCount);
+            _scheduleChangeCountWaiters.Add(waiter);
+            RegisterCancellation(waiter, _scheduleChangeCountWaiters, cancellationToken);
+        }
+
+        return waiter.TaskSource.Task;
     }
 
     /// <summary>
@@ -545,6 +610,23 @@ public sealed class ReminderDiagnosticObserver : IDisposable
             .Any(instance => instance.SiloAddress is { } address && siloAddresses.Contains(address));
     }
 
+    private void ReleaseReadyScheduleChangeWaiters(List<Waiter> ready)
+    {
+        for (var i = _scheduleChangeCountWaiters.Count - 1; i >= 0; i--)
+        {
+            var waiter = _scheduleChangeCountWaiters[i];
+            var count = _scheduleChangeCounts.GetValueOrDefault(
+                new ReminderTickKey(waiter.GrainId, waiter.ReminderName));
+            if (count < waiter.TargetCount)
+            {
+                continue;
+            }
+
+            _scheduleChangeCountWaiters.RemoveAt(i);
+            ready.Add(waiter);
+        }
+    }
+
     private readonly record struct ReminderTickKey(GrainId GrainId, string ReminderName);
     private readonly record struct LocalReminderInstanceKey(object Identity)
     {
@@ -597,6 +679,16 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     private sealed class GlobalQuiescenceWaiter(IReadOnlySet<SiloAddress> siloAddresses) : Waiter
     {
         public IReadOnlySet<SiloAddress> SiloAddresses { get; } = siloAddresses.ToHashSet();
+    }
+
+    private sealed class ScheduleChangeCountWaiter(
+        GrainId grainId,
+        string reminderName,
+        int targetCount) : Waiter
+    {
+        public GrainId GrainId { get; } = grainId;
+        public string ReminderName { get; } = reminderName;
+        public int TargetCount { get; } = targetCount;
     }
 
     /// <inheritdoc/>

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -253,7 +253,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         }
     }
 
-    /// <summary>Gets the number of local reminder instances started for an identity.</summary>
+    /// <summary>Gets the number of local reminder instances started for a reminder.</summary>
     public int GetLocalStartCount(GrainId grainId, string reminderName)
     {
         lock (_lock)
@@ -262,7 +262,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         }
     }
 
-    /// <summary>Gets the number of local reminder instances stopped for an identity.</summary>
+    /// <summary>Gets the number of local reminder instances stopped for a reminder.</summary>
     public int GetLocalStopCount(GrainId grainId, string reminderName)
     {
         lock (_lock)
@@ -271,7 +271,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         }
     }
 
-    /// <summary>Gets the number of local schedule changes for an identity.</summary>
+    /// <summary>Gets the number of local schedule changes for a reminder.</summary>
     public int GetScheduleChangeCount(GrainId grainId, string reminderName)
     {
         lock (_lock)
@@ -280,7 +280,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         }
     }
 
-    /// <summary>Waits for the requested number of local schedule changes for an identity.</summary>
+    /// <summary>Waits for the requested number of local schedule changes for a reminder.</summary>
     public Task WaitForScheduleChangeCountAsync(
         GrainId grainId,
         string reminderName,
@@ -344,17 +344,18 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     public SiloAddress[] GetActiveReminderOwnerSilos(
         GrainId grainId,
         string reminderName,
-        Predicate<SiloAddress?>? ownerFilter = null)
+        IEnumerable<SiloAddress>? activeSilos = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(reminderName);
+        var activeSiloSet = activeSilos?.ToHashSet();
 
         lock (_lock)
         {
             return _activeLocalReminders.TryGetValue(new ReminderTickKey(grainId, reminderName), out var instances)
                 ? instances.Values
-                    .Where(instance => ownerFilter is null || ownerFilter(instance.SiloAddress))
                     .Select(instance => instance.SiloAddress)
                     .OfType<SiloAddress>()
+                    .Where(siloAddress => activeSiloSet is null || activeSiloSet.Contains(siloAddress))
                     .ToArray()
                 : [];
         }
@@ -367,27 +368,27 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     {
         ArgumentOutOfRangeException.ThrowIfNegative(expectedCount);
         ArgumentException.ThrowIfNullOrEmpty(reminderName);
-        return WaitForActiveReminderCountCoreAsync(grainId, expectedCount, reminderName, ownerFilter: null, cancellationToken);
+        return WaitForActiveReminderCountCoreAsync(grainId, expectedCount, reminderName, activeSilos: null, cancellationToken);
     }
 
     /// <summary>
-    /// Waits for a specific number of active local reminder instances which match <paramref name="ownerFilter"/>.
+    /// Waits for a specific number of active local reminder instances on <paramref name="activeSilos"/>.
     /// </summary>
     public Task WaitForActiveReminderCountAsync(
         GrainId grainId,
         int expectedCount,
         CancellationToken cancellationToken,
         string reminderName,
-        Predicate<SiloAddress?> ownerFilter)
+        IEnumerable<SiloAddress> activeSilos)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(expectedCount);
         ArgumentException.ThrowIfNullOrEmpty(reminderName);
-        ArgumentNullException.ThrowIfNull(ownerFilter);
+        ArgumentNullException.ThrowIfNull(activeSilos);
         return WaitForActiveReminderCountCoreAsync(
             grainId,
             expectedCount,
             reminderName,
-            ownerFilter,
+            activeSilos.ToHashSet(),
             cancellationToken);
     }
 
@@ -406,7 +407,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     public Task WaitForReminderQuiescenceAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrEmpty(reminderName);
-        return WaitForActiveReminderCountCoreAsync(grainId, 0, reminderName, ownerFilter: null, cancellationToken);
+        return WaitForActiveReminderCountCoreAsync(grainId, 0, reminderName, activeSilos: null, cancellationToken);
     }
 
     /// <summary>
@@ -471,7 +472,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         GrainId grainId,
         int targetCount,
         string reminderName,
-        Predicate<SiloAddress?>? ownerFilter,
+        HashSet<SiloAddress>? activeSilos,
         CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
@@ -482,12 +483,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         ActiveReminderCountWaiter? waiter;
         lock (_lock)
         {
-            if (GetActiveReminderCountCore(grainId, reminderName, ownerFilter) == targetCount)
+            if (GetActiveReminderCountCore(grainId, reminderName, activeSilos) == targetCount)
             {
                 return Task.CompletedTask;
             }
 
-            waiter = new ActiveReminderCountWaiter(grainId, reminderName, targetCount, ownerFilter);
+            waiter = new ActiveReminderCountWaiter(grainId, reminderName, targetCount, activeSilos);
             _activeReminderCountWaiters.Add(waiter);
             RegisterCancellation(waiter, _activeReminderCountWaiters, cancellationToken);
         }
@@ -553,10 +554,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     private int GetActiveReminderCountCore(
         GrainId grainId,
         string reminderName,
-        Predicate<SiloAddress?>? ownerFilter = null)
+        HashSet<SiloAddress>? activeSilos = null)
     {
         return _activeLocalReminders.TryGetValue(new ReminderTickKey(grainId, reminderName), out var instances)
-            ? instances.Values.Count(instance => ownerFilter is null || ownerFilter(instance.SiloAddress))
+            ? instances.Values.Count(instance =>
+                instance.SiloAddress is { } siloAddress
+                && (activeSilos is null || activeSilos.Contains(siloAddress)))
             : 0;
     }
 
@@ -614,7 +617,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         for (var i = _activeReminderCountWaiters.Count - 1; i >= 0; i--)
         {
             var waiter = _activeReminderCountWaiters[i];
-            if (GetActiveReminderCountCore(waiter.GrainId, waiter.ReminderName, waiter.OwnerFilter) != waiter.TargetCount)
+            if (GetActiveReminderCountCore(waiter.GrainId, waiter.ReminderName, waiter.ActiveSilos) != waiter.TargetCount)
             {
                 continue;
             }
@@ -718,12 +721,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         GrainId grainId,
         string reminderName,
         int targetCount,
-        Predicate<SiloAddress?>? ownerFilter) : Waiter
+        HashSet<SiloAddress>? activeSilos) : Waiter
     {
         public GrainId GrainId { get; } = grainId;
         public string ReminderName { get; } = reminderName;
         public int TargetCount { get; } = targetCount;
-        public Predicate<SiloAddress?>? OwnerFilter { get; } = ownerFilter;
+        public HashSet<SiloAddress>? ActiveSilos { get; } = activeSilos;
     }
 
     private sealed class LocalReminderScheduleWaiter(GrainId grainId, string reminderName) : Waiter

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -339,13 +339,56 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     }
 
     /// <summary>
+    /// Gets one silo address per active local reminder instance, preserving duplicate instances on the same silo.
+    /// </summary>
+    public SiloAddress[] GetActiveReminderOwnerSilos(
+        GrainId grainId,
+        string reminderName,
+        Predicate<SiloAddress?>? ownerFilter = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(reminderName);
+
+        lock (_lock)
+        {
+            return _activeLocalReminders.TryGetValue(new ReminderTickKey(grainId, reminderName), out var instances)
+                ? instances.Values
+                    .Where(instance => ownerFilter is null || ownerFilter(instance.SiloAddress))
+                    .Select(instance => instance.SiloAddress)
+                    .OfType<SiloAddress>()
+                    .ToArray()
+                : [];
+        }
+    }
+
+    /// <summary>
     /// Waits for a specific number of active local reminder owners for a reminder.
     /// </summary>
     public Task WaitForActiveReminderCountAsync(GrainId grainId, int expectedCount, CancellationToken cancellationToken, string reminderName)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(expectedCount);
         ArgumentException.ThrowIfNullOrEmpty(reminderName);
-        return WaitForActiveReminderCountCoreAsync(grainId, expectedCount, reminderName, cancellationToken);
+        return WaitForActiveReminderCountCoreAsync(grainId, expectedCount, reminderName, ownerFilter: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Waits for a specific number of active local reminder instances which match <paramref name="ownerFilter"/>.
+    /// </summary>
+    public Task WaitForActiveReminderCountAsync(
+        GrainId grainId,
+        int expectedCount,
+        CancellationToken cancellationToken,
+        string reminderName,
+        Predicate<SiloAddress?> ownerFilter)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(expectedCount);
+        ArgumentException.ThrowIfNullOrEmpty(reminderName);
+        ArgumentNullException.ThrowIfNull(ownerFilter);
+        return WaitForActiveReminderCountCoreAsync(
+            grainId,
+            expectedCount,
+            reminderName,
+            ownerFilter,
+            cancellationToken);
     }
 
     /// <summary>
@@ -363,7 +406,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     public Task WaitForReminderQuiescenceAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrEmpty(reminderName);
-        return WaitForActiveReminderCountCoreAsync(grainId, 0, reminderName, cancellationToken);
+        return WaitForActiveReminderCountCoreAsync(grainId, 0, reminderName, ownerFilter: null, cancellationToken);
     }
 
     /// <summary>
@@ -424,7 +467,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         return waiter.TaskSource.Task;
     }
 
-    private Task WaitForActiveReminderCountCoreAsync(GrainId grainId, int targetCount, string reminderName, CancellationToken cancellationToken)
+    private Task WaitForActiveReminderCountCoreAsync(
+        GrainId grainId,
+        int targetCount,
+        string reminderName,
+        Predicate<SiloAddress?>? ownerFilter,
+        CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
         {
@@ -434,12 +482,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         ActiveReminderCountWaiter? waiter;
         lock (_lock)
         {
-            if (GetActiveReminderCountCore(grainId, reminderName) == targetCount)
+            if (GetActiveReminderCountCore(grainId, reminderName, ownerFilter) == targetCount)
             {
                 return Task.CompletedTask;
             }
 
-            waiter = new ActiveReminderCountWaiter(grainId, reminderName, targetCount);
+            waiter = new ActiveReminderCountWaiter(grainId, reminderName, targetCount, ownerFilter);
             _activeReminderCountWaiters.Add(waiter);
             RegisterCancellation(waiter, _activeReminderCountWaiters, cancellationToken);
         }
@@ -502,10 +550,13 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         return _tickCountsByReminder.GetValueOrDefault(new ReminderTickKey(grainId, reminderName));
     }
 
-    private int GetActiveReminderCountCore(GrainId grainId, string reminderName)
+    private int GetActiveReminderCountCore(
+        GrainId grainId,
+        string reminderName,
+        Predicate<SiloAddress?>? ownerFilter = null)
     {
         return _activeLocalReminders.TryGetValue(new ReminderTickKey(grainId, reminderName), out var instances)
-            ? instances.Count
+            ? instances.Values.Count(instance => ownerFilter is null || ownerFilter(instance.SiloAddress))
             : 0;
     }
 
@@ -563,7 +614,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         for (var i = _activeReminderCountWaiters.Count - 1; i >= 0; i--)
         {
             var waiter = _activeReminderCountWaiters[i];
-            if (GetActiveReminderCountCore(waiter.GrainId, waiter.ReminderName) != waiter.TargetCount)
+            if (GetActiveReminderCountCore(waiter.GrainId, waiter.ReminderName, waiter.OwnerFilter) != waiter.TargetCount)
             {
                 continue;
             }
@@ -663,11 +714,16 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         public int TargetCount { get; } = targetCount;
     }
 
-    private sealed class ActiveReminderCountWaiter(GrainId grainId, string reminderName, int targetCount) : Waiter
+    private sealed class ActiveReminderCountWaiter(
+        GrainId grainId,
+        string reminderName,
+        int targetCount,
+        Predicate<SiloAddress?>? ownerFilter) : Waiter
     {
         public GrainId GrainId { get; } = grainId;
         public string ReminderName { get; } = reminderName;
         public int TargetCount { get; } = targetCount;
+        public Predicate<SiloAddress?>? OwnerFilter { get; } = ownerFilter;
     }
 
     private sealed class LocalReminderScheduleWaiter(GrainId grainId, string reminderName) : Waiter

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -67,6 +67,17 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         => _clock.AdvanceAsync(amount, cancellationToken);
 
     /// <inheritdoc />
+    public async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        foreach (var silo in _cluster.GetActiveSilos())
+        {
+            await silo.ServiceProvider.GetRequiredService<LocalReminderService>()
+                .TestOnlyRefresh()
+                .WaitAsync(cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
     public Task WaitForOwnerCountAsync(
         GrainId grainId,
         string reminderName,
@@ -127,7 +138,8 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         var silo = AssertSingle(await _cluster.StartSilosAsync(1).WaitAsync(cancellationToken));
         await Task.WhenAll(
             _observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress),
-            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
+            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
+            _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
         return silo.SiloAddress;
     }
 
@@ -137,17 +149,22 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         var silo = _cluster.GetSiloForAddress(siloAddress)
             ?? throw new InvalidOperationException($"Silo {siloAddress} is not active.");
         await _cluster.StopSiloAsync(silo, cancellationToken);
-        await _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+        await Task.WhenAll(
+            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
+            _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
     }
 
     /// <inheritdoc />
     public async Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken)
     {
-        await _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+        await Task.WhenAll(
+            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
+            _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
         var barriers = _cluster.GetActiveSilos().Select(silo =>
             silo.ServiceProvider.GetRequiredService<LocalReminderService>()
                 .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
         await Task.WhenAll(barriers);
+        await RefreshAsync(cancellationToken);
     }
 
     private static InProcessSiloHandle AssertSingle(IReadOnlyList<InProcessSiloHandle> silos)

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -77,12 +77,12 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
             count,
             cancellationToken,
             reminderName,
-            IsActiveSilo);
+            ActiveSilos);
 
     /// <inheritdoc />
     public IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName)
     {
-        return _observer.GetActiveReminderOwnerSilos(grainId, reminderName, IsActiveSilo);
+        return _observer.GetActiveReminderOwnerSilos(grainId, reminderName, ActiveSilos);
     }
 
     /// <inheritdoc />
@@ -154,9 +154,6 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         => silos.Count == 1
             ? silos[0]
             : throw new InvalidOperationException($"Expected one new silo, observed {silos.Count}.");
-
-    private bool IsActiveSilo(SiloAddress? siloAddress)
-        => siloAddress is not null && ActiveSilos.Contains(siloAddress);
 
     internal object AddDuplicateOwnerForTesting(GrainId grainId, string reminderName)
     {

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -1,0 +1,150 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Reminders.TestKit;
+using Orleans.Runtime;
+using Orleans.Runtime.ReminderService;
+using Orleans.TestingHost;
+
+namespace Orleans.Testing.Reminders;
+
+/// <summary>
+/// Adapts an in-process cluster, <see cref="ReminderTestClock"/>, and
+/// <see cref="ReminderDiagnosticObserver"/> to the shared service lifecycle conformance runner.
+/// </summary>
+public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleHarness
+{
+    private readonly InProcessTestCluster _cluster;
+    private readonly ReminderTestClock _clock;
+    private readonly ReminderDiagnosticObserver _observer;
+
+    /// <summary>Initializes the harness.</summary>
+    public ReminderServiceLifecycleHarness(
+        InProcessTestCluster cluster,
+        ReminderTestClock clock,
+        ReminderDiagnosticObserver observer,
+        TimeSpan reminderLoadingWindow)
+    {
+        _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _observer = observer ?? throw new ArgumentNullException(nameof(observer));
+        ReminderLoadingWindow = reminderLoadingWindow;
+    }
+
+    /// <inheritdoc />
+    public IGrainFactory GrainFactory => _cluster.Client;
+
+    /// <inheritdoc />
+    public IReminderTable ReminderTable
+        => _cluster.GetActiveSilos().First().ServiceProvider.GetRequiredService<IReminderTable>();
+
+    /// <inheritdoc />
+    public DateTimeOffset UtcNow => _clock.UtcNow;
+
+    /// <inheritdoc />
+    public TimeSpan ReminderLoadingWindow { get; }
+
+    /// <inheritdoc />
+    public TimeSpan ReminderRefreshPeriod => _clock.RefreshReminderListPeriod;
+
+    /// <inheritdoc />
+    public IReadOnlyList<SiloAddress> ActiveSilos
+        => _cluster.GetActiveSilos().Select(silo => silo.SiloAddress).Order().ToArray();
+
+    /// <inheritdoc />
+    public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken)
+        => WaitForTopologyReconciliationAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
+        => _clock.AdvanceAsync(amount, cancellationToken);
+
+    /// <inheritdoc />
+    public Task WaitForOwnerCountAsync(
+        GrainId grainId,
+        string reminderName,
+        int count,
+        CancellationToken cancellationToken)
+        => GetOwners(grainId, reminderName).Count == count
+            ? Task.CompletedTask
+            : _observer.WaitForActiveReminderCountAsync(grainId, count, cancellationToken, reminderName);
+
+    /// <inheritdoc />
+    public IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName)
+    {
+        var active = ActiveSilos.ToHashSet();
+        return _observer.GetActiveReminderSilos(grainId, reminderName)
+            .Where(active.Contains)
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
+        => _observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cancellationToken);
+
+    /// <inheritdoc />
+    public int GetLocalStartCount(GrainId grainId, string reminderName)
+        => _observer.GetLocalStartCount(grainId, reminderName);
+
+    /// <inheritdoc />
+    public int GetLocalStopCount(GrainId grainId, string reminderName)
+        => _observer.GetLocalStopCount(grainId, reminderName);
+
+    /// <inheritdoc />
+    public int GetScheduleChangeCount(GrainId grainId, string reminderName)
+        => _observer.GetScheduleChangeCount(grainId, reminderName);
+
+    /// <inheritdoc />
+    public Task WaitForScheduleChangeCountAsync(
+        GrainId grainId,
+        string reminderName,
+        int count,
+        CancellationToken cancellationToken)
+        => _observer.WaitForScheduleChangeCountAsync(grainId, reminderName, count, cancellationToken);
+
+    /// <inheritdoc />
+    public Task WaitForTickCountAsync(
+        GrainId grainId,
+        string reminderName,
+        int count,
+        CancellationToken cancellationToken)
+        => _observer.WaitForTickCountAsync(grainId, count, cancellationToken, reminderName);
+
+    /// <inheritdoc />
+    public int GetTickCount(GrainId grainId, string reminderName)
+        => _observer.GetTickCount(grainId, reminderName);
+
+    /// <inheritdoc />
+    public async Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken)
+    {
+        var silo = AssertSingle(await _cluster.StartSilosAsync(1).WaitAsync(cancellationToken));
+        await Task.WhenAll(
+            _observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress),
+            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
+        return silo.SiloAddress;
+    }
+
+    /// <inheritdoc />
+    public async Task LeaveSiloAsync(SiloAddress siloAddress, CancellationToken cancellationToken)
+    {
+        var silo = _cluster.GetSiloForAddress(siloAddress)
+            ?? throw new InvalidOperationException($"Silo {siloAddress} is not active.");
+        await _cluster.StopSiloAsync(silo, cancellationToken);
+        await _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken)
+    {
+        await _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+        var barriers = _cluster.GetActiveSilos().Select(silo =>
+            silo.ServiceProvider.GetRequiredService<LocalReminderService>()
+                .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
+        await Task.WhenAll(barriers);
+    }
+
+    private static InProcessSiloHandle AssertSingle(IReadOnlyList<InProcessSiloHandle> silos)
+        => silos.Count == 1
+            ? silos[0]
+            : throw new InvalidOperationException($"Expected one new silo, observed {silos.Count}.");
+}

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Reminders.Diagnostics;
 using Orleans.Reminders.TestKit;
 using Orleans.Runtime;
 using Orleans.Runtime.ReminderService;
@@ -52,8 +53,14 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         => _cluster.GetActiveSilos().Select(silo => silo.SiloAddress).Order().ToArray();
 
     /// <inheritdoc />
-    public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken)
-        => WaitForTopologyReconciliationAsync(cancellationToken);
+    public async Task WaitForStartupReadinessAsync(CancellationToken cancellationToken)
+    {
+        var startupEvents = ActiveSilos
+            .Select(silo => _observer.WaitForReminderServiceStartedAsync(cancellationToken, silo))
+            .ToArray();
+        await Task.WhenAll(startupEvents);
+        await WaitForTopologyReconciliationAsync(cancellationToken);
+    }
 
     /// <inheritdoc />
     public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
@@ -65,17 +72,17 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         string reminderName,
         int count,
         CancellationToken cancellationToken)
-        => GetOwners(grainId, reminderName).Count == count
-            ? Task.CompletedTask
-            : _observer.WaitForActiveReminderCountAsync(grainId, count, cancellationToken, reminderName);
+        => _observer.WaitForActiveReminderCountAsync(
+            grainId,
+            count,
+            cancellationToken,
+            reminderName,
+            IsActiveSilo);
 
     /// <inheritdoc />
     public IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName)
     {
-        var active = ActiveSilos.ToHashSet();
-        return _observer.GetActiveReminderSilos(grainId, reminderName)
-            .Where(active.Contains)
-            .ToArray();
+        return _observer.GetActiveReminderOwnerSilos(grainId, reminderName, IsActiveSilo);
     }
 
     /// <inheritdoc />
@@ -147,4 +154,29 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         => silos.Count == 1
             ? silos[0]
             : throw new InvalidOperationException($"Expected one new silo, observed {silos.Count}.");
+
+    private bool IsActiveSilo(SiloAddress? siloAddress)
+        => siloAddress is not null && ActiveSilos.Contains(siloAddress);
+
+    internal object AddDuplicateOwnerForTesting(GrainId grainId, string reminderName)
+    {
+        var identity = new object();
+        ReminderEvents.EmitLocalReminderStarted(
+            grainId,
+            reminderName,
+            identity,
+            ActiveSilos.First());
+        return identity;
+    }
+
+    internal void RemoveDuplicateOwnerForTesting(
+        GrainId grainId,
+        string reminderName,
+        object identity)
+        => ReminderEvents.EmitLocalReminderStopped(
+            grainId,
+            reminderName,
+            identity,
+            ReminderEvents.LocalReminderStopReason.Unregistered,
+            ActiveSilos.First());
 }

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans.Reminders.Diagnostics;
 using Orleans.Reminders.TestKit;
 using Orleans.Runtime;
+using Orleans.Runtime.ConsistentRing;
 using Orleans.Runtime.ReminderService;
 using Orleans.TestingHost;
 
@@ -94,6 +95,17 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
     public IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName)
     {
         return _observer.GetActiveReminderOwnerSilos(grainId, reminderName, ActiveSilos);
+    }
+
+    /// <inheritdoc />
+    public bool IsOwner(SiloAddress siloAddress, GrainId grainId)
+    {
+        var silo = _cluster.GetSiloForAddress(siloAddress)
+            ?? throw new InvalidOperationException($"Silo {siloAddress} is not active.");
+        return silo.ServiceProvider
+            .GetRequiredService<IConsistentRingProvider>()
+            .GetMyRange()
+            .InRange(grainId);
     }
 
     /// <inheritdoc />

--- a/test/Orleans.Testing.Reminders/ReminderTestClock.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTestClock.cs
@@ -28,12 +28,19 @@ public sealed class ReminderTestClock : IDisposable
         TimeSpan initializationTimeout)
     {
         TimeProvider = new FakeTimeProvider(initialTime);
+        DiagnosticObserver = ReminderDiagnosticObserver.Create();
         MinimumReminderPeriod = minimumReminderPeriod;
         RefreshReminderListPeriod = refreshReminderListPeriod;
         InitializationTimeout = initializationTimeout;
     }
 
     internal FakeTimeProvider TimeProvider { get; }
+
+    /// <summary>
+    /// Gets the diagnostic observer attached before the cluster is built, so reminder-service startup events are
+    /// available to deterministic lifecycle tests.
+    /// </summary>
+    public ReminderDiagnosticObserver DiagnosticObserver { get; }
 
     /// <summary>
     /// Gets the current reminder clock time.
@@ -146,6 +153,7 @@ public sealed class ReminderTestClock : IDisposable
         }
 
         _disposed = true;
+        DiagnosticObserver.Dispose();
         _advanceLock.Dispose();
     }
 


### PR DESCRIPTION
## Problem

Reminder provider conformance currently verifies table operations but leaves service startup, local ownership, recovery, and topology churn to provider-specific suites. That permits lifecycle semantics to drift and makes timing failures difficult to diagnose.

## Solution

Add a shared deterministic lifecycle runner and in-process harness covering readiness, single-owner registration, in-place updates, removal quiescence, exact-due recovery, stale-owner reconciliation, one-silo join/leave transfer, and cleanup isolation. The harness centralizes fake-time advancement, per-instance diagnostic ownership, explicit startup events, and membership/range-reconciliation barriers. Dedicated setup-only adapters run the same inherited scenarios for in-memory, Azure Table, Cosmos, SQL Server, PostgreSQL, MySQL, Redis, DynamoDB, and Firestore providers. Fault-injection self-tests prove duplicate local instances, owner restarts, and cancellation-safe cleanup are detected.

## Rationale

Keeping identities, schedules, assertions, churn orchestration, and independently bounded scenario cleanup in TestKit limits provider code to backend configuration, produces exact owner/tick diagnostics, and prevents provider-specific retries, whole-table clearing, or timing allowances from concealing semantic failures.