### PR TITLE
fix(test): remove placement timeout race

### DIFF
--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -150,11 +150,8 @@ namespace UnitTests.Runtime
             await lookupStarted.Task;
             timeProvider.Advance(messagingOptions.PlacementTimeout);
 
-            var completedTask = await Task.WhenAny(
-                placementTask,
-                Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken));
-            Assert.Same(placementTask, completedTask);
-            var exception = await Assert.ThrowsAsync<TimeoutException>(() => placementTask);
+            var exception = await Assert.ThrowsAsync<TimeoutException>(
+                () => placementTask.WaitAsync(TestContext.Current.CancellationToken));
             Assert.IsType<Polly.Timeout.TimeoutRejectedException>(exception.InnerException);
 
             lookupCompletion.TrySetResult(default);


### PR DESCRIPTION
## Problem

`GetOrPlaceActivationAsync_WhenLookupDoesNotComplete_TimesOut` advances its fake clock to fire the placement timeout, then requires the resulting asynchronous cancellation propagation to complete within one second of wall-clock time. Under the loaded Windows BVT process, that continuation can be delayed long enough for the real-time delay to win even though the timeout has fired correctly.

## Solution

Await the placement task directly using the xUnit cancellation token and assert its timeout outcome. This preserves a bounded test while removing the scheduler race between the placement continuation and an unrelated wall-clock delay.

Fixes #10852
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10898)