### PR TITLE
test(serialization): cover segmented buffer traversal

### DIFF
--- a/src/Orleans.Serialization/Buffers/PooledBuffer.cs
+++ b/src/Orleans.Serialization/Buffers/PooledBuffer.cs
@@ -376,13 +376,6 @@ public partial struct PooledBuffer : IBufferWriter<byte>, IDisposable
 
                 // Find the starting segment and the offset to copy from.
                 var segmentLength = segment.Length;
-                if (segmentLength == 0)
-                {
-                    CurrentMemory = ReadOnlyMemory<byte>.Empty;
-                    _segment = FinalSegmentSentinel;
-                    return false;
-                }
-
                 CurrentMemory = segment[..segmentLength];
                 _position += segmentLength;
                 _segment = _segment.Next as SequenceSegment;
@@ -395,13 +388,6 @@ public partial struct PooledBuffer : IBufferWriter<byte>, IDisposable
             if (_segment != FinalSegmentSentinel && _buffer.CurrentPosition > 0 && _buffer.WriteHead is { } head)
             {
                 var finalLength = _buffer.CurrentPosition;
-                if (finalLength == 0)
-                {
-                    CurrentMemory = ReadOnlyMemory<byte>.Empty;
-                    _segment = FinalSegmentSentinel;
-                    return false;
-                }
-
                 CurrentMemory = head.Array.AsMemory(0, finalLength);
                 _position += finalLength;
                 Debug.Assert(_position == _buffer.Length);
@@ -472,13 +458,6 @@ public partial struct PooledBuffer : IBufferWriter<byte>, IDisposable
 
                 // Find the starting segment and the offset to copy from.
                 var segmentLength = Math.Min(segment.Length, endPosition - _position);
-                if (segmentLength == 0)
-                {
-                    Current = ReadOnlySpan<byte>.Empty;
-                    _segment = FinalSegmentSentinel;
-                    return false;
-                }
-
                 Current = segment.Span[..segmentLength];
                 _position += segmentLength;
                 _segment = _segment.Next as SequenceSegment;
@@ -491,13 +470,6 @@ public partial struct PooledBuffer : IBufferWriter<byte>, IDisposable
             if (_segment != FinalSegmentSentinel && _buffer.CurrentPosition > 0 && _buffer.WriteHead is { } head && _position < endPosition)
             {
                 var finalLength = Math.Min(_buffer.CurrentPosition, endPosition - _position);
-                if (finalLength == 0)
-                {
-                    Current = ReadOnlySpan<byte>.Empty;
-                    _segment = FinalSegmentSentinel;
-                    return false;
-                }
-
                 Current = head.Array.AsSpan(0, finalLength);
                 _position += finalLength;
                 Debug.Assert(_position == endPosition);

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -497,10 +497,25 @@ namespace Orleans.Serialization.Buffers
         /// <param name="count">The number of bytes to skip.</param>
         public void Skip(long count)
         {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), "Count must be greater than or equal to 0.");
+            }
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (count > Remaining)
+            {
+                ThrowInsufficientData();
+            }
+
             if (IsReadOnlySequenceInput)
             {
-                var end = Position + count;
-                while (Position < end)
+                var end = Position - _sequenceOffset + count;
+                while (Position - _sequenceOffset < end)
                 {
                     var previousBuffersSize = Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input).PreviousBuffersSize;
                     if (end - previousBuffersSize <= _bufferSize)
@@ -515,8 +530,8 @@ namespace Orleans.Serialization.Buffers
             }
             else if (IsBufferSliceInput)
             {
-                var end = Position + count;
-                while (Position < end)
+                var end = Position - _sequenceOffset + count;
+                while (Position - _sequenceOffset < end)
                 {
                     var previousBuffersSize = Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).PreviousBuffersSize;
                     if (end - previousBuffersSize <= _bufferSize)
@@ -531,8 +546,8 @@ namespace Orleans.Serialization.Buffers
             }
             else if (IsArcBufferInput)
             {
-                var end = Position + count;
-                while (Position < end)
+                var end = Position - _sequenceOffset + count;
+                while (Position - _sequenceOffset < end)
                 {
                     var previousBuffersSize = Unsafe.As<TInput, ArcBufferReaderInput>(ref _input).PreviousBuffersSize;
                     if (end - previousBuffersSize <= _bufferSize)
@@ -548,10 +563,6 @@ namespace Orleans.Serialization.Buffers
             else if (IsSpanInput)
             {
                 _bufferPos += (int)count;
-                if (_bufferPos > _currentSpan.Length || count > int.MaxValue)
-                {
-                    ThrowInsufficientData();
-                }
             }
             else if (_input is ReaderInput input)
             {

--- a/test/Orleans.Serialization.UnitTests/ArcBufferWriterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ArcBufferWriterTests.cs
@@ -1212,4 +1212,137 @@ public class ArcBufferWriterTests
         using var slice = writer.PeekSlice(writer.Length);
         return slice.ToArray();
     }
+
+    [Fact]
+    public void IndexOfAny_EmptyValues_ReturnsMinusOne()
+    {
+        using var writer = new ArcBufferWriter();
+        var data = Enumerable.Repeat((byte)0xA5, PageSize + 1).ToArray();
+        WritePages(writer, data);
+
+        Assert.Equal(-1, writer.IndexOfAny([]));
+        Assert.Equal(data.Length, writer.Length);
+        Assert.True(writer.TryPeek(0, out var first));
+        Assert.Equal((byte)0xA5, first);
+    }
+
+    [Fact]
+    public void IndexOfAny_EmptyBuffer_ReturnsMinusOne()
+    {
+        using var writer = new ArcBufferWriter();
+
+        Assert.Equal(-1, writer.IndexOfAny([0x3C]));
+        Assert.Equal(0, writer.Length);
+        Assert.False(writer.TryPeek(0, out _));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2 * PageSize + 1)]
+    [InlineData(PageSize - 1)]
+    [InlineData(PageSize)]
+    [InlineData(PageSize + 1)]
+    public void IndexOfAny_FirstLastAndPageBoundaryMatches_ReturnExpectedOffset(int matchOffset)
+    {
+        using var writer = new ArcBufferWriter();
+        const byte Distractor = 0xA5;
+        const byte Marker = 0x3C;
+        var data = Enumerable.Repeat(Distractor, 2 * PageSize + 2).ToArray();
+        data[matchOffset] = Marker;
+        WritePages(writer, data);
+
+        Assert.Equal(matchOffset, writer.IndexOfAny([Marker]));
+        Assert.Equal(data.Length, writer.Length);
+        Assert.True(writer.TryPeek(matchOffset, out var match));
+        Assert.Equal(Marker, match);
+        if (matchOffset > 0)
+        {
+            Assert.True(writer.TryPeek(matchOffset - 1, out var before));
+            Assert.Equal(Distractor, before);
+        }
+
+        if (matchOffset + 1 < data.Length)
+        {
+            Assert.True(writer.TryPeek(matchOffset + 1, out var after));
+            Assert.Equal(Distractor, after);
+        }
+    }
+
+    [Fact]
+    public void IndexOfAny_NoMatch_ReturnsMinusOne()
+    {
+        using var writer = new ArcBufferWriter();
+        const byte Distractor = 0xA5;
+        var data = Enumerable.Repeat(Distractor, 2 * PageSize + 2).ToArray();
+        WritePages(writer, data);
+
+        Assert.Equal(-1, writer.IndexOfAny([0x31, 0x42]));
+        Assert.Equal(data.Length, writer.Length);
+        Assert.True(writer.TryPeek(data.Length - 1, out var last));
+        Assert.Equal(Distractor, last);
+    }
+
+    [Fact]
+    public void IndexOfAny_AfterAdvanceReader_ReturnsUnreadRelativeOffset()
+    {
+        using var writer = new ArcBufferWriter();
+        const byte Marker = 0x3C;
+        var data = Enumerable.Repeat((byte)0xA5, 2 * PageSize + 2).ToArray();
+        var consumedPrefixLength = PageSize + 1;
+        var markerOffset = consumedPrefixLength + 6;
+        data[markerOffset] = Marker;
+        WritePages(writer, data);
+        writer.AdvanceReader(consumedPrefixLength);
+
+        Assert.Equal(6, writer.IndexOfAny([Marker]));
+        Assert.Equal(data.Length - consumedPrefixLength, writer.Length);
+        Assert.True(writer.TryPeek(6, out var match));
+        Assert.Equal(Marker, match);
+    }
+
+    [Fact]
+    public void IndexOfAny_MultipleNeedles_ReturnsEarliestBufferPosition()
+    {
+        using var writer = new ArcBufferWriter();
+        const byte EarlierMarker = 0x31;
+        const byte LaterMarker = 0x42;
+        var data = Enumerable.Repeat((byte)0xA5, 2 * PageSize + 2).ToArray();
+        var earlierOffset = PageSize - 1;
+        var laterOffset = PageSize + 1;
+        data[earlierOffset] = EarlierMarker;
+        data[laterOffset] = LaterMarker;
+        WritePages(writer, data);
+
+        Assert.Equal(earlierOffset, writer.IndexOfAny([LaterMarker, EarlierMarker]));
+        Assert.Equal(data.Length, writer.Length);
+        Assert.True(writer.TryPeek(earlierOffset, out var earlier));
+        Assert.Equal(EarlierMarker, earlier);
+        Assert.True(writer.TryPeek(laterOffset, out var later));
+        Assert.Equal(LaterMarker, later);
+    }
+
+    [Fact]
+    public void IndexOfAny_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var writer = new ArcBufferWriter();
+        writer.Dispose();
+
+        var exception = Assert.Throws<ObjectDisposedException>(() => writer.IndexOfAny([]));
+        Assert.Equal(nameof(ArcBufferWriter), exception.ObjectName);
+    }
+
+    private static void WritePages(ArcBufferWriter writer, ReadOnlySpan<byte> data)
+    {
+        IBufferWriter<byte> output = writer;
+        var offset = 0;
+        while (offset < data.Length)
+        {
+            var count = Math.Min(PageSize, data.Length - offset);
+            var destination = output.GetSpan();
+            Assert.True(destination.Length >= count);
+            data.Slice(offset, count).CopyTo(destination);
+            output.Advance(count);
+            offset += count;
+        }
+    }
 }

