### PR TITLE
fix(runtime): quiesce client route publication before shutdown

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -502,6 +502,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             }
         }
 
+        var update = builder.ToImmutable();
         try
         {
             LogDebugPublishingRoutes(successor);
@@ -515,7 +516,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                     return;
                 }
 
-                publishTask = remote.OnUpdateClientRoutes(_table);
+                publishTask = remote.OnUpdateClientRoutes(update);
             }
 
             await publishTask.WaitAsync(_shutdownCts.Token);
@@ -602,7 +603,9 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     {
         public Action SchedulePublishUpdate { get => instance._schedulePublishUpdate; set => instance._schedulePublishUpdate = value; }
         public long ObservedConnectedClientsVersion { get => instance._observedConnectedClientsVersion; set => instance._observedConnectedClientsVersion = value; }
-        public Task? NextPublishTask => instance._nextPublishTask;
+        public bool PublishTasksCompleted =>
+            instance._runTask is not { IsCompleted: false }
+            && instance._nextPublishTask is not { IsCompleted: false };
         public void SchedulePublishUpdates() => instance.SchedulePublishUpdates();
         public Task PublishUpdates() => instance.PublishUpdates();
     }

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -640,7 +640,6 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             _refreshTimer.Dispose();
         }
 
-        var inflightPublishTask = Volatile.Read(ref _inflightPublishTask);
         lock (_lockObj)
         {
             runTask = _runTask;
@@ -657,6 +656,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             await publishTask.WaitAsync(cancellationToken).SuppressThrowing();
         }
 
