### PR TITLE
fix(testing): synchronize in-process cluster logging

### DIFF
--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -36,6 +36,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
 {
     private readonly List<InProcessSiloHandle> _silos = [];
     private readonly StringBuilder _log = new();
+    private readonly object _logLock = new();
     private readonly InMemoryTransportConnectionHub _transportHub = new();
     private readonly GrainDirectoryObserver _grainDirectoryObserver = new();
     private readonly InProcessGrainDirectory _grainDirectory;
@@ -1073,7 +1074,10 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// <returns>The log contents.</returns>
     public string GetLog()
     {
-        return _log.ToString();
+        lock (_logLock)
+        {
+            return _log.ToString();
+        }
     }
 
     private void ReportUnobservedException(object? sender, UnhandledExceptionEventArgs eventArgs)
@@ -1084,7 +1088,10 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
 
     private void WriteLog(string format, params object?[] args)
     {
-        _log.AppendFormat(format + Environment.NewLine, args);
+        lock (_logLock)
+        {
+            _log.AppendFormat(format + Environment.NewLine, args);
+        }
     }
 
     private void FlushLogToConsole()

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
@@ -15,9 +15,44 @@ namespace Orleans.TestingHost.Tests;
 public sealed class InProcessTestClusterLifecycleTests
 {
     private const string DiagnosticCategory = "Orleans.TestingHost.Tests.LifecycleFailureProbe";
+    private const int ConcurrentLogReaderCount = 4;
+    private const int ConcurrentLogReadsPerWorker = 100;
+    private const int ConcurrentLogWriterCount = 8;
+    private const int ConcurrentLogWritesPerWorker = 2_500;
     private static readonly EventId SiloStartupFailureEvent = new(7101, "SiloStartupFailed");
     private static readonly EventId ClientStartupFailureEvent = new(7102, "ClientStartupFailed");
     private static readonly EventId SiloStopFailureEvent = new(7103, "SiloStopFailed");
+
+    [Fact]
+    public async Task Log_RemainsConsistentDuringConcurrentWritesAndReads()
+    {
+        await using var cluster = new InProcessTestCluster(new InProcessTestClusterOptions(), new FixedPortAllocator());
+        var start = CreateCompletionSource();
+        var writers = Enumerable.Range(0, ConcurrentLogWriterCount).Select(_ => Task.Run(async () =>
+        {
+            await start.Task;
+            for (var i = 0; i < ConcurrentLogWritesPerWorker; i++)
+            {
+                Assert.Empty(cluster.GetActiveSilos());
+            }
+        }));
+        var readers = Enumerable.Range(0, ConcurrentLogReaderCount).Select(_ => Task.Run(async () =>
+        {
+            await start.Task;
+            for (var i = 0; i < ConcurrentLogReadsPerWorker; i++)
+            {
+                cluster.GetLog();
+                await Task.Yield();
+            }
+        }));
+
+        start.TrySetResult();
+        await Task.WhenAll(writers.Concat(readers));
+
+        var entries = cluster.GetLog().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(ConcurrentLogWriterCount * ConcurrentLogWritesPerWorker, entries.Length);
+        Assert.All(entries, entry => Assert.StartsWith("GetActiveSilos: 0 Silos=", entry, StringComparison.Ordinal));
+    }
 
     [Fact]
     public async Task DeployAsync_WhenOneSiloStartupFails_DisposesEveryBuiltHostAndReportsRootFailure()

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
@@ -35,7 +35,7 @@ public sealed class InProcessTestClusterLifecycleTests
             {
                 Assert.Empty(cluster.GetActiveSilos());
             }
-        }));
+        })).ToArray();
         var readers = Enumerable.Range(0, ConcurrentLogReaderCount).Select(_ => Task.Run(async () =>
         {
             await start.Task;
@@ -44,7 +44,7 @@ public sealed class InProcessTestClusterLifecycleTests
                 cluster.GetLog();
                 await Task.Yield();
             }
-        }));
+        })).ToArray();
 
         start.TrySetResult();
         await Task.WhenAll(writers.Concat(readers));

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterLifecycleTests.cs
@@ -51,7 +51,7 @@ public sealed class InProcessTestClusterLifecycleTests
 
         var entries = cluster.GetLog().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal(ConcurrentLogWriterCount * ConcurrentLogWritesPerWorker, entries.Length);
-        Assert.All(entries, entry => Assert.StartsWith("GetActiveSilos: 0 Silos=", entry, StringComparison.Ordinal));
+        Assert.All(entries, entry => Assert.Equal("GetActiveSilos: 0 Silos=[]", entry));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Concurrent `InProcessTestCluster` activity can read and append to the shared diagnostic `StringBuilder` at the same time, corrupting its internal state and replacing the underlying test result with logging exceptions such as `FormatException`.

## Solution

Serialize log reads and writes with one dedicated lock, preserving complete diagnostic entries during concurrent cluster activity. Add a focused stress regression which exercises concurrent `GetActiveSilos` logging and `GetLog` reads through public APIs.

## Rationale

In-process cluster diagnostics remain consistent under concurrency and retain the original test outcome.

Fixes #10924
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10929)