--- a/test/Orleans.Serialization.UnitTests/PooledBufferTests.cs
+++ b/test/Orleans.Serialization.UnitTests/PooledBufferTests.cs
@@ -370,5 +370,172 @@ namespace Orleans.Serialization.UnitTests
 
             buffer.Dispose();
         }
+
+        [Theory]
+        [InlineData(PooledBufferLayout.Empty)]
+        [InlineData(PooledBufferLayout.SingleUncommitted)]
+        [InlineData(PooledBufferLayout.CommittedWithUncommittedTail)]
+        [InlineData(PooledBufferLayout.MultipleCommitted)]
+        public void DirectSpanEnumerator_MoveNext_TraversesExpectedSegments(PooledBufferLayout layout)
+        {
+            var buffer = new PooledBuffer();
+            try
+            {
+                var (expectedSegments, _) = CreateLayout(ref buffer, layout);
+
+                {
+                    var enumerator = PooledBufferExtensions.GetEnumerator(ref buffer);
+                    foreach (var expected in expectedSegments)
+                    {
+                        Assert.True(enumerator.MoveNext());
+                        Assert.True(expected.AsSpan().SequenceEqual(enumerator.Current));
+                    }
+
+                    Assert.False(enumerator.MoveNext());
+                    Assert.False(enumerator.MoveNext());
+                }
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        [Theory]
+        [InlineData(PooledBufferLayout.Empty)]
+        [InlineData(PooledBufferLayout.SingleUncommitted)]
+        [InlineData(PooledBufferLayout.CommittedWithUncommittedTail)]
+        [InlineData(PooledBufferLayout.MultipleCommitted)]
+        public void DirectMemoryEnumerator_MoveNext_TraversesExpectedSegments(PooledBufferLayout layout)
+        {
+            var buffer = new PooledBuffer();
+            try
+            {
+                var (expectedSegments, _) = CreateLayout(ref buffer, layout);
+
+                {
+                    var enumerator = buffer.MemorySegments.GetEnumerator();
+                    foreach (var expected in expectedSegments)
+                    {
+                        Assert.True(enumerator.MoveNext());
+                        Assert.True(expected.AsSpan().SequenceEqual(enumerator.Current.Span));
+                    }
+
+                    Assert.False(enumerator.MoveNext());
+                    Assert.False(enumerator.MoveNext());
+                }
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        [Theory]
+        [InlineData(PooledBufferLayout.SingleUncommitted)]
+        [InlineData(PooledBufferLayout.CommittedWithUncommittedTail)]
+        public void DirectSpanEnumerator_CurrentAliasesUnderlyingStorage(PooledBufferLayout layout)
+        {
+            var buffer = new PooledBuffer();
+            try
+            {
+                var (expectedSegments, retainedMemory) = CreateLayout(ref buffer, layout);
+
+                {
+                    var enumerator = PooledBufferExtensions.GetEnumerator(ref buffer);
+                    Assert.True(enumerator.MoveNext());
+                    var current = enumerator.Current;
+                    Assert.True(expectedSegments[0].AsSpan().SequenceEqual(current));
+
+                    retainedMemory.Span[1] = 0x7F;
+
+                    Assert.Equal((byte)0x7F, current[1]);
+                    Assert.Equal(expectedSegments[0][0], current[0]);
+                    Assert.Equal(expectedSegments[0][2], current[2]);
+                }
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        [Theory]
+        [InlineData(PooledBufferLayout.SingleUncommitted)]
+        [InlineData(PooledBufferLayout.CommittedWithUncommittedTail)]
+        public void DirectMemoryEnumerator_CurrentAliasesUnderlyingStorage(PooledBufferLayout layout)
+        {
+            var buffer = new PooledBuffer();
+            try
+            {
+                var (expectedSegments, retainedMemory) = CreateLayout(ref buffer, layout);
+
+                {
+                    var enumerator = buffer.MemorySegments.GetEnumerator();
+                    Assert.True(enumerator.MoveNext());
+                    var current = enumerator.Current;
+                    Assert.True(expectedSegments[0].AsSpan().SequenceEqual(current.Span));
+
+                    retainedMemory.Span[1] = 0x7F;
+
+                    Assert.Equal((byte)0x7F, current.Span[1]);
+                    Assert.Equal(expectedSegments[0][0], current.Span[0]);
+                    Assert.Equal(expectedSegments[0][2], current.Span[2]);
+                }
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        private static (byte[][] ExpectedSegments, Memory<byte> RetainedMemory) CreateLayout(
+            ref PooledBuffer buffer,
+            PooledBufferLayout layout)
+        {
+            byte[] firstSegment = [0x11, 0x12, 0x13];
+            byte[] secondSegment = [0x21, 0x22, 0x23, 0x24];
+            byte[] tail = [0x31, 0x32];
+
+            if (layout == PooledBufferLayout.Empty)
+            {
+                return ([], Memory<byte>.Empty);
+            }
+
+            var retainedMemory = WriteUncommitted(ref buffer, firstSegment);
+            if (layout == PooledBufferLayout.SingleUncommitted)
+            {
+                return ([firstSegment], retainedMemory);
+            }
+
+            var nextMemory = buffer.GetMemory(retainedMemory.Length - firstSegment.Length);
+            if (layout == PooledBufferLayout.CommittedWithUncommittedTail)
+            {
+                tail.CopyTo(nextMemory.Span);
+                buffer.Advance(tail.Length);
+                return ([firstSegment, tail], retainedMemory);
+            }
+
+            secondSegment.CopyTo(nextMemory.Span);
+            buffer.Advance(secondSegment.Length);
+            _ = buffer.GetMemory(nextMemory.Length - secondSegment.Length);
+            return ([firstSegment, secondSegment], retainedMemory);
+
+            static Memory<byte> WriteUncommitted(ref PooledBuffer buffer, byte[] content)
+            {
+                var memory = buffer.GetMemory();
+                content.CopyTo(memory.Span);
+                buffer.Advance(content.Length);
+                return memory;
+            }
+        }
+
+        public enum PooledBufferLayout
+        {
+            Empty,
+            SingleUncommitted,
+            CommittedWithUncommittedTail,
+            MultipleCommitted
+        }
     }
 }

--- a/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
@@ -1,17 +1,17 @@
-using CsCheck;
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Buffers.Adaptors;
-using Orleans.Serialization.Session;
-using Orleans.Serialization.TestKit;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
-using Xunit;
-using Orleans.Serialization.Codecs;
-using Orleans.Serialization.WireProtocol;
 using System.Runtime.InteropServices;
+using CsCheck;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Buffers.Adaptors;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Session;
+using Orleans.Serialization.TestKit;
+using Orleans.Serialization.WireProtocol;
+using Xunit;
 
 namespace Orleans.Serialization.UnitTests
 {
@@ -193,6 +193,684 @@ namespace Orleans.Serialization.UnitTests
 
                 base.Dispose(disposing);
             }
+        }
+
+        [Theory]
+        [InlineData(SpanInputKind.Span)]
+        [InlineData(SpanInputKind.ByteArray)]
+        [InlineData(SpanInputKind.ReadOnlyMemory)]
+        public void Skip_SpanBackedInput_AdvancesPositionRemainingAndNextByte(SpanInputKind inputKind)
+        {
+            byte[] input = [0x11, 0x22, 0x33, 0x44, 0x55];
+
+            switch (inputKind)
+            {
+                case SpanInputKind.Span:
+                    VerifySpanSkip(input.AsSpan());
+                    break;
+                case SpanInputKind.ByteArray:
+                    VerifyByteArraySkip(input);
+                    break;
+                case SpanInputKind.ReadOnlyMemory:
+                    VerifyReadOnlyMemorySkip(input.AsMemory());
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(inputKind));
+            }
+        }
+
+        [Theory]
+        [InlineData(0L)]
+        [InlineData(5L)]
+        public void Skip_SpanInput_ZeroAndExactEnd_HasExpectedState(long count)
+        {
+            ReadOnlySpan<byte> input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            var reader = Reader.Create(input, session: null!);
+
+            reader.Skip(count);
+
+            Assert.Equal(count, reader.Position);
+            Assert.Equal(input.Length - count, reader.Remaining);
+            if (count == 0)
+            {
+                Assert.Equal((byte)0x11, reader.ReadByte());
+                Assert.Equal(1, reader.Position);
+                Assert.Equal(4, reader.Remaining);
+            }
+            else
+            {
+                AssertInsufficientData(CaptureReadByteException(ref reader));
+                Assert.Equal(5, reader.Position);
+                Assert.Equal(0, reader.Remaining);
+            }
+        }
+
+        [Theory]
+        [InlineData(6L)]
+        [InlineData((long)int.MaxValue + 1)]
+        public void Skip_SpanInput_InsufficientOrIntOverflowCount_ThrowsWithoutAdvancing(long count)
+        {
+            ReadOnlySpan<byte> input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            var reader = Reader.Create(input, session: null!);
+
+            AssertInsufficientData(CaptureSkipException(ref reader, count));
+            Assert.Equal(0, reader.Position);
+            Assert.Equal(input.Length, reader.Remaining);
+            Assert.Equal((byte)0x11, reader.ReadByte());
+        }
+
+        [Fact]
+        public void Skip_NegativeCount_ThrowsArgumentOutOfRangeWithoutAdvancing()
+        {
+            ReadOnlySpan<byte> input = [0x11, 0x22];
+            var reader = Reader.Create(input, session: null!);
+
+            var exception = Assert.IsType<ArgumentOutOfRangeException>(CaptureSkipException(ref reader, -1));
+            Assert.Equal("count", exception.ParamName);
+            Assert.Equal(0, reader.Position);
+            Assert.Equal(input.Length, reader.Remaining);
+            Assert.Equal((byte)0x11, reader.ReadByte());
+        }
+
+        [Theory]
+        [InlineData(0L)]
+        [InlineData(2L)]
+        [InlineData(3L)]
+        public void Skip_ReadOnlySequence_ZeroExactAndAcrossSegmentBoundaries(long count)
+        {
+            var sequence = CreateSegmentedSequence();
+            byte[] expected = [0x11, 0x12, 0x21, 0x22, 0x31, 0x32];
+            var reader = Reader.Create(sequence, session: null!);
+
+            VerifySuccessfulSkip(ref reader, count, expected.Length - count, expected[(int)count]);
+        }
+
+        [Fact]
+        public void Skip_ReadOnlySequence_ExactEnd_HasExpectedState()
+        {
+            var sequence = CreateSegmentedSequence();
+            var reader = Reader.Create(sequence, session: null!);
+
+            reader.Skip(sequence.Length);
+
+            Assert.Equal(6, reader.Position);
+            Assert.Equal(0, reader.Remaining);
+            AssertInsufficientData(CaptureReadByteException(ref reader));
+        }
+
+        [Theory]
+        [InlineData(7L)]
+        [InlineData(long.MaxValue)]
+        public void Skip_ReadOnlySequence_InsufficientOrVeryLargeCount_ThrowsWithoutAdvancing(long count)
+        {
+            var sequence = CreateSegmentedSequence();
+            var reader = Reader.Create(sequence, session: null!);
+
+            AssertInsufficientData(CaptureSkipException(ref reader, count));
+            Assert.Equal(0, reader.Position);
+            Assert.Equal(sequence.Length, reader.Remaining);
+            Assert.Equal((byte)0x11, reader.ReadByte());
+        }
+
+        [Theory]
+        [InlineData(false, 0L)]
+        [InlineData(false, 2L)]
+        [InlineData(false, 3L)]
+        [InlineData(true, 0L)]
+        [InlineData(true, 2L)]
+        [InlineData(true, 3L)]
+        public void Skip_PooledBufferAndBufferSlice_CrossesCommittedUncommittedBoundary(bool useSlice, long count)
+        {
+            var buffer = CreateCommittedAndUncommittedBuffer();
+            try
+            {
+                byte[] expected = [0x11, 0x12, 0x21, 0x22];
+                var reader = useSlice
+                    ? Reader.Create(buffer.Slice(), session: null!)
+                    : Reader.Create(buffer, session: null!);
+
+                VerifySuccessfulSkip(ref reader, count, expected.Length - count, expected[(int)count]);
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Skip_PooledBufferAndBufferSlice_InsufficientData_ThrowsWithoutAdvancing(bool useSlice)
+        {
+            var buffer = CreateCommittedAndUncommittedBuffer();
+            try
+            {
+                var reader = useSlice
+                    ? Reader.Create(buffer.Slice(), session: null!)
+                    : Reader.Create(buffer, session: null!);
+
+                AssertInsufficientData(CaptureSkipException(ref reader, buffer.Length + 1L));
+                Assert.Equal(0, reader.Position);
+                Assert.Equal(buffer.Length, reader.Remaining);
+                Assert.Equal((byte)0x11, reader.ReadByte());
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        [Theory]
+        [InlineData(0L)]
+        [InlineData(ArcPageSize - 1L)]
+        [InlineData(ArcPageSize)]
+        [InlineData(ArcPageSize + 1L)]
+        public void Skip_ArcBuffer_ZeroExactAndAcrossPageBoundaries(long count)
+        {
+            using var writer = new ArcBufferWriter();
+            var expected = CreateArcBufferData();
+            WriteArcBufferData(writer, expected);
+            using var buffer = writer.PeekSlice(expected.Length);
+            var reader = Reader.Create(buffer, session: null!);
+
+            VerifySuccessfulSkip(ref reader, count, expected.Length - count, expected[(int)count]);
+        }
+
+        [Theory]
+        [InlineData(ArcPageSize + 2L)]
+        [InlineData(ArcPageSize + 3L)]
+        public void Skip_ArcBuffer_ExactEndOrInsufficientData_HasExpectedContract(long count)
+        {
+            using var writer = new ArcBufferWriter();
+            var expected = CreateArcBufferData();
+            WriteArcBufferData(writer, expected);
+            using var buffer = writer.PeekSlice(expected.Length);
+            var reader = Reader.Create(buffer, session: null!);
+
+            if (count == expected.Length)
+            {
+                reader.Skip(count);
+                Assert.Equal(expected.Length, reader.Position);
+                Assert.Equal(0, reader.Remaining);
+                AssertInsufficientData(CaptureReadByteException(ref reader));
+            }
+            else
+            {
+                AssertInsufficientData(CaptureSkipException(ref reader, count));
+                Assert.Equal(0, reader.Position);
+                Assert.Equal(expected.Length, reader.Remaining);
+                Assert.Equal((byte)0x11, reader.ReadByte());
+            }
+        }
+
+        [Theory]
+        [InlineData(0L)]
+        [InlineData(2L)]
+        public void Skip_SeekableStream_UpdatesPositionRemainingAndNextByte(long count)
+        {
+            byte[] input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            using var stream = new MemoryStream(input);
+            var reader = Reader.Create(stream, session: null!);
+
+            VerifySuccessfulSkip(ref reader, count, input.Length - count, input[(int)count]);
+        }
+
+        [Fact]
+        public void Skip_SeekableStream_ExactEnd_HasExpectedState()
+        {
+            byte[] input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            using var stream = new MemoryStream(input);
+            var reader = Reader.Create(stream, session: null!);
+
+            reader.Skip(input.Length);
+
+            Assert.Equal(input.Length, reader.Position);
+            Assert.Equal(0, reader.Remaining);
+            AssertInsufficientData(CaptureReadByteException(ref reader));
+            Assert.Equal(input.Length, reader.Position);
+            Assert.Equal(0, reader.Remaining);
+        }
+
+        [Fact]
+        public void Skip_SeekableStream_PastEnd_ThrowsWithoutAdvancing()
+        {
+            byte[] input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            using var stream = new MemoryStream(input);
+            var reader = Reader.Create(stream, session: null!);
+
+            AssertInsufficientData(CaptureSkipException(ref reader, input.Length + 1L));
+            Assert.Equal(0, reader.Position);
+            Assert.Equal(input.Length, reader.Remaining);
+            Assert.Equal((byte)0x11, reader.ReadByte());
+        }
+
+        [Fact]
+        public void Skip_NonSeekableStream_ZeroCount_DoesNotConsume()
+        {
+            byte[] input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            using var stream = new NonSeekableStream(input);
+            var reader = Reader.Create(stream, session: null!);
+
+            reader.Skip(0);
+
+            Assert.Equal(long.MaxValue, reader.Remaining);
+            Assert.IsType<NotSupportedException>(CapturePositionException(ref reader));
+            Assert.Equal((byte)0x11, reader.ReadByte());
+            Assert.Equal(long.MaxValue, reader.Remaining);
+        }
+
+        [Fact]
+        public void Skip_NonSeekableStream_PositiveCount_ThrowsWithoutConsuming()
+        {
+            byte[] input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            using var stream = new NonSeekableStream(input);
+            var reader = Reader.Create(stream, session: null!);
+
+            Assert.IsType<NotSupportedException>(CaptureSkipException(ref reader, 2));
+            Assert.Equal(long.MaxValue, reader.Remaining);
+            Assert.IsType<NotSupportedException>(CapturePositionException(ref reader));
+            Assert.Equal((byte)0x11, reader.ReadByte());
+            Assert.Equal(long.MaxValue, reader.Remaining);
+        }
+
+        [Theory]
+        [InlineData(SkipInputKind.Span)]
+        [InlineData(SkipInputKind.ReadOnlySequence)]
+        [InlineData(SkipInputKind.PooledBuffer)]
+        [InlineData(SkipInputKind.BufferSlice)]
+        [InlineData(SkipInputKind.ArcBuffer)]
+        [InlineData(SkipInputKind.SeekableStream)]
+        public void Skip_FromNonzeroPosition_AdvancesRelatively(SkipInputKind inputKind)
+        {
+            switch (inputKind)
+            {
+                case SkipInputKind.Span:
+                    VerifySpanRelativeSkip();
+                    break;
+                case SkipInputKind.ReadOnlySequence:
+                    VerifyReadOnlySequenceRelativeSkip();
+                    break;
+                case SkipInputKind.PooledBuffer:
+                    VerifyPooledBufferRelativeSkip(useSlice: false);
+                    break;
+                case SkipInputKind.BufferSlice:
+                    VerifyPooledBufferRelativeSkip(useSlice: true);
+                    break;
+                case SkipInputKind.ArcBuffer:
+                    VerifyArcBufferRelativeSkip();
+                    break;
+                case SkipInputKind.SeekableStream:
+                    VerifySeekableStreamRelativeSkip();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(inputKind));
+            }
+        }
+
+        [Theory]
+        [InlineData(SkipInputKind.ReadOnlySequence)]
+        [InlineData(SkipInputKind.PooledBuffer)]
+        [InlineData(SkipInputKind.BufferSlice)]
+        [InlineData(SkipInputKind.ArcBuffer)]
+        public void Skip_ForkedSegmentedInput_UsesForkRelativePosition(SkipInputKind inputKind)
+        {
+            switch (inputKind)
+            {
+                case SkipInputKind.ReadOnlySequence:
+                    VerifyForkedReadOnlySequenceSkip();
+                    break;
+                case SkipInputKind.PooledBuffer:
+                    VerifyForkedPooledBufferSkip(useSlice: false);
+                    break;
+                case SkipInputKind.BufferSlice:
+                    VerifyForkedPooledBufferSkip(useSlice: true);
+                    break;
+                case SkipInputKind.ArcBuffer:
+                    VerifyForkedArcBufferSkip();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(inputKind));
+            }
+        }
+
+        [Theory]
+        [InlineData(SkipInputKind.ReadOnlySequence)]
+        [InlineData(SkipInputKind.PooledBuffer)]
+        [InlineData(SkipInputKind.BufferSlice)]
+        [InlineData(SkipInputKind.ArcBuffer)]
+        public void Skip_SegmentedInput_NonzeroPositionLongMaxValue_ThrowsWithoutChangingState(SkipInputKind inputKind)
+        {
+            switch (inputKind)
+            {
+                case SkipInputKind.ReadOnlySequence:
+                    VerifyReadOnlySequenceOverflowSkip();
+                    break;
+                case SkipInputKind.PooledBuffer:
+                    VerifyPooledBufferOverflowSkip(useSlice: false);
+                    break;
+                case SkipInputKind.BufferSlice:
+                    VerifyPooledBufferOverflowSkip(useSlice: true);
+                    break;
+                case SkipInputKind.ArcBuffer:
+                    VerifyArcBufferOverflowSkip();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(inputKind));
+            }
+        }
+
+        private static void VerifyForkedReadOnlySequenceSkip()
+        {
+            var sequence = CreateSegmentedSequence();
+            var reader = Reader.Create(sequence, session: null!);
+            reader.ForkFrom(1, out var forked);
+
+            forked.Skip(1);
+
+            Assert.Equal(2, forked.Position);
+            Assert.Equal(4, forked.Remaining);
+            Assert.Equal((byte)0x21, forked.ReadByte());
+        }
+
+        private static void VerifyForkedPooledBufferSkip(bool useSlice)
+        {
+            var buffer = CreateCommittedAndUncommittedBuffer();
+            try
+            {
+                var reader = useSlice
+                    ? Reader.Create(buffer.Slice(), session: null!)
+                    : Reader.Create(buffer, session: null!);
+                reader.ForkFrom(1, out var forked);
+
+                forked.Skip(1);
+
+                Assert.Equal(2, forked.Position);
+                Assert.Equal(2, forked.Remaining);
+                Assert.Equal((byte)0x21, forked.ReadByte());
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        private static void VerifyForkedArcBufferSkip()
+        {
+            using var writer = new ArcBufferWriter();
+            var expected = CreateArcBufferData();
+            WriteArcBufferData(writer, expected);
+            using var buffer = writer.PeekSlice(expected.Length);
+            var reader = Reader.Create(buffer, session: null!);
+            reader.ForkFrom(ArcPageSize - 1, out var forked);
+
+            forked.Skip(1);
+
+            Assert.Equal(ArcPageSize, forked.Position);
+            Assert.Equal(2, forked.Remaining);
+            Assert.Equal((byte)0x41, forked.ReadByte());
+        }
+
+        private static void VerifySpanRelativeSkip()
+        {
+            ReadOnlySpan<byte> input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            var reader = Reader.Create(input, session: null!);
+            VerifyRelativeSkip(ref reader, input.Length, 2, 0x44);
+        }
+
+        private static void VerifyReadOnlySequenceRelativeSkip()
+        {
+            var sequence = CreateSegmentedSequence();
+            var reader = Reader.Create(sequence, session: null!);
+            VerifyRelativeSkip(ref reader, sequence.Length, 2, 0x22);
+        }
+
+        private static void VerifyPooledBufferRelativeSkip(bool useSlice)
+        {
+            var buffer = CreateCommittedAndUncommittedBuffer();
+            try
+            {
+                var reader = useSlice
+                    ? Reader.Create(buffer.Slice(), session: null!)
+                    : Reader.Create(buffer, session: null!);
+                VerifyRelativeSkip(ref reader, buffer.Length, 2, 0x22);
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        private static void VerifyArcBufferRelativeSkip()
+        {
+            using var writer = new ArcBufferWriter();
+            var expected = CreateArcBufferData();
+            WriteArcBufferData(writer, expected);
+            using var buffer = writer.PeekSlice(expected.Length);
+            var reader = Reader.Create(buffer, session: null!);
+            VerifyRelativeSkip(ref reader, expected.Length, ArcPageSize - 1L, 0x41);
+        }
+
+        private static void VerifySeekableStreamRelativeSkip()
+        {
+            byte[] input = [0x11, 0x22, 0x33, 0x44, 0x55];
+            using var stream = new MemoryStream(input);
+            var reader = Reader.Create(stream, session: null!);
+            VerifyRelativeSkip(ref reader, input.Length, 2, 0x44);
+        }
+
+        private static void VerifyRelativeSkip<TInput>(
+            ref Reader<TInput> reader,
+            long inputLength,
+            long count,
+            byte expectedNextByte)
+        {
+            Assert.Equal((byte)0x11, reader.ReadByte());
+            Assert.Equal(1, reader.Position);
+            Assert.Equal(inputLength - 1, reader.Remaining);
+
+            reader.Skip(count);
+
+            Assert.Equal(1 + count, reader.Position);
+            Assert.Equal(inputLength - count - 1, reader.Remaining);
+            Assert.Equal(expectedNextByte, reader.ReadByte());
+            Assert.Equal(2 + count, reader.Position);
+            Assert.Equal(inputLength - count - 2, reader.Remaining);
+        }
+
+        private static void VerifyReadOnlySequenceOverflowSkip()
+        {
+            var sequence = CreateSegmentedSequence();
+            var reader = Reader.Create(sequence, session: null!);
+            VerifySegmentedOverflowSkip(ref reader, sequence.Length, 0x12);
+        }
+
+        private static void VerifyPooledBufferOverflowSkip(bool useSlice)
+        {
+            var buffer = CreateCommittedAndUncommittedBuffer();
+            try
+            {
+                var reader = useSlice
+                    ? Reader.Create(buffer.Slice(), session: null!)
+                    : Reader.Create(buffer, session: null!);
+                VerifySegmentedOverflowSkip(ref reader, buffer.Length, 0x12);
+            }
+            finally
+            {
+                buffer.Dispose();
+            }
+        }
+
+        private static void VerifyArcBufferOverflowSkip()
+        {
+            using var writer = new ArcBufferWriter();
+            var expected = CreateArcBufferData();
+            WriteArcBufferData(writer, expected);
+            using var buffer = writer.PeekSlice(expected.Length);
+            var reader = Reader.Create(buffer, session: null!);
+            VerifySegmentedOverflowSkip(ref reader, expected.Length, 0xA5);
+        }
+
+        private static void VerifySegmentedOverflowSkip<TInput>(
+            ref Reader<TInput> reader,
+            long inputLength,
+            byte expectedNextByte)
+        {
+            Assert.Equal((byte)0x11, reader.ReadByte());
+            Assert.Equal(1, reader.Position);
+            Assert.Equal(inputLength - 1, reader.Remaining);
+
+            AssertInsufficientData(CaptureSkipException(ref reader, long.MaxValue));
+
+            Assert.Equal(1, reader.Position);
+            Assert.Equal(inputLength - 1, reader.Remaining);
+            Assert.Equal(expectedNextByte, reader.ReadByte());
+            Assert.Equal(2, reader.Position);
+            Assert.Equal(inputLength - 2, reader.Remaining);
+        }
+
+        private static void VerifySpanSkip(ReadOnlySpan<byte> input)
+        {
+            var reader = Reader.Create(input, session: null!);
+            VerifySuccessfulSkip(ref reader, 2, 3, 0x33);
+        }
+
+        private static void VerifyByteArraySkip(byte[] input)
+        {
+            var reader = Reader.Create(input, session: null!);
+            VerifySuccessfulSkip(ref reader, 2, 3, 0x33);
+        }
+
+        private static void VerifyReadOnlyMemorySkip(ReadOnlyMemory<byte> input)
+        {
+            var reader = Reader.Create(input, session: null!);
+            VerifySuccessfulSkip(ref reader, 2, 3, 0x33);
+        }
+
+        private static void VerifySuccessfulSkip<TInput>(
+            ref Reader<TInput> reader,
+            long count,
+            long expectedRemaining,
+            byte expectedNextByte)
+        {
+            reader.Skip(count);
+
+            Assert.Equal(count, reader.Position);
+            Assert.Equal(expectedRemaining, reader.Remaining);
+            Assert.Equal(expectedNextByte, reader.ReadByte());
+            Assert.Equal(count + 1, reader.Position);
+            Assert.Equal(expectedRemaining - 1, reader.Remaining);
+        }
+
+        private static Exception CaptureSkipException<TInput>(ref Reader<TInput> reader, long count)
+        {
+            try
+            {
+                reader.Skip(count);
+            }
+            catch (Exception exception)
+            {
+                return exception;
+            }
+
+            return null!;
+        }
+
+        private static Exception CaptureReadByteException<TInput>(ref Reader<TInput> reader)
+        {
+            try
+            {
+                _ = reader.ReadByte();
+            }
+            catch (Exception exception)
+            {
+                return exception;
+            }
+
+            return null!;
+        }
+
+        private static Exception CapturePositionException<TInput>(ref Reader<TInput> reader)
+        {
+            try
+            {
+                _ = reader.Position;
+            }
+            catch (Exception exception)
+            {
+                return exception;
+            }
+
+            return null!;
+        }
+
+        private static void AssertInsufficientData(Exception exception)
+        {
+            var invalidOperationException = Assert.IsType<InvalidOperationException>(exception);
+            Assert.Equal("Insufficient data present in buffer.", invalidOperationException.Message);
+        }
+
+        private static ReadOnlySequence<byte> CreateSegmentedSequence() =>
+            ReadOnlySequenceHelper.CreateReadOnlySequence(
+                [0x11, 0x12],
+                [0x21, 0x22],
+                [0x31, 0x32]);
+
+        private static PooledBuffer CreateCommittedAndUncommittedBuffer()
+        {
+            var buffer = new PooledBuffer();
+            var committedMemory = buffer.GetMemory();
+            new byte[] { 0x11, 0x12 }.CopyTo(committedMemory.Span);
+            buffer.Advance(2);
+
+            var uncommittedMemory = buffer.GetMemory(committedMemory.Length - 2);
+            new byte[] { 0x21, 0x22 }.CopyTo(uncommittedMemory.Span);
+            buffer.Advance(2);
+            return buffer;
+        }
+
+        private static byte[] CreateArcBufferData()
+        {
+            var result = new byte[ArcPageSize + 2];
+            Array.Fill(result, (byte)0xA5);
+            result[0] = 0x11;
+            result[ArcPageSize - 1] = 0x31;
+            result[ArcPageSize] = 0x41;
+            result[ArcPageSize + 1] = 0x51;
+            return result;
+        }
+
+        private static void WriteArcBufferData(ArcBufferWriter writer, ReadOnlySpan<byte> data)
+        {
+            IBufferWriter<byte> output = writer;
+            var offset = 0;
+            while (offset < data.Length)
+            {
+                var count = Math.Min(ArcPageSize, data.Length - offset);
+                var destination = output.GetSpan();
+                Assert.True(destination.Length >= count);
+                data.Slice(offset, count).CopyTo(destination);
+                output.Advance(count);
+                offset += count;
+            }
+        }
+
+        private const int ArcPageSize = ArcBufferWriter.MinimumPageSize;
+
+        public enum SpanInputKind
+        {
+            Span,
+            ByteArray,
+            ReadOnlyMemory
+        }
+
+        public enum SkipInputKind
+        {
+            Span,
+            ReadOnlySequence,
+            PooledBuffer,
+            BufferSlice,
+            ArcBuffer,
+            SeekableStream
         }
     }
 


### PR DESCRIPTION
Part of #10859.

## Problem

Segmented-buffer traversal had several high-CRAP coverage gaps. Direct pooled-buffer enumerators and `ArcBufferWriter.IndexOfAny` were untested, while `Reader<TInput>.Skip` had incomplete boundary coverage and inconsistent invalid-count behavior.

## Solution

- Cover direct pooled-buffer span and memory enumeration across empty, committed, uncommitted-tail, multi-segment, completion, and aliasing scenarios.
- Cover `IndexOfAny` across empty inputs, page boundaries, unread offsets, multiple needles, no-match, and disposal.
- Cover `Reader.Skip` across every input representation, exact and cross-segment boundaries, forked readers, overflow, insufficient data, and stream contracts.
- Validate negative and insufficient skip counts before changing reader state, and calculate segmented skip targets relative to fork offsets.
- Remove zero-length fallback branches which contradict pooled-buffer segment invariants.

## Rationale

The tests assert exact content, position, remaining length, next-byte state, exception contracts, and zero-copy aliasing. Review-discovered overflow and fork-offset defects are fixed at the shared reader boundary instead of being codified as incidental behavior.

## Coverage impact

`Orleans.Serialization` line coverage increases from **77.032%** to **78.295%** and branch coverage from **71.262%** to **72.754%**. The exact line counts move from **10,491/13,619** to **10,652/13,605**: 161 additional executable lines are covered, while the denominator decreases by 14 because unreachable pooled-buffer fallback branches were removed and the new `Reader.Skip` validation partially offsets that cleanup. Uncovered lines therefore decrease by 175, from 3,128 to 2,953.

The selected hotspots now measure:

- `PooledBuffer.SpanEnumerator.MoveNext`: 100% line / 100% branch, CRAP 14
- `PooledBuffer.MemoryEnumerator.MoveNext`: 100% line / 100% branch, CRAP 12
- `ArcBufferWriter.IndexOfAny`: 100% line / 100% branch, CRAP 10
- `Reader<TInput>.Skip`: 94.1% line / 96.4% branch, CRAP 28.16