### PR TITLE
fix(testing): scope diagnostic observers to test clusters

### DIFF
--- a/src/Orleans.BroadcastChannel/BroadcastChannelConsumerExtension.cs
+++ b/src/Orleans.BroadcastChannel/BroadcastChannelConsumerExtension.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Orleans.BroadcastChannel.Diagnostics;
+using Orleans.Configuration;
 using Orleans.Runtime;
 
 namespace Orleans.BroadcastChannel
@@ -17,6 +19,8 @@ namespace Orleans.BroadcastChannel
         private readonly ConcurrentDictionary<InternalChannelId, ICallback> _handlers = new();
         private readonly IOnBroadcastChannelSubscribed _subscriptionObserver;
         private readonly GrainId _grainId;
+        private readonly SiloAddress _siloAddress;
+        private readonly string _clusterId;
         private readonly AsyncLock _lock = new AsyncLock();
 
         private interface ICallback
@@ -49,11 +53,15 @@ namespace Orleans.BroadcastChannel
             }
         }
 
-        public BroadcastChannelConsumerExtension(IGrainContextAccessor grainContextAccessor)
+        public BroadcastChannelConsumerExtension(
+            IGrainContextAccessor grainContextAccessor,
+            IOptions<ClusterOptions> clusterOptions)
         {
             var grainContext = grainContextAccessor.GrainContext;
             _subscriptionObserver = (grainContext?.GrainInstance as IOnBroadcastChannelSubscribed)!;
             _grainId = grainContext?.GrainId ?? default;
+            _siloAddress = grainContext?.Address.SiloAddress ?? throw new ArgumentException("A grain context is required.");
+            _clusterId = clusterOptions.Value.ClusterId;
             if (_subscriptionObserver == null)
             {
                 throw new ArgumentException($"The grain doesn't implement interface {nameof(IOnBroadcastChannelSubscribed)}");
@@ -75,7 +83,7 @@ namespace Orleans.BroadcastChannel
             if (callback != default)
             {
                 await callback.OnPublished(item);
-                BroadcastChannelEvents.EmitItemDelivered(streamId.ProviderName, streamId.ChannelId, _grainId);
+                BroadcastChannelEvents.EmitItemDelivered(streamId.ProviderName, streamId.ChannelId, _grainId, _siloAddress, _clusterId);
             }
         }
 

--- a/src/Orleans.BroadcastChannel/BroadcastChannelProvider.cs
+++ b/src/Orleans.BroadcastChannel/BroadcastChannelProvider.cs
@@ -1,7 +1,9 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.BroadcastChannel.SubscriberTable;
+using Orleans.Configuration;
 
 namespace Orleans.BroadcastChannel
 {
@@ -26,19 +28,24 @@ namespace Orleans.BroadcastChannel
         private readonly IGrainFactory _grainFactory;
         private readonly ImplicitChannelSubscriberTable _subscriberTable;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly SiloAddress? _siloAddress;
+        private readonly string _clusterId;
 
         public BroadcastChannelProvider(
             string providerName,
             BroadcastChannelOptions options,
             IGrainFactory grainFactory,
             ImplicitChannelSubscriberTable subscriberTable,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IServiceProvider serviceProvider)
         {
             _providerName = providerName;
             _options = options;
             _grainFactory = grainFactory;
             _subscriberTable = subscriberTable;
             _loggerFactory = loggerFactory;
+            _siloAddress = serviceProvider.GetService<ILocalSiloDetails>()?.SiloAddress;
+            _clusterId = serviceProvider.GetRequiredService<IOptions<ClusterOptions>>().Value.ClusterId;
         }
 
         /// <inheritdoc />
@@ -49,7 +56,9 @@ namespace Orleans.BroadcastChannel
                 _grainFactory,
                 _subscriberTable,
                 _options.FireAndForgetDelivery,
-                _loggerFactory);
+                _loggerFactory,
+                _siloAddress,
+                _clusterId);
         }
 
         /// <summary>
@@ -65,4 +74,3 @@ namespace Orleans.BroadcastChannel
         }
     }
 }
-

--- a/src/Orleans.BroadcastChannel/BroadcastChannelWriter.cs
+++ b/src/Orleans.BroadcastChannel/BroadcastChannelWriter.cs
@@ -33,19 +33,25 @@ namespace Orleans.BroadcastChannel
         private readonly ImplicitChannelSubscriberTable _subscriberTable;
         private readonly bool _fireAndForgetDelivery;
         private readonly ILogger _logger;
+        private readonly SiloAddress? _siloAddress;
+        private readonly string _clusterId;
 
         public BroadcastChannelWriter(
             InternalChannelId channelId,
             IGrainFactory grainFactory,
             ImplicitChannelSubscriberTable subscriberTable,
             bool fireAndForgetDelivery,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            SiloAddress? siloAddress,
+            string clusterId)
         {
             _channelId = channelId;
             _grainFactory = grainFactory;
             _subscriberTable = subscriberTable;
             _fireAndForgetDelivery = fireAndForgetDelivery;
             _logger = loggerFactory.CreateLogger(LoggingCategory);
+            _siloAddress = siloAddress;
+            _clusterId = clusterId;
         }
 
         /// <inheritdoc />
@@ -61,7 +67,7 @@ namespace Orleans.BroadcastChannel
 
             LogDebugPublishingItem(_logger, item, subscribers.Count);
 
-            BroadcastChannelEvents.EmitItemPublished(_channelId.ProviderName, _channelId.ChannelId, subscribers.Count);
+            BroadcastChannelEvents.EmitItemPublished(_channelId.ProviderName, _channelId.ChannelId, subscribers.Count, _siloAddress, _clusterId);
 
             if (_fireAndForgetDelivery)
             {

--- a/src/Orleans.BroadcastChannel/Diagnostics/BroadcastChannelEvents.cs
+++ b/src/Orleans.BroadcastChannel/Diagnostics/BroadcastChannelEvents.cs
@@ -29,12 +29,33 @@ public static class BroadcastChannelEvents
     /// The base class used for broadcast channel diagnostic events.
     /// </summary>
     /// <param name="providerName">The name of the broadcast channel provider.</param>
-    public abstract class BroadcastChannelEvent(string providerName)
+    /// <param name="siloAddress">The address of the silo associated with the event, if any.</param>
+    /// <param name="clusterId">The identifier of the cluster associated with the event.</param>
+    public abstract class BroadcastChannelEvent(string providerName, SiloAddress? siloAddress, string clusterId)
     {
+        /// <summary>
+        /// Initializes an event without cluster identity.
+        /// </summary>
+        /// <param name="providerName">The name of the broadcast channel provider.</param>
+        protected BroadcastChannelEvent(string providerName)
+            : this(providerName, siloAddress: null, clusterId: string.Empty)
+        {
+        }
+
         /// <summary>
         /// The name of the broadcast channel provider.
         /// </summary>
         public readonly string ProviderName = providerName;
+
+        /// <summary>
+        /// The address of the silo associated with the event, if any.
+        /// </summary>
+        public readonly SiloAddress? SiloAddress = siloAddress;
+
+        /// <summary>
+        /// The identifier of the cluster associated with the event.
+        /// </summary>
+        public readonly string ClusterId = clusterId;
     }
 
     /// <summary>
@@ -43,11 +64,23 @@ public static class BroadcastChannelEvents
     /// <param name="providerName">The name of the broadcast channel provider.</param>
     /// <param name="channelId">The channel ID.</param>
     /// <param name="subscriberCount">The number of subscribers that will receive this item.</param>
+    /// <param name="siloAddress">The address of the silo publishing the item, if any.</param>
+    /// <param name="clusterId">The identifier of the cluster publishing the item.</param>
     public sealed class ItemPublished(
         string providerName,
         ChannelId channelId,
-        int subscriberCount) : BroadcastChannelEvent(providerName)
+        int subscriberCount,
+        SiloAddress? siloAddress,
+        string clusterId) : BroadcastChannelEvent(providerName, siloAddress, clusterId)
     {
+        /// <summary>
+        /// Initializes an event without cluster identity.
+        /// </summary>
+        public ItemPublished(string providerName, ChannelId channelId, int subscriberCount)
+            : this(providerName, channelId, subscriberCount, siloAddress: null, clusterId: string.Empty)
+        {
+        }
+
         /// <summary>
         /// The channel ID.
         /// </summary>
@@ -65,11 +98,23 @@ public static class BroadcastChannelEvents
     /// <param name="providerName">The name of the broadcast channel provider.</param>
     /// <param name="channelId">The channel ID.</param>
     /// <param name="consumerGrainId">The grain ID of the consumer.</param>
+    /// <param name="siloAddress">The address of the silo delivering the item.</param>
+    /// <param name="clusterId">The identifier of the cluster delivering the item.</param>
     public sealed class ItemDelivered(
         string providerName,
         ChannelId channelId,
-        GrainId consumerGrainId) : BroadcastChannelEvent(providerName)
+        GrainId consumerGrainId,
+        SiloAddress? siloAddress,
+        string clusterId) : BroadcastChannelEvent(providerName, siloAddress, clusterId)
     {
+        /// <summary>
+        /// Initializes an event without cluster identity.
+        /// </summary>
+        public ItemDelivered(string providerName, ChannelId channelId, GrainId consumerGrainId)
+            : this(providerName, channelId, consumerGrainId, siloAddress: null, clusterId: string.Empty)
+        {
+        }
+
         /// <summary>
         /// The channel ID.
         /// </summary>
@@ -81,41 +126,45 @@ public static class BroadcastChannelEvents
         public readonly GrainId ConsumerGrainId = consumerGrainId;
     }
 
-    internal static void EmitItemPublished(string providerName, ChannelId channelId, int subscriberCount)
+    internal static void EmitItemPublished(string providerName, ChannelId channelId, int subscriberCount, SiloAddress? siloAddress, string clusterId)
     {
         if (!Listener.IsEnabled(nameof(ItemPublished)))
         {
             return;
         }
 
-        Emit(providerName, channelId, subscriberCount);
+        Emit(providerName, channelId, subscriberCount, siloAddress, clusterId);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static void Emit(string providerName, ChannelId channelId, int subscriberCount)
+        static void Emit(string providerName, ChannelId channelId, int subscriberCount, SiloAddress? siloAddress, string clusterId)
         {
             Listener.Write(nameof(ItemPublished), new ItemPublished(
                 providerName,
                 channelId,
-                subscriberCount));
+                subscriberCount,
+                siloAddress,
+                clusterId));
         }
     }
 
-    internal static void EmitItemDelivered(string providerName, ChannelId channelId, GrainId consumerGrainId)
+    internal static void EmitItemDelivered(string providerName, ChannelId channelId, GrainId consumerGrainId, SiloAddress siloAddress, string clusterId)
     {
         if (!Listener.IsEnabled(nameof(ItemDelivered)))
         {
             return;
         }
 
-        Emit(providerName, channelId, consumerGrainId);
+        Emit(providerName, channelId, consumerGrainId, siloAddress, clusterId);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static void Emit(string providerName, ChannelId channelId, GrainId consumerGrainId)
+        static void Emit(string providerName, ChannelId channelId, GrainId consumerGrainId, SiloAddress siloAddress, string clusterId)
         {
             Listener.Write(nameof(ItemDelivered), new ItemDelivered(
                 providerName,
                 channelId,
-                consumerGrainId));
+                consumerGrainId,
+                siloAddress,
+                clusterId));
         }
     }
 

--- a/src/Orleans.Streaming/Diagnostics/StreamingEvents.cs
+++ b/src/Orleans.Streaming/Diagnostics/StreamingEvents.cs
@@ -355,14 +355,29 @@ public static class StreamingEvents
     /// <param name="streamId">The stream ID.</param>
     /// <param name="subscriptionId">The subscription ID of the consumer.</param>
     /// <param name="siloAddress">The address of the silo handling this delivery.</param>
+    /// <param name="clusterId">The identifier of the cluster handling this delivery.</param>
     /// <param name="sequenceToken">The sequence token of the delivered item.</param>
     public sealed class ItemDelivered(
         string streamProvider,
         StreamId streamId,
         Guid subscriptionId,
         SiloAddress? siloAddress,
+        string clusterId,
         StreamSequenceToken? sequenceToken) : StreamingEvent(streamProvider, siloAddress)
     {
+        /// <summary>
+        /// Initializes an event without cluster identity.
+        /// </summary>
+        public ItemDelivered(
+            string streamProvider,
+            StreamId streamId,
+            Guid subscriptionId,
+            SiloAddress? siloAddress,
+            StreamSequenceToken? sequenceToken)
+            : this(streamProvider, streamId, subscriptionId, siloAddress, clusterId: string.Empty, sequenceToken)
+        {
+        }
+
         /// <summary>
         /// The stream ID.
         /// </summary>
@@ -372,6 +387,11 @@ public static class StreamingEvents
         /// The subscription ID of the consumer.
         /// </summary>
         public readonly Guid SubscriptionId = subscriptionId;
+
+        /// <summary>
+        /// The identifier of the cluster associated with the delivery.
+        /// </summary>
+        public readonly string ClusterId = clusterId;
 
         /// <summary>
         /// The sequence token of the delivered item.
@@ -982,23 +1002,24 @@ public static class StreamingEvents
         }
     }
 
