### PR TITLE
fix(analyzers): clarify Orleans contract identities

### DIFF
--- a/docs/site/src/content/docs/diagnostics/orleans0016.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0016.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0017.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0017.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0018.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0018.md
@@ -1,7 +1,7 @@
 ---
 title: "ORLEANS0018: Grain interface member not declared"
 description: Understand and resolve ORLEANS0018 when an RPC method signature is missing from OrleansContracts.txt.
-ms.date: 08/27/2026
+ms.date: 08/28/2026
 ms.topic: reference
 ---
 
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Available |
 
@@ -17,7 +17,7 @@ ms.topic: reference
 
 An ordinary grain-interface method has no matching contract signature in `OrleansContracts.txt`. Method identity, generic arity, parameter types and order, and return type are part of the signature. Parameter names are not.
 
-The method identity is the source `[Id]` value, the source `[Alias]` value, or the generated xxHash32 ID used by the Orleans code generator. Recording a generated ID in the manifest does not add an attribute or change the runtime identity.
+The method identity is the source `[Id]` value, the source `[Alias]` value, or the generated xxHash32 ID used by the Orleans code generator. The manifest records the resulting identifier before the colon, independent of how source declares it.
 
 ## Impact
 
@@ -25,7 +25,7 @@ Older activations can receive an unknown RPC, and changed identities or payload 
 
 ## How to fix
 
