### PR TITLE
fix(test): retry SQL Server deadlock victims

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -7,6 +7,9 @@ namespace UnitTests.General
 {
     public class SqlServerStorageForTesting : RelationalStorageForTesting
     {
+        private const int DeadlockVictimError = 1205;
+        private const int DatabaseInUseError = 3702;
+
         protected override string ProviderMoniker => "SQLServer";
 
         public SqlServerStorageForTesting(string connectionString)
@@ -180,13 +183,20 @@ namespace UnitTests.General
                     await base.DropDatabaseAsync(databaseName, cancellationToken);
                     return;
                 }
-                catch (SqlException exception) when (exception.Number == 3702 && attempt < maxAttempts)
+                catch (SqlException exception) when (IsRetryableDatabaseResetError(exception.Number) && attempt < maxAttempts)
                 {
-                    Console.WriteLine("SQL Server database '{0}' remained in use after reset attempt {1}; retrying.", databaseName, attempt);
+                    Console.WriteLine(
+                        "SQL Server database '{0}' reset failed with transient error {1} on attempt {2}; retrying.",
+                        databaseName,
+                        exception.Number,
+                        attempt);
                     PrepareForDatabaseReset(databaseName);
                 }
             }
         }
+
+        internal static bool IsRetryableDatabaseResetError(int errorNumber) =>
+            errorNumber is DeadlockVictimError or DatabaseInUseError;
 
         protected override string ExistsDatabaseTemplate
         {

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -11,6 +11,15 @@ public class SqlServerStorageForTestingTests
 {
     private const string TestDatabaseName = "OrleansSqlServerSetupTest";
 
+    [Theory]
+    [InlineData(1205, true)]
+    [InlineData(3702, true)]
+    [InlineData(18456, false)]
+    public void ClassifiesRetryableDatabaseResetErrors(int errorNumber, bool expected)
+    {
+        Assert.Equal(expected, SqlServerStorageForTesting.IsRetryableDatabaseResetError(errorNumber));
+    }
+
     [Fact]
     public async Task RecreatesDatabaseWithActivePooledConnection()
     {


### PR DESCRIPTION
## Problem

SQL Server can choose the test database reset command as a deadlock victim while stale test sessions are being rolled back. The existing bounded retry only handles error 3702, so transient error 1205 fails fixture initialization even though the next reset succeeds.

## Solution

Classify SQL Server errors 1205 and 3702 as retryable database-reset failures. Each retry keeps the existing pool clearing behavior, while unrelated errors and the final failed attempt continue to surface.

## Rationale

SQL Server explicitly guarantees that a deadlock victim's transaction is rolled back and can be rerun. Reusing the established three-attempt reset boundary handles that transient outcome without masking persistent setup failures.

Fixes #10900
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10901)