-    internal static void EmitItemDelivered(string streamProviderName, StreamId streamId, Guid subscriptionId, StreamSequenceToken? sequenceToken)
+    internal static void EmitItemDelivered(string streamProviderName, StreamId streamId, Guid subscriptionId, SiloAddress? siloAddress, string clusterId, StreamSequenceToken? sequenceToken)
     {
         if (!Listener.IsEnabled(nameof(ItemDelivered)))
         {
             return;
         }
 
-        Emit(streamProviderName, streamId, subscriptionId, sequenceToken);
+        Emit(streamProviderName, streamId, subscriptionId, siloAddress, clusterId, sequenceToken);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static void Emit(string streamProviderName, StreamId streamId, Guid subscriptionId, StreamSequenceToken? sequenceToken)
+        static void Emit(string streamProviderName, StreamId streamId, Guid subscriptionId, SiloAddress? siloAddress, string clusterId, StreamSequenceToken? sequenceToken)
         {
             Listener.Write(nameof(ItemDelivered), new ItemDelivered(
                 streamProviderName,
                 streamId,
                 subscriptionId,
-                null,
+                siloAddress,
+                clusterId,
                 sequenceToken));
         }
     }

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Streams.Core;
 
@@ -36,6 +38,8 @@ namespace Orleans.Streams
         private readonly ConcurrentDictionary<GuidId, IStreamSubscriptionHandle> allStreamObservers = new(); // map to different ObserversCollection<T> of different Ts.
         [Id(2)]
         private readonly ILogger logger;
+        [NonSerialized]
+        private readonly string clusterId;
         private const int MAXIMUM_ITEM_STRING_LOG_LENGTH = 128;
         [NonSerialized]
         private readonly IGrainContext? _grainContext;
@@ -50,6 +54,7 @@ namespace Orleans.Streams
             _grainContext = grainContext;
             providerRuntime = providerRt;
             logger = providerRt.ServiceProvider.GetRequiredService<ILogger<StreamConsumerExtension>>();
+            clusterId = providerRt.ServiceProvider.GetRequiredService<IOptions<ClusterOptions>>().Value.ClusterId;
         }
 
         internal StreamSubscriptionHandleImpl<T> SetObserver<T>(
@@ -80,7 +85,9 @@ namespace Orleans.Streams
                     token,
                     filterData,
                     disableHandshake: IsStatelessWorker,
-                    handshakeState: handshakeState);
+                    handshakeState: handshakeState,
+                    siloAddress: _grainContext?.Address.SiloAddress,
+                    clusterId: clusterId);
                 allStreamObservers[subscriptionId] = handle;
                 return handle;
             }

--- a/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumerExtension.cs
@@ -43,6 +43,8 @@ namespace Orleans.Streams
         private const int MAXIMUM_ITEM_STRING_LOG_LENGTH = 128;
         [NonSerialized]
         private readonly IGrainContext? _grainContext;
+        [NonSerialized]
+        private readonly SiloAddress? _siloAddress;
 
         private IStreamSubscriptionObserver? StreamSubscriptionObserver =>
             _grainContext?.GrainInstance as IStreamSubscriptionObserver;
@@ -55,6 +57,7 @@ namespace Orleans.Streams
             providerRuntime = providerRt;
             logger = providerRt.ServiceProvider.GetRequiredService<ILogger<StreamConsumerExtension>>();
             clusterId = providerRt.ServiceProvider.GetRequiredService<IOptions<ClusterOptions>>().Value.ClusterId;
+            _siloAddress = providerRt.ServiceProvider.GetService<ILocalSiloDetails>()?.SiloAddress;
         }
 
         internal StreamSubscriptionHandleImpl<T> SetObserver<T>(
@@ -86,7 +89,7 @@ namespace Orleans.Streams
                     filterData,
                     disableHandshake: IsStatelessWorker,
                     handshakeState: handshakeState,
-                    siloAddress: _grainContext?.Address.SiloAddress,
+                    siloAddress: _siloAddress,
                     clusterId: clusterId);
                 allStreamObservers[subscriptionId] = handle;
                 return handle;

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -30,6 +30,10 @@ namespace Orleans.Streams
         private IAsyncBatchObserver<T>? batchObserver;
         [NonSerialized]
         private SharedHandshakeState? handshakeState;
+        [NonSerialized]
+        private readonly SiloAddress? siloAddress;
+        [NonSerialized]
+        private readonly string? clusterId;
         private StreamHandshakeToken? expectedToken
         {
             get => SharedHandshake.Token;
@@ -67,7 +71,9 @@ namespace Orleans.Streams
             StreamSequenceToken? token,
             string? filterData,
             bool disableHandshake = false,
-            SharedHandshakeState? handshakeState = null)
+            SharedHandshakeState? handshakeState = null,
+            SiloAddress? siloAddress = null,
+            string? clusterId = null)
         {
             this.subscriptionId = subscriptionId ?? throw new ArgumentNullException(nameof(subscriptionId));
             this.observer = observer;
@@ -75,6 +81,8 @@ namespace Orleans.Streams
             this.streamImpl = streamImpl ?? throw new ArgumentNullException(nameof(streamImpl));
             this.filterData = filterData;
             this.handshakeState = handshakeState;
+            this.siloAddress = siloAddress;
+            this.clusterId = clusterId;
             this.isRewindable = streamImpl.IsRewindable && !disableHandshake;
             if (IsRewindable)
             {
@@ -316,11 +324,17 @@ namespace Orleans.Streams
             }
         }
 
-        private static void EmitItemDelivered(string? streamProviderName, StreamId streamId, Guid currentSubscriptionId, StreamSequenceToken sequenceToken)
+        private void EmitItemDelivered(string? streamProviderName, StreamId streamId, Guid currentSubscriptionId, StreamSequenceToken sequenceToken)
         {
             if (streamProviderName is not null)
             {
-                StreamingEvents.EmitItemDelivered(streamProviderName, streamId, currentSubscriptionId, sequenceToken);
+                StreamingEvents.EmitItemDelivered(
+                    streamProviderName,
+                    streamId,
+                    currentSubscriptionId,
+                    siloAddress,
+                    clusterId ?? throw new InvalidOperationException("The stream subscription is not bound to a cluster."),
+                    sequenceToken);
             }
         }
 

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -35,6 +35,7 @@ namespace Orleans.TestingHost;
 public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
 {
     private readonly List<InProcessSiloHandle> _silos = [];
+    private readonly HashSet<IPEndPoint> _siloEndpoints = [];
     private readonly StringBuilder _log = new();
     private readonly object _logLock = new();
     private readonly InMemoryTransportConnectionHub _transportHub = new();
@@ -87,6 +88,20 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     /// The port allocator.
     /// </summary>
     public ITestClusterPortAllocator PortAllocator { get; }
+
+    /// <summary>
+    /// Returns whether the address belongs to this cluster.
+    /// </summary>
+    /// <param name="siloAddress">The silo address.</param>
+    /// <returns><see langword="true"/> when the address belongs to this cluster.</returns>
+    public bool ContainsSilo(SiloAddress siloAddress)
+    {
+        ArgumentNullException.ThrowIfNull(siloAddress);
+        lock (_siloEndpoints)
+        {
+            return _siloEndpoints.Contains(siloAddress.Endpoint);
+        }
+    }
 
     /// <summary>
     /// Configures the test cluster plus client in-process.
@@ -879,19 +894,28 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         InProcessTestSiloSpecificOptions siloOptions,
         CancellationToken cancellationToken)
     {
-        var host = await Task.Run(async () =>
+        var endpoint = new IPEndPoint(IPAddress.Loopback, siloOptions.SiloPort);
+        bool endpointAdded;
+        lock (_siloEndpoints)
         {
-            var siloName = siloOptions.SiloName;
+            endpointAdded = _siloEndpoints.Add(endpoint);
+        }
 
-            var appBuilder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        try
+        {
+            var host = await Task.Run(async () =>
             {
-                ApplicationName = siloName,
-                EnvironmentName = Environments.Development,
-                DisableDefaults = true
-            });
+                var siloName = siloOptions.SiloName;
 
-            var services = appBuilder.Services;
-            TryConfigureFileLogging(Options, services, siloName);
+                var appBuilder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+                {
+                    ApplicationName = siloName,
+                    EnvironmentName = Environments.Development,
+                    DisableDefaults = true
+                });
+
+                var services = appBuilder.Services;
+                TryConfigureFileLogging(Options, services, siloName);
 
             if (Debugger.IsAttached)
             {
@@ -956,28 +980,41 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
                 }
             });
 
-            var host = appBuilder.Build();
-            TestClusterFatalErrorHandler.Attach(host);
-            InitializeTestHooksSystemTarget(host);
-            try
-            {
-                await host.StartAsync(cancellationToken);
-                return host;
-            }
-            catch
-            {
-                await DisposeAsync(host);
-                throw;
-            }
-        }, cancellationToken);
+                var host = appBuilder.Build();
+                TestClusterFatalErrorHandler.Attach(host);
+                InitializeTestHooksSystemTarget(host);
+                try
+                {
+                    await host.StartAsync(cancellationToken);
+                    return host;
+                }
+                catch
+                {
+                    await DisposeAsync(host);
+                    throw;
+                }
+            }, cancellationToken);
 
