### PR TITLE
fix(testing): isolate reminder event continuations

### DIFF
--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -32,6 +32,34 @@ public class ReminderEventsTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public void ReminderDiagnosticObserver_ServiceStartedWait_DoesNotRunContinuationsInline()
+    {
+        using var observer = ReminderDiagnosticObserver.Create();
+        using var continuationRan = new ManualResetEventSlim();
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14010), 11);
+        var waitTask = observer.WaitForReminderServiceStartedAsync(TestContext.Current.CancellationToken, siloAddress);
+        var emitterThread = Environment.CurrentManagedThreadId;
+        var continuationThread = 0;
+
+        _ = waitTask.ContinueWith(
+            _ =>
+            {
+                continuationThread = Environment.CurrentManagedThreadId;
+                continuationRan.Set();
+            },
+            TestContext.Current.CancellationToken,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        ReminderEvents.EmitReminderServiceStarted(siloAddress);
+
+        Assert.True(continuationRan.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        Assert.NotEqual(emitterThread, continuationThread);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_MatchesTickCompleted_ByIdentifiers()
     {
         using var observer = ReminderDiagnosticObserver.Create();

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -1,9 +1,9 @@
 #nullable enable
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Reactive.Threading.Tasks;
 using Orleans;
 using Orleans.Internal;
 using Orleans.Runtime;
@@ -149,10 +149,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     /// </summary>
     public Task<ReminderEvents.TickCompleted> WaitForReminderTickAsync(GrainId grainId, CancellationToken cancellationToken, string? reminderName = null)
     {
-        return _events
-            .OfType<ReminderEvents.TickCompleted>()
-            .FirstAsync(e => MatchesReminder(e, grainId, reminderName))
-            .ToTask(cancellationToken);
+        return WaitForEventAsync(
+            _events.OfType<ReminderEvents.TickCompleted>(),
+            e => MatchesReminder(e, grainId, reminderName),
+            cancellationToken);
     }
 
     /// <summary>
@@ -206,10 +206,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     /// </summary>
     public Task<ReminderEvents.Registered> WaitForReminderRegisteredAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
     {
-        return _events
-            .OfType<ReminderEvents.Registered>()
-            .FirstAsync(e => MatchesReminder(e, grainId, reminderName))
-            .ToTask(cancellationToken);
+        return WaitForEventAsync(
+            _events.OfType<ReminderEvents.Registered>(),
+            e => MatchesReminder(e, grainId, reminderName),
+            cancellationToken);
     }
 
     /// <summary>
@@ -217,10 +217,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     /// </summary>
     public Task<ReminderEvents.ReminderServiceStarted> WaitForReminderServiceStartedAsync(CancellationToken cancellationToken, SiloAddress? siloAddress = null)
     {
-        return _serviceEvents
-            .OfType<ReminderEvents.ReminderServiceStarted>()
-            .FirstAsync(e => siloAddress is null || Equals(e.SiloAddress, siloAddress))
-            .ToTask(cancellationToken);
+        return WaitForEventAsync(
+            _serviceEvents.OfType<ReminderEvents.ReminderServiceStarted>(),
+            e => siloAddress is null || Equals(e.SiloAddress, siloAddress),
+            cancellationToken);
     }
 
     /// <summary>
@@ -228,10 +228,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     /// </summary>
     public Task<ReminderEvents.Unregistered> WaitForReminderUnregisteredAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
     {
-        return _events
-            .OfType<ReminderEvents.Unregistered>()
-            .FirstAsync(e => MatchesReminder(e, grainId, reminderName))
-            .ToTask(cancellationToken);
+        return WaitForEventAsync(
+            _events.OfType<ReminderEvents.Unregistered>(),
+            e => MatchesReminder(e, grainId, reminderName),
+            cancellationToken);
     }
 
     /// <summary>
@@ -328,6 +328,50 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         }
 
         return waiter.TaskSource.Task;
+    }
+
+    private static Task<TEvent> WaitForEventAsync<TEvent>(
+        IObservable<TEvent> events,
+        Func<TEvent, bool> predicate,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<TEvent>(cancellationToken);
+        }
+
+        var completion = new TaskCompletionSource<TEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var subscription = new SingleAssignmentDisposable();
+        var cancellationRegistration = cancellationToken.Register(
+            static state =>
+            {
+                var (source, eventSubscription, token) =
+                    ((TaskCompletionSource<TEvent> Source, SingleAssignmentDisposable Subscription, CancellationToken Token))state!;
+                eventSubscription.Dispose();
+                source.TrySetCanceled(token);
+            },
+            (completion, subscription, cancellationToken));
+
+        subscription.Disposable = events.Subscribe(
+            value =>
+            {
+                if (!predicate(value))
+                {
+                    return;
+                }
+
+                cancellationRegistration.Dispose();
+                subscription.Dispose();
+                completion.TrySetResult(value);
+            },
+            error =>
+            {
+                cancellationRegistration.Dispose();
+                subscription.Dispose();
+                completion.TrySetException(error);
+            });
+        return completion.Task;
+        return completion.Task;
     }
 
     private static bool MatchesReminder(ReminderEvents.ReminderEvent evt, GrainId grainId, string? reminderName)

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -369,6 +369,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                 cancellationRegistration.Dispose();
                 subscription.Dispose();
                 completion.TrySetException(error);
