### PR TITLE
feat(cosmos): support hierarchical partition keys

### DIFF
--- a/docs/site/src/content/docs/grains/grain-persistence/azure-cosmos-db.md
+++ b/docs/site/src/content/docs/grains/grain-persistence/azure-cosmos-db.md
@@ -22,7 +22,7 @@ Configure a named provider with <xref:Orleans.Hosting.HostingExtensions.AddCosmo
 
 The <xref:Orleans.Persistence.Cosmos.DefaultDocumentIdProvider> derives the document ID and partition key for each grain record. To customize either value, implement <xref:Orleans.Persistence.Cosmos.IDocumentIdProvider> and register it using the generic <xref:Orleans.Hosting.HostingExtensions.AddCosmosGrainStorage*?displayProperty=nameWithType> overload.
 
-Single-string partitioning remains the default. It uses <xref:Orleans.Persistence.Cosmos.CosmosGrainStorageOptions.PartitionKeyPath>, which defaults to `/PartitionKey`. Existing providers, containers, and documents continue to use this behavior without configuration changes.
+Single-string partitioning remains the default. It uses <xref:Orleans.Persistence.Cosmos.CosmosGrainStorageOptions.PartitionKeyPath>, which defaults to `/PartitionKey`. Existing containers partitioned by `/GrainType` remain compatible with the default document ID provider when the partition-key options are omitted.
 
 Set <xref:Orleans.Persistence.Cosmos.CosmosGrainStorageOptions.PartitionKeyLevelCount> to `2` or `3` to opt into hierarchical partition keys. Orleans uses these ordered paths:
 
@@ -32,47 +32,13 @@ Set <xref:Orleans.Persistence.Cosmos.CosmosGrainStorageOptions.PartitionKeyLevel
 
 The configured level count selects the first two or all three paths. An HPK-aware <xref:Orleans.Persistence.Cosmos.IDocumentIdProvider> returns the same number of values, in the same order, using <xref:Orleans.Persistence.Cosmos.IDocumentIdProvider.GetDocumentKey*>:
 
-```csharp
-using Microsoft.Extensions.Options;
-using Orleans.Configuration;
-using Orleans.Persistence.Cosmos;
-using Orleans.Runtime;
-
-public sealed class TenantDocumentIdProvider(IOptions<ClusterOptions> clusterOptions) : IDocumentIdProvider
-{
-    private readonly DefaultDocumentIdProvider _defaultProvider = new(clusterOptions);
-
-    public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(
-        string grainType,
-        GrainId grainId)
-    {
-        var tenantId = grainId.Key.ToString()!;
-        return new((_defaultProvider.GetId(grainType, grainId), tenantId));
-    }
-
-    public ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, GrainId grainId)
-    {
-        var tenantId = grainId.Key.ToString()!;
-        return new(new CosmosDocumentKey(
-            _defaultProvider.GetId(grainType, grainId),
-            [tenantId, grainType]));
-    }
-}
-```
+:::code language="csharp" source="../../snippets/compiled/Grains/PersistenceSnippets.cs" id="cosmos_hpk_document_id_provider":::
 
 Register the provider and select the matching depth:
 
-```csharp
-siloBuilder.AddCosmosGrainStorage<TenantDocumentIdProvider>(
-    "cosmosStore",
-    options =>
-    {
-        options.ConfigureCosmosClient(connectionString);
-        options.PartitionKeyLevelCount = 2;
-    });
-```
+:::code language="csharp" source="../../snippets/compiled/Grains/PersistenceSnippets.cs" id="configure_cosmos_hpk_storage":::
 
-At startup, Orleans reads the container definition and compares its partition-key paths with the provider configuration. Startup fails if the mode, path count, path names, or ordering differ. This check also runs when resource creation is disabled. A provider that returns the wrong number of values fails with an <xref:OrleansConfigurationException> before the grain operation reaches Cosmos DB.
+At startup, Orleans reads the container definition and compares its partition-key paths with the provider configuration. Except for the default provider's legacy `/GrainType` compatibility, startup fails if the mode, path count, path names, or ordering differ. This check also runs when resource creation is disabled. A provider that returns the wrong number of values fails with an <xref:Orleans.Runtime.OrleansConfigurationException> before the grain operation reaches Cosmos DB.
 
 Cosmos DB cannot change an existing container's partition-key definition in place. Moving from single-string partitioning to HPK requires a new container and a data copy or [container copy job](https://learn.microsoft.com/azure/cosmos-db/hierarchical-partition-keys-faq#can-i-add-hierarchical-partition-keys-to-existing-containers). Orleans does not migrate the data automatically. All silos using the same provider name must agree on the database, container, partition-key configuration, and provider implementation.
 

--- a/docs/site/src/content/docs/grains/grain-persistence/azure-cosmos-db.md
+++ b/docs/site/src/content/docs/grains/grain-persistence/azure-cosmos-db.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Cosmos DB grain persistence
 description: Configure Azure Cosmos DB for NoSQL as an Orleans grain storage provider.
-ms.date: 08/02/2026
+ms.date: 08/29/2026
 ms.topic: how-to
 ---
 
@@ -22,7 +22,59 @@ Configure a named provider with <xref:Orleans.Hosting.HostingExtensions.AddCosmo
 
 The <xref:Orleans.Persistence.Cosmos.DefaultDocumentIdProvider> derives the document ID and partition key for each grain record. To customize either value, implement <xref:Orleans.Persistence.Cosmos.IDocumentIdProvider> and register it using the generic <xref:Orleans.Hosting.HostingExtensions.AddCosmosGrainStorage*?displayProperty=nameWithType> overload.
 
-Changing the partition-key path or partition-key algorithm after data exists is a data migration. All silos using the same provider name must agree on the database, container, partition-key path, and provider implementation.
+Single-string partitioning remains the default. It uses <xref:Orleans.Persistence.Cosmos.CosmosGrainStorageOptions.PartitionKeyPath>, which defaults to `/PartitionKey`. Existing providers, containers, and documents continue to use this behavior without configuration changes.
+
+Set <xref:Orleans.Persistence.Cosmos.CosmosGrainStorageOptions.PartitionKeyLevelCount> to `2` or `3` to opt into hierarchical partition keys. Orleans uses these ordered paths:
+
+1. `/PartitionKey`
+1. `/PartitionKey2`
+1. `/PartitionKey3`
+
+The configured level count selects the first two or all three paths. An HPK-aware <xref:Orleans.Persistence.Cosmos.IDocumentIdProvider> returns the same number of values, in the same order, using <xref:Orleans.Persistence.Cosmos.IDocumentIdProvider.GetDocumentKey*>:
+
+```csharp
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Persistence.Cosmos;
+using Orleans.Runtime;
+
+public sealed class TenantDocumentIdProvider(IOptions<ClusterOptions> clusterOptions) : IDocumentIdProvider
+{
+    private readonly DefaultDocumentIdProvider _defaultProvider = new(clusterOptions);
+
+    public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(
+        string grainType,
+        GrainId grainId)
+    {
+        var tenantId = grainId.Key.ToString()!;
+        return new((_defaultProvider.GetId(grainType, grainId), tenantId));
+    }
+
+    public ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, GrainId grainId)
+    {
+        var tenantId = grainId.Key.ToString()!;
+        return new(new CosmosDocumentKey(
+            _defaultProvider.GetId(grainType, grainId),
+            [tenantId, grainType]));
+    }
+}
+```
+
+Register the provider and select the matching depth:
+
+```csharp
+siloBuilder.AddCosmosGrainStorage<TenantDocumentIdProvider>(
+    "cosmosStore",
+    options =>
+    {
+        options.ConfigureCosmosClient(connectionString);
+        options.PartitionKeyLevelCount = 2;
+    });
+```
+
+At startup, Orleans reads the container definition and compares its partition-key paths with the provider configuration. Startup fails if the mode, path count, path names, or ordering differ. This check also runs when resource creation is disabled. A provider that returns the wrong number of values fails with an <xref:OrleansConfigurationException> before the grain operation reaches Cosmos DB.
+
+Cosmos DB cannot change an existing container's partition-key definition in place. Moving from single-string partitioning to HPK requires a new container and a data copy or [container copy job](https://learn.microsoft.com/azure/cosmos-db/hierarchical-partition-keys-faq#can-i-add-hierarchical-partition-keys-to-existing-containers). Orleans does not migrate the data automatically. All silos using the same provider name must agree on the database, container, partition-key configuration, and provider implementation.
 
 Use <xref:Orleans.Persistence.Cosmos.CosmosGrainStorageOptions.StateFieldsToIndex> to opt selected serialized state fields into indexing. Index only fields used by operational queries: additional indexing increases write cost. Grain storage itself retrieves records by identity and doesn't provide a general query API.
 

