### PR TITLE
perf(runtime): optimize version selector cache under cluster churn

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/IPAddressComparer.cs
+++ b/src/Orleans.Core.Abstractions/IDs/IPAddressComparer.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Orleans.Runtime;
+
+internal sealed class IPAddressComparer : IComparer<IPAddress>
+{
+    public static IPAddressComparer Instance { get; } = new();
+
+    public int Compare(IPAddress? left, IPAddress? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return 0;
+        }
+
+        if (left is null)
+        {
+            return -1;
+        }
+
+        if (right is null)
+        {
+            return 1;
+        }
+
+        var leftFamily = left.AddressFamily;
+        var rightFamily = right.AddressFamily;
+        if (leftFamily != rightFamily)
+        {
+            return leftFamily < rightFamily ? -1 : 1;
+        }
+
+        if (leftFamily == AddressFamily.InterNetwork)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return left.Address.CompareTo(right.Address);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        Span<byte> leftBytes = stackalloc byte[16];
+        left.TryWriteBytes(leftBytes, out var length);
+        Debug.Assert(length == 16);
+
+        Span<byte> rightBytes = stackalloc byte[16];
+        right.TryWriteBytes(rightBytes, out length);
+        Debug.Assert(length == 16);
+
+        var result = leftBytes.SequenceCompareTo(rightBytes);
+        return result != 0 ? result : left.ScopeId.CompareTo(right.ScopeId);
+    }
+}

--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -564,38 +564,7 @@ namespace Orleans.Runtime
             comp = Endpoint.Port.CompareTo(other.Endpoint.Port);
             if (comp != 0) return comp;
 
-            return CompareIpAddresses(Endpoint.Address, other.Endpoint.Address);
-        }
-
-        // The comparison code is taken from: http://www.codeproject.com/Articles/26550/Extending-the-IPAddress-object-to-allow-relative-c
-        // Also note that this comparison does not handle semantic equivalence  of IPv4 and IPv6 addresses.
-        // In particular, 127.0.0.1 and::1 are semantically the same, but not syntactically.
-        // For more information refer to: http://stackoverflow.com/questions/16618810/compare-ipv4-addresses-in-ipv6-notation 
-        // and http://stackoverflow.com/questions/22187690/ip-address-class-getaddressbytes-method-putting-octets-in-odd-indices-of-the-byt
-        // and dual stack sockets, described at https://msdn.microsoft.com/en-us/library/system.net.ipaddress.maptoipv6(v=vs.110).aspx
-        private static int CompareIpAddresses(IPAddress one, IPAddress two)
-        {
-            var f1 = one.AddressFamily;
-            var f2 = two.AddressFamily;
-            if (f1 != f2)
-                return f1 < f2 ? -1 : 1;
-
-            if (f1 == AddressFamily.InterNetwork)
-            {
-#pragma warning disable CS0618 // Type or member is obsolete
-                return one.Address.CompareTo(two.Address);
-#pragma warning restore CS0618
-            }
-
-            Span<byte> b1 = stackalloc byte[16];
-            one.TryWriteBytes(b1, out var len);
-            Debug.Assert(len == 16);
-
-            Span<byte> b2 = stackalloc byte[16];
-            two.TryWriteBytes(b2, out len);
-            Debug.Assert(len == 16);
-
-            return b1.SequenceCompareTo(b2);
+            return IPAddressComparer.Instance.Compare(Endpoint.Address, other.Endpoint.Address);
         }
     }
 

--- a/src/Orleans.Core/Manifest/GrainVersionManifest.cs
+++ b/src/Orleans.Core/Manifest/GrainVersionManifest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Orleans.Metadata;
 
@@ -10,7 +9,7 @@ namespace Orleans.Runtime.Versions
     /// <summary>
     /// Functionality for querying the declared version of grain interfaces.
     /// </summary>
-    internal class GrainVersionManifest
+    internal sealed class GrainVersionManifest
     {
 #if NET9_0_OR_GREATER
         private readonly Lock _lockObj = new();
@@ -33,11 +32,6 @@ namespace Orleans.Runtime.Versions
             _cache = BuildCache(clusterManifestProvider.Current);
             _localVersions = BuildLocalVersionMap(clusterManifestProvider.LocalGrainManifest);
         }
-
-        /// <summary>
-        /// Gets the current cluster manifest version.
-        /// </summary>
-        public MajorMinorVersion LatestVersion => _clusterManifestProvider.Current.Version;
 
         /// <summary>
         /// Gets the local version for a specified grain interface type.
@@ -72,25 +66,8 @@ namespace Orleans.Runtime.Versions
         /// <returns>All known versions for the specified grain interface.</returns>
         public (MajorMinorVersion Version, ushort[] Result) GetAvailableVersions(GrainInterfaceType interfaceType)
         {
-            var cache = GetCache();
-            if (cache.AvailableVersions.TryGetValue(interfaceType, out var result))
-            {
-                return (cache.Version, result);
-            }
-
-            if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
-            {
-                return GetAvailableVersions(genericInterfaceId);
-            }
-
-            if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
-            {
-                var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
-                return GetAvailableVersions(genericId);
-            }
-
-            // No versions available.
-            return (cache.Version, Array.Empty<ushort>());
+            var snapshot = Capture();
+            return (snapshot.Version, snapshot.GetAvailableVersions(interfaceType));
         }
 
         /// <summary>
@@ -101,25 +78,8 @@ namespace Orleans.Runtime.Versions
         /// <returns>The set of silos which support the specified grain interface type and version.</returns>
         public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainInterfaceType interfaceType, ushort version)
         {
-            var cache = GetCache();
-            if (cache.SupportedSilosByInterface.TryGetValue((interfaceType, version), out var result))
-            {
-                return (cache.Version, result);
-            }
-
-            if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
-            {
-                return GetSupportedSilos(genericInterfaceId, version);
-            }
-
-            if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
-            {
-                var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
-                return GetSupportedSilos(genericId, version);
-            }
-
-            // No supported silos for this version.
-            return (cache.Version, Array.Empty<SiloAddress>());
+            var snapshot = Capture();
+            return (snapshot.Version, snapshot.GetSupportedSilos(interfaceType, version));
         }
 
         /// <summary>
@@ -129,25 +89,8 @@ namespace Orleans.Runtime.Versions
         /// <returns>The silos which support the specified grain type.</returns>
         public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainType grainType)
         {
-            var cache = GetCache();
-            if (cache.SupportedSilosByGrainType.TryGetValue(grainType, out var result))
-            {
-                return (cache.Version, result);
-            }
-
-            if (_genericGrainTypeMapping.TryGetValue(grainType, out var genericGrainType))
-            {
-                return GetSupportedSilos(genericGrainType);
-            }
-
-            if (GenericGrainType.TryParse(grainType, out var generic) && generic.IsConstructed)
-            {
-                var genericId = _genericGrainTypeMapping[grainType] = generic.GetUnconstructedGrainType().GrainType;
-                return GetSupportedSilos(genericId);
-            }
-
-            // No supported silos for this type.
-            return (cache.Version, Array.Empty<SiloAddress>());
+            var snapshot = Capture();
+            return (snapshot.Version, snapshot.GetSupportedSilos(grainType));
         }
 
         /// <summary>
