### PR TITLE
fix(testing): stabilize reminder topology boundaries

### DIFF
--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -33,6 +33,15 @@ public interface IReminderServiceLifecycleHarness
     /// <summary>Gets the currently active silos.</summary>
     IReadOnlyList<SiloAddress> ActiveSilos { get; }
 
+    /// <summary>Registers a reminder through the reminder service on the specified silo.</summary>
+    Task RegisterOnSiloAsync(
+        SiloAddress siloAddress,
+        GrainId grainId,
+        string reminderName,
+        TimeSpan dueTime,
+        TimeSpan period,
+        CancellationToken cancellationToken);
+
     /// <summary>Waits until every active reminder service is ready.</summary>
     Task WaitForStartupReadinessAsync(CancellationToken cancellationToken);
 
@@ -335,9 +344,10 @@ public abstract class ReminderServiceLifecycleTestRunner
     public async Task RunReminderService_StaleOwnerRegistrationReconciles(CancellationToken cancellationToken)
     {
         const string Guarantee = nameof(ReminderService_StaleOwnerRegistrationReconciles);
-        var reminders = CreateGrains(Guarantee, 16);
+        var reminders = new List<(IReminderServiceTestGrain Grain, string Name)>();
         var phase = "join";
         SiloAddress? joined = null;
+        SiloAddress? staleOwner = null;
         await ExecuteWithCleanupAsync(
             Guarantee,
             cancellationToken,
@@ -346,62 +356,148 @@ public abstract class ReminderServiceLifecycleTestRunner
                 try
                 {
                     joined = await _harness.JoinOneSiloAsync(cancellationToken);
-                    phase = "registration";
-                    await Task.WhenAll(reminders.Select(item =>
-                        item.Grain.RegisterOrUpdateAsync(item.Name, TimeSpan.FromSeconds(3), Period)
-                            .WaitAsync(cancellationToken)));
-
-                    phase = "topology reconciliation";
-                    await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-                    phase = "owner reconciliation";
-                    var ownerWaits = reminders
-                        .Select(item => _harness.WaitForOwnerCountAsync(
-                            item.Grain.GetGrainId(),
-                            item.Name,
-                            1,
-                            cancellationToken))
-                        .ToArray();
-                    await _harness.RefreshAsync(cancellationToken);
-                    await Task.WhenAll(ownerWaits);
-                    await _harness.WaitForTopologyReconciliationAsync(cancellationToken);
-                    await Task.WhenAll(reminders.Select(item =>
-                        _harness.WaitForOwnerCountAsync(
-                            item.Grain.GetGrainId(),
-                            item.Name,
-                            1,
-                            cancellationToken)));
-                    foreach (var (grain, name) in reminders)
+                    var grain = CreateGrainOwnedBy(joined, Guarantee);
+                    const string Name = "stale-owner-registration";
+                    reminders.Add((grain, Name));
+                    staleOwner = _harness.ActiveSilos
+                        .Where(silo => !silo.Equals(joined))
+                        .Order()
+                        .First();
+                    var grainId = grain.GetGrainId();
+                    if (!_harness.IsOwner(joined, grainId) || _harness.IsOwner(staleOwner, grainId))
                     {
-                        phase = $"schedule reconciliation for {grain.GetGrainId()}/{name}";
-                        await _harness.WaitForScheduleAsync(grain.GetGrainId(), name, cancellationToken);
-                        if (_harness.GetOwners(grain.GetGrainId(), name).Count != 1)
-                        {
-                            OwnershipFailure(Guarantee, grain.GetGrainId(), name, 1).Throw();
-                        }
+                        Fail(Guarantee, "identity selection")
+                            .WithIdentity(grainId, Name)
+                            .WithExpected($"joined silo {joined} owns the grain and directed silo {staleOwner} does not")
+                            .WithObserved(
+                                $"joinedOwns={_harness.IsOwner(joined, grainId)}, "
+                                + $"directedOwns={_harness.IsOwner(staleOwner, grainId)}")
+                            .Throw();
                     }
+
+                    phase = $"registration through non-owner {staleOwner}";
+                    await _harness.RegisterOnSiloAsync(
+                        staleOwner,
+                        grainId,
+                        Name,
+                        TimeSpan.FromSeconds(3),
+                        Period,
+                        cancellationToken);
+
+                    var ownersBeforeRefresh = _harness.GetOwners(grainId, Name);
+                    var startsBeforeRefresh = _harness.GetLocalStartCount(grainId, Name);
+                    if (ownersBeforeRefresh.Count != 0 || startsBeforeRefresh != 0)
+                    {
+                        Fail(Guarantee, "stale-owner registration")
+                            .WithIdentity(grainId, Name)
+                            .WithExpected(
+                                $"directed non-owner {staleOwner} persists the row without starting a local owner before refresh")
+                            .WithObserved(
+                                $"currentOwner={joined}, owners=[{string.Join(", ", ownersBeforeRefresh)}], "
+                                + $"localStarts={startsBeforeRefresh}")
+                            .Throw();
+                    }
+
+                    phase = "owner reconciliation";
+                    var ownerWait = _harness.WaitForOwnerCountAsync(grainId, Name, 1, cancellationToken);
+                    await _harness.RefreshAsync(cancellationToken);
+                    await ownerWait;
+                    var owners = _harness.GetOwners(grainId, Name);
+                    if (owners.Count != 1 || !owners.Contains(joined) || owners.Contains(staleOwner))
+                    {
+                        Fail(Guarantee, "owner reconciliation")
+                            .WithIdentity(grainId, Name)
+                            .WithExpected($"exactly the current owner {joined}, excluding directed non-owner {staleOwner}")
+                            .WithObserved($"owners=[{string.Join(", ", owners)}]")
+                            .Throw();
+                    }
+
+                    phase = $"schedule reconciliation for {grainId}/{Name}";
+                    await _harness.WaitForScheduleAsync(grainId, Name, cancellationToken);
+                }
+                catch (TimeoutException exception)
+                {
+                    ThrowStaleOwnerPhaseFailure(
+                        Guarantee,
+                        phase,
+                        joined,
+                        staleOwner,
+                        reminders,
+                        exception);
                 }
                 catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
                 {
-                    Fail(Guarantee, phase)
-                        .WithExpected("all registrations reconcile to one current owner with an armed schedule")
-                        .WithObserved(string.Join(
-                            "; ",
-                            reminders.Select(item =>
-                                $"{item.Grain.GetGrainId()}/{item.Name}="
-                                + $"[{string.Join(", ", _harness.GetOwners(item.Grain.GetGrainId(), item.Name))}]")))
-                        .Throw(exception);
+                    ThrowStaleOwnerPhaseFailure(
+                        Guarantee,
+                        phase,
+                        joined,
+                        staleOwner,
+                        reminders,
+                        exception);
                 }
             },
             async cleanupToken =>
             {
-                if (joined is not null && _harness.ActiveSilos.Contains(joined))
+                Exception? topologyFailure = null;
+                try
                 {
-                    await _harness.LeaveSiloAsync(joined, cleanupToken);
-                    await _harness.WaitForTopologyReconciliationAsync(cleanupToken);
+                    if (joined is not null && _harness.ActiveSilos.Contains(joined))
+                    {
+                        await _harness.LeaveSiloAsync(joined, cleanupToken);
+                        await _harness.WaitForTopologyReconciliationAsync(cleanupToken);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    topologyFailure = exception;
                 }
 
-                await CleanupAsync(Guarantee, reminders, cleanupToken);
+                Exception? reminderFailure = null;
+                try
+                {
+                    await CleanupAsync(Guarantee, reminders, cleanupToken);
+                }
+                catch (Exception exception)
+                {
+                    reminderFailure = exception;
+                }
+
+                if (topologyFailure is not null && reminderFailure is not null)
+                {
+                    throw new AggregateException(topologyFailure, reminderFailure);
+                }
+
+                if (topologyFailure is not null)
+                {
+                    ExceptionDispatchInfo.Capture(topologyFailure).Throw();
+                }
+
+                if (reminderFailure is not null)
+                {
+                    ExceptionDispatchInfo.Capture(reminderFailure).Throw();
+                }
             });
+    }
+
+    private void ThrowStaleOwnerPhaseFailure(
+        string guarantee,
+        string phase,
+        SiloAddress? joined,
+        SiloAddress? staleOwner,
+        IReadOnlyList<(IReminderServiceTestGrain Grain, string Name)> reminders,
+        Exception exception)
+    {
+        Fail(guarantee, phase)
+            .WithExpected(
+                "the directed non-owner persists without a local schedule and the current owner starts one schedule after refresh")
+            .WithObserved(
+                $"joined={joined}, directedNonOwner={staleOwner}, "
+                + string.Join(
+                    "; ",
+                    reminders.Select(item =>
+                        $"{item.Grain.GetGrainId()}/{item.Name}="
+                        + $"[{string.Join(", ", _harness.GetOwners(item.Grain.GetGrainId(), item.Name))}]")))
+            .Throw(exception);
     }
 
     /// <summary>Guarantee: one-silo join/leave transfers ownership without duplicates or missed delivery.</summary>