+        var inflightPublishTask = Volatile.Read(ref _inflightPublishTask);
         if (inflightPublishTask is not null)
         {
             await inflightPublishTask.WaitAsync(cancellationToken).SuppressThrowing();

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -38,7 +38,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     private readonly SiloAddress _localSilo;
     private readonly IClusterMembershipService _clusterMembershipService;
     private readonly SiloMessagingOptions _messagingOptions;
-    private readonly CancellationTokenSource _shutdownCts = new();
+    private readonly CancellationTokenSource _stoppingCts = new();
 #if NET9_0_OR_GREATER
     private readonly Lock _lockObj = new();
 #else
@@ -48,7 +48,6 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     private readonly IConnectedClientCollection _connectedClients;
     private Action _schedulePublishUpdate;
     private Task? _runTask;
-    private int _isStopping;
     private MembershipVersion _observedMembershipVersion = MembershipVersion.MinValue;
     private long _observedConnectedClientsVersion = -1;
     private long _localVersion = 1;
@@ -350,12 +349,12 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     private async Task Run()
     {
-        var membershipUpdates = _clusterMembershipService.MembershipUpdates.GetAsyncEnumerator(_shutdownCts.Token);
+        var membershipUpdates = _clusterMembershipService.MembershipUpdates.GetAsyncEnumerator(_stoppingCts.Token);
 
         Task<bool>? membershipTask = null;
         Task<bool>? timerTask = _refreshTimer.NextTick(RandomTimeSpan.Next(_messagingOptions.ClientRegistrationRefresh));
 
-        while (!_shutdownCts.IsCancellationRequested)
+        while (!_stoppingCts.IsCancellationRequested)
         {
             try
             {
@@ -390,7 +389,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                     await PublishUpdates();
                 }
             }
-            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
+            catch (OperationCanceledException) when (_stoppingCts.IsCancellationRequested)
             {
                 // Ignore during shutdown.
                 break;
@@ -404,7 +403,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     private bool ShouldPublish()
     {
-        if (Volatile.Read(ref _isStopping) != 0)
+        if (_stoppingCts.IsCancellationRequested)
         {
             return false;
         }
@@ -412,7 +411,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         EnsureRefreshed();
         lock (_lockObj)
         {
-            if (_isStopping != 0)
+            if (_stoppingCts.IsCancellationRequested)
             {
                 return false;
             }
@@ -443,7 +442,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     {
         lock (_lockObj)
         {
-            if (_isStopping != 0 || _nextPublishTask is Task task && !task.IsCompleted)
+            if (_stoppingCts.IsCancellationRequested || _nextPublishTask is Task task && !task.IsCompleted)
             {
                 return;
             }
@@ -459,7 +458,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>? previousRoutes;
         lock (_lockObj)
         {
-            if (_isStopping != 0)
+            if (_stoppingCts.IsCancellationRequested)
             {
                 return;
             }
@@ -516,7 +515,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             Task publishTask;
             lock (_lockObj)
             {
-                if (_isStopping != 0)
+                if (_stoppingCts.IsCancellationRequested)
                 {
                     return;
                 }
@@ -524,7 +523,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 publishTask = remote.OnUpdateClientRoutes(update);
             }
 
-            await publishTask.WaitAsync(_shutdownCts.Token);
+            await publishTask.WaitAsync(_stoppingCts.Token);
 
             // Record the current lower bound of what the successor knows, so that it can be used to minimize
             // data transfer next time an update is performed.
@@ -546,7 +545,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 _schedulePublishUpdate();
             }
         }
-        catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
+        catch (OperationCanceledException) when (_stoppingCts.IsCancellationRequested)
         {
             // Publication is intentionally canceled while the silo is quiescing.
         }
@@ -586,19 +585,16 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         {
             Task? runTask;
             Task? publishTask;
-            bool beginStopping;
-            lock (_lockObj)
+            if (!_stoppingCts.IsCancellationRequested)
             {
-                beginStopping = _isStopping == 0;
-                Volatile.Write(ref _isStopping, 1);
-                runTask = _runTask;
-                publishTask = _nextPublishTask;
+                _stoppingCts.Cancel();
+                _refreshTimer.Dispose();
             }
 
-            if (beginStopping)
+            lock (_lockObj)
             {
-                _shutdownCts.Cancel();
-                _refreshTimer.Dispose();
+                runTask = _runTask;
+                publishTask = _nextPublishTask;
             }
 
             if (runTask is not null)

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -58,6 +58,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     // For synchronization with remote silos.
     private Task? _nextPublishTask;
+    private Task? _inflightPublishTask;
     private long _publishRequestVersion;
     private SiloAddress? _previousSuccessor;
     private ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>? _publishedTable;
@@ -540,8 +541,37 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 return false;
             }
 
-            var publishTask = remote.OnUpdateClientRoutes(update);
-            await publishTask;
+            var publicationCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            publicationCompletion.Task.Ignore();
+            lock (_lockObj)
+            {
+                if (_stoppingCts.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                _inflightPublishTask = publicationCompletion.Task;
+            }
+
+            if (_stoppingCts.IsCancellationRequested)
+            {
+                publicationCompletion.TrySetResult(false);
+                return false;
+            }
+
+            Task publishTask;
+            try
+            {
+                publishTask = remote.OnUpdateClientRoutes(update);
+            }
+            catch (Exception exception)
+            {
+                publicationCompletion.TrySetException(exception);
+                throw;
+            }
+
+            ObservePublication(publishTask, publicationCompletion).Ignore();
+            await publishTask.WaitAsync(_stoppingCts.Token);
 
             // Record the current lower bound of what the successor knows, so that it can be used to minimize
             // data transfer next time an update is performed.
@@ -567,6 +597,23 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         {
             LogErrorPublishingClientRoutingTableToSilo(exception, successor);
             return false;
+        }
+
+        static async Task ObservePublication(Task publishTask, TaskCompletionSource<bool> publicationCompletion)
+        {
+            try
+            {
+                await publishTask;
+                publicationCompletion.TrySetResult(true);
+            }
+            catch (OperationCanceledException exception)
+            {
+                publicationCompletion.TrySetCanceled(exception.CancellationToken);
+            }
+            catch (Exception exception)
+            {
+                publicationCompletion.TrySetException(exception);
+            }
         }
     }
 
@@ -600,6 +647,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         {
             Task? runTask;
             Task? publishTask;
+            Task? inflightPublishTask;
             if (!_stoppingCts.IsCancellationRequested)
             {
                 _stoppingCts.Cancel();
@@ -610,6 +658,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             {
                 runTask = _runTask;
                 publishTask = _nextPublishTask;
+                inflightPublishTask = _inflightPublishTask;
             }
 
             if (runTask is not null)
@@ -620,6 +669,11 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             if (publishTask is not null)
             {
                 await publishTask.WaitAsync(ct).SuppressThrowing();
+            }
+
+            if (inflightPublishTask is not null)
+            {
+                await inflightPublishTask.WaitAsync(ct).SuppressThrowing();
             }
         }
 
@@ -639,7 +693,8 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 lock (instance._lockObj)
                 {
                     return instance._runTask is not { IsCompleted: false }
-                        && instance._nextPublishTask is not { IsCompleted: false };
+                        && instance._nextPublishTask is not { IsCompleted: false }
+                        && instance._inflightPublishTask is not { IsCompleted: false };
                 }
             }
         }

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -46,6 +46,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 #endif
     private readonly GrainId _localHostedClientId;
     private readonly IConnectedClientCollection _connectedClients;
+    private Func<Task> _onPublishRegistered = static () => Task.CompletedTask;
     private Action _schedulePublishUpdate;
     private Task? _runTask;
     private MembershipVersion _observedMembershipVersion = MembershipVersion.MinValue;
@@ -60,6 +61,8 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     private Task? _nextPublishTask;
     private Task? _inflightPublishTask;
     private long _publishRequestVersion;
+    private SiloAddress? _requestedSuccessor;
+    private ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>? _requestedTable;
     private SiloAddress? _previousSuccessor;
     private ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>? _publishedTable;
 
@@ -442,12 +445,29 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 return;
             }
 
-            var requestVersion = ++_publishRequestVersion;
-            if (_nextPublishTask is Task task && !task.IsCompleted)
+            var successor = _consistentRing.Successor;
+            if (successor is null)
             {
                 return;
             }
 
+            var table = _table;
+            if (_nextPublishTask is Task task && !task.IsCompleted)
+            {
+                if (ReferenceEquals(table, _requestedTable) && successor.Equals(_requestedSuccessor))
+                {
+                    return;
+                }
+
+                _requestedTable = table;
+                _requestedSuccessor = successor;
+                ++_publishRequestVersion;
+                return;
+            }
+
+            _requestedTable = table;
+            _requestedSuccessor = successor;
+            var requestVersion = ++_publishRequestVersion;
             _nextPublishTask = this.QueueTask(() => RunScheduledPublish(requestVersion));
         }
     }
@@ -543,15 +563,8 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
             var publicationCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             publicationCompletion.Task.Ignore();
-            lock (_lockObj)
-            {
-                if (_stoppingCts.IsCancellationRequested)
-                {
-                    return false;
-                }
-
-                _inflightPublishTask = publicationCompletion.Task;
-            }
+            Volatile.Write(ref _inflightPublishTask, publicationCompletion.Task);
+            await _onPublishRegistered();
 
             if (_stoppingCts.IsCancellationRequested)
             {
@@ -617,6 +630,39 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         }
     }
 
+    private async Task QuiescePublishingRoutingTable(CancellationToken cancellationToken)
+    {
+        Task? runTask;
+        Task? publishTask;
+        if (!_stoppingCts.IsCancellationRequested)
+        {
+            _stoppingCts.Cancel();
+            _refreshTimer.Dispose();
+        }
+
+        var inflightPublishTask = Volatile.Read(ref _inflightPublishTask);
+        lock (_lockObj)
+        {
+            runTask = _runTask;
+            publishTask = _nextPublishTask;
+        }
+
+        if (runTask is not null)
+        {
+            await runTask.WaitAsync(cancellationToken).SuppressThrowing();
+        }
+
+        if (publishTask is not null)
+        {
+            await publishTask.WaitAsync(cancellationToken).SuppressThrowing();
+        }
+
+        if (inflightPublishTask is not null)
+        {
+            await inflightPublishTask.WaitAsync(cancellationToken).SuppressThrowing();
+        }
+    }
+
     void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
     {
         lifecycle.Subscribe(
@@ -643,49 +689,17 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             return Task.CompletedTask;
         }
 
-        async Task QuiescePublishingRoutingTable(CancellationToken ct)
-        {
-            Task? runTask;
-            Task? publishTask;
-            Task? inflightPublishTask;
-            if (!_stoppingCts.IsCancellationRequested)
-            {
-                _stoppingCts.Cancel();
-                _refreshTimer.Dispose();
-            }
-
-            lock (_lockObj)
-            {
-                runTask = _runTask;
-                publishTask = _nextPublishTask;
-                inflightPublishTask = _inflightPublishTask;
-            }
-
-            if (runTask is not null)
-            {
-                await runTask.WaitAsync(ct).SuppressThrowing();
-            }
-
-            if (publishTask is not null)
-            {
-                await publishTask.WaitAsync(ct).SuppressThrowing();
-            }
-
-            if (inflightPublishTask is not null)
-            {
-                await inflightPublishTask.WaitAsync(ct).SuppressThrowing();
-            }
-        }
-
         Task StopPublishingRoutingTable(CancellationToken ct) => QuiescePublishingRoutingTable(ct);
     }
 
     internal class TestAccessor(ClientDirectory instance)
     {
         public Action SchedulePublishUpdate { get => instance._schedulePublishUpdate; set => instance._schedulePublishUpdate = value; }
+        public Func<Task> OnPublishRegistered { set => instance._onPublishRegistered = value; }
         public long ObservedConnectedClientsVersion { get => instance._observedConnectedClientsVersion; set => instance._observedConnectedClientsVersion = value; }
         public CancellationToken StoppingToken => instance._stoppingCts.Token;
         public Task DrainScheduler() => instance.RunOrQueueTask(static () => Task.CompletedTask);
+        public Task Quiesce(CancellationToken cancellationToken) => instance.QuiescePublishingRoutingTable(cancellationToken);
         public bool PublishTasksCompleted
         {
             get
@@ -694,7 +708,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 {
                     return instance._runTask is not { IsCompleted: false }
                         && instance._nextPublishTask is not { IsCompleted: false }
-                        && instance._inflightPublishTask is not { IsCompleted: false };
+                        && Volatile.Read(ref instance._inflightPublishTask) is not { IsCompleted: false };
                 }
             }
         }

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -531,7 +531,11 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
             LogDebugSuccessfullyPublishedRoutes(successor);
 
-            _nextPublishTask = null;
+            lock (_lockObj)
+            {
+                _nextPublishTask = null;
+            }
+
             if (ShouldPublish())
             {
                 _schedulePublishUpdate();
@@ -562,7 +566,13 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
         Task StartPublishingRoutingTable(CancellationToken ct)
         {
-            this.RunOrQueueTask(() => _runTask = this.Run()).Ignore();
+            var runTask = this.RunOrQueueTask(Run);
+            lock (_lockObj)
+            {
+                _runTask = runTask;
+            }
+
+            runTask.Ignore();
             return Task.CompletedTask;
         }
 
@@ -574,7 +584,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             lock (_lockObj)
             {
                 beginStopping = _isStopping == 0;
-                _isStopping = 1;
+                Volatile.Write(ref _isStopping, 1);
                 runTask = _runTask;
                 publishTask = _nextPublishTask;
             }
@@ -603,9 +613,17 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     {
         public Action SchedulePublishUpdate { get => instance._schedulePublishUpdate; set => instance._schedulePublishUpdate = value; }
         public long ObservedConnectedClientsVersion { get => instance._observedConnectedClientsVersion; set => instance._observedConnectedClientsVersion = value; }
-        public bool PublishTasksCompleted =>
-            instance._runTask is not { IsCompleted: false }
-            && instance._nextPublishTask is not { IsCompleted: false };
+        public bool PublishTasksCompleted
+        {
+            get
+            {
+                lock (instance._lockObj)
+                {
+                    return instance._runTask is not { IsCompleted: false }
+                        && instance._nextPublishTask is not { IsCompleted: false };
+                }
+            }
+        }
         public void SchedulePublishUpdates() => instance.SchedulePublishUpdates();
         public Task PublishUpdates() => instance.PublishUpdates();
     }

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -58,6 +58,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     // For synchronization with remote silos.
     private Task? _nextPublishTask;
+    private long _publishRequestVersion;
     private SiloAddress? _previousSuccessor;
     private ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>? _publishedTable;
 
@@ -386,7 +387,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
                 if (ShouldPublish())
                 {
-                    await PublishUpdates();
+                    _schedulePublishUpdate();
                 }
             }
             catch (OperationCanceledException) when (_stoppingCts.IsCancellationRequested)
@@ -416,7 +417,8 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 return false;
             }
 