@@ -159,43 +102,78 @@ namespace Orleans.Runtime.Versions
         /// <returns>The set of silos which support the specified grain.</returns>
         public (MajorMinorVersion Version, Dictionary<ushort, SiloAddress[]> Result) GetSupportedSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort[] versions)
         {
-            var result = new Dictionary<ushort, SiloAddress[]>();
+            var snapshot = Capture();
+            return (snapshot.Version, snapshot.GetSupportedSilos(grainType, interfaceType, versions));
+        }
 
-            // Track the minimum version in case of inconsistent reads, since the caller can use that information to
-            // ensure they refresh on the next call.
-            MajorMinorVersion? minCacheVersion = null;
-            foreach (var version in versions)
+        internal Snapshot Capture() => new(this, GetCache());
+
+        private ushort[] GetAvailableVersions(Cache cache, GrainInterfaceType interfaceType)
+        {
+            if (cache.AvailableVersions.TryGetValue(interfaceType, out var result))
             {
-                (var cacheVersion, var silosWithGrain) = this.GetSupportedSilos(grainType);
-                if (!minCacheVersion.HasValue || cacheVersion > minCacheVersion.Value)
-                {
-                    minCacheVersion = cacheVersion;
-                }
-
-                // We need to sort this so the list of silos returned will
-                // be the same across all silos in the cluster
-                SiloAddress[] silosWithCorrectVersion;
-                (cacheVersion, silosWithCorrectVersion) = this.GetSupportedSilos(interfaceType, version);
-
-                if (!minCacheVersion.HasValue || cacheVersion > minCacheVersion.Value)
-                {
-                    minCacheVersion = cacheVersion;
-                }
-
-                result[version] = silosWithCorrectVersion
-                    .Intersect(silosWithGrain)
-                    .OrderBy(addr => addr)
-                    .ToArray();
+                return result;
             }
 
-            if (!minCacheVersion.HasValue) minCacheVersion = MajorMinorVersion.Zero;
+            if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
+            {
+                return GetAvailableVersions(cache, genericInterfaceId);
+            }
 
-            return (minCacheVersion.Value, result);
+            if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
+            {
+                var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
+                return GetAvailableVersions(cache, genericId);
+            }
+
+            return Array.Empty<ushort>();
+        }
+
+        private SiloAddress[] GetSupportedSilos(Cache cache, GrainInterfaceType interfaceType, ushort version)
+        {
+            if (cache.SupportedSilosByInterface.TryGetValue((interfaceType, version), out var result))
+            {
+                return result;
+            }
+
+            if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
+            {
+                return GetSupportedSilos(cache, genericInterfaceId, version);
+            }
+
+            if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
+            {
+                var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
+                return GetSupportedSilos(cache, genericId, version);
+            }
+
+            return Array.Empty<SiloAddress>();
+        }
+
+        private SiloAddress[] GetSupportedSilos(Cache cache, GrainType grainType)
+        {
+            if (cache.SupportedSilosByGrainType.TryGetValue(grainType, out var result))
+            {
+                return result;
+            }
+
+            if (_genericGrainTypeMapping.TryGetValue(grainType, out var genericGrainType))
+            {
+                return GetSupportedSilos(cache, genericGrainType);
+            }
+
+            if (GenericGrainType.TryParse(grainType, out var generic) && generic.IsConstructed)
+            {
+                var genericId = _genericGrainTypeMapping[grainType] = generic.GetUnconstructedGrainType().GrainType;
+                return GetSupportedSilos(cache, genericId);
+            }
+
+            return Array.Empty<SiloAddress>();
         }
 
         private Cache GetCache()
         {
-            var cache = _cache;
+            var cache = Volatile.Read(ref _cache);
             var manifest = _clusterManifestProvider.Current;
             if (manifest.Version == cache.Version)
             {
@@ -204,14 +182,16 @@ namespace Orleans.Runtime.Versions
 
             lock (_lockObj)
             {
-                cache = _cache;
+                cache = Volatile.Read(ref _cache);
                 manifest = _clusterManifestProvider.Current;
                 if (manifest.Version == cache.Version)
                 {
                     return cache;
                 }
 
-                return _cache = BuildCache(manifest);
+                cache = BuildCache(manifest);
+                Volatile.Write(ref _cache, cache);
+                return cache;
             }
         }
 
@@ -274,7 +254,7 @@ namespace Orleans.Runtime.Versions
                     {
                         supportedInterfaces[(id, version)] = new List<SiloAddress> { silo };
                     }
-                    else if (!supportedSilos.Contains(silo))
+                    else
                     {
                         supportedSilos.Add(silo);
                     }
@@ -287,7 +267,7 @@ namespace Orleans.Runtime.Versions
                     {
                         supportedGrains[id] = new List<SiloAddress> { silo };
                     }
-                    else if (!supportedSilos.Contains(silo))
+                    else
                     {
                         supportedSilos.Add(silo);
                     }
@@ -304,21 +284,193 @@ namespace Orleans.Runtime.Versions
             var resultSupportedByInterface = new Dictionary<(GrainInterfaceType, ushort), SiloAddress[]>();
             foreach (var entry in supportedInterfaces)
             {
-                entry.Value.Sort();
+                entry.Value.Sort(SiloAddressOrderingComparer.Instance);
                 resultSupportedByInterface[entry.Key] = entry.Value.ToArray();
             }
 
             var resultSupportedSilosByGrainType = new Dictionary<GrainType, SiloAddress[]>();
             foreach (var entry in supportedGrains)
             {
-                entry.Value.Sort();
+                entry.Value.Sort(SiloAddressOrderingComparer.Instance);
                 resultSupportedSilosByGrainType[entry.Key] = entry.Value.ToArray();
             }
 
             return new Cache(clusterManifest.Version, resultAvailable, resultSupportedByInterface, resultSupportedSilosByGrainType);
         }
 