--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -33,14 +33,20 @@ public interface IReminderServiceLifecycleHarness
     /// <summary>Gets the currently active silos.</summary>
     IReadOnlyList<SiloAddress> ActiveSilos { get; }
 
-    /// <summary>Registers a reminder through the reminder service on the specified silo.</summary>
+    /// <summary>
+    /// Registers a reminder, directing the request through the specified silo when the harness supports directed
+    /// registration. The default implementation uses the grain-facing API through <see cref="GrainFactory"/>.
+    /// </summary>
     Task RegisterOnSiloAsync(
         SiloAddress siloAddress,
         GrainId grainId,
         string reminderName,
         TimeSpan dueTime,
         TimeSpan period,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken)
+        => GrainFactory.GetGrain<IReminderServiceTestGrain>(grainId)
+            .RegisterOrUpdateAsync(reminderName, dueTime, period)
+            .WaitAsync(cancellationToken);
 
     /// <summary>Waits until every active reminder service is ready.</summary>
     Task WaitForStartupReadinessAsync(CancellationToken cancellationToken);

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -32,10 +32,10 @@ namespace Orleans.Runtime.ReminderService
         private readonly ReminderInstruments _reminderInstruments;
         private long localTableSequence;
         // The test barrier reads this state off-scheduler so it remains observable while the service is busy.
-        private readonly object _rangeChangeLock = new();
-        private long rangeChangeGeneration;
-        private TaskCompletionSource rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private Task rangeChangeTask = Task.CompletedTask;
+        private readonly object _reconciliationLock = new();
+        private long reconciliationGeneration;
+        private TaskCompletionSource reconciliationGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private Task reconciliationTask = Task.CompletedTask;
         private uint initialReadCallCount = 0;
         private Task? runTask;
         private readonly object _deliveryLock = new();
@@ -365,7 +365,7 @@ namespace Orleans.Runtime.ReminderService
 
         internal Task TestOnlyRefresh()
         {
-            var refreshTask = new Task<Task>(ReadAndUpdateReminders);
+            var refreshTask = new Task<Task>(() => TrackReconciliation(ReadAndUpdateReminders));
             Scheduler.QueueTask(refreshTask);
             return refreshTask.Unwrap();
         }
@@ -399,28 +399,32 @@ namespace Orleans.Runtime.ReminderService
             CheckRuntimeContext();
 
             _ = base.OnRangeChange(oldRange, newRange, increased);
