### PR TITLE
test(aws): cover DynamoDB configuration

### DIFF
--- a/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBGrainStorageProviderBuilder.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Hosting/DynamoDBGrainStorageProviderBuilder.cs
@@ -38,13 +38,13 @@ internal sealed class DynamoDBGrainStorageProviderBuilder : IProviderBuilder<ISi
                     options.Service = region;
                 }
 
-                var token = configurationSection[nameof(options.SecretKey)];
+                var token = configurationSection[nameof(options.Token)];
                 if (!string.IsNullOrEmpty(token))
                 {
                     options.Token = token;
                 }
 
-                var profileName = configurationSection[nameof(options.SecretKey)];
+                var profileName = configurationSection[nameof(options.ProfileName)];
                 if (!string.IsNullOrEmpty(profileName))
                 {
                     options.ProfileName = profileName;

--- a/test/Extensions/Orleans.AWS.Tests/Reminder/DynamoDBReminderStorageOptionsExtensionsTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Reminder/DynamoDBReminderStorageOptionsExtensionsTests.cs
@@ -1,0 +1,224 @@
+using Orleans.Configuration;
+using Xunit;
+
+namespace AWSUtils.Tests.RemindersTest;
+
+[TestSuite("BVT")]
+[TestProvider("DynamoDB")]
+[TestArea("Reminders")]
+[TestCategory("BVT")]
+[TestCategory("AWS")]
+[TestCategory("DynamoDB")]
+[TestCategory("Reminders")]
+public sealed class DynamoDBReminderStorageOptionsExtensionsTests
+{
+    [Fact]
+    public void ParseConnectionString_Service_SetsService()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("Service=service-sentinel");
+
+        Assert.Equal("service-sentinel", options.Service);
+        Assert.Equal("original-secret", options.SecretKey);
+    }
+
+    [Fact]
+    public void ParseConnectionString_SecretKey_SetsSecretKey()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("SecretKey=secret-sentinel");
+
+        Assert.Equal("secret-sentinel", options.SecretKey);
+        Assert.Equal("original-access", options.AccessKey);
+    }
+
+    [Fact]
+    public void ParseConnectionString_AccessKey_SetsAccessKey()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("AccessKey=access-sentinel");
+
+        Assert.Equal("access-sentinel", options.AccessKey);
+        Assert.Equal("original-secret", options.SecretKey);
+    }
+
+    [Fact]
+    public void ParseConnectionString_ReadCapacityUnits_SetsReadCapacityUnits()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("ReadCapacityUnits=23");
+
+        Assert.Equal(23, options.ReadCapacityUnits);
+        Assert.Equal(29, options.WriteCapacityUnits);
+    }
+
+    [Fact]
+    public void ParseConnectionString_WriteCapacityUnits_SetsWriteCapacityUnits()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("WriteCapacityUnits=17");
+
+        Assert.Equal(17, options.WriteCapacityUnits);
+        Assert.Equal(31, options.ReadCapacityUnits);
+    }
+
+    [Fact]
+    public void ParseConnectionString_UseProvisionedThroughput_SetsUseProvisionedThroughput()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("UseProvisionedThroughput=true");
+
+        Assert.True(options.UseProvisionedThroughput);
+        Assert.False(options.CreateIfNotExists);
+    }
+
+    [Fact]
+    public void ParseConnectionString_CreateIfNotExists_SetsCreateIfNotExists()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("CreateIfNotExists=true");
+
+        Assert.True(options.CreateIfNotExists);
+        Assert.False(options.UpdateIfExists);
+    }
+
+    [Fact]
+    public void ParseConnectionString_UpdateIfExists_SetsUpdateIfExists()
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString("UpdateIfExists=true");
+
+        Assert.True(options.UpdateIfExists);
+        Assert.False(options.CreateIfNotExists);
+    }
+
+    [Fact]
+    public void ParseConnectionString_AllSupportedProperties_AreAppliedTogether()
+    {
+        var options = new DynamoDBReminderStorageOptions();
+
+        options.ParseConnectionString(
+            "Service=service-sentinel;" +
+            "SecretKey=secret-sentinel;" +
+            "AccessKey=access-sentinel;" +
+            "ReadCapacityUnits=23;" +
+            "WriteCapacityUnits=17;" +
+            "UseProvisionedThroughput=false;" +
+            "CreateIfNotExists=false;" +
+            "UpdateIfExists=false");
+
+        Assert.Equal("service-sentinel", options.Service);
+        Assert.Equal("secret-sentinel", options.SecretKey);
+        Assert.Equal("access-sentinel", options.AccessKey);
+        Assert.Equal(23, options.ReadCapacityUnits);
+        Assert.Equal(17, options.WriteCapacityUnits);
+        Assert.False(options.UseProvisionedThroughput);
+        Assert.False(options.CreateIfNotExists);
+        Assert.False(options.UpdateIfExists);
+    }
+
+    [Fact]
+    public void ParseConnectionString_EmptyInput_PreservesDefaults()
+    {
+        var options = new DynamoDBReminderStorageOptions();
+
+        options.ParseConnectionString(string.Empty);
+
+        Assert.Null(options.Service);
+        Assert.Null(options.SecretKey);
+        Assert.Null(options.AccessKey);
+        Assert.Equal(10, options.ReadCapacityUnits);
+        Assert.Equal(5, options.WriteCapacityUnits);
+        Assert.True(options.UseProvisionedThroughput);
+        Assert.True(options.CreateIfNotExists);
+        Assert.True(options.UpdateIfExists);
+        Assert.Equal("OrleansReminders", options.TableName);
+    }
+
+    [Theory]
+    [InlineData("Service=")]
+    [InlineData("SecretKey=")]
+    [InlineData("AccessKey=")]
+    [InlineData("ReadCapacityUnits=")]
+    [InlineData("WriteCapacityUnits=")]
+    [InlineData("UseProvisionedThroughput=")]
+    [InlineData("CreateIfNotExists=")]
+    [InlineData("UpdateIfExists=")]
+    [InlineData("Service")]
+    [InlineData("=value-without-key")]
+    [InlineData("Service=too=many=separators")]
+    [InlineData("Service= ")]
+    public void ParseConnectionString_MissingOrMalformedSegment_PreservesExistingValues(string connectionString)
+    {
+        var options = CreateSentinelOptions();
+
+        options.ParseConnectionString(connectionString);
+
+        AssertSentinelOptions(options);
+    }
+
+    [Theory]
+    [InlineData("ReadCapacityUnits=invalid")]
+    [InlineData("WriteCapacityUnits=invalid")]
+    public void ParseConnectionString_InvalidInteger_ThrowsFormatException(string connectionString)
+    {
+        var options = new DynamoDBReminderStorageOptions();
+
+        Assert.Throws<FormatException>(() => options.ParseConnectionString(connectionString));
+    }
+
+    [Theory]
+    [InlineData("ReadCapacityUnits=2147483648")]
+    [InlineData("WriteCapacityUnits=2147483648")]
+    public void ParseConnectionString_OverflowingInteger_ThrowsOverflowException(string connectionString)
+    {
+        var options = new DynamoDBReminderStorageOptions();
+
+        Assert.Throws<OverflowException>(() => options.ParseConnectionString(connectionString));
+    }
+
+    [Theory]
+    [InlineData("UseProvisionedThroughput=invalid")]
+    [InlineData("CreateIfNotExists=invalid")]
+    [InlineData("UpdateIfExists=invalid")]
+    public void ParseConnectionString_InvalidBoolean_ThrowsFormatException(string connectionString)
+    {
+        var options = new DynamoDBReminderStorageOptions();
+
+        Assert.Throws<FormatException>(() => options.ParseConnectionString(connectionString));
+    }
+
+    private static DynamoDBReminderStorageOptions CreateSentinelOptions() => new()
+    {
+        Service = "original-service",
+        SecretKey = "original-secret",
+        AccessKey = "original-access",
+        ReadCapacityUnits = 31,
+        WriteCapacityUnits = 29,
+        UseProvisionedThroughput = false,
+        CreateIfNotExists = false,
+        UpdateIfExists = false,
+        TableName = "original-table",
+    };
+
+    private static void AssertSentinelOptions(DynamoDBReminderStorageOptions options)
+    {
+        Assert.Equal("original-service", options.Service);
+        Assert.Equal("original-secret", options.SecretKey);
+        Assert.Equal("original-access", options.AccessKey);
+        Assert.Equal(31, options.ReadCapacityUnits);
+        Assert.Equal(29, options.WriteCapacityUnits);
+        Assert.False(options.UseProvisionedThroughput);
+        Assert.False(options.CreateIfNotExists);
+        Assert.False(options.UpdateIfExists);
+        Assert.Equal("original-table", options.TableName);
+    }
+}