-        private class Cache
+        internal readonly struct Snapshot
+        {
+            private readonly GrainVersionManifest _owner;
+            private readonly Cache _cache;
+
+            internal Snapshot(GrainVersionManifest owner, Cache cache)
+            {
+                _owner = owner;
+                _cache = cache;
+            }
+
+            public MajorMinorVersion Version => _cache.Version;
+
+            public ushort[] GetAvailableVersions(GrainInterfaceType interfaceType) =>
+                _owner.GetAvailableVersions(_cache, interfaceType);
+
+            public SiloAddress[] GetSupportedSilos(GrainInterfaceType interfaceType, ushort version) =>
+                _owner.GetSupportedSilos(_cache, interfaceType, version);
+
+            public SiloAddress[] GetSupportedSilos(GrainType grainType) =>
+                _owner.GetSupportedSilos(_cache, grainType);
+
+            public Dictionary<ushort, SiloAddress[]> GetSupportedSilos(
+                GrainType grainType,
+                GrainInterfaceType interfaceType,
+                ushort[] versions) =>
+                GetSupportedSilos(grainType, interfaceType, versions, out _);
+
+            public Dictionary<ushort, SiloAddress[]> GetSupportedSilos(
+                GrainType grainType,
+                GrainInterfaceType interfaceType,
+                ushort[] versions,
+                out SiloAddress[] allSupportedSilos)
+            {
+                var result = new Dictionary<ushort, SiloAddress[]>(versions.Length);
+                var silosWithGrain = GetSupportedSilos(grainType);
+                allSupportedSilos = Array.Empty<SiloAddress>();
+                foreach (var version in versions)
+                {
+                    var supportedSilos = IntersectSorted(
+                        silosWithGrain,
+                        GetSupportedSilos(interfaceType, version));
+                    result[version] = supportedSilos;
+                    allSupportedSilos = UnionSorted(allSupportedSilos, supportedSilos);
+                }
+
+                return result;
+            }
+
+            private static SiloAddress[] UnionSorted(SiloAddress[] left, SiloAddress[] right)
+            {
+                if (left.Length == 0)
+                {
+                    return right;
+                }
+
+                if (right.Length == 0)
+                {
+                    return left;
+                }
+
+                var result = new SiloAddress[left.Length + right.Length];
+                var leftIndex = 0;
+                var rightIndex = 0;
+                var resultIndex = 0;
+                while (leftIndex < left.Length && rightIndex < right.Length)
+                {
+                    var comparison = SiloAddressOrderingComparer.Instance.Compare(left[leftIndex], right[rightIndex]);
+                    if (comparison < 0)
+                    {
+                        result[resultIndex++] = left[leftIndex++];
+                    }
+                    else if (comparison > 0)
+                    {
+                        result[resultIndex++] = right[rightIndex++];
+                    }
+                    else
+                    {
+                        result[resultIndex++] = left[leftIndex++];
+                        ++rightIndex;
+                    }
+                }
+
+                while (leftIndex < left.Length)
+                {
+                    result[resultIndex++] = left[leftIndex++];
+                }
+
+                while (rightIndex < right.Length)
+                {
+                    result[resultIndex++] = right[rightIndex++];
+                }
+
+                if (resultIndex != result.Length)
+                {
+                    Array.Resize(ref result, resultIndex);
+                }
+
+                return result;
+            }
+
+            private static SiloAddress[] IntersectSorted(SiloAddress[] left, SiloAddress[] right)
+            {
+                if (left.Length == 0 || right.Length == 0)
+                {
+                    return Array.Empty<SiloAddress>();
+                }
+
+                var result = new SiloAddress[Math.Min(left.Length, right.Length)];
+                var leftIndex = 0;
+                var rightIndex = 0;
+                var resultIndex = 0;
+                while (leftIndex < left.Length && rightIndex < right.Length)
+                {
+                    var comparison = SiloAddressOrderingComparer.Instance.Compare(left[leftIndex], right[rightIndex]);
+                    if (comparison < 0)
+                    {
+                        ++leftIndex;
+                    }
+                    else if (comparison > 0)
+                    {
+                        ++rightIndex;
+                    }
+                    else
+                    {
+                        result[resultIndex++] = left[leftIndex];
+                        ++leftIndex;
+                        ++rightIndex;
+                    }
+                }
+
+                if (resultIndex == result.Length)
+                {
+                    return result;
+                }
+
+                Array.Resize(ref result, resultIndex);
+                return result;
+            }
+        }
+
+        private sealed class SiloAddressOrderingComparer : IComparer<SiloAddress>
+        {
+            public static SiloAddressOrderingComparer Instance { get; } = new();
+
+            public int Compare(SiloAddress? left, SiloAddress? right)
+            {
+                if (ReferenceEquals(left, right))
+                {
+                    return 0;
+                }
+
+                if (left is null)
+                {
+                    return -1;
+                }
+
+                if (right is null)
+                {
+                    return 1;
+                }
+
+                var result = left.CompareTo(right);
+                if (result != 0 || left.Equals(right))
+                {
+                    return result;
+                }
+
+                return left.Endpoint.Address.ScopeId.CompareTo(right.Endpoint.Address.ScopeId);
+            }
+        }
+
+        internal sealed class Cache
         {
             public Cache(
                 MajorMinorVersion version,
@@ -334,8 +486,8 @@ namespace Orleans.Runtime.Versions
 
             public MajorMinorVersion Version { get; }
             public Dictionary<GrainInterfaceType, ushort[]> AvailableVersions { get; } 
-            public Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> SupportedSilosByInterface { get; } = new Dictionary<(GrainInterfaceType, ushort), SiloAddress[]>();
-            public Dictionary<GrainType, SiloAddress[]> SupportedSilosByGrainType { get; } = new Dictionary<GrainType, SiloAddress[]>();
+            public Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> SupportedSilosByInterface { get; }
+            public Dictionary<GrainType, SiloAddress[]> SupportedSilosByGrainType { get; }
         }
     }
 }

--- a/src/Orleans.Core/Manifest/GrainVersionManifest.cs
+++ b/src/Orleans.Core/Manifest/GrainVersionManifest.cs
@@ -284,14 +284,14 @@ namespace Orleans.Runtime.Versions
             var resultSupportedByInterface = new Dictionary<(GrainInterfaceType, ushort), SiloAddress[]>();
             foreach (var entry in supportedInterfaces)
             {
-                entry.Value.Sort(SiloAddressOrderingComparer.Instance);
+                entry.Value.Sort();
                 resultSupportedByInterface[entry.Key] = entry.Value.ToArray();
             }
 
             var resultSupportedSilosByGrainType = new Dictionary<GrainType, SiloAddress[]>();
             foreach (var entry in supportedGrains)
             {
-                entry.Value.Sort(SiloAddressOrderingComparer.Instance);
+                entry.Value.Sort();
                 resultSupportedSilosByGrainType[entry.Key] = entry.Value.ToArray();
             }
 