+            var status = Status;
+            if (status == GrainServiceStatus.Started)
+            {
+                return TrackReconciliation(ReadAndUpdateReminders);
+            }
+
+            LogIgnoringRangeChange(status);
+            return Task.CompletedTask;
+        }
+
+        private Task TrackReconciliation(Func<Task> reconciliation)
+        {
             var reconciliationTaskSource = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource previousGenerationChanged;
-            lock (_rangeChangeLock)
+            lock (_reconciliationLock)
             {
-                previousGenerationChanged = rangeChangeGenerationChanged;
-                rangeChangeGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
-                rangeChangeGeneration++;
-                rangeChangeTask = reconciliationTaskSource.Task.Unwrap();
+                previousGenerationChanged = reconciliationGenerationChanged;
+                reconciliationGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                reconciliationGeneration++;
+                reconciliationTask = reconciliationTaskSource.Task.Unwrap();
             }
 
             previousGenerationChanged.TrySetResult();
             try
             {
-                var status = Status;
-                var task = status == GrainServiceStatus.Started
-                    ? ReadAndUpdateReminders()
-                    : Task.CompletedTask;
-                if (status != GrainServiceStatus.Started)
-                {
-                    LogIgnoringRangeChange(status);
-                }
-
+                var task = reconciliation();
                 reconciliationTaskSource.SetResult(task);
                 return task;
             }
@@ -435,23 +439,23 @@ namespace Orleans.Runtime.ReminderService
         {
             while (true)
             {
-                // A newer refresh supersedes older results through localTableSequence. Follow generation
-                // changes so a stalled obsolete read does not block the current reconciliation.
+                // A newer tracked refresh supersedes older results through localTableSequence. Follow
+                // reconciliation generations so a stalled obsolete read does not block the current one.
                 long observedGeneration;
                 Task observedTask;
                 Task observedGenerationChanged;
-                lock (_rangeChangeLock)
+                lock (_reconciliationLock)
                 {
-                    observedGeneration = rangeChangeGeneration;
-                    observedTask = rangeChangeTask;
-                    observedGenerationChanged = rangeChangeGenerationChanged.Task;
+                    observedGeneration = reconciliationGeneration;
+                    observedTask = reconciliationTask;
+                    observedGenerationChanged = reconciliationGenerationChanged.Task;
                 }
 
                 await Task.WhenAny(observedTask, observedGenerationChanged).WaitAsync(cancellationToken);
 
-                lock (_rangeChangeLock)
+                lock (_reconciliationLock)
                 {
-                    if (observedGeneration != rangeChangeGeneration)
+                    if (observedGeneration != reconciliationGeneration)
                     {
                         continue;
                     }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -377,6 +377,19 @@ namespace Orleans.Runtime.ReminderService
         internal Task TestOnlyWaitForSiloStatusListeners(CancellationToken cancellationToken)
             => _siloStatusListenerManager.TestOnlyWaitForCurrentMembershipVersion(cancellationToken);
 
+        internal (MembershipVersion Current, MembershipVersion Processed) TestOnlyGetMembershipVersions()
+            => _siloStatusListenerManager.TestOnlyGetMembershipVersions();
+
+        internal string TestOnlyDescribeTopologyState()
+        {
+            lock (_reconciliationLock)
+            {
+                return $"silo={Silo}, serviceStatus={Status}, {_siloStatusListenerManager.TestOnlyDescribeMembershipState()}, "
+                    + $"ringRange={RingRange}, reconciliationGeneration={reconciliationGeneration}, "
+                    + $"reconciliationCompleted={reconciliationTask.IsCompleted}";
+            }
+        }
+
         private void RemoveOutOfRangeReminders(List<Task> removedReminderTasks)
         {
             CheckRuntimeContext();
@@ -499,7 +512,7 @@ namespace Orleans.Runtime.ReminderService
                             await DoInitialReadAndUpdateReminders();
                             break;
                         case GrainServiceStatus.Started:
-                            await ReadAndUpdateReminders();
+                            await TrackReconciliation(ReadAndUpdateReminders);
                             break;
                         default:
                             listRefreshTimer.Dispose();

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -10,6 +10,7 @@ using Orleans.Reminders;
 using Orleans.Reminders.Diagnostics;
 using Orleans.Runtime.ConsistentRing;
 using Orleans.Runtime.Internal;
+using Orleans.Runtime.MembershipService;
 using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.ReminderService
@@ -28,6 +29,7 @@ namespace Orleans.Runtime.ReminderService
         private readonly IAsyncTimer listRefreshTimer; // timer that refreshes our list of reminders to reflect global reminder table
         private readonly GrainReferenceActivator _referenceActivator;
         private readonly GrainInterfaceType _grainInterfaceType;
+        private readonly SiloStatusListenerManager _siloStatusListenerManager;
         private readonly TimeProvider _timeProvider;
         private readonly ReminderInstruments _reminderInstruments;
         private long localTableSequence;
@@ -50,6 +52,7 @@ namespace Orleans.Runtime.ReminderService
             IAsyncTimerFactory asyncTimerFactory,
             IOptions<ReminderOptions> reminderOptions,
             IConsistentRingProvider ringProvider,
+            SiloStatusListenerManager siloStatusListenerManager,
             [FromKeyedServices(ReminderTimeProviderNames.Reminders)] TimeProvider timeProvider,
             ReminderInstruments reminderInstruments,
             SystemTargetShared shared)
@@ -60,6 +63,7 @@ namespace Orleans.Runtime.ReminderService
         {
             _referenceActivator = referenceActivator;
             _grainInterfaceType = interfaceTypeResolver.GetGrainInterfaceType(typeof(IRemindable));
+            _siloStatusListenerManager = siloStatusListenerManager;
             this.reminderOptions = reminderOptions.Value;
             this.reminderTable = reminderTable;
             _timeProvider = timeProvider;
@@ -369,6 +373,9 @@ namespace Orleans.Runtime.ReminderService
             Scheduler.QueueTask(refreshTask);
             return refreshTask.Unwrap();
         }
+
+        internal Task TestOnlyWaitForSiloStatusListeners(CancellationToken cancellationToken)
+            => _siloStatusListenerManager.TestOnlyWaitForCurrentMembershipVersion(cancellationToken);
 
         private void RemoveOutOfRangeReminders(List<Task> removedReminderTasks)
         {

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -150,21 +150,50 @@ internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<
 
     internal async Task TestOnlyWaitForCurrentMembershipVersion(CancellationToken cancellationToken)
     {
-        var targetVersion = _membershipService.CurrentSnapshot.Version;
         while (true)
         {
+            var targetVersion = _membershipService.CurrentSnapshot.Version;
             Task versionChanged;
             lock (_processedMembershipLock)
             {
                 if (_processedMembershipVersion >= targetVersion)
                 {
-                    return;
+                    if (_processedMembershipVersion >= _membershipService.CurrentSnapshot.Version)
+                    {
+                        return;
+                    }
+
+                    continue;
                 }
 
                 versionChanged = _processedMembershipVersionChanged.Task;
             }
 
             await versionChanged.WaitAsync(cancellationToken);
+        }
+    }
+
+    internal string TestOnlyDescribeMembershipState()
+    {
+        var (currentVersion, processedVersion) = TestOnlyGetMembershipVersions();
+        return $"currentMembership={currentVersion}, processedMembership={processedVersion}";
+    }
+
+    internal (MembershipVersion Current, MembershipVersion Processed) TestOnlyGetMembershipVersions()
+    {
+        while (true)
+        {
+            var currentVersion = _membershipService.CurrentSnapshot.Version;
+            MembershipVersion processedVersion;
+            lock (_processedMembershipLock)
+            {
+                processedVersion = _processedMembershipVersion;
+            }
+
+            if (currentVersion == _membershipService.CurrentSnapshot.Version)
+            {
+                return (currentVersion, processedVersion);
+            }
         }
     }
 

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -22,7 +22,10 @@ internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<
     private readonly IMembershipManager _membershipService;
     private readonly ILogger<SiloStatusListenerManager> _logger;
     private readonly IFatalErrorHandler _fatalErrorHandler;
+    private readonly object _processedMembershipLock = new();
     private ImmutableList<WeakReference<ISiloStatusListener>> _listeners = [];
+    private MembershipVersion _processedMembershipVersion = MembershipVersion.MinValue;
+    private TaskCompletionSource _processedMembershipVersionChanged = CreateCompletion();
 
     public SiloStatusListenerManager(
         IMembershipManager membershipManager,
@@ -88,6 +91,7 @@ internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<
                 var update = (previous is null || snapshot.Version == MembershipVersion.MinValue) ? snapshot.AsUpdate() : snapshot.CreateUpdate(previous);
                 NotifyObservers(update);
                 previous = snapshot;
+                MarkMembershipVersionProcessed(snapshot.Version);
             }
         }
         catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
@@ -143,6 +147,47 @@ internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<
             }
         }
     }
+
+    internal async Task TestOnlyWaitForCurrentMembershipVersion(CancellationToken cancellationToken)
+    {
+        var targetVersion = _membershipService.CurrentSnapshot.Version;
+        while (true)
+        {
+            Task versionChanged;
+            lock (_processedMembershipLock)
+            {
+                if (_processedMembershipVersion >= targetVersion)
+                {
+                    return;
+                }
+
+                versionChanged = _processedMembershipVersionChanged.Task;
+            }
+
+            await versionChanged.WaitAsync(cancellationToken);
+        }
+    }
+
+    private void MarkMembershipVersionProcessed(MembershipVersion version)
+    {
+        TaskCompletionSource versionChanged;
+        lock (_processedMembershipLock)
+        {
+            if (version <= _processedMembershipVersion)
+            {
+                return;
+            }
+
+            _processedMembershipVersion = version;
+            versionChanged = _processedMembershipVersionChanged;
+            _processedMembershipVersionChanged = CreateCompletion();
+        }
+
+        versionChanged.TrySetResult();
+    }
+
+    private static TaskCompletionSource CreateCompletion()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
     {

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -19,6 +19,7 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
     private static readonly TimeSpan LoadingWindow = TimeSpan.FromSeconds(5);
     private InProcessTestCluster? _cluster;
     private ReminderTestClock? _clock;
+    private readonly short _initialSilos = 1;
 
     public ReminderServiceLifecycleFixture()
     {
@@ -29,13 +30,18 @@ public sealed class ReminderServiceLifecycleFixture : IAsyncLifetime
         _clock = clock;
     }
 
+    internal ReminderServiceLifecycleFixture(short initialSilos)
+    {
+        _initialSilos = initialSilos;
+    }
+
     public ReminderServiceLifecycleHarness Harness { get; private set; } = null!;
 
     public async ValueTask InitializeAsync()
     {
         try
         {
-            var builder = new InProcessTestClusterBuilder(1);
+            var builder = new InProcessTestClusterBuilder(_initialSilos);
             builder.ConfigureSilo((_, siloBuilder) =>
                 siloBuilder.Configure<ConsistentRingOptions>(options => options.UseVirtualBucketsConsistentRing = false));
             builder.UseIdealizedReminderTable(
@@ -247,6 +253,24 @@ public sealed class FaultyReminderServiceLifecycleTests
     }
 
     [Fact]
+    public Task StaleOwnerRegistrationTargetsOneSpecifiedNonOwner()
+    {
+        DirectedRegistrationHarness? directedHarness = null;
+        return RunFaultAsync(
+            harness => new LifecycleRunner(
+                directedHarness = new DirectedRegistrationHarness(harness),
+                "DirectedStaleOwner"),
+            async (runner, token) =>
+            {
+                await runner.RunReminderService_StaleOwnerRegistrationReconciles(token);
+                Assert.NotNull(directedHarness);
+                Assert.Equal(1, directedHarness.RegistrationCount);
+                Assert.True(directedHarness.TargetedNonOwner);
+            },
+            initialSilos: 2);
+    }
+
+    [Fact]
     public Task JoinLeaveAdvancesToTheExactRemainingDueTime()
     {
         RecordingAdvanceHarness? recordingHarness = null;
@@ -264,9 +288,10 @@ public sealed class FaultyReminderServiceLifecycleTests
 
     private static async Task RunFaultAsync(
         Func<IReminderServiceLifecycleHarness, LifecycleRunner> createRunner,
-        Func<LifecycleRunner, CancellationToken, Task> scenario)
+        Func<LifecycleRunner, CancellationToken, Task> scenario,
+        short initialSilos = 1)
     {
-        var fixture = new ReminderServiceLifecycleFixture();
+        var fixture = new ReminderServiceLifecycleFixture(initialSilos);
         await fixture.InitializeAsync();
         try
         {
@@ -295,6 +320,7 @@ public sealed class FaultyReminderServiceLifecycleTests
         public TimeSpan ReminderRefreshPeriod => Inner.ReminderRefreshPeriod;
         public IReadOnlyList<SiloAddress> ActiveSilos => Inner.ActiveSilos;
         public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => Inner.WaitForStartupReadinessAsync(cancellationToken);
+        public virtual Task RegisterOnSiloAsync(SiloAddress siloAddress, GrainId grainId, string reminderName, TimeSpan dueTime, TimeSpan period, CancellationToken cancellationToken) => Inner.RegisterOnSiloAsync(siloAddress, grainId, reminderName, dueTime, period, cancellationToken);
         public virtual Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => Inner.AdvanceAsync(amount, cancellationToken);
         public virtual Task RefreshAsync(CancellationToken cancellationToken) => Inner.RefreshAsync(cancellationToken);
         public virtual Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
@@ -310,6 +336,31 @@ public sealed class FaultyReminderServiceLifecycleTests
         public Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken) => Inner.JoinOneSiloAsync(cancellationToken);
         public Task LeaveSiloAsync(SiloAddress siloAddress, CancellationToken cancellationToken) => Inner.LeaveSiloAsync(siloAddress, cancellationToken);
         public Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken) => Inner.WaitForTopologyReconciliationAsync(cancellationToken);
+    }
+
+    private sealed class DirectedRegistrationHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)
+    {
+        public int RegistrationCount { get; private set; }
+        public bool TargetedNonOwner { get; private set; }
+
+        public override async Task RegisterOnSiloAsync(
+            SiloAddress siloAddress,
+            GrainId grainId,
+            string reminderName,
+            TimeSpan dueTime,
+            TimeSpan period,
+            CancellationToken cancellationToken)
+        {
+            RegistrationCount++;
+            TargetedNonOwner = !Inner.IsOwner(siloAddress, grainId);
+            await base.RegisterOnSiloAsync(
+                siloAddress,
+                grainId,
+                reminderName,
+                dueTime,
+                period,
+                cancellationToken);
+        }
     }
 
     private sealed class DuplicateOwnerHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -271,6 +271,38 @@ public sealed class FaultyReminderServiceLifecycleTests
     }
 
     [Fact]
+    public async Task DefaultRegistrationImplementationUsesGrainFacingApi()
+    {
+        var fixture = new ReminderServiceLifecycleFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromMinutes(2));
+            var harness = new LegacyLifecycleHarness(fixture.Harness);
+            await harness.WaitForStartupReadinessAsync(cancellation.Token);
+            var grain = harness.GrainFactory.GetGrain<IReminderServiceTestGrain>(
+                Guid.Parse("632db277-28b7-4bd5-a423-35ff4e734f2f"));
+            const string ReminderName = "default-registration";
+
+            await ((IReminderServiceLifecycleHarness)harness).RegisterOnSiloAsync(
+                harness.ActiveSilos[0],
+                grain.GetGrainId(),
+                ReminderName,
+                TimeSpan.FromMinutes(1),
+                TimeSpan.FromMinutes(2),
+                cancellation.Token);
+
+            Assert.Contains(ReminderName, await grain.GetReminderNamesAsync().WaitAsync(cancellation.Token));
+            Assert.True(await grain.UnregisterAsync(ReminderName).WaitAsync(cancellation.Token));
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [Fact]
     public Task JoinLeaveAdvancesToTheExactRemainingDueTime()
     {
         RecordingAdvanceHarness? recordingHarness = null;
@@ -361,6 +393,32 @@ public sealed class FaultyReminderServiceLifecycleTests
                 period,
                 cancellationToken);
         }
