### PR TITLE
ci: compare coverage with current main

### DIFF
--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -1,5 +1,5 @@
 name: Archive test results
-description: Upload diagnostics and require a coverage report for pull requests.
+description: Upload diagnostics and require coverage for pull requests and the default branch.
 
 inputs:
   name:
@@ -40,7 +40,7 @@ runs:
         !TestResults/*.coverage.json
         **/logs/*
   - name: Write coverage metadata
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     shell: pwsh
     run: |
       $metadata = [ordered]@{
@@ -54,27 +54,27 @@ runs:
          Set-Content -LiteralPath 'TestResults/${{ inputs.name }}.coverage.json' -Encoding utf8NoBOM
   - name: Archive coverage
     id: archive-coverage
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     continue-on-error: true
     uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     with:
       name: coverage_${{ inputs.name }}
       if-no-files-found: error
-      retention-days: 1
+      retention-days: ${{ github.event_name == 'push' && 7 || 1 }}
       path: |
         TestResults/${{ inputs.name }}.cobertura.xml
         TestResults/${{ inputs.name }}.coverage.json
   - name: Wait before retrying coverage upload
-    if: github.event_name == 'pull_request' && steps.archive-coverage.outcome == 'failure'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
     shell: pwsh
     run: Start-Sleep -Seconds 30
   - name: Retry coverage upload
-    if: github.event_name == 'pull_request' && steps.archive-coverage.outcome == 'failure'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
     uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     with:
       name: coverage_${{ inputs.name }}
       if-no-files-found: error
-      retention-days: 1
+      retention-days: ${{ github.event_name == 'push' && 7 || 1 }}
       overwrite: true
       path: |
         TestResults/${{ inputs.name }}.cobertura.xml

--- a/.github/actions/dotnet-test/action.yml
+++ b/.github/actions/dotnet-test/action.yml
@@ -23,19 +23,19 @@ runs:
   using: composite
   steps:
   - name: Prepare coverage report
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     shell: pwsh
     run: ./.github/scripts/coverage-report.ps1 -Action Prepare -CoverageId "${{ inputs.coverage-id }}"
   - name: Build and discover tests for static coverage
-    if: github.event_name == 'pull_request' && (runner.os == 'macOS' || inputs.static-instrumentation == 'true')
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && (runner.os == 'macOS' || inputs.static-instrumentation == 'true')
     shell: pwsh
     run: dotnet test --solution Orleans.slnx --framework "${{ inputs.framework }}" --filter-query "${{ inputs.filter-query }}" --list-tests --minimum-expected-tests 1 --max-parallel-test-modules 1
   - name: Test
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.event_name != 'push' || github.ref != format('refs/heads/{0}', github.event.repository.default_branch))
     shell: pwsh
     run: dotnet test --solution Orleans.slnx --framework "${{ inputs.framework }}" --filter-query "${{ inputs.filter-query }}" --minimum-expected-tests 1 --hangdump --hangdump-timeout 10m --crashdump --crashdump-type Full --hangdump-type Full --report-trx --report-trx-filename "test_results_${{ inputs.result-id }}_{asm}_{tfm}_{arch}.trx" --max-parallel-test-modules 1
   - name: Test with dynamic coverage
-    if: github.event_name == 'pull_request' && runner.os != 'macOS' && inputs.static-instrumentation != 'true'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && runner.os != 'macOS' && inputs.static-instrumentation != 'true'
     shell: pwsh
     run: |
       $command = @(
@@ -65,7 +65,7 @@ runs:
       )
       ./.github/scripts/invoke-coverage.ps1 -Settings ./.github/coverage.config.xml -Output "TestResults/${{ inputs.coverage-id }}.cobertura.xml" -RetryLogFile "logs/${{ inputs.coverage-id }}.retry.log" -Command $command
   - name: Test with static coverage
-    if: github.event_name == 'pull_request' && (runner.os == 'macOS' || inputs.static-instrumentation == 'true')
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && (runner.os == 'macOS' || inputs.static-instrumentation == 'true')
     shell: pwsh
     run: |
       $command = @(
@@ -96,6 +96,6 @@ runs:
       )
       ./.github/scripts/invoke-coverage.ps1 -Settings ./.github/coverage.static.config.xml -Output "TestResults/${{ inputs.coverage-id }}.cobertura.xml" -RetryLogFile "logs/${{ inputs.coverage-id }}.retry.log" -IncludeFiles "${{ github.workspace }}/test/**/bin/Debug/${{ inputs.framework }}/*.dll" -Command $command
   - name: Validate coverage report
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     shell: pwsh
     run: ./.github/scripts/coverage-report.ps1 -Action Validate -CoverageId "${{ inputs.coverage-id }}"

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -1,5 +1,5 @@
 name: Setup test environment
-description: Install the .NET SDK and pull request coverage tooling.
+description: Install the .NET SDK and trusted comparison coverage tooling.
 
 runs:
   using: composite
@@ -9,5 +9,5 @@ runs:
     with:
       global-json-file: global.json
   - name: Setup code coverage
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     uses: ./.github/actions/setup-coverage

--- a/.github/coverage-inputs.txt
+++ b/.github/coverage-inputs.txt
@@ -1,0 +1,13 @@
+.github/actions/archive-test-results/action.yml
+.github/actions/dotnet-test/action.yml
+.github/actions/run-tests/action.yml
+.github/actions/setup-coverage/action.yml
+.github/actions/setup-test-environment/action.yml
+.github/coverage-artifacts.txt
+.github/coverage.config.xml
+.github/coverage.static.config.xml
+.github/scripts/coverage-report.ps1
+.github/scripts/invoke-coverage.ps1
+.github/scripts/setup-coverage.ps1
+.github/workflows/ci.yml
+global.json

--- a/.github/scripts/CoverageSummary.cs
+++ b/.github/scripts/CoverageSummary.cs
@@ -156,6 +156,7 @@ public static class CoverageSummaryReader
         var methodIdentity = string.Empty;
         var linesBelongToMethod = false;
         var methodBranchLines = new HashSet<int>();
+        var pendingClassBranches = new List<PendingBranchLine>();
         RepositorySourcePath? sourcePath = null;
         try
         {
@@ -172,6 +173,7 @@ public static class CoverageSummaryReader
                         methodIdentity = string.Empty;
                         linesBelongToMethod = false;
                         methodBranchLines.Clear();
+                        pendingClassBranches.Clear();
                         sourcePath = GetRepositoryPath(reader.GetAttribute("filename"), normalizedSourceRoot);
                         if (reader.IsEmptyElement)
                         {
@@ -235,7 +237,10 @@ public static class CoverageSummaryReader
                         }
                         else if (!methodBranchLines.Contains(lineNumber))
                         {
-                            branchSiteIdentity = $"{classIdentity}\0<non-method>";
+                            pendingClassBranches.Add(
+                                new PendingBranchLine(
+                                    lineNumber,
+                                    reader.GetAttribute("condition-coverage") ?? string.Empty));
                         }
                     }
 
@@ -266,6 +271,24 @@ public static class CoverageSummaryReader
                     }
                     else if (reader.Depth == classDepth && reader.LocalName == "class")
                     {
+                        if (sourcePath is not null)
+                        {
+                            foreach (var pendingBranch in pendingClassBranches)
+                            {
+                                if (!methodBranchLines.Contains(pendingBranch.LineNumber))
+                                {
+                                    ProcessBranch(
+                                        pendingBranch.ConditionCoverage,
+                                        pendingBranch.LineNumber,
+                                        $"{classIdentity}\0<non-method>",
+                                        reportPath,
+                                        sourcePath,
+                                        measuredBranches,
+                                        measuredBranchTotals);
+                                }
+                            }
+                        }
+
                         classDepth = -1;
                         methodDepth = -1;
                         linesDepth = -1;
@@ -273,6 +296,7 @@ public static class CoverageSummaryReader
                         methodIdentity = string.Empty;
                         linesBelongToMethod = false;
                         methodBranchLines.Clear();
+                        pendingClassBranches.Clear();
                         sourcePath = null;
                     }
                 }
@@ -327,7 +351,25 @@ public static class CoverageSummaryReader
             return;
         }
 
-        var conditionCoverage = reader.GetAttribute("condition-coverage") ?? string.Empty;
+        ProcessBranch(
+            reader.GetAttribute("condition-coverage") ?? string.Empty,
+            lineNumber,
+            branchSiteIdentity,
+            reportPath,
+            sourcePath,
+            measuredBranches,
+            measuredBranchTotals);
+    }
+
+    private static void ProcessBranch(
+        string conditionCoverage,
+        int lineNumber,
+        string branchSiteIdentity,
+        string reportPath,
+        RepositorySourcePath sourcePath,
+        Dictionary<string, Dictionary<string, bool>> measuredBranches,
+        Dictionary<string, Dictionary<string, int>> measuredBranchTotals)
+    {
         var match = ConditionCoverage.Match(conditionCoverage);
         if (!match.Success)
         {
@@ -467,6 +509,8 @@ public static class CoverageSummaryReader
             throw new InvalidDataException($"{path} must not be a symbolic link");
         }
     }
+
+    private sealed record PendingBranchLine(int LineNumber, string ConditionCoverage);
 
     private sealed record RepositorySourcePath(string RelativePath, string RepositoryPath);
 }

--- a/.github/scripts/CoverageSummary.cs
+++ b/.github/scripts/CoverageSummary.cs
@@ -58,6 +58,7 @@ public static class CoverageSummaryReader
 
         var measuredFiles = new Dictionary<string, Dictionary<int, bool>>(StringComparer.Ordinal);
         var measuredBranches = new Dictionary<string, Dictionary<string, bool>>(StringComparer.Ordinal);
+        var measuredBranchTotals = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
         var sourceLineCounts = new Dictionary<string, int>(StringComparer.Ordinal);
         var normalizedSourceRoot = resolvedSourceRoot.Replace('\\', '/').TrimEnd('/');
         foreach (var report in reports)
@@ -68,7 +69,8 @@ public static class CoverageSummaryReader
                 normalizedSourceRoot,
                 sourceLineCounts,
                 measuredFiles,
-                measuredBranches);
+                measuredBranches,
+                measuredBranchTotals);
             if (measuredLineEntries == 0)
             {
                 throw new InvalidDataException($"{report} contains no measured lines under the source root");
@@ -108,7 +110,8 @@ public static class CoverageSummaryReader
         string normalizedSourceRoot,
         Dictionary<string, int> sourceLineCounts,
         Dictionary<string, Dictionary<int, bool>> measuredFiles,
-        Dictionary<string, Dictionary<string, bool>> measuredBranches)
+        Dictionary<string, Dictionary<string, bool>> measuredBranches,
+        Dictionary<string, Dictionary<string, int>> measuredBranchTotals)
     {
         AssertNotReparsePoint(reportPath);
         var report = new FileInfo(reportPath);
@@ -147,8 +150,12 @@ public static class CoverageSummaryReader
         using var reader = XmlReader.Create(stringReader, settings);
         var classDepth = -1;
         var methodDepth = -1;
-        var classLinesDepth = -1;
+        var linesDepth = -1;
         var measuredLineEntries = 0;
+        var classIdentity = string.Empty;
+        var methodIdentity = string.Empty;
+        var linesBelongToMethod = false;
+        var methodBranchLines = new HashSet<int>();
         RepositorySourcePath? sourcePath = null;
         try
         {
@@ -160,7 +167,11 @@ public static class CoverageSummaryReader
                     {
                         classDepth = reader.Depth;
                         methodDepth = -1;
-                        classLinesDepth = -1;
+                        linesDepth = -1;
+                        classIdentity = reader.GetAttribute("name") ?? string.Empty;
+                        methodIdentity = string.Empty;
+                        linesBelongToMethod = false;
+                        methodBranchLines.Clear();
                         sourcePath = GetRepositoryPath(reader.GetAttribute("filename"), normalizedSourceRoot);
                         if (reader.IsEmptyElement)
                         {
@@ -179,52 +190,89 @@ public static class CoverageSummaryReader
                         if (!reader.IsEmptyElement)
                         {
                             methodDepth = reader.Depth;
+                            methodIdentity = $"{reader.GetAttribute("name")}\0{reader.GetAttribute("signature")}";
                         }
 
                         continue;
                     }
-                    if (reader.LocalName == "lines" && methodDepth < 0 && reader.Depth == classDepth + 1)
+                    if (reader.LocalName == "lines"
+                        && ((methodDepth >= 0 && reader.Depth == methodDepth + 1)
+                            || (methodDepth < 0 && reader.Depth == classDepth + 1)))
                     {
                         if (!reader.IsEmptyElement)
                         {
-                            classLinesDepth = reader.Depth;
+                            linesDepth = reader.Depth;
+                            linesBelongToMethod = methodDepth >= 0;
                         }
 
                         continue;
                     }
                     if (reader.LocalName != "line"
-                        || classLinesDepth < 0
-                        || reader.Depth != classLinesDepth + 1
+                        || linesDepth < 0
+                        || reader.Depth != linesDepth + 1
                         || sourcePath is null)
                     {
                         continue;
                     }
 
+                    if (!int.TryParse(
+                        reader.GetAttribute("number"),
+                        NumberStyles.Integer,
+                        CultureInfo.InvariantCulture,
+                        out var lineNumber)
+                        || lineNumber <= 0)
+                    {
+                        throw new InvalidDataException(
+                            $"{reportPath} contains invalid line coverage for {sourcePath.RepositoryPath}");
+                    }
+                    var branchSiteIdentity = string.Empty;
+                    if (string.Equals(reader.GetAttribute("branch"), "true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (linesBelongToMethod)
+                        {
+                            methodBranchLines.Add(lineNumber);
+                            branchSiteIdentity = $"{classIdentity}\0{methodIdentity}";
+                        }
+                        else if (!methodBranchLines.Contains(lineNumber))
+                        {
+                            branchSiteIdentity = $"{classIdentity}\0<non-method>";
+                        }
+                    }
+
                     ProcessLine(
                         reader,
+                        lineNumber,
+                        branchSiteIdentity,
                         reportPath,
                         resolvedSourceRoot,
                         sourcePath,
                         sourceLineCounts,
                         measuredFiles,
-                        measuredBranches);
+                        measuredBranches,
+                        measuredBranchTotals);
                     measuredLineEntries++;
                 }
                 else if (reader.NodeType == XmlNodeType.EndElement)
                 {
-                    if (reader.Depth == classLinesDepth && reader.LocalName == "lines")
+                    if (reader.Depth == linesDepth && reader.LocalName == "lines")
                     {
-                        classLinesDepth = -1;
+                        linesDepth = -1;
+                        linesBelongToMethod = false;
                     }
                     else if (reader.Depth == methodDepth && reader.LocalName == "method")
                     {
                         methodDepth = -1;
+                        methodIdentity = string.Empty;
                     }
                     else if (reader.Depth == classDepth && reader.LocalName == "class")
                     {
                         classDepth = -1;
                         methodDepth = -1;
-                        classLinesDepth = -1;
+                        linesDepth = -1;
+                        classIdentity = string.Empty;
+                        methodIdentity = string.Empty;
+                        linesBelongToMethod = false;
+                        methodBranchLines.Clear();
                         sourcePath = null;
                     }
                 }
@@ -240,16 +288,17 @@ public static class CoverageSummaryReader
 
     private static void ProcessLine(
         XmlReader reader,
+        int lineNumber,
+        string branchSiteIdentity,
         string reportPath,
         string resolvedSourceRoot,
         RepositorySourcePath sourcePath,
         Dictionary<string, int> sourceLineCounts,
         Dictionary<string, Dictionary<int, bool>> measuredFiles,
-        Dictionary<string, Dictionary<string, bool>> measuredBranches)
+        Dictionary<string, Dictionary<string, bool>> measuredBranches,
+        Dictionary<string, Dictionary<string, int>> measuredBranchTotals)
     {
-        if (!int.TryParse(reader.GetAttribute("number"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var lineNumber)
-            || !int.TryParse(reader.GetAttribute("hits"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var hits)
-            || lineNumber <= 0
+        if (!int.TryParse(reader.GetAttribute("hits"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var hits)
             || hits < 0)
         {
             throw new InvalidDataException($"{reportPath} contains invalid line coverage for {sourcePath.RepositoryPath}");
@@ -273,7 +322,7 @@ public static class CoverageSummaryReader
         fileLines.TryGetValue(lineNumber, out var covered);
         fileLines[lineNumber] = covered || hits > 0;
 
-        if (!string.Equals(reader.GetAttribute("branch"), "true", StringComparison.OrdinalIgnoreCase))
+        if (branchSiteIdentity.Length == 0)
         {
             return;
         }
@@ -282,7 +331,8 @@ public static class CoverageSummaryReader
         var match = ConditionCoverage.Match(conditionCoverage);
         if (!match.Success)
         {
-            throw new InvalidDataException($"Branch line {lineNumber} has invalid condition coverage '{conditionCoverage}'");
+            throw new InvalidDataException(
+                $"{reportPath} contains invalid condition coverage '{conditionCoverage}' for {sourcePath.RepositoryPath}:{lineNumber}");
         }
         var coveragePercentText = match.Groups[1].Value;
         var coveragePercent = decimal.Parse(coveragePercentText, CultureInfo.InvariantCulture);
@@ -290,7 +340,8 @@ public static class CoverageSummaryReader
         var totalBranches = int.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture);
         if (totalBranches <= 0 || totalBranches > MaximumBranchesPerLine || coveredBranches > totalBranches)
         {
-            throw new InvalidDataException($"Branch line {lineNumber} has inconsistent condition coverage '{conditionCoverage}'");
+            throw new InvalidDataException(
+                $"{reportPath} contains inconsistent condition coverage '{conditionCoverage}' for {sourcePath.RepositoryPath}:{lineNumber}");
         }
 
         var decimalSeparator = coveragePercentText.IndexOf('.');
@@ -303,8 +354,24 @@ public static class CoverageSummaryReader
         var expectedCoveragePercent = 100m * coveredBranches / totalBranches;
         if (Math.Abs(coveragePercent - expectedCoveragePercent) > roundingUnit / 2)
         {
-            throw new InvalidDataException($"Branch line {lineNumber} has inconsistent condition coverage '{conditionCoverage}'");
+            throw new InvalidDataException(
+                $"{reportPath} contains inconsistent condition coverage '{conditionCoverage}' for {sourcePath.RepositoryPath}:{lineNumber}");
         }
+
+        if (!measuredBranchTotals.TryGetValue(sourcePath.RepositoryPath, out var fileBranchTotals))
+        {
+            fileBranchTotals = new Dictionary<string, int>(StringComparer.Ordinal);
+            measuredBranchTotals.Add(sourcePath.RepositoryPath, fileBranchTotals);
+        }
+        var branchSiteKey = $"{branchSiteIdentity}\0{lineNumber}";
+        if (fileBranchTotals.TryGetValue(branchSiteKey, out var existingTotalBranches)
+            && existingTotalBranches != totalBranches)
+        {
+            var displayBranchSite = branchSiteIdentity.Replace('\0', '/');
+            throw new InvalidDataException(
+                $"{reportPath} reports {totalBranches} branches for {sourcePath.RepositoryPath}:{lineNumber} at {displayBranchSite}, expected {existingTotalBranches}");
+        }
+        fileBranchTotals[branchSiteKey] = totalBranches;
 
         if (!measuredBranches.TryGetValue(sourcePath.RepositoryPath, out var fileBranches))
         {
@@ -313,7 +380,7 @@ public static class CoverageSummaryReader
         }
         for (var branch = 0; branch < totalBranches; branch++)
         {
-            var branchKey = $"{lineNumber}\0aggregate\0{branch}";
+            var branchKey = $"{branchSiteKey}\0aggregate\0{branch}";
             fileBranches.TryGetValue(branchKey, out var branchCovered);
             fileBranches[branchKey] = branchCovered || branch < coveredBranches;
         }

--- a/.github/scripts/CoverageSummary.cs
+++ b/.github/scripts/CoverageSummary.cs
@@ -13,17 +13,17 @@ namespace Orleans.Coverage;
 
 public sealed class CoverageSummaryResult
 {
-    public required long CoveredBranches { get; init; }
+    public long CoveredBranches { get; set; }
 
-    public required long CoveredLines { get; init; }
+    public long CoveredLines { get; set; }
 
-    public required int Reports { get; init; }
+    public int Reports { get; set; }
 
-    public required int SourceFiles { get; init; }
+    public int SourceFiles { get; set; }
 
-    public required long TotalBranches { get; init; }
+    public long TotalBranches { get; set; }
 
-    public required long TotalLines { get; init; }
+    public long TotalLines { get; set; }
 }
 
 public static class CoverageSummaryReader

--- a/.github/scripts/CoverageSummary.cs
+++ b/.github/scripts/CoverageSummary.cs
@@ -82,10 +82,6 @@ public static class CoverageSummaryReader
             totalLines += fileLines.Count;
             coveredLines += fileLines.Values.Count(static covered => covered);
         }
-        if (totalLines == 0)
-        {
-            throw new InvalidDataException("Merged coverage report contains no measured lines under the source root");
-        }
 
         long totalBranches = 0;
         long coveredBranches = 0;

--- a/.github/scripts/CoverageSummary.cs
+++ b/.github/scripts/CoverageSummary.cs
@@ -1,0 +1,409 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace Orleans.Coverage;
+
+public sealed class CoverageSummaryResult
+{
+    public required long CoveredBranches { get; init; }
+
+    public required long CoveredLines { get; init; }
+
+    public required int Reports { get; init; }
+
+    public required int SourceFiles { get; init; }
+
+    public required long TotalBranches { get; init; }
+
+    public required long TotalLines { get; init; }
+}
+
+public static class CoverageSummaryReader
+{
+    private const long MaximumReportBytes = 100 * 1024 * 1024;
+    private const long MaximumSourceBytes = 10 * 1024 * 1024;
+    private const int MaximumBranchesPerLine = 1024;
+    private const string DeterministicSourcePrefix = "/_/src/";
+    private static readonly Regex ConditionCoverage = new(
+        @"^\s*(\d+(?:\.\d+)?)%\s+\((\d+)\s*/\s*(\d+)\)\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static CoverageSummaryResult Analyze(string reportDirectory, string sourceRoot)
+    {
+        var resolvedReportDirectory = Path.GetFullPath(reportDirectory);
+        var resolvedSourceRoot = Path.GetFullPath(sourceRoot);
+        AssertNotReparsePoint(resolvedReportDirectory);
+        AssertNotReparsePoint(resolvedSourceRoot);
+
+        var reports = Directory
+            .EnumerateFiles(resolvedReportDirectory, "*.cobertura.xml", SearchOption.AllDirectories)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        if (reports.Length == 0)
+        {
+            throw new InvalidDataException($"No Cobertura reports found under {resolvedReportDirectory}");
+        }
+        if (reports.Length > 1000)
+        {
+            throw new InvalidDataException($"Expected at most 1000 Cobertura reports, found {reports.Length}");
+        }
+
+        var measuredFiles = new Dictionary<string, Dictionary<int, bool>>(StringComparer.Ordinal);
+        var measuredBranches = new Dictionary<string, Dictionary<string, bool>>(StringComparer.Ordinal);
+        var sourceLineCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var normalizedSourceRoot = resolvedSourceRoot.Replace('\\', '/').TrimEnd('/');
+        foreach (var report in reports)
+        {
+            var measuredLineEntries = ReadCoverageReport(
+                report,
+                resolvedSourceRoot,
+                normalizedSourceRoot,
+                sourceLineCounts,
+                measuredFiles,
+                measuredBranches);
+            if (measuredLineEntries == 0)
+            {
+                throw new InvalidDataException($"{report} contains no measured lines under the source root");
+            }
+        }
+
+        long totalLines = 0;
+        long coveredLines = 0;
+        foreach (var fileLines in measuredFiles.Values)
+        {
+            totalLines += fileLines.Count;
+            coveredLines += fileLines.Values.Count(static covered => covered);
+        }
+        if (totalLines == 0)
+        {
+            throw new InvalidDataException("Merged coverage report contains no measured lines under the source root");
+        }
+
+        long totalBranches = 0;
+        long coveredBranches = 0;
+        foreach (var fileBranches in measuredBranches.Values)
+        {
+            totalBranches += fileBranches.Count;
+            coveredBranches += fileBranches.Values.Count(static covered => covered);
+        }
+
+        return new CoverageSummaryResult
+        {
+            CoveredBranches = coveredBranches,
+            CoveredLines = coveredLines,
+            Reports = reports.Length,
+            SourceFiles = measuredFiles.Count,
+            TotalBranches = totalBranches,
+            TotalLines = totalLines,
+        };
+    }
+
+    private static int ReadCoverageReport(
+        string reportPath,
+        string resolvedSourceRoot,
+        string normalizedSourceRoot,
+        Dictionary<string, int> sourceLineCounts,
+        Dictionary<string, Dictionary<int, bool>> measuredFiles,
+        Dictionary<string, Dictionary<string, bool>> measuredBranches)
+    {
+        AssertNotReparsePoint(reportPath);
+        var report = new FileInfo(reportPath);
+        if (report.Length > MaximumReportBytes)
+        {
+            throw new InvalidDataException($"{reportPath} exceeds the 100 MB parsing limit");
+        }
+
+        string reportText;
+        try
+        {
+            reportText = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                .GetString(File.ReadAllBytes(reportPath));
+        }
+        catch (DecoderFallbackException)
+        {
+            throw new InvalidDataException($"{reportPath} must contain valid UTF-8");
+        }
+        if (reportText.Length > 0 && reportText[0] == '\ufeff')
+        {
+            reportText = reportText[1..];
+        }
+        if (reportText.Contains("<!DOCTYPE", StringComparison.OrdinalIgnoreCase)
+            || reportText.Contains("<!ENTITY", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException("Coverage report contains unsupported XML declarations");
+        }
+
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaximumReportBytes,
+        };
+        using var stringReader = new StringReader(reportText);
+        using var reader = XmlReader.Create(stringReader, settings);
+        var classDepth = -1;
+        var methodDepth = -1;
+        var classLinesDepth = -1;
+        var measuredLineEntries = 0;
+        RepositorySourcePath? sourcePath = null;
+        try
+        {
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    if (reader.LocalName == "class")
+                    {
+                        classDepth = reader.Depth;
+                        methodDepth = -1;
+                        classLinesDepth = -1;
+                        sourcePath = GetRepositoryPath(reader.GetAttribute("filename"), normalizedSourceRoot);
+                        if (reader.IsEmptyElement)
+                        {
+                            classDepth = -1;
+                            sourcePath = null;
+                        }
+
+                        continue;
+                    }
+                    if (classDepth < 0)
+                    {
+                        continue;
+                    }
+                    if (reader.LocalName == "method")
+                    {
+                        if (!reader.IsEmptyElement)
+                        {
+                            methodDepth = reader.Depth;
+                        }
+
+                        continue;
+                    }
+                    if (reader.LocalName == "lines" && methodDepth < 0 && reader.Depth == classDepth + 1)
+                    {
+                        if (!reader.IsEmptyElement)
+                        {
+                            classLinesDepth = reader.Depth;
+                        }
+
+                        continue;
+                    }
+                    if (reader.LocalName != "line"
+                        || classLinesDepth < 0
+                        || reader.Depth != classLinesDepth + 1
+                        || sourcePath is null)
+                    {
+                        continue;
+                    }
+
+                    ProcessLine(
+                        reader,
+                        reportPath,
+                        resolvedSourceRoot,
+                        sourcePath,
+                        sourceLineCounts,
+                        measuredFiles,
+                        measuredBranches);
+                    measuredLineEntries++;
+                }
+                else if (reader.NodeType == XmlNodeType.EndElement)
+                {
+                    if (reader.Depth == classLinesDepth && reader.LocalName == "lines")
+                    {
+                        classLinesDepth = -1;
+                    }
+                    else if (reader.Depth == methodDepth && reader.LocalName == "method")
+                    {
+                        methodDepth = -1;
+                    }
+                    else if (reader.Depth == classDepth && reader.LocalName == "class")
+                    {
+                        classDepth = -1;
+                        methodDepth = -1;
+                        classLinesDepth = -1;
+                        sourcePath = null;
+                    }
+                }
+            }
+        }
+        catch (XmlException exception)
+        {
+            throw new InvalidDataException($"{reportPath} contains invalid XML: {exception.Message}", exception);
+        }
+
+        return measuredLineEntries;
+    }
+
+    private static void ProcessLine(
+        XmlReader reader,
+        string reportPath,
+        string resolvedSourceRoot,
+        RepositorySourcePath sourcePath,
+        Dictionary<string, int> sourceLineCounts,
+        Dictionary<string, Dictionary<int, bool>> measuredFiles,
+        Dictionary<string, Dictionary<string, bool>> measuredBranches)
+    {
+        if (!int.TryParse(reader.GetAttribute("number"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var lineNumber)
+            || !int.TryParse(reader.GetAttribute("hits"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var hits)
+            || lineNumber <= 0
+            || hits < 0)
+        {
+            throw new InvalidDataException($"{reportPath} contains invalid line coverage for {sourcePath.RepositoryPath}");
+        }
+
+        if (!sourceLineCounts.TryGetValue(sourcePath.RepositoryPath, out var sourceLineCount))
+        {
+            sourceLineCount = GetSourceLineCount(resolvedSourceRoot, sourcePath);
+            sourceLineCounts.Add(sourcePath.RepositoryPath, sourceLineCount);
+        }
+        if (lineNumber > sourceLineCount)
+        {
+            throw new InvalidDataException($"{reportPath} references line {lineNumber} beyond the end of {sourcePath.RepositoryPath}");
+        }
+
+        if (!measuredFiles.TryGetValue(sourcePath.RepositoryPath, out var fileLines))
+        {
+            fileLines = [];
+            measuredFiles.Add(sourcePath.RepositoryPath, fileLines);
+        }
+        fileLines.TryGetValue(lineNumber, out var covered);
+        fileLines[lineNumber] = covered || hits > 0;
+
+        if (!string.Equals(reader.GetAttribute("branch"), "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var conditionCoverage = reader.GetAttribute("condition-coverage") ?? string.Empty;
+        var match = ConditionCoverage.Match(conditionCoverage);
+        if (!match.Success)
+        {
+            throw new InvalidDataException($"Branch line {lineNumber} has invalid condition coverage '{conditionCoverage}'");
+        }
+        var coveragePercentText = match.Groups[1].Value;
+        var coveragePercent = decimal.Parse(coveragePercentText, CultureInfo.InvariantCulture);
+        var coveredBranches = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+        var totalBranches = int.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture);
+        if (totalBranches <= 0 || totalBranches > MaximumBranchesPerLine || coveredBranches > totalBranches)
+        {
+            throw new InvalidDataException($"Branch line {lineNumber} has inconsistent condition coverage '{conditionCoverage}'");
+        }
+
+        var decimalSeparator = coveragePercentText.IndexOf('.');
+        var decimalPlaces = decimalSeparator >= 0 ? coveragePercentText.Length - decimalSeparator - 1 : 0;
+        var roundingUnit = 1m;
+        for (var digit = 0; digit < decimalPlaces; digit++)
+        {
+            roundingUnit /= 10;
+        }
+        var expectedCoveragePercent = 100m * coveredBranches / totalBranches;
+        if (Math.Abs(coveragePercent - expectedCoveragePercent) > roundingUnit / 2)
+        {
+            throw new InvalidDataException($"Branch line {lineNumber} has inconsistent condition coverage '{conditionCoverage}'");
+        }
+
+        if (!measuredBranches.TryGetValue(sourcePath.RepositoryPath, out var fileBranches))
+        {
+            fileBranches = new Dictionary<string, bool>(StringComparer.Ordinal);
+            measuredBranches.Add(sourcePath.RepositoryPath, fileBranches);
+        }
+        for (var branch = 0; branch < totalBranches; branch++)
+        {
+            var branchKey = $"{lineNumber}\0aggregate\0{branch}";
+            fileBranches.TryGetValue(branchKey, out var branchCovered);
+            fileBranches[branchKey] = branchCovered || branch < coveredBranches;
+        }
+    }
+
+    private static RepositorySourcePath? GetRepositoryPath(string? filename, string normalizedSourceRoot)
+    {
+        if (string.IsNullOrEmpty(filename))
+        {
+            return null;
+        }
+
+        var normalized = filename.Replace('\\', '/');
+        var sourcePrefix = $"{normalizedSourceRoot}/";
+        string relativePath;
+        if (normalized.StartsWith(sourcePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            relativePath = normalized[sourcePrefix.Length..];
+        }
+        else if (normalized.StartsWith(DeterministicSourcePrefix, StringComparison.Ordinal))
+        {
+            relativePath = normalized[DeterministicSourcePrefix.Length..];
+        }
+        else
+        {
+            return null;
+        }
+
+        var pathParts = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (pathParts.Length == 0
+            || relativePath != string.Join('/', pathParts)
+            || pathParts.Any(static part => part is "." or ".."))
+        {
+            throw new InvalidDataException($"Coverage report contains invalid repository source path '{filename}'");
+        }
+        if (pathParts.Any(static part => part is "bin" or "obj"))
+        {
+            return null;
+        }
+
+        return new RepositorySourcePath(relativePath, $"src/{relativePath}");
+    }
+
+    private static int GetSourceLineCount(string resolvedSourceRoot, RepositorySourcePath sourcePath)
+    {
+        var currentPath = resolvedSourceRoot;
+        AssertNotReparsePoint(currentPath);
+        foreach (var part in sourcePath.RelativePath.Split('/'))
+        {
+            currentPath = Path.Combine(currentPath, part);
+            if (!File.Exists(currentPath) && !Directory.Exists(currentPath))
+            {
+                throw new InvalidDataException($"Coverage report references missing source file {sourcePath.RepositoryPath}");
+            }
+
+            AssertNotReparsePoint(currentPath);
+        }
+
+        var sourceFile = new FileInfo(currentPath);
+        if (!sourceFile.Exists)
+        {
+            throw new InvalidDataException($"Coverage report source path {sourcePath.RepositoryPath} is not a file");
+        }
+        if (sourceFile.Length > MaximumSourceBytes)
+        {
+            throw new InvalidDataException($"{currentPath} exceeds the 10 MB source validation limit");
+        }
+
+        var lineCount = 0;
+        using var reader = sourceFile.OpenText();
+        while (reader.ReadLine() is not null)
+        {
+            lineCount++;
+        }
+
+        return lineCount;
+    }
+
+    private static void AssertNotReparsePoint(string path)
+    {
+        var attributes = File.GetAttributes(path);
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new InvalidDataException($"{path} must not be a symbolic link");
+        }
+    }
+
+    private sealed record RepositorySourcePath(string RelativePath, string RepositoryPath);
+}

--- a/.github/scripts/CoverageSummary.cs
+++ b/.github/scripts/CoverageSummary.cs
@@ -316,7 +316,7 @@ public static class CoverageSummaryReader
 
         if (!measuredFiles.TryGetValue(sourcePath.RepositoryPath, out var fileLines))
         {
-            fileLines = [];
+            fileLines = new Dictionary<int, bool>();
             measuredFiles.Add(sourcePath.RepositoryPath, fileLines);
         }
         fileLines.TryGetValue(lineNumber, out var covered);

--- a/.github/scripts/compare-coverage.ps1
+++ b/.github/scripts/compare-coverage.ps1
@@ -152,7 +152,7 @@ $selectionStatus = [string] (Get-RequiredProperty $selection 'status' 'Baseline 
 $selectionReason = [string] (Get-RequiredProperty $selection 'reason' 'Baseline selection')
 $selectionExpectedSha = [string] (Get-RequiredProperty $selection 'expected_sha' 'Baseline selection')
 $baselineStatus = $selectionStatus
-if ($selectionExpectedSha -ne $ExpectedBaselineSha) {
+if ($selectionStatus -ne 'missing' -and $selectionExpectedSha -ne $ExpectedBaselineSha) {
     $baselineStatus = 'stale'
     $selectionReason = "Current main advanced from $selectionExpectedSha to $ExpectedBaselineSha while coverage was aggregated."
 }

--- a/.github/scripts/compare-coverage.ps1
+++ b/.github/scripts/compare-coverage.ps1
@@ -1,0 +1,283 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $CurrentSummary,
+
+    [Parameter(Mandatory)]
+    [string] $CurrentMatrix,
+
+    [Parameter(Mandatory)]
+    [string] $BaselineSelection,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-f]{40}$')]
+    [string] $ExpectedBaselineSha,
+
+    [Parameter(Mandatory)]
+    [string] $JsonOutput,
+
+    [Parameter(Mandatory)]
+    [string] $MarkdownOutput,
+
+    [string] $BaselineSummary,
+
+    [string] $BaselineMatrix,
+
+    [string] $BaselineUnavailableReason
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$invariantCulture = [Globalization.CultureInfo]::InvariantCulture
+
+function Read-JsonFile {
+    param([string] $Path)
+
+    $file = Get-Item -LiteralPath $Path -Force
+    if ($file.Length -gt 1MB) {
+        throw "$Path exceeds the 1 MB parsing limit"
+    }
+    try {
+        return Get-Content -Raw -LiteralPath $file.FullName | ConvertFrom-Json
+    } catch {
+        throw "$Path contains invalid JSON: $($_.Exception.Message)"
+    }
+}
+
+function Get-RequiredProperty {
+    param(
+        [object] $InputObject,
+        [string] $Name,
+        [string] $Identity
+    )
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if (-not $property) {
+        throw "$Identity does not contain '$Name'"
+    }
+
+    return $property.Value
+}
+
+function Get-Metrics {
+    param(
+        [object] $Summary,
+        [string] $Prefix,
+        [string] $Identity
+    )
+
+    $covered = 0L
+    $total = 0L
+    if (-not [long]::TryParse(
+        [string] (Get-RequiredProperty $Summary "covered_$Prefix" $Identity),
+        [Globalization.NumberStyles]::Integer,
+        $invariantCulture,
+        [ref] $covered
+    ) -or
+        -not [long]::TryParse(
+            [string] (Get-RequiredProperty $Summary "total_$Prefix" $Identity),
+            [Globalization.NumberStyles]::Integer,
+            $invariantCulture,
+            [ref] $total
+        ) -or
+        $covered -lt 0 -or
+        $total -lt 0 -or
+        $covered -gt $total -or
+        ($Prefix -eq 'lines' -and $total -eq 0)) {
+        throw "$Identity contains invalid $Prefix counts"
+    }
+
+    $rate = if ($total -gt 0) { [decimal] $covered / $total } else { [decimal] 0 }
+    return [pscustomobject]@{
+        Covered = $covered
+        Display = ($rate * 100).ToString('F2', $invariantCulture) + '%'
+        Rate = $rate
+        Total = $total
+    }
+}
+
+function Get-MatrixIdentity {
+    param(
+        [object] $Matrix,
+        [string] $Identity
+    )
+
+    $testedSha = [string] (Get-RequiredProperty $Matrix 'tested_sha' $Identity)
+    $manifestSha256 = [string] (Get-RequiredProperty $Matrix 'manifest_sha256' $Identity)
+    if ($testedSha -notmatch '^[0-9a-f]{40}$' -or $manifestSha256 -notmatch '^[0-9a-f]{64}$') {
+        throw "$Identity contains invalid coverage identity"
+    }
+
+    return [pscustomobject]@{
+        ManifestSha256 = $manifestSha256
+        TestedSha = $testedSha
+    }
+}
+
+function Get-Variance {
+    param(
+        [object] $Current,
+        [object] $Baseline
+    )
+
+    $rateDelta = $Current.Rate - $Baseline.Rate
+    $percentagePointDelta = $rateDelta * 100
+    $classification = if ($rateDelta -gt 0) {
+        'improved'
+    } elseif ($rateDelta -lt 0) {
+        'regressed'
+    } else {
+        'unchanged'
+    }
+    $sign = if ($percentagePointDelta -gt 0) { '+' } else { '' }
+
+    return [pscustomobject]@{
+        classification = $classification
+        covered_delta = $Current.Covered - $Baseline.Covered
+        percentage_point_delta = $percentagePointDelta
+        percentage_point_delta_display = "$sign$($percentagePointDelta.ToString('F4', $invariantCulture)) pp"
+        rate_delta = $rateDelta
+        total_delta = $Current.Total - $Baseline.Total
+    }
+}
+
+$currentSummaryData = Read-JsonFile $CurrentSummary
+$currentMatrixData = Read-JsonFile $CurrentMatrix
+$selection = Read-JsonFile $BaselineSelection
+$currentLine = Get-Metrics $currentSummaryData 'lines' 'Current coverage summary'
+$currentBranch = Get-Metrics $currentSummaryData 'branches' 'Current coverage summary'
+$currentIdentity = Get-MatrixIdentity $currentMatrixData 'Current coverage matrix'
+
+$selectionStatus = [string] (Get-RequiredProperty $selection 'status' 'Baseline selection')
+$selectionReason = [string] (Get-RequiredProperty $selection 'reason' 'Baseline selection')
+$selectionExpectedSha = [string] (Get-RequiredProperty $selection 'expected_sha' 'Baseline selection')
+$baselineStatus = $selectionStatus
+if ($selectionExpectedSha -ne $ExpectedBaselineSha) {
+    $baselineStatus = 'stale'
+    $selectionReason = "Current main advanced from $selectionExpectedSha to $ExpectedBaselineSha while coverage was aggregated."
+}
+if ($BaselineUnavailableReason) {
+    $baselineStatus = 'missing'
+    $selectionReason = $BaselineUnavailableReason
+}
+if ($baselineStatus -notin 'available', 'missing', 'stale') {
+    throw "Baseline selection contains unsupported status '$baselineStatus'"
+}
+
+$baselineLine = $null
+$baselineBranch = $null
+$lineVariance = $null
+$branchVariance = $null
+$overallConclusion = "baseline-$baselineStatus"
+$baselineIdentity = $null
+if ($baselineStatus -eq 'available') {
+    if (-not $BaselineSummary -or -not $BaselineMatrix) {
+        throw 'Available baseline coverage requires summary and matrix data'
+    }
+
+    $baselineSummaryData = Read-JsonFile $BaselineSummary
+    $baselineMatrixData = Read-JsonFile $BaselineMatrix
+    $baselineLine = Get-Metrics $baselineSummaryData 'lines' 'Baseline coverage summary'
+    $baselineBranch = Get-Metrics $baselineSummaryData 'branches' 'Baseline coverage summary'
+    $baselineIdentity = Get-MatrixIdentity $baselineMatrixData 'Baseline coverage matrix'
+    $selectedBaselineSha = [string] (Get-RequiredProperty $selection 'baseline_sha' 'Baseline selection')
+    if ($selectedBaselineSha -ne $ExpectedBaselineSha -or
+        $baselineIdentity.TestedSha -ne $selectedBaselineSha) {
+        throw 'Baseline coverage identity does not match current main'
+    }
+    if ($baselineIdentity.ManifestSha256 -ne $currentIdentity.ManifestSha256) {
+        throw 'Current and baseline coverage use different matrix manifests'
+    }
+
+    $lineVariance = Get-Variance $currentLine $baselineLine
+    $branchVariance = Get-Variance $currentBranch $baselineBranch
+    $classifications = @($lineVariance.classification, $branchVariance.classification)
+    $overallConclusion = if ($classifications -notcontains 'regressed' -and $classifications -contains 'improved') {
+        'improved'
+    } elseif ($classifications -notcontains 'improved' -and $classifications -contains 'regressed') {
+        'regressed'
+    } elseif ($classifications -contains 'improved' -and $classifications -contains 'regressed') {
+        'mixed'
+    } else {
+        'unchanged'
+    }
+}
+
+$baselineRunUrlProperty = $selection.PSObject.Properties['baseline_run_url']
+$baselineRunUrl = if ($baselineRunUrlProperty) { [string] $baselineRunUrlProperty.Value } else { $null }
+$result = [ordered]@{
+    format_version = 1
+    enforcement = 'report-only'
+    conclusion = $overallConclusion
+    current = [ordered]@{
+        tested_sha = $currentIdentity.TestedSha
+        manifest_sha256 = $currentIdentity.ManifestSha256
+        line_rate = $currentLine.Rate
+        line_rate_display = $currentLine.Display
+        covered_lines = $currentLine.Covered
+        total_lines = $currentLine.Total
+        branch_rate = $currentBranch.Rate
+        branch_rate_display = $currentBranch.Display
+        covered_branches = $currentBranch.Covered
+        total_branches = $currentBranch.Total
+    }
+    baseline = [ordered]@{
+        status = $baselineStatus
+        reason = $selectionReason
+        tested_sha = if ($baselineIdentity) { $baselineIdentity.TestedSha } else { $null }
+        run_url = $baselineRunUrl
+        line_rate = if ($baselineLine) { $baselineLine.Rate } else { $null }
+        line_rate_display = if ($baselineLine) { $baselineLine.Display } else { $null }
+        covered_lines = if ($baselineLine) { $baselineLine.Covered } else { $null }
+        total_lines = if ($baselineLine) { $baselineLine.Total } else { $null }
+        branch_rate = if ($baselineBranch) { $baselineBranch.Rate } else { $null }
+        branch_rate_display = if ($baselineBranch) { $baselineBranch.Display } else { $null }
+        covered_branches = if ($baselineBranch) { $baselineBranch.Covered } else { $null }
+        total_branches = if ($baselineBranch) { $baselineBranch.Total } else { $null }
+    }
+    variance = [ordered]@{
+        lines = $lineVariance
+        branches = $branchVariance
+    }
+}
+$result | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $JsonOutput -Encoding utf8NoBOM
+
+$currentLineCounts = '{0:N0} / {1:N0}' -f $currentLine.Covered, $currentLine.Total
+$currentBranchCounts = '{0:N0} / {1:N0}' -f $currentBranch.Covered, $currentBranch.Total
+$markdown = @(
+    '## Code coverage'
+    ''
+)
+if ($baselineStatus -eq 'available') {
+    $baselineLineCounts = '{0:N0} / {1:N0}' -f $baselineLine.Covered, $baselineLine.Total
+    $baselineBranchCounts = '{0:N0} / {1:N0}' -f $baselineBranch.Covered, $baselineBranch.Total
+    $markdown += @(
+        '| Metric | Pull request | Current main | Variance |'
+        '| --- | ---: | ---: | ---: |'
+        "| Lines | **$($currentLine.Display)** ($currentLineCounts) | **$($baselineLine.Display)** ($baselineLineCounts) | **$($lineVariance.percentage_point_delta_display)** |"
+        "| Branches | **$($currentBranch.Display)** ($currentBranchCounts) | **$($baselineBranch.Display)** ($baselineBranchCounts) | **$($branchVariance.percentage_point_delta_display)** |"
+        ''
+        "**Report-only conclusion:** $overallConclusion."
+        ''
+        "The current-main baseline is commit ``$($baselineIdentity.TestedSha.Substring(0, 10))`` and uses the same reviewed coverage matrix."
+    )
+} else {
+    $markdown += @(
+        '| Metric | Pull request |'
+        '| --- | ---: |'
+        "| Lines | **$($currentLine.Display)** ($currentLineCounts) |"
+        "| Branches | **$($currentBranch.Display)** ($currentBranchCounts) |"
+        ''
+        "**Report-only conclusion:** current-main baseline $baselineStatus."
+        ''
+        $selectionReason
+    )
+}
+$markdown += @(
+    ''
+    'Coverage combines every CI test matrix job, including providers, CodeGen, .NET 8/10, Linux, Windows, and macOS, using canonical physical source and branch identities.'
+    ''
+    'The comparison remains report-only while normal line and branch variance is calibrated.'
+    ''
+)
+Set-Content -LiteralPath $MarkdownOutput -Value ($markdown -join "`n") -Encoding utf8NoBOM

--- a/.github/scripts/get-coverage-input-fingerprint.ps1
+++ b/.github/scripts/get-coverage-input-fingerprint.ps1
@@ -51,8 +51,10 @@ if ($inputs.Count -eq 0) {
     throw 'The coverage input manifest is empty'
 }
 
+$sortedInputs = @($inputs)
+[Array]::Sort($sortedInputs, [StringComparer]::Ordinal)
 $entries = @(
-    foreach ($relativePath in @($inputs | Sort-Object)) {
+    foreach ($relativePath in $sortedInputs) {
         $currentPath = $resolvedRepositoryRoot
         Assert-NotReparsePoint $currentPath
         foreach ($part in $relativePath.Split('/')) {

--- a/.github/scripts/get-coverage-input-fingerprint.ps1
+++ b/.github/scripts/get-coverage-input-fingerprint.ps1
@@ -1,0 +1,84 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $RepositoryRoot,
+
+    [Parameter(Mandatory)]
+    [string] $Manifest,
+
+    [Parameter(Mandatory)]
+    [string] $JsonOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$maximumInputBytes = 10MB
+
+function Assert-NotReparsePoint {
+    param([string] $Path)
+
+    $item = Get-Item -LiteralPath $Path -Force
+    $linkType = $item.PSObject.Properties['LinkType']
+    if (($linkType -and $linkType.Value) -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        throw "$Path must not be a symbolic link"
+    }
+}
+
+$resolvedRepositoryRoot = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+$resolvedManifest = (Resolve-Path -LiteralPath $Manifest).Path
+Assert-NotReparsePoint $resolvedRepositoryRoot
+Assert-NotReparsePoint $resolvedManifest
+
+$inputs = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+foreach ($line in [IO.File]::ReadAllLines($resolvedManifest)) {
+    $relativePath = $line.Trim()
+    if (-not $relativePath) {
+        continue
+    }
+
+    $parts = $relativePath.Split('/', [StringSplitOptions]::RemoveEmptyEntries)
+    if ($relativePath -ne ($parts -join '/') -or
+        $parts.Count -eq 0 -or
+        $parts.Where({ $_ -in '.', '..' }, 'First').Count -gt 0 -or
+        $relativePath -notmatch '^(?:\.github/[A-Za-z0-9._/-]+|global\.json)$') {
+        throw "Invalid coverage input path '$relativePath'"
+    }
+    if (-not $inputs.Add($relativePath)) {
+        throw "Duplicate coverage input path '$relativePath'"
+    }
+}
+if ($inputs.Count -eq 0) {
+    throw 'The coverage input manifest is empty'
+}
+
+$entries = @(
+    foreach ($relativePath in @($inputs | Sort-Object)) {
+        $currentPath = $resolvedRepositoryRoot
+        Assert-NotReparsePoint $currentPath
+        foreach ($part in $relativePath.Split('/')) {
+            $currentPath = Join-Path $currentPath $part
+            if (-not (Test-Path -LiteralPath $currentPath)) {
+                throw "Coverage input '$relativePath' is missing"
+            }
+            Assert-NotReparsePoint $currentPath
+        }
+
+        $inputFile = Get-Item -LiteralPath $currentPath -Force
+        if ($inputFile.PSIsContainer) {
+            throw "Coverage input '$relativePath' is not a file"
+        }
+        if ($inputFile.Length -gt $maximumInputBytes) {
+            throw "Coverage input '$relativePath' exceeds the 10 MB hashing limit"
+        }
+
+        $fileHash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData([IO.File]::ReadAllBytes($inputFile.FullName))).ToLowerInvariant()
+        "$relativePath`0$fileHash"
+    }
+)
+$fingerprintBytes = [Text.UTF8Encoding]::new($false).GetBytes(($entries -join "`n") + "`n")
+$fingerprint = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($fingerprintBytes)).ToLowerInvariant()
+$result = [ordered]@{
+    files = $inputs.Count
+    sha256 = $fingerprint
+}
+$result | ConvertTo-Json | Set-Content -LiteralPath $JsonOutput -Encoding utf8NoBOM

--- a/.github/scripts/select-coverage-baseline.ps1
+++ b/.github/scripts/select-coverage-baseline.ps1
@@ -1,0 +1,142 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $RunsJson,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-f]{40}$')]
+    [string] $ExpectedSha,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[A-Za-z0-9._/-]+$')]
+    [string] $DefaultBranch,
+
+    [Parameter(Mandatory)]
+    [string] $JsonOutput,
+
+    [string] $WorkflowPath = '.github/workflows/ci.yml',
+
+    [DateTimeOffset] $AsOf = [DateTimeOffset]::UtcNow
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-PropertyValue {
+    param(
+        [object] $InputObject,
+        [string] $Name
+    )
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($property) {
+        return $property.Value
+    }
+
+    return $null
+}
+
+function Get-RunIdentity {
+    param([object] $Run)
+
+    $createdAtText = Get-PropertyValue $Run 'created_at'
+    $createdAt = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse(
+        $createdAtText,
+        [Globalization.CultureInfo]::InvariantCulture,
+        [Globalization.DateTimeStyles]::AssumeUniversal,
+        [ref] $createdAt
+    )) {
+        throw "Coverage workflow run contains invalid created_at '$createdAtText'"
+    }
+
+    $runId = 0L
+    if (-not [long]::TryParse(
+        [string] (Get-PropertyValue $Run 'id'),
+        [Globalization.NumberStyles]::Integer,
+        [Globalization.CultureInfo]::InvariantCulture,
+        [ref] $runId
+    ) -or $runId -le 0) {
+        throw 'Coverage workflow run contains an invalid id'
+    }
+
+    $headSha = [string] (Get-PropertyValue $Run 'head_sha')
+    if ($headSha -notmatch '^[0-9a-f]{40}$') {
+        throw "Coverage workflow run contains invalid head_sha '$headSha'"
+    }
+
+    $htmlUrl = [string] (Get-PropertyValue $Run 'html_url')
+    if (-not [Uri]::IsWellFormedUriString($htmlUrl, [UriKind]::Absolute)) {
+        throw "Coverage workflow run contains invalid html_url '$htmlUrl'"
+    }
+
+    return [pscustomobject]@{
+        CreatedAt = $createdAt
+        HeadSha = $headSha
+        HtmlUrl = $htmlUrl
+        Id = $runId
+    }
+}
+
+$runsFile = Get-Item -LiteralPath $RunsJson -Force
+if ($runsFile.Length -gt 10MB) {
+    throw "$RunsJson exceeds the 10 MB parsing limit"
+}
+try {
+    $payload = Get-Content -Raw -LiteralPath $runsFile.FullName | ConvertFrom-Json
+} catch {
+    throw "$RunsJson contains invalid JSON: $($_.Exception.Message)"
+}
+
+$workflowRunsProperty = $payload.PSObject.Properties['workflow_runs']
+if (-not $workflowRunsProperty) {
+    throw "$RunsJson does not contain workflow_runs"
+}
+
+$eligibleRuns = @(
+    foreach ($run in @($workflowRunsProperty.Value)) {
+        if ((Get-PropertyValue $run 'path') -ne $WorkflowPath -or
+            (Get-PropertyValue $run 'event') -ne 'push' -or
+            (Get-PropertyValue $run 'status') -ne 'completed' -or
+            (Get-PropertyValue $run 'conclusion') -ne 'success' -or
+            (Get-PropertyValue $run 'head_branch') -ne $DefaultBranch) {
+            continue
+        }
+
+        Get-RunIdentity $run
+    }
+)
+$eligibleRuns = @(
+    $eligibleRuns |
+        Where-Object { $_.CreatedAt -le $AsOf } |
+        Sort-Object -Property @{ Expression = 'CreatedAt'; Descending = $true }, @{ Expression = 'Id'; Descending = $true }
+)
+
+$status = 'missing'
+$reason = "No successful $WorkflowPath push run is available for $DefaultBranch."
+$selected = $null
+if ($eligibleRuns.Count -gt 0) {
+    $selected = $eligibleRuns | Where-Object { $_.HeadSha -eq $ExpectedSha } | Select-Object -First 1
+    if ($selected) {
+        $status = 'available'
+        $reason = 'The current default-branch commit has a successful same-matrix coverage run.'
+    } else {
+        $status = 'stale'
+        $selected = $eligibleRuns[0]
+        $reason = "The newest successful coverage run tested $($selected.HeadSha), not current main $ExpectedSha."
+    }
+}
+
+$result = [ordered]@{
+    format_version = 1
+    status = $status
+    reason = $reason
+    expected_sha = $ExpectedSha
+    branch = $DefaultBranch
+    workflow_path = $WorkflowPath
+    baseline_sha = if ($selected) { $selected.HeadSha } else { $null }
+    baseline_run_id = if ($selected) { $selected.Id } else { $null }
+    baseline_run_url = if ($selected) { $selected.HtmlUrl } else { $null }
+    baseline_created_at = if ($selected) { $selected.CreatedAt.ToUniversalTime().ToString('O') } else { $null }
+}
+$result | ConvertTo-Json | Set-Content -LiteralPath $JsonOutput -Encoding utf8NoBOM

--- a/.github/scripts/summarize-coverage.ps1
+++ b/.github/scripts/summarize-coverage.ps1
@@ -15,324 +15,41 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-
-$maximumReportBytes = 100MB
-$maximumSourceBytes = 10MB
-$deterministicSourcePrefix = '/_/src/'
 $invariantCulture = [Globalization.CultureInfo]::InvariantCulture
 
-function Assert-NotReparsePoint {
-    param([string] $Path)
-
-    $item = Get-Item -LiteralPath $Path -Force
-    $linkType = $item.PSObject.Properties['LinkType']
-    if (($linkType -and $linkType.Value) -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
-        throw "$Path must not be a symbolic link"
-    }
+if (-not ('Orleans.Coverage.CoverageSummaryReader' -as [type])) {
+    Add-Type -Path (Join-Path $PSScriptRoot 'CoverageSummary.cs')
 }
 
-function Get-RepositoryPath {
-    param(
-        [string] $Filename,
-        [string] $ResolvedSourceRoot
-    )
-
-    $normalized = $Filename.Replace('\', '/')
-    $sourcePrefix = "$ResolvedSourceRoot/"
-    if ($normalized.StartsWith($sourcePrefix, [StringComparison]::OrdinalIgnoreCase)) {
-        $relativePath = $normalized.Substring($sourcePrefix.Length)
-    } elseif ($normalized.StartsWith($deterministicSourcePrefix, [StringComparison]::Ordinal)) {
-        $relativePath = $normalized.Substring($deterministicSourcePrefix.Length)
-    } else {
-        return $null
-    }
-
-    $pathParts = $relativePath.Split('/', [StringSplitOptions]::RemoveEmptyEntries)
-    if ($pathParts.Count -eq 0 -or
-        $relativePath -ne ($pathParts -join '/') -or
-        $pathParts.Where({ $_ -in '.', '..' }, 'First').Count -gt 0) {
-        throw "Coverage report contains invalid repository source path '$Filename'"
-    }
-    if ($pathParts.Where({ $_ -in 'bin', 'obj' }, 'First').Count -gt 0) {
-        return $null
-    }
-
-    return [pscustomobject]@{
-        RelativePath = $relativePath
-        RepositoryPath = "src/$relativePath"
-    }
-}
-
-function Get-SourceLineCount {
-    param(
-        [string] $RelativePath,
-        [string] $ResolvedSourceRoot
-    )
-
-    $currentPath = $ResolvedSourceRoot
-    Assert-NotReparsePoint $currentPath
-    foreach ($part in $RelativePath.Split('/', [StringSplitOptions]::RemoveEmptyEntries)) {
-        $currentPath = Join-Path $currentPath $part
-        if (-not (Test-Path -LiteralPath $currentPath)) {
-            throw "Coverage report references missing source file src/$RelativePath"
-        }
-        Assert-NotReparsePoint $currentPath
-    }
-
-    $sourceFile = Get-Item -LiteralPath $currentPath -Force
-    if (-not $sourceFile.PSIsContainer -and $sourceFile.Length -gt $maximumSourceBytes) {
-        throw "$currentPath exceeds the 10 MB source validation limit"
-    }
-    if ($sourceFile.PSIsContainer) {
-        throw "Coverage report source path src/$RelativePath is not a file"
-    }
-
-    $lineCount = 0
-    $reader = [IO.File]::OpenText($sourceFile.FullName)
-    try {
-        while ($null -ne $reader.ReadLine()) {
-            $lineCount++
-        }
-    } finally {
-        $reader.Dispose()
-    }
-
-    return $lineCount
-}
-
-function Get-BranchCoverage {
-    param([Xml.XmlElement] $LineElement)
-
-    $conditions = @($LineElement.SelectNodes('./*[local-name()="conditions"]/*[local-name()="condition"]'))
-    if ($conditions.Count -eq 0) {
-        throw "Branch line $($LineElement.GetAttribute('number')) contains no conditions"
-    }
-
-    $conditionCoverage = $LineElement.GetAttribute('condition-coverage')
-    if ($conditionCoverage -notmatch '^\s*(\d+(?:\.\d+)?)%\s+\((\d+)\s*/\s*(\d+)\)\s*$') {
-        throw "Branch line $($LineElement.GetAttribute('number')) has invalid condition coverage '$conditionCoverage'"
-    }
-    $coveredBranches = [int] $Matches[2]
-    $totalBranches = [int] $Matches[3]
-    if ($totalBranches -ne $conditions.Count * 2 -or $coveredBranches -gt $totalBranches) {
-        throw "Branch line $($LineElement.GetAttribute('number')) has inconsistent condition coverage '$conditionCoverage'"
-    }
-
-    $branches = [Collections.Generic.Dictionary[string, int]]::new([StringComparer]::Ordinal)
-    $conditionCoveredTotal = 0
-    foreach ($condition in $conditions) {
-        $conditionNumber = 0
-        if (-not [int]::TryParse($condition.GetAttribute('number'), [Globalization.NumberStyles]::Integer, $invariantCulture, [ref] $conditionNumber) -or
-            $conditionNumber -lt 0) {
-            throw "Branch line $($LineElement.GetAttribute('number')) has an invalid condition number"
-        }
-
-        $conditionType = $condition.GetAttribute('type')
-        if (-not $conditionType) {
-            throw "Branch line $($LineElement.GetAttribute('number')) has a condition without a type"
-        }
-
-        $coverage = $condition.GetAttribute('coverage')
-        if ($coverage -notmatch '^\s*(\d+(?:\.\d+)?)%\s*$') {
-            throw "Branch line $($LineElement.GetAttribute('number')) has invalid branch coverage '$coverage'"
-        }
-        $coveragePercent = [decimal]::Parse($Matches[1], $invariantCulture)
-        $covered = [decimal] 2 * $coveragePercent / 100
-        if ($covered -lt 0 -or $covered -gt 2 -or $covered -ne [decimal]::Truncate($covered)) {
-            throw "Branch line $($LineElement.GetAttribute('number')) has unsupported branch coverage '$coverage'"
-        }
-
-        $branchKey = "$conditionNumber`0$conditionType"
-        if (-not $branches.TryAdd($branchKey, [int] $covered)) {
-            throw "Branch line $($LineElement.GetAttribute('number')) contains duplicate condition '$conditionNumber/$conditionType'"
-        }
-        $conditionCoveredTotal += [int] $covered
-    }
-    if ($conditionCoveredTotal -ne $coveredBranches) {
-        throw "Branch line $($LineElement.GetAttribute('number')) has inconsistent condition coverage '$conditionCoverage'"
-    }
-
-    return $branches
-}
-
-function Read-CoverageReport {
-    param(
-        [string] $ReportPath,
-        [string] $ResolvedSourceRoot
-    )
-
-    $report = Get-Item -LiteralPath $ReportPath -Force
-    $linkType = $report.PSObject.Properties['LinkType']
-    if (($linkType -and $linkType.Value) -or ($report.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
-        throw "$ReportPath must not be a symbolic link"
-    }
-    if ($report.Length -gt $maximumReportBytes) {
-        throw "$ReportPath exceeds the 100 MB parsing limit"
-    }
-
-    $encoding = [Text.UTF8Encoding]::new($false, $true)
-    try {
-        $reportText = $encoding.GetString([IO.File]::ReadAllBytes($report.FullName))
-    } catch [Text.DecoderFallbackException] {
-        throw "$ReportPath must contain valid UTF-8"
-    }
-    if ($reportText.Length -gt 0 -and $reportText[0] -eq [char] 0xfeff) {
-        $reportText = $reportText.Substring(1)
-    }
-
-    if ($reportText.IndexOf('<!DOCTYPE', [StringComparison]::OrdinalIgnoreCase) -ge 0 -or
-        $reportText.IndexOf('<!ENTITY', [StringComparison]::OrdinalIgnoreCase) -ge 0) {
-        throw 'Coverage report contains unsupported XML declarations'
-    }
-
-    $settings = [Xml.XmlReaderSettings]::new()
-    $settings.DtdProcessing = [Xml.DtdProcessing]::Prohibit
-    $settings.XmlResolver = $null
-    $settings.MaxCharactersInDocument = $maximumReportBytes
-    $stringReader = [IO.StringReader]::new($reportText)
-    $reader = [Xml.XmlReader]::Create($stringReader, $settings)
-    try {
-        $document = [Xml.XmlDocument]::new()
-        $document.XmlResolver = $null
-        try {
-            $document.Load($reader)
-        } catch [Xml.XmlException] {
-            throw "$ReportPath contains invalid XML: $($_.Exception.Message)"
-        }
-    } finally {
-        $reader.Dispose()
-        $stringReader.Dispose()
-    }
-
-    $measuredFiles = [Collections.Generic.Dictionary[string, Collections.Generic.Dictionary[int, bool]]]::new(
-        [StringComparer]::Ordinal
-    )
-    $measuredBranches = [Collections.Generic.Dictionary[string, Collections.Generic.Dictionary[string, int]]]::new(
-        [StringComparer]::Ordinal
-    )
-    $sourceLineCounts = [Collections.Generic.Dictionary[string, int]]::new([StringComparer]::Ordinal)
-    foreach ($classElement in $document.SelectNodes('//*[local-name()="class"]')) {
-        $filename = $classElement.GetAttribute('filename')
-        if (-not $filename) {
-            continue
-        }
-
-        $sourcePath = Get-RepositoryPath -Filename $filename -ResolvedSourceRoot $ResolvedSourceRoot
-        if (-not $sourcePath) {
-            continue
-        }
-        $repositoryPath = $sourcePath.RepositoryPath
-
-        $linesElement = $classElement.SelectSingleNode('./*[local-name()="lines"]')
-        if (-not $linesElement) {
-            continue
-        }
-
-        $fileLines = $null
-        if (-not $measuredFiles.TryGetValue($repositoryPath, [ref] $fileLines)) {
-            $fileLines = [Collections.Generic.Dictionary[int, bool]]::new()
-            $measuredFiles.Add($repositoryPath, $fileLines)
-        }
-        $fileBranches = $null
-        if (-not $measuredBranches.TryGetValue($repositoryPath, [ref] $fileBranches)) {
-            $fileBranches = [Collections.Generic.Dictionary[string, int]]::new([StringComparer]::Ordinal)
-            $measuredBranches.Add($repositoryPath, $fileBranches)
-        }
-        $sourceLineCount = 0
-        if (-not $sourceLineCounts.TryGetValue($repositoryPath, [ref] $sourceLineCount)) {
-            $sourceLineCount = Get-SourceLineCount -RelativePath $sourcePath.RelativePath -ResolvedSourceRoot $ResolvedSourceRoot
-            $sourceLineCounts.Add($repositoryPath, $sourceLineCount)
-        }
-
-        foreach ($lineElement in $linesElement.SelectNodes('./*[local-name()="line"]')) {
-            $lineNumber = 0
-            $hits = 0
-            if (-not [int]::TryParse($lineElement.GetAttribute('number'), [Globalization.NumberStyles]::Integer, $invariantCulture, [ref] $lineNumber) -or
-                -not [int]::TryParse($lineElement.GetAttribute('hits'), [Globalization.NumberStyles]::Integer, $invariantCulture, [ref] $hits) -or
-                $lineNumber -le 0 -or
-                $hits -lt 0) {
-                throw "$ReportPath contains invalid line coverage for $repositoryPath"
-            }
-            if ($lineNumber -gt $sourceLineCount) {
-                throw "$ReportPath references line $lineNumber beyond the end of $repositoryPath"
-            }
-
-            $covered = $false
-            [void] $fileLines.TryGetValue($lineNumber, [ref] $covered)
-            $fileLines[$lineNumber] = $covered -or $hits -gt 0
-
-            if ($lineElement.GetAttribute('branch').Equals('true', [StringComparison]::OrdinalIgnoreCase)) {
-                $branches = Get-BranchCoverage -LineElement $lineElement
-                foreach ($branch in $branches.GetEnumerator()) {
-                    $branchKey = "$lineNumber`0$($branch.Key)"
-                    $existingCovered = 0
-                    [void] $fileBranches.TryGetValue($branchKey, [ref] $existingCovered)
-                    $fileBranches[$branchKey] = [Math]::Max($existingCovered, $branch.Value)
-                }
-            }
-        }
-    }
-
-    return [pscustomobject]@{
-        Branches = $measuredBranches
-        Files = $measuredFiles
-    }
-}
-
-$resolvedReportDirectory = (Resolve-Path -LiteralPath $ReportDirectory).Path
-$resolvedSourceRootPath = (Resolve-Path -LiteralPath $SourceRoot).Path
-Assert-NotReparsePoint $resolvedSourceRootPath
-$resolvedSourceRoot = [IO.Path]::GetFullPath($resolvedSourceRootPath).Replace('\', '/').TrimEnd('/')
-$reports = @(Get-ChildItem -LiteralPath $resolvedReportDirectory -Recurse -File -Filter '*.cobertura.xml' | Sort-Object FullName)
-if ($reports.Count -eq 0) {
-    throw "No Cobertura reports found under $resolvedReportDirectory"
-}
-if ($reports.Count -ne 1) {
-    throw "Expected one merged Cobertura report, found $($reports.Count)"
-}
-
-$coverageReport = Read-CoverageReport -ReportPath $reports[0].FullName -ResolvedSourceRoot $resolvedSourceRoot
-$measuredFiles = $coverageReport.Files
-$measuredBranches = $coverageReport.Branches
-$totalLines = 0
-$coveredLines = 0
-foreach ($fileLines in $measuredFiles.Values) {
-    $totalLines += $fileLines.Count
-    $coveredLines += @($fileLines.Values | Where-Object { $_ }).Count
-}
-if ($totalLines -eq 0) {
-    throw 'Merged coverage report contains no measured lines under the source root'
-}
-$totalBranches = 0
-$coveredBranches = 0
-foreach ($fileBranches in $measuredBranches.Values) {
-    $totalBranches += $fileBranches.Count * 2
-    $coveredBranches += ($fileBranches.Values | Measure-Object -Sum).Sum
-}
-
-$lineRate = $coveredLines / $totalLines
+$coverage = [Orleans.Coverage.CoverageSummaryReader]::Analyze($ReportDirectory, $SourceRoot)
+$lineRate = $coverage.CoveredLines / $coverage.TotalLines
 $lineRateDisplay = ($lineRate * 100).ToString('F2', $invariantCulture) + '%'
-$branchRate = if ($totalBranches -gt 0) { $coveredBranches / $totalBranches } else { 0 }
+$branchRate = if ($coverage.TotalBranches -gt 0) {
+    $coverage.CoveredBranches / $coverage.TotalBranches
+} else {
+    0
+}
 $branchRateDisplay = ($branchRate * 100).ToString('F2', $invariantCulture) + '%'
 $summary = [ordered]@{
     branch_rate = $branchRate
     branch_rate_display = $branchRateDisplay
-    covered_branches = $coveredBranches
-    covered_lines = $coveredLines
+    covered_branches = $coverage.CoveredBranches
+    covered_lines = $coverage.CoveredLines
     line_rate = $lineRate
     line_rate_display = $lineRateDisplay
-    total_lines = $totalLines
-    total_branches = $totalBranches
-    reports = 1
-    source_files = $measuredFiles.Count
+    total_lines = $coverage.TotalLines
+    total_branches = $coverage.TotalBranches
+    reports = $coverage.Reports
+    source_files = $coverage.SourceFiles
 }
 $summary | ConvertTo-Json | Set-Content -LiteralPath $JsonOutput -Encoding utf8NoBOM
 
-$coveredDisplay = $coveredLines.ToString('N0', $invariantCulture)
-$totalDisplay = $totalLines.ToString('N0', $invariantCulture)
-$coveredBranchesDisplay = $coveredBranches.ToString('N0', $invariantCulture)
-$totalBranchesDisplay = $totalBranches.ToString('N0', $invariantCulture)
-$sourceFileDisplay = $measuredFiles.Count.ToString('N0', $invariantCulture)
+$coveredDisplay = $coverage.CoveredLines.ToString('N0', $invariantCulture)
+$totalDisplay = $coverage.TotalLines.ToString('N0', $invariantCulture)
+$coveredBranchesDisplay = $coverage.CoveredBranches.ToString('N0', $invariantCulture)
+$totalBranchesDisplay = $coverage.TotalBranches.ToString('N0', $invariantCulture)
+$sourceFileDisplay = $coverage.SourceFiles.ToString('N0', $invariantCulture)
+$reportDisplay = $coverage.Reports.ToString('N0', $invariantCulture)
 $markdown = @(
     '## Code coverage'
     ''
@@ -341,7 +58,7 @@ $markdown = @(
     "| Lines | **$lineRateDisplay** | **$coveredDisplay / $totalDisplay** |"
     "| Branches | **$branchRateDisplay** | **$coveredBranchesDisplay / $totalBranchesDisplay** |"
     ''
-    "Measured $sourceFileDisplay source files from the merged coverage report."
+    "Measured $sourceFileDisplay source files across $reportDisplay validated coverage reports."
     ''
     'Coverage combines every CI test matrix job, including providers, CodeGen, .NET 8/10, Linux, Windows, and macOS, and measures loaded repository source under `src/`.'
     ''

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1113,6 +1113,10 @@ exit 0
             $reportingWorkflow `
             'ExpectedBaselineSha = \$currentMain\.object\.sha' `
             'The comparison must revalidate the current-main identity after aggregation.'
+        Assert-Matches `
+            $reportingWorkflow `
+            '\[Uri\]::EscapeDataString\(\$env:DEFAULT_BRANCH\)' `
+            'The current-main ref lookup must encode default branch names.'
     }
 
     Invoke-Test 'requires every successful test job to upload coverage' {

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -104,7 +104,7 @@ function Get-ReportXml {
   <packages>
     <package>
       <classes>
-        <class filename="$encodedSourceFile">
+        <class name="Example" filename="$encodedSourceFile">
           <lines>$Lines</lines>
         </class>
       </classes>
@@ -391,8 +391,10 @@ try {
     Invoke-Test 'rejects branch markers without aggregate counts' {
         $testCase = New-TestCase
         $lines = '<line number="10" hits="1" branch="True" />'
-        [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines))
-        Assert-Throws { Invoke-Summarizer $testCase } 'invalid condition coverage'
+        $report = Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines)
+        Assert-Throws `
+            { Invoke-Summarizer $testCase } `
+            ([regex]::Escape("$report contains invalid condition coverage '' for src/Example.cs:10"))
     }
 
     Invoke-Test 'combines duplicate aggregate branch coverage conservatively' {
@@ -413,6 +415,32 @@ try {
         $summary = Get-Content -Raw $testCase.JsonOutput | ConvertFrom-Json
         Assert-Equal 1 $summary.covered_branches 'Duplicate aggregate covered branches differ.'
         Assert-Equal 2 $summary.total_branches 'Duplicate aggregate total branches differ.'
+    }
+
+    Invoke-Test 'counts distinct branch sites which share a physical line' {
+        $testCase = New-TestCase
+        $sourceFile = [Security.SecurityElement]::Escape((Join-Path $testCase.SourceRoot 'Example.cs'))
+        $xml = @"
+<coverage><packages><package><classes>
+  <class name="ContainingType" filename="$sourceFile">
+    <methods><method name="Method" signature="()"><lines>
+      <line number="10" hits="1" branch="True" condition-coverage="50% (2/4)" />
+    </lines></method></methods>
+    <lines><line number="10" hits="1" branch="True" condition-coverage="50% (2/4)" /></lines>
+  </class>
+  <class name="GeneratedLambda" filename="$sourceFile">
+    <methods><method name="Lambda" signature="()"><lines>
+      <line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" />
+    </lines></method></methods>
+    <lines><line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" /></lines>
+  </class>
+</classes></package></packages></coverage>
+"@
+        [void] (Write-Report $testCase $xml)
+        Invoke-Summarizer $testCase
+        $summary = Get-Content -Raw $testCase.JsonOutput | ConvertFrom-Json
+        Assert-Equal 3 $summary.covered_branches 'Distinct branch site covered branches differ.'
+        Assert-Equal 6 $summary.total_branches 'Distinct branch site total branches differ.'
     }
 
     Invoke-Test 'rejects inconsistent branch coverage' {
@@ -438,6 +466,22 @@ try {
         $lines = '<line number="10" hits="1" branch="True" condition-coverage="0% (0/1025)" />'
         [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines))
         Assert-Throws { Invoke-Summarizer $testCase } 'inconsistent condition coverage'
+    }
+
+    Invoke-Test 'rejects branch denominator drift across reports' {
+        $testCase = New-TestCase
+        $sourceFile = Join-Path $testCase.SourceRoot 'Example.cs'
+        [void] (Write-Report `
+            $testCase `
+            (Get-ReportXml $sourceFile '<line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" />') `
+            'first.cobertura.xml')
+        $secondReport = Write-Report `
+            $testCase `
+            (Get-ReportXml $sourceFile '<line number="10" hits="1" branch="True" condition-coverage="25% (1/4)" />') `
+            'second.cobertura.xml'
+        Assert-Throws `
+            { Invoke-Summarizer $testCase } `
+            ([regex]::Escape("$secondReport reports 4 branches for src/Example.cs:10 at Example/<non-method>, expected 2"))
     }
 
     Invoke-Test 'rejects missing source files' {

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1107,6 +1107,12 @@ exit 0
         $missing = Invoke-Comparison $missingComparison
         Assert-Equal 'baseline-missing' $missing.conclusion 'Missing comparison conclusion differs.'
 
+        $advancedMissingComparison = New-ComparisonCase -BaselineStatus 'missing'
+        $advancedMissingComparison.ExpectedBaselineSha = 'dddddddddddddddddddddddddddddddddddddddd'
+        $advancedMissing = Invoke-Comparison $advancedMissingComparison
+        Assert-Equal 'baseline-missing' $advancedMissing.conclusion 'Advanced missing comparison conclusion differs.'
+        Assert-Equal 'Baseline status is missing.' $advancedMissing.baseline.reason 'Advanced missing comparison reason differs.'
+
         $staleComparison = New-ComparisonCase -BaselineStatus 'available'
         $staleComparison.ExpectedBaselineSha = 'dddddddddddddddddddddddddddddddddddddddd'
         $stale = Invoke-Comparison $staleComparison

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -377,6 +377,44 @@ try {
         Assert-Equal '100.00%' $summary.branch_rate_display 'Displayed branch rate differs.'
     }
 
+    Invoke-Test 'supports aggregate branch counts without conditions' {
+        $testCase = New-TestCase
+        $lines = '<line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" />'
+        [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines))
+        Invoke-Summarizer $testCase
+        $summary = Get-Content -Raw $testCase.JsonOutput | ConvertFrom-Json
+        Assert-Equal 1 $summary.covered_branches 'Aggregate covered branches differ.'
+        Assert-Equal 2 $summary.total_branches 'Aggregate total branches differ.'
+        Assert-Equal '50.00%' $summary.branch_rate_display 'Aggregate branch rate differs.'
+    }
+
+    Invoke-Test 'rejects branch markers without aggregate counts' {
+        $testCase = New-TestCase
+        $lines = '<line number="10" hits="1" branch="True" />'
+        [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines))
+        Assert-Throws { Invoke-Summarizer $testCase } 'invalid condition coverage'
+    }
+
+    Invoke-Test 'combines duplicate aggregate branch coverage conservatively' {
+        $testCase = New-TestCase
+        $sourceFile = [Security.SecurityElement]::Escape((Join-Path $testCase.SourceRoot 'Example.cs'))
+        $xml = @"
+<coverage><packages><package><classes>
+  <class filename="$sourceFile"><lines>
+    <line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" />
+  </lines></class>
+  <class filename="$sourceFile"><lines>
+    <line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" />
+  </lines></class>
+</classes></package></packages></coverage>
+"@
+        [void] (Write-Report $testCase $xml)
+        Invoke-Summarizer $testCase
+        $summary = Get-Content -Raw $testCase.JsonOutput | ConvertFrom-Json
+        Assert-Equal 1 $summary.covered_branches 'Duplicate aggregate covered branches differ.'
+        Assert-Equal 2 $summary.total_branches 'Duplicate aggregate total branches differ.'
+    }
+
     Invoke-Test 'rejects inconsistent branch coverage' {
         $testCase = New-TestCase
         $lines = @'
@@ -384,6 +422,20 @@ try {
   <conditions><condition number="0" type="jump" coverage="50%" /></conditions>
 </line>
 '@
+        [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines))
+        Assert-Throws { Invoke-Summarizer $testCase } 'inconsistent condition coverage'
+    }
+
+    Invoke-Test 'rejects branch percentages inconsistent with counts' {
+        $testCase = New-TestCase
+        $lines = '<line number="10" hits="1" branch="True" condition-coverage="0% (2/2)" />'
+        [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines))
+        Assert-Throws { Invoke-Summarizer $testCase } 'inconsistent condition coverage'
+    }
+
+    Invoke-Test 'rejects excessive per-line branch counts' {
+        $testCase = New-TestCase
+        $lines = '<line number="10" hits="1" branch="True" condition-coverage="0% (0/1025)" />'
         [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs') $lines))
         Assert-Throws { Invoke-Summarizer $testCase } 'inconsistent condition coverage'
     }
@@ -422,12 +474,23 @@ try {
         Assert-Equal 2 $summary.total_lines 'Distinct source line count differs.'
     }
 
-    Invoke-Test 'rejects multiple reports' {
+    Invoke-Test 'combines multiple validated reports' {
         $testCase = New-TestCase
-        $xml = Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs')
-        [void] (Write-Report $testCase $xml 'first.cobertura.xml')
-        [void] (Write-Report $testCase $xml 'second.cobertura.xml')
-        Assert-Throws { Invoke-Summarizer $testCase } 'Expected one merged Cobertura report'
+        $sourceFile = Join-Path $testCase.SourceRoot 'Example.cs'
+        [void] (Write-Report $testCase (Get-ReportXml $sourceFile '<line number="10" hits="0" />') 'first.cobertura.xml')
+        [void] (Write-Report $testCase (Get-ReportXml $sourceFile '<line number="10" hits="1" />') 'second.cobertura.xml')
+        Invoke-Summarizer $testCase
+        $summary = Get-Content -Raw $testCase.JsonOutput | ConvertFrom-Json
+        Assert-Equal 1 $summary.covered_lines 'Multiple report covered lines differ.'
+        Assert-Equal 1 $summary.total_lines 'Multiple report total lines differ.'
+        Assert-Equal 2 $summary.reports 'Multiple report count differs.'
+    }
+
+    Invoke-Test 'requires canonical source lines from every report' {
+        $testCase = New-TestCase
+        [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.SourceRoot 'Example.cs')) 'product.cobertura.xml')
+        [void] (Write-Report $testCase (Get-ReportXml (Join-Path $testCase.Root 'test/ExampleTests.cs')) 'tests.cobertura.xml')
+        Assert-Throws { Invoke-Summarizer $testCase } 'tests\.cobertura\.xml contains no measured lines under the source root'
     }
 
     Invoke-Test 'rejects reports without source lines' {
@@ -673,7 +736,7 @@ exit 0
         }
     }
 
-    Invoke-Test 'validates the exact coverage matrix before trusted merging' {
+    Invoke-Test 'validates the exact coverage matrix before trusted aggregation' {
         $workflow = Get-Content -Raw -LiteralPath $testResultsWorkflowPath
         $validator = Get-Content -Raw -LiteralPath $validateCoverageArtifactsScriptPath
         $expectedArtifacts = @(Get-Content -LiteralPath $expectedCoverageArtifactsPath)
@@ -684,16 +747,13 @@ exit 0
         Assert-Equal 0 ([regex]::Matches($workflow, 'merge-multiple:\s*true')).Count 'Coverage downloads must preserve artifact identities.'
         Assert-Matches `
             $workflow `
-            '(?s)Validate coverage matrix.*?Merge coverage' `
-            'Coverage artifact validation must run before merging.'
+            '(?s)Validate coverage matrix.*?Summarize coverage' `
+            'Coverage artifact validation must run before aggregation.'
         Assert-Matches `
             $workflow `
             '(?s)validate-coverage-artifacts\.ps1.*?coverage-artifacts\.txt' `
             'Trusted coverage reporting must use the reviewed artifact manifest.'
-        Assert-Matches `
-            $workflow `
-            'dotnet-coverage merge @reports' `
-            'Coverage reports must be merged directly by dotnet-coverage.'
+        Assert-Equal 0 ([regex]::Matches($workflow, 'dotnet-coverage merge')).Count 'The trusted reporter must preserve raw branch identities.'
         Assert-Matches `
             $validator `
             'Coverage artifact set differs from the expected CI matrix' `
@@ -968,22 +1028,26 @@ exit 0
         Assert-Equal 'Current-main artifacts are unavailable.' $unavailable.baseline.reason 'Unavailable comparison reason differs.'
     }
 
-    Invoke-Test 'merges coverage only in the trusted reporting workflow' {
+    Invoke-Test 'aggregates coverage only in the trusted reporting workflow' {
         $ciWorkflow = Get-Content -Raw -LiteralPath $workflowPath
         $reportingWorkflow = Get-Content -Raw -LiteralPath $testResultsWorkflowPath
         Assert-Equal 0 ([regex]::Matches($ciWorkflow, 'dotnet-coverage merge')).Count 'Pull request code must not merge its own coverage.'
         Assert-Matches `
             $reportingWorkflow `
-            '(?s)Checkout trusted reporter.*?Validate coverage matrix.*?Verify tested commit.*?Download covered source.*?Merge coverage.*?Summarize coverage' `
+            '(?s)Checkout trusted reporter.*?Validate coverage matrix.*?Verify tested commit.*?Download covered source.*?Summarize coverage' `
             'Trusted reporting must validate raw reports against the covered source before summarizing.'
+        Assert-Matches `
+            $reportingWorkflow `
+            '(?s)Summarize coverage.*?-ReportDirectory coverage-data' `
+            'Canonical coverage must be summarized directly from the validated raw reports.'
         Assert-Matches `
             $reportingWorkflow `
             '(?s)Pin trusted main.*?TRUSTED_MAIN_SHA: \$\{\{ steps\.trusted-main\.outputs\.sha \}\}.*?-ExpectedSha \$env:TRUSTED_MAIN_SHA' `
             'Baseline selection must use the exact main snapshot executing the trusted reporter.'
         Assert-Matches `
             $reportingWorkflow `
-            '(?s)Download covered source.*?Verify trusted coverage inputs.*?get-coverage-input-fingerprint\.ps1.*?Merge coverage' `
-            'Pull request coverage inputs must match the pinned trusted reporter before merging.'
+            '(?s)Download covered source.*?Verify trusted coverage inputs.*?get-coverage-input-fingerprint\.ps1.*?Summarize coverage' `
+            'Pull request coverage inputs must match the pinned trusted reporter before aggregation.'
         Assert-Equal 13 (@(Get-Content -LiteralPath $coverageInputsPath)).Count 'Trusted coverage input count differs.'
         Assert-Matches `
             $reportingWorkflow `
@@ -999,7 +1063,7 @@ exit 0
             'The coverage check must compare canonical coverage with current main.'
         Assert-Matches `
             $reportingWorkflow `
-            '(?s)Select current-main baseline.*?Download current-main coverage.*?Validate current-main coverage matrix.*?Aggregate current-main coverage.*?Compare coverage with current main' `
+            '(?s)Select current-main baseline.*?Download current-main coverage.*?Validate current-main coverage matrix.*?Summarize current-main coverage.*?Compare coverage with current main' `
             'The trusted reporter must aggregate the same current-main matrix before comparison.'
         Assert-Matches `
             $reportingWorkflow `

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -6,6 +6,9 @@ $ErrorActionPreference = 'Stop'
 
 $scriptPath = Join-Path $PSScriptRoot 'summarize-coverage.ps1'
 $coverageConfigPath = Join-Path $PSScriptRoot '../coverage.config.xml'
+$coverageInputFingerprintScriptPath = Join-Path $PSScriptRoot 'get-coverage-input-fingerprint.ps1'
+$coverageInputsPath = Join-Path $PSScriptRoot '../coverage-inputs.txt'
+$compareCoverageScriptPath = Join-Path $PSScriptRoot 'compare-coverage.ps1'
 $coverageReportScriptPath = Join-Path $PSScriptRoot 'coverage-report.ps1'
 $coverageStaticConfigPath = Join-Path $PSScriptRoot '../coverage.static.config.xml'
 $archiveTestResultsActionPath = Join-Path $PSScriptRoot '../actions/archive-test-results/action.yml'
@@ -15,6 +18,7 @@ $azureVariablesPath = Join-Path $PSScriptRoot '../../.azure/pipelines/templates/
 $dotnetTestActionPath = Join-Path $PSScriptRoot '../actions/dotnet-test/action.yml'
 $invokeCoverageScriptPath = Join-Path $PSScriptRoot 'invoke-coverage.ps1'
 $runTestsActionPath = Join-Path $PSScriptRoot '../actions/run-tests/action.yml'
+$selectCoverageBaselineScriptPath = Join-Path $PSScriptRoot 'select-coverage-baseline.ps1'
 $setupCoverageScriptPath = Join-Path $PSScriptRoot 'setup-coverage.ps1'
 $testResultsWorkflowPath = Join-Path $PSScriptRoot '../workflows/test-results.yml'
 $validateCoverageArtifactsScriptPath = Join-Path $PSScriptRoot 'validate-coverage-artifacts.ps1'
@@ -160,6 +164,129 @@ function Write-ArtifactMetadata {
     $metadata |
         ConvertTo-Json |
         Set-Content -LiteralPath (Join-Path $ArtifactDirectory "$CoverageId.coverage.json") -Encoding utf8NoBOM
+}
+
+function Write-Json {
+    param(
+        [string] $Path,
+        [object] $Value
+    )
+
+    $Value |
+        ConvertTo-Json -Depth 8 |
+        Set-Content -LiteralPath $Path -Encoding utf8NoBOM
+}
+
+function New-WorkflowRun {
+    param(
+        [long] $Id,
+        [string] $HeadSha,
+        [string] $CreatedAt,
+        [string] $Event = 'push',
+        [string] $Status = 'completed',
+        [string] $Conclusion = 'success',
+        [string] $HeadBranch = 'main',
+        [string] $Path = '.github/workflows/ci.yml'
+    )
+
+    return [ordered]@{
+        id = $Id
+        head_sha = $HeadSha
+        created_at = $CreatedAt
+        event = $Event
+        status = $Status
+        conclusion = $Conclusion
+        head_branch = $HeadBranch
+        path = $Path
+        html_url = "https://github.com/dotnet/orleans/actions/runs/$Id"
+    }
+}
+
+function New-ComparisonCase {
+    param(
+        [long] $CurrentCoveredLines = 9,
+        [long] $CurrentTotalLines = 10,
+        [long] $CurrentCoveredBranches = 7,
+        [long] $CurrentTotalBranches = 8,
+        [long] $BaselineCoveredLines = 8,
+        [long] $BaselineTotalLines = 10,
+        [long] $BaselineCoveredBranches = 6,
+        [long] $BaselineTotalBranches = 8,
+        [string] $BaselineStatus = 'available',
+        [string] $ExpectedBaselineSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        [string] $SelectedBaselineSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        [string] $CurrentManifestSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        [string] $BaselineManifestSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    )
+
+    $testCase = New-TestCase
+    $comparison = @{
+        CurrentSummary = Join-Path $testCase.Root 'current-summary.json'
+        CurrentMatrix = Join-Path $testCase.Root 'current-matrix.json'
+        BaselineSelection = Join-Path $testCase.Root 'baseline-selection.json'
+        BaselineSummary = Join-Path $testCase.Root 'baseline-summary.json'
+        BaselineMatrix = Join-Path $testCase.Root 'baseline-matrix.json'
+        JsonOutput = Join-Path $testCase.Root 'comparison.json'
+        MarkdownOutput = Join-Path $testCase.Root 'comparison.md'
+        ExpectedBaselineSha = $ExpectedBaselineSha
+    }
+
+    Write-Json $comparison.CurrentSummary ([ordered]@{
+        covered_lines = $CurrentCoveredLines
+        total_lines = $CurrentTotalLines
+        covered_branches = $CurrentCoveredBranches
+        total_branches = $CurrentTotalBranches
+    })
+    Write-Json $comparison.CurrentMatrix ([ordered]@{
+        tested_sha = 'cccccccccccccccccccccccccccccccccccccccc'
+        manifest_sha256 = $CurrentManifestSha
+    })
+    Write-Json $comparison.BaselineSelection ([ordered]@{
+        format_version = 1
+        status = $BaselineStatus
+        reason = "Baseline status is $BaselineStatus."
+        expected_sha = $ExpectedBaselineSha
+        baseline_sha = $SelectedBaselineSha
+        baseline_run_url = 'https://github.com/dotnet/orleans/actions/runs/42'
+    })
+    Write-Json $comparison.BaselineSummary ([ordered]@{
+        covered_lines = $BaselineCoveredLines
+        total_lines = $BaselineTotalLines
+        covered_branches = $BaselineCoveredBranches
+        total_branches = $BaselineTotalBranches
+    })
+    Write-Json $comparison.BaselineMatrix ([ordered]@{
+        tested_sha = $SelectedBaselineSha
+        manifest_sha256 = $BaselineManifestSha
+    })
+
+    return $comparison
+}
+
+function Invoke-Comparison {
+    param(
+        [hashtable] $Comparison,
+        [string] $BaselineUnavailableReason
+    )
+
+    $parameters = @{
+        CurrentSummary = $Comparison.CurrentSummary
+        CurrentMatrix = $Comparison.CurrentMatrix
+        BaselineSelection = $Comparison.BaselineSelection
+        ExpectedBaselineSha = $Comparison.ExpectedBaselineSha
+        JsonOutput = $Comparison.JsonOutput
+        MarkdownOutput = $Comparison.MarkdownOutput
+    }
+    $selection = Get-Content -Raw $Comparison.BaselineSelection | ConvertFrom-Json
+    if ($BaselineUnavailableReason) {
+        $parameters.BaselineUnavailableReason = $BaselineUnavailableReason
+    } elseif ($selection.status -eq 'available') {
+        $parameters.BaselineSummary = $Comparison.BaselineSummary
+        $parameters.BaselineMatrix = $Comparison.BaselineMatrix
+    }
+
+    & $compareCoverageScriptPath @parameters
+    return Get-Content -Raw $Comparison.JsonOutput | ConvertFrom-Json
 }
 
 function Invoke-Test {
@@ -379,6 +506,7 @@ try {
 
     Invoke-Test 'uses external coverage collection for CI builds' {
         $dotnetTestAction = Get-Content -Raw -LiteralPath $dotnetTestActionPath
+        $setupTestEnvironmentAction = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot '../actions/setup-test-environment/action.yml')
         $coverageReportScript = Get-Content -Raw -LiteralPath $coverageReportScriptPath
         $coverageConfigs = @(
             Get-Content -Raw -LiteralPath $coverageConfigPath
@@ -439,6 +567,15 @@ try {
             $dotnetTestAction `
             'dotnet test --solution Orleans\.slnx' `
             'Test partitions must use native solution discovery.'
+        Assert-Equal 5 ([regex]::Matches($dotnetTestAction, "github\.event_name == 'push'.*?github\.event\.repository\.default_branch")).Count 'Current-main coverage condition count differs.'
+        Assert-Matches `
+            $dotnetTestAction `
+            "github\.event_name != 'push' \|\| github\.ref != format\('refs/heads/\{0\}', github\.event\.repository\.default_branch\)" `
+            'Current-main test jobs must use the coverage collector instead of the ordinary test path.'
+        Assert-Matches `
+            $setupTestEnvironmentAction `
+            "github\.event_name == 'push'.*?github\.event\.repository\.default_branch" `
+            'Current-main test jobs must install the coverage collector.'
     }
 
     Invoke-Test 'retries only the uninitialized coverage handle failure' {
@@ -646,6 +783,191 @@ exit 0
             'reference multiple tested commits'
     }
 
+    Invoke-Test 'selects the newest successful exact current-main run' {
+        $testCase = New-TestCase
+        $expectedSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $runsJson = Join-Path $testCase.Root 'runs.json'
+        $selectionJson = Join-Path $testCase.Root 'selection.json'
+        Write-Json $runsJson ([ordered]@{
+            workflow_runs = @(
+                (New-WorkflowRun 40 $expectedSha '2026-08-31T10:00:00Z')
+                (New-WorkflowRun 42 $expectedSha '2026-08-31T12:00:00Z')
+                (New-WorkflowRun 43 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' '2026-08-31T13:00:00Z' -Event 'pull_request')
+            )
+        })
+
+        & $selectCoverageBaselineScriptPath `
+            -RunsJson $runsJson `
+            -ExpectedSha $expectedSha `
+            -DefaultBranch main `
+            -AsOf '2026-09-01T00:00:00Z' `
+            -JsonOutput $selectionJson
+        $selection = Get-Content -Raw $selectionJson | ConvertFrom-Json
+        Assert-Equal 'available' $selection.status 'Baseline status differs.'
+        Assert-Equal 42 $selection.baseline_run_id 'Baseline run identity differs.'
+        Assert-Equal $expectedSha $selection.baseline_sha 'Baseline commit identity differs.'
+    }
+
+    Invoke-Test 'reports stale current-main baseline data' {
+        $testCase = New-TestCase
+        $runsJson = Join-Path $testCase.Root 'runs.json'
+        $selectionJson = Join-Path $testCase.Root 'selection.json'
+        Write-Json $runsJson ([ordered]@{
+            workflow_runs = @(
+                (New-WorkflowRun 40 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' '2026-08-31T10:00:00Z')
+            )
+        })
+
+        & $selectCoverageBaselineScriptPath `
+            -RunsJson $runsJson `
+            -ExpectedSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' `
+            -DefaultBranch main `
+            -AsOf '2026-09-01T00:00:00Z' `
+            -JsonOutput $selectionJson
+        $selection = Get-Content -Raw $selectionJson | ConvertFrom-Json
+        Assert-Equal 'stale' $selection.status 'Stale baseline status differs.'
+        Assert-Matches $selection.reason 'not current main' 'Stale baseline reason differs.'
+    }
+
+    Invoke-Test 'reports missing current-main baseline data' {
+        $testCase = New-TestCase
+        $runsJson = Join-Path $testCase.Root 'runs.json'
+        $selectionJson = Join-Path $testCase.Root 'selection.json'
+        Write-Json $runsJson ([ordered]@{
+            workflow_runs = @(
+                (New-WorkflowRun 40 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' '2026-08-31T10:00:00Z' -Status 'in_progress' -Conclusion $null)
+            )
+        })
+
+        & $selectCoverageBaselineScriptPath `
+            -RunsJson $runsJson `
+            -ExpectedSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+            -DefaultBranch main `
+            -AsOf '2026-09-01T00:00:00Z' `
+            -JsonOutput $selectionJson
+        $selection = Get-Content -Raw $selectionJson | ConvertFrom-Json
+        Assert-Equal 'missing' $selection.status 'Missing baseline status differs.'
+    }
+
+    Invoke-Test 'does not select historical pull request coverage as the main baseline' {
+        $testCase = New-TestCase
+        $expectedSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $runsJson = Join-Path $testCase.Root 'runs.json'
+        $selectionJson = Join-Path $testCase.Root 'selection.json'
+        Write-Json $runsJson ([ordered]@{
+            workflow_runs = @(
+                (New-WorkflowRun 42 $expectedSha '2026-08-31T12:00:00Z' -Event 'pull_request')
+            )
+        })
+
+        & $selectCoverageBaselineScriptPath `
+            -RunsJson $runsJson `
+            -ExpectedSha $expectedSha `
+            -DefaultBranch main `
+            -AsOf '2026-09-01T00:00:00Z' `
+            -JsonOutput $selectionJson
+        $selection = Get-Content -Raw $selectionJson | ConvertFrom-Json
+        Assert-Equal 'missing' $selection.status 'Pull request coverage must not become the main baseline.'
+        Assert-Equal $null $selection.baseline_run_id 'Pull request coverage must not publish a baseline run identity.'
+    }
+
+    Invoke-Test 'fingerprints trusted coverage inputs' {
+        $testCase = New-TestCase
+        $repository = Join-Path $testCase.Root 'repository'
+        [void] (New-Item -ItemType Directory -Path (Join-Path $repository '.github/scripts') -Force)
+        [IO.File]::WriteAllText((Join-Path $repository '.github/scripts/first.ps1'), 'first', [Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllText((Join-Path $repository 'global.json'), '{}', [Text.UTF8Encoding]::new($false))
+        $manifest = Join-Path $testCase.Root 'inputs.txt'
+        [IO.File]::WriteAllLines(
+            $manifest,
+            @('global.json', '.github/scripts/first.ps1'),
+            [Text.UTF8Encoding]::new($false)
+        )
+        $firstOutput = Join-Path $testCase.Root 'first.json'
+        $secondOutput = Join-Path $testCase.Root 'second.json'
+        & $coverageInputFingerprintScriptPath -RepositoryRoot $repository -Manifest $manifest -JsonOutput $firstOutput
+        [IO.File]::WriteAllText((Join-Path $repository '.github/scripts/first.ps1'), 'changed', [Text.UTF8Encoding]::new($false))
+        & $coverageInputFingerprintScriptPath -RepositoryRoot $repository -Manifest $manifest -JsonOutput $secondOutput
+        $first = Get-Content -Raw $firstOutput | ConvertFrom-Json
+        $second = Get-Content -Raw $secondOutput | ConvertFrom-Json
+        Assert-Equal 2 $first.files 'Coverage input file count differs.'
+        Assert-Equal $false ($first.sha256 -eq $second.sha256) 'Coverage input changes must change the fingerprint.'
+    }
+
+    Invoke-Test 'rejects unsafe coverage input paths' {
+        $testCase = New-TestCase
+        $manifest = Join-Path $testCase.Root 'inputs.txt'
+        [IO.File]::WriteAllText($manifest, '../ci.yml', [Text.UTF8Encoding]::new($false))
+        Assert-Throws `
+            {
+                & $coverageInputFingerprintScriptPath `
+                    -RepositoryRoot $testCase.Root `
+                    -Manifest $manifest `
+                    -JsonOutput (Join-Path $testCase.Root 'fingerprint.json')
+            } `
+            'Invalid coverage input path'
+    }
+
+    Invoke-Test 'reports line and branch variance' {
+        $comparison = New-ComparisonCase
+        $result = Invoke-Comparison $comparison
+        Assert-Equal 'improved' $result.conclusion 'Coverage conclusion differs.'
+        Assert-Equal '+10.0000 pp' $result.variance.lines.percentage_point_delta_display 'Line variance differs.'
+        Assert-Equal '+12.5000 pp' $result.variance.branches.percentage_point_delta_display 'Branch variance differs.'
+        Assert-Equal 1 $result.variance.lines.covered_delta 'Covered line variance differs.'
+        Assert-Equal 0 $result.variance.lines.total_delta 'Total line variance differs.'
+    }
+
+    Invoke-Test 'reports mixed coverage conclusions' {
+        $comparison = New-ComparisonCase `
+            -CurrentCoveredBranches 5 `
+            -BaselineCoveredBranches 6
+        $result = Invoke-Comparison $comparison
+        Assert-Equal 'mixed' $result.conclusion 'Mixed coverage conclusion differs.'
+        Assert-Equal 'improved' $result.variance.lines.classification 'Line conclusion differs.'
+        Assert-Equal 'regressed' $result.variance.branches.classification 'Branch conclusion differs.'
+    }
+
+    Invoke-Test 'reports regressed and unchanged coverage conclusions' {
+        $regressedComparison = New-ComparisonCase `
+            -CurrentCoveredLines 7 `
+            -CurrentCoveredBranches 5
+        $regressed = Invoke-Comparison $regressedComparison
+        Assert-Equal 'regressed' $regressed.conclusion 'Regressed coverage conclusion differs.'
+
+        $unchangedComparison = New-ComparisonCase `
+            -CurrentCoveredLines 8 `
+            -CurrentCoveredBranches 6
+        $unchanged = Invoke-Comparison $unchangedComparison
+        Assert-Equal 'unchanged' $unchanged.conclusion 'Unchanged coverage conclusion differs.'
+    }
+
+    Invoke-Test 'requires the same matrix and current-main identity' {
+        $manifestMismatch = New-ComparisonCase `
+            -BaselineManifestSha 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+        Assert-Throws { Invoke-Comparison $manifestMismatch } 'different matrix manifests'
+
+        $shaMismatch = New-ComparisonCase `
+            -SelectedBaselineSha 'dddddddddddddddddddddddddddddddddddddddd'
+        Assert-Throws { Invoke-Comparison $shaMismatch } 'does not match current main'
+    }
+
+    Invoke-Test 'reports missing and stale comparison conclusions' {
+        $missingComparison = New-ComparisonCase -BaselineStatus 'missing'
+        $missing = Invoke-Comparison $missingComparison
+        Assert-Equal 'baseline-missing' $missing.conclusion 'Missing comparison conclusion differs.'
+
+        $staleComparison = New-ComparisonCase -BaselineStatus 'available'
+        $staleComparison.ExpectedBaselineSha = 'dddddddddddddddddddddddddddddddddddddddd'
+        $stale = Invoke-Comparison $staleComparison
+        Assert-Equal 'baseline-stale' $stale.conclusion 'Stale comparison conclusion differs.'
+
+        $unavailableComparison = New-ComparisonCase
+        $unavailable = Invoke-Comparison $unavailableComparison 'Current-main artifacts are unavailable.'
+        Assert-Equal 'baseline-missing' $unavailable.conclusion 'Unavailable comparison conclusion differs.'
+        Assert-Equal 'Current-main artifacts are unavailable.' $unavailable.baseline.reason 'Unavailable comparison reason differs.'
+    }
+
     Invoke-Test 'merges coverage only in the trusted reporting workflow' {
         $ciWorkflow = Get-Content -Raw -LiteralPath $workflowPath
         $reportingWorkflow = Get-Content -Raw -LiteralPath $testResultsWorkflowPath
@@ -656,6 +978,15 @@ exit 0
             'Trusted reporting must validate raw reports against the covered source before summarizing.'
         Assert-Matches `
             $reportingWorkflow `
+            '(?s)Pin trusted main.*?TRUSTED_MAIN_SHA: \$\{\{ steps\.trusted-main\.outputs\.sha \}\}.*?-ExpectedSha \$env:TRUSTED_MAIN_SHA' `
+            'Baseline selection must use the exact main snapshot executing the trusted reporter.'
+        Assert-Matches `
+            $reportingWorkflow `
+            '(?s)Download covered source.*?Verify trusted coverage inputs.*?get-coverage-input-fingerprint\.ps1.*?Merge coverage' `
+            'Pull request coverage inputs must match the pinned trusted reporter before merging.'
+        Assert-Equal 13 (@(Get-Content -LiteralPath $coverageInputsPath)).Count 'Trusted coverage input count differs.'
+        Assert-Matches `
+            $reportingWorkflow `
             'github\.event\.workflow_run\.conclusion == ''success''' `
             'Coverage reporting must require a successful complete CI run.'
         Assert-Matches `
@@ -664,8 +995,16 @@ exit 0
             'Coverage comparison must remain report-only during calibration.'
         Assert-Matches `
             $reportingWorkflow `
-            'branch coverage: \$BRANCH_RATE' `
-            'The coverage check must publish canonical branch coverage.'
+            'Compare coverage with current main' `
+            'The coverage check must compare canonical coverage with current main.'
+        Assert-Matches `
+            $reportingWorkflow `
+            '(?s)Select current-main baseline.*?Download current-main coverage.*?Validate current-main coverage matrix.*?Aggregate current-main coverage.*?Compare coverage with current main' `
+            'The trusted reporter must aggregate the same current-main matrix before comparison.'
+        Assert-Matches `
+            $reportingWorkflow `
+            'ExpectedBaselineSha = \$currentMain\.object\.sha' `
+            'The comparison must revalidate the current-main identity after aggregation.'
     }
 
     Invoke-Test 'requires every successful test job to upload coverage' {
@@ -673,7 +1012,12 @@ exit 0
         Assert-Matches `
             $archiveTestResultsAction `
             'if-no-files-found: error' `
-            'Each successful pull request test job must publish coverage.'
+            'Each successful pull request or current-main test job must publish coverage.'
+        Assert-Matches `
+            $archiveTestResultsAction `
+            "github\.event_name == 'push'.*?github\.event\.repository\.default_branch" `
+            'Current-main test jobs must publish the same raw coverage artifacts.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, "github\.event_name == 'push' && 7 \|\| 1")).Count 'Current-main coverage retention count differs.'
         Assert-Matches `
             $archiveTestResultsAction `
             '(?s)path:\s*\|.*?TestResults/\$\{\{ inputs\.name \}\}\.cobertura\.xml.*?TestResults/\$\{\{ inputs\.name \}\}\.coverage\.json' `
@@ -689,7 +1033,7 @@ exit 0
             'Test result upload attempts must remain non-gating and retry with overwrite.'
         Assert-Matches `
             $archiveTestResultsAction `
-            "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: github\.event_name == 'pull_request'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n.*?^  - name: Retry coverage upload\r?\n    if: github\.event_name == 'pull_request' && steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
+            "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: .*?github\.event_name == 'pull_request'.*?github\.event_name == 'push'.*?\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n.*?^  - name: Retry coverage upload\r?\n    if: .*?steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
             'Coverage upload must retry with overwrite and keep the final attempt gating.'
     }
 

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -443,6 +443,26 @@ try {
         Assert-Equal 6 $summary.total_branches 'Distinct branch site total branches differ.'
     }
 
+    Invoke-Test 'does not double count class lines which precede methods' {
+        $testCase = New-TestCase
+        $sourceFile = [Security.SecurityElement]::Escape((Join-Path $testCase.SourceRoot 'Example.cs'))
+        $xml = @"
+<coverage><packages><package><classes>
+  <class name="ContainingType" filename="$sourceFile">
+    <lines><line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" /></lines>
+    <methods><method name="Method" signature="()"><lines>
+      <line number="10" hits="1" branch="True" condition-coverage="50% (1/2)" />
+    </lines></method></methods>
+  </class>
+</classes></package></packages></coverage>
+"@
+        [void] (Write-Report $testCase $xml)
+        Invoke-Summarizer $testCase
+        $summary = Get-Content -Raw $testCase.JsonOutput | ConvertFrom-Json
+        Assert-Equal 1 $summary.covered_branches 'Reordered covered branches differ.'
+        Assert-Equal 2 $summary.total_branches 'Reordered total branches differ.'
+    }
+
     Invoke-Test 'rejects inconsistent branch coverage' {
         $testCase = New-TestCase
         $lines = @'
@@ -820,30 +840,41 @@ exit 0
         $expectedArtifacts = Join-Path $testCase.Root 'expected.txt'
         [IO.File]::WriteAllLines(
             $expectedArtifacts,
-            @('test_output_first', 'test_output_second'),
+            @('test_output_a', 'test_output_B'),
             [Text.UTF8Encoding]::new($false)
         )
-        $firstArtifact = Join-Path $testCase.ReportDirectory 'coverage_test_output_first'
+        $firstArtifact = Join-Path $testCase.ReportDirectory 'coverage_test_output_a'
         [void] (New-Item -ItemType Directory -Path $firstArtifact)
         [IO.File]::WriteAllText(
-            (Join-Path $firstArtifact 'test_output_first.cobertura.xml'),
+            (Join-Path $firstArtifact 'test_output_a.cobertura.xml'),
             '<coverage />',
             [Text.UTF8Encoding]::new($false)
         )
-        Write-ArtifactMetadata $firstArtifact 'test_output_first'
+        Write-ArtifactMetadata $firstArtifact 'test_output_a'
         Assert-Throws `
             { Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts } `
-            'Missing: coverage_test_output_second'
+            'Missing: coverage_test_output_B'
 
-        $secondArtifact = Join-Path $testCase.ReportDirectory 'coverage_test_output_second'
+        $secondArtifact = Join-Path $testCase.ReportDirectory 'coverage_test_output_B'
         [void] (New-Item -ItemType Directory -Path $secondArtifact)
         [IO.File]::WriteAllText(
-            (Join-Path $secondArtifact 'test_output_second.cobertura.xml'),
+            (Join-Path $secondArtifact 'test_output_B.cobertura.xml'),
             '<coverage />',
             [Text.UTF8Encoding]::new($false)
         )
-        Write-ArtifactMetadata $secondArtifact 'test_output_second'
+        Write-ArtifactMetadata $secondArtifact 'test_output_B'
         Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts | Out-Null
+        $validationPath = Join-Path $testCase.Root 'validation.json'
+        $firstManifestSha = (Get-Content -Raw $validationPath | ConvertFrom-Json).manifest_sha256
+        $previousCulture = [Threading.Thread]::CurrentThread.CurrentCulture
+        try {
+            [Threading.Thread]::CurrentThread.CurrentCulture = [Globalization.CultureInfo]::GetCultureInfo('tr-TR')
+            Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts | Out-Null
+        } finally {
+            [Threading.Thread]::CurrentThread.CurrentCulture = $previousCulture
+        }
+        $secondManifestSha = (Get-Content -Raw $validationPath | ConvertFrom-Json).manifest_sha256
+        Assert-Equal $firstManifestSha $secondManifestSha 'Artifact manifest fingerprints must use ordinal ordering.'
 
         $unexpectedArtifact = Join-Path $testCase.ReportDirectory 'coverage_test_output_unexpected'
         [void] (New-Item -ItemType Directory -Path $unexpectedArtifact)
@@ -979,22 +1010,37 @@ exit 0
         $testCase = New-TestCase
         $repository = Join-Path $testCase.Root 'repository'
         [void] (New-Item -ItemType Directory -Path (Join-Path $repository '.github/scripts') -Force)
-        [IO.File]::WriteAllText((Join-Path $repository '.github/scripts/first.ps1'), 'first', [Text.UTF8Encoding]::new($false))
-        [IO.File]::WriteAllText((Join-Path $repository 'global.json'), '{}', [Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllText((Join-Path $repository '.github/scripts/a.ps1'), 'first', [Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllText((Join-Path $repository '.github/scripts/B.ps1'), 'second', [Text.UTF8Encoding]::new($false))
         $manifest = Join-Path $testCase.Root 'inputs.txt'
         [IO.File]::WriteAllLines(
             $manifest,
-            @('global.json', '.github/scripts/first.ps1'),
+            @('.github/scripts/a.ps1', '.github/scripts/B.ps1'),
             [Text.UTF8Encoding]::new($false)
         )
         $firstOutput = Join-Path $testCase.Root 'first.json'
+        $reorderedOutput = Join-Path $testCase.Root 'reordered.json'
         $secondOutput = Join-Path $testCase.Root 'second.json'
         & $coverageInputFingerprintScriptPath -RepositoryRoot $repository -Manifest $manifest -JsonOutput $firstOutput
-        [IO.File]::WriteAllText((Join-Path $repository '.github/scripts/first.ps1'), 'changed', [Text.UTF8Encoding]::new($false))
+        [IO.File]::WriteAllLines(
+            $manifest,
+            @('.github/scripts/B.ps1', '.github/scripts/a.ps1'),
+            [Text.UTF8Encoding]::new($false)
+        )
+        $previousCulture = [Threading.Thread]::CurrentThread.CurrentCulture
+        try {
+            [Threading.Thread]::CurrentThread.CurrentCulture = [Globalization.CultureInfo]::GetCultureInfo('tr-TR')
+            & $coverageInputFingerprintScriptPath -RepositoryRoot $repository -Manifest $manifest -JsonOutput $reorderedOutput
+        } finally {
+            [Threading.Thread]::CurrentThread.CurrentCulture = $previousCulture
+        }
+        [IO.File]::WriteAllText((Join-Path $repository '.github/scripts/a.ps1'), 'changed', [Text.UTF8Encoding]::new($false))
         & $coverageInputFingerprintScriptPath -RepositoryRoot $repository -Manifest $manifest -JsonOutput $secondOutput
         $first = Get-Content -Raw $firstOutput | ConvertFrom-Json
+        $reordered = Get-Content -Raw $reorderedOutput | ConvertFrom-Json
         $second = Get-Content -Raw $secondOutput | ConvertFrom-Json
         Assert-Equal 2 $first.files 'Coverage input file count differs.'
+        Assert-Equal $first.sha256 $reordered.sha256 'Coverage input fingerprints must use ordinal ordering.'
         Assert-Equal $false ($first.sha256 -eq $second.sha256) 'Coverage input changes must change the fingerprint.'
     }
 

--- a/.github/scripts/validate-coverage-artifacts.ps1
+++ b/.github/scripts/validate-coverage-artifacts.ps1
@@ -46,7 +46,9 @@ foreach ($line in [IO.File]::ReadAllLines($resolvedExpectedArtifacts)) {
 if ($expected.Count -eq 0) {
     throw 'The expected coverage artifact set is empty'
 }
-$manifestText = (@($expected.Keys | Sort-Object) -join "`n") + "`n"
+$sortedArtifactNames = @($expected.Keys)
+[Array]::Sort($sortedArtifactNames, [StringComparer]::Ordinal)
+$manifestText = ($sortedArtifactNames -join "`n") + "`n"
 $manifestBytes = [Text.UTF8Encoding]::new($false).GetBytes($manifestText)
 $manifestSha256 = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($manifestBytes)).ToLowerInvariant()
 

--- a/.github/scripts/validate-coverage-artifacts.ps1
+++ b/.github/scripts/validate-coverage-artifacts.ps1
@@ -46,6 +46,9 @@ foreach ($line in [IO.File]::ReadAllLines($resolvedExpectedArtifacts)) {
 if ($expected.Count -eq 0) {
     throw 'The expected coverage artifact set is empty'
 }
+$manifestText = (@($expected.Keys | Sort-Object) -join "`n") + "`n"
+$manifestBytes = [Text.UTF8Encoding]::new($false).GetBytes($manifestText)
+$manifestSha256 = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($manifestBytes)).ToLowerInvariant()
 
 $actual = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
 $testedSha = $null
@@ -118,6 +121,7 @@ if ($missing.Count -gt 0 -or $unexpected.Count -gt 0) {
 
 $summary = [ordered]@{
     artifacts = $actual.Count
+    manifest_sha256 = $manifestSha256
     tested_sha = $testedSha
 }
 $summary | ConvertTo-Json | Set-Content -LiteralPath $JsonOutput -Encoding utf8NoBOM

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -134,7 +134,6 @@ jobs:
             throw 'The pull request changes trusted coverage collection inputs. Merge reviewed coverage infrastructure changes before measuring other pull requests.'
           }
       - name: Summarize coverage
-        id: coverage
         shell: pwsh
         run: |
           ./.github/scripts/summarize-coverage.ps1 `
@@ -142,10 +141,6 @@ jobs:
             -SourceRoot "$env:GITHUB_WORKSPACE/coverage-source/src" `
             -MarkdownOutput coverage-summary.md `
             -JsonOutput coverage-summary.json
-
-          $coverage = Get-Content -Raw coverage-summary.json | ConvertFrom-Json
-          "branch-rate=$($coverage.branch_rate_display)" >> $env:GITHUB_OUTPUT
-          "line-rate=$($coverage.line_rate_display)" >> $env:GITHUB_OUTPUT
       - name: Select current-main baseline
         id: current-main
         shell: pwsh

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -233,7 +233,8 @@ jobs:
           REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
           SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          $currentMain = gh api "repos/$env:GITHUB_REPOSITORY/git/ref/heads/$env:DEFAULT_BRANCH" | ConvertFrom-Json
+          $encodedDefaultBranch = [Uri]::EscapeDataString($env:DEFAULT_BRANCH)
+          $currentMain = gh api "repos/$env:GITHUB_REPOSITORY/git/ref/heads/$encodedDefaultBranch" | ConvertFrom-Json
           $parameters = @{
             CurrentSummary = 'coverage-summary.json'
             CurrentMatrix = 'coverage-matrix.json'

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -11,9 +11,6 @@ permissions:
   contents: read
   actions: read
 
-env:
-  DOTNET_COVERAGE_VERSION: 18.5.2
-
 jobs:
   report:
     name: Report test results
@@ -74,11 +71,6 @@ jobs:
       - name: Test coverage reporting
         shell: pwsh
         run: ./.github/scripts/test-summarize-coverage.ps1
-      - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          global-json-file: global.json
-      - uses: ./.github/actions/setup-coverage
       - name: Download coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -141,18 +133,12 @@ jobs:
           if ($tested.sha256 -ne $trusted.sha256) {
             throw 'The pull request changes trusted coverage collection inputs. Merge reviewed coverage infrastructure changes before measuring other pull requests.'
           }
-      - name: Merge coverage
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force coverage | Out-Null
-          $reports = @(Get-ChildItem -LiteralPath coverage-data -Recurse -File -Filter '*.cobertura.xml' | Select-Object -ExpandProperty FullName)
-          dotnet-coverage merge @reports --output coverage/coverage.cobertura.xml --output-format cobertura --nologo
       - name: Summarize coverage
         id: coverage
         shell: pwsh
         run: |
           ./.github/scripts/summarize-coverage.ps1 `
-            -ReportDirectory coverage `
+            -ReportDirectory coverage-data `
             -SourceRoot "$env:GITHUB_WORKSPACE/coverage-source/src" `
             -MarkdownOutput coverage-summary.md `
             -JsonOutput coverage-summary.json
@@ -230,21 +216,14 @@ jobs:
             --gzip \
             --directory current-main-source \
             --strip-components 1
-      - name: Aggregate current-main coverage
+      - name: Summarize current-main coverage
         id: current-main-summary
         if: steps.current-main-source.outcome == 'success'
         continue-on-error: true
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force current-main-coverage | Out-Null
-          $reports = @(Get-ChildItem -LiteralPath current-main-coverage-data -Recurse -File -Filter '*.cobertura.xml' | Select-Object -ExpandProperty FullName)
-          dotnet-coverage merge @reports --output current-main-coverage/coverage.cobertura.xml --output-format cobertura --nologo
-          if ($LASTEXITCODE -ne 0) {
-            throw "Current-main coverage merge failed with exit code $LASTEXITCODE"
-          }
-
           ./.github/scripts/summarize-coverage.ps1 `
-            -ReportDirectory current-main-coverage `
+            -ReportDirectory current-main-coverage-data `
             -SourceRoot "$env:GITHUB_WORKSPACE/current-main-source/src" `
             -MarkdownOutput current-main-summary.md `
             -JsonOutput current-main-summary.json

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -173,7 +173,7 @@ jobs:
             "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" `
             -f "branch=$env:DEFAULT_BRANCH" `
             -f event=push `
-            -f status=success `
+            -f status=completed `
             -f per_page=100 |
             Set-Content -LiteralPath current-main-runs.json -Encoding utf8NoBOM
 

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -67,7 +67,9 @@ jobs:
       - name: Pin trusted main
         id: trusted-main
         shell: pwsh
-        run: '"sha=$(git rev-parse HEAD)" >> $env:GITHUB_OUTPUT'
+        run: |
+          $trustedMainSha = git rev-parse HEAD
+          "sha=$trustedMainSha" >> $env:GITHUB_OUTPUT
       - name: Test coverage reporting
         shell: pwsh
         run: ./.github/scripts/test-summarize-coverage.ps1

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -67,6 +67,10 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
+      - name: Pin trusted main
+        id: trusted-main
+        shell: pwsh
+        run: '"sha=$(git rev-parse HEAD)" >> $env:GITHUB_OUTPUT'
       - name: Test coverage reporting
         shell: pwsh
         run: ./.github/scripts/test-summarize-coverage.ps1
@@ -120,6 +124,23 @@ jobs:
             --gzip \
             --directory coverage-source \
             --strip-components 1
+      - name: Verify trusted coverage inputs
+        shell: pwsh
+        run: |
+          ./.github/scripts/get-coverage-input-fingerprint.ps1 `
+            -RepositoryRoot . `
+            -Manifest ./.github/coverage-inputs.txt `
+            -JsonOutput trusted-coverage-inputs.json
+          ./.github/scripts/get-coverage-input-fingerprint.ps1 `
+            -RepositoryRoot coverage-source `
+            -Manifest ./.github/coverage-inputs.txt `
+            -JsonOutput tested-coverage-inputs.json
+
+          $trusted = Get-Content -Raw trusted-coverage-inputs.json | ConvertFrom-Json
+          $tested = Get-Content -Raw tested-coverage-inputs.json | ConvertFrom-Json
+          if ($tested.sha256 -ne $trusted.sha256) {
+            throw 'The pull request changes trusted coverage collection inputs. Merge reviewed coverage infrastructure changes before measuring other pull requests.'
+          }
       - name: Merge coverage
         shell: pwsh
         run: |
@@ -129,11 +150,6 @@ jobs:
       - name: Summarize coverage
         id: coverage
         shell: pwsh
-        env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
-          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           ./.github/scripts/summarize-coverage.ps1 `
             -ReportDirectory coverage `
@@ -142,52 +158,184 @@ jobs:
             -JsonOutput coverage-summary.json
 
           $coverage = Get-Content -Raw coverage-summary.json | ConvertFrom-Json
-          $culture = [Globalization.CultureInfo]::InvariantCulture
-          $coveredLines = $coverage.covered_lines.ToString('N0', $culture)
-          $coveredBranches = $coverage.covered_branches.ToString('N0', $culture)
-          $totalLines = $coverage.total_lines.ToString('N0', $culture)
-          $totalBranches = $coverage.total_branches.ToString('N0', $culture)
-          $sourceFiles = $coverage.source_files.ToString('N0', $culture)
+          "branch-rate=$($coverage.branch_rate_display)" >> $env:GITHUB_OUTPUT
+          "line-rate=$($coverage.line_rate_display)" >> $env:GITHUB_OUTPUT
+      - name: Select current-main baseline
+        id: current-main
+        shell: pwsh
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_MAIN_SHA: ${{ steps.trusted-main.outputs.sha }}
+        run: |
+          gh api `
+            --method GET `
+            "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" `
+            -f "branch=$env:DEFAULT_BRANCH" `
+            -f event=push `
+            -f status=success `
+            -f per_page=100 |
+            Set-Content -LiteralPath current-main-runs.json -Encoding utf8NoBOM
+
+          ./.github/scripts/select-coverage-baseline.ps1 `
+            -RunsJson current-main-runs.json `
+            -ExpectedSha $env:TRUSTED_MAIN_SHA `
+            -DefaultBranch $env:DEFAULT_BRANCH `
+            -JsonOutput current-main-selection.json
+
+          $selection = Get-Content -Raw current-main-selection.json | ConvertFrom-Json
+          "run-id=$($selection.baseline_run_id)" >> $env:GITHUB_OUTPUT
+          "sha=$($selection.baseline_sha)" >> $env:GITHUB_OUTPUT
+          "status=$($selection.status)" >> $env:GITHUB_OUTPUT
+      - name: Download current-main coverage
+        id: current-main-download
+        if: steps.current-main.outputs.status == 'available'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          path: current-main-coverage-data
+          pattern: coverage_test_output_*
+          run-id: ${{ steps.current-main.outputs.run-id }}
+      - name: Validate current-main coverage matrix
+        id: current-main-matrix
+        if: steps.current-main-download.outcome == 'success'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          ./.github/scripts/validate-coverage-artifacts.ps1 `
+            -ReportDirectory current-main-coverage-data `
+            -ExpectedArtifacts ./.github/coverage-artifacts.txt `
+            -JsonOutput current-main-matrix.json
+
+          $matrix = Get-Content -Raw current-main-matrix.json | ConvertFrom-Json
+          if ($matrix.tested_sha -ne '${{ steps.current-main.outputs.sha }}') {
+            throw "Current-main coverage tested $($matrix.tested_sha), expected ${{ steps.current-main.outputs.sha }}"
+          }
+      - name: Download current-main source
+        id: current-main-source
+        if: steps.current-main-matrix.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TESTED_SHA: ${{ steps.current-main.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir current-main-source
+          gh api "repos/$GITHUB_REPOSITORY/tarball/$TESTED_SHA" > current-main-source.tar.gz
+          tar \
+            --extract \
+            --file current-main-source.tar.gz \
+            --gzip \
+            --directory current-main-source \
+            --strip-components 1
+      - name: Aggregate current-main coverage
+        id: current-main-summary
+        if: steps.current-main-source.outcome == 'success'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force current-main-coverage | Out-Null
+          $reports = @(Get-ChildItem -LiteralPath current-main-coverage-data -Recurse -File -Filter '*.cobertura.xml' | Select-Object -ExpandProperty FullName)
+          dotnet-coverage merge @reports --output current-main-coverage/coverage.cobertura.xml --output-format cobertura --nologo
+          if ($LASTEXITCODE -ne 0) {
+            throw "Current-main coverage merge failed with exit code $LASTEXITCODE"
+          }
+
+          ./.github/scripts/summarize-coverage.ps1 `
+            -ReportDirectory current-main-coverage `
+            -SourceRoot "$env:GITHUB_WORKSPACE/current-main-source/src" `
+            -MarkdownOutput current-main-summary.md `
+            -JsonOutput current-main-summary.json
+      - name: Compare coverage with current main
+        id: comparison
+        shell: pwsh
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPORT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          $currentMain = gh api "repos/$env:GITHUB_REPOSITORY/git/ref/heads/$env:DEFAULT_BRANCH" | ConvertFrom-Json
+          $parameters = @{
+            CurrentSummary = 'coverage-summary.json'
+            CurrentMatrix = 'coverage-matrix.json'
+            BaselineSelection = 'current-main-selection.json'
+            ExpectedBaselineSha = $currentMain.object.sha
+            JsonOutput = 'coverage-comparison.json'
+            MarkdownOutput = 'coverage-comparison.md'
+          }
+
+          $selection = Get-Content -Raw current-main-selection.json | ConvertFrom-Json
+          if ($selection.status -eq 'available') {
+            $unavailableReason = if ('${{ steps.current-main-download.outcome }}' -ne 'success') {
+              'The current-main coverage artifacts are unavailable.'
+            } elseif ('${{ steps.current-main-matrix.outcome }}' -ne 'success') {
+              'The current-main coverage artifacts failed trusted matrix validation.'
+            } elseif ('${{ steps.current-main-source.outcome }}' -ne 'success') {
+              'The exact current-main source archive is unavailable.'
+            } elseif ('${{ steps.current-main-summary.outcome }}' -ne 'success') {
+              'The current-main coverage aggregate could not be summarized.'
+            } else {
+              $null
+            }
+
+            if ($unavailableReason) {
+              $parameters.BaselineUnavailableReason = $unavailableReason
+            } else {
+              $parameters.BaselineSummary = 'current-main-summary.json'
+              $parameters.BaselineMatrix = 'current-main-matrix.json'
+            }
+          }
+
+          ./.github/scripts/compare-coverage.ps1 @parameters
+          $comparison = Get-Content -Raw coverage-comparison.json | ConvertFrom-Json
+          $title = if ($comparison.baseline.status -eq 'available') {
+            'Line {0} ({1}), branch {2} ({3})' -f `
+              $comparison.current.line_rate_display, `
+              $comparison.variance.lines.percentage_point_delta_display, `
+              $comparison.current.branch_rate_display, `
+              $comparison.variance.branches.percentage_point_delta_display
+          } else {
+            'Line {0}, branch {1}; current-main baseline {2}' -f `
+              $comparison.current.line_rate_display, `
+              $comparison.current.branch_rate_display, `
+              $comparison.baseline.status
+          }
+
           $comment = @(
             '<!-- orleans-code-coverage -->'
-            '## Code coverage'
-            ''
-            ('**{0} line coverage** - **{1} / {2} lines**' -f $coverage.line_rate_display, $coveredLines, $totalLines)
-            ''
-            ('**{0} branch coverage** - **{1} / {2} branches**' -f $coverage.branch_rate_display, $coveredBranches, $totalBranches)
+            (Get-Content -Raw coverage-comparison.md).TrimEnd()
             ''
             '<details>'
             '<summary>Coverage details</summary>'
             ''
-            ('- **Source files:** {0}' -f $sourceFiles)
-            '- **Scope:** every CI test matrix job, including providers, CodeGen, .NET 8/10, Linux, Windows, and macOS'
-            '- **Sources:** maintained repository code under `src/` loaded by the complete CI test scope'
-            ('- **Commit:** [`{0}`]({1}/commit/{2})' -f $env:HEAD_SHA.Substring(0, 10), $env:REPOSITORY_URL, $env:HEAD_SHA)
-            ('- [View the test run and merged coverage artifact]({0})' -f $env:SOURCE_RUN_URL)
-            ('- [View the coverage reporting run]({0})' -f $env:REPORT_RUN_URL)
+            ('- **Pull request commit:** [`{0}`]({1}/commit/{2})' -f $env:HEAD_SHA.Substring(0, 10), $env:REPOSITORY_URL, $env:HEAD_SHA)
+            ('- [View the pull request test run and coverage artifacts]({0})' -f $env:SOURCE_RUN_URL)
+            ('- [View the trusted coverage reporting run]({0})' -f $env:REPORT_RUN_URL)
             ''
             '</details>'
           ) -join "`n"
           Set-Content -LiteralPath coverage-comment.md -Value $comment -Encoding utf8NoBOM
-
-          Get-Content -Raw coverage-summary.md >> $env:GITHUB_STEP_SUMMARY
-          "branch-rate=$($coverage.branch_rate_display)" >> $env:GITHUB_OUTPUT
-          "line-rate=$($coverage.line_rate_display)" >> $env:GITHUB_OUTPUT
+          Get-Content -Raw coverage-comparison.md >> $env:GITHUB_STEP_SUMMARY
+          "title=$title" >> $env:GITHUB_OUTPUT
       - name: Publish coverage check
         env:
           DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           EXTERNAL_ID: coverage-${{ github.event.workflow_run.id }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          BRANCH_RATE: ${{ steps.coverage.outputs.branch-rate }}
-          LINE_RATE: ${{ steps.coverage.outputs.line-rate }}
+          TITLE: ${{ steps.comparison.outputs.title }}
         run: |
           jq -n \
            --arg details_url "$DETAILS_URL" \
            --arg external_id "$EXTERNAL_ID" \
            --arg head_sha "$HEAD_SHA" \
-           --arg title "Line coverage: $LINE_RATE, branch coverage: $BRANCH_RATE" \
-           --rawfile summary coverage-summary.md \
+           --arg title "$TITLE" \
+           --rawfile summary coverage-comparison.md \
            '{
              name: "Code Coverage",
              head_sha: $head_sha,


### PR DESCRIPTION
## Problem

Pull request coverage has canonical line and branch metrics, but it has no validated current-main comparison and default-branch runs do not retain the same raw coverage matrix. Native Cobertura merging can also remove ambiguous branch conditions, preventing a trustworthy canonical branch summary.

## Solution

- Collect and retain the exact 60-partition coverage matrix on default-branch pushes using the same receipts as pull requests.
- Pin the trusted reporter to one main snapshot, require pull request coverage inputs to match it, and select only a successful exact-SHA default-branch push as the baseline.
- Aggregate validated raw reports directly with canonical physical line identities and conservative per-line branch ordinals, preserving branch counts which `dotnet-coverage merge` can discard.
- Report signed line/branch rate and count variance with explicit improved, regressed, mixed, unchanged, baseline-missing, and baseline-stale states.
- Keep the coverage check successful during calibration while trusted data validation remains gating.
- Cover baseline identity, historical PR exclusion, per-partition source contribution, missing/stale data, variance, conclusions, branch metadata compatibility, and coverage-input fingerprints in the script suite.

Advances #10867
Fixes #10953