-            if (_nextPublishTask is Task task && !task.IsCompleted)
+            var successor = _consistentRing.Successor;
+            if (successor is null)
             {
                 return false;
             }
@@ -426,15 +428,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 return true;
             }
 
-            // If there is no successor, or the successor is equal to the successor the last time the table was published,
-            // then there is no need to publish.
-            var successor = _consistentRing.Successor;
-            if (successor is null || successor.Equals(_previousSuccessor))
-            {
-                return false;
-            }
-
-            return true;
+            return !successor.Equals(_previousSuccessor);
         }
     }
 
@@ -442,16 +436,45 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     {
         lock (_lockObj)
         {
-            if (_stoppingCts.IsCancellationRequested || _nextPublishTask is Task task && !task.IsCompleted)
+            if (_stoppingCts.IsCancellationRequested)
             {
                 return;
             }
 
-            _nextPublishTask = this.RunOrQueueTask(PublishUpdates);
+            var requestVersion = ++_publishRequestVersion;
+            if (_nextPublishTask is Task task && !task.IsCompleted)
+            {
+                return;
+            }
+
+            _nextPublishTask = this.QueueTask(() => RunScheduledPublish(requestVersion));
         }
     }
 
-    private async Task PublishUpdates()
+    private async Task RunScheduledPublish(long requestVersion)
+    {
+        bool published;
+        bool newerRequest;
+        try
+        {
+            published = await PublishUpdates();
+        }
+        finally
+        {
+            lock (_lockObj)
+            {
+                _nextPublishTask = null;
+                newerRequest = _publishRequestVersion > requestVersion;
+            }
+        }
+
+        if (newerRequest || published && ShouldPublish())
+        {
+            _schedulePublishUpdate();
+        }
+    }
+
+    private async Task<bool> PublishUpdates()
     {
         SiloAddress? successor;
         ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)> newRoutes;