+    }
+
+    private sealed class LegacyLifecycleHarness(IReminderServiceLifecycleHarness inner) : IReminderServiceLifecycleHarness
+    {
+        public IGrainFactory GrainFactory => inner.GrainFactory;
+        public IReminderTable ReminderTable => inner.ReminderTable;
+        public DateTimeOffset UtcNow => inner.UtcNow;
+        public TimeSpan ReminderLoadingWindow => inner.ReminderLoadingWindow;
+        public TimeSpan ReminderRefreshPeriod => inner.ReminderRefreshPeriod;
+        public IReadOnlyList<SiloAddress> ActiveSilos => inner.ActiveSilos;
+        public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => inner.WaitForStartupReadinessAsync(cancellationToken);
+        public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => inner.AdvanceAsync(amount, cancellationToken);
+        public Task RefreshAsync(CancellationToken cancellationToken) => inner.RefreshAsync(cancellationToken);
+        public Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
+        public IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName) => inner.GetOwners(grainId, reminderName);
+        public bool IsOwner(SiloAddress siloAddress, GrainId grainId) => inner.IsOwner(siloAddress, grainId);
+        public Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
+        public int GetLocalStartCount(GrainId grainId, string reminderName) => inner.GetLocalStartCount(grainId, reminderName);
+        public int GetLocalStopCount(GrainId grainId, string reminderName) => inner.GetLocalStopCount(grainId, reminderName);
+        public int GetScheduleChangeCount(GrainId grainId, string reminderName) => inner.GetScheduleChangeCount(grainId, reminderName);
+        public Task WaitForScheduleChangeCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => inner.WaitForScheduleChangeCountAsync(grainId, reminderName, count, cancellationToken);
+        public Task WaitForTickCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => inner.WaitForTickCountAsync(grainId, reminderName, count, cancellationToken);
+        public int GetTickCount(GrainId grainId, string reminderName) => inner.GetTickCount(grainId, reminderName);
+        public Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken) => inner.JoinOneSiloAsync(cancellationToken);
+        public Task LeaveSiloAsync(SiloAddress siloAddress, CancellationToken cancellationToken) => inner.LeaveSiloAsync(siloAddress, cancellationToken);
+        public Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken) => inner.WaitForTopologyReconciliationAsync(cancellationToken);
     }
 
     private sealed class DuplicateOwnerHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -382,7 +382,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = TimeSpan.FromMinutes(10);