+            },
+            () =>
+            {
+                cancellationRegistration.Dispose();
+                subscription.Dispose();
+                completion.TrySetException(new InvalidOperationException("The diagnostic event stream completed before a matching event was observed."));
             });
         return completion.Task;
         return completion.Task;

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -361,7 +361,19 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         subscription.Disposable = events.Subscribe(
             value =>
             {
-                if (!predicate(value))
+                bool matches;
+                try
+                {
+                    matches = predicate(value);
+                }
+                catch (Exception exception)
+                {
+                    subscription.Dispose();
+                    completion.TrySetException(exception);
+                    return;
+                }
+
+                if (!matches)
                 {
                     return;
                 }

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -377,7 +377,6 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                 completion.TrySetException(new InvalidOperationException("The diagnostic event stream completed before a matching event was observed."));
             });
         return completion.Task;
-        return completion.Task;
     }
 
     private static bool MatchesReminder(ReminderEvents.ReminderEvent evt, GrainId grainId, string? reminderName)

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -351,6 +351,12 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                 source.TrySetCanceled(token);
             },
             (completion, subscription, cancellationToken));
+        _ = completion.Task.ContinueWith(
+            static (_, state) => ((CancellationTokenRegistration)state!).Dispose(),
+            cancellationRegistration,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
         subscription.Disposable = events.Subscribe(
             value =>
@@ -360,19 +366,16 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                     return;
                 }
 
-                cancellationRegistration.Dispose();
                 subscription.Dispose();
                 completion.TrySetResult(value);
             },
             error =>
             {
-                cancellationRegistration.Dispose();
                 subscription.Dispose();
                 completion.TrySetException(error);
             },
             () =>
             {
-                cancellationRegistration.Dispose();
                 subscription.Dispose();
                 completion.TrySetException(new InvalidOperationException("The diagnostic event stream completed before a matching event was observed."));
             });


### PR DESCRIPTION
## Problem

`ReminderTestKit_StaleRefreshCannotRestoreUnregisteredReminder` can resume directly on the `LocalReminderService` diagnostic-event thread after awaiting `ReminderServiceStarted`. The failed CI artifact shows the grain turn starting immediately and then waiting 30 seconds for its nested local reminder-service request, without reaching reminder storage. The existing Rx `ToTask` conversion permits synchronous caller continuations at this scheduler boundary.

## Solution

Complete diagnostic event waits through task sources configured with `RunContinuationsAsynchronously`, while preserving replay, filtering, cancellation, error propagation, and subscription cleanup. Add a regression which verifies that a service-start waiter cannot run an `ExecuteSynchronously` continuation on the event emitter thread.

## Rationale

Reminder diagnostic waits are phase barriers. Resuming consumers independently from the runtime event producer keeps subsequent grain calls outside the reminder-service scheduler turn and applies the same continuation guarantee already used by the observer's lifecycle-state waiters.

Fixes #10893
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10899)