-        return new InProcessSiloHandle
+            return new InProcessSiloHandle
+            {
+                Name = siloOptions.SiloName,
+                SiloHost = host,
+                SiloAddress = host.Services.GetRequiredService<ILocalSiloDetails>().SiloAddress,
+                GatewayAddress = host.Services.GetRequiredService<ILocalSiloDetails>().GatewayAddress,
+            };
+        }
+        catch
         {
-            Name = siloOptions.SiloName,
-            SiloHost = host,
-            SiloAddress = host.Services.GetRequiredService<ILocalSiloDetails>().SiloAddress,
-            GatewayAddress = host.Services.GetRequiredService<ILocalSiloDetails>().GatewayAddress,
-        };
+            if (endpointAdded)
+            {
+                lock (_siloEndpoints)
+                {
+                    _siloEndpoints.Remove(endpoint);
+                }
+            }
+
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Orleans.TestingHost/InProcTestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/InProcTestClusterBuilder.cs
@@ -11,6 +11,8 @@ namespace Orleans.TestingHost;
 /// <summary>Configuration builder for starting a <see cref="InProcessTestCluster"/>.</summary>
 public sealed class InProcessTestClusterBuilder
 {
+    private InProcessTestCluster? _cluster;
+
     /// <summary>
     /// Initializes a new instance of <see cref="InProcessTestClusterBuilder"/> using the default options.
     /// </summary>
@@ -109,8 +111,18 @@ public sealed class InProcessTestClusterBuilder
 
         ConfigureDefaultPorts();
 
-        var testCluster = new InProcessTestCluster(Options, portAllocator);
-        return testCluster;
+        return _cluster = new InProcessTestCluster(Options, portAllocator);
+    }
+
+    /// <summary>
+    /// Returns whether the address belongs to the cluster built by this builder.
+    /// </summary>
+    /// <param name="siloAddress">The silo address.</param>
+    /// <returns><see langword="true"/> when the address belongs to this cluster.</returns>
+    public bool ContainsSilo(SiloAddress siloAddress)
+    {
+        ArgumentNullException.ThrowIfNull(siloAddress);
+        return _cluster?.ContainsSilo(siloAddress) == true;
     }
 
     /// <summary>

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -37,6 +37,7 @@ namespace Orleans.TestingHost
     public class TestCluster : IDisposable, IAsyncDisposable
     {
         private readonly List<SiloHandle> additionalSilos = new List<SiloHandle>();
+        private readonly HashSet<IPEndPoint> siloEndpoints = [];
         private readonly TestClusterOptions options;
         private readonly StringBuilder log = new StringBuilder();
         private readonly InMemoryTransportConnectionHub _transportHub = new();
@@ -95,6 +96,20 @@ namespace Orleans.TestingHost
         /// If the cluster is being configured via ClusterConfiguration, then this object may not reflect the true settings.
         /// </remarks>
         public TestClusterOptions Options => this.options;
+
+        /// <summary>
+        /// Returns whether the address belongs to this cluster.
+        /// </summary>
+        /// <param name="siloAddress">The silo address.</param>
+        /// <returns><see langword="true"/> when the address belongs to this cluster.</returns>
+        public bool ContainsSilo(SiloAddress siloAddress)
+        {
+            ArgumentNullException.ThrowIfNull(siloAddress);
+            lock (siloEndpoints)
+            {
+                return siloEndpoints.Contains(siloAddress.Endpoint);
+            }
+        }
 
         /// <summary>
         /// The internal client interface.
@@ -1101,6 +1116,13 @@ namespace Orleans.TestingHost
             // Add overrides.
             if (configurationOverrides != null) configurationSources.AddRange(configurationOverrides);
             var siloSpecificOptions = TestSiloSpecificOptions.Create(this, clusterOptions, instanceNumber, startSiloOnNewPort);
+            var endpoint = new IPEndPoint(IPAddress.Loopback, siloSpecificOptions.SiloPort);
+            bool endpointAdded;
+            lock (siloEndpoints)
+            {
+                endpointAdded = siloEndpoints.Add(endpoint);
+            }
+
             configurationSources.Add(new MemoryConfigurationSource
             {
                 InitialData = siloSpecificOptions.ToDictionary()
@@ -1112,13 +1134,28 @@ namespace Orleans.TestingHost
                 configurationBuilder.Add(source);
             }
             var configuration = configurationBuilder.Build();
-            var handle = await _createSiloAsyncWithCancellation(
-                siloSpecificOptions.SiloName,
-                configuration,
-                cancellationToken);
-            handle.InstanceNumber = (short)instanceNumber;
-            Interlocked.Increment(ref this.startedInstances);
-            return handle;
+            try
+            {
+                var handle = await _createSiloAsyncWithCancellation(
+                    siloSpecificOptions.SiloName,
+                    configuration,
+                    cancellationToken);
+                handle.InstanceNumber = (short)instanceNumber;
+                Interlocked.Increment(ref this.startedInstances);
+                return handle;
+            }
+            catch
+            {
+                if (endpointAdded)
+                {
+                    lock (siloEndpoints)
+                    {
+                        siloEndpoints.Remove(endpoint);
+                    }
+                }
+
+                throw;
+            }
         }
 
         private async Task StopSiloAsync(SiloHandle instance, bool stopGracefully, CancellationToken cancellationToken)

--- a/src/Orleans.TestingHost/TestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/TestClusterBuilder.cs
@@ -19,6 +19,7 @@ namespace Orleans.TestingHost
         private readonly List<Action> configureBuilderActions = new List<Action>();
         private Func<string, IConfiguration, Task<SiloHandle>>? _createSiloAsync;
         private Func<string, IConfiguration, CancellationToken, Task<SiloHandle>>? _createSiloAsyncWithCancellation;
+        private TestCluster? _cluster;
 
         /// <summary>
         /// Initializes a new instance of <see cref="TestClusterBuilder"/> using the default options.
@@ -181,7 +182,7 @@ namespace Orleans.TestingHost
             configuration.GetSection("Orleans").Bind(finalOptions);
 
             var configSources = new ReadOnlyCollection<IConfigurationSource>(configBuilder.Sources);
-            var testCluster = new TestCluster(finalOptions, configSources, portAllocator);
+            var testCluster = _cluster = new TestCluster(finalOptions, configSources, portAllocator);
             if (_createSiloAsyncWithCancellation is not null)
             {
                 testCluster.CreateSiloAsyncWithCancellation = CreateSiloAsyncWithCancellation;
@@ -192,6 +193,17 @@ namespace Orleans.TestingHost
             }
 
             return testCluster;
+        }
+
+        /// <summary>
+        /// Returns whether the address belongs to the cluster built by this builder.
+        /// </summary>
+        /// <param name="siloAddress">The silo address.</param>
+        /// <returns><see langword="true"/> when the address belongs to this cluster.</returns>
+        public bool ContainsSilo(SiloAddress siloAddress)
+        {
+            ArgumentNullException.ThrowIfNull(siloAddress);
+            return _cluster?.ContainsSilo(siloAddress) == true;
         }
 
         /// <summary>

--- a/src/api/Orleans.BroadcastChannel/Orleans.BroadcastChannel.cs
+++ b/src/api/Orleans.BroadcastChannel/Orleans.BroadcastChannel.cs
@@ -162,8 +162,11 @@ namespace Orleans.BroadcastChannel.Diagnostics
 
         public abstract partial class BroadcastChannelEvent
         {
+            public readonly string ClusterId;
             public readonly string ProviderName;
+            public readonly Runtime.SiloAddress? SiloAddress;
             protected BroadcastChannelEvent(string providerName) { }
+            protected BroadcastChannelEvent(string providerName, Runtime.SiloAddress? siloAddress, string clusterId) { }
         }
 
         public sealed partial class ItemDelivered : BroadcastChannelEvent
@@ -171,6 +174,7 @@ namespace Orleans.BroadcastChannel.Diagnostics
             public readonly ChannelId ChannelId;
             public readonly Runtime.GrainId ConsumerGrainId;
             public ItemDelivered(string providerName, ChannelId channelId, Runtime.GrainId consumerGrainId) : base(default!) { }
+            public ItemDelivered(string providerName, ChannelId channelId, Runtime.GrainId consumerGrainId, Runtime.SiloAddress? siloAddress, string clusterId) : base(default!, default, default!) { }
         }
 
         public sealed partial class ItemPublished : BroadcastChannelEvent
@@ -178,6 +182,7 @@ namespace Orleans.BroadcastChannel.Diagnostics
             public readonly ChannelId ChannelId;
             public readonly int SubscriberCount;
             public ItemPublished(string providerName, ChannelId channelId, int subscriberCount) : base(default!) { }
+            public ItemPublished(string providerName, ChannelId channelId, int subscriberCount, Runtime.SiloAddress? siloAddress, string clusterId) : base(default!, default, default!) { }
         }
     }
 }

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1176,10 +1176,12 @@ namespace Orleans.Streaming.Diagnostics
 
         public sealed partial class ItemDelivered : StreamingEvent
         {
+            public readonly string ClusterId;
             public readonly Streams.StreamSequenceToken? SequenceToken;
             public readonly Runtime.StreamId StreamId;
             public readonly System.Guid SubscriptionId;
             public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
+            public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, string clusterId, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
         }
 
         public sealed partial class MessageDelivered : StreamingEvent

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -86,6 +86,8 @@ namespace Orleans.TestingHost
 
         public IClusterClient Client { get { throw null; } }
 
+        public bool ContainsSilo(Runtime.SiloAddress siloAddress) { throw null; }
+
         public InProcessTestClusterOptions Options { get { throw null; } }
 
         public ITestClusterPortAllocator PortAllocator { get { throw null; } }
@@ -214,6 +216,8 @@ namespace Orleans.TestingHost
         public InProcessTestClusterBuilder ConfigureSilo(System.Action<InProcessTestSiloSpecificOptions, Hosting.ISiloBuilder> configureSiloDelegate) { throw null; }
 
         public InProcessTestClusterBuilder ConfigureSiloHost(System.Action<InProcessTestSiloSpecificOptions, Microsoft.Extensions.Hosting.IHostApplicationBuilder> configureSiloHostDelegate) { throw null; }
+
+        public bool ContainsSilo(Runtime.SiloAddress siloAddress) { throw null; }
 
         public static string CreateClusterId() { throw null; }
     }
@@ -375,6 +379,8 @@ namespace Orleans.TestingHost
 
         public IClusterClient Client { get { throw null; } }
 
+        public bool ContainsSilo(Runtime.SiloAddress siloAddress) { throw null; }
+
         public System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.Configuration.IConfigurationSource> ConfigurationSources { get { throw null; } }
 
         public System.Func<string, Microsoft.Extensions.Configuration.IConfiguration, System.Threading.Tasks.Task<SiloHandle>> CreateSiloAsync { set { } }
@@ -511,6 +517,8 @@ namespace Orleans.TestingHost
             where T : new() { throw null; }
 
         public TestCluster Build() { throw null; }
+
+        public bool ContainsSilo(Runtime.SiloAddress siloAddress) { throw null; }
 
         public TestClusterBuilder ConfigureBuilder(System.Action configureDelegate) { throw null; }
 

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSFIFOStreamTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSFIFOStreamTests.cs
@@ -122,7 +122,7 @@ public class SQSFIFOStreamTests : TestClusterPerTest
             return;
         }
 
-        runner = new SingleStreamTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME);
+        runner = new SingleStreamTestRunner(this.HostedCluster, SQS_STREAM_PROVIDER_NAME);
     }
 
     public override async ValueTask DisposeAsync()
@@ -254,7 +254,7 @@ public class SQSFIFOStreamTests : TestClusterPerTest
     [Fact]
     public async Task SQS_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 16, false);
+        var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, SQS_STREAM_PROVIDER_NAME, 16, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             cancellationToken: TestContext.Current.CancellationToken);
     }
@@ -262,7 +262,7 @@ public class SQSFIFOStreamTests : TestClusterPerTest
     [Fact]
     public async Task SQS_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 17, false);
+        var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, SQS_STREAM_PROVIDER_NAME, 17, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             () => HostedCluster.StartAdditionalSilo(),
             cancellationToken: TestContext.Current.CancellationToken);

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSStreamTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSStreamTests.cs
@@ -93,7 +93,7 @@ namespace AWSUtils.Tests.Streaming
             {
                 return;
             }
-            runner = new SingleStreamTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME);
+            runner = new SingleStreamTestRunner(this.HostedCluster, SQS_STREAM_PROVIDER_NAME);
         }
 
         public override async ValueTask DisposeAsync()
@@ -223,7 +223,7 @@ namespace AWSUtils.Tests.Streaming
         [Fact]
         public async Task SQS_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 16, false);
+            var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, SQS_STREAM_PROVIDER_NAME, 16, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
                 cancellationToken: TestContext.Current.CancellationToken);
         }
@@ -231,7 +231,7 @@ namespace AWSUtils.Tests.Streaming
         [Fact]
         public async Task SQS_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, SQS_STREAM_PROVIDER_NAME, 17, false);
+            var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, SQS_STREAM_PROVIDER_NAME, 17, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
                 () => HostedCluster.StartAdditionalSilo(),
                 cancellationToken: TestContext.Current.CancellationToken);

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
@@ -91,7 +91,7 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
         await WaitForStreamingProviderReadyAsync(cancellationToken);
 
         // the runner must only be created after base initialization
-        _runner = new SingleStreamTestRunner(InternalClient, AdoNetStreamProviderName);
+        _runner = new SingleStreamTestRunner(HostedCluster, AdoNetStreamProviderName);
     }
 
     protected override void ConfigureTestCluster(TestClusterBuilder builder)
@@ -204,7 +204,7 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
     [Fact, TestCategory("Functional")]
     public async Task AdoNet_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(InternalClient, AdoNetStreamProviderName, 16, false);
+        var multiRunner = new MultipleStreamsTestRunner(HostedCluster, AdoNetStreamProviderName, 16, false);
 
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             cancellationToken: TestContext.Current.CancellationToken);
@@ -213,7 +213,7 @@ public abstract class AdoNetStreamingTests : TestClusterPerTest
     [Fact, TestCategory("Functional")]
     public async Task AdoNet_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(InternalClient, AdoNetStreamProviderName, 17, false);
+        var multiRunner = new MultipleStreamsTestRunner(HostedCluster, AdoNetStreamProviderName, 17, false);
 
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             () => HostedCluster.StartAdditionalSilo(),

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamingTests.cs
@@ -132,7 +132,7 @@ namespace Tester.AzureUtils.Streaming
             {
                 _preconditionsException?.Throw();
                 await Cluster!.DeployAsync();
-                Runner = new SingleStreamTestRunner(Cluster.InternalClient!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME); // DeployAsync initializes the client.
+                Runner = new SingleStreamTestRunner(Cluster, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME); // DeployAsync initializes the client.
             }
         }
 
@@ -238,7 +238,7 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!.InternalClient!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 16, false); // The fixture deploys the client.
+            var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 16, false); // The fixture deploys the client.
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
                 cancellationToken: TestContext.Current.CancellationToken);
         }
@@ -246,7 +246,7 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!.InternalClient!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 17, false); // The fixture deploys the client.
+            var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 17, false); // The fixture deploys the client.
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
                 fixture.Cluster!.StartAdditionalSilo,
                 cancellationToken: TestContext.Current.CancellationToken);

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
@@ -150,7 +150,7 @@ namespace UnitTests.HaloTests.Streaming
             IProducerEventCountingGrain producer = this.fixture.GrainFactory.GetGrain<IProducerEventCountingGrain>(producerGuid);
             await producer.BecomeProducer(_streamId, _streamProvider);
 
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(Timeout);
 