@@ -394,40 +394,69 @@ public sealed class ReminderTestKitClusterIntegrationTests
             await using var firstRefreshB = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             await using var followingRefreshA = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             await using var followingRefreshB = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
-            var oneOwner = observer.WaitForActiveReminderCountAsync(grainId, 1, cancellation.Token, "single-owner");
-            await grain.RegisterReminderAsync("single-owner", dueTime, TimeSpan.FromMinutes(2)).WaitAsync(cancellation.Token);
+            var firstRefreshABlocked = firstRefreshA.WaitUntilBlockedAsync(cancellation.Token);
+            var firstRefreshBBlocked = firstRefreshB.WaitUntilBlockedAsync(cancellation.Token);
+            var followingRefreshABlocked = followingRefreshA.WaitUntilBlockedAsync(cancellation.Token);
+            var followingRefreshBBlocked = followingRefreshB.WaitUntilBlockedAsync(cancellation.Token);
+            var phase = "registration";
+            try
+            {
+                var oneOwner = observer.WaitForActiveReminderCountAsync(grainId, 1, cancellation.Token, "single-owner");
+                await grain.RegisterReminderAsync("single-owner", dueTime, TimeSpan.FromMinutes(2)).WaitAsync(cancellation.Token);
 
-            await AdvanceUntilAsync(
-                clock,
-                Task.WhenAll(
-                    firstRefreshA.WaitUntilBlockedAsync(cancellation.Token),
-                    firstRefreshB.WaitUntilBlockedAsync(cancellation.Token)),
-                cancellation.Token);
-            firstRefreshA.Release();
-            firstRefreshB.Release();
-            await AdvanceUntilAsync(
-                clock,
-                Task.WhenAll(
-                    followingRefreshA.WaitUntilBlockedAsync(cancellation.Token),
-                    followingRefreshB.WaitUntilBlockedAsync(cancellation.Token)),
-                cancellation.Token);
-            await oneOwner;
-            await observer.WaitForLocalReminderScheduleAsync(grainId, "single-owner", cancellation.Token);
+                phase = "first refresh wave";
+                await AdvanceUntilAsync(
+                    clock,
+                    Task.WhenAll(firstRefreshABlocked, firstRefreshBBlocked),
+                    cancellation.Token);
+                firstRefreshA.Release();
+                firstRefreshB.Release();
 
-            Assert.Single(observer.GetActiveReminderSilos(grainId, "single-owner"));
-            var tick = observer.WaitForReminderTickAsync(grainId, cancellation.Token, "single-owner");
-            var remaining = firstTickTime - clock.UtcNow.UtcDateTime;
-            Assert.True(remaining > TimeSpan.Zero);
-            await clock.AdvanceAsync(remaining, cancellation.Token);
-            var completed = await tick;
-            await observer.WaitForLocalReminderScheduleAsync(grainId, "single-owner", cancellation.Token);
+                phase = "following refresh wave";
+                await AdvanceUntilAsync(
+                    clock,
+                    Task.WhenAll(followingRefreshABlocked, followingRefreshBBlocked),
+                    cancellation.Token);
 
-            Assert.Equal(firstTickTime, completed.Status.CurrentTickTime);
-            Assert.Equal(1, observer.GetActiveReminderCount(grainId, "single-owner"));
-            Assert.Equal(1, observer.GetTickCount(grainId, "single-owner"));
-            Assert.Single(oracle.Snapshot());
-            followingRefreshA.Release();
-            followingRefreshB.Release();
+                phase = "single owner reconciliation";
+                await oneOwner;
+                await observer.WaitForLocalReminderScheduleAsync(grainId, "single-owner", cancellation.Token);
+
+                Assert.Single(observer.GetActiveReminderSilos(grainId, "single-owner"));
+                var tick = observer.WaitForReminderTickAsync(grainId, cancellation.Token, "single-owner");
+                var remaining = firstTickTime - clock.UtcNow.UtcDateTime;
+                Assert.True(remaining > TimeSpan.Zero);
+                phase = "exact due delivery";
+                await clock.AdvanceAsync(remaining, cancellation.Token);
+                var completed = await tick;
+                await observer.WaitForLocalReminderScheduleAsync(grainId, "single-owner", cancellation.Token);
+
+                Assert.Equal(firstTickTime, completed.Status.CurrentTickTime);
+                Assert.Equal(1, observer.GetActiveReminderCount(grainId, "single-owner"));
+                Assert.Equal(1, observer.GetTickCount(grainId, "single-owner"));
+                Assert.Single(oracle.Snapshot());
+            }
+            catch (OperationCanceledException exception) when (
+                cancellation.IsCancellationRequested
+                && !testCancellationToken.IsCancellationRequested)
+            {
+                var owners = observer.GetActiveReminderSilos(grainId, "single-owner");
+                var operations = oracle.Operations.TakeLast(8);
+                throw new TimeoutException(
+                    $"Two-silo reminder scenario timed out during '{phase}'. "
+                    + $"blockedReads=[firstA={firstRefreshABlocked.IsCompleted}, firstB={firstRefreshBBlocked.IsCompleted}, "
+                    + $"followingA={followingRefreshABlocked.IsCompleted}, followingB={followingRefreshBBlocked.IsCompleted}], "
+                    + $"owners=[{string.Join(", ", owners.Select(silo => silo.ToString()))}], "
+                    + $"operations=[{string.Join("; ", operations)}].",
+                    exception);
+            }
+            finally
+            {
+                firstRefreshA.Release();
+                firstRefreshB.Release();
+                followingRefreshA.Release();
+                followingRefreshB.Release();
+            }
         }
         finally
         {
@@ -455,12 +484,25 @@ public sealed class ReminderTestKitClusterIntegrationTests
         CancellationToken cancellationToken)
     {
         await cluster.DeployAsync(cancellationToken);
-
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cancellation.CancelAfter(TimeSpan.FromSeconds(30));
         var started = cluster.Silos.Select(silo =>
             observer.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress));
         await Task.WhenAll(started);