-Prefer preserving the existing method and adding a new method for changed behavior. Review payload compatibility, increment the interface version when appropriate, and apply **Add to OrleansContracts.txt**. The code fix records the existing effective wire identity and does not increment `[Version]` or modify source attributes.
+Prefer preserving the existing method and adding a new method for changed behavior. Review payload compatibility, increment the interface version when appropriate, and apply **Add to OrleansContracts.txt**. The code fix records the CLR signature and effective wire identity in the manifest. Source attributes remain unchanged.
 
 Apply **Regenerate OrleansContracts.txt** to rebuild the complete project manifest, or use **Fix all in solution** to update every affected project. Review the generated diff using the [contract compatibility guidance](../grains/grain-versioning/contract-compatibility-analyzer.md#regenerate-the-manifest).
 

--- a/docs/site/src/content/docs/diagnostics/orleans0019.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0019.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0020.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0020.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Info |
 | Code fix | Available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0021.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0021.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Not available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0022.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0022.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0023.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0023.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0024.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0024.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0025.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0025.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Not available |
 

--- a/docs/site/src/content/docs/diagnostics/orleans0027.md
+++ b/docs/site/src/content/docs/diagnostics/orleans0027.md
@@ -1,7 +1,7 @@
 ---
 title: "ORLEANS0027: Grain interface member removed from source"
 description: Understand and resolve ORLEANS0027 when OrleansContracts.txt retains an RPC method which is absent from source.
-ms.date: 08/27/2026
+ms.date: 08/28/2026
 ms.topic: reference
 ---
 
@@ -9,13 +9,13 @@ ms.topic: reference
 
 | Property | Value |
 | --- | --- |
-| Category | Orleans.Versioning |
+| Category | Versioning |
 | Severity | Warning |
 | Code fix | Not available |
 
 ## Cause
 
-`OrleansContracts.txt` declares an RPC method signature which is absent from the matching source grain interface. The manifest identity is an explicit `[Id]` or `[Alias]` value when present in source; otherwise, it is the generated method ID already used by Orleans on the wire.
+`OrleansContracts.txt` declares an RPC method signature which is absent from the matching source grain interface. The value before the colon is the effective method identity Orleans uses on the wire.
 
 ## Impact
 

--- a/docs/site/src/content/docs/grains/grain-versioning/contract-compatibility-analyzer.md
+++ b/docs/site/src/content/docs/grains/grain-versioning/contract-compatibility-analyzer.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans contract compatibility analyzer
 description: Track grain RPC contracts during development to identify changes which can break rolling upgrades.
-ms.date: 08/27/2026
+ms.date: 08/28/2026
 ms.topic: concept-article
 ---
 
@@ -18,6 +18,15 @@ The analyzer is **disabled by default**. Enable it explicitly in a project file 
 ```
 
 Projects which use `Microsoft.Orleans.Sdk`, `Microsoft.Orleans.Client`, or `Microsoft.Orleans.Server` already receive the Orleans analyzers through those packages. A project which references `Microsoft.Orleans.Analyzers` directly can use the same property.
+
+To promote every contract diagnostic, configure the standard `Versioning` category:
+
+```ini
+[*.cs]
+dotnet_analyzer_diagnostic.category-Versioning.severity = error
+```
+
+This also promotes informational diagnostics such as `ORLEANS0020`. Configure `dotnet_diagnostic.ORLEANS####.severity` entries instead when only selected contract diagnostics should change severity.
 
 ## Configure the manifest path
 
@@ -54,9 +63,9 @@ dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostic
 
 Run the command from the repository root. Replace `PATH_TO_PROJECT_OR_SOLUTION` with the path to the owning `.csproj` to regenerate one manifest, or a `.sln`/`.slnx` path to regenerate manifests in every affected project. The `--severity info` option includes `ORLEANS0020`, allowing the command to create a missing manifest.
 
-Regeneration edits `OrleansContracts.txt` files only. It does not add or change `[Alias]`, `[Id]`, `[GrainType]`, or `[GrainInterfaceType]` attributes in source. Attribute-like syntax in the manifest records the effective identity which Orleans already uses at runtime.
+Regeneration edits `OrleansContracts.txt` files only. Source `[Alias]`, `[Id]`, `[GrainType]`, and `[GrainInterfaceType]` attributes remain unchanged.
 
-For a method without `[Id]` or `[Alias]`, the manifest records the same generated xxHash32 method ID which the Orleans code generator already uses on the wire. The preceding comment records the CLR signature so reviewers can map the wire ID back to source. A one-time upgrade from an older manifest format can therefore replace a CLR method name with its existing generated ID; this records the current wire contract and does not change it.
+Every method line places the effective wire identity before a colon, followed by the CLR method name and signature. The identity is the source `[Id]` value, source `[Alias]` value, or the generated xxHash32 method ID already used by the Orleans code generator. The stable identity appears first so contract-breaking changes are prominent in diffs, while CLR-only renames keep the same leading value.
 
 After the command completes:
 
@@ -70,7 +79,7 @@ Add the generated file to source control and review its diff before committing. 
 - A removed source contract becomes `*RETIRED*`, preserving its identity history and preventing accidental reuse.
 - A removed RPC method remains in the manifest and reports `ORLEANS0027` until the method is restored or the wire break is explicitly accepted by removing the retained signature.
 - A `[Version]` change affects version-aware routing and must align with the rolling-upgrade design.
-- A CLR comment-only change records a refactor while the explicit Orleans identity remains stable.
+- A changed CLR method name with an unchanged identity records a refactor while the Orleans wire contract remains stable.
 
 Coding agents should regenerate the manifest instead of hand-editing active entries, retain retired history, and explain the compatibility impact of each contract diff in the change description.
 
@@ -85,15 +94,15 @@ Interface methods are indented beneath their interface:
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Contoso.Grains.ICartGrain")] Contoso.Grains.ICartGrain [Version(1)]
-  # Contoso.Grains.ICartGrain.AddAsync(Item item) -> Task
-  15793847(Contoso.Grains.Item) -> Task
-  # Contoso.Grains.ICartGrain.GetAsync() -> Task<Cart>
-  857AC6B2() -> Task<Contoso.Grains.Cart>
+  15793847: AddAsync(Contoso.Grains.Item) -> Task
+  857AC6B2: GetAsync() -> Task<Contoso.Grains.Cart>
 
 class [GrainType("cart")] Contoso.Grains.CartGrain
 ```
@@ -105,14 +114,13 @@ Explicit identities remain visible alongside their CLR names:
 ```text
 # Contoso.Grains.ICartGrain
 interface [GrainInterfaceType("cart")] Contoso.Grains.ICartGrain [Version(1)]
-  # Contoso.Grains.ICartGrain.AddAsync(Item item) -> Task
-  [Alias("add")] add(Contoso.Grains.Item) -> Task
+  add: AddAsync(Contoso.Grains.Item) -> Task
 
 # Contoso.Grains.CartGrain
 class [GrainType("cart")] Contoso.Grains.CartGrain
 ```
 
-`[Alias("...")]` on a manifest method records that the identity comes from a source `[Alias]` attribute. An unmarked eight-digit hexadecimal method identity is the generated wire ID. Comments record CLR names when they improve traceability; comments are informational and aren't part of contract matching.
+The value before the colon is the effective runtime identity. A source `[Id(42)]`, source `[Alias("42")]`, and generated method ID `42` describe the same wire identity. The manifest records that result as `42:` and keeps source provenance in source code. Syntax-sensitive characters in aliases are backslash-escaped.
 
 `*RETIRED*` marks an intentionally removed contract:
 

--- a/src/Dashboard/Orleans.Dashboard/OrleansContracts.txt
+++ b/src/Dashboard/Orleans.Dashboard/OrleansContracts.txt
@@ -4,35 +4,37 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.Dashboard.Core.IDashboardGrain")] Orleans.Dashboard.Core.IDashboardGrain [Version(0)]
-  [Alias("GetClusterTracing")] GetClusterTracing() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>
-  [Alias("GetCounters")] GetCounters(string[]) -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.DashboardCounters>>
-  [Alias("GetGrainState")] GetGrainState(string?, string?) -> Task<Orleans.Concurrency.Immutable<string>>
-  [Alias("GetGrainTracing")] GetGrainTracing(string) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>>
-  [Alias("GetGrainTypes")] GetGrainTypes(string[]) -> Task<Orleans.Concurrency.Immutable<string[]>>
-  [Alias("GetSiloTracing")] GetSiloTracing(string) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>
-  [Alias("InitializeAsync")] InitializeAsync() -> Task
-  [Alias("SubmitTracing")] SubmitTracing(string, Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.SiloGrainTraceEntry[]>) -> Task
-  [Alias("TopGrainMethods")] TopGrainMethods(int, string[]) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.History.GrainMethodAggregate[]>>>
+  GetClusterTracing: GetClusterTracing() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>
+  GetCounters: GetCounters(string[]) -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.DashboardCounters>>
+  GetGrainState: GetGrainState(string?, string?) -> Task<Orleans.Concurrency.Immutable<string>>
+  GetGrainTracing: GetGrainTracing(string) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>>
+  GetGrainTypes: GetGrainTypes(string[]) -> Task<Orleans.Concurrency.Immutable<string[]>>
+  GetSiloTracing: GetSiloTracing(string) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>
+  InitializeAsync: InitializeAsync() -> Task
+  SubmitTracing: SubmitTracing(string, Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.SiloGrainTraceEntry[]>) -> Task
+  TopGrainMethods: TopGrainMethods(int, string[]) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.History.GrainMethodAggregate[]>>>
 
 interface [GrainInterfaceType("Orleans.Dashboard.Core.IDashboardRemindersGrain")] Orleans.Dashboard.Core.IDashboardRemindersGrain [Version(0)]
-  [Alias("GetReminders")] GetReminders(int, int) -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.ReminderResponse>>
+  GetReminders: GetReminders(int, int) -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.ReminderResponse>>
 
 interface [GrainInterfaceType("Orleans.Dashboard.Core.ISiloGrainProxy")] Orleans.Dashboard.Core.ISiloGrainProxy [Version(0)]
-  [Alias("GetMetadata")] GetMetadata() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, string>>>
+  GetMetadata: GetMetadata() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, string>>>
 
 interface [GrainInterfaceType("Orleans.Dashboard.Core.ISiloGrainService")] Orleans.Dashboard.Core.ISiloGrainService [Version(0)]
-  [Alias("Enable")] Enable(bool) -> Task
-  [Alias("GetCounters")] GetCounters() -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.StatCounter[]>>
-  [Alias("GetExtendedProperties")] GetExtendedProperties() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, string?>>>
-  [Alias("GetLifecycleStages")] GetLifecycleStages() -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.LifecycleStageInfo[]>>
-  [Alias("GetRuntimeStatistics")] GetRuntimeStatistics() -> Task<Orleans.Concurrency.Immutable<Orleans.Runtime.SiloRuntimeStatistics?[]>>
-  [Alias("ReportCounters")] ReportCounters(Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.StatCounter[]>) -> Task
-  [Alias("SetVersion")] SetVersion(string, string) -> Task
+  Enable: Enable(bool) -> Task
+  GetCounters: GetCounters() -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.StatCounter[]>>
+  GetExtendedProperties: GetExtendedProperties() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, string?>>>
+  GetLifecycleStages: GetLifecycleStages() -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.LifecycleStageInfo[]>>
+  GetRuntimeStatistics: GetRuntimeStatistics() -> Task<Orleans.Concurrency.Immutable<Orleans.Runtime.SiloRuntimeStatistics?[]>>
+  ReportCounters: ReportCounters(Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.StatCounter[]>) -> Task
+  SetVersion: SetVersion(string, string) -> Task
 
 class [GrainType("dashboard")] Orleans.Dashboard.Implementation.Grains.DashboardGrain
 

--- a/src/Orleans.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Orleans.Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,14 +6,14 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ORLEANS0026 | Usage | Error | Invalid invokable base type mapping
 ORLEANS0014 | Usage | Warning | ConfigureAwaitAnalyzer, Grain code should not use ConfigureAwait(false) or ConfigureAwait without ContinueOnCapturedContext
-ORLEANS0016 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface not declared in OrleansContracts.txt
-ORLEANS0017 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface version mismatch between code and file
-ORLEANS0018 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface member not declared in OrleansContracts.txt
-ORLEANS0019 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed interface not marked as *RETIRED*
-ORLEANS0020 | Orleans.Versioning | Info | GrainInterfaceVersionAnalyzer, OrleansContracts.txt file is missing
-ORLEANS0021 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Duplicate interface declaration in file
-ORLEANS0022 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain class not declared in OrleansContracts.txt
-ORLEANS0023 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain class alias mismatch
-ORLEANS0024 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed grain class not marked as *RETIRED*
-ORLEANS0025 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Duplicate grain class declaration in file
-ORLEANS0027 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed grain interface member remains in OrleansContracts.txt
+ORLEANS0016 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface not declared in OrleansContracts.txt
+ORLEANS0017 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface version mismatch between code and file
+ORLEANS0018 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface member not declared in OrleansContracts.txt
+ORLEANS0019 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed interface not marked as *RETIRED*
+ORLEANS0020 | Versioning | Info | GrainInterfaceVersionAnalyzer, OrleansContracts.txt file is missing
+ORLEANS0021 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Duplicate interface declaration in file
+ORLEANS0022 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain class not declared in OrleansContracts.txt
+ORLEANS0023 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain class alias mismatch
+ORLEANS0024 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed grain class not marked as *RETIRED*
+ORLEANS0025 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Duplicate grain class declaration in file
+ORLEANS0027 | Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed grain interface member remains in OrleansContracts.txt

--- a/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -23,6 +24,7 @@ namespace Orleans.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
 {
+    private const string DiagnosticCategory = "Versioning";
     public const string EnableAnalyzerPropertyName = "EnableOrleansContractsAnalyzer";
     public const string RuleId0016 = "ORLEANS0016";
     public const string RuleId0017 = "ORLEANS0017";
@@ -39,8 +41,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
     // Property bag keys for code fixes
     internal const string InterfaceNamePropertyKey = "InterfaceName";
     internal const string MemberNamePropertyKey = "MemberName";
-    internal const string MemberAliasPropertyKey = "MemberAlias";
-    internal const string MemberClrSignaturePropertyKey = "MemberClrSignature";
+    internal const string MemberWireIdentityPropertyKey = "MemberWireIdentity";
     internal const string ExpectedVersionPropertyKey = "ExpectedVersion";
     internal const string ActualVersionPropertyKey = "ActualVersion";
     internal const string ExpectedSignaturePropertyKey = "ExpectedSignature";
@@ -55,7 +56,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0016,
         title: new LocalizableResourceString(nameof(Resources.GrainInterfaceNotDeclaredTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceNotDeclaredMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceNotDeclaredDescription), Resources.ResourceManager, typeof(Resources)),
@@ -65,7 +66,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0017,
         title: new LocalizableResourceString(nameof(Resources.GrainInterfaceVersionMismatchTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceVersionMismatchMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceVersionMismatchDescription), Resources.ResourceManager, typeof(Resources)),
@@ -75,7 +76,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0018,
         title: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberNotDeclaredTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberNotDeclaredMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberNotDeclaredDescription), Resources.ResourceManager, typeof(Resources)),
@@ -85,7 +86,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0027,
         title: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberRemovedTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberRemovedMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberRemovedDescription), Resources.ResourceManager, typeof(Resources)),
@@ -96,7 +97,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0019,
         title: new LocalizableResourceString(nameof(Resources.GrainInterfaceRemovedNotRetiredTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceRemovedNotRetiredMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceRemovedNotRetiredDescription), Resources.ResourceManager, typeof(Resources)),
@@ -107,7 +108,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0020,
         title: new LocalizableResourceString(nameof(Resources.OrleansContractsFileMissingTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.OrleansContractsFileMissingMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.OrleansContractsFileMissingDescription), Resources.ResourceManager, typeof(Resources)),
@@ -118,7 +119,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0021,
         title: new LocalizableResourceString(nameof(Resources.GrainInterfaceDuplicateDeclarationTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceDuplicateDeclarationMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceDuplicateDeclarationDescription), Resources.ResourceManager, typeof(Resources)),
@@ -128,7 +129,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0022,
         title: new LocalizableResourceString(nameof(Resources.GrainClassNotDeclaredTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassNotDeclaredMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainClassNotDeclaredDescription), Resources.ResourceManager, typeof(Resources)),
@@ -138,7 +139,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0023,
         title: new LocalizableResourceString(nameof(Resources.GrainClassAliasMismatchTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassAliasMismatchMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainClassAliasMismatchDescription), Resources.ResourceManager, typeof(Resources)),
@@ -148,7 +149,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0024,
         title: new LocalizableResourceString(nameof(Resources.GrainClassRemovedNotRetiredTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassRemovedNotRetiredMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainClassRemovedNotRetiredDescription), Resources.ResourceManager, typeof(Resources)),
@@ -159,7 +160,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         id: RuleId0025,
         title: new LocalizableResourceString(nameof(Resources.GrainClassDuplicateDeclarationTitle), Resources.ResourceManager, typeof(Resources)),
         messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassDuplicateDeclarationMessageFormat), Resources.ResourceManager, typeof(Resources)),
-        category: "Orleans.Versioning",
+        category: DiagnosticCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainClassDuplicateDeclarationDescription), Resources.ResourceManager, typeof(Resources)),
@@ -379,22 +380,22 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             foreach (var member in sourceMembers)
             {
                 var memberSignature = GetMethodSignature(member);
-                var memberAlias = GetAliasFromAttribute(member);
-
-                if (!declaredInterface.Members.Values.Any(declaredMember =>
-                    GrainInterfaceVersionAnalyzer.IsMatchingMember(
+                var declaredMember = declaredInterface.Members.Values
+                    .Where(candidate => GrainInterfaceVersionAnalyzer.IsMatchingMember(
                         declaredInterface.Name,
-                        declaredMember.Signature,
-                        declaredMember.Alias,
-                        member)))
+                        candidate.Signature,
+                        candidate.WireIdentity,
+                        member))
+                    .FirstOrDefault();
+
+                if (declaredMember is null)
                 {
                     // Member not found - interface has changed
                     var properties = ImmutableDictionary<string, string?>.Empty
                         .Add(InterfaceNamePropertyKey, interfaceName)
                         .Add(GrainInterfaceTypePropertyKey, grainInterfaceType)
-                        .Add(MemberNamePropertyKey, memberSignature)
-                        .Add(MemberAliasPropertyKey, memberAlias)
-                        .Add(MemberClrSignaturePropertyKey, RequiresClrComment(member) ? GetClrMethodSignature(member) : null);
+                        .Add(MemberNamePropertyKey, GetManifestMethodSignature(member))
+                        .Add(MemberWireIdentityPropertyKey, GetMethodWireIdentity(member).ToManifestMetadata());
 
                     foreach (var location in member.Locations.Where(l => l.IsInSource))
                     {
@@ -402,9 +403,9 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
                             MemberNotDeclaredRule,
                             location,
                             properties,
-                            memberSignature,
-                            interfaceName,
-                            GetClrMethodSignature(member)));
+                            GetClrMethodSignature(member),
+                            GetMethodWireIdentity(member).Value,
+                            interfaceName));
                     }
                 }
             }
@@ -417,7 +418,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
                         GrainInterfaceVersionAnalyzer.IsMatchingHistoricalMember(
                             declaredInterface.Name,
                             declaredMember.Signature,
-                            declaredMember.Alias,
+                            declaredMember.WireIdentity,
                             member)))
                     {
                         continue;
@@ -427,11 +428,14 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
                         .Add(InterfaceNamePropertyKey, interfaceName)
                         .Add(GrainInterfaceTypePropertyKey, grainInterfaceType)
                         .Add(MemberNamePropertyKey, declaredMember.Signature);
+                    var declaredMemberLine = GrainInterfaceFileParser.FormatMemberDeclaration(
+                        declaredMember.Signature,
+                        declaredMember.WireIdentity);
                     _removedMemberDiagnostics.Add(Diagnostic.Create(
                         RemovedMemberRule,
                         declaredMember.GetLocation(sourceText, _grainInterfacesFile.Path),
                         properties,
-                        declaredMember.Signature,
+                        declaredMemberLine,
                         interfaceName));
                 }
             }
@@ -809,9 +813,8 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
 
     internal static string GetMethodSignature(IMethodSymbol method)
     {
-        var methodId = GetAttributeValue(method, Constants.IdAttributeFullyQualifiedName);
-        var methodAlias = GetStringAttributeValue(method, Constants.AliasAttributeFullyQualifiedName);
-        return GetMethodSignature(method, methodId ?? methodAlias ?? MethodIdProvider.Create(method));
+        var identity = GetMethodWireIdentity(method);
+        return GetMethodSignature(method, identity.Value);
     }
 
     private static string GetMethodSignature(IMethodSymbol method, object methodId)
@@ -836,6 +839,24 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         sb.Append(GetContractTypeName(method.ReturnType));
 
         return sb.ToString();
+    }
+
+    internal static string GetManifestMethodSignature(IMethodSymbol method)
+        => GetMethodSignature(method, method.Name);
+
+    internal static MethodWireIdentity GetMethodWireIdentity(IMethodSymbol method)
+    {
+        if (GetAttributeValue(method, Constants.IdAttributeFullyQualifiedName) is { } methodId)
+        {
+            return new MethodWireIdentity(methodId.ToString());
+        }
+
+        if (GetStringAttributeValue(method, Constants.AliasAttributeFullyQualifiedName) is { } methodAlias)
+        {
+            return new MethodWireIdentity(methodAlias);
+        }
+
+        return new MethodWireIdentity(MethodIdProvider.Create(method));
     }
 
     internal static string GetClrMethodSignature(IMethodSymbol method)
@@ -865,25 +886,6 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         return sb.ToString();
     }
 
-    internal static bool RequiresClrComment(IMethodSymbol method)
-    {
-        var methodId = GetAttributeValue(method, Constants.IdAttributeFullyQualifiedName)?.ToString();
-        var methodAlias = GetStringAttributeValue(method, Constants.AliasAttributeFullyQualifiedName);
-        if (methodId is null && methodAlias is null)
-        {
-            return true;
-        }
-
-        if (methodId is not null && !string.Equals(methodId, method.Name, StringComparison.Ordinal)
-            || methodAlias is not null && !string.Equals(methodAlias, method.Name, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        return method.Parameters.Any(parameter => HasMeaningfulTypeAlias(parameter.Type))
-            || HasMeaningfulTypeAlias(method.ReturnType);
-    }
-
     internal static bool IdentityDiffersFromClrName(string? identity, INamedTypeSymbol type)
     {
         if (identity is null)
@@ -896,9 +898,6 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             && !string.Equals(identity, type.MetadataName, StringComparison.Ordinal)
             && !string.Equals(identity, fullName, StringComparison.Ordinal);
     }
-
-    internal static string NormalizeLegacyMethodSignature(string signature)
-        => Regex.Replace(signature, @"\s+[A-Za-z_]\w*(?=\s*[,)\]])", "");
 
     internal static string NormalizeStoredMemberSignature(string signature, string interfaceName)
     {
@@ -915,111 +914,37 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
     internal static bool IsMatchingMember(
         string declaredInterfaceName,
         string storedSignature,
-        string? storedAlias,
+        MethodWireIdentity storedWireIdentity,
         IMethodSymbol member)
     {
-        var memberSignature = GetMethodSignature(member);
-        var sourceMethodId = GetAttributeValue(member, Constants.IdAttributeFullyQualifiedName);
-        var sourceMethodAlias = GetStringAttributeValue(member, Constants.AliasAttributeFullyQualifiedName);
-        if (storedAlias is not null)
-        {
-            if (!string.Equals(
-                storedAlias,
-                sourceMethodAlias,
-                StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            var storedIdentity = storedAlias + GrainInterfaceFileParser.GetMethodAritySuffix(storedSignature);
-            var parameterListStart = memberSignature.IndexOf('(');
-            if (parameterListStart < 0
-                || !string.Equals(
-                    storedIdentity,
-                    memberSignature.Substring(0, parameterListStart),
-                    StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            var canonicalStoredSignature = GrainInterfaceFileParser.GetCanonicalMemberSignature(
-                storedSignature,
-                storedAlias);
-            if (string.Equals(
-                NormalizeStoredMemberSignature(canonicalStoredSignature, declaredInterfaceName),
-                memberSignature,
-                StringComparison.Ordinal))
-            {
-                return true;
-            }
-
-            return string.Equals(
-                GetNormalizedSignatureSuffix(storedSignature),
-                GetNormalizedSignatureSuffix(GetClrMethodSignature(member)),
-                StringComparison.Ordinal);
-        }
-
-        var normalizedStoredSignature = NormalizeStoredMemberSignature(storedSignature, declaredInterfaceName);
-        if (sourceMethodAlias is not null)
-        {
-            return false;
-        }
-
-        if (sourceMethodId is not null)
-        {
-            return string.Equals(normalizedStoredSignature, memberSignature, StringComparison.Ordinal);
-        }
-
-        if (string.Equals(normalizedStoredSignature, memberSignature, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (string.Equals(
-            normalizedStoredSignature,
-            GetMethodSignature(member, member.Name),
-            StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        var normalized = NormalizeLegacyMethodSignature(storedSignature);
-        var clrSignature = GetClrMethodSignature(member);
-        var containingTypePrefix =
-            $"{member.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "")}.";
-        return string.Equals(normalized, NormalizeLegacyMethodSignature(clrSignature), StringComparison.Ordinal)
-            || string.Equals(
-                normalized,
-                NormalizeLegacyMethodSignature(clrSignature.Substring(containingTypePrefix.Length)),
+        var sourceWireIdentity = GetMethodWireIdentity(member);
+        return string.Equals(
+                storedWireIdentity.Value,
+                sourceWireIdentity.Value,
+                StringComparison.Ordinal)
+            && string.Equals(
+                GrainInterfaceFileParser.GetMethodAritySuffix(storedSignature),
+                GrainInterfaceFileParser.GetMethodAritySuffix(GetManifestMethodSignature(member)),
+                StringComparison.Ordinal)
+            && string.Equals(
+                GetSignatureSuffix(storedSignature),
+                GetSignatureSuffix(GetManifestMethodSignature(member)),
                 StringComparison.Ordinal);
     }
 
     internal static bool IsMatchingHistoricalMember(
         string declaredInterfaceName,
         string storedSignature,
-        string? storedAlias,
+        MethodWireIdentity storedWireIdentity,
         IMethodSymbol member)
     {
-        if (IsMatchingMember(declaredInterfaceName, storedSignature, storedAlias, member))
-        {
-            return true;
-        }
-
-        var sourceMethodAlias = GetStringAttributeValue(member, Constants.AliasAttributeFullyQualifiedName);
-        return storedAlias is null
-            && sourceMethodAlias is not null
-            && string.Equals(
-                NormalizeStoredMemberSignature(storedSignature, declaredInterfaceName),
-                GetMethodSignature(member),
-                StringComparison.Ordinal);
+        return IsMatchingMember(declaredInterfaceName, storedSignature, storedWireIdentity, member);
     }
 
-    private static string GetNormalizedSignatureSuffix(string signature)
+    private static string GetSignatureSuffix(string signature)
     {
         var parameterListStart = signature.IndexOf('(');
-        return parameterListStart < 0
-            ? NormalizeLegacyMethodSignature(signature)
-            : NormalizeLegacyMethodSignature(signature.Substring(parameterListStart));
+        return parameterListStart < 0 ? signature : signature.Substring(parameterListStart);
     }
 
     private static string GetContractTypeName(ITypeSymbol type)
@@ -1087,27 +1012,6 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         return $"{genericName}<{string.Join(", ", namedType.TypeArguments.Select(GetContractTypeName))}>";
     }
 
-    private static bool HasMeaningfulTypeAlias(ITypeSymbol type)
-    {
-        if (type is IArrayTypeSymbol array)
-        {
-            return HasMeaningfulTypeAlias(array.ElementType);
-        }
-
-        if (type is not INamedTypeSymbol namedType)
-        {
-            return false;
-        }
-
-        var alias = GetStringAttributeValue(namedType.OriginalDefinition, Constants.AliasAttributeFullyQualifiedName);
-        if (IdentityDiffersFromClrName(alias, namedType.OriginalDefinition))
-        {
-            return true;
-        }
-
-        return namedType.TypeArguments.Any(HasMeaningfulTypeAlias);
-    }
-
     private static object? GetAttributeValue(ISymbol symbol, string attributeName)
         => symbol.GetAttributes()
             .FirstOrDefault(attribute => string.Equals(attribute.AttributeClass?.ToDisplayString(), attributeName, StringComparison.Ordinal))
@@ -1125,6 +1029,7 @@ internal sealed class GrainInterfaceData
     public List<DeclaredGrainInterface> Interfaces { get; } = new();
 
     public List<DeclaredGrainClass> Classes { get; } = new();
+
 }
 
 /// <summary>
@@ -1158,13 +1063,14 @@ internal sealed class DeclaredGrainInterface
 /// </summary>
 internal sealed class DeclaredGrainMember
 {
-    public DeclaredGrainMember(string signature)
+    public DeclaredGrainMember(string signature, MethodWireIdentity wireIdentity)
     {
         Signature = signature;
+        WireIdentity = wireIdentity;
     }
 
     public string Signature { get; }
-    public string? Alias { get; set; }
+    public MethodWireIdentity WireIdentity { get; }
     public TextSpan Span { get; set; }
 
     public Location GetLocation(SourceText sourceText, string filePath)
@@ -1172,6 +1078,40 @@ internal sealed class DeclaredGrainMember
         var lineSpan = sourceText.Lines.GetLinePositionSpan(Span);
         return Location.Create(filePath, Span, lineSpan);
     }
+}
+
+internal readonly struct MethodWireIdentity
+{
+    public MethodWireIdentity(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public string ToManifestMetadata()
+    {
+        var result = new StringBuilder(Value.Length);
+        foreach (var character in Value)
+        {
+            result.Append(character switch
+            {
+                '\\' => @"\\",
+                ':' => @"\:",
+                '#' => @"\#",
+                ' ' => @"\s",
+                '\r' => @"\r",
+                '\n' => @"\n",
+                '\t' => @"\t",
+                _ when char.IsControl(character) || char.IsWhiteSpace(character)
+                    => $"\\u{((int)character).ToString("X4", CultureInfo.InvariantCulture)}",
+                _ => character.ToString()
+            });
+        }
+
+        return result.ToString();
+    }
+
 }
 
 /// <summary>
@@ -1218,10 +1158,10 @@ internal static class GrainInterfaceFileParser
         @"^(?<retired>\*RETIRED\*\s*)?class\s+(\[(?:GrainType|Alias)\(""(?<alias>[^""]+)""\)\]\s*)?(?<name>[\w]+(?:<[\w,\s]+>)?(?:\.[\w]+(?:<[\w,\s]+>)?)*)$",
         RegexOptions.Compiled);
 
-    // Member line: [Alias("x")] Namespace.IInterface<T>.Method(params) -> ReturnType
-    // The signature includes the full interface name (possibly generic) and method
+    // Member line: 0123ABCD: Method(params) -> ReturnType
+    // The value is the effective wire identity, independent of how source declares it.
     private static readonly Regex MemberPattern = new(
-        @"^(\[Alias\(""(?<alias>[^""]+)""\)\]\s*)?(?<signature>.+\(.*\)\s*->\s*.+)$",
+        @"^(?<signature>.+\(.*\)\s*->\s*.+)$",
         RegexOptions.Compiled);
 
     internal static bool TryGetInterfaceName(string line, out string name)
@@ -1281,9 +1221,9 @@ internal static class GrainInterfaceFileParser
 
     internal static bool TryGetMemberSignature(string line, out string signature)
     {
-        if (TryGetMemberDeclaration(line, out signature, out var alias))
+        if (TryGetMemberDeclaration(line, out signature, out var wireIdentity))
         {
-            signature = GetCanonicalMemberSignature(signature, alias);
+            signature = GetCanonicalMemberSignature(signature, wireIdentity);
             return true;
         }
 
@@ -1291,32 +1231,52 @@ internal static class GrainInterfaceFileParser
         return false;
     }
 
-    internal static bool TryGetMemberDeclaration(string line, out string signature, out string? alias)
+    internal static bool TryGetMemberDeclaration(
+        string line,
+        out string signature,
+        out MethodWireIdentity wireIdentity)
     {
-        var match = MemberPattern.Match(StripClrComment(line));
+        var declaration = StripClrComment(line);
+        var identityDelimiter = FindIdentityDelimiter(declaration);
+        if (identityDelimiter < 0)
+        {
+            signature = string.Empty;
+            wireIdentity = default;
+            return false;
+        }
+
+        wireIdentity = new MethodWireIdentity(
+            UnescapeWireIdentity(declaration.Substring(0, identityDelimiter)));
+        declaration = declaration.Substring(identityDelimiter + 2);
+        var match = MemberPattern.Match(declaration);
         if (match.Success)
         {
             signature = match.Groups["signature"].Value;
-            alias = match.Groups["alias"].Success ? match.Groups["alias"].Value : null;
             return true;
         }
 
         signature = string.Empty;
-        alias = null;
+        wireIdentity = default;
         return false;
     }
 
-    internal static string GetCanonicalMemberSignature(string signature, string? alias)
+    internal static string GetCanonicalMemberSignature(
+        string signature,
+        MethodWireIdentity wireIdentity)
     {
-        if (alias is null)
-        {
-            return signature;
-        }
-
         var parameterListStart = signature.IndexOf('(');
         return parameterListStart < 0
             ? signature
-            : alias + GetMethodAritySuffix(signature) + signature.Substring(parameterListStart);
+            : $"{wireIdentity.Value.Length}:{wireIdentity.Value}"
+                + GetMethodAritySuffix(signature)
+                + signature.Substring(parameterListStart);
+    }
+
+    internal static string FormatMemberDeclaration(
+        string signature,
+        MethodWireIdentity wireIdentity)
+    {
+        return $"{wireIdentity.ToManifestMetadata()}: {signature}";
     }
 
     internal static string GetMethodAritySuffix(string signature)
@@ -1366,6 +1326,70 @@ internal static class GrainInterfaceFileParser
         const string Prefix = " # CLR: ";
         var index = line.IndexOf(Prefix, StringComparison.Ordinal);
         return (index < 0 ? line : line.Substring(0, index)).Trim();
+    }
+
+    private static int FindIdentityDelimiter(string declaration)
+    {
+        var escaped = false;
+        for (var index = 0; index < declaration.Length - 1; index++)
+        {
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if (declaration[index] == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (declaration[index] == ':' && declaration[index + 1] == ' ')
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static string UnescapeWireIdentity(string value)
+    {
+        var result = new StringBuilder(value.Length);
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (value[index] == '\\' && index + 1 < value.Length)
+            {
+                if (value[index + 1] == 'u'
+                    && index + 5 < value.Length
+                    && ushort.TryParse(
+                        value.Substring(index + 2, 4),
+                        NumberStyles.HexNumber,
+                        CultureInfo.InvariantCulture,
+                        out var codePoint))
+                {
+                    result.Append((char)codePoint);
+                    index += 5;
+                    continue;
+                }
+
+                index++;
+                result.Append(value[index] switch
+                {
+                    'r' => '\r',
+                    'n' => '\n',
+                    't' => '\t',
+                    's' => ' ',
+                    _ => value[index]
+                });
+                continue;
+            }
+
+            result.Append(value[index]);
+        }
+
+        return result.ToString();
     }
 
     public static (GrainInterfaceData Data, List<Diagnostic>? Errors) Parse(SourceText sourceText, string filePath)
@@ -1464,15 +1488,12 @@ internal static class GrainInterfaceFileParser
             }
 
             // Try to match member declaration
-            var memberMatch = MemberPattern.Match(lineText);
-            if (memberMatch.Success && currentInterface is not null)
+            if (currentInterface is not null
+                && TryGetMemberDeclaration(lineText, out var signature, out var wireIdentity))
             {
-                var signature = memberMatch.Groups["signature"].Value;
-                var alias = memberMatch.Groups["alias"].Success ? memberMatch.Groups["alias"].Value : null;
-
-                currentInterface.Members[signature] = new DeclaredGrainMember(signature)
+                var key = GetCanonicalMemberSignature(signature, wireIdentity);
+                currentInterface.Members[key] = new DeclaredGrainMember(signature, wireIdentity)
                 {
-                    Alias = alias,
                     Span = textLine.Span
                 };
             }

--- a/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
@@ -379,7 +379,6 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             // Check members
             foreach (var member in sourceMembers)
             {
-                var memberSignature = GetMethodSignature(member);
                 var declaredMember = declaredInterface.Members.Values
                     .Where(candidate => GrainInterfaceVersionAnalyzer.IsMatchingMember(
                         declaredInterface.Name,
@@ -848,7 +847,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
     {
         if (GetAttributeValue(method, Constants.IdAttributeFullyQualifiedName) is { } methodId)
         {
-            return new MethodWireIdentity(methodId.ToString());
+            return new MethodWireIdentity(Convert.ToString(methodId, CultureInfo.InvariantCulture)!);
         }
 
         if (GetStringAttributeValue(method, Constants.AliasAttributeFullyQualifiedName) is { } methodAlias)

--- a/src/Orleans.Analyzers/GrainInterfaceVersionCodeFix.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionCodeFix.cs
@@ -37,7 +37,9 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         $"# {RegenerationCommand}",
         "# Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION",
         "# The regeneration command edits this manifest only; it does not change source attributes.",
-        "# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.",
+        "# OrleansContracts format: 2",
+        "# Method lines use: wire-identity: CLR-signature.",
+        "# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.",
         "# Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.",
         "# Details: https://aka.ms/orleans/OrleansContracts.txt"
     ];
@@ -108,7 +110,8 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                     && HasProperty(diagnostic, GrainInterfaceVersionAnalyzer.ActualVersionPropertyKey),
             GrainInterfaceVersionAnalyzer.RuleId0018
                 => HasProperty(diagnostic, GrainInterfaceVersionAnalyzer.InterfaceNamePropertyKey)
-                    && HasProperty(diagnostic, GrainInterfaceVersionAnalyzer.MemberNamePropertyKey),
+                    && HasProperty(diagnostic, GrainInterfaceVersionAnalyzer.MemberNamePropertyKey)
+                    && HasProperty(diagnostic, GrainInterfaceVersionAnalyzer.MemberWireIdentityPropertyKey),
             GrainInterfaceVersionAnalyzer.RuleId0019
                 => HasProperty(diagnostic, GrainInterfaceVersionAnalyzer.InterfaceNamePropertyKey),
             GrainInterfaceVersionAnalyzer.RuleId0020 => true,
@@ -429,16 +432,11 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         foreach (var member in type.GetMembers()
             .OfType<IMethodSymbol>()
             .Where(member => member.MethodKind == MethodKind.Ordinary && !member.IsStatic)
-            .OrderBy(GrainInterfaceVersionAnalyzer.GetMethodSignature, StringComparer.Ordinal))
+            .OrderBy(GrainInterfaceVersionAnalyzer.GetManifestMethodSignature, StringComparer.Ordinal))
         {
-            if (GrainInterfaceVersionAnalyzer.RequiresClrComment(member))
-            {
-                lines.Add($"  # {GrainInterfaceVersionAnalyzer.GetClrMethodSignature(member)}");
-            }
-
-            lines.Add($"  {FormatStoredMember(
-                GrainInterfaceVersionAnalyzer.GetMethodSignature(member),
-                GetAliasFromAttributes(member))}");
+            lines.Add($"  {GrainInterfaceFileParser.FormatMemberDeclaration(
+                GrainInterfaceVersionAnalyzer.GetManifestMethodSignature(member),
+                GrainInterfaceVersionAnalyzer.GetMethodWireIdentity(member))}");
         }
     }
 
@@ -616,9 +614,15 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                 break;
             }
 
-            if (GrainInterfaceFileParser.TryGetMemberSignature(result[generatedBlockEnd], out var memberSignature))
+            if (GrainInterfaceFileParser.TryGetMemberDeclaration(
+                result[generatedBlockEnd],
+                out var memberSignature,
+                out var memberWireIdentity))
             {
-                generatedMembers.Add(GetHistoricalMemberKey(memberSignature, historicalInterfaceName));
+                generatedMembers.Add(GetHistoricalMemberKey(
+                    memberSignature,
+                    memberWireIdentity,
+                    historicalInterfaceName));
             }
 
             generatedBlockEnd++;
@@ -637,7 +641,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             if (!GrainInterfaceFileParser.TryGetMemberDeclaration(
                 line,
                 out var memberSignature,
-                out var memberAlias))
+                out var memberWireIdentity))
             {
                 pendingComment = null;
                 continue;
@@ -650,7 +654,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                     && GrainInterfaceVersionAnalyzer.IsMatchingHistoricalMember(
                         historicalInterfaceName,
                         memberSignature,
-                        memberAlias,
+                        memberWireIdentity,
                         member)))
             {
                 pendingComment = null;
@@ -658,9 +662,12 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             }
 
             var normalizedSignature = GrainInterfaceVersionAnalyzer.NormalizeStoredMemberSignature(
-                GrainInterfaceFileParser.GetCanonicalMemberSignature(memberSignature, memberAlias),
+                memberSignature,
                 historicalInterfaceName);
-            var historicalMemberKey = GetHistoricalMemberKey(normalizedSignature, historicalInterfaceName);
+            var historicalMemberKey = GetHistoricalMemberKey(
+                memberSignature,
+                memberWireIdentity,
+                historicalInterfaceName);
             if (generatedMembers.Add(historicalMemberKey))
             {
                 if (pendingComment is not null)
@@ -668,16 +675,22 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                     result.Insert(generatedBlockEnd++, $"  {pendingComment}");
                 }
 
-                result.Insert(generatedBlockEnd++, $"  {FormatStoredMember(historicalMemberKey, memberAlias)}");
+                result.Insert(generatedBlockEnd++, $"  {GrainInterfaceFileParser.FormatMemberDeclaration(
+                    normalizedSignature,
+                    memberWireIdentity)}");
             }
 
             pendingComment = null;
         }
     }
 
-    private static string GetHistoricalMemberKey(string signature, string interfaceName)
-        => GrainInterfaceVersionAnalyzer.NormalizeLegacyMethodSignature(
-            GrainInterfaceVersionAnalyzer.NormalizeStoredMemberSignature(signature, interfaceName));
+    private static string GetHistoricalMemberKey(
+        string signature,
+        MethodWireIdentity wireIdentity,
+        string interfaceName)
+        => GrainInterfaceVersionAnalyzer.NormalizeStoredMemberSignature(
+            GrainInterfaceFileParser.GetCanonicalMemberSignature(signature, wireIdentity),
+            interfaceName);
 
     private static void AppendBlockSeparator(List<string> lines)
     {
@@ -806,8 +819,9 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             return;
         }
 
-        diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.MemberClrSignaturePropertyKey, out var memberClrSignature);
-        diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.MemberAliasPropertyKey, out var memberAlias);
+        diagnostic.Properties.TryGetValue(
+            GrainInterfaceVersionAnalyzer.MemberWireIdentityPropertyKey,
+            out var memberWireIdentity);
         diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.GrainInterfaceTypePropertyKey, out var grainInterfaceType);
 
         context.RegisterCodeFix(
@@ -818,8 +832,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                     interfaceName!,
                     grainInterfaceType,
                     memberSignature!,
-                    memberAlias,
-                    memberClrSignature,
+                    memberWireIdentity!,
                     ct),
                 equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0018),
             diagnostic);
@@ -1106,7 +1119,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         var interfaceLine = sb.ToString();
 
         // Build member lines
-        var memberLines = new List<(string Signature, string? Alias, string? ClrSignature)>();
+        var memberLines = new List<(string Signature, MethodWireIdentity WireIdentity)>();
         foreach (var member in symbol.GetMembers().OfType<IMethodSymbol>())
         {
             if (member.MethodKind != MethodKind.Ordinary || member.IsStatic)
@@ -1114,13 +1127,10 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                 continue;
             }
 
-            var memberSignature = GrainInterfaceVersionAnalyzer.GetMethodSignature(member);
+            var memberSignature = GrainInterfaceVersionAnalyzer.GetManifestMethodSignature(member);
             memberLines.Add((
                 memberSignature,
-                GetAliasFromAttributes(member),
-                GrainInterfaceVersionAnalyzer.RequiresClrComment(member)
-                    ? GrainInterfaceVersionAnalyzer.GetClrMethodSignature(member)
-                    : null));
+                GrainInterfaceVersionAnalyzer.GetMethodWireIdentity(member)));
         }
 
         // Find or create the OrleansContracts.txt file
@@ -1158,11 +1168,9 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             newContent += interfaceLine;
             foreach (var member in memberLines)
             {
-                if (member.ClrSignature is not null)
-                {
-                    newContent += $"{newLine}  # {member.ClrSignature}";
-                }
-                newContent += $"{newLine}  {FormatStoredMember(member.Signature, member.Alias)}";
+                newContent += $"{newLine}  {GrainInterfaceFileParser.FormatMemberDeclaration(
+                    member.Signature,
+                    member.WireIdentity)}";
             }
             newContent = SortContractEntries(newContent, newLine);
 
@@ -1179,11 +1187,10 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             AppendLine(content, interfaceLine, DefaultNewLine);
             foreach (var member in memberLines)
             {
-                if (member.ClrSignature is not null)
-                {
-                    AppendLine(content, $"  # {member.ClrSignature}", DefaultNewLine);
-                }
-                AppendLine(content, $"  {FormatStoredMember(member.Signature, member.Alias)}", DefaultNewLine);
+                AppendLine(
+                    content,
+                    $"  {GrainInterfaceFileParser.FormatMemberDeclaration(member.Signature, member.WireIdentity)}",
+                    DefaultNewLine);
             }
 
             var newText = Microsoft.CodeAnalysis.Text.SourceText.From(SortContractEntries(content.ToString(), DefaultNewLine), Utf8NoBom);
@@ -1266,8 +1273,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         string interfaceName,
         string? grainInterfaceType,
         string memberSignature,
-        string? memberAlias,
-        string? memberClrSignature,
+        string memberWireIdentity,
         CancellationToken cancellationToken)
     {
         var project = document.Project;
@@ -1303,7 +1309,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                     || trimmedLine.StartsWith("#", StringComparison.Ordinal)
                     || GrainInterfaceFileParser.TryGetContractName(trimmedLine, out _)))
             {
-                AppendMember(newLines, memberSignature, memberAlias, memberClrSignature, newLine);
+                AppendMember(newLines, memberSignature, memberWireIdentity, newLine);
                 insertedMember = true;
             }
 
@@ -1319,7 +1325,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         // If we didn't insert the member yet, append it at the end
         if (foundInterface && !insertedMember)
         {
-            AppendMember(newLines, memberSignature, memberAlias, memberClrSignature, newLine);
+            AppendMember(newLines, memberSignature, memberWireIdentity, newLine);
         }
 
         // Remove trailing newline added by AppendLine
@@ -1522,18 +1528,17 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             else if (GrainInterfaceFileParser.TryGetMemberDeclaration(
                 line,
                 out var storedMemberSignature,
-                out var memberAlias))
+                out var memberWireIdentity))
             {
-                var memberSignature = GrainInterfaceFileParser.GetCanonicalMemberSignature(
-                    storedMemberSignature,
-                    memberAlias);
                 var inlineComment = GrainInterfaceFileParser.GetClrComment(line);
-                var normalizedMemberLine = NormalizeMemberLine(memberSignature, currentBlock.Name);
+                var memberComment = pendingComment
+                    ?? (inlineComment.Length > 0 ? NormalizeComment(inlineComment) : null);
+                var normalizedMemberLine = NormalizeMemberLine(storedMemberSignature, currentBlock.Name);
                 currentBlock.Members.Add((
                     normalizedMemberLine,
                     normalizedMemberLine,
-                    memberAlias,
-                    pendingComment ?? (inlineComment.Length > 0 ? NormalizeComment(inlineComment) : null)));
+                    memberWireIdentity,
+                    memberComment));
                 pendingComment = null;
             }
             else if (!string.IsNullOrWhiteSpace(line))
@@ -1579,13 +1584,15 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             result.Add(block.Declaration);
             foreach (var member in block.Members
                 .OrderBy(member => member.Signature, StringComparer.Ordinal)
-                .ThenBy(member => member.Line, StringComparer.Ordinal))
+                .ThenBy(member => member.WireIdentity.Value, StringComparer.Ordinal))
             {
                 if (member.ClrComment is not null)
                 {
                     result.Add($"  {member.ClrComment}");
                 }
-                result.Add($"  {FormatStoredMember(member.Line, member.Alias)}");
+                result.Add($"  {GrainInterfaceFileParser.FormatMemberDeclaration(
+                    member.Line,
+                    member.WireIdentity)}");
             }
             result.AddRange(block.OtherLines);
         }
@@ -1600,6 +1607,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             or "# This file is auto-generated by the Orleans contract analyzer."
             or "# Update source contracts, then regenerate this file by following:"
             or "# https://aka.ms/orleans/OrleansContracts.txt"
+            or "# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash."
             or "# This file tracks grain interface versions for compatibility during rolling upgrades."
             or "# Format:"
             or "#   # Namespace.GrainClass"
@@ -1648,22 +1656,12 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
     private static void AppendMember(
         StringBuilder builder,
         string memberSignature,
-        string? memberAlias,
-        string? memberClrSignature,
+        string memberWireIdentity,
         string newLine)
-    {
-        if (!string.IsNullOrEmpty(memberClrSignature))
-        {
-            AppendLine(builder, $"  # {memberClrSignature}", newLine);
-        }
-
-        AppendLine(builder, $"  {FormatStoredMember(memberSignature, memberAlias)}", newLine);
-    }
-
-    private static string FormatStoredMember(string memberSignature, string? memberAlias)
-        => memberAlias is null
-            ? memberSignature
-            : $"[Alias(\"{memberAlias}\")] {memberSignature}";
+        => AppendLine(
+            builder,
+            $"  {memberWireIdentity}: {memberSignature}",
+            newLine);
 
     private static ushort GetVersionFromAttributes(ISymbol symbol)
     {
@@ -1680,23 +1678,6 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         }
 
         return 0;
-    }
-
-    private static string? GetAliasFromAttributes(ISymbol symbol)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (string.Equals(attribute.AttributeClass?.ToDisplayString(), Constants.AliasAttributeFullyQualifiedName, StringComparison.Ordinal))
-            {
-                if (attribute.ConstructorArguments.Length > 0 &&
-                    attribute.ConstructorArguments[0].Value is string alias)
-                {
-                    return alias;
-                }
-            }
-        }
-
-        return null;
     }
 
     private static string? GetGrainTypeFromAttributes(ISymbol symbol)
@@ -1744,7 +1725,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
 
         public string? ClrComment { get; }
 
-        public List<(string Signature, string Line, string? Alias, string? ClrComment)> Members { get; } = new();
+        public List<(string Signature, string Line, MethodWireIdentity WireIdentity, string? ClrComment)> Members { get; } = new();
 
         public List<string> OtherLines { get; } = new();
     }

--- a/src/Orleans.Analyzers/Resources.Designer.cs
+++ b/src/Orleans.Analyzers/Resources.Designer.cs
@@ -481,7 +481,7 @@ namespace Orleans.Analyzers {
                 return ResourceManager.GetString("GrainInterfaceRemovedNotRetiredTitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Add an OrleansContracts.txt file to track Orleans contracts for compatibility during rolling upgrades..
         /// </summary>

--- a/src/Orleans.Analyzers/Resources.resx
+++ b/src/Orleans.Analyzers/Resources.resx
@@ -236,7 +236,7 @@
     <value>Grain interface member not declared in OrleansContracts.txt</value>
   </data>
   <data name="GrainInterfaceMemberNotDeclaredMessageFormat" xml:space="preserve">
-    <value>Grain interface source member '{2}' with wire signature '{0}' is not declared in OrleansContracts.txt for interface '{1}'. Run the regeneration command in the file header for the owning project or solution, then review the diff for wire compatibility. See https://aka.ms/orleans/OrleansContracts.txt for details.</value>
+    <value>Grain interface source member '{0}' with effective wire identity '{1}' is not declared in OrleansContracts.txt for interface '{2}'. Run the regeneration command in the file header for the owning project or solution, then review the diff for wire compatibility. See https://aka.ms/orleans/OrleansContracts.txt for details.</value>
   </data>
   <data name="GrainInterfaceMemberNotDeclaredDescription" xml:space="preserve">
     <value>When adding or modifying grain interface members, update OrleansContracts.txt and increment the interface version.</value>

--- a/src/Orleans.BroadcastChannel/OrleansContracts.txt
+++ b/src/Orleans.BroadcastChannel/OrleansContracts.txt
@@ -4,12 +4,12 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.BroadcastChannel.IBroadcastChannelConsumerExtension")] Orleans.BroadcastChannel.IBroadcastChannelConsumerExtension [Version(0)]
-  # Orleans.BroadcastChannel.IBroadcastChannelConsumerExtension.OnError(InternalChannelId streamId, Exception exception) -> Task
-  73F72B20(Orleans.BroadcastChannel.InternalChannelId, System.Exception) -> Task
-  # Orleans.BroadcastChannel.IBroadcastChannelConsumerExtension.OnPublished(InternalChannelId streamId, object item) -> Task
-  B1E55518(Orleans.BroadcastChannel.InternalChannelId, object) -> Task
+  73F72B20: OnError(Orleans.BroadcastChannel.InternalChannelId, System.Exception) -> Task
+  B1E55518: OnPublished(Orleans.BroadcastChannel.InternalChannelId, object) -> Task

--- a/src/Orleans.Core.Abstractions/OrleansContracts.txt
+++ b/src/Orleans.Core.Abstractions/OrleansContracts.txt
@@ -4,15 +4,15 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.Core.Internal.IGrainManagementExtension")] Orleans.Core.Internal.IGrainManagementExtension [Version(0)]
-  # Orleans.Core.Internal.IGrainManagementExtension.DeactivateOnIdle() -> ValueTask
-  1B9614D1() -> ValueTask
-  # Orleans.Core.Internal.IGrainManagementExtension.MigrateOnIdle() -> ValueTask
-  4CC93B45() -> ValueTask
+  1B9614D1: DeactivateOnIdle() -> ValueTask
+  4CC93B45: MigrateOnIdle() -> ValueTask
 
 interface [GrainInterfaceType("Orleans.IGrain")] Orleans.IGrain [Version(0)]
 
@@ -31,20 +31,14 @@ interface [GrainInterfaceType("Orleans.IGrainWithStringKey")] Orleans.IGrainWith
 interface [GrainInterfaceType("Orleans.ISystemTarget")] Orleans.ISystemTarget [Version(0)]
 
 interface [GrainInterfaceType("Orleans.Runtime.IAsyncEnumerableGrainExtension")] Orleans.Runtime.IAsyncEnumerableGrainExtension [Version(0)]
-  # Orleans.Runtime.IAsyncEnumerableGrainExtension.StartEnumeration<T>(Guid requestId, IAsyncEnumerableRequest<T> request) -> ValueTask<(EnumerationResult Status, object? Value)>
-  370CD5AB`1(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
-  # Orleans.Runtime.IAsyncEnumerableGrainExtension.DisposeAsync(Guid requestId) -> ValueTask
-  3C6D7209(System.Guid) -> ValueTask
-  # Orleans.Runtime.IAsyncEnumerableGrainExtension.StartEnumeration<T>(Guid requestId, IAsyncEnumerableRequest<T> request, CancellationToken cancellationToken) -> ValueTask<(EnumerationResult Status, object? Value)>
-  8678B466`1(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
-  # Orleans.Runtime.IAsyncEnumerableGrainExtension.MoveNext<T>(Guid requestId) -> ValueTask<(EnumerationResult Status, object? Value)>
-  A7FA7E30`1(System.Guid) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
-  # Orleans.Runtime.IAsyncEnumerableGrainExtension.MoveNext<T>(Guid requestId, CancellationToken cancellationToken) -> ValueTask<(EnumerationResult Status, object? Value)>
-  E60EA75B`1(System.Guid, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  3C6D7209: DisposeAsync(System.Guid) -> ValueTask
+  A7FA7E30: MoveNext`1(System.Guid) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  E60EA75B: MoveNext`1(System.Guid, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  370CD5AB: StartEnumeration`1(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  8678B466: StartEnumeration`1(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
 
 interface [GrainInterfaceType("Orleans.Runtime.ICancellationSourcesExtension")] Orleans.Runtime.ICancellationSourcesExtension [Version(0)]
-  # Orleans.Runtime.ICancellationSourcesExtension.CancelRemoteToken(Guid tokenId) -> Task
-  50F75C16(System.Guid) -> Task
+  50F75C16: CancelRemoteToken(System.Guid) -> Task
 
 interface [GrainInterfaceType("Orleans.Runtime.IGrainExtension")] Orleans.Runtime.IGrainExtension [Version(0)]
 

--- a/src/Orleans.Core/OrleansContracts.txt
+++ b/src/Orleans.Core/OrleansContracts.txt
@@ -4,130 +4,84 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.ClientObservers.IClientGatewayObserver")] Orleans.ClientObservers.IClientGatewayObserver [Version(0)]
-  # Orleans.ClientObservers.IClientGatewayObserver.StopSendingToGateway(SiloAddress gateway) -> void
-  AFB768FD(Orleans.Runtime.SiloAddress) -> void
+  AFB768FD: StopSendingToGateway(Orleans.Runtime.SiloAddress) -> void
 
 interface [GrainInterfaceType("Orleans.IMembershipTableSystemTarget")] Orleans.IMembershipTableSystemTarget [Version(0)]
 
 interface [GrainInterfaceType("Orleans.ISiloControl")] Orleans.ISiloControl [Version(0)]
-  # Orleans.ISiloControl.ForceRuntimeStatisticsCollection() -> Task
-  0C7DBD0C() -> Task
-  # Orleans.ISiloControl.Ping(string message) -> Task
-  1422B0B7(string) -> Task
-  # Orleans.ISiloControl.SendControlCommandToProvider<T>(string providerName, int command, object? arg) -> Task<object?>
-  355CA3FA`1(string, int, object?) -> Task<object?>
-  # Orleans.ISiloControl.GetDetailedGrainReport(GrainId grainId) -> Task<DetailedGrainReport>
-  45172562(Orleans.Runtime.GrainId) -> Task<Orleans.Runtime.DetailedGrainReport>
-  # Orleans.ISiloControl.ForceActivationCollection(TimeSpan ageLimit) -> Task
-  45D07D09(System.TimeSpan) -> Task
-  # Orleans.ISiloControl.GetSimpleGrainStatistics() -> Task<SimpleGrainStatistic[]>
-  6DE16EF7() -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
-  # Orleans.ISiloControl.GetActiveGrains(GrainType grainType) -> Task<List<GrainId>>
-  85797C87(Orleans.Runtime.GrainType) -> Task<System.Collections.Generic.List<Orleans.Runtime.GrainId>>
-  # Orleans.ISiloControl.GetDetailedGrainStatistics(string[]? types) -> Task<List<DetailedGrainStatistic>>
-  B0F4C24B(string[]) -> Task<System.Collections.Generic.List<Orleans.Runtime.DetailedGrainStatistic>>
-  # Orleans.ISiloControl.GetActivationCount() -> Task<int>
-  C4C370A5() -> Task<int>
-  # Orleans.ISiloControl.MigrateRandomActivations(SiloAddress target, int count) -> Task
-  E8327F0B(Orleans.Runtime.SiloAddress, int) -> Task
-  # Orleans.ISiloControl.GetRuntimeStatistics() -> Task<SiloRuntimeStatistics>
-  F18EAF24() -> Task<Orleans.Runtime.SiloRuntimeStatistics>
-  # Orleans.ISiloControl.ForceGarbageCollection() -> Task
-  F388CED1() -> Task
-  # Orleans.ISiloControl.GetGrainStatistics() -> Task<List<Tuple<GrainId, string, int>>>
-  FF707A30() -> Task<System.Collections.Generic.List<System.Tuple<Orleans.Runtime.GrainId, string, int>>>
+  45D07D09: ForceActivationCollection(System.TimeSpan) -> Task
+  F388CED1: ForceGarbageCollection() -> Task
+  0C7DBD0C: ForceRuntimeStatisticsCollection() -> Task
+  C4C370A5: GetActivationCount() -> Task<int>
+  85797C87: GetActiveGrains(Orleans.Runtime.GrainType) -> Task<System.Collections.Generic.List<Orleans.Runtime.GrainId>>
+  45172562: GetDetailedGrainReport(Orleans.Runtime.GrainId) -> Task<Orleans.Runtime.DetailedGrainReport>
+  B0F4C24B: GetDetailedGrainStatistics(string[]) -> Task<System.Collections.Generic.List<Orleans.Runtime.DetailedGrainStatistic>>
+  FF707A30: GetGrainStatistics() -> Task<System.Collections.Generic.List<System.Tuple<Orleans.Runtime.GrainId, string, int>>>
+  F18EAF24: GetRuntimeStatistics() -> Task<Orleans.Runtime.SiloRuntimeStatistics>
+  6DE16EF7: GetSimpleGrainStatistics() -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
+  E8327F0B: MigrateRandomActivations(Orleans.Runtime.SiloAddress, int) -> Task
+  1422B0B7: Ping(string) -> Task
+  355CA3FA: SendControlCommandToProvider`1(string, int, object?) -> Task<object?>
 
 interface [GrainInterfaceType("Orleans.Placement.Rebalancing.IActivationRebalancerMonitor")] Orleans.Placement.Rebalancing.IActivationRebalancerMonitor [Version(0)]
-  [Alias("Report")] Report(RebalancingReport) -> Task
+  Report: Report(RebalancingReport) -> Task
 
 interface [GrainInterfaceType("Orleans.Placement.Rebalancing.IActivationRebalancerWorker")] Orleans.Placement.Rebalancing.IActivationRebalancerWorker [Version(0)]
-  [Alias("GetReport")] GetReport() -> ValueTask<RebalancingReport>
-  [Alias("ResumeRebalancing")] ResumeRebalancing() -> Task
-  [Alias("SuspendRebalancing")] SuspendRebalancing(System.TimeSpan?) -> Task
+  GetReport: GetReport() -> ValueTask<RebalancingReport>
+  ResumeRebalancing: ResumeRebalancing() -> Task
+  SuspendRebalancing: SuspendRebalancing(System.TimeSpan?) -> Task
 
 interface [GrainInterfaceType("Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget")] Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget [Version(0)]
-  # Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget.FlushBuffers() -> ValueTask
-  11731652() -> ValueTask
-  # Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget.SetActivationCountOffset(int activationCountOffset) -> ValueTask
-  135356E5(int) -> ValueTask
-  # Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget.ResetCounters() -> ValueTask
-  21852A09() -> ValueTask
-  # Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget.AcceptExchangeRequest(AcceptExchangeRequest request) -> ValueTask<AcceptExchangeResponse>
-  9D8EDC44(Orleans.Placement.Repartitioning.AcceptExchangeRequest) -> ValueTask<Orleans.Placement.Repartitioning.AcceptExchangeResponse>
-  # Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget.GetActivationCount() -> ValueTask<int>
-  9FB525F3() -> ValueTask<int>
-  # Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget.TriggerExchangeRequest() -> ValueTask
-  A6EE4757() -> ValueTask
-  # Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget.GetGrainCallFrequencies() -> ValueTask<ImmutableArray<(Edge, ulong)>>
-  C4497899() -> ValueTask<System.Collections.Immutable.ImmutableArray<(Orleans.Placement.Repartitioning.Edge, ulong)>>
+  9D8EDC44: AcceptExchangeRequest(Orleans.Placement.Repartitioning.AcceptExchangeRequest) -> ValueTask<Orleans.Placement.Repartitioning.AcceptExchangeResponse>
+  11731652: FlushBuffers() -> ValueTask
+  9FB525F3: GetActivationCount() -> ValueTask<int>
+  C4497899: GetGrainCallFrequencies() -> ValueTask<System.Collections.Immutable.ImmutableArray<(Orleans.Placement.Repartitioning.Edge, ulong)>>
+  21852A09: ResetCounters() -> ValueTask
+  135356E5: SetActivationCountOffset(int) -> ValueTask
+  A6EE4757: TriggerExchangeRequest() -> ValueTask
 
 interface [GrainInterfaceType("Orleans.Runtime.IClusterManifestSystemTarget")] Orleans.Runtime.IClusterManifestSystemTarget [Version(0)]
-  # Orleans.Runtime.IClusterManifestSystemTarget.GetClusterManifest() -> ValueTask<ClusterManifest>
-  40D39F85() -> ValueTask<Orleans.Metadata.ClusterManifest>
-  # Orleans.Runtime.IClusterManifestSystemTarget.GetClusterManifestUpdate(MajorMinorVersion previousVersion) -> ValueTask<ClusterManifestUpdate?>
-  4EFCA109(Orleans.Metadata.MajorMinorVersion) -> ValueTask<Orleans.Runtime.ClusterManifestUpdate?>
+  40D39F85: GetClusterManifest() -> ValueTask<Orleans.Metadata.ClusterManifest>
+  4EFCA109: GetClusterManifestUpdate(Orleans.Metadata.MajorMinorVersion) -> ValueTask<Orleans.Runtime.ClusterManifestUpdate?>
 
 interface [GrainInterfaceType("Orleans.Runtime.IDeploymentLoadPublisher")] Orleans.Runtime.IDeploymentLoadPublisher [Version(0)]
-  # Orleans.Runtime.IDeploymentLoadPublisher.UpdateRuntimeStatistics(SiloAddress siloAddress, SiloRuntimeStatistics siloStats) -> Task
-  C5255F0C(Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloRuntimeStatistics) -> Task
+  C5255F0C: UpdateRuntimeStatistics(Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloRuntimeStatistics) -> Task
 
 interface [GrainInterfaceType("Orleans.Runtime.IGrainCallCancellationExtension")] Orleans.Runtime.IGrainCallCancellationExtension [Version(0)]
-  # Orleans.Runtime.IGrainCallCancellationExtension.CancelRequestAsync(GrainId senderGrainId, CorrelationId messageId) -> ValueTask
-  FA239824(Orleans.Runtime.GrainId, Orleans.Runtime.CorrelationId) -> ValueTask
+  FA239824: CancelRequestAsync(Orleans.Runtime.GrainId, Orleans.Runtime.CorrelationId) -> ValueTask
 
 interface [GrainInterfaceType("Orleans.Runtime.IManagementGrain")] Orleans.Runtime.IManagementGrain [Version(0)]
-  # Orleans.Runtime.IManagementGrain.GetDetailedGrainStatistics(string[]? types, SiloAddress[]? hostsIds) -> Task<DetailedGrainStatistic[]>
-  0A1C0D82(string[], Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.DetailedGrainStatistic[]>
-  # Orleans.Runtime.IManagementGrain.GetGrainCallFrequencies(SiloAddress[]? hostsIds) -> Task<List<GrainCallFrequency>>
-  0F06E027(Orleans.Runtime.SiloAddress[]) -> Task<System.Collections.Generic.List<Orleans.Runtime.GrainCallFrequency>>
-  # Orleans.Runtime.IManagementGrain.GetRuntimeStatistics(SiloAddress[] hostsIds) -> Task<SiloRuntimeStatistics[]>
-  2D761B36(Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.SiloRuntimeStatistics[]>
-  # Orleans.Runtime.IManagementGrain.GetActivationAddress(IAddressable reference) -> ValueTask<SiloAddress?>
-  317D82B6(Orleans.Runtime.IAddressable) -> ValueTask<Orleans.Runtime.SiloAddress?>
-  # Orleans.Runtime.IManagementGrain.ForceActivationCollection(SiloAddress[] hostsIds, TimeSpan ageLimit) -> Task
-  329F9A1B(Orleans.Runtime.SiloAddress[], System.TimeSpan) -> Task
-  # Orleans.Runtime.IManagementGrain.GetSimpleGrainStatistics(SiloAddress[] hostsIds) -> Task<SimpleGrainStatistic[]>
-  3CFF788C(Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
-  # Orleans.Runtime.IManagementGrain.GetActiveGrains(GrainType type) -> ValueTask<List<GrainId>>
-  3DB7923B(Orleans.Runtime.GrainType) -> ValueTask<System.Collections.Generic.List<Orleans.Runtime.GrainId>>
-  # Orleans.Runtime.IManagementGrain.GetHosts(bool onlyActive) -> Task<Dictionary<SiloAddress, SiloStatus>>
-  4C0864C2(bool) -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloStatus>>
-  # Orleans.Runtime.IManagementGrain.ForceActivationCollection(TimeSpan ageLimit) -> Task
-  54E6D1D1(System.TimeSpan) -> Task
-  # Orleans.Runtime.IManagementGrain.ResetGrainCallFrequencies(SiloAddress[]? hostsIds) -> ValueTask
-  54FE0FEC(Orleans.Runtime.SiloAddress[]) -> ValueTask
-  # Orleans.Runtime.IManagementGrain.ForceGarbageCollection(SiloAddress[] hostsIds) -> Task
-  5922EB76(Orleans.Runtime.SiloAddress[]) -> Task
-  # Orleans.Runtime.IManagementGrain.GetSimpleGrainStatistics() -> Task<SimpleGrainStatistic[]>
-  ACCE9D6A() -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
-  # Orleans.Runtime.IManagementGrain.GetGrainActivationCount(GrainReference grainReference) -> Task<int>
-  AEDE93F6(GrainRef) -> Task<int>
-  # Orleans.Runtime.IManagementGrain.ForceRuntimeStatisticsCollection(SiloAddress[] siloAddresses) -> Task
-  B761B345(Orleans.Runtime.SiloAddress[]) -> Task
-  # Orleans.Runtime.IManagementGrain.GetDetailedHosts(bool onlyActive) -> Task<MembershipEntry[]>
-  CC6CCBC3(bool) -> Task<Orleans.MembershipEntry[]>
-  # Orleans.Runtime.IManagementGrain.GetTotalActivationCount() -> Task<int>
-  D7365B43() -> Task<int>
-  # Orleans.Runtime.IManagementGrain.SendControlCommandToProvider<T>(string providerName, int command, object? arg) -> Task<object?[]>
-  F67965CC`1(string, int, object?) -> Task<object?[]>
+  329F9A1B: ForceActivationCollection(Orleans.Runtime.SiloAddress[], System.TimeSpan) -> Task
+  54E6D1D1: ForceActivationCollection(System.TimeSpan) -> Task
+  5922EB76: ForceGarbageCollection(Orleans.Runtime.SiloAddress[]) -> Task
+  B761B345: ForceRuntimeStatisticsCollection(Orleans.Runtime.SiloAddress[]) -> Task
+  317D82B6: GetActivationAddress(Orleans.Runtime.IAddressable) -> ValueTask<Orleans.Runtime.SiloAddress?>
+  3DB7923B: GetActiveGrains(Orleans.Runtime.GrainType) -> ValueTask<System.Collections.Generic.List<Orleans.Runtime.GrainId>>
+  0A1C0D82: GetDetailedGrainStatistics(string[], Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.DetailedGrainStatistic[]>
+  CC6CCBC3: GetDetailedHosts(bool) -> Task<Orleans.MembershipEntry[]>
+  AEDE93F6: GetGrainActivationCount(GrainRef) -> Task<int>
+  0F06E027: GetGrainCallFrequencies(Orleans.Runtime.SiloAddress[]) -> Task<System.Collections.Generic.List<Orleans.Runtime.GrainCallFrequency>>
+  4C0864C2: GetHosts(bool) -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloStatus>>
+  2D761B36: GetRuntimeStatistics(Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.SiloRuntimeStatistics[]>
+  ACCE9D6A: GetSimpleGrainStatistics() -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
+  3CFF788C: GetSimpleGrainStatistics(Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
+  D7365B43: GetTotalActivationCount() -> Task<int>
+  54FE0FEC: ResetGrainCallFrequencies(Orleans.Runtime.SiloAddress[]) -> ValueTask
+  F67965CC: SendControlCommandToProvider`1(string, int, object?) -> Task<object?[]>
 
 interface [GrainInterfaceType("Orleans.Runtime.IMembershipService")] Orleans.Runtime.IMembershipService [Version(0)]
-  # Orleans.Runtime.IMembershipService.ProbeIndirectly(SiloAddress target, TimeSpan probeTimeout, int probeNumber) -> Task<IndirectProbeResponse>
-  0F85FAAF(Orleans.Runtime.SiloAddress, System.TimeSpan, int) -> Task<Orleans.Runtime.IndirectProbeResponse>
-  # Orleans.Runtime.IMembershipService.MembershipChangeNotification(MembershipTableSnapshot snapshot) -> Task
-  22A02D46(Orleans.Runtime.MembershipTableSnapshot) -> Task
-  # Orleans.Runtime.IMembershipService.Ping(int pingNumber) -> Task
-  39AB7071(int) -> Task
+  22A02D46: MembershipChangeNotification(Orleans.Runtime.MembershipTableSnapshot) -> Task
+  39AB7071: Ping(int) -> Task
+  0F85FAAF: ProbeIndirectly(Orleans.Runtime.SiloAddress, System.TimeSpan, int) -> Task<Orleans.Runtime.IndirectProbeResponse>
 
 interface [GrainInterfaceType("Orleans.Storage.IMemoryStorageGrain")] Orleans.Storage.IMemoryStorageGrain [Version(0)]
-  # Orleans.Storage.IMemoryStorageGrain.ReadStateAsync<T>(string grainStoreKey) -> Task<IGrainState<T>?>
-  45659318`1(string) -> Task<Orleans.IGrainState<T>>
-  # Orleans.Storage.IMemoryStorageGrain.WriteStateAsync<T>(string grainStoreKey, IGrainState<T> grainState) -> Task<string>
-  7CC6CA25`1(string, Orleans.IGrainState<T>) -> Task<string>
-  # Orleans.Storage.IMemoryStorageGrain.DeleteStateAsync<T>(string grainStoreKey, string? eTag) -> Task
-  B7CADD03`1(string, string?) -> Task
+  B7CADD03: DeleteStateAsync`1(string, string?) -> Task
+  45659318: ReadStateAsync`1(string) -> Task<Orleans.IGrainState<T>>
+  7CC6CA25: WriteStateAsync`1(string, Orleans.IGrainState<T>) -> Task<string>

--- a/src/Orleans.DurableJobs/OrleansContracts.txt
+++ b/src/Orleans.DurableJobs/OrleansContracts.txt
@@ -4,16 +4,16 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.DurableJobs.IDurableJobReceiverExtension")] Orleans.DurableJobs.IDurableJobReceiverExtension [Version(0)]
-  # Orleans.DurableJobs.IDurableJobReceiverExtension.HandleDurableJobAsync(IJobRunContext context, CancellationToken attemptCancellationToken) -> ValueTask<DurableJobRunResult>
-  703DB2D4(Orleans.DurableJobs.IJobRunContext, System.Threading.CancellationToken) -> ValueTask<Orleans.DurableJobs.DurableJobRunResult>
+  703DB2D4: HandleDurableJobAsync(Orleans.DurableJobs.IJobRunContext, System.Threading.CancellationToken) -> ValueTask<Orleans.DurableJobs.DurableJobRunResult>
 
 interface [GrainInterfaceType("Orleans.DurableJobs.ILocalDurableJobManagerSystemTarget")] Orleans.DurableJobs.ILocalDurableJobManagerSystemTarget [Version(0)]
-  # Orleans.DurableJobs.ILocalDurableJobManagerSystemTarget.CancelAsync(DurableJob job, CancellationToken requestCancellationToken) -> Task<bool>
-  4D559F22(Orleans.DurableJobs.DurableJob, System.Threading.CancellationToken) -> Task<bool>
+  4D559F22: CancelAsync(Orleans.DurableJobs.DurableJob, System.Threading.CancellationToken) -> Task<bool>
 
 class [GrainType("localdurablejobmanager")] Orleans.DurableJobs.LocalDurableJobManager

--- a/src/Orleans.EventSourcing/OrleansContracts.txt
+++ b/src/Orleans.EventSourcing/OrleansContracts.txt
@@ -4,18 +4,16 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.EventSourcing.ILogConsistencyProtocolParticipant")] Orleans.EventSourcing.ILogConsistencyProtocolParticipant [Version(0)]
-  # Orleans.EventSourcing.ILogConsistencyProtocolParticipant.PreActivateProtocolParticipant() -> Task
-  0DB087C8() -> Task
-  # Orleans.EventSourcing.ILogConsistencyProtocolParticipant.PostActivateProtocolParticipant() -> Task
-  22FD7D72() -> Task
-  # Orleans.EventSourcing.ILogConsistencyProtocolParticipant.DeactivateProtocolParticipant() -> Task
-  A36FC884() -> Task
+  A36FC884: DeactivateProtocolParticipant() -> Task
+  22FD7D72: PostActivateProtocolParticipant() -> Task
+  0DB087C8: PreActivateProtocolParticipant() -> Task
 
 interface [GrainInterfaceType("Orleans.SystemTargetInterfaces.ILogConsistencyProtocolGateway")] Orleans.SystemTargetInterfaces.ILogConsistencyProtocolGateway [Version(0)]
-  # Orleans.SystemTargetInterfaces.ILogConsistencyProtocolGateway.RelayMessage(GrainId id, ILogConsistencyProtocolMessage payload) -> Task<ILogConsistencyProtocolMessage?>
-  C86A1066(Orleans.Runtime.GrainId, Orleans.EventSourcing.ILogConsistencyProtocolMessage) -> Task<Orleans.EventSourcing.ILogConsistencyProtocolMessage?>
+  C86A1066: RelayMessage(Orleans.Runtime.GrainId, Orleans.EventSourcing.ILogConsistencyProtocolMessage) -> Task<Orleans.EventSourcing.ILogConsistencyProtocolMessage?>

--- a/src/Orleans.Persistence.Memory/OrleansContracts.txt
+++ b/src/Orleans.Persistence.Memory/OrleansContracts.txt
@@ -4,7 +4,9 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 

--- a/src/Orleans.Reminders/OrleansContracts.txt
+++ b/src/Orleans.Reminders/OrleansContracts.txt
@@ -4,41 +4,30 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.IRemindable")] Orleans.IRemindable [Version(0)]
-  # Orleans.IRemindable.ReceiveReminder(string reminderName, TickStatus status) -> Task
-  6461BF2F(string, Orleans.Runtime.TickStatus) -> Task
+  6461BF2F: ReceiveReminder(string, Orleans.Runtime.TickStatus) -> Task
 
 interface [GrainInterfaceType("Orleans.IReminderService")] Orleans.IReminderService [Version(0)]
-  # Orleans.IReminderService.RegisterOrUpdateReminder(GrainId grainId, string reminderName, TimeSpan dueTime, TimeSpan period) -> Task<IGrainReminder>
-  1281C86D(Orleans.Runtime.GrainId, string, System.TimeSpan, System.TimeSpan) -> Task<Orleans.Runtime.IGrainReminder>
-  # Orleans.IReminderService.GetReminders(GrainId grainId) -> Task<List<IGrainReminder>>
-  419EB51E(Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.List<Orleans.Runtime.IGrainReminder>>
-  # Orleans.IReminderService.Start() -> Task
-  5CF78F8A() -> Task
-  # Orleans.IReminderService.UnregisterReminder(IGrainReminder reminder) -> Task
-  A7AF84A8(Orleans.Runtime.IGrainReminder) -> Task
-  # Orleans.IReminderService.GetReminder(GrainId grainId, string reminderName) -> Task<IGrainReminder?>
-  AC622EEB(Orleans.Runtime.GrainId, string) -> Task<Orleans.Runtime.IGrainReminder?>
-  # Orleans.IReminderService.Stop() -> Task
-  DCFCA00D() -> Task
+  AC622EEB: GetReminder(Orleans.Runtime.GrainId, string) -> Task<Orleans.Runtime.IGrainReminder?>
+  419EB51E: GetReminders(Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.List<Orleans.Runtime.IGrainReminder>>
+  1281C86D: RegisterOrUpdateReminder(Orleans.Runtime.GrainId, string, System.TimeSpan, System.TimeSpan) -> Task<Orleans.Runtime.IGrainReminder>
+  5CF78F8A: Start() -> Task
+  DCFCA00D: Stop() -> Task
+  A7AF84A8: UnregisterReminder(Orleans.Runtime.IGrainReminder) -> Task
 
 interface [GrainInterfaceType("Orleans.IReminderTableGrain")] Orleans.IReminderTableGrain [Version(0)]
-  # Orleans.IReminderTableGrain.ReadRows(uint begin, uint end) -> Task<ReminderTableData>
-  13558B55(uint, uint) -> Task<Orleans.ReminderTableData>
-  # Orleans.IReminderTableGrain.UpsertRow(ReminderEntry entry) -> Task<string?>
-  873299B5(Orleans.ReminderEntry) -> Task<string?>
-  # Orleans.IReminderTableGrain.TestOnlyClearTable() -> Task
-  8EBE0523() -> Task
-  # Orleans.IReminderTableGrain.ReadRow(GrainId grainId, string reminderName) -> Task<ReminderEntry?>
-  ECA791DE(Orleans.Runtime.GrainId, string) -> Task<Orleans.ReminderEntry?>
-  # Orleans.IReminderTableGrain.ReadRows(GrainId grainId) -> Task<ReminderTableData>
-  EEEF6FCA(Orleans.Runtime.GrainId) -> Task<Orleans.ReminderTableData>
-  # Orleans.IReminderTableGrain.RemoveRow(GrainId grainId, string reminderName, string eTag) -> Task<bool>
-  FF391E0B(Orleans.Runtime.GrainId, string, string) -> Task<bool>
+  ECA791DE: ReadRow(Orleans.Runtime.GrainId, string) -> Task<Orleans.ReminderEntry?>
+  EEEF6FCA: ReadRows(Orleans.Runtime.GrainId) -> Task<Orleans.ReminderTableData>
+  13558B55: ReadRows(uint, uint) -> Task<Orleans.ReminderTableData>
+  FF391E0B: RemoveRow(Orleans.Runtime.GrainId, string, string) -> Task<bool>
+  8EBE0523: TestOnlyClearTable() -> Task
+  873299B5: UpsertRow(Orleans.ReminderEntry) -> Task<string?>
 
 class [GrainType("localreminderservice")] Orleans.Runtime.ReminderService.LocalReminderService
 

--- a/src/Orleans.Runtime/OrleansContracts.txt
+++ b/src/Orleans.Runtime/OrleansContracts.txt
@@ -4,7 +4,9 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
@@ -19,8 +21,7 @@ class [GrainType("deploymentloadpublisher")] Orleans.Runtime.DeploymentLoadPubli
 class [GrainType("developmentleaseprovider")] Orleans.Runtime.Development.DevelopmentLeaseProviderGrain
 
 interface [GrainInterfaceType("Orleans.Runtime.Development.IDevelopmentLeaseProviderGrain")] Orleans.Runtime.Development.IDevelopmentLeaseProviderGrain [Version(0)]
-  # Orleans.Runtime.Development.IDevelopmentLeaseProviderGrain.Reset() -> Task
-  847FCE12() -> Task
+  847FCE12: Reset() -> Task
 
 class [GrainType("graincallcancellationmanager")] Orleans.Runtime.GrainCallCancellationManager
 
@@ -33,27 +34,25 @@ class [GrainType("distributedremotegraindirectory")] Orleans.Runtime.GrainDirect
 class [GrainType("graindirectorypartition")] Orleans.Runtime.GrainDirectory.GrainDirectoryPartition
 
 interface [GrainInterfaceType("Orleans.Runtime.GrainDirectory.IGrainDirectoryClient")] Orleans.Runtime.GrainDirectory.IGrainDirectoryClient [Version(0)]
-  [Alias("GetRegisteredActivations")] GetRegisteredActivations(Orleans.Runtime.MembershipVersion, RingRange, bool, System.Threading.CancellationToken) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>>
-  [Alias("RecoverRegisteredActivations")] RecoverRegisteredActivations(Orleans.Runtime.MembershipVersion, RingRange, Orleans.Runtime.SiloAddress, int, System.Threading.CancellationToken) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>>
+  GetRegisteredActivations: GetRegisteredActivations(Orleans.Runtime.MembershipVersion, RingRange, bool, System.Threading.CancellationToken) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>>
+  RecoverRegisteredActivations: RecoverRegisteredActivations(Orleans.Runtime.MembershipVersion, RingRange, Orleans.Runtime.SiloAddress, int, System.Threading.CancellationToken) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>>
 
 interface [GrainInterfaceType("Orleans.Runtime.GrainDirectory.IGrainDirectoryPartition")] Orleans.Runtime.GrainDirectory.IGrainDirectoryPartition [Version(0)]
-  [Alias("AcknowledgeSnapshotTransferAsync")] AcknowledgeSnapshotTransferAsync(Orleans.Runtime.SiloAddress, int, Orleans.Runtime.MembershipVersion, System.Threading.CancellationToken) -> ValueTask<bool>
-  [Alias("DeregisterAsync")] DeregisterAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainAddress, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<bool>>
-  [Alias("GetSnapshotAsync")] GetSnapshotAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.MembershipVersion, RingRange, System.Threading.CancellationToken) -> ValueTask<GrainDirectoryPartitionSnapshot>
-  [Alias("LookupAsync")] LookupAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainId, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<Orleans.Runtime.GrainAddress?>>
-  [Alias("RegisterAsync")] RegisterAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainAddress, Orleans.Runtime.GrainAddress?, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<Orleans.Runtime.GrainAddress>>
+  AcknowledgeSnapshotTransferAsync: AcknowledgeSnapshotTransferAsync(Orleans.Runtime.SiloAddress, int, Orleans.Runtime.MembershipVersion, System.Threading.CancellationToken) -> ValueTask<bool>
+  DeregisterAsync: DeregisterAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainAddress, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<bool>>
+  GetSnapshotAsync: GetSnapshotAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.MembershipVersion, RingRange, System.Threading.CancellationToken) -> ValueTask<GrainDirectoryPartitionSnapshot>
+  LookupAsync: LookupAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainId, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<Orleans.Runtime.GrainAddress?>>
+  RegisterAsync: RegisterAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainAddress, Orleans.Runtime.GrainAddress?, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<Orleans.Runtime.GrainAddress>>
 
 interface [GrainInterfaceType("Orleans.Runtime.GrainDirectory.IGrainDirectoryTestHooks")] Orleans.Runtime.GrainDirectory.IGrainDirectoryTestHooks [Version(0)]
-  [Alias("CheckActivationsAsync")] CheckActivationsAsync(Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainId>>>
-  [Alias("CheckIntegrityAsync")] CheckIntegrityAsync() -> ValueTask
-  [Alias("RecoverAndCheckIntegrityAsync")] RecoverAndCheckIntegrityAsync() -> ValueTask
-  [Alias("WaitForMembershipVersionAsync")] WaitForMembershipVersionAsync(Orleans.Runtime.MembershipVersion) -> ValueTask
+  CheckActivationsAsync: CheckActivationsAsync(Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainId>>>
+  CheckIntegrityAsync: CheckIntegrityAsync() -> ValueTask
+  RecoverAndCheckIntegrityAsync: RecoverAndCheckIntegrityAsync() -> ValueTask
+  WaitForMembershipVersionAsync: WaitForMembershipVersionAsync(Orleans.Runtime.MembershipVersion) -> ValueTask
 
 interface [GrainInterfaceType("Orleans.Runtime.GrainDirectory.IRemoteClientDirectory")] Orleans.Runtime.GrainDirectory.IRemoteClientDirectory [Version(0)]
-  # Orleans.Runtime.GrainDirectory.IRemoteClientDirectory.OnUpdateClientRoutes(ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)> update) -> Task
-  972F9953(System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, (System.Collections.Immutable.ImmutableHashSet<Orleans.Runtime.GrainId>, long)>) -> Task
-  # Orleans.Runtime.GrainDirectory.IRemoteClientDirectory.GetClientRoutes(ImmutableDictionary<SiloAddress, long> knownRoutes) -> Task<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>>
-  A6E49CD1(System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, long>) -> Task<System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, (System.Collections.Immutable.ImmutableHashSet<Orleans.Runtime.GrainId>, long)>>
+  A6E49CD1: GetClientRoutes(System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, long>) -> Task<System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, (System.Collections.Immutable.ImmutableHashSet<Orleans.Runtime.GrainId>, long)>>
+  972F9953: OnUpdateClientRoutes(System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, (System.Collections.Immutable.ImmutableHashSet<Orleans.Runtime.GrainId>, long)>) -> Task
 
 class [GrainType("localgraindirectoryclientcompatibility")] Orleans.Runtime.GrainDirectory.LocalGrainDirectoryClientCompatibility
 
@@ -62,32 +61,24 @@ class [GrainType("localgraindirectorypartitioncompatibility")] Orleans.Runtime.G
 class [GrainType("remotegraindirectory")] Orleans.Runtime.GrainDirectory.RemoteGrainDirectory
 
 interface [GrainInterfaceType("Orleans.Runtime.IActivationMigrationManagerSystemTarget")] Orleans.Runtime.IActivationMigrationManagerSystemTarget [Version(0)]
-  # Orleans.Runtime.IActivationMigrationManagerSystemTarget.AcceptMigratingGrains(List<GrainMigrationPackage> migratingGrains) -> ValueTask
-  29E9E63F(System.Collections.Generic.List<Orleans.Runtime.GrainMigrationPackage>) -> ValueTask
+  29E9E63F: AcceptMigratingGrains(System.Collections.Generic.List<Orleans.Runtime.GrainMigrationPackage>) -> ValueTask
 
 interface [GrainInterfaceType("Orleans.Runtime.ICatalog")] Orleans.Runtime.ICatalog [Version(0)]
-  # Orleans.Runtime.ICatalog.DeleteActivations(List<GrainAddress> activationAddresses, DeactivationReasonCode reasonCode, string reasonText) -> Task
-  C4A56D7C(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>, Orleans.DeactivationReasonCode, string) -> Task
+  C4A56D7C: DeleteActivations(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>, Orleans.DeactivationReasonCode, string) -> Task
 
 interface [GrainInterfaceType("Orleans.Runtime.IGrainCallCancellationManagerSystemTarget")] Orleans.Runtime.IGrainCallCancellationManagerSystemTarget [Version(0)]
-  # Orleans.Runtime.IGrainCallCancellationManagerSystemTarget.CancelCallsAsync(List<GrainCallCancellationRequest> cancellationRequests) -> ValueTask
-  AF79F3FA(System.Collections.Generic.List<Orleans.Runtime.GrainCallCancellationRequest>) -> ValueTask
+  AF79F3FA: CancelCallsAsync(System.Collections.Generic.List<Orleans.Runtime.GrainCallCancellationRequest>) -> ValueTask
 
 interface [GrainInterfaceType("Orleans.Runtime.IGrainTimerInvoker")] Orleans.Runtime.IGrainTimerInvoker [Version(0)]
-  # Orleans.Runtime.IGrainTimerInvoker.InvokeCallbackAsync() -> Task
-  3F6C2672() -> Task
+  3F6C2672: InvokeCallbackAsync() -> Task
 
 interface [GrainInterfaceType("Orleans.Runtime.IRemoteGrainDirectory")] Orleans.Runtime.IRemoteGrainDirectory [Version(0)]
-  # Orleans.Runtime.IRemoteGrainDirectory.LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList) -> Task<List<AddressAndTag>>
-  7DF50601(System.Collections.Generic.List<(Orleans.Runtime.GrainId, int)>) -> Task<System.Collections.Generic.List<Orleans.GrainDirectory.AddressAndTag>>
-  # Orleans.Runtime.IRemoteGrainDirectory.AcceptSplitPartition(List<GrainAddress> singleActivations) -> Task
-  9ABE3793(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>) -> Task
-  # Orleans.Runtime.IRemoteGrainDirectory.RegisterMany(List<GrainAddress> addresses) -> Task
-  CD06EAEE(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>) -> Task
+  9ABE3793: AcceptSplitPartition(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>) -> Task
+  7DF50601: LookUpMany(System.Collections.Generic.List<(Orleans.Runtime.GrainId, int)>) -> Task<System.Collections.Generic.List<Orleans.GrainDirectory.AddressAndTag>>
+  CD06EAEE: RegisterMany(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>) -> Task
 
 interface [GrainInterfaceType("Orleans.Runtime.ISiloManifestSystemTarget")] Orleans.Runtime.ISiloManifestSystemTarget [Version(0)]
-  # Orleans.Runtime.ISiloManifestSystemTarget.GetSiloManifest() -> ValueTask<GrainManifest>
-  1857A4C8() -> ValueTask<Orleans.Metadata.GrainManifest>
+  1857A4C8: GetSiloManifest() -> ValueTask<Orleans.Metadata.GrainManifest>
 
 class [GrainType("management")] Orleans.Runtime.Management.ManagementGrain
 
@@ -96,7 +87,7 @@ class [GrainType("membershipsystemtarget")] Orleans.Runtime.MembershipService.Me
 class [GrainType("membershiptablesystemtarget")] Orleans.Runtime.MembershipService.MembershipTableSystemTarget
 
 interface [GrainInterfaceType("Orleans.Runtime.MembershipService.SiloMetadata.ISiloMetadataSystemTarget")] Orleans.Runtime.MembershipService.SiloMetadata.ISiloMetadataSystemTarget [Version(0)]
-  [Alias("GetSiloMetadata")] GetSiloMetadata() -> Task<Orleans.Runtime.MembershipService.SiloMetadata.SiloMetadata>
+  GetSiloMetadata: GetSiloMetadata() -> Task<Orleans.Runtime.MembershipService.SiloMetadata.SiloMetadata>
 
 class [GrainType("silometadatasystemtarget")] Orleans.Runtime.MembershipService.SiloMetadata.SiloMetadataSystemTarget
 
@@ -113,21 +104,13 @@ interface [GrainInterfaceType("Orleans.Runtime.TestHooks.ITestHooksSystemTarget"
 class [GrainType("testhookssystemtarget")] Orleans.Runtime.TestHooks.TestHooksSystemTarget
 
 interface [GrainInterfaceType("Orleans.Runtime.Versions.IVersionStoreGrain")] Orleans.Runtime.Versions.IVersionStoreGrain [Version(0)]
-  # Orleans.Runtime.Versions.IVersionStoreGrain.SetCompatibilityStrategy(GrainInterfaceType interfaceType, CompatibilityStrategy strategy) -> Task
-  1B7F13C8(Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Compatibility.CompatibilityStrategy) -> Task
-  # Orleans.Runtime.Versions.IVersionStoreGrain.SetSelectorStrategy(GrainInterfaceType interfaceType, VersionSelectorStrategy strategy) -> Task
-  3E6DDE3E(Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Selector.VersionSelectorStrategy) -> Task
-  # Orleans.Runtime.Versions.IVersionStoreGrain.SetCompatibilityStrategy(CompatibilityStrategy strategy) -> Task
-  67A0B5AA(Orleans.Versions.Compatibility.CompatibilityStrategy) -> Task
-  # Orleans.Runtime.Versions.IVersionStoreGrain.GetCompatibilityStrategy() -> Task<CompatibilityStrategy?>
-  67EF9A39() -> Task<Orleans.Versions.Compatibility.CompatibilityStrategy?>
-  # Orleans.Runtime.Versions.IVersionStoreGrain.GetCompatibilityStrategies() -> Task<Dictionary<GrainInterfaceType, CompatibilityStrategy>>
-  7261373F() -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Compatibility.CompatibilityStrategy>>
-  # Orleans.Runtime.Versions.IVersionStoreGrain.GetSelectorStrategies() -> Task<Dictionary<GrainInterfaceType, VersionSelectorStrategy>>
-  743D88ED() -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Selector.VersionSelectorStrategy>>
-  # Orleans.Runtime.Versions.IVersionStoreGrain.GetSelectorStrategy() -> Task<VersionSelectorStrategy?>
-  8A72848A() -> Task<Orleans.Versions.Selector.VersionSelectorStrategy?>
-  # Orleans.Runtime.Versions.IVersionStoreGrain.SetSelectorStrategy(VersionSelectorStrategy strategy) -> Task
-  E7532DE3(Orleans.Versions.Selector.VersionSelectorStrategy) -> Task
+  7261373F: GetCompatibilityStrategies() -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Compatibility.CompatibilityStrategy>>
+  67EF9A39: GetCompatibilityStrategy() -> Task<Orleans.Versions.Compatibility.CompatibilityStrategy?>
+  743D88ED: GetSelectorStrategies() -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Selector.VersionSelectorStrategy>>
+  8A72848A: GetSelectorStrategy() -> Task<Orleans.Versions.Selector.VersionSelectorStrategy?>
+  1B7F13C8: SetCompatibilityStrategy(Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Compatibility.CompatibilityStrategy) -> Task
+  67A0B5AA: SetCompatibilityStrategy(Orleans.Versions.Compatibility.CompatibilityStrategy) -> Task
+  3E6DDE3E: SetSelectorStrategy(Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Selector.VersionSelectorStrategy) -> Task
+  E7532DE3: SetSelectorStrategy(Orleans.Versions.Selector.VersionSelectorStrategy) -> Task
 
 class [GrainType("versionstore")] Orleans.Runtime.Versions.VersionStoreGrain

--- a/src/Orleans.Streaming/OrleansContracts.txt
+++ b/src/Orleans.Streaming/OrleansContracts.txt
@@ -4,15 +4,15 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.Providers.IMemoryStreamQueueGrain")] Orleans.Providers.IMemoryStreamQueueGrain [Version(0)]
-  # Orleans.Providers.IMemoryStreamQueueGrain.Enqueue(MemoryMessageData data) -> Task
-  74D60341(Orleans.Providers.MemoryMessageData) -> Task
-  # Orleans.Providers.IMemoryStreamQueueGrain.Dequeue(int maxCount) -> Task<List<MemoryMessageData>>
-  7A8F8C1A(int) -> Task<System.Collections.Generic.List<Orleans.Providers.MemoryMessageData>>
+  7A8F8C1A: Dequeue(int) -> Task<System.Collections.Generic.List<Orleans.Providers.MemoryMessageData>>
+  74D60341: Enqueue(Orleans.Providers.MemoryMessageData) -> Task
 
 class [GrainType("memorystreamqueue")] Orleans.Providers.MemoryStreamQueueGrain
 
@@ -22,70 +22,43 @@ class [GrainType("stream.checkpoint.configured")] Orleans.Streams.ConfiguredStre
 interface [GrainInterfaceType("Orleans.Streams.IConfiguredStreamCheckpointerGrain")] Orleans.Streams.IConfiguredStreamCheckpointerGrain [Version(0)]
 
 interface [GrainInterfaceType("Orleans.Streams.IPersistentStreamPullingAgent")] Orleans.Streams.IPersistentStreamPullingAgent [Version(0)]
-  # Orleans.Streams.IPersistentStreamPullingAgent.Initialize() -> Task
-  06009D9C() -> Task
-  # Orleans.Streams.IPersistentStreamPullingAgent.Shutdown() -> Task
-  620FF905() -> Task
+  06009D9C: Initialize() -> Task
+  620FF905: Shutdown() -> Task
 
 interface [GrainInterfaceType("Orleans.Streams.IPersistentStreamPullingManager")] Orleans.Streams.IPersistentStreamPullingManager [Version(0)]
-  # Orleans.Streams.IPersistentStreamPullingManager.Initialize() -> Task
-  455AB850() -> Task
-  # Orleans.Streams.IPersistentStreamPullingManager.StartAgents() -> Task
-  54E9E970() -> Task
-  # Orleans.Streams.IPersistentStreamPullingManager.StopAgents() -> Task
-  BBD50CFF() -> Task
-  # Orleans.Streams.IPersistentStreamPullingManager.ExecuteCommand(PersistentStreamProviderCommand command, object? arg) -> Task<object?>
-  DE756D95(Orleans.Providers.Streams.Common.PersistentStreamProviderCommand, object?) -> Task<object?>
-  # Orleans.Streams.IPersistentStreamPullingManager.Stop() -> Task
-  F4B5B5AA() -> Task
+  DE756D95: ExecuteCommand(Orleans.Providers.Streams.Common.PersistentStreamProviderCommand, object?) -> Task<object?>
+  455AB850: Initialize() -> Task
+  54E9E970: StartAgents() -> Task
+  F4B5B5AA: Stop() -> Task
+  BBD50CFF: StopAgents() -> Task
 
 interface [GrainInterfaceType("Orleans.Streams.IPubSubRendezvousGrain")] Orleans.Streams.IPubSubRendezvousGrain [Version(0)]
-  # Orleans.Streams.IPubSubRendezvousGrain.Validate() -> Task
-  20AA72BF() -> Task
-  # Orleans.Streams.IPubSubRendezvousGrain.FaultSubscription(GuidId subscriptionId) -> Task
-  2821FCF5(Orleans.Runtime.GuidId) -> Task
-  # Orleans.Streams.IPubSubRendezvousGrain.ProducerCount(QualifiedStreamId streamId) -> Task<int>
-  29B61035(Orleans.Runtime.QualifiedStreamId) -> Task<int>
-  # Orleans.Streams.IPubSubRendezvousGrain.RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, GrainId streamConsumer, string? filterData) -> Task
-  5E7E20BC(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId, string?) -> Task
-  # Orleans.Streams.IPubSubRendezvousGrain.ConsumerCount(QualifiedStreamId streamId) -> Task<int>
-  5F72C5CF(Orleans.Runtime.QualifiedStreamId) -> Task<int>
-  # Orleans.Streams.IPubSubRendezvousGrain.GetAllSubscriptions(QualifiedStreamId streamId, GrainId streamConsumer) -> Task<List<StreamSubscription>>
-  7DBE84FA(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.List<Orleans.Streams.Core.StreamSubscription>>
-  # Orleans.Streams.IPubSubRendezvousGrain.DiagGetConsumers(QualifiedStreamId streamId) -> Task<PubSubSubscriptionState[]>
-  8A033955(Orleans.Runtime.QualifiedStreamId) -> Task<Orleans.Streams.PubSubSubscriptionState[]>
-  # Orleans.Streams.IPubSubRendezvousGrain.UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId) -> Task
-  974334B6(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId) -> Task
-  # Orleans.Streams.IPubSubRendezvousGrain.RegisterProducer(QualifiedStreamId streamId, GrainId streamProducer) -> Task<ISet<PubSubSubscriptionState>>
-  B5FFB7F3(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.ISet<Orleans.Streams.PubSubSubscriptionState>>
-  # Orleans.Streams.IPubSubRendezvousGrain.UnregisterProducer(QualifiedStreamId streamId, GrainId streamProducer) -> Task
-  C017B47D(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task
+  5F72C5CF: ConsumerCount(Orleans.Runtime.QualifiedStreamId) -> Task<int>
+  8A033955: DiagGetConsumers(Orleans.Runtime.QualifiedStreamId) -> Task<Orleans.Streams.PubSubSubscriptionState[]>
+  2821FCF5: FaultSubscription(Orleans.Runtime.GuidId) -> Task
+  7DBE84FA: GetAllSubscriptions(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.List<Orleans.Streams.Core.StreamSubscription>>
+  29B61035: ProducerCount(Orleans.Runtime.QualifiedStreamId) -> Task<int>
+  5E7E20BC: RegisterConsumer(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId, string?) -> Task
+  B5FFB7F3: RegisterProducer(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.ISet<Orleans.Streams.PubSubSubscriptionState>>
+  974334B6: UnregisterConsumer(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId) -> Task
+  C017B47D: UnregisterProducer(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task
+  20AA72BF: Validate() -> Task
 
 interface [GrainInterfaceType("Orleans.Streams.IStreamCheckpointerGrain")] Orleans.Streams.IStreamCheckpointerGrain [Version(0)]
-  # Orleans.Streams.IStreamCheckpointerGrain.Update(string offset, string expectedCheckpoint, CancellationToken cancellationToken) -> ValueTask<string>
-  7AB50A87(string, string, System.Threading.CancellationToken) -> ValueTask<string>
-  # Orleans.Streams.IStreamCheckpointerGrain.Load(CancellationToken cancellationToken) -> ValueTask<string>
-  DE3727A1(System.Threading.CancellationToken) -> ValueTask<string>
+  DE3727A1: Load(System.Threading.CancellationToken) -> ValueTask<string>
+  7AB50A87: Update(string, string, System.Threading.CancellationToken) -> ValueTask<string>
 
 interface [GrainInterfaceType("Orleans.Streams.IStreamConsumerExtension")] Orleans.Streams.IStreamConsumerExtension [Version(0)]
-  # Orleans.Streams.IStreamConsumerExtension.DeliverMutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken? handshakeToken) -> Task<StreamHandshakeToken?>
-  31840DDE(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, object, Orleans.Streams.StreamSequenceToken, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
-  # Orleans.Streams.IStreamConsumerExtension.CompleteStream(GuidId subscriptionId) -> Task
-  49F94A48(Orleans.Runtime.GuidId) -> Task
-  # Orleans.Streams.IStreamConsumerExtension.ErrorInStream(GuidId subscriptionId, Exception exc) -> Task
-  4C676CAF(Orleans.Runtime.GuidId, System.Exception) -> Task
-  # Orleans.Streams.IStreamConsumerExtension.DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken? handshakeToken) -> Task<StreamHandshakeToken?>
-  6D8FAEB2(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, object, Orleans.Streams.StreamSequenceToken, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
-  # Orleans.Streams.IStreamConsumerExtension.DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, IBatchContainer item, StreamHandshakeToken? handshakeToken) -> Task<StreamHandshakeToken?>
-  B9CFF2C9(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Streams.IBatchContainer, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
-  # Orleans.Streams.IStreamConsumerExtension.GetSequenceToken(GuidId subscriptionId) -> Task<StreamHandshakeToken?>
-  C265B3CB(Orleans.Runtime.GuidId) -> Task<Orleans.Streams.StreamHandshakeToken?>
+  49F94A48: CompleteStream(Orleans.Runtime.GuidId) -> Task
+  B9CFF2C9: DeliverBatch(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Streams.IBatchContainer, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
+  6D8FAEB2: DeliverImmutable(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, object, Orleans.Streams.StreamSequenceToken, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
+  31840DDE: DeliverMutable(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, object, Orleans.Streams.StreamSequenceToken, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
+  4C676CAF: ErrorInStream(Orleans.Runtime.GuidId, System.Exception) -> Task
+  C265B3CB: GetSequenceToken(Orleans.Runtime.GuidId) -> Task<Orleans.Streams.StreamHandshakeToken?>
 
 interface [GrainInterfaceType("Orleans.Streams.IStreamProducerExtension")] Orleans.Streams.IStreamProducerExtension [Version(0)]
-  # Orleans.Streams.IStreamProducerExtension.AddSubscriber(GuidId subscriptionId, QualifiedStreamId streamId, GrainId streamConsumer, string? filterData) -> Task
-  1341E3D4(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId, string?) -> Task
-  # Orleans.Streams.IStreamProducerExtension.RemoveSubscriber(GuidId subscriptionId, QualifiedStreamId streamId) -> Task
-  B98BA876(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId) -> Task
+  1341E3D4: AddSubscriber(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId, string?) -> Task
+  B98BA876: RemoveSubscriber(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId) -> Task
 
 class [GrainType("persistentstreampullingagent")] Orleans.Streams.PersistentStreamPullingAgent
 

--- a/src/Orleans.TestingHost/OrleansContracts.txt
+++ b/src/Orleans.TestingHost/OrleansContracts.txt
@@ -4,22 +4,18 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.TestingHost.IStorageFaultGrain")] Orleans.TestingHost.IStorageFaultGrain [Version(0)]
-  # Orleans.TestingHost.IStorageFaultGrain.AddFaultOnRead(GrainId grainId, Exception exception) -> Task
-  1150D526(Orleans.Runtime.GrainId, System.Exception) -> Task
-  # Orleans.TestingHost.IStorageFaultGrain.AddFaultOnClear(GrainId grainId, Exception exception) -> Task
-  1A607A31(Orleans.Runtime.GrainId, System.Exception) -> Task
-  # Orleans.TestingHost.IStorageFaultGrain.OnRead(GrainId grainId) -> Task
-  5D91E1AF(Orleans.Runtime.GrainId) -> Task
-  # Orleans.TestingHost.IStorageFaultGrain.AddFaultOnWrite(GrainId grainId, Exception exception) -> Task
-  B9852E6E(Orleans.Runtime.GrainId, System.Exception) -> Task
-  # Orleans.TestingHost.IStorageFaultGrain.OnClear(GrainId grainId) -> Task
-  C94BA77C(Orleans.Runtime.GrainId) -> Task
-  # Orleans.TestingHost.IStorageFaultGrain.OnWrite(GrainId grainId) -> Task
-  E8594820(Orleans.Runtime.GrainId) -> Task
+  1A607A31: AddFaultOnClear(Orleans.Runtime.GrainId, System.Exception) -> Task
+  1150D526: AddFaultOnRead(Orleans.Runtime.GrainId, System.Exception) -> Task
+  B9852E6E: AddFaultOnWrite(Orleans.Runtime.GrainId, System.Exception) -> Task
+  C94BA77C: OnClear(Orleans.Runtime.GrainId) -> Task
+  5D91E1AF: OnRead(Orleans.Runtime.GrainId) -> Task
+  E8594820: OnWrite(Orleans.Runtime.GrainId) -> Task
 
 class [GrainType("storagefault")] Orleans.TestingHost.StorageFaultGrain

--- a/src/Orleans.Transactions.TestKit.Base/OrleansContracts.txt
+++ b/src/Orleans.Transactions.TestKit.Base/OrleansContracts.txt
@@ -4,26 +4,24 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 class [GrainType("consistencytest")] Orleans.Transactions.TestKit.Consistency.ConsistencyTestGrain
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.Consistency.IConsistencyTestGrain")] Orleans.Transactions.TestKit.Consistency.IConsistencyTestGrain [Version(0)]
-  # Orleans.Transactions.TestKit.Consistency.IConsistencyTestGrain.Run(ConsistencyTestOptions options, int depth, string stack, int max, DateTime stopAfter) -> Task<Observation[]>
-  2EB318CB(Orleans.Transactions.TestKit.Consistency.ConsistencyTestOptions, int, string, int, System.DateTime) -> Task<Orleans.Transactions.TestKit.Consistency.Observation[]>
+  2EB318CB: Run(Orleans.Transactions.TestKit.Consistency.ConsistencyTestOptions, int, string, int, System.DateTime) -> Task<Orleans.Transactions.TestKit.Consistency.Observation[]>
 
 # Orleans.Transactions.TestKit.Correctnesss.DoubleStateTransactionalGrain
 class [GrainType("txn-correctness-DoubleStateTransactionalGrain")] Orleans.Transactions.TestKit.Correctnesss.DoubleStateTransactionalGrain
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain")] Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain [Version(0)]
-  # Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain.SetBit(int newValue) -> Task
-  0183C2F5(int) -> Task
-  # Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain.Ping() -> Task
-  9A5740F1() -> Task
-  # Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain.Get() -> Task<List<BitArrayState>>
-  B821F3B1() -> Task<System.Collections.Generic.List<Orleans.Transactions.TestKit.Correctnesss.BitArrayState>>
+  B821F3B1: Get() -> Task<System.Collections.Generic.List<Orleans.Transactions.TestKit.Correctnesss.BitArrayState>>
+  9A5740F1: Ping() -> Task
+  0183C2F5: SetBit(int) -> Task
 
 # Orleans.Transactions.TestKit.Correctnesss.MaxStateTransactionalGrain
 class [GrainType("txn-correctness-MaxStateTransactionalGrain")] Orleans.Transactions.TestKit.Correctnesss.MaxStateTransactionalGrain
@@ -47,104 +45,68 @@ class [GrainType("exclusivelocktransactiontest")] Orleans.Transactions.TestKit.E
 class [GrainType("faultinjectiontransactioncoordinator")] Orleans.Transactions.TestKit.FaultInjectionTransactionCoordinatorGrain
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.ICreateAttributionGrain")] Orleans.Transactions.TestKit.ICreateAttributionGrain [Version(0)]
-  # Orleans.Transactions.TestKit.ICreateAttributionGrain.GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers) -> Task<List<string?>?[]>
-  3EFBDD5D(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+  3EFBDD5D: GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.ICreateOrJoinAttributionGrain")] Orleans.Transactions.TestKit.ICreateOrJoinAttributionGrain [Version(0)]
-  # Orleans.Transactions.TestKit.ICreateOrJoinAttributionGrain.GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers) -> Task<List<string?>?[]>
-  C9B8ECB8(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+  C9B8ECB8: GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.IExclusiveLockCoordinatorGrain")] Orleans.Transactions.TestKit.IExclusiveLockCoordinatorGrain [Version(0)]
-  # Orleans.Transactions.TestKit.IExclusiveLockCoordinatorGrain.ReadThenWrite(ITransactionTestGrain grain, int value) -> Task
-  148E55F3(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
-  # Orleans.Transactions.TestKit.IExclusiveLockCoordinatorGrain.ReadThenWriteWithExclusiveLock(IExclusiveLockTransactionTestGrain grain, int value) -> Task
-  F880C5FF(Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain, int) -> Task
+  148E55F3: ReadThenWrite(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
+  F880C5FF: ReadThenWriteWithExclusiveLock(Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain, int) -> Task
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain")] Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain [Version(0)]
-  # Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain.Get() -> Task<int[]>
-  16E53FE3() -> Task<int[]>
-  # Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain.Add(int numberToAdd) -> Task<int[]>
-  81B05CD8(int) -> Task<int[]>
-  # Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain.Set(int newValue) -> Task
-  BD3AA4D0(int) -> Task
+  81B05CD8: Add(int) -> Task<int[]>
+  16E53FE3: Get() -> Task<int[]>
+  BD3AA4D0: Set(int) -> Task
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.IFaultInjectionTransactionCoordinatorGrain")] Orleans.Transactions.TestKit.IFaultInjectionTransactionCoordinatorGrain [Version(0)]
-  # Orleans.Transactions.TestKit.IFaultInjectionTransactionCoordinatorGrain.MultiGrainSet(List<IFaultInjectionTransactionTestGrain> grains, int numberToAdd) -> Task
-  70FF7C60(System.Collections.Generic.List<Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.IFaultInjectionTransactionCoordinatorGrain.MultiGrainAddAndFaultInjection(List<IFaultInjectionTransactionTestGrain> grains, int numberToAdd, FaultInjectionControl? faultInjection) -> Task
-  E67D54A5(System.Collections.Generic.List<Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain>, int, Orleans.Transactions.TestKit.FaultInjectionControl?) -> Task
+  E67D54A5: MultiGrainAddAndFaultInjection(System.Collections.Generic.List<Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain>, int, Orleans.Transactions.TestKit.FaultInjectionControl?) -> Task
+  70FF7C60: MultiGrainSet(System.Collections.Generic.List<Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain>, int) -> Task
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain")] Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain [Version(0)]
-  # Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain.Set(int newValue) -> Task
-  8389970A(int) -> Task
-  # Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain.Add(int numberToAdd, FaultInjectionControl? faultInjectionControl) -> Task
-  A4CAE05C(int, Orleans.Transactions.TestKit.FaultInjectionControl?) -> Task
-  # Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain.Deactivate() -> Task
-  A6C1652E() -> Task
-  # Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain.Get() -> Task<int>
-  C752DF7D() -> Task<int>
+  A4CAE05C: Add(int, Orleans.Transactions.TestKit.FaultInjectionControl?) -> Task
+  A6C1652E: Deactivate() -> Task
+  C752DF7D: Get() -> Task<int>
+  8389970A: Set(int) -> Task
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.IJoinAttributionGrain")] Orleans.Transactions.TestKit.IJoinAttributionGrain [Version(0)]
-  # Orleans.Transactions.TestKit.IJoinAttributionGrain.GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers) -> Task<List<string?>?[]>
-  B1619F67(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+  B1619F67: GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.INoAttributionGrain")] Orleans.Transactions.TestKit.INoAttributionGrain [Version(0)]
-  # Orleans.Transactions.TestKit.INoAttributionGrain.GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers) -> Task<List<string?>?[]>
-  BC7E3A79(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+  BC7E3A79: GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.INotAllowedAttributionGrain")] Orleans.Transactions.TestKit.INotAllowedAttributionGrain [Version(0)]
-  # Orleans.Transactions.TestKit.INotAllowedAttributionGrain.GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers) -> Task<List<string?>?[]>
-  891D027E(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+  891D027E: GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.ISupportedAttributionGrain")] Orleans.Transactions.TestKit.ISupportedAttributionGrain [Version(0)]
-  # Orleans.Transactions.TestKit.ISupportedAttributionGrain.GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers) -> Task<List<string?>?[]>
-  BC7DBC0A(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+  BC7DBC0A: GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.ISuppressAttributionGrain")] Orleans.Transactions.TestKit.ISuppressAttributionGrain [Version(0)]
-  # Orleans.Transactions.TestKit.ISuppressAttributionGrain.GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers) -> Task<List<string?>?[]>
-  5A02311D(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+  5A02311D: GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.ITransactionCommitterTestGrain")] Orleans.Transactions.TestKit.ITransactionCommitterTestGrain [Version(0)]
-  # Orleans.Transactions.TestKit.ITransactionCommitterTestGrain.Commit(ITransactionCommitOperation<IRemoteCommitService> operation) -> Task
-  C44BE2A4(Orleans.Transactions.Abstractions.ITransactionCommitOperation<Orleans.Transactions.TestKit.IRemoteCommitService>) -> Task
+  C44BE2A4: Commit(Orleans.Transactions.Abstractions.ITransactionCommitOperation<Orleans.Transactions.TestKit.IRemoteCommitService>) -> Task
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.ITransactionCoordinatorGrain")] Orleans.Transactions.TestKit.ITransactionCoordinatorGrain [Version(0)]
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainAddAndThrow(List<ITransactionTestGrain> grain, List<ITransactionTestGrain> grains, int numberToAdd) -> Task
-  2760260D(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainAdd(List<ITransactionTestGrain> grains, int numberToAdd) -> Task
-  3A6B9237(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.UpdateViolated(ITransactionTestGrain grains, int numberToAdd) -> Task
-  485592B2(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainDouble(List<ITransactionTestGrain> grains) -> Task
-  5FC2E7A1(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainSetBit(List<ITransactionalBitArrayGrain> grains, int bitIndex) -> Task
-  5FF4F216(System.Collections.Generic.List<Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainSet(List<ITransactionTestGrain> grains, int numberToAdd) -> Task
-  78D54907(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainAdd(ITransactionCommitterTestGrain committer, ITransactionCommitOperation<IRemoteCommitService> operation, List<ITransactionTestGrain> grains, int numberToAdd) -> Task
-  8EE5E563(Orleans.Transactions.TestKit.ITransactionCommitterTestGrain, Orleans.Transactions.Abstractions.ITransactionCommitOperation<Orleans.Transactions.TestKit.IRemoteCommitService>, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainDoubleByRWRW(List<ITransactionTestGrain> grains, int numberToAdd) -> Task
-  9EFEA7F3(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.MultiGrainDoubleByWRWR(List<ITransactionTestGrain> grains, int numberToAdd) -> Task
-  B4376B4D(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.AddAndThrow(ITransactionTestGrain grain, int numberToAdd) -> Task
-  D3EF444F(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionCoordinatorGrain.OrphanCallTransaction() -> Task
-  EDCC120B() -> Task
+  D3EF444F: AddAndThrow(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
+  8EE5E563: MultiGrainAdd(Orleans.Transactions.TestKit.ITransactionCommitterTestGrain, Orleans.Transactions.Abstractions.ITransactionCommitOperation<Orleans.Transactions.TestKit.IRemoteCommitService>, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  3A6B9237: MultiGrainAdd(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  2760260D: MultiGrainAddAndThrow(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  5FC2E7A1: MultiGrainDouble(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>) -> Task
+  9EFEA7F3: MultiGrainDoubleByRWRW(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  B4376B4D: MultiGrainDoubleByWRWR(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  78D54907: MultiGrainSet(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  5FF4F216: MultiGrainSetBit(System.Collections.Generic.List<Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain>, int) -> Task
+  EDCC120B: OrphanCallTransaction() -> Task
+  485592B2: UpdateViolated(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
 
 interface [GrainInterfaceType("Orleans.Transactions.TestKit.ITransactionTestGrain")] Orleans.Transactions.TestKit.ITransactionTestGrain [Version(0)]
-  # Orleans.Transactions.TestKit.ITransactionTestGrain.AddAndThrow(int numberToAdd) -> Task
-  25B066B5(int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionTestGrain.SetAndThrow(int numberToSet) -> Task
-  35C87F81(int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionTestGrain.Deactivate() -> Task
-  35D6FD32() -> Task
-  # Orleans.Transactions.TestKit.ITransactionTestGrain.Get() -> Task<int[]>
-  8DAA79AA() -> Task<int[]>
-  # Orleans.Transactions.TestKit.ITransactionTestGrain.Set(int newValue) -> Task
-  CE9EC80B(int) -> Task
-  # Orleans.Transactions.TestKit.ITransactionTestGrain.Add(int numberToAdd) -> Task<int[]>
-  DC07DAEA(int) -> Task<int[]>
+  DC07DAEA: Add(int) -> Task<int[]>
+  25B066B5: AddAndThrow(int) -> Task
+  35D6FD32: Deactivate() -> Task
+  8DAA79AA: Get() -> Task<int[]>
+  CE9EC80B: Set(int) -> Task
+  35C87F81: SetAndThrow(int) -> Task
 
 class [GrainType("joinattribution")] Orleans.Transactions.TestKit.JoinAttributionGrain
 

--- a/src/Orleans.Transactions/OrleansContracts.txt
+++ b/src/Orleans.Transactions/OrleansContracts.txt
@@ -4,26 +4,20 @@
 # dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024
 # Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION
 # The regeneration command edits this manifest only; it does not change source attributes.
-# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.
+# OrleansContracts format: 2
+# Method lines use: wire-identity: CLR-signature.
+# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.
 # Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.
 # Details: https://aka.ms/orleans/OrleansContracts.txt
 
 interface [GrainInterfaceType("Orleans.Transactions.Abstractions.ITransactionManagerExtension")] Orleans.Transactions.Abstractions.ITransactionManagerExtension [Version(0)]
-  # Orleans.Transactions.Abstractions.ITransactionManagerExtension.Prepared(string resourceId, Guid transactionId, DateTime timestamp, ParticipantId resource, TransactionalStatus status) -> Task
-  12BEFA17(string, System.Guid, System.DateTime, Orleans.Transactions.ParticipantId, Orleans.Transactions.TransactionalStatus) -> Task
-  # Orleans.Transactions.Abstractions.ITransactionManagerExtension.Ping(string resourceId, Guid transactionId, DateTime timeStamp, ParticipantId resource) -> Task
-  AC4A9AEB(string, System.Guid, System.DateTime, Orleans.Transactions.ParticipantId) -> Task
-  # Orleans.Transactions.Abstractions.ITransactionManagerExtension.PrepareAndCommit(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp, List<ParticipantId> writeResources, int totalParticipants) -> Task<TransactionalStatus>
-  B024EFA6(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime, System.Collections.Generic.List<Orleans.Transactions.ParticipantId>, int) -> Task<Orleans.Transactions.TransactionalStatus>
+  AC4A9AEB: Ping(string, System.Guid, System.DateTime, Orleans.Transactions.ParticipantId) -> Task
+  B024EFA6: PrepareAndCommit(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime, System.Collections.Generic.List<Orleans.Transactions.ParticipantId>, int) -> Task<Orleans.Transactions.TransactionalStatus>
+  12BEFA17: Prepared(string, System.Guid, System.DateTime, Orleans.Transactions.ParticipantId, Orleans.Transactions.TransactionalStatus) -> Task
 
 interface [GrainInterfaceType("Orleans.Transactions.Abstractions.ITransactionalResourceExtension")] Orleans.Transactions.Abstractions.ITransactionalResourceExtension [Version(0)]
-  # Orleans.Transactions.Abstractions.ITransactionalResourceExtension.CommitReadOnly(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp) -> Task<TransactionalStatus>
-  1BB071FE(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime) -> Task<Orleans.Transactions.TransactionalStatus>
-  # Orleans.Transactions.Abstractions.ITransactionalResourceExtension.Prepare(string resourceId, Guid transactionId, AccessCounter accessCount, DateTime timeStamp, ParticipantId transactionManager) -> Task
-  2ADCC608(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime, Orleans.Transactions.ParticipantId) -> Task
-  # Orleans.Transactions.Abstractions.ITransactionalResourceExtension.Confirm(string resourceId, Guid transactionId, DateTime timeStamp) -> Task
-  5DDDE6F0(string, System.Guid, System.DateTime) -> Task
-  # Orleans.Transactions.Abstractions.ITransactionalResourceExtension.Cancel(string resourceId, Guid transactionId, DateTime timeStamp, TransactionalStatus status) -> Task
-  80028AB9(string, System.Guid, System.DateTime, Orleans.Transactions.TransactionalStatus) -> Task
-  # Orleans.Transactions.Abstractions.ITransactionalResourceExtension.Abort(string resourceId, Guid transactionId) -> Task
-  BD051D23(string, System.Guid) -> Task
+  BD051D23: Abort(string, System.Guid) -> Task
+  80028AB9: Cancel(string, System.Guid, System.DateTime, Orleans.Transactions.TransactionalStatus) -> Task
+  1BB071FE: CommitReadOnly(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime) -> Task<Orleans.Transactions.TransactionalStatus>
+  5DDDE6F0: Confirm(string, System.Guid, System.DateTime) -> Task
+  2ADCC608: Prepare(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime, Orleans.Transactions.ParticipantId) -> Task

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -33,7 +33,9 @@ public class GrainInterfaceVersionAnalyzerTest
         "# dotnet format PATH_TO_PROJECT_OR_SOLUTION analyzers --severity info --diagnostics ORLEANS0016 ORLEANS0017 ORLEANS0018 ORLEANS0019 ORLEANS0020 ORLEANS0022 ORLEANS0023 ORLEANS0024\n" +
         "# Verify with: dotnet build PATH_TO_PROJECT_OR_SOLUTION\n" +
         "# The regeneration command edits this manifest only; it does not change source attributes.\n" +
-        "# Methods without [Id] or [Alias] use the Orleans code generator's existing wire ID hash.\n" +
+        "# OrleansContracts format: 2\n" +
+        "# Method lines use: wire-identity: CLR-signature.\n" +
+        "# The identity is the identifier Orleans uses at runtime, whether generated or declared in source.\n" +
         "# Review every diff: identity or signature changes can break wire compatibility during rolling upgrades.\n" +
         "# Details: https://aka.ms/orleans/OrleansContracts.txt\n\n";
 
@@ -179,6 +181,7 @@ public class GrainInterfaceVersionAnalyzerTest
     public async Task AnalyzerDisabled_NoDiagnostic()
     {
         const string source = @"
+[Version(1)]
 public interface IMyGrain : IGrain
 {
     Task DoSomething();
@@ -224,7 +227,7 @@ public interface IMyGrain : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task
+41F3F487: DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -288,7 +291,7 @@ public interface IMyGrain : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task
+41F3F487: DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -312,7 +315,7 @@ public interface IMyGrain : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task
+41F3F487: DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -356,14 +359,14 @@ public interface IMyGrain : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task
+41F3F487: DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
         Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
         var diagnostic = diagnostics.First(d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
         Assert.Contains("NewMethod", diagnostic.GetMessage());
-        Assert.Contains("8E43BF4F() -> Task", diagnostic.GetMessage());
+        Assert.Contains("8E43BF4F", diagnostic.GetMessage());
     }
 
     [Fact]
@@ -379,11 +382,159 @@ public interface IMyGrain : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task
+41F3F487: DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
         Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task CanonicalGeneratedIdentity_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task NewMethod();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  8E43BF4F: NewMethod() -> Task
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CanonicalIdIdentity_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    [Id(42)]
+    Task Ping();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  42: Ping() -> Task
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CanonicalAliasIdentity_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    [Alias(""stable-ping"")]
+    Task Ping();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  stable-ping: Ping() -> Task
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CanonicalAliasIdentity_WithEscapedDelimiter_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    [Alias("" # CLR: stable:ping\\v2\u0085next "")]
+    Task Ping();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  \s\#\sCLR\:\sstable\:ping\\v2\u0085next\s: Ping() -> Task
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CanonicalMemberKeys_SeparateIdentityFromGenericArity()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    [Alias(""a"")]
+    Task First<T>();
+
+    [Alias(""a`1"")]
+    Task Second();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  a: First`1() -> Task
+  a`1: Second() -> Task
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task EquivalentGeneratedAndAliasIdentity_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    [Alias(""8E43BF4F"")]
+    Task NewMethod();
+}
+";
+        const string contractsFile =
+            "interface IMyGrain [Version(1)]\n  8E43BF4F: NewMethod() -> Task\n";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Theory]
+    [InlineData("[Id(46529181)]")]
+    [InlineData("")]
+    public async Task EquivalentGeneratedAndIdIdentity_NoDiagnostic(string sourceAttribute)
+    {
+        var source = $@"
+[Version(1)]
+public interface IMyGrain : IGrain
+{{
+    {sourceAttribute}
+    Task Method26();
+}}
+";
+        const string contractsFile =
+            "interface IMyGrain [Version(1)]\n  46529181: Method26() -> Task\n";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
     }
 
     [Fact]
@@ -399,7 +550,7 @@ public interface IMyGrain : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething(string name, int count) -> Task
+2DB8A137: DoSomething(string, int) -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -407,18 +558,19 @@ IMyGrain.DoSomething(string name, int count) -> Task
     }
 
     [Fact]
-    public async Task LegacyMemberParameterRename_NoDiagnostic()
+    public async Task AliasedMemberParameterRename_NoDiagnostic()
     {
         const string source = @"
 [Version(1)]
 public interface IMyGrain : IGrain
 {
+    [Alias(""stable-method"")]
     Task DoSomething(string renamed, int newCount);
 }
 ";
         const string contractsFile = @"
 IMyGrain [Version(1)]
-IMyGrain.DoSomething(string original, int oldCount) -> Task
+stable-method: DoSomething(string, int) -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -433,13 +585,14 @@ IMyGrain.DoSomething(string original, int oldCount) -> Task
 [Version(1)]
 public interface IMyGrain : IGrain
 {
+    [Alias(""tuple-method"")]
     Task DoSomething((int X, int Y) value);
 }
 ";
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething((int X, int Y) value) -> Task
+tuple-method: DoSomething((int, int)) -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -458,13 +611,14 @@ namespace NamespaceA
 [Version(1)]
 public interface IMyGrain : IGrain
 {
+    [Alias(""stable-method"")]
     Task DoSomething(NamespaceA.Request request);
 }
 ";
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething(NamespaceB.Request request) -> Task
+stable-method: DoSomething(NamespaceB.Request) -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -502,7 +656,7 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  ReadStateAsync`1(T) -> Task<T>
+  0105B5F1: ReadStateAsync`1(T) -> Task<T>
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -517,12 +671,13 @@ interface IMyGrain [Version(1)]
 [Version(1)]
 public interface IMyGrain : IGrain
 {
+    [Alias(""read-state"")]
     Task<T1> ReadStateAsync<T1, T2>(T1 first, T2 second);
 }
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  ReadStateAsync`1(T) -> Task<T>
+  read-state: ReadStateAsync`1(T) -> Task<T>
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -542,8 +697,8 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  ExistingAsync() -> Task
-  RemovedAsync() -> Task
+  629F4AD1: ExistingAsync() -> Task
+  C1BEB0D0: RemovedAsync() -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -556,7 +711,7 @@ interface IMyGrain [Version(1)]
     }
 
     [Fact]
-    public async Task LegacyAliasedMemberRename_NoDiagnostic()
+    public async Task AliasedMemberRename_NoDiagnostic()
     {
         const string source = @"
 [Version(1)]
@@ -568,7 +723,7 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  [Alias(""stable-method"")] IMyGrain.OldName(string original) -> Task
+  stable-method: OldName(string) -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -578,7 +733,7 @@ interface IMyGrain [Version(1)]
     }
 
     [Fact]
-    public async Task UnmarkedSameNameAlias_ReportsManifestUpgrade()
+    public async Task AliasIdentityMismatch_ReportsAddedAndRemovedSignatures()
     {
         const string source = @"
 [Version(1)]
@@ -590,13 +745,13 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  Method() -> Task
+  old-method: Method() -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
 
         Assert.Contains(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
-        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0027);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0027);
     }
 
     [Fact]