--- a/docs/site/src/content/docs/snippets/compiled/Grains/PersistenceSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Grains/PersistenceSnippets.cs
@@ -12,6 +12,9 @@ namespace Documentation.Grains.Persistence.Cosmos
     // <azure_identity_using_cosmos>
 using Azure.Identity;
     // </azure_identity_using_cosmos>
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Persistence.Cosmos;
 
     internal static class CosmosStorage
     {
@@ -30,6 +33,50 @@ siloBuilder.AddCosmosGrainStorage(
         options.IsResourceCreationEnabled = false;
     });
             // </configure_cosmos_storage>
+        }
+    }
+
+    // <cosmos_hpk_document_id_provider>
+    /// <summary>
+    /// Derives a document ID and two ordered partition-key values for each grain record.
+    /// </summary>
+    public sealed class TenantDocumentIdProvider(IOptions<ClusterOptions> clusterOptions) : IDocumentIdProvider
+    {
+        private readonly DefaultDocumentIdProvider _defaultProvider = new(clusterOptions);
+
+        /// <inheritdoc />
+        public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(
+            string grainType,
+            GrainId grainId)
+        {
+            var tenantId = grainId.Key.ToString()!;
+            return new((_defaultProvider.GetId(grainType, grainId), tenantId));
+        }
+
+        /// <inheritdoc />
+        public ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, GrainId grainId)
+        {
+            var tenantId = grainId.Key.ToString()!;
+            return new(new CosmosDocumentKey(
+                _defaultProvider.GetId(grainType, grainId),
+                [tenantId, grainType]));
+        }
+    }
+    // </cosmos_hpk_document_id_provider>
+
+    internal static class CosmosHierarchicalPartitionKeys
+    {
+        internal static void Configure(ISiloBuilder siloBuilder, string connectionString)
+        {
+            // <configure_cosmos_hpk_storage>
+siloBuilder.AddCosmosGrainStorage<TenantDocumentIdProvider>(
+    "cosmosStore",
+    options =>
+    {
+        options.ConfigureCosmosClient(connectionString);
+        options.PartitionKeyLevelCount = 2;
+    });
+            // </configure_cosmos_hpk_storage>
         }
     }
 }

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosDocumentKey.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosDocumentKey.cs
@@ -1,0 +1,8 @@
+namespace Orleans.Persistence.Cosmos;
+
+/// <summary>
+/// Identifies a Cosmos DB grain-state document and its ordered partition-key values.
+/// </summary>
+/// <param name="DocumentId">The document identifier.</param>
+/// <param name="PartitionKeyValues">The partition-key values, in container partition-key path order.</param>
+public readonly record struct CosmosDocumentKey(string DocumentId, IReadOnlyList<string> PartitionKeyValues);

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -11,12 +11,17 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
 {
     private const string ANY_ETAG = "*";
     private const string GRAINTYPE_PARTITION_KEY_PATH = "/GrainType";
+    private static readonly string[] HIERARCHICAL_PARTITION_KEY_PATHS = [
+        CosmosGrainStorageOptions.DEFAULT_PARTITION_KEY_PATH,
+        "/PartitionKey2",
+        "/PartitionKey3"
+    ];
     private readonly ILogger _logger;
     private readonly CosmosGrainStorageOptions _options;
     private readonly string _name;
     private readonly IServiceProvider _serviceProvider;
     private readonly string _serviceId;
-    private string _partitionKeyPath;
+    private readonly string[] _partitionKeyPaths;
     private readonly IDocumentIdProvider _documentIdProvider;
     private readonly IActivatorProvider _activatorProvider;
     private readonly ICosmosOperationExecutor _executor;
@@ -40,24 +45,24 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
         _documentIdProvider = documentIdProvider;
         _activatorProvider = activatorProvider;
         _executor = options.OperationExecutor;
-        _partitionKeyPath = _options.PartitionKeyPath;
+        _partitionKeyPaths = GetPartitionKeyPaths(options, name);
     }
 
     public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
     {
-        var (id, partitionKey) = await _documentIdProvider.GetDocumentIdentifiers(grainType, grainId);
+        var documentKey = await ResolveDocumentKey(grainType, grainId);
+        var id = documentKey.DocumentId;
 
-        LogTraceReadingState(grainType, id, grainId, _options.ContainerName, partitionKey);
+        LogTraceReadingState(grainType, id, grainId, _options.ContainerName, documentKey.PartitionKey.ToString());
 
         try
         {
-            var pk = new PartitionKey(partitionKey);
             var entity = await _executor.ExecuteOperation(static args =>
             {
                 var (self, id, pk) = args;
                 return self._container.ReadItemAsync<GrainStateEntity<T>>(id, pk);
             },
-            (this, id, pk)).ConfigureAwait(false);
+            (this, id, documentKey.PartitionKey)).ConfigureAwait(false);
 
             if (entity.Resource.State != null)
             {
@@ -95,24 +100,18 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
 
     public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
     {
-        var (id, partitionKey) = await _documentIdProvider.GetDocumentIdentifiers(grainType, grainId);
+        var documentKey = await ResolveDocumentKey(grainType, grainId);
+        var id = documentKey.DocumentId;
 
-        LogTraceWritingState(grainType, id, grainId, grainState.ETag, _options.ContainerName, partitionKey);
+        LogTraceWritingState(grainType, id, grainId, grainState.ETag, _options.ContainerName, documentKey.PartitionKey.ToString());
 
         ItemResponse<GrainStateEntity<T>>? response = null;
 
         try
         {
-            var entity = new GrainStateEntity<T>
-            {
-                ETag = grainState.ETag,
-                Id = id,
-                GrainType = grainType,
-                State = grainState.State,
-                PartitionKey = partitionKey
-            };
+            var entity = CreateEntity(documentKey, grainType, grainState.State, grainState.ETag);
 
-            var pk = new PartitionKey(partitionKey);
+            var pk = documentKey.PartitionKey;
             if (string.IsNullOrWhiteSpace(grainState.ETag))
             {
                 response = await _executor.ExecuteOperation(
@@ -163,11 +162,12 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
 
     public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
     {
-        var (id, partitionKey) = await _documentIdProvider.GetDocumentIdentifiers(grainType, grainId);
+        var documentKey = await ResolveDocumentKey(grainType, grainId);
+        var id = documentKey.DocumentId;
 
-        LogTraceClearingState(grainType, id, grainId, grainState.ETag, _options.DeleteStateOnClear, _options.ContainerName, partitionKey);
+        LogTraceClearingState(grainType, id, grainId, grainState.ETag, _options.DeleteStateOnClear, _options.ContainerName, documentKey.PartitionKey.ToString());
 
-        var pk = new PartitionKey(partitionKey);
+        var pk = documentKey.PartitionKey;
         var requestOptions = new ItemRequestOptions { IfMatchEtag = grainState.ETag };
         try
         {
@@ -208,14 +208,7 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
             }
             else
             {
-                var entity = new GrainStateEntity<T>
-                {
-                    ETag = grainState.ETag,
-                    Id = id,
-                    GrainType = grainType,
-                    State = default,
-                    PartitionKey = partitionKey
-                };
+                var entity = CreateEntity<T>(documentKey, grainType, default, grainState.ETag);
 
                 var response = await _executor.ExecuteOperation(static args =>
                 {
@@ -259,6 +252,12 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
         {
             LogDebugInit(_name, _serviceId, _options.ContainerName, _options.DeleteStateOnClear);
 
+            if (_partitionKeyPaths.Length > 1 && _documentIdProvider is DefaultDocumentIdProvider)
+            {
+                throw new OrleansConfigurationException(
+                    $"Azure Cosmos DB grain storage provider '{_name}' is configured for {_partitionKeyPaths.Length}-level hierarchical partition keys, but the default or legacy document identifier provider supplies only one partition-key value. Configure an HPK-aware {nameof(IDocumentIdProvider)}.");
+            }
+
             await InitializeCosmosClient().ConfigureAwait(false);
 
             if (_options.IsResourceCreationEnabled)
@@ -272,6 +271,7 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
             }
 
             _container = _client.GetContainer(_options.DatabaseName, _options.ContainerName);
+            await ValidateContainerPartitionKeyDefinition(ct).ConfigureAwait(false);
 
             stopWatch.Stop();
             LogDebugInitializingProvider(_name, GetType().Name, _options.InitStage, stopWatch.ElapsedMilliseconds);
@@ -304,11 +304,16 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
         var dbResponse = await _client.CreateDatabaseIfNotExistsAsync(_options.DatabaseName, _options.DatabaseThroughput);
         var db = dbResponse.Database;
 
-        var stateContainer = new ContainerProperties(_options.ContainerName, _options.PartitionKeyPath);
+        var stateContainer = _partitionKeyPaths.Length == 1
+            ? new ContainerProperties(_options.ContainerName, _partitionKeyPaths[0])
+            : new ContainerProperties(_options.ContainerName, _partitionKeyPaths);
         stateContainer.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
         stateContainer.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/*" });
         stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = $"/{nameof(GrainStateEntity<object>.GrainType)}/?" });
-        stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = ToScalarIndexPath(_options.PartitionKeyPath) });
+        foreach (var partitionKeyPath in _partitionKeyPaths)
+        {
+            stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = ToScalarIndexPath(partitionKeyPath) });
+        }
 
         if (_options.StateFieldsToIndex != null)
         {
@@ -327,8 +332,8 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
             if (containerResponse.StatusCode == HttpStatusCode.OK || containerResponse.StatusCode == HttpStatusCode.Created)
             {
                 var container = containerResponse.Resource;
-                _partitionKeyPath = container.PartitionKeyPath;
-                if (_partitionKeyPath == GRAINTYPE_PARTITION_KEY_PATH &&
+                if (_partitionKeyPaths.Length == 1 &&
+                    container.PartitionKeyPaths is [GRAINTYPE_PARTITION_KEY_PATH] &&
                     (_documentIdProvider is not DefaultDocumentIdProvider defaultProvider || defaultProvider.HasCustomPartitionKeyProvider))
                     throw new OrleansConfigurationException("Custom document id or partition key providers are not compatible with partition key path set to /GrainType");
             }
@@ -340,6 +345,116 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
             await Task.Delay(1000);
         }
     }
+
+    private async Task ValidateContainerPartitionKeyDefinition(CancellationToken cancellationToken)
+    {
+        var response = await _container.ReadContainerAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        ValidateContainerPartitionKeyPaths(_partitionKeyPaths, response.Resource.PartitionKeyPaths, _name, _options.ContainerName);
+    }
+
+    internal static void ValidateContainerPartitionKeyPaths(
+        IReadOnlyList<string> configuredPaths,
+        IReadOnlyList<string>? containerPaths,
+        string providerName,
+        string containerName)
+    {
+        if (containerPaths is not null && configuredPaths.SequenceEqual(containerPaths, StringComparer.Ordinal))
+        {
+            return;
+        }
+
+        var configuredDescription = DescribePartitionKeyDefinition(configuredPaths);
+        var containerDescription = containerPaths is null
+            ? "an unavailable partition-key definition"
+            : DescribePartitionKeyDefinition(containerPaths);
+        throw new OrleansConfigurationException(
+            $"Azure Cosmos DB grain storage provider '{providerName}' is configured for {configuredDescription}, but container '{containerName}' uses {containerDescription}. The configured partition-key paths must match the existing container in number, order, and name.");
+    }
+
+    internal async ValueTask<ResolvedDocumentKey> ResolveDocumentKey(string grainType, GrainId grainId)
+    {
+        var documentKey = await _documentIdProvider.GetDocumentKey(grainType, grainId).ConfigureAwait(false);
+        var partitionKeyValues = documentKey.PartitionKeyValues?.ToArray();
+        if (partitionKeyValues is null || partitionKeyValues.Length != _partitionKeyPaths.Length)
+        {
+            var actualCount = partitionKeyValues?.Length ?? 0;
+            throw new OrleansConfigurationException(
+                $"The {nameof(IDocumentIdProvider)} for Azure Cosmos DB grain storage provider '{_name}' returned {actualCount} partition-key value(s) for grain '{grainId}', but {PartitionKeyLevelCountDescription(_partitionKeyPaths.Length)} requires {_partitionKeyPaths.Length}.");
+        }
+
+        if (partitionKeyValues.Any(static value => value is null))
+        {
+            throw new OrleansConfigurationException(
+                $"The {nameof(IDocumentIdProvider)} for Azure Cosmos DB grain storage provider '{_name}' returned a null partition-key value for grain '{grainId}'. Partition-key values must be non-null strings.");
+        }
+
+        var partitionKey = partitionKeyValues.Length == 1
+            ? new PartitionKey(partitionKeyValues[0])
+            : BuildHierarchicalPartitionKey(partitionKeyValues);
+        return new(documentKey.DocumentId, partitionKeyValues, partitionKey);
+    }
+
+    private static PartitionKey BuildHierarchicalPartitionKey(IEnumerable<string> partitionKeyValues)
+    {
+        var builder = new PartitionKeyBuilder();
+        foreach (var value in partitionKeyValues)
+        {
+            builder.Add(value);
+        }
+
+        return builder.Build();
+    }
+
+    internal static GrainStateEntity<T> CreateEntity<T>(ResolvedDocumentKey documentKey, string grainType, T? state, string? etag)
+    {
+        return new GrainStateEntity<T>
+        {
+            ETag = etag,
+            Id = documentKey.DocumentId,
+            GrainType = grainType,
+            State = state,
+            PartitionKey = documentKey.PartitionKeyValues[0],
+            PartitionKey2 = documentKey.PartitionKeyValues.Length > 1 ? documentKey.PartitionKeyValues[1] : null,
+            PartitionKey3 = documentKey.PartitionKeyValues.Length > 2 ? documentKey.PartitionKeyValues[2] : null
+        };
+    }
+
+    private static string[] GetPartitionKeyPaths(CosmosGrainStorageOptions options, string providerName)
+    {
+        if (options.PartitionKeyLevelCount is < 1 or > 3)
+        {
+            throw new OrleansConfigurationException(
+                $"Azure Cosmos DB grain storage provider '{providerName}' has an invalid {nameof(options.PartitionKeyLevelCount)} value of {options.PartitionKeyLevelCount}. Supported values are 1, 2, and 3.");
+        }
+
+        if (options.PartitionKeyLevelCount == 1)
+        {
+            if (string.IsNullOrWhiteSpace(options.PartitionKeyPath))
+            {
+                throw new OrleansConfigurationException(
+                    $"Azure Cosmos DB grain storage provider '{providerName}' has an invalid {nameof(options.PartitionKeyPath)} value.");
+            }
+
+            return [options.PartitionKeyPath];
+        }
+
+        if (!string.Equals(options.PartitionKeyPath, CosmosGrainStorageOptions.DEFAULT_PARTITION_KEY_PATH, StringComparison.Ordinal))
+        {
+            throw new OrleansConfigurationException(
+                $"Azure Cosmos DB grain storage provider '{providerName}' cannot use a custom {nameof(options.PartitionKeyPath)} with hierarchical partition keys. Hierarchical partition keys use /PartitionKey, /PartitionKey2, and /PartitionKey3 in order.");
+        }
+
+        return HIERARCHICAL_PARTITION_KEY_PATHS[..options.PartitionKeyLevelCount];
+    }
+
+    private static string DescribePartitionKeyDefinition(IReadOnlyList<string> paths)
+    {
+        var mode = paths.Count == 1 ? "single-string partitioning" : $"{paths.Count}-level hierarchical partitioning";
+        return $"{mode} with path(s) [{string.Join(", ", paths)}]";
+    }
+
+    private static string PartitionKeyLevelCountDescription(int levelCount) =>
+        levelCount == 1 ? "single-string partitioning" : $"{levelCount}-level hierarchical partitioning";
 
     private async Task TryDeleteDatabase()
     {
@@ -445,6 +560,11 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
     )]
     private partial void LogErrorDeletingDatabase(Exception exception);
 }
+
+internal readonly record struct ResolvedDocumentKey(
+    string DocumentId,
+    string[] PartitionKeyValues,
+    PartitionKey PartitionKey);
 
 public static class CosmosStorageFactory
 {

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -351,13 +351,20 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
     private async Task ValidateContainerPartitionKeyDefinition(CancellationToken cancellationToken)
     {
         var response = await _container.ReadContainerAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        ValidateContainerPartitionKeyPaths(_partitionKeyPaths, response.Resource.PartitionKeyPaths, _name, _options.ContainerName);
+        var containerPaths = response.Resource.PartitionKeyPaths;
+        var usesSingleGrainTypePartitioning = _partitionKeyPaths.Length == 1 && containerPaths is [GRAINTYPE_PARTITION_KEY_PATH];
 
-        if (_partitionKeyPaths.Length == 1 &&
-            response.Resource.PartitionKeyPaths is [GRAINTYPE_PARTITION_KEY_PATH] &&
+        if (usesSingleGrainTypePartitioning &&
             (_documentIdProvider is not DefaultDocumentIdProvider defaultProvider || defaultProvider.HasCustomPartitionKeyProvider))
         {
             throw new OrleansConfigurationException("Custom document id or partition key providers are not compatible with partition key path set to /GrainType");
+        }
+
+        var usesLegacyDefaultPartitioning = usesSingleGrainTypePartitioning &&
+            string.Equals(_partitionKeyPaths[0], CosmosGrainStorageOptions.DEFAULT_PARTITION_KEY_PATH, StringComparison.Ordinal);
+        if (!usesLegacyDefaultPartitioning)
+        {
+            ValidateContainerPartitionKeyPaths(_partitionKeyPaths, containerPaths, _name, _options.ContainerName);
         }
     }
 

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -259,6 +259,8 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
             }
 
             await InitializeCosmosClient().ConfigureAwait(false);
+            _container = _client.GetContainer(_options.DatabaseName, _options.ContainerName);
+            var containerValidated = false;
 
             if (_options.IsResourceCreationEnabled)
             {
@@ -266,12 +268,21 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
                 {
                     await TryDeleteDatabase().ConfigureAwait(false);
                 }
+                else
+                {
+                    containerValidated = await ValidateContainerPartitionKeyDefinitionIfExists(ct).ConfigureAwait(false);
+                }
 
-                await TryCreateResources().ConfigureAwait(false);
+                if (!containerValidated)
+                {
+                    await TryCreateResources().ConfigureAwait(false);
+                }
             }
 
-            _container = _client.GetContainer(_options.DatabaseName, _options.ContainerName);
-            await ValidateContainerPartitionKeyDefinition(ct).ConfigureAwait(false);
+            if (!containerValidated)
+            {
+                await ValidateContainerPartitionKeyDefinition(ct).ConfigureAwait(false);
+            }
 
             stopWatch.Stop();
             LogDebugInitializingProvider(_name, GetType().Name, _options.InitStage, stopWatch.ElapsedMilliseconds);
@@ -329,15 +340,6 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
         {
             var containerResponse = await db.CreateContainerIfNotExistsAsync(stateContainer, _options.ContainerThroughputProperties);
 
-            if (containerResponse.StatusCode == HttpStatusCode.OK || containerResponse.StatusCode == HttpStatusCode.Created)
-            {
-                var container = containerResponse.Resource;
-                if (_partitionKeyPaths.Length == 1 &&
-                    container.PartitionKeyPaths is [GRAINTYPE_PARTITION_KEY_PATH] &&
-                    (_documentIdProvider is not DefaultDocumentIdProvider defaultProvider || defaultProvider.HasCustomPartitionKeyProvider))
-                    throw new OrleansConfigurationException("Custom document id or partition key providers are not compatible with partition key path set to /GrainType");
-            }
-
             if (retry == maxRetries || dbResponse.StatusCode != HttpStatusCode.Created || containerResponse.StatusCode == HttpStatusCode.Created)
             {
                 break;  // Apparently some throttling logic returns HttpStatusCode.OK (not 429) when the collection wasn't created in a new DB.
@@ -350,6 +352,29 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
     {
         var response = await _container.ReadContainerAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         ValidateContainerPartitionKeyPaths(_partitionKeyPaths, response.Resource.PartitionKeyPaths, _name, _options.ContainerName);
+
+        if (_partitionKeyPaths.Length == 1 &&
+            response.Resource.PartitionKeyPaths is [GRAINTYPE_PARTITION_KEY_PATH] &&
+            (_documentIdProvider is not DefaultDocumentIdProvider defaultProvider || defaultProvider.HasCustomPartitionKeyProvider))
+        {
+            throw new OrleansConfigurationException("Custom document id or partition key providers are not compatible with partition key path set to /GrainType");
+        }
+    }
+
+    /// <summary>
+    /// Validates the existing container, returning <see langword="false"/> when the database or container does not exist.
+    /// </summary>
+    private async Task<bool> ValidateContainerPartitionKeyDefinitionIfExists(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await ValidateContainerPartitionKeyDefinition(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (CosmosException exception) when (exception.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
+        }
     }
 
     internal static void ValidateContainerPartitionKeyPaths(

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosStorageOptions.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosStorageOptions.cs
@@ -9,7 +9,7 @@ public class CosmosGrainStorageOptions : CosmosOptions
 {
     private const string ORLEANS_STORAGE_CONTAINER = "OrleansStorage";
     public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
-    private const string DEFAULT_PARTITION_KEY_PATH = "/PartitionKey";
+    internal const string DEFAULT_PARTITION_KEY_PATH = "/PartitionKey";
 
     /// <summary>
     /// Stage of silo lifecycle where storage should be initialized. Storage must be initialized prior to use.
@@ -28,7 +28,19 @@ public class CosmosGrainStorageOptions : CosmosOptions
     /// </summary>
     public List<string> StateFieldsToIndex { get; set; } = new();
 
+    /// <summary>
+    /// Gets or sets the partition-key path used when <see cref="PartitionKeyLevelCount"/> is <c>1</c>.
+    /// </summary>
     public string PartitionKeyPath { get; set; } = DEFAULT_PARTITION_KEY_PATH;
+
+    /// <summary>
+    /// Gets or sets the number of partition-key levels. The supported values are <c>1</c>, <c>2</c>, and <c>3</c>.
+    /// The default is <c>1</c>.
+    /// </summary>
+    /// <remarks>
+    /// Values greater than <c>1</c> use <c>/PartitionKey</c>, <c>/PartitionKey2</c>, and <c>/PartitionKey3</c>, in order.
+    /// </remarks>
+    public int PartitionKeyLevelCount { get; set; } = 1;
 
     /// <summary>
     /// Initializes a new <see cref="CosmosGrainStorageOptions"/> instance.

--- a/src/Azure/Orleans.Persistence.Cosmos/IDocumentIdProvider.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/IDocumentIdProvider.cs
@@ -12,4 +12,16 @@ public interface IDocumentIdProvider
     /// <param name="grainId">The grain identifier.</param>
     /// <returns>The document id and partition key.</returns>
     ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId);
+
+    /// <summary>
+    /// Gets the document identifier and ordered partition-key values for the specified grain.
+    /// </summary>
+    /// <param name="grainType">The grain type.</param>
+    /// <param name="grainId">The grain identifier.</param>
+    /// <returns>The document identifier and ordered partition-key values.</returns>
+    async ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, GrainId grainId)
+    {
+        var (documentId, partitionKey) = await GetDocumentIdentifiers(grainType, grainId).ConfigureAwait(false);
+        return new(documentId, new[] { partitionKey });
+    }
 }

--- a/src/Azure/Orleans.Persistence.Cosmos/Models/GrainStateEntity.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/Models/GrainStateEntity.cs
@@ -15,4 +15,14 @@ internal class GrainStateEntity<TState> : BaseEntity
     [JsonProperty(nameof(PartitionKey))]
     [JsonPropertyName(nameof(PartitionKey))]
     public string PartitionKey { get; set; } = default!;
+
+    [JsonProperty(nameof(PartitionKey2), NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName(nameof(PartitionKey2))]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PartitionKey2 { get; set; }
+
+    [JsonProperty(nameof(PartitionKey3), NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName(nameof(PartitionKey3))]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PartitionKey3 { get; set; }
 }

--- a/src/Azure/Orleans.Persistence.Cosmos/README.md
+++ b/src/Azure/Orleans.Persistence.Cosmos/README.md
@@ -37,6 +37,48 @@ var builder = Host.CreateApplicationBuilder(args)
 await builder.RunAsync();
 ```
 
+## Hierarchical partition keys
+
+Single-string partitioning remains the default and continues to use `PartitionKeyPath`, which defaults to `/PartitionKey`. Existing applications do not need code or configuration changes.
+
+To opt into a two-level or three-level hierarchical partition key, set `PartitionKeyLevelCount` and register an `IDocumentIdProvider` that returns the same number of ordered values from `GetDocumentKey`:
+
+```csharp
+public sealed class TenantDocumentIdProvider(
+    IOptions<ClusterOptions> clusterOptions) : IDocumentIdProvider
+{
+    private readonly DefaultDocumentIdProvider _defaultProvider = new(clusterOptions);
+
+    public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(
+        string grainType,
+        GrainId grainId)
+    {
+        var tenantId = grainId.Key.ToString()!;
+        return new((_defaultProvider.GetId(grainType, grainId), tenantId));
+    }
+
+    public ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, GrainId grainId)
+    {
+        var tenantId = grainId.Key.ToString()!;
+        return new(new CosmosDocumentKey(
+            _defaultProvider.GetId(grainType, grainId),
+            [tenantId, grainType]));
+    }
+}
+
+siloBuilder.AddCosmosGrainStorage<TenantDocumentIdProvider>(
+    "cosmosStore",
+    options =>
+    {
+        options.ConfigureCosmosClient(connectionString);
+        options.PartitionKeyLevelCount = 2;
+    });
+```
+
+Two levels use `/PartitionKey` and `/PartitionKey2`. Three levels also use `/PartitionKey3`. The values returned by `GetDocumentKey` must follow that order.
+
+During startup, Orleans verifies that the actual container has the configured path count, names, and order. The check runs even when resource creation is disabled. Cosmos DB cannot convert an existing single-key container to HPK in place. Create a new container and copy the data when migrating; Orleans does not perform that migration.
+
 ## Example - Using Grain Storage in a Grain
 ```csharp
 // Define grain state class

--- a/src/api/Azure/Orleans.Persistence.Cosmos/Orleans.Persistence.Cosmos.cs
+++ b/src/api/Azure/Orleans.Persistence.Cosmos/Orleans.Persistence.Cosmos.cs
@@ -79,6 +79,38 @@ namespace Orleans.Persistence.Cosmos
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 
+    public readonly partial struct CosmosDocumentKey : System.IEquatable<CosmosDocumentKey>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public CosmosDocumentKey(string DocumentId, System.Collections.Generic.IReadOnlyList<string> PartitionKeyValues) { }
+
+        public string DocumentId { get { throw null; } init { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> PartitionKeyValues { get { throw null; } init { } }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        public readonly void Deconstruct(out string DocumentId, out System.Collections.Generic.IReadOnlyList<string> PartitionKeyValues) { throw null; }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        public readonly bool Equals(CosmosDocumentKey other) { throw null; }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        public override readonly bool Equals(object obj) { throw null; }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        public override readonly int GetHashCode() { throw null; }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        public static bool operator ==(CosmosDocumentKey left, CosmosDocumentKey right) { throw null; }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        public static bool operator !=(CosmosDocumentKey left, CosmosDocumentKey right) { throw null; }
+
+        [System.Runtime.CompilerServices.CompilerGenerated]
+        public override readonly string ToString() { throw null; }
+    }
+
     public sealed partial class CosmosGrainStorage : Storage.IGrainStorage, ILifecycleParticipant<Runtime.ISiloLifecycle>
     {
         public CosmosGrainStorage(string name, CosmosGrainStorageOptions options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, System.IServiceProvider serviceProvider, Microsoft.Extensions.Options.IOptions<Configuration.ClusterOptions> clusterOptions, IDocumentIdProvider documentIdProvider, Serialization.Serializers.IActivatorProvider activatorProvider) { }
@@ -98,6 +130,8 @@ namespace Orleans.Persistence.Cosmos
         public bool DeleteStateOnClear { get { throw null; } set { } }
 
         public int InitStage { get { throw null; } set { } }
+
+        public int PartitionKeyLevelCount { get { throw null; } set { } }
 
         public string PartitionKeyPath { get { throw null; } set { } }
 
@@ -164,6 +198,8 @@ namespace Orleans.Persistence.Cosmos
     public partial interface IDocumentIdProvider
     {
         System.Threading.Tasks.ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, Runtime.GrainId grainId);
+        [System.Diagnostics.DebuggerStepThrough]
+        System.Threading.Tasks.ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, Runtime.GrainId grainId);
     }
 
     [System.Obsolete("Use IDocumentIdProvider instead.")]

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkIntegrationTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkIntegrationTests.cs
@@ -1,0 +1,385 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+using Orleans.Configuration;
+using Orleans.Persistence.Cosmos;
+using Orleans.Runtime;
+using Orleans.Storage;
+using TestExtensions;
+
+namespace Tester.Cosmos.Persistence;
+
+/// <summary>
+/// Tests hierarchical partition keys against Azure Cosmos DB or the Cosmos DB emulator.
+/// </summary>
+[Collection(TestEnvironmentFixture.DefaultCollection)]
+[TestCategory("Persistence"), TestCategory("Cosmos")]
+[TestSuite("Functional")]
+[TestProvider("Cosmos")]
+[TestArea("Persistence")]
+public class CosmosGrainStorageHpkIntegrationTests
+{
+    private readonly IServiceProvider _services;
+
+    public CosmosGrainStorageHpkIntegrationTests(TestEnvironmentFixture fixture)
+    {
+        CosmosTestUtils.CheckCosmosStorage();
+        _services = fixture.Services;
+    }
+
+    [Theory, TestCategory("Functional")]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async Task HierarchicalPartitionKeys_SupportFullLifecycleAndOptimisticConcurrency(int partitionKeyLevelCount)
+    {
+        var databaseName = $"OrleansHpk{Guid.NewGuid():N}";
+        const string containerName = "GrainState";
+        var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "cluster", ServiceId = "service" });
+        var documentIdProvider = new HierarchicalDocumentIdProvider(clusterOptions, partitionKeyLevelCount);
+        var options = CreateOptions(databaseName, containerName, partitionKeyLevelCount, deleteStateOnClear: false);
+        var client = await options.CreateClient(_services);
+
+        try
+        {
+            var storage = await StartStorage(options, clusterOptions, documentIdProvider);
+            var grainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N"));
+            const string grainType = "test-grain-type";
+            var state = new GrainState<TestState> { State = new TestState { Value = 1 } };
+
+            await storage.WriteStateAsync(grainType, grainId, state);
+            Assert.True(state.RecordExists);
+            Assert.False(string.IsNullOrWhiteSpace(state.ETag));
+
+            var storedState = new GrainState<TestState> { State = new TestState() };
+            await storage.ReadStateAsync(grainType, grainId, storedState);
+            Assert.True(storedState.RecordExists);
+            Assert.Equal(1, storedState.State.Value);
+
+            var documentKey = await documentIdProvider.GetDocumentKey(grainType, grainId);
+            var partitionKey = BuildPartitionKey(documentKey.PartitionKeyValues);
+            var document = await client.GetContainer(databaseName, containerName).ReadItemAsync<JObject>(
+                documentKey.DocumentId,
+                partitionKey,
+                cancellationToken: TestContext.Current.CancellationToken);
+            Assert.Equal("tenant", document.Resource.Value<string>("PartitionKey"));
+            Assert.Equal(grainType, document.Resource.Value<string>("PartitionKey2"));
+            Assert.Equal(partitionKeyLevelCount == 3 ? "region" : null, document.Resource.Value<string>("PartitionKey3"));
+
+            var staleEtag = storedState.ETag;
+            storedState.State.Value = 2;
+            await storage.WriteStateAsync(grainType, grainId, storedState);
+
+            var staleState = new GrainState<TestState>
+            {
+                ETag = staleEtag,
+                State = new TestState { Value = 3 }
+            };
+            await Assert.ThrowsAsync<CosmosConditionNotSatisfiedException>(
+                () => storage.WriteStateAsync(grainType, grainId, staleState));
+
+            await storage.ClearStateAsync(grainType, grainId, storedState);
+            Assert.False(storedState.RecordExists);
+            var clearedState = new GrainState<TestState> { State = new TestState() };
+            await storage.ReadStateAsync(grainType, grainId, clearedState);
+            Assert.False(clearedState.RecordExists);
+
+            var deleteOptions = CreateOptions(databaseName, containerName, partitionKeyLevelCount, deleteStateOnClear: true);
+            var deleteStorage = await StartStorage(deleteOptions, clusterOptions, documentIdProvider);
+            var deleteGrainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N"));
+            var deleteState = new GrainState<TestState> { State = new TestState { Value = 4 } };
+            await deleteStorage.WriteStateAsync(grainType, deleteGrainId, deleteState);
+            var deleteDocumentKey = await documentIdProvider.GetDocumentKey(grainType, deleteGrainId);
+            await deleteStorage.ClearStateAsync(grainType, deleteGrainId, deleteState);
+
+            var exception = await Assert.ThrowsAsync<CosmosException>(() =>
+                client.GetContainer(databaseName, containerName).ReadItemAsync<JObject>(
+                    deleteDocumentKey.DocumentId,
+                    BuildPartitionKey(deleteDocumentKey.PartitionKeyValues),
+                    cancellationToken: TestContext.Current.CancellationToken));
+            Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
+        }
+        finally
+        {
+            await DeleteDatabase(client, databaseName);
+            client.Dispose();
+        }
+    }
+
+    [Theory, TestCategory("Functional")]
+    [InlineData(SinglePartitionKeyProviderKind.Default)]
+    [InlineData(SinglePartitionKeyProviderKind.ExistingDocumentIdProvider)]
+    [InlineData(SinglePartitionKeyProviderKind.LegacyPartitionKeyProvider)]
+    public async Task SinglePartitionKeyMode_PreservesExistingProviderBehavior(SinglePartitionKeyProviderKind providerKind)
+    {
+        var databaseName = $"OrleansSingleKey{Guid.NewGuid():N}";
+        const string containerName = "GrainState";
+        var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "cluster", ServiceId = "service" });
+        var options = CreateOptions(databaseName, containerName, 1, deleteStateOnClear: false);
+        var client = await options.CreateClient(_services);
+        var defaultProvider = new DefaultDocumentIdProvider(clusterOptions);
+        IDocumentIdProvider documentIdProvider = providerKind switch
+        {
+            SinglePartitionKeyProviderKind.Default => defaultProvider,
+            SinglePartitionKeyProviderKind.ExistingDocumentIdProvider => new ExistingDocumentIdProvider(defaultProvider),
+#pragma warning disable CS0618 // Type or member is obsolete
+            _ => new DefaultDocumentIdProvider(clusterOptions, new LegacyPartitionKeyProvider())
+#pragma warning restore CS0618 // Type or member is obsolete
+        };
+
+        try
+        {
+            var storage = await StartStorage(options, clusterOptions, documentIdProvider);
+            var properties = await client.GetContainer(databaseName, containerName).ReadContainerAsync(
+                cancellationToken: TestContext.Current.CancellationToken);
+            Assert.Equal(["/PartitionKey"], properties.Resource.PartitionKeyPaths);
+
+            var grainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N"));
+            var state = new GrainState<TestState> { State = new TestState { Value = 5 } };
+            await storage.WriteStateAsync("grain-type", grainId, state);
+            var readState = new GrainState<TestState> { State = new TestState() };
+            await storage.ReadStateAsync("grain-type", grainId, readState);
+
+            Assert.True(readState.RecordExists);
+            Assert.Equal(5, readState.State.Value);
+        }
+        finally
+        {
+            await DeleteDatabase(client, databaseName);
+            client.Dispose();
+        }
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task CustomSinglePartitionKeyPath_RemainsSupported()
+    {
+        var databaseName = $"OrleansCustomPath{Guid.NewGuid():N}";
+        const string containerName = "GrainState";
+        var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "cluster", ServiceId = "service" });
+        var options = CreateOptions(databaseName, containerName, 1, deleteStateOnClear: false);
+        options.PartitionKeyPath = "/GrainType";
+        var client = await options.CreateClient(_services);
+
+        try
+        {
+            var storage = await StartStorage(options, clusterOptions, new DefaultDocumentIdProvider(clusterOptions));
+            var properties = await client.GetContainer(databaseName, containerName).ReadContainerAsync(
+                cancellationToken: TestContext.Current.CancellationToken);
+            Assert.Equal(["/GrainType"], properties.Resource.PartitionKeyPaths);
+
+            var grainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N"));
+            var state = new GrainState<TestState> { State = new TestState { Value = 6 } };
+            await storage.WriteStateAsync("grain-type", grainId, state);
+            var readState = new GrainState<TestState> { State = new TestState() };
+            await storage.ReadStateAsync("grain-type", grainId, readState);
+
+            Assert.True(readState.RecordExists);
+            Assert.Equal(6, readState.State.Value);
+        }
+        finally
+        {
+            await DeleteDatabase(client, databaseName);
+            client.Dispose();
+        }
+    }
+
+    [Theory, TestCategory("Functional")]
+    [MemberData(nameof(MismatchedContainerDefinitions))]
+    public async Task Startup_RejectsMismatchedContainerPartitionKeyDefinition(
+        int configuredLevelCount,
+        string[] containerPaths,
+        bool resourceCreationEnabled)
+    {
+        var databaseName = $"OrleansHpkMismatch{Guid.NewGuid():N}";
+        const string containerName = "GrainState";
+        var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "cluster", ServiceId = "service" });
+        var options = CreateOptions(databaseName, containerName, configuredLevelCount, deleteStateOnClear: false);
+        var client = await options.CreateClient(_services);
+
+        try
+        {
+            await CreateContainer(client, databaseName, containerName, containerPaths);
+            options.IsResourceCreationEnabled = resourceCreationEnabled;
+            var provider = new HierarchicalDocumentIdProvider(clusterOptions, configuredLevelCount);
+
+            var exception = await Assert.ThrowsAsync<WrappedException>(
+                () => StartStorage(options, clusterOptions, provider));
+
+            Assert.EndsWith(nameof(OrleansConfigurationException), exception.OriginalExceptionType);
+            Assert.Contains("number, order, and name", exception.Message);
+        }
+        finally
+        {
+            await DeleteDatabase(client, databaseName);
+            client.Dispose();
+        }
+    }
+
+    [Theory, TestCategory("Functional")]
+    [InlineData(2, true)]
+    [InlineData(3, false)]
+    public async Task Startup_AcceptsMatchingHierarchicalPartitionKeyDefinition(int partitionKeyLevelCount, bool resourceCreationEnabled)
+    {
+        var databaseName = $"OrleansHpkMatch{Guid.NewGuid():N}";
+        const string containerName = "GrainState";
+        var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "cluster", ServiceId = "service" });
+        var options = CreateOptions(databaseName, containerName, partitionKeyLevelCount, deleteStateOnClear: false);
+        var client = await options.CreateClient(_services);
+
+        try
+        {
+            var paths = GetHierarchicalPaths(partitionKeyLevelCount);
+            await CreateContainer(client, databaseName, containerName, paths);
+            options.IsResourceCreationEnabled = resourceCreationEnabled;
+            var provider = new HierarchicalDocumentIdProvider(clusterOptions, partitionKeyLevelCount);
+
+            var storage = await StartStorage(options, clusterOptions, provider);
+
+            Assert.NotNull(storage);
+        }
+        finally
+        {
+            await DeleteDatabase(client, databaseName);
+            client.Dispose();
+        }
+    }
+
+    public static TheoryData<int, string[], bool> MismatchedContainerDefinitions => new()
+    {
+        { 2, ["/PartitionKey"], true },
+        { 1, ["/PartitionKey", "/PartitionKey2"], true },
+        { 2, ["/PartitionKey", "/PartitionKey2", "/PartitionKey3"], true },
+        { 2, ["/PartitionKey2", "/PartitionKey"], true },
+        { 2, ["/PartitionKey", "/Different"], true },
+        { 2, ["/PartitionKey"], false }
+    };
+
+    private CosmosGrainStorageOptions CreateOptions(
+        string databaseName,
+        string containerName,
+        int partitionKeyLevelCount,
+        bool deleteStateOnClear)
+    {
+        var options = new CosmosGrainStorageOptions
+        {
+            DatabaseName = databaseName,
+            ContainerName = containerName,
+            PartitionKeyLevelCount = partitionKeyLevelCount,
+            DeleteStateOnClear = deleteStateOnClear
+        };
+        options.ConfigureTestDefaults();
+        return options;
+    }
+
+    private async Task<CosmosGrainStorage> StartStorage(
+        CosmosGrainStorageOptions options,
+        IOptions<ClusterOptions> clusterOptions,
+        IDocumentIdProvider documentIdProvider)
+    {
+        var storage = ActivatorUtilities.CreateInstance<CosmosGrainStorage>(
+            _services,
+            options,
+            clusterOptions,
+            "TestStorage",
+            documentIdProvider);
+        var lifecycle = ActivatorUtilities.CreateInstance<SiloLifecycleSubject>(_services);
+        storage.Participate(lifecycle);
+        await lifecycle.OnStart();
+        return storage;
+    }
+
+    private static async Task CreateContainer(
+        CosmosClient client,
+        string databaseName,
+        string containerName,
+        IReadOnlyList<string> partitionKeyPaths)
+    {
+        var database = await client.CreateDatabaseIfNotExistsAsync(databaseName);
+        var properties = partitionKeyPaths.Count == 1
+            ? new ContainerProperties(containerName, partitionKeyPaths[0])
+            : new ContainerProperties(containerName, partitionKeyPaths);
+        await database.Database.CreateContainerIfNotExistsAsync(properties);
+    }
+
+    private static PartitionKey BuildPartitionKey(IReadOnlyList<string> values)
+    {
+        if (values.Count == 1)
+        {
+            return new PartitionKey(values[0]);
+        }
+
+        var builder = new PartitionKeyBuilder();
+        foreach (var value in values)
+        {
+            builder.Add(value);
+        }
+
+        return builder.Build();
+    }
+
+    private static string[] GetHierarchicalPaths(int partitionKeyLevelCount) =>
+        (new[] { "/PartitionKey", "/PartitionKey2", "/PartitionKey3" })[..partitionKeyLevelCount];
+
+    private static async Task DeleteDatabase(CosmosClient client, string databaseName)
+    {
+        try
+        {
+            await client.GetDatabase(databaseName).DeleteAsync();
+        }
+        catch (CosmosException exception) when (exception.StatusCode == HttpStatusCode.NotFound)
+        {
+        }
+    }
+
+    private sealed class HierarchicalDocumentIdProvider : IDocumentIdProvider
+    {
+        private readonly DefaultDocumentIdProvider _defaultProvider;
+        private readonly int _partitionKeyLevelCount;
+
+        public HierarchicalDocumentIdProvider(IOptions<ClusterOptions> clusterOptions, int partitionKeyLevelCount)
+        {
+            _defaultProvider = new DefaultDocumentIdProvider(clusterOptions);
+            _partitionKeyLevelCount = partitionKeyLevelCount;
+        }
+
+        public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId) =>
+            new((_defaultProvider.GetId(grainType, grainId), "tenant"));
+
+        public ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, GrainId grainId)
+        {
+            var values = _partitionKeyLevelCount switch
+            {
+                1 => new[] { "tenant" },
+                2 => new[] { "tenant", grainType },
+                _ => new[] { "tenant", grainType, "region" }
+            };
+            return new(new CosmosDocumentKey(_defaultProvider.GetId(grainType, grainId), values));
+        }
+    }
+
+    private sealed class ExistingDocumentIdProvider(DefaultDocumentIdProvider defaultProvider) : IDocumentIdProvider
+    {
+        public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId) =>
+            new((defaultProvider.GetId(grainType, grainId), "custom-partition"));
+    }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    private sealed class LegacyPartitionKeyProvider : IPartitionKeyProvider
+    {
+        public ValueTask<string> GetPartitionKey(string grainType, GrainId grainId) => new("legacy-partition");
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    public enum SinglePartitionKeyProviderKind
+    {
+        Default,
+        ExistingDocumentIdProvider,
+        LegacyPartitionKeyProvider
+    }
+
+    private sealed class TestState
+    {
+        public int Value { get; set; }
+    }
+}

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkIntegrationTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkIntegrationTests.cs
@@ -206,7 +206,7 @@ public class CosmosGrainStorageHpkIntegrationTests
             var exception = await Assert.ThrowsAsync<WrappedException>(
                 () => StartStorage(options, clusterOptions, provider));
 
-            Assert.EndsWith(nameof(OrleansConfigurationException), exception.OriginalExceptionType);
+            Assert.Contains(nameof(OrleansConfigurationException), exception.OriginalExceptionType);
             Assert.Contains("number, order, and name", exception.Message);
         }
         finally

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkIntegrationTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkIntegrationTests.cs
@@ -185,6 +185,46 @@ public class CosmosGrainStorageHpkIntegrationTests
     }
 
     [Theory, TestCategory("Functional")]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ExistingGrainTypeContainer_RemainsSupportedWithDefaultOptions(bool resourceCreationEnabled)
+    {
+        var databaseName = $"OrleansLegacyGrainType{Guid.NewGuid():N}";
+        const string containerName = "GrainState";
+        var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "cluster", ServiceId = "service" });
+        var options = new CosmosGrainStorageOptions
+        {
+            DatabaseName = databaseName,
+            ContainerName = containerName,
+            DeleteStateOnClear = false,
+            IsResourceCreationEnabled = resourceCreationEnabled
+        };
+        options.ConfigureTestDefaults();
+        var client = await options.CreateClient(_services);
+
+        try
+        {
+            await CreateContainer(client, databaseName, containerName, ["/GrainType"]);
+            var storage = await StartStorage(options, clusterOptions, new DefaultDocumentIdProvider(clusterOptions));
+            var grainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N"));
+            const string grainType = "grain-type";
+            var state = new GrainState<TestState> { State = new TestState { Value = 7 } };
+
+            await storage.WriteStateAsync(grainType, grainId, state);
+            var readState = new GrainState<TestState> { State = new TestState() };
+            await storage.ReadStateAsync(grainType, grainId, readState);
+
+            Assert.True(readState.RecordExists);
+            Assert.Equal(7, readState.State.Value);
+        }
+        finally
+        {
+            await DeleteDatabase(client, databaseName);
+            client.Dispose();
+        }
+    }
+
+    [Theory, TestCategory("Functional")]
     [MemberData(nameof(MismatchedContainerDefinitions))]
     public async Task Startup_RejectsMismatchedContainerPartitionKeyDefinition(
         int configuredLevelCount,

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageHpkTests.cs
@@ -1,0 +1,209 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Orleans.Configuration;
+using Orleans.Persistence.Cosmos;
+using Orleans.Runtime;
+using Orleans.Serialization.Serializers;
+
+namespace Tester.Cosmos.Persistence;
+
+[TestCategory("Cosmos"), TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("Cosmos")]
+[TestArea("Persistence")]
+public class CosmosGrainStorageHpkTests
+{
+    private static readonly GrainId TestGrainId = GrainId.Create("test-type", "test-key");
+
+    [Fact]
+    public void PartitionKeyLevelCount_DefaultsToOne()
+    {
+        var options = new CosmosGrainStorageOptions();
+
+        Assert.Equal(1, options.PartitionKeyLevelCount);
+        Assert.Equal("/PartitionKey", options.PartitionKeyPath);
+    }
+
+    [Fact]
+    public async Task ExistingDocumentIdProvider_AdaptsToSinglePartitionKeyValue()
+    {
+        IDocumentIdProvider provider = new ExistingDocumentIdProvider();
+
+        var key = await provider.GetDocumentKey("grain-type", TestGrainId);
+
+        Assert.Equal("document-id", key.DocumentId);
+        Assert.Equal(["partition-key"], key.PartitionKeyValues);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async Task ResolveDocumentKey_BuildsCompleteHierarchicalPartitionKey(int levelCount)
+    {
+        var values = Enumerable.Range(1, levelCount).Select(index => $"value-{index}").ToArray();
+        var storage = CreateStorage(levelCount, new HierarchicalDocumentIdProvider(values));
+
+        var key = await storage.ResolveDocumentKey("grain-type", TestGrainId);
+
+        var expectedBuilder = new PartitionKeyBuilder();
+        foreach (var value in values)
+        {
+            expectedBuilder.Add(value);
+        }
+
+        Assert.Equal("document-id", key.DocumentId);
+        Assert.Equal(values, key.PartitionKeyValues);
+        Assert.Equal(expectedBuilder.Build(), key.PartitionKey);
+    }
+
+    [Theory]
+    [InlineData(2, 1)]
+    [InlineData(2, 3)]
+    [InlineData(3, 2)]
+    public async Task ResolveDocumentKey_RejectsPartitionKeyValueCountMismatch(int configuredLevelCount, int providedValueCount)
+    {
+        var values = Enumerable.Range(1, providedValueCount).Select(index => $"value-{index}").ToArray();
+        var storage = CreateStorage(configuredLevelCount, new HierarchicalDocumentIdProvider(values));
+
+        var exception = await Assert.ThrowsAsync<OrleansConfigurationException>(
+            async () => await storage.ResolveDocumentKey("grain-type", TestGrainId));
+
+        Assert.Contains($"returned {providedValueCount} partition-key value(s)", exception.Message);
+        Assert.Contains($"requires {configuredLevelCount}", exception.Message);
+    }
+
+    [Fact]
+    public async Task CreateEntity_PopulatesEveryHierarchicalPartitionKeyProperty()
+    {
+        var storage = CreateStorage(3, new HierarchicalDocumentIdProvider("tenant", "grain-type", "region"));
+        var key = await storage.ResolveDocumentKey("grain-type", TestGrainId);
+
+        var entity = CosmosGrainStorage.CreateEntity(key, "grain-type", new TestState { Value = 7 }, "etag");
+
+        Assert.Equal("tenant", entity.PartitionKey);
+        Assert.Equal("grain-type", entity.PartitionKey2);
+        Assert.Equal("region", entity.PartitionKey3);
+    }
+
+    [Fact]
+    public async Task CreateEntity_OmitsUnusedPartitionKeyPropertiesInLegacyMode()
+    {
+        var storage = CreateStorage(1, new ExistingDocumentIdProvider());
+        var key = await storage.ResolveDocumentKey("grain-type", TestGrainId);
+        var entity = CosmosGrainStorage.CreateEntity(key, "grain-type", new TestState { Value = 7 }, "etag");
+
+        var newtonsoftJson = JsonConvert.SerializeObject(entity);
+        var systemTextJson = System.Text.Json.JsonSerializer.Serialize(entity);
+
+        Assert.DoesNotContain(nameof(GrainStateEntity<object>.PartitionKey2), newtonsoftJson);
+        Assert.DoesNotContain(nameof(GrainStateEntity<object>.PartitionKey3), newtonsoftJson);
+        Assert.DoesNotContain(nameof(GrainStateEntity<object>.PartitionKey2), systemTextJson);
+        Assert.DoesNotContain(nameof(GrainStateEntity<object>.PartitionKey3), systemTextJson);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    public void Constructor_RejectsUnsupportedPartitionKeyLevelCount(int levelCount)
+    {
+        var options = new CosmosGrainStorageOptions { PartitionKeyLevelCount = levelCount };
+
+        var exception = Assert.Throws<OrleansConfigurationException>(() => CreateStorage(options, new ExistingDocumentIdProvider()));
+
+        Assert.Contains("Supported values are 1, 2, and 3", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_PreservesCustomSinglePartitionKeyPath()
+    {
+        var options = new CosmosGrainStorageOptions { PartitionKeyPath = "/CustomPartitionKey" };
+
+        var storage = CreateStorage(options, new ExistingDocumentIdProvider());
+
+        CosmosGrainStorage.ValidateContainerPartitionKeyPaths(
+            [options.PartitionKeyPath],
+            ["/CustomPartitionKey"],
+            "test",
+            "container");
+        Assert.NotNull(storage);
+    }
+
+    [Theory]
+    [MemberData(nameof(MismatchedContainerPartitionKeyDefinitions))]
+    public void ValidateContainerPartitionKeyPaths_RejectsMismatches(string[] configuredPaths, string[] containerPaths)
+    {
+        var exception = Assert.Throws<OrleansConfigurationException>(() =>
+            CosmosGrainStorage.ValidateContainerPartitionKeyPaths(configuredPaths, containerPaths, "test", "container"));
+
+        Assert.Contains("number, order, and name", exception.Message);
+        Assert.Contains(string.Join(", ", configuredPaths), exception.Message);
+        Assert.Contains(string.Join(", ", containerPaths), exception.Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(MatchingContainerPartitionKeyDefinitions))]
+    public void ValidateContainerPartitionKeyPaths_AcceptsExactMatch(string[] configuredPaths, string[] containerPaths)
+    {
+        CosmosGrainStorage.ValidateContainerPartitionKeyPaths(configuredPaths, containerPaths, "test", "container");
+    }
+
+    public static TheoryData<string[], string[]> MismatchedContainerPartitionKeyDefinitions => new()
+    {
+        { ["/PartitionKey", "/PartitionKey2"], ["/PartitionKey"] },
+        { ["/PartitionKey"], ["/PartitionKey", "/PartitionKey2"] },
+        { ["/PartitionKey", "/PartitionKey2"], ["/PartitionKey", "/PartitionKey2", "/PartitionKey3"] },
+        { ["/PartitionKey", "/PartitionKey2"], ["/PartitionKey2", "/PartitionKey"] },
+        { ["/PartitionKey", "/PartitionKey2"], ["/PartitionKey", "/Different"] }
+    };
+
+    public static TheoryData<string[], string[]> MatchingContainerPartitionKeyDefinitions => new()
+    {
+        { ["/PartitionKey"], ["/PartitionKey"] },
+        { ["/CustomPartitionKey"], ["/CustomPartitionKey"] },
+        { ["/PartitionKey", "/PartitionKey2"], ["/PartitionKey", "/PartitionKey2"] },
+        { ["/PartitionKey", "/PartitionKey2", "/PartitionKey3"], ["/PartitionKey", "/PartitionKey2", "/PartitionKey3"] }
+    };
+
+    private static CosmosGrainStorage CreateStorage(int partitionKeyLevelCount, IDocumentIdProvider documentIdProvider)
+    {
+        return CreateStorage(
+            new CosmosGrainStorageOptions { PartitionKeyLevelCount = partitionKeyLevelCount },
+            documentIdProvider);
+    }
+
+    private static CosmosGrainStorage CreateStorage(CosmosGrainStorageOptions options, IDocumentIdProvider documentIdProvider)
+    {
+        var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+        return new CosmosGrainStorage(
+            "test",
+            options,
+            services.GetRequiredService<ILoggerFactory>(),
+            services,
+            Options.Create(new ClusterOptions { ServiceId = "service" }),
+            documentIdProvider,
+            activatorProvider: null!);
+    }
+
+    private sealed class ExistingDocumentIdProvider : IDocumentIdProvider
+    {
+        public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId) =>
+            new(("document-id", "partition-key"));
+    }
+
+    private sealed class HierarchicalDocumentIdProvider(params string[] partitionKeyValues) : IDocumentIdProvider
+    {
+        public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId) =>
+            new(("document-id", partitionKeyValues[0]));
+
+        public ValueTask<CosmosDocumentKey> GetDocumentKey(string grainType, GrainId grainId) =>
+            new(new CosmosDocumentKey("document-id", partitionKeyValues));
+    }
+
+    private sealed class TestState
+    {
+        public int Value { get; set; }
+    }
+}

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
@@ -121,9 +121,12 @@ public class CosmosHostingExtensionsTests
             new FirstPartitionKeyProvider());
 
         var identifiers = await provider.GetDocumentIdentifiers("grain-type", GrainId.Create("type", "key"));
+        var documentKey = await ((IDocumentIdProvider)provider).GetDocumentKey("grain-type", GrainId.Create("type", "key"));
 
         Assert.Equal("first", identifiers.PartitionKey);
         Assert.Equal("service__type_key", identifiers.DocumentId);
+        Assert.Equal("service__type_key", documentKey.DocumentId);
+        Assert.Equal(["first"], documentKey.PartitionKeyValues);
     }
 
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
Closes #9899

## Problem

Cosmos grain storage models each record with a single string partition key, so applications cannot use Cosmos DB hierarchical partition keys for tenant-aware distribution without replacing the storage provider.

## Solution

- Add an ordered document-key contract that supports one, two, or three string partition-key components while preserving existing `IDocumentIdProvider` implementations.
- Persist the selected components in fixed fields and use the same resolved values for Cosmos point operations.
- Validate configured partition-key paths against existing containers, including legacy `/GrainType` compatibility for the built-in provider.
- Document HPK configuration with compiled snippets and focused compatibility coverage.

## Rationale

Keeping document identity and ordered partition-key values together prevents request keys from drifting from persisted fields. The level count makes HPK opt-in, preserves existing single-key behavior, and rejects mismatched container definitions during startup.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10926)