+    }
+
+    private static async Task DeployAndWaitForStableReminderTopologyAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer,
+        CancellationToken cancellationToken)
+    {
+        await cluster.DeployAsync(cancellationToken);
+        await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+            cluster,
+            observer,
+            cluster.Silos,
+            TimeSpan.FromSeconds(30),
+            cancellationToken);
     }
 
     private static async Task AdvanceUntilAsync(

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -304,6 +304,50 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task RangeChangeBarrier_FollowsLatestRefresh()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
+        var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
+        var obsoleteRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+        RangeReadGate? currentRead = null;
+        try
+        {
+            var obsoleteRangeChange = reminderService.TestOnlyChangeRange(oldRange, newRange, increased: false);
+            await obsoleteRead.WaitUntilBlockedAsync(cancellation.Token);
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+
+            currentRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+            var currentRefresh = reminderService.TestOnlyRefresh();
+            await currentRead.WaitUntilBlockedAsync(cancellation.Token);
+            Assert.False(reconciliationTask.IsCompleted);
+
+            currentRead.Release();
+            await Task.WhenAll(currentRefresh, reconciliationTask).WaitAsync(cancellation.Token);
+            Assert.False(obsoleteRangeChange.IsCompleted);
+
+            obsoleteRead.Release();
+            await obsoleteRangeChange.WaitAsync(cancellation.Token);
+        }
+        finally
+        {
+            obsoleteRead.Release();
+            currentRead?.Release();
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task RangeChangeBarrier_PropagatesCurrentProviderReadFailure()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -257,6 +257,51 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task SiloStatusListenerBarrier_WaitsForCurrentMembershipVersion()
+    {
+        var initialSilo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        var listener = new BlockingSiloStatusListener(initialSilo.SiloAddress);
+        var statusOracle = initialSilo.ServiceProvider.GetRequiredService<ISiloStatusOracle>();
+        Assert.True(statusOracle.SubscribeToSiloStatusEvents(listener));
+        Task<List<InProcessSiloHandle>>? startTask = null;
+        InProcessSiloHandle? joinedSilo = null;
+        try
+        {
+            startTask = fixture.HostedCluster.StartSilosAsync(1, cancellation.Token);
+            await listener.WaitUntilBlockedAsync(cancellation.Token);
+
+            var reminderService = initialSilo.ServiceProvider.GetRequiredService<LocalReminderService>();
+            var barrier = reminderService.TestOnlyWaitForSiloStatusListeners(cancellation.Token);
+            Assert.False(barrier.IsCompleted);
+
+            listener.Release();
+            joinedSilo = Assert.Single(await startTask.WaitAsync(cancellation.Token));
+            await barrier;
+        }
+        finally
+        {
+            listener.Release();
+            statusOracle.UnSubscribeFromSiloStatusEvents(listener);
+            if (joinedSilo is null && startTask is not null)
+            {
+                using var startupCleanup = new CancellationTokenSource(TestConstants.InitTimeout);
+                joinedSilo = Assert.Single(await startTask.WaitAsync(startupCleanup.Token));
+            }
+
+            if (joinedSilo is not null)
+            {
+                using var siloCleanup = new CancellationTokenSource(TestConstants.InitTimeout);
+                await fixture.HostedCluster.StopSiloAsync(joinedSilo, siloCleanup.Token);
+                await fixture.HostedCluster.WaitForLivenessToStabilizeAsync();
+            }
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task RangeChangeBarrier_FollowsLatestReconciliation()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
@@ -544,6 +589,31 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
                 ReminderHarness.Dispose();
             }
         }
+    }
+
+    private sealed class BlockingSiloStatusListener(SiloAddress localSilo) : ISiloStatusListener
+    {
+        private readonly TaskCompletionSource _blocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ManualResetEventSlim _release = new();
+        private int _hasBlocked;
+
+        public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
+        {
+            if (updatedSilo.Equals(localSilo)
+                || status != SiloStatus.Active
+                || Interlocked.Exchange(ref _hasBlocked, 1) != 0)
+            {
+                return;
+            }
+
+            _blocked.TrySetResult();
+            _release.Wait();
+        }
+
+        public Task WaitUntilBlockedAsync(CancellationToken cancellationToken)
+            => _blocked.Task.WaitAsync(cancellationToken);
+
+        public void Release() => _release.Set();
     }
 
     private sealed class NullReturningReminderTable : IReminderTable

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -262,7 +262,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         var initialSilo = Assert.Single(fixture.HostedCluster.Silos);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
-        var listener = new BlockingSiloStatusListener(initialSilo.SiloAddress);
+        using var listener = new BlockingSiloStatusListener(initialSilo.SiloAddress);
         var statusOracle = initialSilo.ServiceProvider.GetRequiredService<ISiloStatusOracle>();
         Assert.True(statusOracle.SubscribeToSiloStatusEvents(listener));
         Task<List<InProcessSiloHandle>>? startTask = null;
@@ -591,7 +591,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         }
     }
 
-    private sealed class BlockingSiloStatusListener(SiloAddress localSilo) : ISiloStatusListener
+    private sealed class BlockingSiloStatusListener(SiloAddress localSilo) : ISiloStatusListener, IDisposable
     {
         private readonly TaskCompletionSource _blocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ManualResetEventSlim _release = new();
@@ -614,6 +614,8 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             => _blocked.Task.WaitAsync(cancellationToken);
 
         public void Release() => _release.Set();
+
+        public void Dispose() => _release.Dispose();
     }
 
     private sealed class NullReturningReminderTable : IReminderTable

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -6,6 +6,7 @@ using Orleans.Reminders.TestKit;
 using Orleans.Runtime;
 using Orleans.Runtime.ConsistentRing;
 using Orleans.Runtime.ReminderService;
+using Orleans.Runtime.Services;
 using Orleans.TestingHost;
 
 namespace Orleans.Testing.Reminders;