@@ -612,7 +767,7 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  [Alias(""old-method"")] IMyGrain.Method() -> Task
+  old-method: Method() -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -622,7 +777,7 @@ interface IMyGrain [Version(1)]
     }
 
     [Fact]
-    public async Task ExplicitId_DoesNotMatchLegacyMethodName()
+    public async Task ExplicitId_DoesNotMatchDifferentWireIdentity()
     {
         const string source = @"
 [Version(1)]
@@ -634,7 +789,7 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  Ping() -> Task
+  Ping: Ping() -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -655,7 +810,7 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  [Alias(""old-method"")] IMyGrain.Method() -> Task
+  old-method: Method() -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -677,7 +832,7 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  [Alias(""stable-method"")] IMyGrain.Method() -> Task
+  stable-method: Method() -> Task
 ";
 
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
@@ -818,7 +973,7 @@ public interface IMyObserver : IGrainObserver
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyObserver [Version(0)]
-IMyObserver.OnEvent(string value) -> void
+3DCBC519: OnEvent(string) -> void
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -866,7 +1021,7 @@ namespace MyApp.Grains
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 MyApp.Grains.IMyGrain [Version(1)]
-MyApp.Grains.IMyGrain.DoSomething() -> Task
+4057D20A: DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -894,7 +1049,7 @@ public interface IMyGrain : IGrain
 # Another comment
 IMyGrain [Version(1)]
 # Comment between entries
-IMyGrain.DoSomething() -> Task
+41F3F487: DoSomething() -> Task
 # Final comment
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
@@ -1139,10 +1294,9 @@ public interface INewGrain : IGrain
         Assert.Empty(diagnostics);
         Assert.Contains("# IOldGrain\ninterface [GrainInterfaceType(\"stable-interface\")] IOldGrain [Version(0)]", contractsFile);
         Assert.Contains(
-            "  [Alias(\"stable-method\")] stable-method(request) -> Task<response>",
+            "  stable-method: OldMethod(request) -> Task<response>",
             contractsFile);
         Assert.Contains("# IOldGrain", contractsFile);
-        Assert.Contains("# IOldGrain.OldMethod", contractsFile);
     }
 
     [Fact]