@@ -365,7 +365,7 @@ namespace Orleans.Runtime.Versions
                 var resultIndex = 0;
                 while (leftIndex < left.Length && rightIndex < right.Length)
                 {
-                    var comparison = SiloAddressOrderingComparer.Instance.Compare(left[leftIndex], right[rightIndex]);
+                    var comparison = left[leftIndex].CompareTo(right[rightIndex]);
                     if (comparison < 0)
                     {
                         result[resultIndex++] = left[leftIndex++];
@@ -412,7 +412,7 @@ namespace Orleans.Runtime.Versions
                 var resultIndex = 0;
                 while (leftIndex < left.Length && rightIndex < right.Length)
                 {
-                    var comparison = SiloAddressOrderingComparer.Instance.Compare(left[leftIndex], right[rightIndex]);
+                    var comparison = left[leftIndex].CompareTo(right[rightIndex]);
                     if (comparison < 0)
                     {
                         ++leftIndex;
@@ -436,37 +436,6 @@ namespace Orleans.Runtime.Versions
 
                 Array.Resize(ref result, resultIndex);
                 return result;
-            }
-        }
-
-        private sealed class SiloAddressOrderingComparer : IComparer<SiloAddress>
-        {
-            public static SiloAddressOrderingComparer Instance { get; } = new();
-
-            public int Compare(SiloAddress? left, SiloAddress? right)
-            {
-                if (ReferenceEquals(left, right))
-                {
-                    return 0;
-                }
-
-                if (left is null)
-                {
-                    return -1;
-                }
-
-                if (right is null)
-                {
-                    return 1;
-                }
-
-                var result = left.CompareTo(right);
-                if (result != 0 || left.Equals(right))
-                {
-                    return result;
-                }
-
-                return left.Endpoint.Address.ScopeId.CompareTo(right.Endpoint.Address.ScopeId);
             }
         }
 

--- a/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
+++ b/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
@@ -33,11 +33,21 @@ namespace Orleans.Runtime.Versions
         {
             var key = ValueTuple.Create(grainType, interfaceId, requestedVersion);
             var slot = suitableSilosCache.GetOrAdd(key, static _ => new());
-            while (true)
+            var snapshot = this.grainInterfaceVersions.Capture();
+            var generation = Volatile.Read(ref this.cacheGeneration);
+            var value = Volatile.Read(ref slot.Value);
+            if (value is not null
+                && value.CacheGeneration == generation
+                && value.ManifestVersion == snapshot.Version)
             {
-                var snapshot = this.grainInterfaceVersions.Capture();
-                var generation = Volatile.Read(ref this.cacheGeneration);
-                var value = Volatile.Read(ref slot.Value);
+                return value.Entry;
+            }
+
+            lock (slot)
+            {
+                snapshot = this.grainInterfaceVersions.Capture();
+                generation = Volatile.Read(ref this.cacheGeneration);
+                value = Volatile.Read(ref slot.Value);
                 if (value is not null
                     && value.CacheGeneration == generation
                     && value.ManifestVersion == snapshot.Version)
@@ -45,26 +55,13 @@ namespace Orleans.Runtime.Versions
                     return value.Entry;
                 }
 
-                lock (slot)
+                var entry = GetSuitableSilosImpl(snapshot, key);
+                if (generation == Volatile.Read(ref this.cacheGeneration))
                 {
-                    snapshot = this.grainInterfaceVersions.Capture();
-                    generation = Volatile.Read(ref this.cacheGeneration);
-                    value = Volatile.Read(ref slot.Value);
-                    if (value is not null
-                        && value.CacheGeneration == generation
-                        && value.ManifestVersion == snapshot.Version)
-                    {
-                        return value.Entry;
-                    }
-
-                    var entry = GetSuitableSilosImpl(snapshot, key);
-                    if (generation == Volatile.Read(ref this.cacheGeneration))
-                    {
-                        Volatile.Write(ref slot.Value, new(generation, snapshot.Version, entry));
-                    }
-
-                    return entry;
+                    Volatile.Write(ref slot.Value, new(generation, snapshot.Version, entry));
                 }
+
+                return entry;
             }
         }
 

--- a/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
+++ b/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Orleans.Metadata;
 using Orleans.Runtime.Versions.Compatibility;
@@ -8,31 +8,21 @@ using Orleans.Runtime.Versions.Selector;
 
 namespace Orleans.Runtime.Versions
 {
-    internal class CachedVersionSelectorManager
+    internal sealed class CachedVersionSelectorManager
     {
-#if NET9_0_OR_GREATER
-        private readonly Lock cacheLock = new();
-#else
-        private readonly object cacheLock = new();
-#endif
-        private readonly Dictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry> suitableSilosCache;
+        private readonly ConcurrentDictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CacheSlot> suitableSilosCache;
         private readonly GrainVersionManifest grainInterfaceVersions;
-        private readonly IClusterMembershipService clusterMembershipService;
-        private MajorMinorVersion observedManifestVersion;
         private long cacheGeneration;
 
         public CachedVersionSelectorManager(
             GrainVersionManifest grainInterfaceVersions,
             VersionSelectorManager versionSelectorManager,
-            CompatibilityDirectorManager compatibilityDirectorManager,
-            IClusterMembershipService clusterMembershipService)
+            CompatibilityDirectorManager compatibilityDirectorManager)
         {
             this.grainInterfaceVersions = grainInterfaceVersions;
             this.VersionSelectorManager = versionSelectorManager;
             this.CompatibilityDirectorManager = compatibilityDirectorManager;
-            this.clusterMembershipService = clusterMembershipService;
-            this.observedManifestVersion = grainInterfaceVersions.LatestVersion;
-            this.suitableSilosCache = new Dictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry>();
+            this.suitableSilosCache = new();
         }
 
         public VersionSelectorManager VersionSelectorManager { get; }
@@ -42,76 +32,54 @@ namespace Orleans.Runtime.Versions
         public CachedEntry GetSuitableSilos(GrainType grainType, GrainInterfaceType interfaceId, ushort requestedVersion)
         {
             var key = ValueTuple.Create(grainType, interfaceId, requestedVersion);
-            var spinner = new SpinWait();
+            var slot = suitableSilosCache.GetOrAdd(key, static _ => new());
             while (true)
             {
-                CacheState state;
-                lock (this.cacheLock)
+                var snapshot = this.grainInterfaceVersions.Capture();
+                var generation = Volatile.Read(ref this.cacheGeneration);
+                var value = Volatile.Read(ref slot.Value);
+                if (value is not null
+                    && value.CacheGeneration == generation
+                    && value.ManifestVersion == snapshot.Version)
                 {
-                    state = ObserveCacheState();
-                    if (state.ManifestVersion.Major == state.MembershipVersion.Value
-                        && suitableSilosCache.TryGetValue(key, out var cachedEntry)
-                        && cachedEntry.Generation == state.Generation)
-                    {
-                        return cachedEntry;
-                    }
+                    return value.Entry;
                 }
 
-                var (resultVersion, entry) = GetSuitableSilosImpl(key, state.Generation);
-                lock (this.cacheLock)
+                lock (slot)
                 {
-                    var current = ObserveCacheState();
-                    if (current.Generation == state.Generation
-                        && resultVersion == current.ManifestVersion
-                        && resultVersion.Major == current.MembershipVersion.Value)
+                    snapshot = this.grainInterfaceVersions.Capture();
+                    generation = Volatile.Read(ref this.cacheGeneration);
+                    value = Volatile.Read(ref slot.Value);
+                    if (value is not null
+                        && value.CacheGeneration == generation
+                        && value.ManifestVersion == snapshot.Version)
                     {
-                        return suitableSilosCache[key] = entry;
+                        return value.Entry;
                     }
-                }
 
-                spinner.SpinOnce();
+                    var entry = GetSuitableSilosImpl(snapshot, key);
+                    if (generation == Volatile.Read(ref this.cacheGeneration))
+                    {
+                        Volatile.Write(ref slot.Value, new(generation, snapshot.Version, entry));
+                    }
+
+                    return entry;
+                }
             }
         }
 
-        public SiloAddress[] GetSupportedSilos(GrainType grainType)
-        {
-            var spinner = new SpinWait();
-            while (true)
-            {
-                CacheState state;
-                lock (this.cacheLock)
-                {
-                    state = ObserveCacheState();
-                }
-
-                var (resultVersion, result) = this.grainInterfaceVersions.GetSupportedSilos(grainType);
-                lock (this.cacheLock)
-                {
-                    var current = ObserveCacheState();
-                    if (current.Generation == state.Generation
-                        && resultVersion == current.ManifestVersion
-                        && resultVersion.Major == current.MembershipVersion.Value)
-                    {
-                        return result;
-                    }
-                }
-
-                spinner.SpinOnce();
-            }
-        }
+        public SiloAddress[] GetSupportedSilos(GrainType grainType) =>
+            this.grainInterfaceVersions.Capture().GetSupportedSilos(grainType);
 
         public void ResetCache()
         {
-            lock (this.cacheLock)
-            {
-                ++this.cacheGeneration;
-                this.suitableSilosCache.Clear();
-            }
+            Interlocked.Increment(ref this.cacheGeneration);
+            this.suitableSilosCache.Clear();
         }
 
-        private (MajorMinorVersion Version, CachedEntry Entry) GetSuitableSilosImpl(
-            (GrainType Type, GrainInterfaceType Interface, ushort Version) key,
-            long generation)
+        private CachedEntry GetSuitableSilosImpl(
+            GrainVersionManifest.Snapshot snapshot,
+            (GrainType Type, GrainInterfaceType Interface, ushort Version) key)
         {
             var grainType = key.Type;
             var interfaceType = key.Interface;
@@ -119,46 +87,32 @@ namespace Orleans.Runtime.Versions
 
             var versionSelector = this.VersionSelectorManager.GetSelector(interfaceType);
             var compatibilityDirector = this.CompatibilityDirectorManager.GetDirector(interfaceType);
-            (var version, var available) = this.grainInterfaceVersions.GetAvailableVersions(interfaceType);
+            var available = snapshot.GetAvailableVersions(interfaceType);
             var versions = versionSelector.GetSuitableVersion(
                 requestedVersion, 
                 available, 
                 compatibilityDirector);
 
-            (_, var result) = this.grainInterfaceVersions.GetSupportedSilos(grainType, interfaceType, versions);
-
-            return (
-                version,
-                new CachedEntry
-                {
-                    Generation = generation,
-                    SuitableSilos = result.SelectMany(sv => sv.Value).Distinct().OrderBy(addr => addr).ToArray(),
-                    SuitableSilosByVersion = result,
-                });
-        }
-
-        private CacheState ObserveCacheState()
-        {
-            var membershipVersion = this.clusterMembershipService.CurrentSnapshot.Version;
-            var manifestVersion = this.grainInterfaceVersions.LatestVersion;
-            if (manifestVersion != this.observedManifestVersion)
+            var result = snapshot.GetSupportedSilos(grainType, interfaceType, versions, out var suitableSilos);
+            return new CachedEntry
             {
-                this.observedManifestVersion = manifestVersion;
-                ++this.cacheGeneration;
-            }
-
-            return new CacheState(this.cacheGeneration, membershipVersion, manifestVersion);
+                SuitableSilos = suitableSilos,
+                SuitableSilosByVersion = result,
+            };
         }
 