@@ -16,6 +17,7 @@ namespace Orleans.Testing.Reminders;
 /// </summary>
 public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleHarness
 {
+    private static readonly TimeSpan TopologyStabilizationTimeout = TimeSpan.FromSeconds(30);
     private readonly InProcessTestCluster _cluster;
     private readonly ReminderTestClock _clock;
     private readonly ReminderDiagnosticObserver _observer;
@@ -54,14 +56,8 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         => _cluster.GetActiveSilos().Select(silo => silo.SiloAddress).Order().ToArray();
 
     /// <inheritdoc />
-    public async Task WaitForStartupReadinessAsync(CancellationToken cancellationToken)
-    {
-        var startupEvents = ActiveSilos
-            .Select(silo => _observer.WaitForReminderServiceStartedAsync(cancellationToken, silo))
-            .ToArray();
-        await Task.WhenAll(startupEvents);
-        await WaitForTopologyReconciliationAsync(cancellationToken);
-    }
+    public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken)
+        => StabilizeTopologyAsync(_cluster.GetActiveSilos(), cancellationToken);
 
     /// <inheritdoc />
     public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)
@@ -70,12 +66,27 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
     /// <inheritdoc />
     public async Task RefreshAsync(CancellationToken cancellationToken)
     {
-        foreach (var silo in _cluster.GetActiveSilos())
-        {
-            await silo.ServiceProvider.GetRequiredService<LocalReminderService>()
-                .TestOnlyRefresh()
-                .WaitAsync(cancellationToken);
-        }
+        var refreshes = _cluster.GetActiveSilos()
+            .Select(silo => silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyRefresh())
+            .ToArray();
+        await Task.WhenAll(refreshes).WaitAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task RegisterOnSiloAsync(
+        SiloAddress siloAddress,
+        GrainId grainId,
+        string reminderName,
+        TimeSpan dueTime,
+        TimeSpan period,
+        CancellationToken cancellationToken)
+    {
+        var silo = _cluster.GetSiloForAddress(siloAddress)
+            ?? throw new InvalidOperationException($"Silo {siloAddress} is not active.");
+        var client = new DirectedReminderServiceClient(silo.ServiceProvider);
+        await client.GetReminderService(siloAddress)
+            .RegisterOrUpdateReminder(grainId, reminderName, dueTime, period)
+            .WaitAsync(cancellationToken);
     }
 
     /// <inheritdoc />
@@ -148,10 +159,7 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
     public async Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken)
     {
         var silo = AssertSingle(await _cluster.StartSilosAsync(1).WaitAsync(cancellationToken));
-        await Task.WhenAll(
-            _observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress),
-            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
-            _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
+        await StabilizeTopologyAsync([silo], cancellationToken);
         return silo.SiloAddress;
     }
 
@@ -167,21 +175,18 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
     }
 
     /// <inheritdoc />
-    public async Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken)
-    {
-        await Task.WhenAll(
-            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
-            _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
-        var activeSilos = _cluster.GetActiveSilos();
-        await Task.WhenAll(activeSilos.Select(silo =>
-            silo.ServiceProvider.GetRequiredService<LocalReminderService>()
-                .TestOnlyWaitForSiloStatusListeners(cancellationToken)));
-        await RefreshAsync(cancellationToken);
-        var barriers = activeSilos.Select(silo =>
-            silo.ServiceProvider.GetRequiredService<LocalReminderService>()
-                .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
-        await Task.WhenAll(barriers);
-    }
+    public Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken)
+        => StabilizeTopologyAsync(_cluster.GetActiveSilos(), cancellationToken);
+
+    private async Task StabilizeTopologyAsync(
+        IEnumerable<InProcessSiloHandle> readySilos,
+        CancellationToken cancellationToken)
+        => await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+            _cluster,
+            _observer,
+            readySilos,
+            TopologyStabilizationTimeout,
+            cancellationToken);
 
     private static InProcessSiloHandle AssertSingle(IReadOnlyList<InProcessSiloHandle> silos)
         => silos.Count == 1
@@ -209,4 +214,10 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
             identity,
             ReminderEvents.LocalReminderStopReason.Unregistered,
             ActiveSilos.First());