@@ -1207,7 +1361,8 @@ public interface IMyGrain : IGrain
             GrainInterfaceVersionAnalyzer.RuleId0018,
             GrainInterfaceVersionAnalyzer.RuleId0027);
         Assert.Contains(diagnostics, diagnostic => diagnostic.GetMessage().Contains("NewName", StringComparison.Ordinal));
-        Assert.Contains("# IMyGrain.OldName() -> Task", contractsFile);
+        Assert.Contains(": OldName() -> Task", contractsFile);
+        Assert.Contains("OldName() -> Task", contractsFile);
     }
 
     [Fact]
@@ -1507,9 +1662,33 @@ public interface IMyGrain : IGrain
         string clrSignature,
         string contractSignatureSuffix)
     {
+        var parameterListStart = clrSignature.IndexOf('(');
+        var methodStart = clrSignature.LastIndexOf('.', parameterListStart - 1) + 1;
+        var methodName = clrSignature.Substring(methodStart, parameterListStart - methodStart);
+        var genericStart = methodName.IndexOf('<');
+        if (genericStart >= 0)
+        {
+            var genericEnd = methodName.LastIndexOf('>');
+            var arity = 1;
+            for (var index = genericStart + 1; index < genericEnd; index++)
+            {
+                if (methodName[index] == ',')
+                {
+                    arity++;
+                }
+            }
+
+            methodName = $"{methodName.Substring(0, genericStart)}`{arity}";
+            var suffixArityEnd = contractSignatureSuffix.IndexOf('(');
+            if (contractSignatureSuffix.StartsWith("`", StringComparison.Ordinal)
+                && suffixArityEnd >= 0)
+            {
+                contractSignatureSuffix = contractSignatureSuffix.Substring(suffixArityEnd);
+            }
+        }
+
         var pattern =
-            $"(?m)^  # {Regex.Escape(clrSignature)}\\r?$\\n" +
-            $"  [0-9A-F]{{8}}{Regex.Escape(contractSignatureSuffix)}\\r?$";
+            $"(?m)^  [0-9A-F]{{8}}: {Regex.Escape(methodName + contractSignatureSuffix)}\\r?$";
         Assert.Matches(pattern, content);
     }
 
