### PR TITLE
perf(serialization): avoid delimiter array allocations

### DIFF
--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameParser.cs
@@ -23,10 +23,9 @@ public static class RuntimeTypeNameParser
     internal const char GenericTypeIndicator = '`';
     internal const char NestedTypeIndicator = '+';
     internal const char AssemblyIndicator = ',';
-    internal static ReadOnlySpan<char> LiteralDelimiters => new[] { LiteralDelimiter };
-    internal static ReadOnlySpan<char> TupleDelimiters => new[] { CompoundAliasElementSeparator, CompoundAliasEndIndicator };
-    internal static ReadOnlySpan<char> AssemblyDelimiters => new[] { ArrayEndIndicator, CompoundAliasElementSeparator, CompoundAliasEndIndicator };
-    internal static ReadOnlySpan<char> TypeNameDelimiters => new[] { ArrayStartIndicator, ArrayEndIndicator, PointerIndicator, ReferenceIndicator, AssemblyIndicator, GenericTypeIndicator, NestedTypeIndicator };
+    internal static ReadOnlySpan<char> LiteralDelimiters => "\"";
+    internal static ReadOnlySpan<char> AssemblyDelimiters => "],)";
+    internal static ReadOnlySpan<char> TypeNameDelimiters => "[]*&,`+";
 
     /// <summary>
     /// Parse the provided value as a type name.


### PR DESCRIPTION
RuntimeTypeNameParser currently creates a new character array whenever its delimiter spans are accessed. Every named type segment uses the type-name delimiters, with additional arrays created for assembly-qualified names and compound alias literals.\n\nBack the delimiter spans with string literals and remove the unused tuple delimiter property. This preserves parsing behavior while eliminating short-lived array allocations from type-name parsing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10966)