@@ -179,7 +179,7 @@ namespace UnitTests.HaloTests.Streaming
             IConsumerEventCountingGrain consumer = this.fixture.GrainFactory.GetGrain<IConsumerEventCountingGrain>(consumerGuid);
             await consumer.BecomeConsumer(_streamId, _streamProvider);
 
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(Timeout);
 

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -37,7 +37,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     {
         private static readonly TimeSpan ReminderServiceStartupTimeout = TimeSpan.FromMinutes(5);
         private ReminderTestClock? _reminderClock;
-        private readonly ReminderDiagnosticObserver _startupObserver = ReminderDiagnosticObserver.Create();
+        private ReminderDiagnosticObserver? _startupObserver;
         internal ReminderTestClock ReminderClock
         {
             get
@@ -51,6 +51,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
 
         protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
         {
+            _startupObserver = ReminderDiagnosticObserver.Create(builder);
             _reminderClock = builder.AddReminderTestClock();
             builder.ConfigureSilo((_, siloBuilder) =>
             {
@@ -74,7 +75,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
                 TestContext.Current.CancellationToken);
             cancellation.CancelAfter(ReminderServiceStartupTimeout);
             var startedTasks = silos
-                .Select(silo => _startupObserver.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress))
+                .Select(silo => _startupObserver!.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress))
                 .ToArray();
 
             try
@@ -102,7 +103,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
             finally
             {
                 _reminderClock?.Dispose();
-                _startupObserver.Dispose();
+                _startupObserver?.Dispose();
             }
         }
     }

--- a/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamTests.cs
@@ -65,7 +65,7 @@ public sealed class RedisStreamTests : TestClusterPerTest
     [Fact]
     public async Task Redis_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(InternalClient, StreamProviderName, 16, false);
+        var multiRunner = new MultipleStreamsTestRunner(HostedCluster, StreamProviderName, 16, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             cancellationToken: TestContext.Current.CancellationToken);
     }
@@ -73,7 +73,7 @@ public sealed class RedisStreamTests : TestClusterPerTest
     [Fact]
     public async Task Redis_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(InternalClient, StreamProviderName, 17, false);
+        var multiRunner = new MultipleStreamsTestRunner(HostedCluster, StreamProviderName, 17, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             () => HostedCluster.StartAdditionalSilo(),
             cancellationToken: TestContext.Current.CancellationToken);
@@ -97,7 +97,7 @@ public sealed class RedisStreamTests : TestClusterPerTest
         {
             return;
         }
-        _runner = new SingleStreamTestRunner(InternalClient, StreamProviderName);
+        _runner = new SingleStreamTestRunner(HostedCluster, StreamProviderName);
     }
 
     public override async ValueTask DisposeAsync()

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisStreamTests.cs
@@ -105,7 +105,7 @@ namespace Orleans.Streaming.Kinesis.Tests
             {
                 return;
             }
-            runner = new SingleStreamTestRunner(this.InternalClient, KINESIS_STREAM_PROVIDER_NAME);
+            runner = new SingleStreamTestRunner(this.HostedCluster, KINESIS_STREAM_PROVIDER_NAME);
         }
 
         public override async ValueTask DisposeAsync()
@@ -239,7 +239,7 @@ namespace Orleans.Streaming.Kinesis.Tests
         [Fact]
         public async Task Kinesis_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, KINESIS_STREAM_PROVIDER_NAME, 16, false);
+            var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, KINESIS_STREAM_PROVIDER_NAME, 16, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
                 cancellationToken: TestContext.Current.CancellationToken);
         }
@@ -247,7 +247,7 @@ namespace Orleans.Streaming.Kinesis.Tests
         [Fact]
         public async Task Kinesis_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, KINESIS_STREAM_PROVIDER_NAME, 17, false);
+            var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, KINESIS_STREAM_PROVIDER_NAME, 17, false);
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
                 () => HostedCluster.StartAdditionalSilo(),
                 cancellationToken: TestContext.Current.CancellationToken);

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamTests.cs
@@ -114,7 +114,7 @@ public class NatsStreamTests : TestClusterPerTest
             return;
 
         }
-        runner = new SingleStreamTestRunner(this.InternalClient, NatsStreamProviderName);
+        runner = new SingleStreamTestRunner(this.HostedCluster, NatsStreamProviderName);
     }
 
     public override async ValueTask DisposeAsync()
@@ -245,7 +245,7 @@ public class NatsStreamTests : TestClusterPerTest
     [Fact]
     public async Task Nats_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, NatsStreamProviderName, 16, false);
+        var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, NatsStreamProviderName, 16, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             cancellationToken: TestContext.Current.CancellationToken);
     }
@@ -253,7 +253,7 @@ public class NatsStreamTests : TestClusterPerTest
     [Fact]
     public async Task Nats_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
     {
-        var multiRunner = new MultipleStreamsTestRunner(this.InternalClient, NatsStreamProviderName, 17, false);
+        var multiRunner = new MultipleStreamsTestRunner(this.HostedCluster, NatsStreamProviderName, 17, false);
         await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
             () => this.HostedCluster.StartAdditionalSilo(),
             cancellationToken: TestContext.Current.CancellationToken);

--- a/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
@@ -52,7 +52,7 @@ public class DiagnosticInfrastructureRegressionTests
     [Fact, TestCategory("BVT")]
     public async Task GrainDiagnosticObserver_WaitForAnyGrainDeactivatedAsync_TimesOut()
     {
-        using var observer = GrainDiagnosticObserver.Create();
+        using var observer = GrainDiagnosticObserver.CreateForAllSilos();
 
         await Assert.ThrowsAsync<TimeoutException>(() => observer.WaitForAnyGrainDeactivatedAsync(_ => false, TimeSpan.FromMilliseconds(100)));
     }
@@ -62,7 +62,7 @@ public class DiagnosticInfrastructureRegressionTests
     [Fact, TestCategory("BVT")]
     public async Task GrainDiagnosticObserver_WaitAfterTimeout_CanObserveLaterEvent()
     {
-        using var observer = GrainDiagnosticObserver.Create();
+        using var observer = GrainDiagnosticObserver.CreateForAllSilos();
         var grainId = GrainId.Create("test", "grain-1");
 
         await Assert.ThrowsAsync<TimeoutException>(() => observer.WaitForGrainCreatedAsync(grainId, TimeSpan.FromMilliseconds(100)));
@@ -79,10 +79,41 @@ public class DiagnosticInfrastructureRegressionTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task GrainAndTimerDiagnosticObservers_IgnoreOtherSilos()
+    {
+        var targetSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11990), 1);
+        var otherSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11991), 1);
+        var grainId = GrainId.Create("test", "shared-grain");
+        var targetContext = CreateGrainContext(targetSilo, grainId);
+        var otherContext = CreateGrainContext(otherSilo, grainId);
+        var timer = Substitute.For<IGrainTimer>();
+        using var grainObserver = GrainDiagnosticObserver.Create(targetSilo);
+        using var timerObserver = TimerDiagnosticObserver.Create(targetSilo);
+
+        var grainWait = grainObserver.WaitForGrainCreatedAsync(grainId, TimeSpan.FromSeconds(1));
+        var timerWait = timerObserver.WaitForTimerCreatedAsync(grainId, TimeSpan.FromSeconds(1));
+        GrainLifecycleEvents.EmitCreated(otherContext);
+        GrainTimerEvents.EmitCreated(otherContext, TimeSpan.Zero, TimeSpan.FromSeconds(1), timer);
+
+        Assert.False(grainWait.IsCompleted);
+        Assert.False(timerWait.IsCompleted);
+
+        GrainLifecycleEvents.EmitCreated(targetContext);
+        GrainTimerEvents.EmitCreated(targetContext, TimeSpan.Zero, TimeSpan.FromSeconds(1), timer);
+
+        Assert.Same(targetContext, (await grainWait).GrainContext);
+        Assert.Same(targetContext, (await timerWait).GrainContext);
+        Assert.Single(grainObserver.CreatedEvents);
+        Assert.Single(timerObserver.CreatedEvents);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task RebalancerDiagnosticObserver_WaitForCycleAsync_ReturnsNewEvent()
     {
-        using var observer = RebalancerDiagnosticObserver.Create();
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12000), 1);
+        using var observer = RebalancerDiagnosticObserver.Create(siloAddress);
 
         ActivationRebalancerEvents.EmitCycleStop(siloAddress, 1, 1, 0.1, TimeSpan.FromMilliseconds(1), false);
 
@@ -100,10 +131,31 @@ public class DiagnosticInfrastructureRegressionTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task RebalancerDiagnosticObserver_IgnoresOtherSilos()
+    {
+        var targetSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12010), 1);
+        var otherSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12011), 1);
+        using var observer = RebalancerDiagnosticObserver.Create(targetSilo);
+
+        var waitTask = observer.WaitForSessionStopAsync(TimeSpan.FromSeconds(1));
+        ActivationRebalancerEvents.EmitSessionStop(otherSilo, "other", 1);
+
+        Assert.False(waitTask.IsCompleted);
+
+        ActivationRebalancerEvents.EmitSessionStop(targetSilo, "target", 2);
+
+        var result = await waitTask;
+        Assert.Equal(targetSilo, result.SiloAddress);
+        Assert.Single(observer.SessionStopEvents);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task RebalancerDiagnosticObserver_WaitForSessionStopAsync_ReturnsNewEvent()
     {
-        using var observer = RebalancerDiagnosticObserver.Create();
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12001), 2);
+        using var observer = RebalancerDiagnosticObserver.Create(siloAddress);
 
         ActivationRebalancerEvents.EmitSessionStop(siloAddress, "existing", 1);
 
@@ -123,8 +175,8 @@ public class DiagnosticInfrastructureRegressionTests
     [Fact, TestCategory("BVT")]
     public async Task RebalancerDiagnosticObserver_WaitAfterTimeout_CanObserveLaterEvent()
     {
-        using var observer = RebalancerDiagnosticObserver.Create();
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12002), 3);
+        using var observer = RebalancerDiagnosticObserver.Create(siloAddress);
 
         var timedOutWaitTask = observer.WaitForSessionStopAsync(TimeSpan.Zero);
         Assert.True(timedOutWaitTask.IsCompleted);
@@ -147,7 +199,8 @@ public class DiagnosticInfrastructureRegressionTests
     [Fact, TestCategory("BVT")]
     public async Task RebalancerDiagnosticObserver_Dispose_CompletesOutstandingWaiters()
     {
-        var observer = RebalancerDiagnosticObserver.Create();
+        var observer = RebalancerDiagnosticObserver.Create(
+            SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12003), 4));
         var waitTask = observer.WaitForSessionStopAsync();
 
         observer.Dispose();
@@ -180,5 +233,13 @@ public class DiagnosticInfrastructureRegressionTests
         var actualThreadId = threadSegment[(threadSegment.LastIndexOf(' ') + 1)..];
 
         Assert.Equal(loggedThreadId.ToString(CultureInfo.InvariantCulture), actualThreadId);
+    }
+
+    private static IGrainContext CreateGrainContext(SiloAddress siloAddress, GrainId grainId)
+    {
+        var result = Substitute.For<IGrainContext>();
+        result.GrainId.Returns(grainId);
+        result.Address.Returns(GrainAddress.NewActivationAddress(siloAddress, grainId));
+        return result;
     }
 }