@@ -1643,7 +1822,7 @@ public class CartGrain : Grain, IGrainWithStringKey
         var content = (await changedSolution.GetAdditionalDocument(additionalDocumentId!)!
             .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
         Assert.Contains("interface [GrainInterfaceType(\"cart\")] ICartGrain [Version(2)]", content);
-        Assert.Contains("  [Alias(\"read\")] read(int) -> Task<string>", content);
+        Assert.Contains("  read: GetAsync(int) -> Task<string>", content);
         Assert.Contains("class [GrainType(\"cart\")] CartGrain", content);
     }
 
@@ -1698,6 +1877,96 @@ public class CartGrain : Grain, IGrainWithStringKey
             (await document.GetTextAsync(TestContext.Current.CancellationToken)).ToString(),
             "IMyGrain.Pong() -> Task",
             "() -> Task");
+    }
+
+    [Fact]
+    public async Task CodeFix_RegenerateProject_MigratesHashFirstManifest()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task NewMethod();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(0)]
+  # IMyGrain.NewMethod() -> Task
+  8E43BF4F() -> Task
+";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0017,
+            RegenerateCodeActionTitle);
+        var content = (await changedSolution.GetAdditionalDocument(additionalDocumentId!)!
+            .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
+
+        Assert.Contains("  8E43BF4F: NewMethod() -> Task", content);
+        Assert.DoesNotContain("# IMyGrain.NewMethod", content);
+        Assert.Empty(await GetDiagnosticsAsync(source, content));
+    }
+
+    [Fact]
+    public async Task CodeFix_RegenerateProject_MigratesNameBasedManifest()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task NewMethod();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(0)]
+  IMyGrain.NewMethod() -> Task
+";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0017,
+            RegenerateCodeActionTitle);
+        var content = (await changedSolution.GetAdditionalDocument(additionalDocumentId!)!
+            .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
+
+        Assert.Contains("  8E43BF4F: NewMethod() -> Task", content);
+        Assert.DoesNotContain("IMyGrain.NewMethod", content);
+        Assert.Empty(await GetDiagnosticsAsync(source, content));
+    }
+
+    [Fact]
+    public async Task CodeFix_RegenerateProject_EmitsSourceIdentityMetadataWithoutEditingSource()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+    [Id(42)]
+    Task Ping();
+
+    [Alias(""stable-pong"")]
+    Task Pong();
+}
+";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(
+            source,
+            grainInterfacesFileContent: null,
+            GrainInterfaceVersionAnalyzer.RuleId0020,
+            RegenerateCodeActionTitle);
+
+        var content = (await changedSolution.GetAdditionalDocument(additionalDocumentId!)!
+            .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
+        Assert.Contains("  42: Ping() -> Task", content);
+        Assert.Contains("  stable-pong: Pong() -> Task", content);
+
+        var sourceText = (await changedSolution.Projects.Single().Documents
+            .Single(document => document.Name == "Test.cs")
+            .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
+        Assert.Contains("[Id(42)]", sourceText);
+        Assert.Contains("[Alias(\"stable-pong\")]", sourceText);
+        Assert.DoesNotContain("stable-pong: Pong", sourceText);
     }
 
     [Fact]
@@ -2001,8 +2270,8 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  ExistingAsync() -> Task
-  RemovedAsync() -> Task
+  629F4AD1: ExistingAsync() -> Task
+  C1BEB0D0: RemovedAsync() -> Task
 ";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(
@@ -2015,7 +2284,7 @@ interface IMyGrain [Version(1)]
             .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
         AssertContainsGeneratedMethod(content, "IMyGrain.ExistingAsync() -> Task", "() -> Task");
         AssertContainsGeneratedMethod(content, "IMyGrain.NewAsync() -> Task", "() -> Task");
-        Assert.Contains("  RemovedAsync() -> Task", content);
+        Assert.Contains("  C1BEB0D0: RemovedAsync() -> Task", content);
 
         var diagnostics = await GetDiagnosticsAsync(source, content);
         Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
@@ -2023,7 +2292,7 @@ interface IMyGrain [Version(1)]
     }
 
     [Fact]