-        private readonly record struct CacheState(
-            long Generation,
-            MembershipVersion MembershipVersion,
-            MajorMinorVersion ManifestVersion);
+        private sealed class CacheSlot
+        {
+            public CachedValue? Value;
+        }
+
+        private sealed record CachedValue(
+            long CacheGeneration,
+            MajorMinorVersion ManifestVersion,
+            CachedEntry Entry);
 
         internal struct CachedEntry
         {
-            public long Generation { get; set; }
-
             public SiloAddress[] SuitableSilos { get; set; }
 
             public Dictionary<ushort, SiloAddress[]> SuitableSilosByVersion { get; set; }

--- a/src/Orleans.Runtime/Versions/Compatibility/CompatibilityDirectorManager.cs
+++ b/src/Orleans.Runtime/Versions/Compatibility/CompatibilityDirectorManager.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -7,21 +8,26 @@ using Orleans.Versions.Compatibility;
 
 namespace Orleans.Runtime.Versions.Compatibility
 {
-    internal class CompatibilityDirectorManager
+    internal sealed class CompatibilityDirectorManager
     {
         private readonly CompatibilityStrategy strategyFromConfig;
         private readonly IServiceProvider serviceProvider;
-        private readonly Dictionary<GrainInterfaceType, ICompatibilityDirector> compatibilityDirectors;
+        private readonly ConcurrentDictionary<GrainInterfaceType, ICompatibilityDirector> compatibilityDirectors;
+        private ICompatibilityDirector defaultDirector;
 
-        public ICompatibilityDirector Default { get; private set; }
+        public ICompatibilityDirector Default
+        {
+            get => Volatile.Read(ref defaultDirector);
+            private set => Volatile.Write(ref defaultDirector, value);
+        }
 
 
         public CompatibilityDirectorManager(IServiceProvider serviceProvider, IOptions<GrainVersioningOptions> options)
         {
             this.serviceProvider = serviceProvider;
             this.strategyFromConfig = serviceProvider.GetRequiredKeyedService<CompatibilityStrategy>(options.Value.DefaultCompatibilityStrategy);
-            this.compatibilityDirectors = new Dictionary<GrainInterfaceType, ICompatibilityDirector>();
-            Default = ResolveVersionDirector(serviceProvider, this.strategyFromConfig);
+            this.compatibilityDirectors = new();
+            defaultDirector = ResolveVersionDirector(serviceProvider, this.strategyFromConfig);
         }
 
         public ICompatibilityDirector GetDirector(GrainInterfaceType interfaceType)
@@ -40,7 +46,7 @@ namespace Orleans.Runtime.Versions.Compatibility
         {
             if (strategy == null)
             {
-                compatibilityDirectors.Remove(interfaceType);
+                compatibilityDirectors.TryRemove(interfaceType, out _);
             }
             else
             {

--- a/src/Orleans.Runtime/Versions/Selector/VersionDirectorManager.cs
+++ b/src/Orleans.Runtime/Versions/Selector/VersionDirectorManager.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -7,20 +8,25 @@ using Orleans.Versions.Selector;
 
 namespace Orleans.Runtime.Versions.Selector
 {
-    internal class VersionSelectorManager
+    internal sealed class VersionSelectorManager
     {
         private readonly VersionSelectorStrategy strategyFromConfig;
         private readonly IServiceProvider serviceProvider;
-        private readonly Dictionary<GrainInterfaceType, IVersionSelector> versionSelectors;
+        private readonly ConcurrentDictionary<GrainInterfaceType, IVersionSelector> versionSelectors;
+        private IVersionSelector defaultSelector;
 
-        public IVersionSelector Default { get; set; }
+        public IVersionSelector Default
+        {
+            get => Volatile.Read(ref defaultSelector);
+            set => Volatile.Write(ref defaultSelector, value);
+        }
 
         public VersionSelectorManager(IServiceProvider serviceProvider, IOptions<GrainVersioningOptions> options)
         {
             this.serviceProvider = serviceProvider;
             this.strategyFromConfig = serviceProvider.GetRequiredKeyedService<VersionSelectorStrategy>(options.Value.DefaultVersionSelectorStrategy);
-            Default = ResolveVersionSelector(serviceProvider, this.strategyFromConfig);
-            versionSelectors = new Dictionary<GrainInterfaceType, IVersionSelector>();
+            defaultSelector = ResolveVersionSelector(serviceProvider, this.strategyFromConfig);
+            versionSelectors = new();
         }
 
         public IVersionSelector GetSelector(GrainInterfaceType interfaceType)
@@ -40,7 +46,7 @@ namespace Orleans.Runtime.Versions.Selector
         {
             if (strategy == null)
             {
-                versionSelectors.Remove(interfaceType);
+                versionSelectors.TryRemove(interfaceType, out _);
             }
             else
             {

--- a/test/Orleans.Core.Tests/General/Identifiertests.cs
+++ b/test/Orleans.Core.Tests/General/Identifiertests.cs
@@ -45,7 +45,7 @@ namespace UnitTests.General
         [TestSuite("BVT")]
         [TestProvider("None")]
         [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
-        public void SiloAddressComparisonDistinguishesIpv6ScopeIds()
+        public void SiloAddressComparisonDistinguishesIPv6ScopeIds()
         {
             var addressBytes = IPAddress.Parse("fe80::1").GetAddressBytes();
             var lowerScopeAddress = new IPAddress(addressBytes, scopeid: 1);

--- a/test/Orleans.Core.Tests/General/Identifiertests.cs
+++ b/test/Orleans.Core.Tests/General/Identifiertests.cs
@@ -45,6 +45,22 @@ namespace UnitTests.General
         [TestSuite("BVT")]
         [TestProvider("None")]
         [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
+        public void SiloAddressComparisonDistinguishesIpv6ScopeIds()
+        {
+            var addressBytes = IPAddress.Parse("fe80::1").GetAddressBytes();
+            var lowerScopeAddress = new IPAddress(addressBytes, scopeid: 1);
+            var higherScopeAddress = new IPAddress(addressBytes, scopeid: 2);
+            var lowerScopeSilo = SiloAddress.New(lowerScopeAddress, 11111, 1);
+            var higherScopeSilo = SiloAddress.New(higherScopeAddress, 11111, 1);
+
+            Assert.True(IPAddressComparer.Instance.Compare(lowerScopeAddress, higherScopeAddress) < 0);
+            Assert.True(lowerScopeSilo.CompareTo(higherScopeSilo) < 0);
+            Assert.NotEqual(lowerScopeSilo, higherScopeSilo);
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [Fact, TestCategory("BVT"), TestCategory("Identifiers")]
         public void UniqueKeyKeyExtGrainCategoryDisallowsNullKeyExtension()
         {
             Assert.Throws<ArgumentNullException>(() =>

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -185,7 +185,7 @@ public class ClusterManifestProviderTests
             (localSilo, SiloStatus.Active),
             (remoteSilo, SiloStatus.Active)));
         var manifest = new GrainVersionManifest(clusterManifestProvider);
-        var selectorManager = CreateCachedVersionSelectorManager(manifest, membership);
+        var selectorManager = CreateCachedVersionSelectorManager(manifest);
 
         var initial = selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1);
         SiloAddress[] initialSilos = initial.SuitableSilos;
@@ -214,9 +214,7 @@ public class ClusterManifestProviderTests
             1,
             (localSilo, SiloStatus.Active),
             (remoteSilo, SiloStatus.Active)));
-        var selectorManager = CreateCachedVersionSelectorManager(
-            new GrainVersionManifest(clusterManifestProvider),
-            membership);
+        var selectorManager = CreateCachedVersionSelectorManager(new GrainVersionManifest(clusterManifestProvider));
 
         Assert.Equal(new[] { localSilo }, selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos);
 
@@ -228,43 +226,75 @@ public class ClusterManifestProviderTests
     }
 
     [Fact]
-    public async Task CachedVersionSelectorManager_RetriesUntilMembershipAndManifestVersionsConverge()
+    public void GrainVersionManifest_CapturedSnapshotRemainsConsistentAfterManifestAdvances()
     {
         var localSilo = CreateSiloAddress(11111, 1);
         var remoteSilo = CreateSiloAddress(11112, 1);
         var clusterManifestProvider = new TestClusterManifestProvider(CreateClusterManifest(1, 0, localSilo));
-        using var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
-            2,
-            (localSilo, SiloStatus.Active),
-            (remoteSilo, SiloStatus.Active)));
-        var selectorManager = CreateCachedVersionSelectorManager(
-            new GrainVersionManifest(clusterManifestProvider),
-            membership);
-
-        var suitableSilosRead = membership.ObserveNextSnapshotRead();
-        var suitableSilosTask = Task.Run(
-            () => selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1));
-        await suitableSilosRead.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
-        Assert.False(suitableSilosTask.IsCompleted);
+        var manifest = new GrainVersionManifest(clusterManifestProvider);
+        var snapshot = manifest.Capture();
 
         clusterManifestProvider.Current = CreateClusterManifest(2, 0, remoteSilo);
 
-        var suitableSilos = await suitableSilosTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
-        Assert.Equal(new[] { remoteSilo }, suitableSilos.SuitableSilos);
+        Assert.Equal(new MajorMinorVersion(1, 0), snapshot.Version);
+        Assert.Equal(new[] { localSilo }, snapshot.GetSupportedSilos(TestGrainType));
 
-        membership.Update(CreateMembershipSnapshot(
-            3,
-            (localSilo, SiloStatus.Active),
-            (remoteSilo, SiloStatus.Active)));
-        var supportedSilosRead = membership.ObserveNextSnapshotRead();
-        var supportedSilosTask = Task.Run(() => selectorManager.GetSupportedSilos(TestGrainType));
-        await supportedSilosRead.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
-        Assert.False(supportedSilosTask.IsCompleted);
+        var updated = manifest.Capture();
+        Assert.Equal(new MajorMinorVersion(2, 0), updated.Version);
+        Assert.Equal(new[] { remoteSilo }, updated.GetSupportedSilos(TestGrainType));
+    }
 
-        clusterManifestProvider.Current = CreateClusterManifest(3, 0, localSilo, remoteSilo);
+    [Fact]
+    public void GrainVersionManifest_DoesNotIntersectSilosWithDifferentIpv6Scopes()
+    {
+        var addressBytes = IPAddress.Parse("fe80::1").GetAddressBytes();
+        var grainSilo = SiloAddress.New(new IPAddress(addressBytes, scopeid: 1), 11111, 1);
+        var interfaceSilo = SiloAddress.New(new IPAddress(addressBytes, scopeid: 2), 11111, 1);
+        var completeManifest = CreateGrainManifest();
+        var grainOnlyManifest = new GrainManifest(
+            completeManifest.Grains,
+            ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+        var interfaceOnlyManifest = new GrainManifest(
+            ImmutableDictionary<GrainType, GrainProperties>.Empty,
+            completeManifest.Interfaces);
+        var clusterManifest = new ClusterManifest(
+            new MajorMinorVersion(1, 0),
+            ImmutableDictionary.CreateRange(
+            [
+                new KeyValuePair<SiloAddress, GrainManifest>(grainSilo, grainOnlyManifest),
+                new KeyValuePair<SiloAddress, GrainManifest>(interfaceSilo, interfaceOnlyManifest),
+            ]));
+        var manifest = new GrainVersionManifest(new TestClusterManifestProvider(clusterManifest));
 
-        var supportedSilos = await supportedSilosTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
-        Assert.Equal(new[] { localSilo, remoteSilo }, supportedSilos.OrderBy(static silo => silo));
+        var result = manifest.GetSupportedSilos(
+            TestGrainType,
+            TestInterfaceType,
+            versions: [1]);
+
+        Assert.Empty(result.Result[1]);
+    }
+
+    [Fact]
+    public async Task CachedVersionSelectorManager_ResetDoesNotPublishInFlightResult()
+    {
+        var silo = CreateSiloAddress(11111, 1);
+        var selectorManager = CreateCachedVersionSelectorManager(
+            new GrainVersionManifest(
+                new TestClusterManifestProvider(CreateClusterManifest(1, 0, silo))));
+        var selector = new BlockingVersionSelector();
+        selectorManager.VersionSelectorManager.Default = selector;
+
+        var firstCall = Task.Run(
+            () => selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1),
+            TestContext.Current.CancellationToken);
+        await selector.Entered.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        selectorManager.ResetCache();
+        selector.Release();
+
+        Assert.Equal(new[] { silo }, (await firstCall).SuitableSilos);
+        Assert.Equal(new[] { silo }, selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos);
+        Assert.Equal(2, selector.CallCount);
     }
 
     private static ClusterManifestProvider CreateClusterManifestProvider(
@@ -302,9 +332,7 @@ public class ClusterManifestProviderTests
         return grainFactory;
     }
 
-    private static CachedVersionSelectorManager CreateCachedVersionSelectorManager(
-        GrainVersionManifest manifest,
-        IClusterMembershipService membership)
+    private static CachedVersionSelectorManager CreateCachedVersionSelectorManager(GrainVersionManifest manifest)
     {
         var services = new ServiceCollection();
         services.AddOptions<GrainVersioningOptions>();
@@ -318,8 +346,7 @@ public class ClusterManifestProviderTests
         return new CachedVersionSelectorManager(
             manifest,
             new VersionSelectorManager(serviceProvider, options),
-            new CompatibilityDirectorManager(serviceProvider, options),
-            membership);
+            new CompatibilityDirectorManager(serviceProvider, options));
     }
 
     private static ClusterManifest CreateClusterManifest(long major, long minor, params SiloAddress[] silos)
@@ -479,7 +506,6 @@ public class ClusterManifestProviderTests
     {
         private readonly AsyncEnumerable<ClusterMembershipSnapshot> _updates;
         private ClusterMembershipSnapshot _currentSnapshot = ClusterMembershipSnapshot.Default;
-        private TaskCompletionSource? _nextSnapshotRead;
 
         public TestClusterMembershipService(ClusterMembershipSnapshot initialSnapshot)
         {
@@ -491,23 +517,12 @@ public class ClusterManifestProviderTests
 
         public ClusterMembershipSnapshot CurrentSnapshot
         {
-            get
-            {
-                Volatile.Read(ref _nextSnapshotRead)?.TrySetResult();
-                return Volatile.Read(ref _currentSnapshot);
-            }
+            get => Volatile.Read(ref _currentSnapshot);
         }
 
         public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => _updates;
 
         public void Update(ClusterMembershipSnapshot snapshot) => _updates.Publish(snapshot);
-
-        public Task ObserveNextSnapshotRead()
-        {
-            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            Interlocked.Exchange(ref _nextSnapshotRead, completion);
-            return completion.Task;
-        }
 
         public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) => default;
 
@@ -519,6 +534,33 @@ public class ClusterManifestProviderTests
     private sealed class TestSiloManifestSystemTarget(GrainManifest manifest) : ISiloManifestSystemTarget
     {
         public ValueTask<GrainManifest> GetSiloManifest() => new(manifest);
+    }
+
+    private sealed class BlockingVersionSelector : IVersionSelector
+    {
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _callCount;
+
+        public Task Entered => _entered.Task;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public ushort[] GetSuitableVersion(
+            ushort requestedVersion,
+            ushort[] availableVersions,
+            ICompatibilityDirector compatibilityDirector)
+        {
+            if (Interlocked.Increment(ref _callCount) == 1)
+            {
+                _entered.TrySetResult();
+                _release.Task.GetAwaiter().GetResult();
+            }
+
+            return availableVersions;
+        }
+
+        public void Release() => _release.TrySetResult();
     }
 
     private sealed class TestClusterManifestProvider(ClusterManifest initialManifest) : IClusterManifestProvider

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -180,10 +180,6 @@ public class ClusterManifestProviderTests
         var localSilo = CreateSiloAddress(11111, 1);
         var remoteSilo = CreateSiloAddress(11112, 1);
         var clusterManifestProvider = new TestClusterManifestProvider(CreateClusterManifest(1, 0, localSilo, remoteSilo));
-        using var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
-            1,
-            (localSilo, SiloStatus.Active),
-            (remoteSilo, SiloStatus.Active)));
         var manifest = new GrainVersionManifest(clusterManifestProvider);
         var selectorManager = CreateCachedVersionSelectorManager(manifest);
 
@@ -192,10 +188,6 @@ public class ClusterManifestProviderTests
         Assert.Equal(new[] { localSilo, remoteSilo }, initialSilos.OrderBy(static silo => silo));
         Assert.Equal(new[] { localSilo, remoteSilo }, selectorManager.GetSupportedSilos(TestGrainType).OrderBy(static silo => silo));
 
-        membership.Update(CreateMembershipSnapshot(
-            2,
-            (localSilo, SiloStatus.ShuttingDown),
-            (remoteSilo, SiloStatus.Active)));
         clusterManifestProvider.Current = CreateClusterManifest(2, 0, remoteSilo);
 
         var updated = selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1);
@@ -210,10 +202,6 @@ public class ClusterManifestProviderTests
         var localSilo = CreateSiloAddress(11111, 1);
         var remoteSilo = CreateSiloAddress(11112, 1);
         var clusterManifestProvider = new TestClusterManifestProvider(CreateClusterManifest(1, 0, localSilo));
-        using var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
-            1,
-            (localSilo, SiloStatus.Active),
-            (remoteSilo, SiloStatus.Active)));
         var selectorManager = CreateCachedVersionSelectorManager(new GrainVersionManifest(clusterManifestProvider));
 
         Assert.Equal(new[] { localSilo }, selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos);
@@ -294,6 +282,36 @@ public class ClusterManifestProviderTests
 
         Assert.Equal(new[] { silo }, (await firstCall).SuitableSilos);
         Assert.Equal(new[] { silo }, selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos);
+        Assert.Equal(2, selector.CallCount);
+    }
+
+    [Fact]
+    public async Task CachedVersionSelectorManager_SerializesRefreshesForTheSameKey()
+    {
+        var localSilo = CreateSiloAddress(11111, 1);
+        var remoteSilo = CreateSiloAddress(11112, 1);
+        var manifestProvider = new TestClusterManifestProvider(CreateClusterManifest(1, 0, localSilo));
+        var selectorManager = CreateCachedVersionSelectorManager(new GrainVersionManifest(manifestProvider));
+        var selector = new BlockingVersionSelector();
+        selectorManager.VersionSelectorManager.Default = selector;
+
+        var firstCall = Task.Run(
+            () => selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1),
+            TestContext.Current.CancellationToken);
+        await selector.Entered.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        manifestProvider.Current = CreateClusterManifest(2, 0, remoteSilo);
+        var secondCall = Task.Run(
+            () => selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1),
+            TestContext.Current.CancellationToken);
+        Assert.False(secondCall.IsCompleted);
+        Assert.Equal(1, selector.CallCount);
+
+        selector.Release();
+
+        Assert.Equal(new[] { localSilo }, (await firstCall).SuitableSilos);
+        Assert.Equal(new[] { remoteSilo }, (await secondCall).SuitableSilos);
+        Assert.Equal(new[] { remoteSilo }, selectorManager.GetSuitableSilos(TestGrainType, TestInterfaceType, requestedVersion: 1).SuitableSilos);
         Assert.Equal(2, selector.CallCount);
     }
 

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -245,7 +245,7 @@ public class ClusterManifestProviderTests
     }
 
     [Fact]
