### PR TITLE
fix(reminders): observe completed retries before timeout

### DIFF
--- a/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableRetryPolicy.cs
@@ -147,14 +147,23 @@ internal static class ReminderTableRetryPolicy
             try
             {
                 var attempt = operation();
-                remaining = timeout - stopwatch.Elapsed;
-                if (remaining <= TimeSpan.Zero)
+                T value;
+                if (attempt.IsCompleted)
                 {
-                    lastException = new TimeoutException("The retry timeout elapsed while starting the operation.");
-                    ThrowTimeout();
+                    value = await attempt;
+                }
+                else
+                {
+                    remaining = timeout - stopwatch.Elapsed;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        lastException = new TimeoutException("The retry timeout elapsed while starting the operation.");
+                        ThrowTimeout();
+                    }
+
+                    value = await attempt.WaitAsync(remaining, cancellationToken);
                 }
 
-                var value = await attempt.WaitAsync(remaining, cancellationToken);
                 lastException = null;
                 lastObservation = describe(value);
                 if (succeeded(value))

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTableRetryPolicyTests.cs
@@ -153,7 +153,34 @@ public class ReminderTableRetryPolicyTests
     }
 
     [Fact]
-    public async Task UniformPolicy_EnforcesDeadlineAfterStartingFirstAttempt()
+    public async Task UniformPolicy_ObservesCompletedFirstAttemptAfterDeadline()
+    {
+        var invocations = 0;
+
+        var result = await ReminderTableRetryPolicy.ExecuteUntilAsync(
+            () =>
+            {
+                invocations++;
+                Thread.Sleep(TimeSpan.FromMilliseconds(20));
+                return Task.FromResult("late-success");
+            },
+            _ => true,
+            "DelayedStart",
+            "ReadGuarantee",
+            "ReadRow",
+            "a completed result",
+            value => value,
+            "read convergence",
+            TimeSpan.FromMilliseconds(1),
+            TimeSpan.FromMilliseconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("late-success", result);
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public async Task UniformPolicy_ObservesCompletedFaultAfterDeadline()
     {
         var invocations = 0;
 
@@ -163,15 +190,15 @@ public class ReminderTableRetryPolicyTests
                 {
                     invocations++;
                     Thread.Sleep(TimeSpan.FromMilliseconds(20));
-                    return Task.FromResult("late-success");
+                    return Task.FromException<string>(new InvalidOperationException("late-contention"));
                 },
                 _ => true,
                 "DelayedStart",
-                "ReadGuarantee",
-                "ReadRow",
-                "a result within the deadline",
+                "MutationGuarantee",
+                "UpsertRow",
+                "a completed mutation",
                 value => value,
-                "read convergence",
+                "mutation retry",
                 TimeSpan.FromMilliseconds(1),
                 TimeSpan.FromMilliseconds(5),
                 TestContext.Current.CancellationToken));
@@ -179,7 +206,7 @@ public class ReminderTableRetryPolicyTests
         Assert.Equal(1, invocations);
         Assert.Contains("attempts=1", exception.Message, StringComparison.Ordinal);
         Assert.Contains("Last observation: <no completed attempt>", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("Last exception: System.TimeoutException", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Last exception: System.InvalidOperationException: late-contention", exception.Message, StringComparison.Ordinal);
     }
 
     private sealed class TestRunner(IReminderTable table, string providerName)


### PR DESCRIPTION
## Problem

`ReminderTableRetryPolicy` checked the elapsed budget after invoking an operation but before observing the returned task. Under scheduler pressure, a synchronously completed or faulted attempt could be replaced by a synthetic startup timeout, hiding the successful result or the real provider exception.

## Solution

Observe tasks which are already complete before applying the remaining deadline. Incomplete tasks continue to use the remaining budget, preserving the hard bound introduced in #10819. Focused regressions cover completed successful and faulted attempts after invocation consumes the budget.

## Rationale

The retry policy now reports the operation outcome that is already available at the deadline boundary while retaining timeout enforcement for outstanding work.

Fixes #10906
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10916)