-    public async Task CodeFix_RegenerateProject_PreservesAliasesAndDeduplicatesLegacyMembers()
+    public async Task CodeFix_RegenerateProject_PreservesAliasesAndDeduplicatesMembers()
     {
         const string source = @"
 [Version(1)]
@@ -2035,9 +2304,9 @@ public interface IMyGrain : IGrain
 ";
         const string contractsFile = @"
 interface IMyGrain [Version(1)]
-  ExistingAsync() -> Task
-  [Alias(""removed"")] IMyGrain.RemovedAsync(string value) -> Task
-  removed(string) -> Task
+  629F4AD1: ExistingAsync() -> Task
+  removed: RemovedAsync(string) -> Task
+  removed: RemovedAsync(string) -> Task
 ";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(
@@ -2048,15 +2317,15 @@ interface IMyGrain [Version(1)]
 
         var content = (await changedSolution.GetAdditionalDocument(additionalDocumentId!)!
             .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
-        Assert.Equal(1, content.Split(new[] { "removed(string) -> Task" }, StringSplitOptions.None).Length - 1);
-        Assert.Contains("[Alias(\"removed\")] removed(string) -> Task", content);
+        Assert.Equal(1, content.Split(new[] { "removed:" }, StringSplitOptions.None).Length - 1);
+        Assert.Contains("removed: RemovedAsync(string) -> Task", content);
 
         var diagnostics = await GetDiagnosticsAsync(source, content);
         Assert.Single(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0027);
     }
 
     [Fact]
-    public async Task CodeFix_RegenerateProject_DeduplicatesSemanticallyEquivalentLegacyMembers()
+    public async Task CodeFix_RegenerateProject_DropsUnrecognizedPreReleaseMemberSyntax()
     {
         const string source = @"
 namespace Models
@@ -2095,7 +2364,7 @@ interface IMyGrain [Version(1)]
     }
 
     [Fact]
-    public async Task CodeFix_RegenerateProject_PreservesRemovedMembersOnNestedLegacyInterfaces()
+    public async Task CodeFix_RegenerateProject_PreservesRemovedMembersOnNestedInterfaces()
     {
         const string source = @"
 public class Outer
@@ -2110,8 +2379,8 @@ public class Outer
 ";
         const string contractsFile = @"
 interface Outer.IInnerGrain [Version(1)]
-  ExistingAsync() -> Task
-  RemovedAsync() -> Task
+  D4692090: ExistingAsync() -> Task
+  5F9C2FBA: RemovedAsync() -> Task
 ";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(
@@ -2122,7 +2391,7 @@ interface Outer.IInnerGrain [Version(1)]
 
         var content = (await changedSolution.GetAdditionalDocument(additionalDocumentId!)!
             .GetTextAsync(TestContext.Current.CancellationToken)).ToString();
-        Assert.Contains("  RemovedAsync() -> Task", content);
+        Assert.Contains("  5F9C2FBA: RemovedAsync() -> Task", content);
         Assert.Contains(
             await GetDiagnosticsAsync(source, content),
             diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0027);
@@ -2184,7 +2453,7 @@ interface Outer.IInnerGrain [Version(1)]
                 GrainInterfaceVersionAnalyzer.RuleId0016,
                 "Contract missing",
                 "Contract missing",
-                "Orleans.Versioning",
+                "Versioning",
                 DiagnosticSeverity.Warning,
                 isEnabledByDefault: true),
             Location.None);