-    public void GrainVersionManifest_DoesNotIntersectSilosWithDifferentIpv6Scopes()
+    public void GrainVersionManifest_DoesNotIntersectSilosWithDifferentIPv6Scopes()
     {
         var addressBytes = IPAddress.Parse("fe80::1").GetAddressBytes();
         var grainSilo = SiloAddress.New(new IPAddress(addressBytes, scopeid: 1), 11111, 1);

--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -437,9 +437,7 @@ namespace UnitTests.Runtime
                 }));
         }
 
-        private static CachedVersionSelectorManager CreateCachedVersionSelectorManager(
-            GrainVersionManifest manifest,
-            IClusterMembershipService membership)
+        private static CachedVersionSelectorManager CreateCachedVersionSelectorManager(GrainVersionManifest manifest)
         {
             var services = new ServiceCollection();
             services.AddOptions<GrainVersioningOptions>();
@@ -453,8 +451,7 @@ namespace UnitTests.Runtime
             return new CachedVersionSelectorManager(
                 manifest,
                 new VersionSelectorManager(serviceProvider, options),
-                new CompatibilityDirectorManager(serviceProvider, options),
-                membership);
+                new CompatibilityDirectorManager(serviceProvider, options));
         }
 
         private static ServiceProvider CreateServiceProvider(
@@ -565,7 +562,7 @@ namespace UnitTests.Runtime
                 ClusterManifestProvider = manifestProvider ?? new TestClusterManifestProvider(CreateClusterManifest(manifestSilos, useFilter, interfaceVersion: interfaceVersion));
                 _membershipVersion = ClusterManifestProvider.Current.Version.Major;
                 ClusterMembershipService = new TestClusterMembershipService(CreateMembershipSnapshot(_membershipVersion, _siloStatuses));
-                VersionSelectorManager = CreateCachedVersionSelectorManager(new GrainVersionManifest(ClusterManifestProvider), ClusterMembershipService);
+                VersionSelectorManager = CreateCachedVersionSelectorManager(new GrainVersionManifest(ClusterManifestProvider));
                 FilterDirector = useFilter ? new TestPlacementFilterDirector() : null;
                 ServiceProvider = CreateServiceProvider(FilterDirector, messagingOptions, timeProvider);
 


### PR DESCRIPTION
PR #10597 established generation-consistent placement compatibility selection. In large clusters, the synchronized cache path and manifest index construction can dominate placement latency when membership changes frequently.

This follow-up preserves snapshot consistency while improving scaling:

- captures one immutable manifest generation for each compatibility calculation
- serves cache hits without a global monitor and coordinates refreshes per cache key
- publishes selector and compatibility strategy changes through concurrency-safe registries
- builds manifest silo indexes in linear time by relying on manifest key uniqueness
- intersects and unions sorted silo sets without LINQ allocation chains, using an equality-consistent ordering for scoped IPv6 addresses
- covers captured-generation behavior, reset races, IPv6 scope identity, and placement integration

BenchmarkDotNet ShortRun measurements on .NET 10 with 1,000 silos, 32 grain types, and 16 concurrent callers showed:

| Scenario | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Concurrent cached selection | 328.6 ns | 69.4 ns | 4.7x |
| Churn burst selection | 12.09 ms | 0.679 ms | 17.8x |
| Manifest index rebuild | 296.3 ms | 8.7 ms | 34x |
| Churn allocation | 250.8 KB | 108.4 KB | 57% lower |
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10946)