### PR TITLE
test(streaming): cover subscription lifecycle

### DIFF
--- a/src/Orleans.Streaming/Internal/StreamConsumer.cs
+++ b/src/Orleans.Streaming/Internal/StreamConsumer.cs
@@ -266,13 +266,13 @@ namespace Orleans.Streams
         {
             if (handle == null)
                 throw new ArgumentNullException(nameof(handle));
+            if (handle is StreamSubscriptionHandleImpl<T> { IsValid: false })
+                throw new ArgumentException("Handle is no longer valid.  It has been used to unsubscribe or resume.", nameof(handle));
             if (!handle.StreamId.Equals(stream.StreamId))
                 throw new ArgumentException("Handle is not for this stream.", nameof(handle));
             var handleImpl = handle as StreamSubscriptionHandleImpl<T>;
             if (handleImpl == null)
                 throw new ArgumentException("Handle type not supported.", nameof(handle));
-            if (!handleImpl.IsValid)
-                throw new ArgumentException("Handle is no longer valid.  It has been used to unsubscribe or resume.", nameof(handle));
             return handleImpl;
         }
 

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -212,8 +212,8 @@ namespace Orleans.Streams
                 // Check if this even already has been delivered
                 if (IsRewindable)
                 {
-                    var currentHandshakeToken = StreamHandshakeToken.CreateDeliveyToken(currentToken);
-                    if (this.expectedToken.Equals(currentHandshakeToken))
+                    if (this.expectedToken is DeliveryToken deliveryToken
+                        && deliveryToken.Token.Equals(currentToken))
                         return this.expectedToken;
                 }
             }

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -212,7 +212,8 @@ namespace Orleans.Streams
                 // Check if this even already has been delivered
                 if (IsRewindable)
                 {
-                    if (this.expectedToken.Equals(currentToken))
+                    var currentHandshakeToken = StreamHandshakeToken.CreateDeliveyToken(currentToken);
+                    if (this.expectedToken.Equals(currentHandshakeToken))
                         return this.expectedToken;
                 }
             }

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamConsumerLifecycleTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamConsumerLifecycleTests.cs
@@ -333,10 +333,10 @@ public class StreamConsumerLifecycleTests
             => Extension.SetObserver(
                 subscriptionId,
                 Stream,
-                observer,
+                observer: observer,
                 batchObserver: null,
-                token,
-                filterData);
+                token: token,
+                filterData: filterData);
 
         public StreamSubscriptionHandleImpl<int> Register(
             GuidId subscriptionId,
@@ -347,9 +347,9 @@ public class StreamConsumerLifecycleTests
                 subscriptionId,
                 Stream,
                 observer: null,
-                observer,
-                token,
-                filterData);
+                batchObserver: observer,
+                token: token,
+                filterData: filterData);
 
         public void AssertNoStreamProviderAcquisitions()
         {

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamConsumerLifecycleTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamConsumerLifecycleTests.cs
@@ -1,0 +1,619 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+public class StreamConsumerLifecycleTests
+{
+    [Fact]
+    public async Task ResumeAsync_SuccessReplacesRegistrationPreservesIdentityAndInvalidatesOldHandle()
+    {
+        using var fixture = new ConsumerFixture();
+        var subscriptionId = CreateSubscriptionId();
+        var startToken = new EventSequenceTokenV2(10, 2);
+        var oldObserver = new RecordingObserver();
+        var oldHandle = fixture.Register(subscriptionId, oldObserver, token: startToken, filterData: "region=west");
+        var initialHandshake = oldHandle.GetSequenceToken();
+        var replacementObserver = new RecordingObserver();
+
+        var result = await fixture.Consumer.ResumeAsync(oldHandle, replacementObserver);
+
+        var replacement = Assert.IsType<StreamSubscriptionHandleImpl<int>>(result);
+        Assert.False(oldHandle.IsValid);
+        Assert.False(oldHandle.HasObserver);
+        Assert.True(replacement.IsValid);
+        Assert.True(replacement.HasObserver);
+        Assert.Same(subscriptionId, replacement.SubscriptionId);
+        Assert.Equal(oldHandle.HandleId, replacement.HandleId);
+        Assert.Equal("region=west", replacement.FilterData);
+        Assert.Same(initialHandshake, replacement.GetSequenceToken());
+        Assert.Same(replacement, Assert.Single(fixture.Extension.GetAllStreamHandles<int>()));
+        Assert.Equal(1, fixture.Runtime.BindCalls);
+        Assert.Equal(0, fixture.PubSub.InvocationCount);
+        fixture.AssertNoStreamProviderAcquisitions();
+    }
+
+    [Fact]
+    public async Task ResumeAsync_SetObserverFailureLeavesOldHandleRegisteredAndRetryable()
+    {
+        using var fixture = new ConsumerFixture();
+        var subscriptionId = CreateSubscriptionId();
+        var oldObserver = new RecordingObserver();
+        var oldHandle = fixture.Register(
+            subscriptionId,
+            oldObserver,
+            token: new EventSequenceTokenV2(20, 1),
+            filterData: "retry");
+        var initialHandshake = oldHandle.GetSequenceToken();
+        var failure = new InvalidOperationException("set-observer failed");
+        fixture.Runtime.FailNextObserverRegistration(failure);
+
+        var caught = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.Consumer.ResumeAsync(oldHandle, new RecordingObserver()));
+
+        Assert.Same(failure, caught);
+        Assert.True(oldHandle.IsValid);
+        Assert.True(oldHandle.HasObserver);
+        Assert.Same(oldHandle, Assert.Single(fixture.Extension.GetAllStreamHandles<int>()));
+        Assert.Same(initialHandshake, oldHandle.GetSequenceToken());
+        Assert.Equal(1, fixture.Runtime.BindCalls);
+
+        var replacement = Assert.IsType<StreamSubscriptionHandleImpl<int>>(
+            await fixture.Consumer.ResumeAsync(oldHandle, new RecordingObserver()));
+
+        Assert.False(oldHandle.IsValid);
+        Assert.True(replacement.IsValid);
+        Assert.Same(subscriptionId, replacement.SubscriptionId);
+        Assert.Equal(oldHandle.HandleId, replacement.HandleId);
+        Assert.Equal("retry", replacement.FilterData);
+        Assert.Same(initialHandshake, replacement.GetSequenceToken());
+        Assert.Same(replacement, Assert.Single(fixture.Extension.GetAllStreamHandles<int>()));
+        Assert.Equal(1, fixture.Runtime.BindCalls);
+        Assert.Equal(0, fixture.PubSub.InvocationCount);
+        fixture.AssertNoStreamProviderAcquisitions();
+    }
+
+    [Fact]
+    public async Task UnsubscribeAsync_RemovesLocallyBeforeUnregisterAndInvalidatesAfterSuccess()
+    {
+        using var fixture = new ConsumerFixture();
+        var subscriptionId = CreateSubscriptionId();
+        var handle = fixture.Register(subscriptionId, new RecordingObserver());
+        var snapshots = new List<(int RegistryCount, bool HandleValid)>();
+        fixture.PubSub.OnUnregister = _ =>
+        {
+            snapshots.Add((fixture.Extension.GetAllStreamHandles<int>().Count, handle.IsValid));
+            return Task.CompletedTask;
+        };
+
+        await fixture.Consumer.UnsubscribeAsync(handle);
+
+        Assert.Equal([(0, true)], snapshots);
+        Assert.False(handle.IsValid);
+        Assert.False(handle.HasObserver);
+        Assert.Empty(fixture.Extension.GetAllStreamHandles<int>());
+        var call = Assert.Single(fixture.PubSub.UnregisterCalls);
+        Assert.Same(subscriptionId, call.SubscriptionId);
+        Assert.Equal(fixture.Stream.InternalStreamId, call.StreamId);
+        Assert.Equal(1, fixture.PubSub.InvocationCount);
+        Assert.Equal(1, fixture.Runtime.BindCalls);
+        fixture.AssertNoStreamProviderAcquisitions();
+    }
+
+    [Fact]
+    public async Task UnsubscribeAsync_UnregisterFailureLeavesHandleValidAndSecondCallRetries()
+    {
+        using var fixture = new ConsumerFixture();
+        var subscriptionId = CreateSubscriptionId();
+        var handle = fixture.Register(subscriptionId, new RecordingObserver());
+        var failure = new InvalidOperationException("unregister failed");
+        var snapshots = new List<(int RegistryCount, bool HandleValid)>();
+        fixture.PubSub.OnUnregister = call =>
+        {
+            snapshots.Add((fixture.Extension.GetAllStreamHandles<int>().Count, handle.IsValid));
+            return call.Attempt == 1 ? Task.FromException(failure) : Task.CompletedTask;
+        };
+
+        var caught = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.Consumer.UnsubscribeAsync(handle));
+
+        Assert.Same(failure, caught);
+        Assert.Equal([(0, true)], snapshots);
+        Assert.True(handle.IsValid);
+        Assert.True(handle.HasObserver);
+        Assert.Empty(fixture.Extension.GetAllStreamHandles<int>());
+
+        await fixture.Consumer.UnsubscribeAsync(handle);
+
+        Assert.Equal([(0, true), (0, true)], snapshots);
+        Assert.False(handle.IsValid);
+        Assert.Equal(2, fixture.PubSub.UnregisterCalls.Count);
+        Assert.All(fixture.PubSub.UnregisterCalls, call =>
+        {
+            Assert.Same(subscriptionId, call.SubscriptionId);
+            Assert.Equal(fixture.Stream.InternalStreamId, call.StreamId);
+        });
+        Assert.Equal(2, fixture.PubSub.InvocationCount);
+        Assert.Equal(1, fixture.Runtime.BindCalls);
+        fixture.AssertNoStreamProviderAcquisitions();
+    }
+
+    [Fact]
+    public async Task CheckHandleValidity_NullHandleRejectsBeforeAnyMutation()
+    {
+        using var fixture = new ConsumerFixture();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.Consumer.ResumeAsync(null!, new RecordingObserver()));
+
+        Assert.Equal("handle", exception.ParamName);
+        fixture.AssertNoLifecycleMutations();
+    }
+
+    [Fact]
+    public async Task CheckHandleValidity_ForeignStreamHandleRejectsBeforeAnyMutation()
+    {
+        using var fixture = new ConsumerFixture();
+        var foreignStream = fixture.CreateStream(StreamId.Create("phase-2", "foreign"));
+        var handle = new StreamSubscriptionHandleImpl<int>(CreateSubscriptionId(), foreignStream);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => fixture.Consumer.ResumeAsync(handle, new RecordingObserver()));
+
+        Assert.Equal("handle", exception.ParamName);
+        Assert.Contains("not for this stream", exception.Message);
+        Assert.True(handle.IsValid);
+        fixture.AssertNoLifecycleMutations();
+    }
+
+    [Fact]
+    public async Task CheckHandleValidity_UnsupportedHandleTypeRejectsBeforeAnyMutation()
+    {
+        using var fixture = new ConsumerFixture();
+        var handle = new ForeignSubscriptionHandle(fixture.Stream.StreamId);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => fixture.Consumer.ResumeAsync(handle, new RecordingObserver()));
+
+        Assert.Equal("handle", exception.ParamName);
+        Assert.Contains("type not supported", exception.Message);
+        fixture.AssertNoLifecycleMutations();
+    }
+
+    [Fact]
+    public async Task StreamConsumerExtension_RegistryRoutesBySubscriptionAndStopsAfterRemoval()
+    {
+        using var fixture = new ConsumerFixture();
+        var itemSubscriptionId = CreateSubscriptionId();
+        var batchSubscriptionId = CreateSubscriptionId();
+        var itemObserver = new RecordingObserver();
+        var batchObserver = new RecordingBatchObserver();
+        var itemStartToken = new EventSequenceTokenV2(30, 3);
+        var batchStartToken = new EventSequenceTokenV2(40, 4);
+        var itemHandle = fixture.Register(itemSubscriptionId, itemObserver, token: itemStartToken);
+        var batchHandle = fixture.Register(batchSubscriptionId, batchObserver, token: batchStartToken);
+        var itemHandshake = await fixture.Extension.GetSequenceToken(itemSubscriptionId);
+        var batchHandshake = await fixture.Extension.GetSequenceToken(batchSubscriptionId);
+        var deliveredItemToken = new EventSequenceTokenV2(31, 5);
+        var deliveredBatchToken = new EventSequenceTokenV2(41, 6);
+        var batch = new TestBatchContainer(fixture.Stream.StreamId, deliveredBatchToken, 71);
+        var streamError = new InvalidOperationException("stream failed");
+
+        await fixture.Extension.DeliverMutable(
+            itemSubscriptionId,
+            fixture.Stream.InternalStreamId,
+            61,
+            deliveredItemToken,
+            itemHandshake);
+        await fixture.Extension.DeliverBatch(
+            batchSubscriptionId,
+            fixture.Stream.InternalStreamId,
+            batch,
+            batchHandshake);
+        await fixture.Extension.CompleteStream(itemSubscriptionId);
+        await fixture.Extension.ErrorInStream(batchSubscriptionId, streamError);
+
+        Assert.Same(itemStartToken, Assert.IsType<StartToken>(itemHandshake).Token);
+        Assert.Same(batchStartToken, Assert.IsType<StartToken>(batchHandshake).Token);
+        Assert.Equal([61], itemObserver.Items);
+        Assert.Same(deliveredItemToken, Assert.Single(itemObserver.Tokens));
+        var deliveredBatch = Assert.Single(batchObserver.Batches);
+        var deliveredBatchItem = Assert.Single(deliveredBatch);
+        Assert.Equal(71, deliveredBatchItem.Item);
+        Assert.Same(deliveredBatchToken, deliveredBatchItem.Token);
+        Assert.Equal(1, itemObserver.CompletionCalls);
+        Assert.Same(streamError, Assert.Single(batchObserver.Errors));
+        Assert.Empty(batchObserver.Completions);
+        Assert.Empty(itemObserver.Errors);
+        Assert.Contains(itemHandle, fixture.Extension.GetAllStreamHandles<int>());
+        Assert.Contains(batchHandle, fixture.Extension.GetAllStreamHandles<int>());
+
+        Assert.True(fixture.Extension.RemoveObserver(itemSubscriptionId));
+        Assert.False(fixture.Extension.RemoveObserver(itemSubscriptionId));
+        Assert.Null(await fixture.Extension.DeliverImmutable(
+            itemSubscriptionId,
+            fixture.Stream.InternalStreamId,
+            62,
+            new EventSequenceTokenV2(32),
+            handshakeToken: null));
+        await fixture.Extension.CompleteStream(itemSubscriptionId);
+        await fixture.Extension.ErrorInStream(itemSubscriptionId, new InvalidOperationException("dropped"));
+
+        Assert.Null(await fixture.Extension.GetSequenceToken(itemSubscriptionId));
+        Assert.Equal([61], itemObserver.Items);
+        Assert.Equal(1, itemObserver.CompletionCalls);
+        Assert.Empty(itemObserver.Errors);
+        Assert.Same(batchHandle, Assert.Single(fixture.Extension.GetAllStreamHandles<int>()));
+        Assert.Equal(0, fixture.PubSub.InvocationCount);
+        Assert.Equal(0, fixture.Runtime.BindCalls);
+        fixture.AssertNoStreamProviderAcquisitions();
+    }
+
+    [Fact]
+    public async Task ResumeAsync_InvalidatedConcreteHandle_RejectsBeforeBoundExtensionOrLifecycleMutation()
+    {
+        using var fixture = new ConsumerFixture();
+        var observer = new RecordingObserver();
+        var handle = fixture.Register(CreateSubscriptionId(), observer, filterData: "invalidated");
+        handle.Invalidate();
+        Assert.True(fixture.Runtime.IsExtensionCreated);
+        Assert.Same(handle, Assert.Single(fixture.Extension.GetAllStreamHandles<int>()));
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => fixture.Consumer.ResumeAsync(handle, new RecordingObserver()));
+
+        Assert.Equal("handle", exception.ParamName);
+        Assert.Equal(
+            "Handle is no longer valid.  It has been used to unsubscribe or resume. (Parameter 'handle')",
+            exception.Message);
+        Assert.False(handle.IsValid);
+        Assert.False(handle.HasObserver);
+        Assert.Same(handle, Assert.Single(fixture.Extension.GetAllStreamHandles<int>()));
+        Assert.Equal(0, fixture.Runtime.BindCalls);
+        Assert.Equal(0, fixture.PubSub.InvocationCount);
+        Assert.Empty(observer.Items);
+        Assert.Empty(observer.Tokens);
+        Assert.Empty(observer.Errors);
+        Assert.Equal(0, observer.CompletionCalls);
+        fixture.AssertNoStreamProviderAcquisitions();
+    }
+
+    private static GuidId CreateSubscriptionId()
+        => GuidId.GetGuidId(SubscriptionMarker.MarkAsExplicitSubscriptionId(Guid.NewGuid()));
+
+    private sealed class ConsumerFixture : IDisposable
+    {
+        private const string ProviderName = "phase-2-provider";
+
+        public ConsumerFixture()
+        {
+            Runtime = new RecordingStreamProviderRuntime();
+            PubSub = new RecordingStreamPubSub();
+            StreamProvider = new CountingStreamProvider();
+            Stream = CreateStream(StreamId.Create("phase-2", Guid.NewGuid()));
+            Consumer = new StreamConsumer<int>(
+                Stream,
+                ProviderName,
+                Runtime,
+                PubSub,
+                NullLogger<StreamConsumer<int>>.Instance,
+                isRewindable: true);
+        }
+
+        public RecordingStreamProviderRuntime Runtime { get; }
+        public RecordingStreamPubSub PubSub { get; }
+        public CountingStreamProvider StreamProvider { get; }
+        public StreamImpl<int> Stream { get; }
+        public StreamConsumer<int> Consumer { get; }
+        public StreamConsumerExtension Extension => Runtime.Extension;
+
+        public StreamImpl<int> CreateStream(StreamId streamId)
+            => new(
+                new QualifiedStreamId(ProviderName, streamId),
+                StreamProvider,
+                isRewindable: true,
+                NSubstitute.Substitute.For<IRuntimeClient>());
+
+        public StreamSubscriptionHandleImpl<int> Register(
+            GuidId subscriptionId,
+            RecordingObserver observer,
+            StreamSequenceToken? token = null,
+            string? filterData = null)
+            => Extension.SetObserver(
+                subscriptionId,
+                Stream,
+                observer,
+                batchObserver: null,
+                token,
+                filterData);
+
+        public StreamSubscriptionHandleImpl<int> Register(
+            GuidId subscriptionId,
+            RecordingBatchObserver observer,
+            StreamSequenceToken? token = null,
+            string? filterData = null)
+            => Extension.SetObserver(
+                subscriptionId,
+                Stream,
+                observer: null,
+                observer,
+                token,
+                filterData);
+
+        public void AssertNoStreamProviderAcquisitions()
+        {
+            Assert.Equal(0, StreamProvider.ConsumerInterfaceAcquisitions);
+            Assert.Equal(0, StreamProvider.ProducerInterfaceAcquisitions);
+        }
+
+        public void AssertNoLifecycleMutations()
+        {
+            Assert.False(Runtime.IsExtensionCreated);
+            Assert.Equal(0, Runtime.BindCalls);
+            Assert.Equal(0, PubSub.InvocationCount);
+            AssertNoStreamProviderAcquisitions();
+        }
+
+        public void Dispose() => Runtime.Dispose();
+    }
+
+    private sealed class RecordingStreamProviderRuntime : IStreamProviderRuntime, IDisposable
+    {
+        private readonly ServiceProvider serviceProvider;
+        private StreamConsumerExtension? extension;
+        private Exception? nextObserverRegistrationFailure;
+
+        public RecordingStreamProviderRuntime()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ILogger<StreamConsumerExtension>>(NullLogger<StreamConsumerExtension>.Instance);
+            services.AddSingleton<IOptions<ClusterOptions>>(
+                Options.Create(new ClusterOptions { ClusterId = "phase-2-cluster" }));
+            services.AddSingleton<IGrainContextAccessor>(new NullGrainContextAccessor());
+            serviceProvider = services.BuildServiceProvider();
+        }
+
+        public int BindCalls { get; private set; }
+        public bool IsExtensionCreated => extension is not null;
+        public StreamConsumerExtension Extension => extension ??= new StreamConsumerExtension(this);
+        public IGrainFactory GrainFactory => throw new NotSupportedException();
+        public IServiceProvider ServiceProvider => serviceProvider;
+
+        public (TExtension Extension, TExtensionInterface ExtensionReference)
+            BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
+            where TExtension : class, TExtensionInterface
+            where TExtensionInterface : class, IGrainExtension
+        {
+            BindCalls++;
+            if (typeof(TExtension) != typeof(StreamConsumerExtension)
+                || typeof(TExtensionInterface) != typeof(IStreamConsumerExtension))
+            {
+                throw new NotSupportedException(
+                    $"Unexpected extension binding: {typeof(TExtension)} / {typeof(TExtensionInterface)}.");
+            }
+
+            extension ??= (StreamConsumerExtension)(object)newExtensionFunc();
+            return ((TExtension)(object)extension, (TExtensionInterface)(object)extension);
+        }
+
+        public string ExecutingEntityIdentity()
+        {
+            if (nextObserverRegistrationFailure is { } failure)
+            {
+                nextObserverRegistrationFailure = null;
+                throw failure;
+            }
+
+            return "phase-2-consumer";
+        }
+
+        public StreamDirectory GetStreamDirectory() => throw new NotSupportedException();
+        public IStreamPubSub? PubSub(StreamPubSubType pubSubType) => throw new NotSupportedException();
+
+        public void FailNextObserverRegistration(Exception exception)
+            => nextObserverRegistrationFailure = exception;
+
+        public void Dispose() => serviceProvider.Dispose();
+    }
+
+    private sealed class NullGrainContextAccessor : IGrainContextAccessor
+    {
+        public IGrainContext GrainContext => null!;
+    }
+
+    private sealed class RecordingStreamPubSub : IStreamPubSub
+    {
+        public List<UnregisterCall> UnregisterCalls { get; } = [];
+        public Func<UnregisterCall, Task>? OnUnregister { get; set; }
+        public int InvocationCount { get; private set; }
+
+        public Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
+        {
+            InvocationCount++;
+            var call = new UnregisterCall(subscriptionId, streamId, UnregisterCalls.Count + 1);
+            UnregisterCalls.Add(call);
+            return OnUnregister?.Invoke(call) ?? Task.CompletedTask;
+        }
+
+        public Task<ISet<PubSubSubscriptionState>> RegisterProducer(
+            QualifiedStreamId streamId,
+            GrainId streamProducer)
+        {
+            InvocationCount++;
+            return Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>());
+        }
+
+        public Task UnregisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
+        {
+            InvocationCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task RegisterConsumer(
+            GuidId subscriptionId,
+            QualifiedStreamId streamId,
+            GrainId streamConsumer,
+            string? filterData)
+        {
+            InvocationCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<int> ProducerCount(QualifiedStreamId streamId)
+        {
+            InvocationCount++;
+            return Task.FromResult(0);
+        }
+
+        public Task<int> ConsumerCount(QualifiedStreamId streamId)
+        {
+            InvocationCount++;
+            return Task.FromResult(0);
+        }
+
+        public Task<List<StreamSubscription>> GetAllSubscriptions(
+            QualifiedStreamId streamId,
+            GrainId streamConsumer = default)
+        {
+            InvocationCount++;
+            return Task.FromResult(new List<StreamSubscription>());
+        }
+
+        public GuidId CreateSubscriptionId(QualifiedStreamId streamId, GrainId streamConsumer)
+        {
+            InvocationCount++;
+            return StreamConsumerLifecycleTests.CreateSubscriptionId();
+        }
+
+        public Task<bool> FaultSubscription(QualifiedStreamId streamId, GuidId subscriptionId)
+        {
+            InvocationCount++;
+            return Task.FromResult(false);
+        }
+    }
+
+    private sealed record UnregisterCall(
+        GuidId SubscriptionId,
+        QualifiedStreamId StreamId,
+        int Attempt);
+
+    private sealed class CountingStreamProvider : IInternalStreamProvider
+    {
+        public int ConsumerInterfaceAcquisitions { get; private set; }
+        public int ProducerInterfaceAcquisitions { get; private set; }
+
+        IInternalAsyncObservable<T> IInternalStreamProvider.GetConsumerInterface<T>(IAsyncStream<T> streamId)
+        {
+            ConsumerInterfaceAcquisitions++;
+            throw new InvalidOperationException("The lifecycle tests must not acquire the consumer interface.");
+        }
+
+        IInternalAsyncBatchObserver<T> IInternalStreamProvider.GetProducerInterface<T>(IAsyncStream<T> streamId)
+        {
+            ProducerInterfaceAcquisitions++;
+            throw new InvalidOperationException("The lifecycle tests must not acquire the producer interface.");
+        }
+    }
+
+    private sealed class RecordingObserver : IAsyncObserver<int>
+    {
+        public List<int> Items { get; } = [];
+        public List<StreamSequenceToken?> Tokens { get; } = [];
+        public List<Exception> Errors { get; } = [];
+        public int CompletionCalls { get; private set; }
+
+        public Task OnNextAsync(int item, StreamSequenceToken? token = null)
+        {
+            Items.Add(item);
+            Tokens.Add(token);
+            return Task.CompletedTask;
+        }
+
+        public Task OnCompletedAsync()
+        {
+            CompletionCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task OnErrorAsync(Exception ex)
+        {
+            Errors.Add(ex);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingBatchObserver : IAsyncBatchObserver<int>
+    {
+        public List<IList<SequentialItem<int>>> Batches { get; } = [];
+        public List<Exception> Errors { get; } = [];
+        public List<bool> Completions { get; } = [];
+
+        public Task OnNextAsync(IList<SequentialItem<int>> items)
+        {
+            Batches.Add(items.ToList());
+            return Task.CompletedTask;
+        }
+
+        public Task OnCompletedAsync()
+        {
+            Completions.Add(true);
+            return Task.CompletedTask;
+        }
+
+        public Task OnErrorAsync(Exception ex)
+        {
+            Errors.Add(ex);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestBatchContainer(
+        StreamId streamId,
+        StreamSequenceToken sequenceToken,
+        int item) : IBatchContainer
+    {
+        public StreamId StreamId { get; } = streamId;
+        public StreamSequenceToken SequenceToken { get; } = sequenceToken;
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
+        {
+            yield return Tuple.Create((T)(object)item, SequenceToken);
+        }
+
+        public bool ImportRequestContext() => false;
+    }
+
+    private sealed class ForeignSubscriptionHandle(StreamId streamId) : StreamSubscriptionHandle<int>
+    {
+        public override Guid HandleId { get; } = Guid.NewGuid();
+        public override string ProviderName => "phase-2-provider";
+        public override StreamId StreamId { get; } = streamId;
+
+        public override bool Equals(StreamSubscriptionHandle<int>? other) => ReferenceEquals(this, other);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj);
+        public override int GetHashCode() => HandleId.GetHashCode();
+
+        public override Task<StreamSubscriptionHandle<int>> ResumeAsync(
+            IAsyncObserver<int> observer,
+            StreamSequenceToken? token = null)
+            => throw new NotSupportedException();
+
+        public override Task<StreamSubscriptionHandle<int>> ResumeAsync(
+            IAsyncBatchObserver<int> observer,
+            StreamSequenceToken? token = null)
+            => throw new NotSupportedException();
+
+        public override Task UnsubscribeAsync() => throw new NotSupportedException();
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamSubscriptionHandleImplTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamSubscriptionHandleImplTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -1546,7 +1547,7 @@ public class StreamSubscriptionHandleImplTests
 
         public void OnError(Exception error)
         {
-            throw error;
+            ExceptionDispatchInfo.Throw(error);
         }
 
         public void OnNext(Orleans.Streaming.Diagnostics.StreamingEvents.StreamingEvent value)

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamSubscriptionHandleImplTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamSubscriptionHandleImplTests.cs
@@ -74,4 +74,1532 @@ public class StreamSubscriptionHandleImplTests
             : SubscriptionMarker.MarkAsExplicitSubscriptionId(Guid.NewGuid());
         return GuidId.GetGuidId(subscriptionGuid);
     }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [TestArea("Streaming")]
+    [Fact]
+    public async Task DeliverItem_AcknowledgedDuplicate_ReturnsExpectedTokenWithoutRedelivery()
+    {
+        var token = new EventSequenceTokenV2(42, 3);
+        var expectedToken = StreamHandshakeToken.CreateDeliveyToken(token);
+        var handshakeState = new StreamSubscriptionHandleImpl<int>.SharedHandshakeState { Token = expectedToken };
+        var observer = new RecordingObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            handshakeState: handshakeState);
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+
+        var result = await fixture.Handle.DeliverItem(17, token, expectedToken);
+
+        Assert.Same(expectedToken, result);
+        Assert.Same(expectedToken, fixture.Handle.GetSequenceToken());
+        Assert.Empty(observer.Items);
+        Assert.Empty(diagnostics.Items);
+        Assert.Equal(0, fixture.Provider.ConsumerInterfaceAcquisitions);
+        Assert.Equal(0, fixture.Provider.ProducerInterfaceAcquisitions);
+    }
+
+    private static HandleFixture CreateFixture(
+        bool isRewindable,
+        IAsyncObserver<int>? observer = null,
+        IAsyncBatchObserver<int>? batchObserver = null,
+        StreamSequenceToken? token = null,
+        string? filterData = "phase-1-filter",
+        bool disableHandshake = false,
+        StreamSubscriptionHandleImpl<int>.SharedHandshakeState? handshakeState = null,
+        GuidId? subscriptionId = null,
+        StreamId? streamId = null,
+        string? providerName = null,
+        string clusterId = "phase-1-cluster")
+    {
+        var provider = new CountingStreamProvider<int>();
+        var actualStreamId = streamId ?? StreamId.Create("phase-1", Guid.NewGuid());
+        var actualProviderName = providerName ?? $"phase-1-provider-{Guid.NewGuid():N}";
+        var qualifiedStreamId = new QualifiedStreamId(actualProviderName, actualStreamId);
+        var runtimeClient = NSubstitute.Substitute.For<IRuntimeClient>();
+        var stream = new StreamImpl<int>(qualifiedStreamId, provider, isRewindable, runtimeClient);
+        var handle = new StreamSubscriptionHandleImpl<int>(
+            subscriptionId ?? CreateSubscriptionId(implicitSubscription: false),
+            observer,
+            batchObserver,
+            stream,
+            token,
+            filterData,
+            disableHandshake,
+            handshakeState,
+            siloAddress: null,
+            clusterId);
+        return new(handle, stream, provider);
+    }
+
+    private sealed record HandleFixture(
+        StreamSubscriptionHandleImpl<int> Handle,
+        StreamImpl<int> Stream,
+        CountingStreamProvider<int> Provider);
+
+    private sealed class CountingStreamProvider<T> : IInternalStreamProvider
+    {
+        public CountingStreamProvider()
+        {
+            Consumer = new RecordingConsumer<T>();
+            Producer = new NoOpProducer<T>();
+        }
+
+        public int ConsumerInterfaceAcquisitions { get; private set; }
+        public int ProducerInterfaceAcquisitions { get; private set; }
+        public RecordingConsumer<T> Consumer { get; }
+        public NoOpProducer<T> Producer { get; }
+
+        IInternalAsyncObservable<TRequested> IInternalStreamProvider.GetConsumerInterface<TRequested>(
+            IAsyncStream<TRequested> streamId)
+        {
+            ConsumerInterfaceAcquisitions++;
+            Assert.Equal(typeof(T), typeof(TRequested));
+            return (IInternalAsyncObservable<TRequested>)(object)Consumer;
+        }
+
+        IInternalAsyncBatchObserver<TRequested> IInternalStreamProvider.GetProducerInterface<TRequested>(
+            IAsyncStream<TRequested> streamId)
+        {
+            ProducerInterfaceAcquisitions++;
+            Assert.Equal(typeof(T), typeof(TRequested));
+            return (IInternalAsyncBatchObserver<TRequested>)(object)Producer;
+        }
+    }
+
+    private sealed class NoOpProducer<T> : IInternalAsyncBatchObserver<T>
+    {
+        public Task Cleanup() => Task.CompletedTask;
+        public Task OnCompletedAsync() => Task.CompletedTask;
+        public Task OnErrorAsync(Exception ex) => Task.CompletedTask;
+        public Task OnNextAsync(T item, StreamSequenceToken? token = null) => Task.CompletedTask;
+        public Task OnNextBatchAsync(IEnumerable<T> batch, StreamSequenceToken? token = null) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingConsumer<T> : IInternalAsyncObservable<T>
+    {
+        public List<StreamSubscriptionHandle<T>> ResumeHandles { get; } = [];
+        public List<IAsyncObserver<T>> ResumeObservers { get; } = [];
+        public List<IAsyncBatchObserver<T>> ResumeBatchObservers { get; } = [];
+        public List<StreamSequenceToken?> ResumeTokens { get; } = [];
+        public List<StreamSubscriptionHandle<T>> UnsubscribeHandles { get; } = [];
+        public StreamSubscriptionHandle<T>? Replacement { get; set; }
+        public Exception? ResumeException { get; set; }
+        public Exception? UnsubscribeException { get; set; }
+
+        public Task Cleanup() => Task.CompletedTask;
+
+        public Task<IList<StreamSubscriptionHandle<T>>> GetAllSubscriptions()
+            => Task.FromResult<IList<StreamSubscriptionHandle<T>>>([]);
+
+        public Task<StreamSubscriptionHandle<T>> ResumeAsync(
+            StreamSubscriptionHandle<T> handle,
+            IAsyncObserver<T> observer,
+            StreamSequenceToken? token = null)
+        {
+            ResumeHandles.Add(handle);
+            ResumeObservers.Add(observer);
+            ResumeTokens.Add(token);
+            return ResumeException is null
+                ? Task.FromResult(Replacement!)
+                : Task.FromException<StreamSubscriptionHandle<T>>(ResumeException);
+        }
+
+        public Task<StreamSubscriptionHandle<T>> ResumeAsync(
+            StreamSubscriptionHandle<T> handle,
+            IAsyncBatchObserver<T> observer,
+            StreamSequenceToken? token = null)
+        {
+            ResumeHandles.Add(handle);
+            ResumeBatchObservers.Add(observer);
+            ResumeTokens.Add(token);
+            return ResumeException is null
+                ? Task.FromResult(Replacement!)
+                : Task.FromException<StreamSubscriptionHandle<T>>(ResumeException);
+        }
+
+        public Task<StreamSubscriptionHandle<T>> SubscribeAsync(IAsyncObserver<T> observer)
+            => throw new NotSupportedException();
+
+        public Task<StreamSubscriptionHandle<T>> SubscribeAsync(
+            IAsyncObserver<T> observer,
+            StreamSequenceToken? token,
+            string? filterData = null)
+            => throw new NotSupportedException();
+
+        public Task<StreamSubscriptionHandle<T>> SubscribeAsync(IAsyncBatchObserver<T> observer)
+            => throw new NotSupportedException();
+
+        public Task<StreamSubscriptionHandle<T>> SubscribeAsync(
+            IAsyncBatchObserver<T> observer,
+            StreamSequenceToken? token)
+            => throw new NotSupportedException();
+
+        public Task UnsubscribeAsync(StreamSubscriptionHandle<T> handle)
+        {
+            UnsubscribeHandles.Add(handle);
+            return UnsubscribeException is null
+                ? Task.CompletedTask
+                : Task.FromException(UnsubscribeException);
+        }
+    }
+
+    private sealed class RecordingObserver<T> : IAsyncObserver<T>
+    {
+        private int nextCallCount;
+
+        public List<T> Items { get; } = [];
+        public List<StreamSequenceToken?> Tokens { get; } = [];
+        public List<object?> RequestContexts { get; } = [];
+        public List<Exception> Errors { get; } = [];
+        public List<string> Timeline { get; } = [];
+        public int? FailOnNextCall { get; set; }
+        public Exception? NextException { get; set; }
+        public Exception? CompletionException { get; set; }
+        public Exception? ErrorCallbackException { get; set; }
+        public int CompletionCalls { get; private set; }
+
+        public Task OnNextAsync(T item, StreamSequenceToken? token = null)
+        {
+            nextCallCount++;
+            Items.Add(item);
+            Tokens.Add(token);
+            RequestContexts.Add(RequestContext.Get(RequestContextKey));
+            Timeline.Add($"observer-attempt:{item}");
+            if (nextCallCount == FailOnNextCall)
+            {
+                return Task.FromException(NextException!);
+            }
+
+            Timeline.Add($"observer-accepted:{item}");
+            return Task.CompletedTask;
+        }
+
+        public Task OnCompletedAsync()
+        {
+            CompletionCalls++;
+            return CompletionException is null
+                ? Task.CompletedTask
+                : Task.FromException(CompletionException);
+        }
+
+        public Task OnErrorAsync(Exception ex)
+        {
+            Errors.Add(ex);
+            return ErrorCallbackException is null
+                ? Task.CompletedTask
+                : Task.FromException(ErrorCallbackException);
+        }
+    }
+
+    private const string RequestContextKey = "stream-subscription-handle-phase-1";
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void Constructor_RewindableHandle_PreservesExactIdentityAndStartToken()
+    {
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: false);
+        var streamId = StreamId.Create("orders", "rewindable");
+        var startToken = new EventSequenceTokenV2(17, 4);
+        var observer = new RecordingObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            token: startToken,
+            filterData: "region=west",
+            subscriptionId: subscriptionId,
+            streamId: streamId,
+            providerName: "rewindable-provider");
+
+        Assert.True(fixture.Handle.IsValid);
+        Assert.True(fixture.Handle.IsRewindable);
+        Assert.True(fixture.Handle.HasObserver);
+        Assert.Same(subscriptionId, fixture.Handle.SubscriptionId);
+        Assert.Equal(subscriptionId.Guid, fixture.Handle.HandleId);
+        Assert.Equal("rewindable-provider", fixture.Handle.ProviderName);
+        Assert.Equal(streamId, fixture.Handle.StreamId);
+        Assert.Equal("region=west", fixture.Handle.FilterData);
+        Assert.True(fixture.Handle.SameStreamId(fixture.Stream.InternalStreamId));
+        var handshake = Assert.IsType<StartToken>(fixture.Handle.GetSequenceToken());
+        Assert.Same(startToken, handshake.Token);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void Constructor_NonRewindableHandle_HasNoStartToken()
+    {
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: false);
+        var streamId = StreamId.Create("orders", "non-rewindable");
+        var suppliedToken = new EventSequenceTokenV2(23, 2);
+        var batchObserver = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: false,
+            batchObserver: batchObserver,
+            token: suppliedToken,
+            filterData: "priority",
+            subscriptionId: subscriptionId,
+            streamId: streamId,
+            providerName: "non-rewindable-provider");
+
+        Assert.True(fixture.Handle.IsValid);
+        Assert.False(fixture.Handle.IsRewindable);
+        Assert.True(fixture.Handle.HasObserver);
+        Assert.Same(subscriptionId, fixture.Handle.SubscriptionId);
+        Assert.Equal(subscriptionId.Guid, fixture.Handle.HandleId);
+        Assert.Equal("non-rewindable-provider", fixture.Handle.ProviderName);
+        Assert.Equal(streamId, fixture.Handle.StreamId);
+        Assert.Equal("priority", fixture.Handle.FilterData);
+        Assert.Null(fixture.Handle.GetSequenceToken());
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void Constructor_DisabledRewind_HasNoStartToken()
+    {
+        var suppliedToken = new EventSequenceTokenV2(29, 7);
+        var fixture = CreateFixture(
+            isRewindable: true,
+            token: suppliedToken,
+            disableHandshake: true);
+
+        Assert.True(fixture.Handle.IsValid);
+        Assert.False(fixture.Handle.IsRewindable);
+        Assert.Null(fixture.Handle.GetSequenceToken());
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task HandleId_RemainsStableAcrossDispatchAndTerminalCallbacks()
+    {
+        var dispatchId = CreateSubscriptionId(implicitSubscription: false);
+        var dispatchObserver = new RecordingObserver<int>();
+        var dispatch = CreateFixture(
+            isRewindable: true,
+            observer: dispatchObserver,
+            token: new EventSequenceTokenV2(30),
+            subscriptionId: dispatchId);
+        var dispatchToken = new EventSequenceTokenV2(31, 1);
+        await dispatch.Handle.DeliverItem(31, dispatchToken, dispatch.Handle.GetSequenceToken());
+
+        var completionId = CreateSubscriptionId(implicitSubscription: false);
+        var completionObserver = new RecordingObserver<int>();
+        var completion = CreateFixture(
+            isRewindable: false,
+            observer: completionObserver,
+            subscriptionId: completionId);
+        await completion.Handle.CompleteStream();
+
+        var errorId = CreateSubscriptionId(implicitSubscription: false);
+        var errorObserver = new RecordingBatchObserver<int>();
+        var error = CreateFixture(
+            isRewindable: false,
+            batchObserver: errorObserver,
+            subscriptionId: errorId);
+        var streamError = new InvalidOperationException("terminal");
+        await error.Handle.ErrorInStream(streamError);
+
+        Assert.Equal(dispatchId.Guid, dispatch.Handle.HandleId);
+        Assert.Equal(completionId.Guid, completion.Handle.HandleId);
+        Assert.Equal(errorId.Guid, error.Handle.HandleId);
+        Assert.Equal([31], dispatchObserver.Items);
+        Assert.Equal(1, completionObserver.CompletionCalls);
+        Assert.Same(streamError, Assert.Single(errorObserver.Errors));
+        AssertNoProviderAcquisitions(dispatch);
+        AssertNoProviderAcquisitions(completion);
+        AssertNoProviderAcquisitions(error);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void EqualityAndHashCode_AreBasedOnlyOnSubscriptionId()
+    {
+        var sharedId = CreateSubscriptionId(implicitSubscription: false);
+        var firstFixture = CreateFixture(
+            isRewindable: false,
+            subscriptionId: sharedId,
+            streamId: StreamId.Create("first", "stream"));
+        var sameIdFixture = CreateFixture(
+            isRewindable: true,
+            subscriptionId: sharedId,
+            streamId: StreamId.Create("second", "stream"));
+        var differentIdFixture = CreateFixture(
+            isRewindable: false,
+            subscriptionId: CreateSubscriptionId(implicitSubscription: false));
+        var first = firstFixture.Handle;
+        var sameIdDifferentStream = sameIdFixture.Handle;
+        var differentId = differentIdFixture.Handle;
+        var foreign = new ForeignSubscriptionHandle(first.StreamId);
+
+        Assert.Equal(first, sameIdDifferentStream);
+        Assert.True(first.Equals((object)sameIdDifferentStream));
+        Assert.Equal(first.GetHashCode(), sameIdDifferentStream.GetHashCode());
+        Assert.NotEqual(first, differentId);
+        Assert.False(first.Equals((StreamSubscriptionHandle<int>?)null));
+        Assert.False(first.Equals(foreign));
+        Assert.False(first.Equals(new object()));
+        AssertNoProviderAcquisitions(firstFixture);
+        AssertNoProviderAcquisitions(sameIdFixture);
+        AssertNoProviderAcquisitions(differentIdFixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void ToString_ReportsExactValidAndInvalidIdentity()
+    {
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: false);
+        var fixture = CreateFixture(
+            isRewindable: false,
+            subscriptionId: subscriptionId,
+            streamId: StreamId.Create("format", "identity"),
+            providerName: "format-provider");
+        var expectedStreamIdentity = fixture.Stream.InternalStreamId.ToString();
+
+        Assert.Equal(
+            $"StreamSubscriptionHandleImpl:Stream={expectedStreamIdentity},HandleId={subscriptionId.Guid}",
+            fixture.Handle.ToString());
+
+        fixture.Handle.Invalidate();
+
+        Assert.Equal(
+            $"StreamSubscriptionHandleImpl:Stream=null,HandleId={subscriptionId.Guid}",
+            fixture.Handle.ToString());
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void ValidateResumeToken_NonDeliveryExpectedToken_ReturnsExpectedToken()
+    {
+        var startToken = new EventSequenceTokenV2(40, 2);
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: new RecordingObserver<int>(),
+            token: startToken,
+            subscriptionId: CreateSubscriptionId(implicitSubscription: true));
+        var expected = fixture.Handle.GetSequenceToken();
+
+        fixture.Handle.ValidateResumeToken(new EventSequenceTokenV2(39, 9));
+
+        Assert.Same(expected, fixture.Handle.GetSequenceToken());
+        Assert.Same(startToken, Assert.IsType<StartToken>(expected).Token);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void ValidateResumeToken_WithoutObserver_ReturnsExpectedToken()
+    {
+        var acknowledgedToken = new EventSequenceTokenV2(41, 3);
+        var expected = StreamHandshakeToken.CreateDeliveyToken(acknowledgedToken);
+        var fixture = CreateFixture(
+            isRewindable: true,
+            handshakeState: new StreamSubscriptionHandleImpl<int>.SharedHandshakeState { Token = expected },
+            subscriptionId: CreateSubscriptionId(implicitSubscription: true));
+
+        fixture.Handle.ValidateResumeToken(new EventSequenceTokenV2(40, 8));
+
+        Assert.False(fixture.Handle.HasObserver);
+        Assert.Same(expected, fixture.Handle.GetSequenceToken());
+        Assert.Same(acknowledgedToken, Assert.IsType<DeliveryToken>(expected).Token);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void ValidateResumeToken_ExplicitSubscriptionId_ReturnsExpectedToken()
+    {
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: false);
+        var acknowledgedToken = new EventSequenceTokenV2(43, 5);
+        var expected = StreamHandshakeToken.CreateDeliveyToken(acknowledgedToken);
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: new RecordingObserver<int>(),
+            handshakeState: new StreamSubscriptionHandleImpl<int>.SharedHandshakeState { Token = expected },
+            subscriptionId: subscriptionId);
+
+        fixture.Handle.ValidateResumeToken(new EventSequenceTokenV2(42, 1));
+
+        Assert.Same(subscriptionId, fixture.Handle.SubscriptionId);
+        Assert.Equal(subscriptionId.Guid, fixture.Handle.HandleId);
+        Assert.Same(expected, fixture.Handle.GetSequenceToken());
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public void ValidateResumeToken_NullToken_UsesTheDocumentedInitialHandshake()
+    {
+        var acknowledgedToken = new EventSequenceTokenV2(44, 6);
+        var expected = StreamHandshakeToken.CreateDeliveyToken(acknowledgedToken);
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: new RecordingObserver<int>(),
+            handshakeState: new StreamSubscriptionHandleImpl<int>.SharedHandshakeState { Token = expected },
+            subscriptionId: CreateSubscriptionId(implicitSubscription: true));
+
+        fixture.Handle.ValidateResumeToken(token: null);
+
+        Assert.Same(expected, fixture.Handle.GetSequenceToken());
+        Assert.Same(acknowledgedToken, Assert.IsType<DeliveryToken>(fixture.Handle.GetSequenceToken()).Token);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverItem_MatchingHandshake_ForwardsExactItemAndTokenThenAcknowledges()
+    {
+        var startToken = new EventSequenceTokenV2(50);
+        var deliveredToken = new EventSequenceTokenV2(51, 2);
+        var observer = new RecordingObserver<int>();
+        var fixture = CreateFixture(isRewindable: true, observer: observer, token: startToken);
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName, observer.Timeline);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+        var expectedHandshake = fixture.Handle.GetSequenceToken();
+
+        var result = await fixture.Handle.DeliverItem(5102, deliveredToken, expectedHandshake);
+
+        Assert.Null(result);
+        Assert.Equal([5102], observer.Items);
+        Assert.Same(deliveredToken, Assert.Single(observer.Tokens));
+        Assert.Equal(
+            ["observer-attempt:5102", "observer-accepted:5102", "diagnostic:51:2"],
+            observer.Timeline);
+        AssertDeliveryHandshake(fixture.Handle, deliveredToken);
+        var diagnostic = Assert.Single(diagnostics.Items);
+        Assert.Equal(fixture.Handle.ProviderName, diagnostic.StreamProvider);
+        Assert.Equal(fixture.Handle.StreamId, diagnostic.StreamId);
+        Assert.Equal(fixture.Handle.HandleId, diagnostic.SubscriptionId);
+        Assert.Equal("phase-1-cluster", diagnostic.ClusterId);
+        Assert.Same(deliveredToken, diagnostic.SequenceToken);
+        Assert.Null(diagnostic.SiloAddress);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverItem_EventIndexedTokens_PreserveCallOrderAndTokenIdentity()
+    {
+        var token0 = new EventSequenceTokenV2(60, 0);
+        var token1 = new EventSequenceTokenV2(60, 1);
+        var token2 = new EventSequenceTokenV2(60, 2);
+        var observer = new RecordingObserver<string>();
+        var fixture = CreateStringFixture(observer, token0);
+
+        await fixture.Handle.DeliverItem("zero", token0, fixture.Handle.GetSequenceToken());
+        await fixture.Handle.DeliverItem("one", token1, fixture.Handle.GetSequenceToken());
+        await fixture.Handle.DeliverItem("two", token2, fixture.Handle.GetSequenceToken());
+
+        Assert.Equal(["zero", "one", "two"], observer.Items);
+        Assert.Collection(
+            observer.Tokens,
+            actual => Assert.Same(token0, actual),
+            actual => Assert.Same(token1, actual),
+            actual => Assert.Same(token2, actual));
+        Assert.Equal([60L, 60L, 60L], observer.Tokens.Select(token => token!.SequenceNumber));
+        Assert.Equal([0, 1, 2], observer.Tokens.Select(token => token!.EventIndex));
+        AssertDeliveryHandshake(fixture.Handle, token2);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_ItemObserver_PreservesItemOrderAndEventIndexedTokenIdentity()
+    {
+        var startToken = new EventSequenceTokenV2(69);
+        var token0 = new EventSequenceTokenV2(70, 0);
+        var token1 = new EventSequenceTokenV2(70, 1);
+        var token2 = new EventSequenceTokenV2(70, 2);
+        var observer = new RecordingObserver<int>();
+        var fixture = CreateFixture(isRewindable: true, observer: observer, token: startToken);
+        var batch = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            token2,
+            (700, token0),
+            (701, token1),
+            (702, token2));
+
+        var result = await fixture.Handle.DeliverBatch(batch, fixture.Handle.GetSequenceToken());
+
+        Assert.Null(result);
+        Assert.Equal([700, 701, 702], observer.Items);
+        Assert.Collection(
+            observer.Tokens,
+            actual => Assert.Same(token0, actual),
+            actual => Assert.Same(token1, actual),
+            actual => Assert.Same(token2, actual));
+        Assert.Equal([70L, 70L, 70L], observer.Tokens.Select(token => token!.SequenceNumber));
+        Assert.Equal([0, 1, 2], observer.Tokens.Select(token => token!.EventIndex));
+        AssertDeliveryHandshake(fixture.Handle, token2);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_BatchObserver_PreservesSequentialItemsAndTokenIdentity()
+    {
+        var startToken = new EventSequenceTokenV2(79);
+        var token0 = new EventSequenceTokenV2(80, 0);
+        var token1 = new EventSequenceTokenV2(80, 1);
+        var token2 = new EventSequenceTokenV2(80, 2);
+        var observer = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(isRewindable: true, batchObserver: observer, token: startToken);
+        var batch = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            token2,
+            (800, token0),
+            (801, token1),
+            (802, token2));
+
+        var result = await fixture.Handle.DeliverBatch(batch, fixture.Handle.GetSequenceToken());
+
+        Assert.Null(result);
+        var delivered = Assert.Single(observer.Batches);
+        Assert.Equal([800, 801, 802], delivered.Select(item => item.Item));
+        Assert.Collection(
+            delivered,
+            item => Assert.Same(token0, item.Token),
+            item => Assert.Same(token1, item.Token),
+            item => Assert.Same(token2, item.Token));
+        Assert.Equal([80L, 80L, 80L], delivered.Select(item => item.Token.SequenceNumber));
+        Assert.Equal([0, 1, 2], delivered.Select(item => item.Token.EventIndex));
+        AssertDeliveryHandshake(fixture.Handle, token2);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_EmptyBatch_DoesNotInvokeBatchObserver()
+    {
+        var startToken = new EventSequenceTokenV2(89);
+        var batchToken = new EventSequenceTokenV2(90);
+        var observer = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(isRewindable: true, batchObserver: observer, token: startToken);
+        var batch = new TestBatchContainer(fixture.Handle.StreamId, batchToken);
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+
+        var result = await fixture.Handle.DeliverBatch(batch, fixture.Handle.GetSequenceToken());
+
+        Assert.Null(result);
+        Assert.Empty(observer.Batches);
+        Assert.Empty(diagnostics.Items);
+        AssertDeliveryHandshake(fixture.Handle, batchToken);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_ContainerBatch_ItemObserver_PreservesInnerOrderAndRequestContextScopes()
+    {
+        RequestContext.Clear();
+        var firstToken = new EventSequenceTokenV2(100, 0);
+        var secondToken = new EventSequenceTokenV2(101, 0);
+        var thirdToken = new EventSequenceTokenV2(101, 1);
+        var observer = new RecordingObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            token: new EventSequenceTokenV2(99));
+        var first = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            firstToken,
+            contextValue: "first-context",
+            (1000, firstToken));
+        var second = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            thirdToken,
+            contextValue: "second-context",
+            (1010, secondToken),
+            (1011, thirdToken));
+        var batch = new TestBatchContainerBatch(
+            fixture.Handle.StreamId,
+            thirdToken,
+            first,
+            second);
+
+        try
+        {
+            var result = await fixture.Handle.DeliverBatch(batch, fixture.Handle.GetSequenceToken());
+
+            Assert.Null(result);
+            Assert.Equal([1000, 1010, 1011], observer.Items);
+            Assert.Equal(["first-context", "second-context", "second-context"], observer.RequestContexts);
+            Assert.Equal(1, first.ImportRequestContextCalls);
+            Assert.Equal(1, second.ImportRequestContextCalls);
+            Assert.Equal([null], first.ContextBeforeImport);
+            Assert.Equal([null], second.ContextBeforeImport);
+            Assert.Null(RequestContext.Get(RequestContextKey));
+            AssertDeliveryHandshake(fixture.Handle, thirdToken);
+            AssertNoProviderAcquisitions(fixture);
+        }
+        finally
+        {
+            RequestContext.Clear();
+        }
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_ContainerBatch_BatchObserver_FlattensWithoutReordering()
+    {
+        var token0 = new EventSequenceTokenV2(110, 0);
+        var token1 = new EventSequenceTokenV2(111, 0);
+        var token2 = new EventSequenceTokenV2(111, 1);
+        var observer = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: true,
+            batchObserver: observer,
+            token: new EventSequenceTokenV2(109));
+        var first = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            token0,
+            contextValue: "not-imported-first",
+            (1100, token0));
+        var second = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            token2,
+            contextValue: "not-imported-second",
+            (1110, token1),
+            (1111, token2));
+        var batch = new TestBatchContainerBatch(fixture.Handle.StreamId, token2, first, second);
+
+        var result = await fixture.Handle.DeliverBatch(batch, fixture.Handle.GetSequenceToken());
+
+        Assert.Null(result);
+        var delivered = Assert.Single(observer.Batches);
+        Assert.Equal([1100, 1110, 1111], delivered.Select(item => item.Item));
+        Assert.Collection(
+            delivered,
+            item => Assert.Same(token0, item.Token),
+            item => Assert.Same(token1, item.Token),
+            item => Assert.Same(token2, item.Token));
+        Assert.Equal(0, first.ImportRequestContextCalls);
+        Assert.Equal(0, second.ImportRequestContextCalls);
+        AssertDeliveryHandshake(fixture.Handle, token2);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_AcceptedItems_EmitOneDiagnosticEachAfterAcceptanceWithExactMetadata()
+    {
+        var token0 = new EventSequenceTokenV2(120, 0);
+        var token1 = new EventSequenceTokenV2(120, 1);
+        var observer = new RecordingObserver<int>();
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: false);
+        var streamId = StreamId.Create("diagnostics", "metadata");
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            token: new EventSequenceTokenV2(119),
+            subscriptionId: subscriptionId,
+            streamId: streamId,
+            providerName: "diagnostic-provider",
+            clusterId: "diagnostic-cluster");
+        var batch = new TestBatchContainer(
+            streamId,
+            token1,
+            (1200, token0),
+            (1201, token1));
+        var diagnostics = new RecordingStreamingEventObserver("diagnostic-provider", observer.Timeline);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+
+        await fixture.Handle.DeliverBatch(batch, fixture.Handle.GetSequenceToken());
+
+        Assert.Equal(
+            [
+                "observer-attempt:1200",
+                "observer-accepted:1200",
+                "diagnostic:120:0",
+                "observer-attempt:1201",
+                "observer-accepted:1201",
+                "diagnostic:120:1",
+            ],
+            observer.Timeline);
+        Assert.Collection(
+            diagnostics.Items,
+            item =>
+            {
+                Assert.Equal("diagnostic-provider", item.StreamProvider);
+                Assert.Equal(streamId, item.StreamId);
+                Assert.Equal(subscriptionId.Guid, item.SubscriptionId);
+                Assert.Equal("diagnostic-cluster", item.ClusterId);
+                Assert.Null(item.SiloAddress);
+                Assert.Same(token0, item.SequenceToken);
+            },
+            item =>
+            {
+                Assert.Equal("diagnostic-provider", item.StreamProvider);
+                Assert.Equal(streamId, item.StreamId);
+                Assert.Equal(subscriptionId.Guid, item.SubscriptionId);
+                Assert.Equal("diagnostic-cluster", item.ClusterId);
+                Assert.Null(item.SiloAddress);
+                Assert.Same(token1, item.SequenceToken);
+            });
+        AssertDeliveryHandshake(fixture.Handle, token1);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverItem_ObserverFailsOnce_PropagatesSameExceptionAndRetryRedeliversThenAcknowledges()
+    {
+        var startToken = new EventSequenceTokenV2(129);
+        var deliveredToken = new EventSequenceTokenV2(130, 4);
+        var expectedFailure = new InvalidOperationException("fail once");
+        var observer = new RecordingObserver<int>
+        {
+            FailOnNextCall = 1,
+            NextException = expectedFailure,
+        };
+        var fixture = CreateFixture(isRewindable: true, observer: observer, token: startToken);
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+        var expectedHandshake = fixture.Handle.GetSequenceToken();
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.Handle.DeliverItem(1304, deliveredToken, expectedHandshake));
+
+        Assert.Same(expectedFailure, failure);
+        Assert.Same(expectedHandshake, fixture.Handle.GetSequenceToken());
+        Assert.Equal([1304], observer.Items);
+        Assert.Empty(diagnostics.Items);
+
+        var result = await fixture.Handle.DeliverItem(1304, deliveredToken, expectedHandshake);
+
+        Assert.Null(result);
+        Assert.Equal([1304, 1304], observer.Items);
+        Assert.Collection(
+            observer.Tokens,
+            actual => Assert.Same(deliveredToken, actual),
+            actual => Assert.Same(deliveredToken, actual));
+        Assert.Same(deliveredToken, Assert.Single(diagnostics.Items).SequenceToken);
+        AssertDeliveryHandshake(fixture.Handle, deliveredToken);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_ItemObserverFailsAtItemN_RetryRedeliversWholeBatchInExactOrder()
+    {
+        var token0 = new EventSequenceTokenV2(140, 0);
+        var token1 = new EventSequenceTokenV2(140, 1);
+        var token2 = new EventSequenceTokenV2(140, 2);
+        var expectedFailure = new InvalidOperationException("second item fails once");
+        var observer = new RecordingObserver<int>
+        {
+            FailOnNextCall = 2,
+            NextException = expectedFailure,
+        };
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            token: new EventSequenceTokenV2(139));
+        var batch = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            token2,
+            (1400, token0),
+            (1401, token1),
+            (1402, token2));
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+        var expectedHandshake = fixture.Handle.GetSequenceToken();
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.Handle.DeliverBatch(batch, expectedHandshake));
+
+        Assert.Same(expectedFailure, failure);
+        Assert.Equal([1400, 1401], observer.Items);
+        Assert.Same(expectedHandshake, fixture.Handle.GetSequenceToken());
+        Assert.Same(token0, Assert.Single(diagnostics.Items).SequenceToken);
+
+        var result = await fixture.Handle.DeliverBatch(batch, expectedHandshake);
+
+        Assert.Null(result);
+        Assert.Equal([1400, 1401, 1400, 1401, 1402], observer.Items);
+        Assert.Collection(
+            diagnostics.Items,
+            item => Assert.Same(token0, item.SequenceToken),
+            item => Assert.Same(token0, item.SequenceToken),
+            item => Assert.Same(token1, item.SequenceToken),
+            item => Assert.Same(token2, item.SequenceToken));
+        AssertDeliveryHandshake(fixture.Handle, token2);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_BatchObserverFailsOnce_EmitsNoDiagnosticsUntilRetrySucceeds()
+    {
+        var token0 = new EventSequenceTokenV2(150, 0);
+        var token1 = new EventSequenceTokenV2(150, 1);
+        var expectedFailure = new InvalidOperationException("batch fails once");
+        var observer = new RecordingBatchObserver<int>
+        {
+            FailOnNextCall = 1,
+            NextException = expectedFailure,
+        };
+        var fixture = CreateFixture(
+            isRewindable: true,
+            batchObserver: observer,
+            token: new EventSequenceTokenV2(149));
+        var batch = new TestBatchContainer(
+            fixture.Handle.StreamId,
+            token1,
+            (1500, token0),
+            (1501, token1));
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+        var expectedHandshake = fixture.Handle.GetSequenceToken();
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.Handle.DeliverBatch(batch, expectedHandshake));
+
+        Assert.Same(expectedFailure, failure);
+        Assert.Same(expectedHandshake, fixture.Handle.GetSequenceToken());
+        Assert.Empty(diagnostics.Items);
+        Assert.Single(observer.Batches);
+
+        var result = await fixture.Handle.DeliverBatch(batch, expectedHandshake);
+
+        Assert.Null(result);
+        Assert.Equal(2, observer.Batches.Count);
+        Assert.All(observer.Batches, delivered => Assert.Equal([1500, 1501], delivered.Select(item => item.Item)));
+        Assert.All(
+            observer.Batches,
+            delivered => Assert.Collection(
+                delivered,
+                item => Assert.Same(token0, item.Token),
+                item => Assert.Same(token1, item.Token)));
+        Assert.Collection(
+            diagnostics.Items,
+            item => Assert.Same(token0, item.SequenceToken),
+            item => Assert.Same(token1, item.SequenceToken));
+        AssertDeliveryHandshake(fixture.Handle, token1);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverItem_MismatchedHandshake_ReturnsExpectedTokenWithoutSideEffects()
+    {
+        var observer = new RecordingObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            token: new EventSequenceTokenV2(159));
+        var expected = fixture.Handle.GetSequenceToken();
+        var mismatched = StreamHandshakeToken.CreateStartToken(new EventSequenceTokenV2(158));
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+
+        var result = await fixture.Handle.DeliverItem(1600, new EventSequenceTokenV2(160), mismatched);
+
+        Assert.Same(expected, result);
+        Assert.Same(expected, fixture.Handle.GetSequenceToken());
+        Assert.Empty(observer.Items);
+        Assert.Empty(diagnostics.Items);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_MismatchedHandshake_ReturnsExpectedTokenWithoutSideEffects()
+    {
+        var observer = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: true,
+            batchObserver: observer,
+            token: new EventSequenceTokenV2(169));
+        var expected = fixture.Handle.GetSequenceToken();
+        var token = new EventSequenceTokenV2(170);
+        var batch = new TestBatchContainer(fixture.Handle.StreamId, token, (1700, token));
+        var mismatched = StreamHandshakeToken.CreateStartToken(new EventSequenceTokenV2(168));
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+
+        var result = await fixture.Handle.DeliverBatch(batch, mismatched);
+
+        Assert.Same(expected, result);
+        Assert.Same(expected, fixture.Handle.GetSequenceToken());
+        Assert.Empty(observer.Batches);
+        Assert.Empty(diagnostics.Items);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverBatch_AcknowledgedDuplicate_ReturnsExpectedTokenWithoutRedelivery()
+    {
+        var token = new EventSequenceTokenV2(180, 3);
+        var expected = StreamHandshakeToken.CreateDeliveyToken(token);
+        var observer = new RecordingObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            handshakeState: new StreamSubscriptionHandleImpl<int>.SharedHandshakeState { Token = expected });
+        var batch = new TestBatchContainer(fixture.Handle.StreamId, token, (1803, token));
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+
+        var result = await fixture.Handle.DeliverBatch(batch, expected);
+
+        Assert.Same(expected, result);
+        Assert.Same(expected, fixture.Handle.GetSequenceToken());
+        Assert.Empty(observer.Items);
+        Assert.Empty(diagnostics.Items);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Theory, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public async Task CompleteStream_ForwardsOrPropagatesExactly(int mode)
+    {
+        var itemObserver = mode is 0 or 2 ? new RecordingObserver<int>() : null;
+        var batchObserver = mode is 1 or 3 ? new RecordingBatchObserver<int>() : null;
+        var expectedFailure = new InvalidOperationException("completion callback failed");
+        if (mode == 2)
+        {
+            itemObserver!.CompletionException = expectedFailure;
+        }
+        else if (mode == 3)
+        {
+            batchObserver!.CompletionException = expectedFailure;
+        }
+
+        var fixture = CreateFixture(
+            isRewindable: false,
+            observer: itemObserver,
+            batchObserver: batchObserver);
+
+        if (mode is 2 or 3)
+        {
+            var failure = await Assert.ThrowsAsync<InvalidOperationException>(fixture.Handle.CompleteStream);
+            Assert.Same(expectedFailure, failure);
+        }
+        else
+        {
+            var task = fixture.Handle.CompleteStream();
+            Assert.True(task.IsCompletedSuccessfully);
+            await task;
+        }
+
+        Assert.Equal(mode is 0 or 2 ? 1 : 0, itemObserver?.CompletionCalls ?? 0);
+        Assert.Equal(mode is 1 or 3 ? 1 : 0, batchObserver?.CompletionCalls ?? 0);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Theory, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public async Task ErrorInStream_ForwardsOrPropagatesExactly(int mode)
+    {
+        var itemObserver = mode is 0 or 2 ? new RecordingObserver<int>() : null;
+        var batchObserver = mode is 1 or 3 ? new RecordingBatchObserver<int>() : null;
+        var streamError = new InvalidOperationException("stream error");
+        var callbackFailure = new ApplicationException("error callback failed");
+        if (mode == 2)
+        {
+            itemObserver!.ErrorCallbackException = callbackFailure;
+        }
+        else if (mode == 3)
+        {
+            batchObserver!.ErrorCallbackException = callbackFailure;
+        }
+
+        var fixture = CreateFixture(
+            isRewindable: false,
+            observer: itemObserver,
+            batchObserver: batchObserver);
+
+        if (mode is 2 or 3)
+        {
+            var failure = await Assert.ThrowsAsync<ApplicationException>(
+                () => fixture.Handle.ErrorInStream(streamError));
+            Assert.Same(callbackFailure, failure);
+        }
+        else
+        {
+            var task = fixture.Handle.ErrorInStream(streamError);
+            Assert.True(task.IsCompletedSuccessfully);
+            await task;
+        }
+
+        if (itemObserver is not null)
+        {
+            Assert.Same(streamError, Assert.Single(itemObserver.Errors));
+        }
+        else if (batchObserver is not null)
+        {
+            Assert.Same(streamError, Assert.Single(batchObserver.Errors));
+        }
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Theory, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    [InlineData(false, false, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    [InlineData(true, true, true)]
+    public async Task ResumeAsync_DelegatesExactArgumentsAndPreservesResultOrException(
+        bool useBatchObserver,
+        bool supplyToken,
+        bool fail)
+    {
+        var fixture = CreateFixture(isRewindable: false);
+        var replacement = CreateFixture(
+            isRewindable: false,
+            subscriptionId: fixture.Handle.SubscriptionId).Handle;
+        var token = supplyToken ? new EventSequenceTokenV2(190, 7) : null;
+        var expectedFailure = new InvalidOperationException("resume failed");
+        fixture.Provider.Consumer.Replacement = replacement;
+        fixture.Provider.Consumer.ResumeException = fail ? expectedFailure : null;
+        var itemObserver = new RecordingObserver<int>();
+        var batchObserver = new RecordingBatchObserver<int>();
+
+        Task<StreamSubscriptionHandle<int>> operation = useBatchObserver
+            ? fixture.Handle.ResumeAsync(batchObserver, token)
+            : fixture.Handle.ResumeAsync(itemObserver, token);
+
+        if (fail)
+        {
+            var failure = await Assert.ThrowsAsync<InvalidOperationException>(() => operation);
+            Assert.Same(expectedFailure, failure);
+        }
+        else
+        {
+            Assert.Same(replacement, await operation);
+        }
+
+        Assert.Same(fixture.Handle, Assert.Single(fixture.Provider.Consumer.ResumeHandles));
+        Assert.Same(token, Assert.Single(fixture.Provider.Consumer.ResumeTokens));
+        if (useBatchObserver)
+        {
+            Assert.Same(batchObserver, Assert.Single(fixture.Provider.Consumer.ResumeBatchObservers));
+            Assert.Empty(fixture.Provider.Consumer.ResumeObservers);
+        }
+        else
+        {
+            Assert.Same(itemObserver, Assert.Single(fixture.Provider.Consumer.ResumeObservers));
+            Assert.Empty(fixture.Provider.Consumer.ResumeBatchObservers);
+        }
+        Assert.Equal(1, fixture.Provider.ConsumerInterfaceAcquisitions);
+        Assert.Equal(0, fixture.Provider.ProducerInterfaceAcquisitions);
+    }
+
+    [Theory, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UnsubscribeAsync_DelegatesExactHandleAndPropagatesSameException(bool fail)
+    {
+        var fixture = CreateFixture(isRewindable: false);
+        var expectedFailure = new InvalidOperationException("unsubscribe failed");
+        fixture.Provider.Consumer.UnsubscribeException = fail ? expectedFailure : null;
+
+        var operation = fixture.Handle.UnsubscribeAsync();
+        if (fail)
+        {
+            var failure = await Assert.ThrowsAsync<InvalidOperationException>(() => operation);
+            Assert.Same(expectedFailure, failure);
+        }
+        else
+        {
+            await operation;
+            Assert.True(operation.IsCompletedSuccessfully);
+        }
+
+        Assert.Same(fixture.Handle, Assert.Single(fixture.Provider.Consumer.UnsubscribeHandles));
+        Assert.Equal(1, fixture.Provider.ConsumerInterfaceAcquisitions);
+        Assert.Equal(0, fixture.Provider.ProducerInterfaceAcquisitions);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task Invalidate_ClearsStreamAndObserversAndMarksHandleInvalid()
+    {
+        var subscriptionId = CreateSubscriptionId(implicitSubscription: false);
+        var itemObserver = new RecordingObserver<int>();
+        var batchObserver = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: false,
+            observer: itemObserver,
+            batchObserver: batchObserver,
+            subscriptionId: subscriptionId);
+
+        fixture.Handle.Invalidate();
+        await fixture.Handle.CompleteStream();
+        await fixture.Handle.ErrorInStream(new InvalidOperationException("ignored"));
+
+        Assert.False(fixture.Handle.IsValid);
+        Assert.False(fixture.Handle.HasObserver);
+        Assert.Equal(subscriptionId.Guid, fixture.Handle.HandleId);
+        Assert.Equal(0, itemObserver.CompletionCalls);
+        Assert.Empty(itemObserver.Errors);
+        Assert.Equal(0, batchObserver.CompletionCalls);
+        Assert.Empty(batchObserver.Errors);
+        Assert.Throws<NullReferenceException>(() => fixture.Handle.ProviderName);
+        Assert.Throws<NullReferenceException>(() => fixture.Handle.StreamId);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task InvalidHandle_IgnoresDeliveryCompletionAndErrorWithoutProviderAccess()
+    {
+        var itemObserver = new RecordingObserver<int>();
+        var batchObserver = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(
+            isRewindable: false,
+            observer: itemObserver,
+            batchObserver: batchObserver);
+        var token = new EventSequenceTokenV2(200);
+        var batch = new TestBatchContainer(fixture.Handle.StreamId, token, (2000, token));
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+        fixture.Handle.Invalidate();
+
+        var itemResult = await fixture.Handle.DeliverItem(2000, token, handshakeToken: null);
+        var batchResult = await fixture.Handle.DeliverBatch(batch, handshakeToken: null);
+        var completion = fixture.Handle.CompleteStream();
+        var error = fixture.Handle.ErrorInStream(new InvalidOperationException("ignored"));
+        await Task.WhenAll(completion, error);
+
+        Assert.Null(itemResult);
+        Assert.Null(batchResult);
+        Assert.True(completion.IsCompletedSuccessfully);
+        Assert.True(error.IsCompletedSuccessfully);
+        Assert.Empty(itemObserver.Items);
+        Assert.Equal(0, itemObserver.CompletionCalls);
+        Assert.Empty(itemObserver.Errors);
+        Assert.Empty(batchObserver.Batches);
+        Assert.Equal(0, batchObserver.CompletionCalls);
+        Assert.Empty(batchObserver.Errors);
+        Assert.Empty(diagnostics.Items);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Theory, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public async Task InvalidHandle_ResumeAndUnsubscribeFailImmediatelyWithoutProviderAccess(int operation)
+    {
+        var fixture = CreateFixture(isRewindable: false);
+        var itemObserver = new RecordingObserver<int>();
+        var batchObserver = new RecordingBatchObserver<int>();
+        var token = new EventSequenceTokenV2(210, 6);
+        fixture.Handle.Invalidate();
+
+        var failure = operation switch
+        {
+            0 => await Assert.ThrowsAsync<InvalidOperationException>(
+                () => fixture.Handle.ResumeAsync(itemObserver)),
+            1 => await Assert.ThrowsAsync<InvalidOperationException>(
+                () => fixture.Handle.ResumeAsync(itemObserver, token)),
+            2 => await Assert.ThrowsAsync<InvalidOperationException>(
+                () => fixture.Handle.ResumeAsync(batchObserver)),
+            3 => await Assert.ThrowsAsync<InvalidOperationException>(
+                () => fixture.Handle.ResumeAsync(batchObserver, token)),
+            _ => await Assert.ThrowsAsync<InvalidOperationException>(fixture.Handle.UnsubscribeAsync),
+        };
+
+        Assert.Equal(
+            "Handle is no longer valid. It has been used to unsubscribe or resume.",
+            failure.Message);
+        Assert.Empty(fixture.Provider.Consumer.ResumeHandles);
+        Assert.Empty(fixture.Provider.Consumer.UnsubscribeHandles);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverItem_BatchObserver_ForwardsOneExactSequentialItemAndAdvancesExactDeliveryToken()
+    {
+        var startToken = new EventSequenceTokenV2(220, 1);
+        var deliveredToken = new EventSequenceTokenV2(221, 7);
+        var observer = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(isRewindable: true, batchObserver: observer, token: startToken);
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+        var expectedHandshake = fixture.Handle.GetSequenceToken();
+
+        var result = await fixture.Handle.DeliverItem(2217, deliveredToken, expectedHandshake);
+
+        Assert.Null(result);
+        var batch = Assert.Single(observer.Batches);
+        var item = Assert.Single(batch);
+        Assert.Equal(2217, item.Item);
+        Assert.Same(deliveredToken, item.Token);
+        Assert.Equal(221L, item.Token.SequenceNumber);
+        Assert.Equal(7, item.Token.EventIndex);
+        AssertDeliveryHandshake(fixture.Handle, deliveredToken);
+        var diagnostic = Assert.Single(diagnostics.Items);
+        Assert.Same(deliveredToken, diagnostic.SequenceToken);
+        Assert.Equal(fixture.Handle.HandleId, diagnostic.SubscriptionId);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverItem_WrongItemType_ThrowsDocumentedInvalidCastWithoutSideEffects()
+    {
+        var startToken = new EventSequenceTokenV2(230, 2);
+        var deliveredToken = new EventSequenceTokenV2(231, 3);
+        var observer = new RecordingBatchObserver<int>();
+        var fixture = CreateFixture(isRewindable: true, batchObserver: observer, token: startToken);
+        var diagnostics = new RecordingStreamingEventObserver(fixture.Handle.ProviderName);
+        using var subscription = Orleans.Streaming.Diagnostics.StreamingEvents.AllEvents.Subscribe(diagnostics);
+        var expectedHandshake = fixture.Handle.GetSequenceToken();
+
+        var exception = await Assert.ThrowsAsync<InvalidCastException>(
+            () => fixture.Handle.DeliverItem("not-an-int", deliveredToken, expectedHandshake));
+
+        Assert.Equal("Received an item of type String, expected System.Int32", exception.Message);
+        Assert.Same(expectedHandshake, fixture.Handle.GetSequenceToken());
+        Assert.Empty(observer.Batches);
+        Assert.Empty(observer.Errors);
+        Assert.Equal(0, observer.CompletionCalls);
+        Assert.Empty(diagnostics.Items);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    [Fact, TestSuite("BVT"), TestProvider("None"), TestArea("Streaming")]
+    public async Task DeliverItem_ObserverReplacesHandshakeDuringAcceptance_ReturnsReplacementWithoutOverwritingIt()
+    {
+        var initialSequenceToken = new EventSequenceTokenV2(240, 4);
+        var initialHandshake = StreamHandshakeToken.CreateStartToken(initialSequenceToken);
+        var replacementSequenceToken = new EventSequenceTokenV2(300, 6);
+        var replacementHandshake = StreamHandshakeToken.CreateStartToken(replacementSequenceToken);
+        var deliveredToken = new EventSequenceTokenV2(241, 5);
+        var handshakeState = new StreamSubscriptionHandleImpl<int>.SharedHandshakeState { Token = initialHandshake };
+        var observer = new HandshakeReplacingObserver<int>(
+            () => handshakeState.Token = replacementHandshake);
+        var fixture = CreateFixture(
+            isRewindable: true,
+            observer: observer,
+            handshakeState: handshakeState);
+
+        var result = await fixture.Handle.DeliverItem(2415, deliveredToken, initialHandshake);
+
+        Assert.Same(replacementHandshake, result);
+        Assert.Same(replacementHandshake, handshakeState.Token);
+        Assert.Same(replacementHandshake, fixture.Handle.GetSequenceToken());
+        Assert.Same(replacementSequenceToken, Assert.IsType<StartToken>(fixture.Handle.GetSequenceToken()).Token);
+        Assert.Equal([2415], observer.Items);
+        Assert.Same(deliveredToken, Assert.Single(observer.Tokens));
+        Assert.Equal(1, observer.ReplacementCalls);
+        AssertNoProviderAcquisitions(fixture);
+    }
+
+    private static void AssertNoProviderAcquisitions(HandleFixture fixture)
+    {
+        Assert.Equal(0, fixture.Provider.ConsumerInterfaceAcquisitions);
+        Assert.Equal(0, fixture.Provider.ProducerInterfaceAcquisitions);
+    }
+
+    private static void AssertDeliveryHandshake(
+        StreamSubscriptionHandleImpl<int> handle,
+        StreamSequenceToken expectedToken)
+    {
+        Assert.Same(expectedToken, Assert.IsType<DeliveryToken>(handle.GetSequenceToken()).Token);
+    }
+
+    private static void AssertDeliveryHandshake(
+        StreamSubscriptionHandleImpl<string> handle,
+        StreamSequenceToken expectedToken)
+    {
+        Assert.Same(expectedToken, Assert.IsType<DeliveryToken>(handle.GetSequenceToken()).Token);
+    }
+
+    private static StringHandleFixture CreateStringFixture(
+        IAsyncObserver<string> observer,
+        StreamSequenceToken token)
+    {
+        var provider = new CountingStreamProvider<string>();
+        var streamId = StreamId.Create("phase-1", Guid.NewGuid());
+        var qualifiedStreamId = new QualifiedStreamId($"phase-1-provider-{Guid.NewGuid():N}", streamId);
+        var runtimeClient = NSubstitute.Substitute.For<IRuntimeClient>();
+        var stream = new StreamImpl<string>(qualifiedStreamId, provider, isRewindable: true, runtimeClient);
+        var handle = new StreamSubscriptionHandleImpl<string>(
+            CreateSubscriptionId(implicitSubscription: false),
+            observer,
+            batchObserver: null,
+            stream,
+            token,
+            filterData: null,
+            clusterId: "phase-1-cluster");
+        return new(handle, provider);
+    }
+
+    private static void AssertNoProviderAcquisitions(StringHandleFixture fixture)
+    {
+        Assert.Equal(0, fixture.Provider.ConsumerInterfaceAcquisitions);
+        Assert.Equal(0, fixture.Provider.ProducerInterfaceAcquisitions);
+    }
+
+    private sealed record StringHandleFixture(
+        StreamSubscriptionHandleImpl<string> Handle,
+        CountingStreamProvider<string> Provider);
+
+    private sealed class RecordingBatchObserver<T> : IAsyncBatchObserver<T>
+    {
+        private int nextCallCount;
+
+        public List<IList<SequentialItem<T>>> Batches { get; } = [];
+        public List<Exception> Errors { get; } = [];
+        public int? FailOnNextCall { get; set; }
+        public Exception? NextException { get; set; }
+        public Exception? CompletionException { get; set; }
+        public Exception? ErrorCallbackException { get; set; }
+        public int CompletionCalls { get; private set; }
+
+        public Task OnNextAsync(IList<SequentialItem<T>> items)
+        {
+            nextCallCount++;
+            Batches.Add(items.ToList());
+            return nextCallCount == FailOnNextCall
+                ? Task.FromException(NextException!)
+                : Task.CompletedTask;
+        }
+
+        public Task OnCompletedAsync()
+        {
+            CompletionCalls++;
+            return CompletionException is null
+                ? Task.CompletedTask
+                : Task.FromException(CompletionException);
+        }
+
+        public Task OnErrorAsync(Exception ex)
+        {
+            Errors.Add(ex);
+            return ErrorCallbackException is null
+                ? Task.CompletedTask
+                : Task.FromException(ErrorCallbackException);
+        }
+    }
+
+    private sealed class TestBatchContainer : IBatchContainer
+    {
+        private readonly (int Item, StreamSequenceToken Token)[] events;
+        private readonly object? contextValue;
+
+        public TestBatchContainer(
+            StreamId streamId,
+            StreamSequenceToken sequenceToken,
+            params (int Item, StreamSequenceToken Token)[] events)
+            : this(streamId, sequenceToken, contextValue: null, events)
+        {
+        }
+
+        public TestBatchContainer(
+            StreamId streamId,
+            StreamSequenceToken sequenceToken,
+            object? contextValue,
+            params (int Item, StreamSequenceToken Token)[] events)
+        {
+            StreamId = streamId;
+            SequenceToken = sequenceToken;
+            this.contextValue = contextValue;
+            this.events = events;
+        }
+
+        public StreamId StreamId { get; }
+        public StreamSequenceToken SequenceToken { get; }
+        public int ImportRequestContextCalls { get; private set; }
+        public List<object?> ContextBeforeImport { get; } = [];
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
+            => events.Select(item => Tuple.Create((T)(object)item.Item, item.Token));
+
+        public bool ImportRequestContext()
+        {
+            ImportRequestContextCalls++;
+            ContextBeforeImport.Add(RequestContext.Get(RequestContextKey));
+            if (contextValue is null)
+            {
+                return false;
+            }
+
+            RequestContext.Set(RequestContextKey, contextValue);
+            return true;
+        }
+    }
+
+    private sealed class TestBatchContainerBatch(
+        StreamId streamId,
+        StreamSequenceToken sequenceToken,
+        params IBatchContainer[] batchContainers) : IBatchContainerBatch
+    {
+        public List<IBatchContainer> BatchContainers { get; } = [.. batchContainers];
+        public StreamId StreamId { get; } = streamId;
+        public StreamSequenceToken SequenceToken { get; } = sequenceToken;
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
+            => throw new InvalidOperationException("The outer container must be flattened through BatchContainers.");
+
+        public bool ImportRequestContext()
+            => throw new InvalidOperationException("The outer container must not import request context.");
+    }
+
+    private sealed class RecordingStreamingEventObserver(
+        string providerName,
+        List<string>? timeline = null)
+        : IObserver<Orleans.Streaming.Diagnostics.StreamingEvents.StreamingEvent>
+    {
+        public List<Orleans.Streaming.Diagnostics.StreamingEvents.ItemDelivered> Items { get; } = [];
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+            throw error;
+        }
+
+        public void OnNext(Orleans.Streaming.Diagnostics.StreamingEvents.StreamingEvent value)
+        {
+            if (value is Orleans.Streaming.Diagnostics.StreamingEvents.ItemDelivered item
+                && string.Equals(providerName, item.StreamProvider, StringComparison.Ordinal))
+            {
+                Items.Add(item);
+                timeline?.Add($"diagnostic:{item.SequenceToken!.SequenceNumber}:{item.SequenceToken.EventIndex}");
+            }
+        }
+    }
+
+    private sealed class ForeignSubscriptionHandle(StreamId streamId) : StreamSubscriptionHandle<int>
+    {
+        public override Guid HandleId { get; } = Guid.NewGuid();
+        public override string ProviderName => "foreign";
+        public override StreamId StreamId { get; } = streamId;
+
+        public override bool Equals(StreamSubscriptionHandle<int>? other) => ReferenceEquals(this, other);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj);
+        public override int GetHashCode() => HandleId.GetHashCode();
+
+        public override Task<StreamSubscriptionHandle<int>> ResumeAsync(
+            IAsyncObserver<int> observer,
+            StreamSequenceToken? token = null)
+            => throw new NotSupportedException();
+
+        public override Task<StreamSubscriptionHandle<int>> ResumeAsync(
+            IAsyncBatchObserver<int> observer,
+            StreamSequenceToken? token = null)
+            => throw new NotSupportedException();
+
+        public override Task UnsubscribeAsync() => throw new NotSupportedException();
+    }
+
+    private sealed class HandshakeReplacingObserver<T>(Action replaceHandshake) : IAsyncObserver<T>
+    {
+        public List<T> Items { get; } = [];
+        public List<StreamSequenceToken?> Tokens { get; } = [];
+        public int ReplacementCalls { get; private set; }
+
+        public Task OnNextAsync(T item, StreamSequenceToken? token = null)
+        {
+            Items.Add(item);
+            Tokens.Add(token);
+            ReplacementCalls++;
+            replaceHandshake();
+            return Task.CompletedTask;
+        }
+
+        public Task OnCompletedAsync() => throw new NotSupportedException();
+
+        public Task OnErrorAsync(Exception ex) => throw new NotSupportedException();
+    }
 }


### PR DESCRIPTION
## Problem

The stream subscription lifecycle had a CRAP 420 delivery hotspot and limited direct coverage of ordered delivery, retries, terminal callbacks, resume, unsubscribe, and invalid-handle behavior.

## Solution

- Add deterministic in-memory tests for item and batch identity, ordering, event indexes, diagnostics, observer failures, retries, completion, errors, resume, unsubscribe, and provider-operation invariants.
- Compare item delivery acknowledgements using a delivery-handshake token, matching batch delivery and preventing duplicate redelivery.
- Validate an invalidated concrete handle before reading its cleared stream identity, preserving the documented `ArgumentException` contract.

## Rationale

The tests exercise lifecycle guarantees directly without external providers or timing dependencies. The selected `StreamSubscriptionHandleImpl` target now exceeds 90% line and branch coverage and the CRAP 420 hotspot is eliminated.

Contributes to #10862.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10957)