@@ -2486,9 +2755,9 @@ public interface IMiddle : IGrain
 ";
         const string grainInterfacesFile = "# OrleansContracts.txt\n" +
             "IZulu [Version(1)]\n" +
-            "IZulu.Method() -> Task\n\n" +
+            "zulu: Method() -> Task\n\n" +
             "interface IAlpha [Version(1)]\n" +
-            "IAlpha.Method() -> Task";
+            "alpha: Method() -> Task";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0016);
 
@@ -2506,8 +2775,43 @@ public interface IMiddle : IGrain
         Assert.True(middleInterface < zuluInterface);
         AssertContainsGeneratedMethod(content, "IMiddle.Alpha() -> Task", "() -> Task");
         AssertContainsGeneratedMethod(content, "IMiddle.Zeta() -> Task", "() -> Task");
-        Assert.Contains("interface IAlpha [Version(1)]\n  Method() -> Task", content);
-        Assert.Contains("interface IZulu [Version(1)]\n  Method() -> Task", content);
+        Assert.Contains("interface IAlpha [Version(1)]\n  alpha: Method() -> Task", content);
+        Assert.Contains("interface IZulu [Version(1)]\n  zulu: Method() -> Task", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_SortsDuplicateClrSignaturesByWireIdentity()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+    Task NewAsync();
+}
+";
+        const string alphaFirst = @"
+interface IMyGrain [Version(0)]
+  alpha: RemovedAsync() -> Task
+  zeta: RemovedAsync() -> Task
+";
+        const string zetaFirst = @"
+interface IMyGrain [Version(0)]
+  zeta: RemovedAsync() -> Task
+  alpha: RemovedAsync() -> Task
+";
+
+        var first = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            alphaFirst,
+            GrainInterfaceVersionAnalyzer.RuleId0018);
+        var second = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            zetaFirst,
+            GrainInterfaceVersionAnalyzer.RuleId0018);
+
+        Assert.Equal(first, second);
+        Assert.True(
+            first.IndexOf("alpha: RemovedAsync()", StringComparison.Ordinal)
+                < first.IndexOf("zeta: RemovedAsync()", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -2636,7 +2940,7 @@ public interface IMyGrain : IGrain
 ";
         const string grainInterfacesFile = @"# OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task";
+41F3F487: DoSomething() -> Task";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0017);
 
@@ -2670,10 +2974,10 @@ public interface IFooBar : IGrain
 ";
         const string grainInterfacesFile = @"# OrleansContracts.txt
 IFooBar [Version(1)]
-IFooBar.DoSomething() -> Task
+E0A3D19A: DoSomething() -> Task
 
 IFoo [Version(1)]
-IFoo.DoSomething() -> Task";
+4BC6AD4C: DoSomething() -> Task";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0017);
 
@@ -2698,7 +3002,7 @@ public interface IMyGrain : IGrain
     Task DoSomething();
 }
 ";
-        const string grainInterfacesFile = "# OrleansContracts.txt\nIMyGrain [Version(1)]\nIMyGrain.DoSomething() -> Task\n";
+        const string grainInterfacesFile = "# OrleansContracts.txt\nIMyGrain [Version(1)]\n41F3F487: DoSomething() -> Task\n";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0017);
 