@@ -460,13 +483,13 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         {
             if (_stoppingCts.IsCancellationRequested)
             {
-                return;
+                return false;
             }
 
             successor = _consistentRing.Successor;
             if (successor is null)
             {
-                return;
+                return false;
             }
 
             if (!successor.Equals(_previousSuccessor))
@@ -481,7 +504,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         if (ReferenceEquals(previousRoutes, newRoutes))
         {
             LogDebugSkippingPublishingRoutes();
-            return;
+            return false;
         }
 
         // Try to find the minimum amount of information required to update the successor.
@@ -514,11 +537,11 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             var remote = _grainFactory.GetSystemTarget<IRemoteClientDirectory>(Constants.ClientDirectoryType, successor);
             if (_stoppingCts.IsCancellationRequested)
             {
-                return;
+                return false;
             }
 
             var publishTask = remote.OnUpdateClientRoutes(update);
-            await publishTask.WaitAsync(_stoppingCts.Token);
+            await publishTask;
 
             // Record the current lower bound of what the successor knows, so that it can be used to minimize
             // data transfer next time an update is performed.
@@ -531,22 +554,19 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                     _publishedTable = newRoutes;
                     _previousSuccessor = successor;
                 }
-
-                _nextPublishTask = null;
             }
 
-            if (ShouldPublish())
-            {
-                _schedulePublishUpdate();
-            }
+            return true;
         }
         catch (OperationCanceledException) when (_stoppingCts.IsCancellationRequested)
         {
             // Publication is intentionally canceled while the silo is quiescing.
+            return false;
         }
         catch (Exception exception)
         {
             LogErrorPublishingClientRoutingTableToSilo(exception, successor);
+            return false;
         }
     }
 