--- a/test/Orleans.Core.Tests/Diagnostics/MembershipEventsTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/MembershipEventsTests.cs
@@ -62,8 +62,8 @@ public class MembershipEventsTests
     [Fact, TestCategory("BVT")]
     public async Task MembershipDiagnosticObserver_DerivesStatusTransitions_FromViewChanged()
     {
-        using var observer = MembershipDiagnosticObserver.Create();
         var observerSilo = CreateSiloAddress(12111, 3);
+        using var observer = MembershipDiagnosticObserver.Create(observerSilo);
         var subjectSilo = CreateSiloAddress(12112, 4);
 
         MembershipEvents.EmitViewChanged(
@@ -80,6 +80,36 @@ public class MembershipEventsTests
         Assert.Equal(SiloStatus.Joining, transition.OldEntry!.Status);
         Assert.Equal(SiloStatus.Active, transition.NewEntry.Status);
         Assert.Same(observerSilo, transition.ObserverSiloAddress);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task MembershipDiagnosticObserver_IgnoresOtherObserverSilos()
+    {
+        var observerSilo = CreateSiloAddress(12121, 1);
+        var otherObserverSilo = CreateSiloAddress(12122, 1);
+        var subjectSilo = CreateSiloAddress(12123, 1);
+        using var observer = MembershipDiagnosticObserver.Create(observerSilo);
+
+        MembershipEvents.EmitViewChanged(
+            CreateSnapshot(1, CreateEntry(subjectSilo, SiloStatus.Joining)),
+            otherObserverSilo);
+        MembershipEvents.EmitViewChanged(
+            CreateSnapshot(2, CreateEntry(subjectSilo, SiloStatus.Dead)),
+            otherObserverSilo);
+        MembershipEvents.EmitViewChanged(
+            CreateSnapshot(1, CreateEntry(subjectSilo, SiloStatus.Joining)),
+            observerSilo);
+        MembershipEvents.EmitViewChanged(
+            CreateSnapshot(2, CreateEntry(subjectSilo, SiloStatus.Active)),
+            observerSilo);
+
+        var transition = await observer.WaitForSiloBecameActiveAsync(subjectSilo, TimeSpan.FromSeconds(1));
+
+        Assert.Equal(SiloStatus.Joining, transition.OldEntry!.Status);
+        Assert.Equal(observerSilo, transition.ObserverSiloAddress);
+        Assert.Equal(2, observer.ViewChangedEvents.Count);
     }
 
     private static MembershipEntry CreateEntry(SiloAddress siloAddress, SiloStatus status)

--- a/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
@@ -49,7 +49,7 @@ namespace DefaultCluster.Tests.TimerTests
 
         private async Task<int> AdvanceDefaultTimerTicksAsync(ITimerGrain grain, TimeSpan period)
         {
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             for (var expectedTickCount = 1; expectedTickCount <= ExpectedDefaultTimerTicks; expectedTickCount++)
             {
                 await AdvanceTimerToTickCountAsync(grain, timerObserver, period, expectedTickCount);
@@ -62,7 +62,7 @@ namespace DefaultCluster.Tests.TimerTests
         private async Task AdvanceDefaultTimerTicksAsync<TGrain>(IReadOnlyList<TGrain> grains, TimeSpan period)
             where TGrain : ITimerGrain
         {
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             for (var expectedTickCount = 1; expectedTickCount <= ExpectedDefaultTimerTicks; expectedTickCount++)
             {
                 var waitForTicks = Task.WhenAll(grains.Select(g => timerObserver.WaitForTickCountAsync(g, expectedTickCount, TimerDiagnosticTimeout)));
@@ -116,7 +116,7 @@ namespace DefaultCluster.Tests.TimerTests
 
         private async Task RunSelfDisposingTimerAsync(ITimerCallGrain grain)
         {
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             var runTimer = grain.RunSelfDisposingTimer();
             var created = await timerObserver.WaitForTimerCreatedAsync(grain, TimerDiagnosticTimeout);
             using var cts = new CancellationTokenSource(TimerDiagnosticTimeout);
@@ -352,7 +352,7 @@ namespace DefaultCluster.Tests.TimerTests
             ITimerCallGrain? grain = null;
 
             Exception? error = null;
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             try
             {
                 grain = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
@@ -402,7 +402,7 @@ namespace DefaultCluster.Tests.TimerTests
         {
             var grain = GrainFactory.GetGrain<ITimerRequestGrain>(GetRandomGrainId());
 
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             var numTimers = await grain.TestAllTimerOverloads();
             var waitForTimers = timerObserver.WaitForTickCountAsync(grain, numTimers, TimerDiagnosticTimeout);
             await fixture.AdvanceTimeAsync(TimerOverloadDueTime);
@@ -444,7 +444,7 @@ namespace DefaultCluster.Tests.TimerTests
             const string testName = "NonReentrantGrainTimer_Test";
             var delay = OneShotTimerDelay;
 
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             var grain = GrainFactory.GetGrain<INonReentrantTimerCallGrain>(GetRandomGrainId());
 
             // Schedule multiple timers with the same delay
@@ -482,7 +482,7 @@ namespace DefaultCluster.Tests.TimerTests
             const string testName = nameof(GrainTimer_Change);
             TimeSpan delay = OneShotTimerDelay;
 
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             var grain = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
 
             await grain.StartTimer(testName, delay);
@@ -631,7 +631,7 @@ namespace DefaultCluster.Tests.TimerTests
             IPocoTimerCallGrain? grain = null;
 
             Exception? error = null;
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             try
             {
                 grain = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
@@ -681,7 +681,7 @@ namespace DefaultCluster.Tests.TimerTests
         {
             var grain = GrainFactory.GetGrain<IPocoTimerRequestGrain>(GetRandomGrainId());
 
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             var numTimers = await grain.TestAllTimerOverloads();
             var waitForTimers = timerObserver.WaitForTickCountAsync(grain, numTimers, TimerDiagnosticTimeout);
             await fixture.AdvanceTimeAsync(TimerOverloadDueTime);
@@ -703,7 +703,7 @@ namespace DefaultCluster.Tests.TimerTests
             const string testName = "NonReentrantGrainTimer_Test";
             var delay = OneShotTimerDelay;
 
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             var grain = GrainFactory.GetGrain<IPocoNonReentrantTimerCallGrain>(GetRandomGrainId());
 
             // Schedule multiple timers with the same delay
@@ -740,7 +740,7 @@ namespace DefaultCluster.Tests.TimerTests
             const string testName = nameof(GrainTimer_Change);
             TimeSpan delay = OneShotTimerDelay;
 
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var timerObserver = TimerDiagnosticObserver.Create(fixture.HostedCluster);
             var grain = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
 
             await grain.StartTimer(testName, delay);

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -23,7 +23,7 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
         var cancellationToken = TestContext.Current.CancellationToken;
         var serviceProvider = Cluster.GetSiloServiceProvider();
         var rebalancer = serviceProvider.GetRequiredService<IActivationRebalancer>();
-        using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
+        using var rebalancerEvents = RebalancerDiagnosticObserver.Create(Cluster);
 
         var sessionStarted = rebalancerEvents.WaitForSessionStartAsync(WaitTimeout).WaitAsync(cancellationToken);
         await rebalancer.ResumeRebalancing();

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/DynamicRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/DynamicRebalancingTests.cs
@@ -19,7 +19,7 @@ public class DynamicRebalancingTests(RebalancerFixture fixture, ITestOutputHelpe
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var tasks = new List<Task>();
-        using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
+        using var rebalancerEvents = RebalancerDiagnosticObserver.Create(Cluster);
         var rebalancer = Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0);
         var rebalancerHost = (await rebalancer.GetReport()).Host;
 

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
@@ -34,7 +34,7 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var tasks = new List<Task>();
-        using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
+        using var rebalancerEvents = RebalancerDiagnosticObserver.Create(Cluster);
         var rebalancer = Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0);
         var targetHost = Cluster.Silos[1].SiloAddress;
 

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
@@ -19,7 +19,7 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var tasks = new List<Task>();
-        using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
+        using var rebalancerEvents = RebalancerDiagnosticObserver.Create(Cluster);
         var rebalancer = Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0);
         var rebalancerHost = (await rebalancer.GetReport()).Host;
 

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -49,8 +49,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {
@@ -95,8 +95,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {
@@ -128,8 +128,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var builder = new InProcessTestClusterBuilder(1);
         var oracle = builder.UseIdealizedReminderTable();
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {
@@ -173,8 +173,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
             builder,
             minimumReminderPeriod: TimeSpan.FromSeconds(1),
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {
@@ -217,8 +217,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
             builder,
             minimumReminderPeriod: TimeSpan.FromSeconds(1),
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {
@@ -268,8 +268,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
             builder,
             minimumReminderPeriod: TimeSpan.FromSeconds(1),
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {
@@ -322,8 +322,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
             builder,
             minimumReminderPeriod: TimeSpan.FromSeconds(1),
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {
@@ -377,8 +377,8 @@ public sealed class ReminderTestKitClusterIntegrationTests
             builder,
             minimumReminderPeriod: TimeSpan.FromSeconds(1),
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
-        using var observer = ReminderDiagnosticObserver.Create();
         var cluster = builder.Build();
+        using var observer = ReminderDiagnosticObserver.Create(cluster);
 
         try
         {

--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -34,7 +34,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public void ReminderDiagnosticObserver_ServiceStartedWait_DoesNotRunContinuationsInline()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         using var continuationRan = new ManualResetEventSlim();
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14010), 11);
         var waitTask = observer.WaitForReminderServiceStartedAsync(TestContext.Current.CancellationToken, siloAddress);
@@ -62,7 +62,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_MatchesTickCompleted_ByIdentifiers()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var now = DateTime.UtcNow;
@@ -86,7 +86,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_WaitsForAdditionalTickCount_FromCurrentState()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var now = DateTime.UtcNow;
@@ -116,7 +116,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_WaitsForTickCondition_UntilConditionIsSatisfied()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(TestConstants.InitTimeout);
         var grainId = GrainId.Create("test", "grain");
@@ -197,7 +197,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_WaitsForReminderQuiescence_FromLifecycleEvents()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var identity1 = new object();
@@ -228,7 +228,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_GlobalQuiescenceIgnoresUnrelatedSilos()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var clusterIdentity = new object();
@@ -267,7 +267,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_CountsDuplicateInstancesOnOneSilo()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         var grainId = GrainId.Create("test", "duplicate-owner");
         const string reminderName = "reminder";
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14010), 11);
@@ -308,7 +308,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_CanceledQuiescenceWait_RemainsCanceled()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
@@ -342,7 +342,7 @@ public class ReminderEventsTests
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_WaitsForCurrentOwnerSchedule_AfterOwnershipChange()
     {
-        using var observer = ReminderDiagnosticObserver.Create();
+        using var observer = ReminderDiagnosticObserver.CreateForAllSilos();
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var previousOwner = new object();

--- a/test/Orleans.Reminders.Tests/MinimalReminderTests.cs
+++ b/test/Orleans.Reminders.Tests/MinimalReminderTests.cs
@@ -16,10 +16,11 @@ namespace UnitTests.CatalogTests
 
         public class Fixture : BaseTestClusterFixture
         {
-            public ReminderDiagnosticObserver ReminderObserver { get; } = ReminderDiagnosticObserver.Create();
+            public ReminderDiagnosticObserver ReminderObserver { get; private set; } = null!;
 
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
+                ReminderObserver = ReminderDiagnosticObserver.Create(builder);
                 builder.AddSiloBuilderConfigurator<SiloConfiguration>();
             }
 
@@ -32,7 +33,7 @@ namespace UnitTests.CatalogTests
                 }
                 finally
                 {
-                    ReminderObserver.Dispose();
+                    ReminderObserver?.Dispose();
                 }
             }
         }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarness.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderLifecycleHarness.cs
@@ -18,12 +18,12 @@ public sealed class ReminderLifecycleHarness : IDisposable
     private readonly InProcessTestCluster? _cluster;
 
     public ReminderLifecycleHarness()
-        : this(ReminderDiagnosticObserver.Create(), cluster: null)
+        : this(ReminderDiagnosticObserver.CreateForAllSilos(), cluster: null)
     {
     }
 
     public ReminderLifecycleHarness(InProcessTestCluster cluster)
-        : this(ReminderDiagnosticObserver.Create(), cluster)
+        : this(ReminderDiagnosticObserver.Create(cluster), cluster)
     {
     }
 

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -807,8 +807,8 @@ namespace UnitTests.ActivationsLifeCycleTests
             var cancellationToken = TestContext.Current.CancellationToken;
             await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
 
-            using var grainObserver = GrainDiagnosticObserver.Create();
-            using var timerObserver = TimerDiagnosticObserver.Create();
+            using var grainObserver = GrainDiagnosticObserver.Create(testCluster);
+            using var timerObserver = TimerDiagnosticObserver.Create(testCluster);
 
             const string timerName = nameof(GrainAndTimerDiagnosticsExposeRuntimeInstances);
             var grain = this.testCluster.GrainFactory!.GetGrain<INonReentrantTimerCallGrain>(GetRandomGrainId());

--- a/test/Orleans.Streaming.Tests/StreamingTests/BroadcastChannels/BroadcastChannelTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/BroadcastChannels/BroadcastChannelTests.cs
@@ -116,7 +116,7 @@ namespace Tester.StreamingTests.BroadcastChannel
             var grainKey = Guid.NewGuid().ToString("N");
             var channelId = ChannelId.Create("some-namespace", grainKey);
 
-            using var observer = BroadcastChannelDiagnosticObserver.Create();
+            using var observer = BroadcastChannelDiagnosticObserver.Create(_fixture.HostedCluster);
             var stream = provider.GetChannelWriter<int>(channelId);
 
             await stream.Publish(1);
@@ -151,7 +151,7 @@ namespace Tester.StreamingTests.BroadcastChannel
         {
             var grainKey = Guid.NewGuid().ToString("N");
 
-            using var observer = BroadcastChannelDiagnosticObserver.Create();
+            using var observer = BroadcastChannelDiagnosticObserver.Create(_fixture.HostedCluster);
             var channels = new List<(ChannelId ChannelId, int ExpectedValue)>();
 
             for (var i = 0; i < 10; i++)
@@ -187,7 +187,7 @@ namespace Tester.StreamingTests.BroadcastChannel
             var grainKey = Guid.NewGuid().ToString("N");
             var channelId = ChannelId.Create("multiple-namespaces-0", grainKey);
 
-            using var observer = BroadcastChannelDiagnosticObserver.Create();
+            using var observer = BroadcastChannelDiagnosticObserver.Create(_fixture.HostedCluster);
             var stream = provider.GetChannelWriter<int>(channelId);
 
             await stream.Publish(1);
@@ -233,7 +233,7 @@ namespace Tester.StreamingTests.BroadcastChannel
             var grainKey = Guid.NewGuid().ToString("N");
             var channelId = ChannelId.Create("multiple-namespaces-0", grainKey);
 
-            using var observer = BroadcastChannelDiagnosticObserver.Create();
+            using var observer = BroadcastChannelDiagnosticObserver.Create(_fixture.HostedCluster);
             var stream = provider.GetChannelWriter<int>(channelId);
 
             var badGrain = _fixture.Client.GetGrain<ISimpleSubscriberGrain>(grainKey);

--- a/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
@@ -33,7 +33,7 @@ namespace Tester.StreamingTests
 
             // Hard kill client
             var droppedClients = GetConnectedClients();
-            using var gatewayObserver = GatewayDiagnosticObserver.Create();
+            using var gatewayObserver = GatewayDiagnosticObserver.Create(testHost);
             await testHost.KillClientAsync();
             await WaitForDroppedClientsAsync(droppedClients, gatewayObserver, cancellationToken);
 
@@ -63,8 +63,8 @@ namespace Tester.StreamingTests
 
             // Hard kill client
             var droppedClients = GetConnectedClients();
-            using var gatewayObserver = GatewayDiagnosticObserver.Create();
-            using var streamingObserver = StreamingDiagnosticObserver.Create();
+            using var gatewayObserver = GatewayDiagnosticObserver.Create(testHost);
+            using var streamingObserver = StreamingDiagnosticObserver.Create(testHost);
             await testHost.KillClientAsync();
             await WaitForDroppedClientsAsync(droppedClients, gatewayObserver, cancellationToken);
 
@@ -102,7 +102,7 @@ namespace Tester.StreamingTests
             int eventsProduced,
             CancellationToken cancellationToken)
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(testHost);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(_timeout);
             var streamId = StreamId.Create(streamNamespace, streamGuid);
@@ -147,7 +147,7 @@ namespace Tester.StreamingTests
             int[] eventCount,
             CancellationToken cancellationToken)
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(testHost);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(_timeout);
             var streamId = StreamId.Create(streamNamespace, streamGuid);

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
@@ -42,7 +42,7 @@ namespace Tester.StreamingTests
         [Fact]
         public async Task ActiveImplicitSubscriptionRejectsRewindAndContinuesForward()
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cancellation.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
@@ -90,7 +90,7 @@ namespace Tester.StreamingTests
         [Fact]
         public async Task ObserverReplacementDuringFirstDeliveryPreservesRewindRejection()
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cancellation.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);

--- a/test/Orleans.Streaming.Tests/StreamingTests/MultipleStreamsTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MultipleStreamsTestRunner.cs
@@ -16,10 +16,37 @@ namespace UnitTests.Streaming
         private readonly int testNumber;
         private readonly bool runFullTest;
         private readonly IInternalClusterClient client;
+        private readonly Func<int, SingleStreamTestRunner> createRunner;
 
-        internal MultipleStreamsTestRunner(IInternalClusterClient client, string streamProvider, int testNum = 0, bool fullTest = true)
+        internal MultipleStreamsTestRunner(TestCluster testCluster, string streamProvider, int testNum = 0, bool fullTest = true)
+            : this(
+                testCluster.InternalClient!,
+                index => new SingleStreamTestRunner(testCluster, streamProvider, index, fullTest),
+                streamProvider,
+                testNum,
+                fullTest)
+        {
+        }
+
+        internal MultipleStreamsTestRunner(InProcessTestCluster testCluster, string streamProvider, int testNum = 0, bool fullTest = true)
+            : this(
+                testCluster.InternalClient!,
+                index => new SingleStreamTestRunner(testCluster, streamProvider, index, fullTest),
+                streamProvider,
+                testNum,
+                fullTest)
+        {
+        }
+
+        private MultipleStreamsTestRunner(
+            IInternalClusterClient client,
+            Func<int, SingleStreamTestRunner> createRunner,
+            string streamProvider,
+            int testNum,
+            bool fullTest)
         {
             this.client = client;
+            this.createRunner = createRunner;
             this.streamProviderName = streamProvider;
             this.logger = (TestingUtils.CreateDefaultLoggerFactory($"{this.GetType().Name}.log")).CreateLogger<MultipleStreamsTestRunner>();
             this.testNumber = testNum;
@@ -41,7 +68,7 @@ namespace UnitTests.Streaming
             List<Task> tasks = new List<Task>();
             for (int i = 0; i < 10; i++)
             {
-                runners.Add(new SingleStreamTestRunner(this.client, this.streamProviderName, i, runFullTest));
+                runners.Add(createRunner(i));
             }
             foreach (var runner in runners)
             {

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -207,7 +207,8 @@ namespace UnitTests.StreamingTests
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
 
             var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
-            using var diagnostics = StreamingDiagnosticObserver.Create();
+            using var diagnostics = StreamingDiagnosticObserver.Create(
+                SiloAddress.New(IPAddress.Loopback, 11111, 1));
             var inactive = diagnostics.WaitForStreamInactiveAsync(streamId.StreamId, "provider", CancellationToken.None);
 
             var agent = CreateAgent(pubSub, queueId, receiver: receiver, timeProvider: timeProvider);

--- a/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestsRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/ProgrammaticSubscribeTestsRunner.cs
@@ -44,7 +44,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
     [Fact]
     public async Task StreamingTests_Consumer_Producer_Subscribe()
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cts.CancelAfter(_timeout);
         var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
@@ -81,7 +81,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
         cts.Token.ThrowIfCancellationRequested();
         await producer.BecomeProducer(streamId.Guid, streamId.Namespace, streamId.ProviderName);
 
-        using (var phaseOneObserver = StreamingDiagnosticObserver.Create())
+        using (var phaseOneObserver = StreamingDiagnosticObserver.Create(fixture.HostedCluster))
         {
             await ProduceExactCountAsync(producer, EventCountPerPhase, cts.Token);
             await phaseOneObserver.WaitForItemDeliveryCountAsync(rxStreamId, EventCountPerPhase * subscriptions.Count, StreamProviderName, cts.Token);
@@ -90,7 +90,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
         //the subscription to remove
         var subscription = subscriptions[0];
         // remove subscription
-        using (var removalObserver = StreamingDiagnosticObserver.Create())
+        using (var removalObserver = StreamingDiagnosticObserver.Create(fixture.HostedCluster))
         {
             await subscriptionManager.RemoveSubscription(streamId, subscription.SubscriptionId);
             await removalObserver.WaitForSubscriptionRemovedAsync(rxStreamId, StreamProviderName, cts.Token);
@@ -101,7 +101,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
         //assert consumer grain's onAdd func got called.
         Assert.True((await consumerUnSub.GetCountOfOnAddFuncCalled()) > 0);
 
-        using (var phaseTwoObserver = StreamingDiagnosticObserver.Create())
+        using (var phaseTwoObserver = StreamingDiagnosticObserver.Create(fixture.HostedCluster))
         {
             await ProduceExactCountAsync(producer, EventCountPerPhase, cts.Token);
             await phaseTwoObserver.WaitForItemDeliveryCountAsync(rxStreamId, EventCountPerPhase, StreamProviderName, cts.Token);
@@ -155,7 +155,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
         //set up subscriptions
         await subscriptionManager.SetupStreamingSubscriptionForStream<IJerk_ConsumerGrain>(streamId, 10);
 
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cts.CancelAfter(_timeout);
 
@@ -179,7 +179,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
     [Fact(Skip = "https://github.com/dotnet/orleans/issues/5650")]
     public async Task StreamingTests_Consumer_Producer_SubscribeToTwoStream_MessageWithPolymorphism()
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cts.CancelAfter(_timeout);
         var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);
@@ -226,7 +226,7 @@ public abstract class ProgrammaticSubscribeTestsRunner
     [Fact]
     public async Task StreamingTests_Consumer_Producer_SubscribeToStreamsHandledByDifferentStreamProvider()
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cts.CancelAfter(_timeout);
         var subscriptionManager = new SubscriptionManager(this.fixture.HostedCluster);

--- a/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ProgrammaticSubscribeTests/SubscriptionObserverWithImplicitSubscribingTestRunner.cs
@@ -30,7 +30,7 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
         [Fact]
         public virtual async Task StreamingTests_Consumer_Producer_Subscribe()
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(_timeout);
             var streamId = new FullStreamIdentity(Guid.NewGuid(), ImplicitSubscribeGrain.StreamNameSpace, StreamProviderName);
@@ -56,7 +56,7 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
         [Fact]
         public virtual async Task StreamingTests_Consumer_Producer_SubscribeToTwoStream_MessageWithPolymorphism()
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(_timeout);
             var streamId = new FullStreamIdentity(Guid.NewGuid(), ImplicitSubscribeGrain.StreamNameSpace, StreamProviderName);
@@ -98,7 +98,7 @@ namespace Tester.StreamingTests.ProgrammaticSubscribeTests
         [Fact]
         public virtual async Task StreamingTests_Consumer_Producer_SubscribeToStreamsHandledByDifferentStreamProvider()
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(_timeout);
             var streamId = new FullStreamIdentity(Guid.NewGuid(), ImplicitSubscribeGrain.StreamNameSpace, StreamProviderName);

--- a/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Streams;
+using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
 using Tester;
@@ -29,10 +30,27 @@ public class SingleStreamTestRunner
     private readonly int testNumber;
     private readonly bool runFullTest;
     private readonly IInternalClusterClient client;
+    private readonly Func<StreamingDiagnosticObserver> createObserver;
 
-    internal SingleStreamTestRunner(IInternalClusterClient client, string streamProvider, int testNum = 0, bool fullTest = true)
+    internal SingleStreamTestRunner(TestCluster testCluster, string streamProvider, int testNum = 0, bool fullTest = true)
+        : this(testCluster.InternalClient!, () => StreamingDiagnosticObserver.Create(testCluster), streamProvider, testNum, fullTest)
+    {
+    }
+
+    internal SingleStreamTestRunner(InProcessTestCluster testCluster, string streamProvider, int testNum = 0, bool fullTest = true)
+        : this(testCluster.InternalClient!, () => StreamingDiagnosticObserver.Create(testCluster), streamProvider, testNum, fullTest)
+    {
+    }
+
+    private SingleStreamTestRunner(
+        IInternalClusterClient client,
+        Func<StreamingDiagnosticObserver> createObserver,
+        string streamProvider,
+        int testNum,
+        bool fullTest)
     {
         this.client = client;
+        this.createObserver = createObserver;
         this.streamProviderName = streamProvider;
         this.logger = TestingUtils.CreateDefaultLoggerFactory($"{this.GetType().Name}.log").CreateLogger<SingleStreamTestRunner>();
         this.testNumber = testNum;
@@ -274,7 +292,7 @@ public class SingleStreamTestRunner
         Assert.NotEqual(0, consumerCount);
 
         var producedBefore = await producer.ExpectedItemsProduced;
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = createObserver();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(_timeout);
 
@@ -291,7 +309,7 @@ public class SingleStreamTestRunner
         int count,
         CancellationToken cancellationToken)
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = createObserver();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(_timeout);
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamBatchingTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamBatchingTestRunner.cs
@@ -25,7 +25,7 @@ namespace UnitTests.StreamingTests
         {
             const int ExpectedConsumed = 30;
             Guid streamGuid = Guid.NewGuid();
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
             using var cts = new CancellationTokenSource(Timeout);
 
             IStreamProvider provider = this.fixture.Client.GetStreamProvider(StreamBatchingTestConst.ProviderName);
@@ -46,7 +46,7 @@ namespace UnitTests.StreamingTests
             const int ItemsPerBatch = 10;
             const int ExpectedConsumed = BatchesSent * ItemsPerBatch;
             Guid streamGuid = Guid.NewGuid();
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
             using var cts = new CancellationTokenSource(Timeout);
 
             IStreamProvider provider = this.fixture.Client.GetStreamProvider(StreamBatchingTestConst.ProviderName);
@@ -67,7 +67,7 @@ namespace UnitTests.StreamingTests
             const int ItemsPerBatch = 10;
             const int ExpectedConsumed = BatchesSent * ItemsPerBatch;
             Guid streamGuid = Guid.NewGuid();
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(fixture.HostedCluster);
             using var cts = new CancellationTokenSource(Timeout);
 
             IStreamProvider provider = this.fixture.Client.GetStreamProvider(StreamBatchingTestConst.ProviderName);

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamPubSubReliabilityTests.cs
@@ -121,8 +121,8 @@ namespace UnitTests.StreamingTests
             await deactivatingConsumer.BecomeConsumer(subscribedStreamId, StreamProviderName);
 
             var timeout = TimeSpan.FromSeconds(30);
-            using var streamObserver = StreamingDiagnosticObserver.Create();
-            using var grainObserver = GrainDiagnosticObserver.Create();
+            using var streamObserver = StreamingDiagnosticObserver.Create(HostedCluster);
+            using var grainObserver = GrainDiagnosticObserver.Create(HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(timeout);
             var deliveryTask = streamObserver.WaitForItemDeliveryCountAsync(producedStreamId, 1, StreamProviderName, cts.Token);
@@ -140,7 +140,7 @@ namespace UnitTests.StreamingTests
             Guid streamId,
             CancellationToken cancellationToken)
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
 
             // Consumer
             IStreamLifecycleConsumerGrain consumer = this.GrainFactory.GetGrain<IStreamLifecycleConsumerGrain>(Guid.NewGuid());

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
@@ -59,7 +59,7 @@ namespace Tester.StreamingTests
         [Fact]
         public virtual async Task PreviousEventEvictedFromCacheTest()
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
@@ -107,7 +107,7 @@ namespace Tester.StreamingTests
         [Fact]
         public virtual async Task PreviousEventEvictedFromCacheWithFilterTest()
         {
-            using var observer = StreamingDiagnosticObserver.Create();
+            using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(30));
             var streamProvider = this.Client.GetStreamProvider(StreamProviderName);

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -101,7 +101,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
 
     protected virtual async Task ResumeAfterInactivityImpl(bool waitForCacheToFlush)
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
         var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
         var key = Guid.NewGuid();
         var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
@@ -145,7 +145,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     [Fact]
     public virtual async Task ResumeAfterDeactivation()
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
         var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
         var key = Guid.NewGuid();
         var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);
@@ -169,7 +169,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     [Fact]
     public virtual async Task ResumeAfterDeactivationActiveStream()
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(HostedCluster);
         var streamProvider = this.Client.GetStreamProvider(StreamProviderName);
         var key = Guid.NewGuid();
         var stream = streamProvider.GetStream<byte[]>(nameof(IImplicitSubscriptionCounterGrain), key);

--- a/test/Orleans.Streaming.Tests/StreamingTests/SubscriptionMultiplicityTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SubscriptionMultiplicityTestRunner.cs
@@ -346,7 +346,7 @@ public class SubscriptionMultiplicityTestRunner
         string streamNamespace,
         CancellationToken cancellationToken = default)
     {
-        using var grainObserver = GrainDiagnosticObserver.Create();
+        using var grainObserver = GrainDiagnosticObserver.Create(testCluster);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(Timeout);
 
@@ -613,7 +613,7 @@ public class SubscriptionMultiplicityTestRunner
             await producer.ClearNumberProduced();
         }
 
-        using var deliveryObserver = StreamingDiagnosticObserver.Create();
+        using var deliveryObserver = StreamingDiagnosticObserver.Create(testCluster);
         await ProduceExactCountAsync(producer, target, cancellationToken);
         var produced = await producer.GetNumberProduced();
 
@@ -719,7 +719,7 @@ public class SubscriptionMultiplicityTestRunner
         }
 
         await producer.ClearNumberProduced();
-        using var deliveryObserver = StreamingDiagnosticObserver.Create();
+        using var deliveryObserver = StreamingDiagnosticObserver.Create(testCluster);
         try
         {
             await producer.StartPeriodicProducing(cancellationToken);
@@ -782,14 +782,14 @@ public class SubscriptionMultiplicityTestRunner
 
     private async Task WaitForSubscriptionRegisteredAsync(StreamId streamId, Func<Task> action, CancellationToken cancellationToken)
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(testCluster);
         await action();
         await observer.WaitForSubscriptionRegisteredAsync(streamId, streamProviderName, cancellationToken);
     }
 
     private async Task WaitForSubscriptionDetachedAsync(StreamId streamId, Func<Task> action, CancellationToken cancellationToken)
     {
-        using var observer = StreamingDiagnosticObserver.Create();
+        using var observer = StreamingDiagnosticObserver.Create(testCluster);
         await action();
         await observer.WaitForSubscriptionDetachedAsync(streamId, streamProviderName, cancellationToken);
     }

--- a/test/Orleans.Testing.Reminders/DiagnosticObserverSiloScope.cs
+++ b/test/Orleans.Testing.Reminders/DiagnosticObserverSiloScope.cs
@@ -1,0 +1,48 @@
+using Orleans.Runtime;
+using Orleans.TestingHost;
+
+namespace Orleans.Testing.Reminders;
+
+internal sealed class DiagnosticObserverSiloScope
+{
+    private readonly Func<SiloAddress, bool> _containsSilo;
+
+    private DiagnosticObserverSiloScope(Func<SiloAddress, bool> containsSilo)
+    {
+        _containsSilo = containsSilo;
+    }
+
+    public static DiagnosticObserverSiloScope For(InProcessTestCluster cluster)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        return new(cluster.ContainsSilo);
+    }
+
+    public static DiagnosticObserverSiloScope For(InProcessTestClusterBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return new(builder.ContainsSilo);
+    }
+
+    public static DiagnosticObserverSiloScope For(TestCluster cluster)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        return new(cluster.ContainsSilo);
+    }
+
+    public static DiagnosticObserverSiloScope For(TestClusterBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return new(builder.ContainsSilo);
+    }
+
+    public static DiagnosticObserverSiloScope For(SiloAddress siloAddress)
+    {
+        ArgumentNullException.ThrowIfNull(siloAddress);
+        return new(candidate => siloAddress.Endpoint.Equals(candidate.Endpoint));
+    }
+
+    public static DiagnosticObserverSiloScope All { get; } = new(static _ => true);
+
+    public bool Matches(SiloAddress? siloAddress) => siloAddress is not null && _containsSilo(siloAddress);
+}

--- a/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/test/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -7,6 +7,7 @@ using System.Reactive.Subjects;
 using Orleans;
 using Orleans.Internal;
 using Orleans.Runtime;
+using Orleans.TestingHost;
 using ReminderEvents = Orleans.Reminders.Diagnostics.ReminderEvents;
 
 namespace Orleans.Testing.Reminders;
@@ -42,18 +43,25 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     /// <summary>
     /// Creates a new instance of the observer and starts listening for reminder diagnostic events.
     /// </summary>
-    public static ReminderDiagnosticObserver Create()
-    {
-        return new ReminderDiagnosticObserver();
-    }
+    public static ReminderDiagnosticObserver Create(TestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
+
+    public static ReminderDiagnosticObserver Create(TestClusterBuilder builder) => new(DiagnosticObserverSiloScope.For(builder));
+
+    public static ReminderDiagnosticObserver Create(InProcessTestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
+
+    public static ReminderDiagnosticObserver Create(InProcessTestClusterBuilder builder) => new(DiagnosticObserverSiloScope.For(builder));
+
+    public static ReminderDiagnosticObserver Create(SiloAddress siloAddress) => new(DiagnosticObserverSiloScope.For(siloAddress));
+
+    public static ReminderDiagnosticObserver CreateForAllSilos() => new(DiagnosticObserverSiloScope.All);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReminderDiagnosticObserver"/> class.
     /// </summary>
-    public ReminderDiagnosticObserver()
+    private ReminderDiagnosticObserver(DiagnosticObserverSiloScope scope)
     {
-        _events = ReminderEvents.AllEvents.Replay();
-        _serviceEvents = ReminderEvents.ServiceEvents.Replay();
+        _events = ReminderEvents.AllEvents.Where(e => scope.Matches(e.SiloAddress)).Replay();
+        _serviceEvents = ReminderEvents.ServiceEvents.Where(e => scope.Matches(e.SiloAddress)).Replay();
         _storageSubscription = _events.Subscribe(StoreEvent);
         _connection = _events.Connect();
         _serviceConnection = _serviceEvents.Connect();

--- a/test/Orleans.Testing.Reminders/ReminderTestClock.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTestClock.cs
@@ -22,13 +22,14 @@ public sealed class ReminderTestClock : IDisposable
     private bool _disposed;
 
     private ReminderTestClock(
+        InProcessTestClusterBuilder builder,
         DateTimeOffset initialTime,
         TimeSpan minimumReminderPeriod,
         TimeSpan refreshReminderListPeriod,
         TimeSpan initializationTimeout)
     {
         TimeProvider = new FakeTimeProvider(initialTime);
-        DiagnosticObserver = ReminderDiagnosticObserver.Create();
+        DiagnosticObserver = ReminderDiagnosticObserver.Create(builder);
         MinimumReminderPeriod = minimumReminderPeriod;
         RefreshReminderListPeriod = refreshReminderListPeriod;
         InitializationTimeout = initializationTimeout;
@@ -79,6 +80,7 @@ public sealed class ReminderTestClock : IDisposable
         ArgumentNullException.ThrowIfNull(builder);
 
         var clock = new ReminderTestClock(
+            builder,
             new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
             minimumReminderPeriod ?? TimeSpan.FromMinutes(1),
             refreshReminderListPeriod ?? TimeSpan.FromSeconds(1),

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/BroadcastChannelDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/BroadcastChannelDiagnosticObserver.cs
@@ -4,6 +4,7 @@ using System.Reactive.Threading.Tasks;
 using Orleans.BroadcastChannel;
 using Orleans.BroadcastChannel.Diagnostics;
 using Orleans.Runtime;
+using Orleans.TestingHost;
 
 namespace TestExtensions;
 
@@ -23,11 +24,13 @@ public sealed class BroadcastChannelDiagnosticObserver : IDisposable
     /// <summary>
     /// Creates a new instance of the observer and starts listening for broadcast channel diagnostic events.
     /// </summary>
-    public static BroadcastChannelDiagnosticObserver Create() => new();
+    public static BroadcastChannelDiagnosticObserver Create(TestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
 
-    private BroadcastChannelDiagnosticObserver()
+    public static BroadcastChannelDiagnosticObserver Create(InProcessTestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
+
+    private BroadcastChannelDiagnosticObserver(DiagnosticObserverSiloScope scope)
     {
-        _events = BroadcastChannelEvents.AllEvents.Replay();
+        _events = BroadcastChannelEvents.AllEvents.Where(e => scope.Matches(e.SiloAddress, e.ClusterId)).Replay();
         _connection = _events.Connect();
     }
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/DiagnosticObserverSiloScope.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/DiagnosticObserverSiloScope.cs
@@ -48,8 +48,9 @@ internal sealed class DiagnosticObserverSiloScope
 
     public bool Matches(SiloAddress? siloAddress, string? clusterId = null) =>
         IncludesAllSilos
-        || (siloAddress is not null && _containsSilo(siloAddress))
-        || (clusterId is not null && clusterId == _clusterId);
+        || (siloAddress is not null
+            ? _containsSilo(siloAddress)
+            : clusterId is not null && clusterId == _clusterId);
 
     private static bool HasSameEndpoint(SiloAddress left, SiloAddress right) => left.Endpoint.Equals(right.Endpoint);
 }

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/DiagnosticObserverSiloScope.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/DiagnosticObserverSiloScope.cs
@@ -1,0 +1,55 @@
+using Orleans.Runtime;
+using Orleans.TestingHost;
+
+namespace TestExtensions;
+
+internal sealed class DiagnosticObserverSiloScope
+{
+    private readonly Func<SiloAddress, bool> _containsSilo;
+    private readonly string? _clusterId;
+
+    private DiagnosticObserverSiloScope(
+        Func<SiloAddress, bool> containsSilo,
+        string? clusterId = null,
+        bool includesAllSilos = false)
+    {
+        _containsSilo = containsSilo;
+        _clusterId = clusterId;
+        IncludesAllSilos = includesAllSilos;
+    }
+
+    public static DiagnosticObserverSiloScope For(InProcessTestCluster cluster)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        return new(cluster.ContainsSilo, cluster.Options.ClusterId);
+    }
+
+    public static DiagnosticObserverSiloScope For(InProcessTestClusterBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return new(builder.ContainsSilo, builder.Options.ClusterId);
+    }
+
+    public static DiagnosticObserverSiloScope For(TestCluster cluster)
+    {
+        ArgumentNullException.ThrowIfNull(cluster);
+        return new(cluster.ContainsSilo, cluster.Options.ClusterId);
+    }
+
+    public static DiagnosticObserverSiloScope For(SiloAddress siloAddress)
+    {
+        ArgumentNullException.ThrowIfNull(siloAddress);
+        return new(candidate => HasSameEndpoint(siloAddress, candidate));
+    }
+
+    public static DiagnosticObserverSiloScope All { get; } = new(static _ => true, includesAllSilos: true);
+
+    public bool IncludesAllSilos { get; }
+
+    public bool Matches(SiloAddress? siloAddress, string? clusterId = null) =>
+        IncludesAllSilos
+        || (siloAddress is not null && _containsSilo(siloAddress))
+        || (clusterId is not null && clusterId == _clusterId);
+
+    private static bool HasSameEndpoint(SiloAddress left, SiloAddress right) => left.Endpoint.Equals(right.Endpoint);
+}

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/GatewayDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/GatewayDiagnosticObserver.cs
@@ -3,6 +3,7 @@ using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using Orleans.Core.Diagnostics;
 using Orleans.Runtime;
+using Orleans.TestingHost;
 
 namespace TestExtensions;
 
@@ -11,11 +12,17 @@ public sealed class GatewayDiagnosticObserver : IDisposable
     private readonly IConnectableObservable<GatewayEvents.GatewayEvent> _events;
     private readonly IDisposable _connection;
 
-    public static GatewayDiagnosticObserver Create() => new();
+    public static GatewayDiagnosticObserver Create(TestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
 
-    private GatewayDiagnosticObserver()
+    public static GatewayDiagnosticObserver Create(InProcessTestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
+
+    internal static GatewayDiagnosticObserver Create(SiloAddress siloAddress) => new(DiagnosticObserverSiloScope.For(siloAddress));
+
+    private GatewayDiagnosticObserver(DiagnosticObserverSiloScope scope)
     {
-        _events = GatewayEvents.AllEvents.Replay();
+        _events = GatewayEvents.AllEvents
+            .Where(e => e is GatewayEvents.ClientDropped dropped && scope.Matches(dropped.SiloAddress))
+            .Replay();
         _connection = _events.Connect();
     }
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/GrainDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/GrainDiagnosticObserver.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reactive.Linq;
 using Orleans.Runtime.Diagnostics;
+using Orleans.TestingHost;
 
 namespace TestExtensions;
 
@@ -50,10 +52,22 @@ public sealed class GrainDiagnosticObserver : IDisposable, IObserver<GrainLifecy
     /// <summary>
     /// Creates a new instance of the observer and starts listening for grain diagnostic events.
     /// </summary>
-    public static GrainDiagnosticObserver Create()
+    public static GrainDiagnosticObserver Create(TestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    public static GrainDiagnosticObserver Create(InProcessTestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    internal static GrainDiagnosticObserver Create(SiloAddress siloAddress) => Create(DiagnosticObserverSiloScope.For(siloAddress));
+
+    internal static GrainDiagnosticObserver CreateForAllSilos() => Create(DiagnosticObserverSiloScope.All);
+
+    private static GrainDiagnosticObserver Create(DiagnosticObserverSiloScope scope)
     {
         var observer = new GrainDiagnosticObserver();
-        observer._subscription = GrainLifecycleEvents.AllEvents.Subscribe(observer);
+        observer._subscription = scope.IncludesAllSilos
+            ? GrainLifecycleEvents.AllEvents.Subscribe(observer)
+            : GrainLifecycleEvents.AllEvents
+                .Where(e => scope.Matches(e.GrainContext.Address.SiloAddress))
+                .Subscribe(observer);
         Interlocked.Increment(ref observer._listenerSubscriptionCount);
         return observer;
     }

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/MembershipDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/MembershipDiagnosticObserver.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.Reactive.Linq;
 using Orleans.Core.Diagnostics;
+using Orleans.TestingHost;
 
 namespace TestExtensions;
 
@@ -75,10 +77,18 @@ internal sealed class MembershipDiagnosticObserver : IDisposable, IObserver<Memb
     /// <summary>
     /// Creates a new instance of the observer and starts listening for membership diagnostic events.
     /// </summary>
-    public static MembershipDiagnosticObserver Create()
+    public static MembershipDiagnosticObserver Create(TestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    public static MembershipDiagnosticObserver Create(InProcessTestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    internal static MembershipDiagnosticObserver Create(SiloAddress siloAddress) => Create(DiagnosticObserverSiloScope.For(siloAddress));
+
+    private static MembershipDiagnosticObserver Create(DiagnosticObserverSiloScope scope)
     {
         var observer = new MembershipDiagnosticObserver();
-        observer._subscription = MembershipEvents.AllEvents.Subscribe(observer);
+        observer._subscription = MembershipEvents.AllEvents
+            .Where(e => e is MembershipEvents.ViewChanged viewChanged && scope.Matches(viewChanged.ObserverSiloAddress))
+            .Subscribe(observer);
         return observer;
     }
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/PlacementDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/PlacementDiagnosticObserver.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using System.Reactive.Linq;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Diagnostics;
+using Orleans.TestingHost;
 
 namespace TestExtensions;
 
@@ -51,10 +53,21 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
     /// Creates a new instance of the observer and starts listening for placement diagnostic events.
     /// </summary>
     /// <param name="logger">Optional logger for debug output.</param>
-    public static PlacementDiagnosticObserver Create(ILogger? logger = null)
+    public static PlacementDiagnosticObserver Create(TestCluster cluster, ILogger? logger = null) =>
+        Create(DiagnosticObserverSiloScope.For(cluster), logger);
+
+    public static PlacementDiagnosticObserver Create(InProcessTestCluster cluster, ILogger? logger = null) =>
+        Create(DiagnosticObserverSiloScope.For(cluster), logger);
+
+    internal static PlacementDiagnosticObserver Create(SiloAddress siloAddress, ILogger? logger = null) =>
+        Create(DiagnosticObserverSiloScope.For(siloAddress), logger);
+
+    private static PlacementDiagnosticObserver Create(DiagnosticObserverSiloScope scope, ILogger? logger)
     {
         var observer = new PlacementDiagnosticObserver(logger);
-        observer._subscription = DeploymentLoadPublisherEvents.AllEvents.Subscribe(observer);
+        observer._subscription = DeploymentLoadPublisherEvents.AllEvents
+            .Where(e => scope.Matches(GetObserverSilo(e)))
+            .Subscribe(observer);
         observer._placementListenerSubscriptionCount = 1;
         return observer;
     }
@@ -63,6 +76,16 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
     {
         _logger = logger;
     }
+
+    private static SiloAddress GetObserverSilo(DeploymentLoadPublisherEvents.DeploymentLoadPublisherEvent value) =>
+        value switch
+        {
+            DeploymentLoadPublisherEvents.Published published => published.SiloAddress,
+            DeploymentLoadPublisherEvents.Received received => received.ReceiverSilo,
+            DeploymentLoadPublisherEvents.ClusterRefreshed refreshed => refreshed.SiloAddress,
+            DeploymentLoadPublisherEvents.Removed removed => removed.ObserverSilo,
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
 
     /// <summary>
     /// Waits for statistics to be published from a specific silo.

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using System.Reactive.Linq;
 using Orleans.Runtime;
 using Orleans.Runtime.Diagnostics;
+using Orleans.TestingHost;
 
 namespace TestExtensions;
 
@@ -46,10 +48,18 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     /// <summary>
     /// Creates a new instance of the observer and starts listening for rebalancer diagnostic events.
     /// </summary>
-    public static RebalancerDiagnosticObserver Create()
+    public static RebalancerDiagnosticObserver Create(TestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    public static RebalancerDiagnosticObserver Create(InProcessTestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    internal static RebalancerDiagnosticObserver Create(SiloAddress siloAddress) => Create(DiagnosticObserverSiloScope.For(siloAddress));
+
+    private static RebalancerDiagnosticObserver Create(DiagnosticObserverSiloScope scope)
     {
         var observer = new RebalancerDiagnosticObserver();
-        observer._subscription = ActivationRebalancerEvents.AllEvents.Subscribe(observer);
+        observer._subscription = ActivationRebalancerEvents.AllEvents
+            .Where(e => scope.Matches(e.SiloAddress))
+            .Subscribe(observer);
         return observer;
     }
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
@@ -3,6 +3,7 @@ using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Streams;
+using Orleans.TestingHost;
 using StreamingEvents = Orleans.Streaming.Diagnostics.StreamingEvents;
 
 namespace TestExtensions;
@@ -23,11 +24,19 @@ public sealed class StreamingDiagnosticObserver : IDisposable
     /// <summary>
     /// Creates a new instance of the observer and starts listening for streaming diagnostic events.
     /// </summary>
-    public static StreamingDiagnosticObserver Create() => new();
+    public static StreamingDiagnosticObserver Create(TestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
 
-    private StreamingDiagnosticObserver()
+    public static StreamingDiagnosticObserver Create(InProcessTestCluster cluster) => new(DiagnosticObserverSiloScope.For(cluster));
+
+    public static StreamingDiagnosticObserver Create(SiloAddress siloAddress) => new(DiagnosticObserverSiloScope.For(siloAddress));
+
+    private StreamingDiagnosticObserver(DiagnosticObserverSiloScope scope)
     {
-        _events = StreamingEvents.AllEvents.Replay();
+        _events = StreamingEvents.AllEvents
+            .Where(e => e is StreamingEvents.ItemDelivered delivered
+                ? scope.Matches(delivered.SiloAddress, delivered.ClusterId)
+                : scope.Matches(e.SiloAddress))
+            .Replay();
         _connection = _events.Connect();
     }
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/TimerDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/TimerDiagnosticObserver.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.Reactive.Linq;
 using Orleans.Runtime.Diagnostics;
+using Orleans.TestingHost;
 
 namespace TestExtensions;
 
@@ -44,10 +46,22 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
     /// <summary>
     /// Creates a new instance of the observer and starts listening for timer diagnostic events.
     /// </summary>
-    public static TimerDiagnosticObserver Create()
+    public static TimerDiagnosticObserver Create(TestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    public static TimerDiagnosticObserver Create(InProcessTestCluster cluster) => Create(DiagnosticObserverSiloScope.For(cluster));
+
+    internal static TimerDiagnosticObserver Create(SiloAddress siloAddress) => Create(DiagnosticObserverSiloScope.For(siloAddress));
+
+    internal static TimerDiagnosticObserver CreateForAllSilos() => Create(DiagnosticObserverSiloScope.All);
+
+    private static TimerDiagnosticObserver Create(DiagnosticObserverSiloScope scope)
     {
         var observer = new TimerDiagnosticObserver();
-        observer._subscription = GrainTimerEvents.AllEvents.Subscribe(observer);
+        observer._subscription = scope.IncludesAllSilos
+            ? GrainTimerEvents.AllEvents.Subscribe(observer)
+            : GrainTimerEvents.AllEvents
+                .Where(e => scope.Matches(e.GrainContext.Address.SiloAddress))
+                .Subscribe(observer);
         return observer;
     }
 


### PR DESCRIPTION
## Problem

Diagnostic observer helpers subscribe to process-wide listeners. In-process test clusters can therefore retain and count events emitted by unrelated silos or concurrent test suites, allowing foreign events to satisfy waits or contaminate observer state.

## Solution

Scope integration-test observers to their owning `TestCluster` or `InProcessTestCluster` before events enter replay buffers and collections. Track silo endpoints before startup so startup, shutdown, additional-silo, and restart events remain observable. Broadcast-channel and client stream-delivery diagnostics now carry cluster identity for events without a server silo address.

Update observer call sites to provide their cluster explicitly, while synthetic diagnostics tests use explicitly named all-silo factories. Preserve the existing public diagnostic event constructors and update generated API surfaces.

## Rationale

Filtering at the subscription boundary isolates observer state and retained payloads between concurrently running suites. Endpoint and cluster identity together cover server and client events throughout the complete test-cluster lifecycle.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10945)