--- a/test/Extensions/Orleans.AWS.Tests/StorageTests/DynamoDBGrainStorageProviderBuilderTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/StorageTests/DynamoDBGrainStorageProviderBuilderTests.cs
@@ -1,0 +1,329 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Storage;
+using Xunit;
+
+namespace AWSUtils.Tests.StorageTests;
+
+[TestSuite("BVT")]
+[TestProvider("DynamoDB")]
+[TestArea("Persistence")]
+[TestCategory("BVT")]
+[TestCategory("AWS")]
+[TestCategory("DynamoDB")]
+[TestCategory("Persistence")]
+public sealed class DynamoDBGrainStorageProviderBuilderTests
+{
+    private const string ProviderName = "configured-storage";
+
+    [Fact]
+    public void Configure_MinimalConfiguration_RegistersCredentialFreeDefaults()
+    {
+        var (builder, defaultSerializer) = ConfigureBuilder();
+
+        using var services = builder.Services.BuildServiceProvider();
+        var options = GetOptions(services);
+
+        Assert.Null(options.AccessKey);
+        Assert.Null(options.SecretKey);
+        Assert.Null(options.Token);
+        Assert.Null(options.ProfileName);
+        Assert.Null(options.Service);
+        Assert.Equal(string.Empty, options.ServiceId);
+        Assert.Equal("OrleansGrainState", options.TableName);
+        Assert.Equal(10, options.ReadCapacityUnits);
+        Assert.Equal(5, options.WriteCapacityUnits);
+        Assert.True(options.UseProvisionedThroughput);
+        Assert.True(options.CreateIfNotExists);
+        Assert.True(options.UpdateIfExists);
+        Assert.False(options.DeleteStateOnClear);
+        Assert.Null(options.TimeToLive);
+        Assert.Same(defaultSerializer, options.GrainStorageSerializer);
+    }
+
+    [Fact]
+    public void Configure_FullConfiguration_BindsEverySupportedSetting()
+    {
+        const string serializerKey = "custom-serializer";
+        var keyedSerializer = new FakeGrainStorageSerializer();
+        var (builder, defaultSerializer) = ConfigureBuilder(
+            (nameof(DynamoDBStorageOptions.Service), "service-sentinel"),
+            ("Region", "region-sentinel"),
+            (nameof(DynamoDBStorageOptions.AccessKey), "access-sentinel"),
+            (nameof(DynamoDBStorageOptions.SecretKey), "secret-sentinel"),
+            (nameof(DynamoDBStorageOptions.Token), "token-sentinel"),
+            (nameof(DynamoDBStorageOptions.ProfileName), "profile-sentinel"),
+            (nameof(DynamoDBStorageOptions.ServiceId), "service-id-sentinel"),
+            (nameof(DynamoDBStorageOptions.TableName), "table-sentinel"),
+            (nameof(DynamoDBStorageOptions.ReadCapacityUnits), "23"),
+            (nameof(DynamoDBStorageOptions.WriteCapacityUnits), "17"),
+            (nameof(DynamoDBStorageOptions.UseProvisionedThroughput), "false"),
+            (nameof(DynamoDBStorageOptions.CreateIfNotExists), "false"),
+            (nameof(DynamoDBStorageOptions.UpdateIfExists), "false"),
+            (nameof(DynamoDBStorageOptions.DeleteStateOnClear), "true"),
+            (nameof(DynamoDBStorageOptions.TimeToLive), "01:02:03"),
+            ("SerializerKey", serializerKey));
+        builder.Services.AddKeyedSingleton<IGrainStorageSerializer>(serializerKey, keyedSerializer);
+
+        using var services = builder.Services.BuildServiceProvider();
+        var options = GetOptions(services);
+
+        Assert.Equal("service-sentinel", options.Service);
+        Assert.NotEqual("region-sentinel", options.Service);
+        Assert.Equal("access-sentinel", options.AccessKey);
+        Assert.Equal("secret-sentinel", options.SecretKey);
+        Assert.Equal("token-sentinel", options.Token);
+        Assert.Equal("profile-sentinel", options.ProfileName);
+        Assert.Equal("service-id-sentinel", options.ServiceId);
+        Assert.Equal("table-sentinel", options.TableName);
+        Assert.Equal(23, options.ReadCapacityUnits);
+        Assert.Equal(17, options.WriteCapacityUnits);
+        Assert.False(options.UseProvisionedThroughput);
+        Assert.False(options.CreateIfNotExists);
+        Assert.False(options.UpdateIfExists);
+        Assert.True(options.DeleteStateOnClear);
+        Assert.Equal(TimeSpan.FromHours(1) + TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(3), options.TimeToLive);
+        Assert.Same(keyedSerializer, options.GrainStorageSerializer);
+        Assert.NotSame(defaultSerializer, options.GrainStorageSerializer);
+    }
+
+    [Fact]
+    public void Configure_RegionWithoutService_UsesRegion()
+    {
+        var (builder, _) = ConfigureBuilder(("Region", "region-sentinel"));
+
+        using var services = builder.Services.BuildServiceProvider();
+        var options = GetOptions(services);
+
+        Assert.Equal("region-sentinel", options.Service);
+        Assert.Null(options.AccessKey);
+    }
+
+    [Theory]
+    [InlineData(nameof(DynamoDBStorageOptions.ReadCapacityUnits), "not-an-integer")]
+    [InlineData(nameof(DynamoDBStorageOptions.WriteCapacityUnits), "not-an-integer")]
+    [InlineData(nameof(DynamoDBStorageOptions.UseProvisionedThroughput), "not-a-boolean")]
+    [InlineData(nameof(DynamoDBStorageOptions.CreateIfNotExists), "not-a-boolean")]
+    [InlineData(nameof(DynamoDBStorageOptions.UpdateIfExists), "not-a-boolean")]
+    [InlineData(nameof(DynamoDBStorageOptions.DeleteStateOnClear), "not-a-boolean")]
+    [InlineData(nameof(DynamoDBStorageOptions.TimeToLive), "not-a-timespan")]
+    public void Configure_InvalidTypedValue_PreservesDefault(string key, string invalidValue)
+    {
+        var (builder, _) = ConfigureBuilder((key, invalidValue));
+        using var services = builder.Services.BuildServiceProvider();
+        DynamoDBStorageOptions? options = null;
+
+        var exception = Record.Exception(() => options = GetOptions(services));
+
+        Assert.Null(exception);
+        Assert.NotNull(options);
+        Assert.Equal(10, options.ReadCapacityUnits);
+        Assert.Equal(5, options.WriteCapacityUnits);
+        Assert.True(options.UseProvisionedThroughput);
+        Assert.True(options.CreateIfNotExists);
+        Assert.True(options.UpdateIfExists);
+        Assert.False(options.DeleteStateOnClear);
+        Assert.Null(options.TimeToLive);
+    }
+
+    [Fact]
+    public void Configure_DistinctTokenAndProfileName_MapFromTheirOwnKeys()
+    {
+        var (builder, _) = ConfigureBuilder(
+            (nameof(DynamoDBStorageOptions.SecretKey), "secret-sentinel"),
+            (nameof(DynamoDBStorageOptions.Token), "token-sentinel"),
+            (nameof(DynamoDBStorageOptions.ProfileName), "profile-sentinel"));
+
+        using var services = builder.Services.BuildServiceProvider();
+        var options = GetOptions(services);
+
+        Assert.Equal("token-sentinel", options.Token);
+        Assert.NotEqual("secret-sentinel", options.Token);
+        Assert.Equal("profile-sentinel", options.ProfileName);
+        Assert.NotEqual("secret-sentinel", options.ProfileName);
+    }
+
+    [Fact]
+    public void Configure_SerializerKey_ResolvesMatchingKeyedSerializer()
+    {
+        const string serializerKey = "custom-serializer";
+        var keyedSerializer = new FakeGrainStorageSerializer();
+        var (builder, defaultSerializer) = ConfigureBuilder(("SerializerKey", serializerKey));
+        builder.Services.AddKeyedSingleton<IGrainStorageSerializer>(serializerKey, keyedSerializer);
+
+        using var services = builder.Services.BuildServiceProvider();
+        var options = GetOptions(services);
+
+        Assert.Same(keyedSerializer, options.GrainStorageSerializer);
+        Assert.NotSame(defaultSerializer, options.GrainStorageSerializer);
+    }
+
+    [Fact]
+    public void Configure_WithoutSerializerKey_UsesDefaultSerializer()
+    {
+        var keyedSerializer = new FakeGrainStorageSerializer();
+        var (builder, defaultSerializer) = ConfigureBuilder();
+        builder.Services.AddKeyedSingleton<IGrainStorageSerializer>("unused-serializer", keyedSerializer);
+
+        using var services = builder.Services.BuildServiceProvider();
+        var options = GetOptions(services);
+
+        Assert.Same(defaultSerializer, options.GrainStorageSerializer);
+        Assert.NotSame(keyedSerializer, options.GrainStorageSerializer);
+    }
+
+    [Fact]
+    public void Configure_RegistersNamedOptionsValidatorAndKeyedStorageDescriptor()
+    {
+        var (builder, _) = ConfigureBuilder(
+            (nameof(DynamoDBStorageOptions.TableName), "named-table"),
+            (nameof(DynamoDBStorageOptions.ServiceId), "named-service"));
+        var storageDescriptor = Assert.Single(
+            builder.Services,
+            descriptor => descriptor.IsKeyedService
+                && descriptor.ServiceType == typeof(IGrainStorage)
+                && Equals(descriptor.ServiceKey, ProviderName));
+
+        Assert.Equal(ProviderName, storageDescriptor.ServiceKey);
+        Assert.Equal(typeof(IGrainStorage), storageDescriptor.ServiceType);
+        Assert.NotNull(storageDescriptor.KeyedImplementationFactory);
+
+        using var services = builder.Services.BuildServiceProvider();
+        var monitor = services.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>();
+        var namedOptions = monitor.Get(ProviderName);
+        var defaultOptions = monitor.Get(Options.DefaultName);
+        var validator = Assert.IsType<DynamoDBGrainStorageOptionsValidator>(
+            Assert.Single(services.GetServices<IConfigurationValidator>()));
+
+        Assert.Equal("named-table", namedOptions.TableName);
+        Assert.Equal("named-service", namedOptions.ServiceId);
+        Assert.Equal("OrleansGrainState", defaultOptions.TableName);
+        Assert.Equal(string.Empty, defaultOptions.ServiceId);
+        validator.ValidateConfiguration();
+    }
+
+    [Fact]
+    public void ValidateConfiguration_ValidProvisionedOptions_Succeeds()
+    {
+        var options = CreateValidOptions();
+        var validator = new DynamoDBGrainStorageOptionsValidator(options, ProviderName);
+
+        var exception = Record.Exception(validator.ValidateConfiguration);
+
+        Assert.Null(exception);
+        Assert.True(options.UseProvisionedThroughput);
+        Assert.Equal(11, options.ReadCapacityUnits);
+        Assert.Equal(7, options.WriteCapacityUnits);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateConfiguration_BlankTableName_Throws(string? tableName)
+    {
+        var options = CreateValidOptions();
+        options.TableName = tableName!;
+        var validator = new DynamoDBGrainStorageOptionsValidator(options, ProviderName);
+
+        var exception = Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+
+        Assert.Contains(ProviderName, exception.Message);
+        Assert.Contains(nameof(DynamoDBStorageOptions.TableName), exception.Message);
+    }
+
+    [Fact]
+    public void ValidateConfiguration_ProvisionedReadCapacityZero_Throws()
+    {
+        var options = CreateValidOptions();
+        options.ReadCapacityUnits = 0;
+        var validator = new DynamoDBGrainStorageOptionsValidator(options, ProviderName);
+
+        var exception = Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+
+        Assert.Contains(ProviderName, exception.Message);
+        Assert.Contains(nameof(DynamoDBStorageOptions.ReadCapacityUnits), exception.Message);
+        Assert.DoesNotContain(nameof(DynamoDBStorageOptions.WriteCapacityUnits), exception.Message);
+    }
+
+    [Fact]
+    public void ValidateConfiguration_ProvisionedWriteCapacityZero_Throws()
+    {
+        var options = CreateValidOptions();
+        options.WriteCapacityUnits = 0;
+        var validator = new DynamoDBGrainStorageOptionsValidator(options, ProviderName);
+
+        var exception = Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+
+        Assert.Contains(ProviderName, exception.Message);
+        Assert.Contains(nameof(DynamoDBStorageOptions.WriteCapacityUnits), exception.Message);
+        Assert.DoesNotContain(nameof(DynamoDBStorageOptions.ReadCapacityUnits), exception.Message);
+    }
+
+    [Fact]
+    public void ValidateConfiguration_NonProvisionedZeroCapacities_Succeeds()
+    {
+        var options = CreateValidOptions();
+        options.UseProvisionedThroughput = false;
+        options.ReadCapacityUnits = 0;
+        options.WriteCapacityUnits = 0;
+        var validator = new DynamoDBGrainStorageOptionsValidator(options, ProviderName);
+
+        var exception = Record.Exception(validator.ValidateConfiguration);
+
+        Assert.Null(exception);
+        Assert.False(options.UseProvisionedThroughput);
+        Assert.Equal(0, options.ReadCapacityUnits);
+        Assert.Equal(0, options.WriteCapacityUnits);
+    }
+
+    private static (TestSiloBuilder Builder, IGrainStorageSerializer DefaultSerializer) ConfigureBuilder(
+        params (string Key, string? Value)[] settings)
+    {
+        var values = settings.ToDictionary(
+            setting => $"Storage:{setting.Key}",
+            setting => setting.Value);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+        var builder = new TestSiloBuilder(configuration);
+        var defaultSerializer = new FakeGrainStorageSerializer();
+        builder.Services.AddSingleton<IGrainStorageSerializer>(defaultSerializer);
+
+        new DynamoDBGrainStorageProviderBuilder().Configure(
+            builder,
+            ProviderName,
+            configuration.GetSection("Storage"));
+
+        return (builder, defaultSerializer);
+    }
+
+    private static DynamoDBStorageOptions GetOptions(IServiceProvider services)
+        => services.GetRequiredService<IOptionsMonitor<DynamoDBStorageOptions>>().Get(ProviderName);
+
+    private static DynamoDBStorageOptions CreateValidOptions() => new()
+    {
+        TableName = "valid-table",
+        UseProvisionedThroughput = true,
+        ReadCapacityUnits = 11,
+        WriteCapacityUnits = 7,
+    };
+
+    private sealed class TestSiloBuilder(IConfiguration configuration) : ISiloBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = configuration;
+    }
+
+    private sealed class FakeGrainStorageSerializer : IGrainStorageSerializer
+    {
+        public BinaryData Serialize<T>(T? input) => throw new NotSupportedException();
+
+        public T? Deserialize<T>(BinaryData input) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Part of #10861.

DynamoDB grain-storage configuration and reminder parsing were high-risk uncovered paths. The provider builder also sourced both `Token` and `ProfileName` from `SecretKey`, preventing independent configuration.

This change adds credential-free BVT coverage for complete/default builder configuration, Service/Region precedence, invalid typed values, keyed serializers, named registration, validator outcomes, and every reminder connection-string parsing branch. It also maps `Token` and `ProfileName` from their own keys.

Focused coverage impact:

| Method | Line coverage | Branch coverage | CRAP |
| --- | ---: | ---: | ---: |
| Grain-storage provider configuration | 0% → 100% (70/70) | 0% → 100% (32/32) | 1056 → 32 |
| Reminder connection parsing | 0% → 100% (59/59) | 0% → 100% (64/64) | 4160 → 64 |
| Grain-storage options validation | 0% → 100% (14/14) | 0% → 100% (8/8) | 72 → 8 |

The canonical DynamoDB provider lane discovers all 50 new cases, and the tests run without AWS credentials or DynamoDB Local.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10952)