@@ -2710,7 +3014,7 @@ public interface IMyGrain : IGrain
         var content = changedText.ToString();
 
         Assert.DoesNotContain("\r", content);
-        Assert.Equal(GeneratedHeader + "interface IMyGrain [Version(2)]\n  DoSomething() -> Task\n", content);
+        Assert.Equal(GeneratedHeader + "interface IMyGrain [Version(2)]\n  41F3F487: DoSomething() -> Task\n", content);
     }
 
     #endregion
@@ -2730,7 +3034,7 @@ public interface IMyGrain : IGrain
 ";
         const string grainInterfacesFile = @"# OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task";
+41F3F487: DoSomething() -> Task";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0018);
 
@@ -2763,7 +3067,7 @@ public interface IMyGrain : IGrain
 ";
         const string grainInterfacesFile = @"# OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task";
+41F3F487: DoSomething() -> Task";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0018);
 
@@ -2774,8 +3078,7 @@ IMyGrain.DoSomething() -> Task";
         var changedText = await changedDocument!.GetTextAsync(TestContext.Current.CancellationToken);
         var content = changedText.ToString();
 
-        Assert.Contains("\n  [Alias(\"new-method\")] new-method(int) -> Task", content);
-        Assert.Contains("  # IMyGrain.NewMethod(int value) -> Task", content);
+        Assert.Contains("\n  new-method: NewMethod(int) -> Task", content);
     }
 
     [Fact]
@@ -2797,7 +3100,7 @@ public interface IMyGrain : IGrain
             GrainInterfaceVersionAnalyzer.RuleId0018);
 
         Assert.Equal(
-            GeneratedHeader + "interface IMyGrain [Version(1)]\n  [Alias(\"NewMethod\")] NewMethod() -> Task\n",
+            GeneratedHeader + "interface IMyGrain [Version(1)]\n  NewMethod: NewMethod() -> Task\n",
             content);
     }
 
@@ -2844,7 +3147,7 @@ public interface IFooBar : IGrain
         const string grainInterfacesFile = @"# OrleansContracts.txt
 IFoo [Version(1)]
 IFooBar [Version(1)]
-IFooBar.ExistingMethod() -> Task";
+037556D9: ExistingMethod() -> Task";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0018);
 
@@ -2901,7 +3204,7 @@ public interface IMyGrain<T> : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain<T> [Version(1)]
-IMyGrain<T>.DoSomething(T value) -> Task
+7DDCD155: DoSomething(T) -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -2923,7 +3226,7 @@ public interface IMyGrain<T> : IGrain where T : class
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain<T> [Version(1)]
-IMyGrain<T>.DoSomething(T value) -> Task
+7DDCD155: DoSomething(T) -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -2943,7 +3246,7 @@ public interface IMyGrain<TKey, TValue> : IGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain<TKey, TValue> [Version(1)]
-IMyGrain<TKey, TValue>.DoSomething(TKey key, TValue value) -> Task
+96A32DB8: DoSomething(TKey, TValue) -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -3051,10 +3354,10 @@ public interface IDerivedGrain : IBaseGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IBaseGrain [Version(1)]
-IBaseGrain.DoBase() -> Task
+E1000F29: DoBase() -> Task
 
 IDerivedGrain [Version(1)]
-IDerivedGrain.DoDerived() -> Task
+BDD4EFFA: DoDerived() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -3083,7 +3386,7 @@ public interface IDerivedGrain : IBaseGrain
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IBaseGrain [Version(1)]
-IBaseGrain.DoBase() -> Task
+E1000F29: DoBase() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -3106,7 +3409,7 @@ public interface IMyGrain : IGrainWithStringKey
         const string grainInterfacesFile = @"
 # OrleansContracts.txt
 IMyGrain [Version(1)]
-IMyGrain.DoSomething() -> Task
+41F3F487: DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -3168,11 +3471,11 @@ public interface IMyGrain : IGrain
     Task DoSomething();
 }
 ";
-        const string contractsFile = "# OrleansContracts.txt\r\nIMyGrain [Version(1)]\r\nIMyGrain.DoSomething() -> Task\r\n";
+        const string contractsFile = "# OrleansContracts.txt\r\nIMyGrain [Version(1)]\r\n41F3F487: DoSomething() -> Task\r\n";
         var expectedContractsFile =
             GeneratedHeader.Replace("\n", "\r\n", StringComparison.Ordinal) +
             "interface IMyGrain [Version(2)]\r\n" +
-            "  DoSomething() -> Task\r\n";
+            "  41F3F487: DoSomething() -> Task\r\n";
         var properties = ImmutableDictionary<string, string?>.Empty
             .Add("InterfaceName", "IMyGrain")
             .Add("ActualVersion", "2");

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -428,6 +429,36 @@ interface IMyGrain [Version(1)]
         var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
 
         Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task CanonicalIdIdentity_UsesInvariantFormatting()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    [Id(42)]
+    Task Ping();
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  42: Ping() -> Task
+";
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ar-SA");
+
+            var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+            Assert.Empty(diagnostics);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #10869.

The hash-first method layout obscured the CLR method being reviewed and represented generated, `[Id]`, and `[Alias]` identities differently. This change makes every method entry identity-first and uniform:

```text
remove: RemoveAsync(string) -> Task
```

The analyzer now compares the effective runtime identity string regardless of whether source provides it through `[Id]`, `[Alias]`, or the generated method hash. Regeneration keeps CLR signatures inline, escapes syntax-sensitive identity characters, updates manifests only, and produces deterministic ordering which makes wire-breaking identity changes prominent in diffs.

The analyzer category is shortened from `Orleans.Versioning` to the conventional `Versioning`, yielding the standard `category-Versioning` editorconfig syntax.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10910)