+
+    private sealed class DirectedReminderServiceClient(IServiceProvider serviceProvider)
+        : GrainServiceClient<IReminderService>(serviceProvider)
+    {
+        public IReminderService GetReminderService(SiloAddress siloAddress) => GetGrainService(siloAddress);
+    }
 }

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -172,8 +172,12 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         await Task.WhenAll(
             _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
             _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
+        var activeSilos = _cluster.GetActiveSilos();
+        await Task.WhenAll(activeSilos.Select(silo =>
+            silo.ServiceProvider.GetRequiredService<LocalReminderService>()
+                .TestOnlyWaitForSiloStatusListeners(cancellationToken)));
         await RefreshAsync(cancellationToken);
-        var barriers = _cluster.GetActiveSilos().Select(silo =>
+        var barriers = activeSilos.Select(silo =>
             silo.ServiceProvider.GetRequiredService<LocalReminderService>()
                 .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
         await Task.WhenAll(barriers);

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -17,7 +17,6 @@ namespace Orleans.Testing.Reminders;
 /// </summary>
 public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleHarness
 {
-    private static readonly TimeSpan TopologyStabilizationTimeout = TimeSpan.FromSeconds(30);
     private readonly InProcessTestCluster _cluster;
     private readonly ReminderTestClock _clock;
     private readonly ReminderDiagnosticObserver _observer;
@@ -185,7 +184,7 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
             _cluster,
             _observer,
             readySilos,
-            TopologyStabilizationTimeout,
+            Timeout.InfiniteTimeSpan,
             cancellationToken);
 
     private static InProcessSiloHandle AssertSingle(IReadOnlyList<InProcessSiloHandle> silos)

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -172,11 +172,11 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
         await Task.WhenAll(
             _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
             _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
+        await RefreshAsync(cancellationToken);
         var barriers = _cluster.GetActiveSilos().Select(silo =>
             silo.ServiceProvider.GetRequiredService<LocalReminderService>()
                 .TestOnlyWaitForRangeChangeReconciliation(cancellationToken));
         await Task.WhenAll(barriers);
-        await RefreshAsync(cancellationToken);
     }
 
     private static InProcessSiloHandle AssertSingle(IReadOnlyList<InProcessSiloHandle> silos)

--- a/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.Runtime.ReminderService;
+using Orleans.TestingHost;
+
+namespace Orleans.Testing.Reminders;
+
+/// <summary>
+/// Establishes the topology boundary required by deterministic reminder tests.
+/// </summary>
+public static class ReminderTopologyStabilizer
+{
+    /// <summary>
+    /// Waits for reminder service readiness, stable membership visibility, and current reminder reconciliation.
+    /// </summary>
+    public static async Task<IReadOnlyList<InProcessSiloHandle>> WaitForStableTopologyAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer,
+        IEnumerable<InProcessSiloHandle> readySilos,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        ArgumentNullException.ThrowIfNull(observer);
+        ArgumentNullException.ThrowIfNull(readySilos);
+
+        var requiredReadySilos = readySilos
+            .DistinctBy(silo => silo.SiloAddress)
+            .OrderBy(silo => silo.SiloAddress)
+            .ToArray();
+        var expectedActiveSilos = Array.Empty<InProcessSiloHandle>();
+        var phase = "reminder service readiness";
+        using var timeoutCancellation = new CancellationTokenSource(timeout);
+        using var phaseCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutCancellation.Token,
+            cancellationToken);
+        try
+        {
+            var ready = requiredReadySilos
+                .Select(silo => observer.WaitForReminderServiceStartedAsync(
+                    phaseCancellation.Token,
+                    silo.SiloAddress))
+                .ToArray();
+            await Task.WhenAll(ready);
+
+            while (true)
+            {
+                phase = "liveness and manifest convergence";
+                await Task.WhenAll(
+                    cluster.WaitForLivenessToStabilizeAsync().WaitAsync(phaseCancellation.Token),
+                    cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(phaseCancellation.Token));
+
+                phase = "active silo selection";
+                expectedActiveSilos = cluster.GetActiveSilos()
+                    .OrderBy(silo => silo.SiloAddress)
+                    .ToArray();
+                var expectedAddresses = expectedActiveSilos.Select(silo => silo.SiloAddress).ToArray();
+                var missingReadySilos = requiredReadySilos
+                    .Select(silo => silo.SiloAddress)
+                    .Except(expectedAddresses)
+                    .ToArray();
+                if (missingReadySilos.Length > 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Ready reminder services are not active: [{string.Join(", ", missingReadySilos.Select(silo => silo.ToString()))}]. "
+                        + $"Active silos: [{string.Join(", ", expectedAddresses.Select(silo => silo.ToString()))}].");
+                }
+
+                phase = "selected active reminder service readiness";
+                var activeServicesReady = expectedActiveSilos
+                    .Select(silo => observer.WaitForReminderServiceStartedAsync(
+                        phaseCancellation.Token,
+                        silo.SiloAddress))
+                    .ToArray();
+                await Task.WhenAll(activeServicesReady);
+
+                var reminderServices = expectedActiveSilos
+                    .Select(silo => silo.ServiceProvider.GetRequiredService<LocalReminderService>())
+                    .ToArray();
+                var selectedMembershipVersions = reminderServices
+                    .Select(service => service.TestOnlyGetMembershipVersions().Current)
+                    .ToArray();
+
+                phase = "silo status listener delivery";
+                await Task.WhenAll(reminderServices.Select(service =>
+                    service.TestOnlyWaitForSiloStatusListeners(phaseCancellation.Token)));
+
+                phase = "stable topology refresh";
+                var refreshes = reminderServices.Select(service => service.TestOnlyRefresh()).ToArray();
+                await Task.WhenAll(refreshes).WaitAsync(phaseCancellation.Token);
+
+                phase = "latest reminder reconciliation";
+                var reconciliations = reminderServices.Select(service =>
+                    service.TestOnlyWaitForRangeChangeReconciliation(phaseCancellation.Token)).ToArray();
+                await Task.WhenAll(reconciliations);
+
+                phase = "active silo and membership version verification";
+                var observedAddresses = cluster.GetActiveSilos()
+                    .Select(silo => silo.SiloAddress)
+                    .Order()
+                    .ToArray();
+                var observedMembershipVersions = reminderServices
+                    .Select(service => service.TestOnlyGetMembershipVersions())
+                    .ToArray();
+                var expectedAddressSet = expectedAddresses.ToHashSet();
+                var manifestsConverged = expectedActiveSilos.All(silo =>
+                    expectedAddressSet.SetEquals(
+                        silo.ServiceProvider.GetRequiredService<IClusterManifestProvider>().Current.Silos.Keys));
+                var topologyChanged = !observedAddresses.SequenceEqual(expectedAddresses)
+                    || !manifestsConverged
+                    || observedMembershipVersions.Select(versions => versions.Current).Distinct().Count() != 1
+                    || observedMembershipVersions
+                        .Where((versions, index) =>
+                            versions.Current != selectedMembershipVersions[index]
+                            || versions.Processed != versions.Current)
+                        .Any();
+                if (!topologyChanged)
+                {
+                    return expectedActiveSilos;
+                }
+            }
+        }
+        catch (OperationCanceledException exception) when (
+            timeoutCancellation.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(DescribeFailure(cluster, expectedActiveSilos, phase, timeout), exception);
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(
+                DescribeFailure(cluster, expectedActiveSilos, phase, timeout),
+                exception,
+                cancellationToken);
+        }
+    }
+
+    private static string DescribeFailure(
+        InProcessTestCluster cluster,
+        IReadOnlyList<InProcessSiloHandle> expectedActiveSilos,
+        string phase,
+        TimeSpan timeout)
+    {
+        var expected = expectedActiveSilos.Select(silo => silo.SiloAddress.ToString());
+        var observed = cluster.GetActiveSilos()
+            .OrderBy(silo => silo.SiloAddress)
+            .ToArray();
+        var states = observed.Select(silo =>
+            silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyDescribeTopologyState());
+        return $"Reminder topology did not stabilize during '{phase}' within {timeout}. "
+            + $"Expected active silos: [{string.Join(", ", expected)}]. "
+            + $"Observed active silos: [{string.Join(", ", observed.Select(silo => silo.SiloAddress.ToString()))}]. "
+            + $"States: [{string.Join("; ", states)}].";
+    }
+}


### PR DESCRIPTION
## Problem

Reminder lifecycle tests treated service startup, membership convergence, and reminder reconciliation as separate partial signals. A silo could report ready while its current membership version had not yet flowed through all status listeners, or a newer range or periodic refresh could supersede the reconciliation being awaited. Tests then refreshed stale ranges, observed duplicate owners, blocked deterministic oracle reads, or timed out reminder registration under provider load.

The stale-owner scenario also used 16 concurrent registrations during uncontrolled topology propagation, making provider throttling and routing timing part of the assertion.

## Solution

- Establish one reusable topology boundary which waits for reminder-service readiness, liveness and manifest convergence, a materialized active-silo set, per-silo membership listener delivery, an explicit FIFO refresh, and the latest tracked reconciliation generation. Retry when membership versions, manifests, or the active set move during the boundary.
- Track periodic refreshes in the same reconciliation generation as range changes and explicit test refreshes.
- Replace the probabilistic registration burst with one deterministic registration sent directly through a specified non-owner reminder service after topology stability, then verify that only the current owner schedules it after refresh.
- Apply the stable boundary to lifecycle churn and the topology-sensitive two-silo TestKit scenario, with phase, membership, ring, reconciliation, oracle-gate, and owner diagnostics. Cleanup releases blocked operations and independently restores topology and persisted rows.

## Rationale

The failures are synchronization defects introduced by the lifecycle and TestKit scenarios, not reminder ownership regressions. The runtime already guarantees that a non-owner registration is persisted without starting a stale local schedule; the revised tests exercise that invariant directly while using explicit lifecycle boundaries for topology convergence.

Fixes #10928
Fixes #10934
Fixes #10938
Fixes #10940
Fixes #10943
Fixes #10955
Fixes #10962