@@ -610,6 +630,8 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     {
         public Action SchedulePublishUpdate { get => instance._schedulePublishUpdate; set => instance._schedulePublishUpdate = value; }
         public long ObservedConnectedClientsVersion { get => instance._observedConnectedClientsVersion; set => instance._observedConnectedClientsVersion = value; }
+        public CancellationToken StoppingToken => instance._stoppingCts.Token;
+        public Task DrainScheduler() => instance.RunOrQueueTask(static () => Task.CompletedTask);
         public bool PublishTasksCompleted
         {
             get

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -354,7 +354,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     private async Task Run()
     {
-        var membershipUpdates = _clusterMembershipService.MembershipUpdates.GetAsyncEnumerator(_stoppingCts.Token);
+        await using var membershipUpdates = _clusterMembershipService.MembershipUpdates.GetAsyncEnumerator(_stoppingCts.Token);
 
         Task<bool>? membershipTask = null;
         Task<bool>? timerTask = _refreshTimer.NextTick(RandomTimeSpan.Next(_messagingOptions.ClientRegistrationRefresh));

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -48,6 +48,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     private readonly IConnectedClientCollection _connectedClients;
     private Action _schedulePublishUpdate;
     private Task? _runTask;
+    private int _isStopping;
     private MembershipVersion _observedMembershipVersion = MembershipVersion.MinValue;
     private long _observedConnectedClientsVersion = -1;
     private long _localVersion = 1;
@@ -403,9 +404,19 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     private bool ShouldPublish()
     {
+        if (Volatile.Read(ref _isStopping) != 0)
+        {
+            return false;
+        }
+
         EnsureRefreshed();
         lock (_lockObj)
         {
+            if (_isStopping != 0)
+            {
+                return false;
+            }
+
             if (_nextPublishTask is Task task && !task.IsCompleted)
             {
                 return false;
@@ -432,7 +443,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
     {
         lock (_lockObj)
         {
-            if (_nextPublishTask is Task task && !task.IsCompleted)
+            if (_isStopping != 0 || _nextPublishTask is Task task && !task.IsCompleted)
             {
                 return;
             }
@@ -496,7 +507,18 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             LogDebugPublishingRoutes(successor);
 
             var remote = _grainFactory.GetSystemTarget<IRemoteClientDirectory>(Constants.ClientDirectoryType, successor);
-            await remote.OnUpdateClientRoutes(_table).WaitAsync(_shutdownCts.Token);
+            Task publishTask;
+            lock (_lockObj)
+            {
+                if (_isStopping != 0)
+                {
+                    return;
+                }
+
+                publishTask = remote.OnUpdateClientRoutes(_table);
+            }
+
+            await publishTask.WaitAsync(_shutdownCts.Token);
 
             // Record the current lower bound of what the successor knows, so that it can be used to minimize
             // data transfer next time an update is performed.
@@ -514,6 +536,9 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
                 _schedulePublishUpdate();
             }
         }
+        catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
+        {
+        }
         catch (Exception exception)
         {
             LogErrorPublishingClientRoutingTableToSilo(exception, successor);
@@ -522,6 +547,12 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
     {
+        lifecycle.Subscribe(
+            $"{nameof(ClientDirectory)}.Quiesce",
+            ServiceLifecycleStage.Active,
+            static _ => Task.CompletedTask,
+            QuiescePublishingRoutingTable);
+
         lifecycle.Subscribe(
             nameof(ClientDirectory),
             ServiceLifecycleStage.RuntimeGrainServices,
@@ -534,27 +565,45 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             return Task.CompletedTask;
         }
 
-        async Task StopPublishingRoutingTable(CancellationToken ct)
+        async Task QuiescePublishingRoutingTable(CancellationToken ct)
         {
-            _shutdownCts.Cancel();
-            _refreshTimer?.Dispose();
-
-            if (_runTask is Task task)
+            Task? runTask;
+            Task? publishTask;
+            bool beginStopping;
+            lock (_lockObj)
             {
-                await task.WaitAsync(ct).SuppressThrowing();
+                beginStopping = _isStopping == 0;
+                _isStopping = 1;
+                runTask = _runTask;
+                publishTask = _nextPublishTask;
             }
 
-            if (_nextPublishTask is Task publishTask)
+            if (beginStopping)
+            {
+                _shutdownCts.Cancel();
+                _refreshTimer.Dispose();
+            }
+
+            if (runTask is not null)
+            {
+                await runTask.WaitAsync(ct).SuppressThrowing();
+            }
+
+            if (publishTask is not null)
             {
                 await publishTask.WaitAsync(ct).SuppressThrowing();
             }
         }
+
+        Task StopPublishingRoutingTable(CancellationToken ct) => QuiescePublishingRoutingTable(ct);
     }
 
     internal class TestAccessor(ClientDirectory instance)
     {
         public Action SchedulePublishUpdate { get => instance._schedulePublishUpdate; set => instance._schedulePublishUpdate = value; }
         public long ObservedConnectedClientsVersion { get => instance._observedConnectedClientsVersion; set => instance._observedConnectedClientsVersion = value; }
+        public Task? NextPublishTask => instance._nextPublishTask;
+        public void SchedulePublishUpdates() => instance.SchedulePublishUpdates();
         public Task PublishUpdates() => instance.PublishUpdates();
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -454,20 +454,30 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
     private async Task PublishUpdates()
     {
-        // Publish clients to the next two silos in the ring
-        var successor = _consistentRing.Successor;
-        if (successor is null)
+        SiloAddress? successor;
+        ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)> newRoutes;
+        ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>? previousRoutes;
+        lock (_lockObj)
         {
-            return;
-        }
+            if (_isStopping != 0)
+            {
+                return;
+            }
 
-        if (successor.Equals(_previousSuccessor))
-        {
-            _publishedTable = null;
-        }
+            successor = _consistentRing.Successor;
+            if (successor is null)
+            {
+                return;
+            }
 
-        var newRoutes = _table;
-        var previousRoutes = _publishedTable;
+            if (!successor.Equals(_previousSuccessor))
+            {
+                _publishedTable = null;
+            }
+
+            newRoutes = _table;
+            previousRoutes = _publishedTable;
+        }
 
         if (ReferenceEquals(previousRoutes, newRoutes))
         {
@@ -477,18 +487,13 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
         // Try to find the minimum amount of information required to update the successor.
         var builder = newRoutes.ToBuilder();
+        builder.Remove(successor);
         if (previousRoutes is not null)
         {
             foreach (var pair in previousRoutes)
             {
                 var silo = pair.Key;
                 var (_, version) = pair.Value;
-                if (silo.Equals(successor))
-                {
-                    // No need to publish updates to the silo which originated them.
-                    continue;
-                }
-
                 if (!builder.TryGetValue(silo, out var published))
                 {
                     continue;
@@ -523,16 +528,16 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
 
             // Record the current lower bound of what the successor knows, so that it can be used to minimize
             // data transfer next time an update is performed.
-            if (ReferenceEquals(_publishedTable, previousRoutes))
-            {
-                _publishedTable = newRoutes;
-                _previousSuccessor = successor;
-            }
-
             LogDebugSuccessfullyPublishedRoutes(successor);
 
             lock (_lockObj)
             {
+                if (ReferenceEquals(_publishedTable, previousRoutes))
+                {
+                    _publishedTable = newRoutes;
+                    _previousSuccessor = successor;
+                }
+
                 _nextPublishTask = null;
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -512,17 +512,12 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
             LogDebugPublishingRoutes(successor);
 
             var remote = _grainFactory.GetSystemTarget<IRemoteClientDirectory>(Constants.ClientDirectoryType, successor);
-            Task publishTask;
-            lock (_lockObj)
+            if (_stoppingCts.IsCancellationRequested)
             {
-                if (_stoppingCts.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                publishTask = remote.OnUpdateClientRoutes(update);
+                return;
             }
 
+            var publishTask = remote.OnUpdateClientRoutes(update);
             await publishTask.WaitAsync(_stoppingCts.Token);
 
             // Record the current lower bound of what the successor knows, so that it can be used to minimize

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -548,6 +548,7 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         }
         catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
         {
+            // Publication is intentionally canceled while the silo is quiescing.
         }
         catch (Exception exception)
         {

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -457,6 +457,38 @@ namespace NonSilo.Tests.Directory
         }
 
         [Fact]
+        public async Task ScheduledPublicationIgnoresDuplicateInFlightTrigger()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var remoteSilo = Silo("127.0.0.1:222@100");
+            var remoteDirectory = _remoteDirectories.GetOrAdd(remoteSilo, Substitute.For<IRemoteClientDirectory>());
+            var publicationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var publicationRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            remoteDirectory.OnUpdateClientRoutes(default!).ReturnsForAnyArgs(_ =>
+            {
+                publicationStarted.TrySetResult(true);
+                return publicationRelease.Task;
+            });
+
+            _clusterMembershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remoteSilo");
+            _testAccessor.SchedulePublishUpdate = _testAccessor.SchedulePublishUpdates;
+            var localClient = Client("local");
+            SetLocalClients([localClient]);
+            Assert.True(_directory.TryLocalLookup(localClient, out _));
+
+            _testAccessor.SchedulePublishUpdates();
+            await publicationStarted.Task.WaitAsync(cancellationToken);
+            _testAccessor.SchedulePublishUpdates();
+
+            publicationRelease.TrySetResult(true);
+            await _testAccessor.DrainScheduler().WaitAsync(cancellationToken);
+            await _testAccessor.DrainScheduler().WaitAsync(cancellationToken);
+
+            _ = remoteDirectory.Received(1).OnUpdateClientRoutes(
+                Arg.Any<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>>());
+        }
+
+        [Fact]
         public async Task ScheduledPublicationFailureRepublishesInFlightChangesOnce()
         {
             var cancellationToken = TestContext.Current.CancellationToken;
@@ -517,6 +549,43 @@ namespace NonSilo.Tests.Directory
 
             _ = remoteDirectory.Received(1).OnUpdateClientRoutes(
                 Arg.Any<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>>());
+        }
+
+        [Fact]
+        public async Task QuiescenceTracksPublicationRegisteredBeforeRpcStarts()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var remoteSilo = Silo("127.0.0.1:222@100");
+            var remoteDirectory = _remoteDirectories.GetOrAdd(remoteSilo, Substitute.For<IRemoteClientDirectory>());
+            var publicationRegistered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var publicationRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _testAccessor.OnPublishRegistered = async () =>
+            {
+                publicationRegistered.TrySetResult(true);
+                await publicationRelease.Task;
+            };
+
+            _clusterMembershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remoteSilo");
+            var localClient = Client("local");
+            SetLocalClients([localClient]);
+            Assert.True(_directory.TryLocalLookup(localClient, out _));
+
+            try
+            {
+                _testAccessor.SchedulePublishUpdates();
+                await publicationRegistered.Task.WaitAsync(cancellationToken);
+
+                var quiesce = _testAccessor.Quiesce(cancellationToken);
+                publicationRelease.TrySetResult(true);
+                await quiesce;
+
+                _ = remoteDirectory.DidNotReceive().OnUpdateClientRoutes(
+                    Arg.Any<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>>());
+            }
+            finally
+            {
+                publicationRelease.TrySetResult(true);
+            }
         }
 
         [Fact]

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -429,11 +429,10 @@ namespace NonSilo.Tests.Directory
                 static _ => Task.CompletedTask,
                 _ =>
                 {
-                    publicationStoppedBeforeMembershipShutdown = _testAccessor.NextPublishTask?.IsCompleted == true;
+                    publicationStoppedBeforeMembershipShutdown = _testAccessor.PublishTasksCompleted;
                     return Task.CompletedTask;
                 });
 
-            await _lifecycle.OnStart(cancellationToken);
             var lifecycleStopped = false;
             try
             {
@@ -441,7 +440,7 @@ namespace NonSilo.Tests.Directory
                 SetLocalClients([localClient]);
                 Assert.True(_directory.TryLocalLookup(localClient, out _));
 
-                _testAccessor.SchedulePublishUpdates();
+                await _lifecycle.OnStart(cancellationToken);
                 await publicationStarted.Task.WaitAsync(cancellationToken);
 
                 await _lifecycle.OnStop(cancellationToken);
@@ -450,7 +449,7 @@ namespace NonSilo.Tests.Directory
                 Assert.True(
                     publicationStoppedBeforeMembershipShutdown,
                     "Client route publication remained active when the membership shutdown stage began.");
-                Assert.True(_testAccessor.NextPublishTask?.IsCompletedSuccessfully);
+                Assert.True(_testAccessor.PublishTasksCompleted);
 
                 var update = ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>.Empty.Add(
                     remoteSilo,

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -359,6 +359,7 @@ namespace NonSilo.Tests.Directory
 
                     if (callNumber == 1)
                     {
+                        Assert.DoesNotContain(silo, update);
                         Assert.True(update.TryGetValue(otherRemoteSilo, out var siloUpdate));
                         Assert.Contains(remoteClientId2, siloUpdate.ConnectedClients);
                     }
@@ -392,17 +393,13 @@ namespace NonSilo.Tests.Directory
             await _directory.OnUpdateClientRoutes(builder.ToImmutable());
             Assert.Equal(1, totalUpdateCalls[0]);
 
-            var oldSuccessor = calledSilos.Last();
-            _clusterMembershipService.UpdateSiloStatus(oldSuccessor, SiloStatus.Dead, "blah");
-            var newSuccessor = GetOtherRemoteSilo(oldSuccessor);
-            totalUpdateCalls[0] = 0;
-
-            // Add clients locally and see that they are propagated to the new successor.
+            var successor = Assert.Single(calledSilos);
             SetLocalClients(new List<GrainId> { remoteClientId, remoteClientId2 });
-            builder = ImmutableDictionary.CreateBuilder<SiloAddress, (ImmutableHashSet<GrainId>, long)>();
-            builder[oldSuccessor] = (ImmutableHashSet.CreateRange(new[] { remoteClientId2 }), 4);
-            await _directory.OnUpdateClientRoutes(builder.ToImmutable());
-            Assert.Equal(1, totalUpdateCalls[0]);
+            await _directory.OnUpdateClientRoutes(
+                ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>.Empty);
+
+            Assert.Equal(2, totalUpdateCalls[0]);
+            Assert.All(calledSilos, calledSilo => Assert.Equal(successor, calledSilo));
         }
 
         [Fact]

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -338,6 +338,7 @@ namespace NonSilo.Tests.Directory
 
             var totalUpdateCalls = new[] { 0 };
             var calledSilos = new List<SiloAddress>();
+            var publishedUpdates = new List<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>>();
             SiloAddress GetOtherRemoteSilo(SiloAddress silo) => silo.Equals(remoteSilo) ? remoteSilo2 : remoteSilo;
             IRemoteClientDirectory CreateRemoteDirectory(SiloAddress silo)
             {
@@ -354,27 +355,9 @@ namespace NonSilo.Tests.Directory
                 remoteDirectory.OnUpdateClientRoutes(default!).ReturnsForAnyArgs(info =>
                 {
                     calledSilos.Add(silo);
-                    var callNumber = ++totalUpdateCalls[0];
+                    ++totalUpdateCalls[0];
                     var update = info.ArgAt<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>>(0);
-
-                    if (callNumber == 1)
-                    {
-                        Assert.DoesNotContain(silo, update);
-                        Assert.True(update.TryGetValue(otherRemoteSilo, out var siloUpdate));
-                        Assert.Contains(remoteClientId2, siloUpdate.ConnectedClients);
-                    }
-                    else if (callNumber == 2)
-                    {
-                        // There should only be one silo in this update since the other remote silo is dead and this silo already has its own latest state.
-                        Assert.Single(update);
-                        Assert.True(update.TryGetValue(_localSilo, out var siloUpdate));
-                        Assert.Equal(3, siloUpdate.ConnectedClients.Count);
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException("Unexpected call");
-                    }
-
+                    publishedUpdates.Add(update);
                     return Task.CompletedTask;
                 });
 
@@ -394,12 +377,146 @@ namespace NonSilo.Tests.Directory
             Assert.Equal(1, totalUpdateCalls[0]);
 
             var successor = Assert.Single(calledSilos);
+            var initialUpdate = Assert.Single(publishedUpdates);
+            Assert.DoesNotContain(successor, initialUpdate);
+            Assert.True(initialUpdate.TryGetValue(GetOtherRemoteSilo(successor), out var remoteUpdate));
+            Assert.Contains(remoteClientId2, remoteUpdate.ConnectedClients);
+
             SetLocalClients(new List<GrainId> { remoteClientId, remoteClientId2 });
             await _directory.OnUpdateClientRoutes(
                 ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>.Empty);
 
             Assert.Equal(2, totalUpdateCalls[0]);
             Assert.All(calledSilos, calledSilo => Assert.Equal(successor, calledSilo));
+            var followUpUpdate = publishedUpdates[1];
+            Assert.Single(followUpUpdate);
+            Assert.True(followUpUpdate.TryGetValue(_localSilo, out var localUpdate));
+            Assert.Equal(3, localUpdate.ConnectedClients.Count);
+        }
+
+        [Fact]
+        public async Task ScheduledPublicationRepublishesChangesObservedInFlight()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var remoteSilo = Silo("127.0.0.1:222@100");
+            var remoteDirectory = _remoteDirectories.GetOrAdd(remoteSilo, Substitute.For<IRemoteClientDirectory>());
+            var firstPublicationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondPublicationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstPublicationRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var publicationCount = 0;
+            var firstClient = Client("local1");
+            var secondClient = Client("local2");
+            ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>? followUpUpdate = null;
+            remoteDirectory.OnUpdateClientRoutes(default!).ReturnsForAnyArgs(info =>
+            {
+                var update = info.ArgAt<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)>>(0);
+                return Interlocked.Increment(ref publicationCount) switch
+                {
+                    1 => SignalAndReturn(firstPublicationStarted, firstPublicationRelease.Task),
+                    2 => CaptureFollowUpAndReturn(secondPublicationStarted, update),
+                    _ => throw new InvalidOperationException("Unexpected publication"),
+                };
+            });
+
+            _clusterMembershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remoteSilo");
+            _testAccessor.SchedulePublishUpdate = _testAccessor.SchedulePublishUpdates;
+            SetLocalClients([firstClient]);
+            Assert.True(_directory.TryLocalLookup(firstClient, out _));
+
+            _testAccessor.SchedulePublishUpdates();
+            await firstPublicationStarted.Task.WaitAsync(cancellationToken);
+
+            SetLocalClients([firstClient, secondClient]);
+            await _directory.OnUpdateClientRoutes(
+                ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>.Empty);
+
+            firstPublicationRelease.TrySetResult(true);
+            await secondPublicationStarted.Task.WaitAsync(cancellationToken);
+            await _testAccessor.DrainScheduler().WaitAsync(cancellationToken);
+
+            Assert.NotNull(followUpUpdate);
+            Assert.True(followUpUpdate.TryGetValue(_localSilo, out var localUpdate));
+            Assert.Contains(secondClient, localUpdate.ConnectedClients);
+            _ = remoteDirectory.Received(2).OnUpdateClientRoutes(
+                Arg.Any<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>>());
+
+            static Task SignalAndReturn(TaskCompletionSource<bool> started, Task task)
+            {
+                started.TrySetResult(true);
+                return task;
+            }
+
+            Task CaptureFollowUpAndReturn(
+                TaskCompletionSource<bool> started,
+                ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId> ConnectedClients, long Version)> update)
+            {
+                followUpUpdate = update;
+                started.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task ScheduledPublicationFailureRepublishesInFlightChangesOnce()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var remoteSilo = Silo("127.0.0.1:222@100");
+            var remoteDirectory = _remoteDirectories.GetOrAdd(remoteSilo, Substitute.For<IRemoteClientDirectory>());
+            var firstPublicationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondPublicationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstPublicationRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var publicationCount = 0;
+            remoteDirectory.OnUpdateClientRoutes(default!).ReturnsForAnyArgs(_ =>
+            {
+                return Interlocked.Increment(ref publicationCount) switch
+                {
+                    1 => SignalAndReturn(firstPublicationStarted, firstPublicationRelease.Task),
+                    2 => SignalAndReturn(secondPublicationStarted, Task.CompletedTask),
+                    _ => throw new InvalidOperationException("Unexpected publication"),
+                };
+            });
+
+            _clusterMembershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remoteSilo");
+            _testAccessor.SchedulePublishUpdate = _testAccessor.SchedulePublishUpdates;
+            var localClient = Client("local");
+
+            _testAccessor.SchedulePublishUpdates();
+            await firstPublicationStarted.Task.WaitAsync(cancellationToken);
+
+            SetLocalClients([localClient]);
+            await _directory.OnUpdateClientRoutes(
+                ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>.Empty);
+
+            firstPublicationRelease.TrySetException(new TimeoutException("Unable"));
+            await secondPublicationStarted.Task.WaitAsync(cancellationToken);
+            await _testAccessor.DrainScheduler().WaitAsync(cancellationToken);
+            _ = remoteDirectory.Received(2).OnUpdateClientRoutes(
+                Arg.Any<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>>());
+
+            static Task SignalAndReturn(TaskCompletionSource<bool> started, Task task)
+            {
+                started.TrySetResult(true);
+                return task;
+            }
+        }
+
+        [Fact]
+        public async Task ScheduledPublicationFailureWaitsForNextTrigger()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var remoteSilo = Silo("127.0.0.1:222@100");
+            var remoteDirectory = _remoteDirectories.GetOrAdd(remoteSilo, Substitute.For<IRemoteClientDirectory>());
+            remoteDirectory.OnUpdateClientRoutes(default!).ReturnsForAnyArgs(_ => throw new TimeoutException("Unable"));
+
+            _clusterMembershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remoteSilo");
+            _testAccessor.SchedulePublishUpdate = _testAccessor.SchedulePublishUpdates;
+
+            _testAccessor.SchedulePublishUpdates();
+            await _testAccessor.DrainScheduler().WaitAsync(cancellationToken);
+            await _testAccessor.DrainScheduler().WaitAsync(cancellationToken);
+
+            _ = remoteDirectory.Received(1).OnUpdateClientRoutes(
+                Arg.Any<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>>());
         }
 
         [Fact]
@@ -417,8 +534,10 @@ namespace NonSilo.Tests.Directory
             });
 
             _clusterMembershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remoteSilo");
+            _testAccessor.SchedulePublishUpdate = _testAccessor.SchedulePublishUpdates;
             ((ILifecycleParticipant<ISiloLifecycle>)_directory).Participate(_lifecycle);
 
+            var membershipShutdownStarted = false;
             var publicationStoppedBeforeMembershipShutdown = false;
             _lifecycle.Subscribe(
                 "MembershipShutdownObserver",
@@ -426,6 +545,7 @@ namespace NonSilo.Tests.Directory
                 static _ => Task.CompletedTask,
                 _ =>
                 {
+                    membershipShutdownStarted = true;
                     publicationStoppedBeforeMembershipShutdown = _testAccessor.PublishTasksCompleted;
                     return Task.CompletedTask;
                 });
@@ -440,7 +560,19 @@ namespace NonSilo.Tests.Directory
                 await _lifecycle.OnStart(cancellationToken);
                 await publicationStarted.Task.WaitAsync(cancellationToken);
 
-                await _lifecycle.OnStop(cancellationToken);
+                var quiescing = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                using var registration = _testAccessor.StoppingToken.Register(
+                    static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true),
+                    quiescing);
+                var lifecycleStop = _lifecycle.OnStop(cancellationToken);
+                await quiescing.Task.WaitAsync(cancellationToken);
+                await _testAccessor.DrainScheduler().WaitAsync(cancellationToken);
+
+                Assert.False(lifecycleStop.IsCompleted);
+                Assert.False(membershipShutdownStarted);
+
+                publicationRelease.TrySetResult(true);
+                await lifecycleStop;
                 lifecycleStopped = true;
 
                 Assert.True(

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -405,6 +405,72 @@ namespace NonSilo.Tests.Directory
             Assert.Equal(1, totalUpdateCalls[0]);
         }
 
+        [Fact]
+        public async Task PublishingStopsBeforeMembershipShutdownBegins()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var remoteSilo = Silo("127.0.0.1:222@100");
+            var remoteDirectory = _remoteDirectories.GetOrAdd(remoteSilo, Substitute.For<IRemoteClientDirectory>());
+            var publicationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var publicationRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            remoteDirectory.OnUpdateClientRoutes(default!).ReturnsForAnyArgs(_ =>
+            {
+                publicationStarted.TrySetResult(true);
+                return publicationRelease.Task;
+            });
+
+            _clusterMembershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remoteSilo");
+            ((ILifecycleParticipant<ISiloLifecycle>)_directory).Participate(_lifecycle);
+
+            var publicationStoppedBeforeMembershipShutdown = false;
+            _lifecycle.Subscribe(
+                "MembershipShutdownObserver",
+                ServiceLifecycleStage.BecomeActive,
+                static _ => Task.CompletedTask,
+                _ =>
+                {
+                    publicationStoppedBeforeMembershipShutdown = _testAccessor.NextPublishTask?.IsCompleted == true;
+                    return Task.CompletedTask;
+                });
+
+            await _lifecycle.OnStart(cancellationToken);
+            var lifecycleStopped = false;
+            try
+            {
+                var localClient = Client("local");
+                SetLocalClients([localClient]);
+                Assert.True(_directory.TryLocalLookup(localClient, out _));
+
+                _testAccessor.SchedulePublishUpdates();
+                await publicationStarted.Task.WaitAsync(cancellationToken);
+
+                await _lifecycle.OnStop(cancellationToken);
+                lifecycleStopped = true;
+
+                Assert.True(
+                    publicationStoppedBeforeMembershipShutdown,
+                    "Client route publication remained active when the membership shutdown stage began.");
+                Assert.True(_testAccessor.NextPublishTask?.IsCompletedSuccessfully);
+
+                var update = ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>.Empty.Add(
+                    remoteSilo,
+                    (ImmutableHashSet.Create(Client("remote")), 2));
+                await _directory.OnUpdateClientRoutes(update);
+                _testAccessor.SchedulePublishUpdates();
+
+                _ = remoteDirectory.Received(1).OnUpdateClientRoutes(
+                    Arg.Any<ImmutableDictionary<SiloAddress, (ImmutableHashSet<GrainId>, long)>>());
+            }
+            finally
+            {
+                publicationRelease.TrySetResult(true);
+                if (!lifecycleStopped)
+                {
+                    await _lifecycle.OnStop(CancellationToken.None);
+                }
+            }
+        }
+
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
         private static GrainId Client(string id) => ClientGrainId.Create(id).GrainId;


### PR DESCRIPTION
ClientDirectory continued publishing until the RuntimeGrainServices shutdown stage, after membership shutdown had already begun. A route update could therefore remain in flight from a retiring silo, and its response could time out after the source and successor left the cluster. This was the failure captured in #10904.

Quiesce client route publication at the Active-stage boundary, drain tracked publication work before the membership transition, and reject new publication scheduling once shutdown begins. Normal shutdown cancellation now completes without an error log.

Add a deterministic lifecycle test which blocks a publication, verifies it completes before the membership shutdown stage, and verifies later updates cannot schedule another publication.

Fixes #10904

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10917)