### PR TITLE
fix(runtime): synchronize stateless worker status

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -176,9 +176,39 @@ internal sealed partial class ActivationData :
     /// </summary>
     internal bool IsUsingGrainDirectory => PlacementStrategy.IsUsingGrainDirectory;
 
-    public int WaitingCount => _waitingRequests.Count;
-    public bool IsInactive => !IsCurrentlyExecuting && _waitingRequests.Count == 0;
-    public bool IsCurrentlyExecuting => _runningRequests.Count > 0;
+    public int WaitingCount
+    {
+        get
+        {
+            lock (this)
+            {
+                return _waitingRequests.Count;
+            }
+        }
+    }
+
+    public bool IsInactive => GetRequestStatus().IsInactive;
+
+    public bool IsCurrentlyExecuting
+    {
+        get
+        {
+            lock (this)
+            {
+                return _runningRequests.Count > 0;
+            }
+        }
+    }
+
+    internal (int WaitingCount, bool IsInactive) GetRequestStatus()
+    {
+        lock (this)
+        {
+            var waitingCount = _waitingRequests.Count;
+            return (waitingCount, waitingCount == 0 && _runningRequests.Count == 0);
+        }
+    }
+
     public IWorkItemScheduler Scheduler => _workItemGroup;
     public Task Deactivated => GetDeactivationCompletionSource().Task;
 
@@ -447,7 +477,7 @@ internal sealed partial class ActivationData :
     {
         lock (this)
         {
-            return _runningRequests.Count + WaitingCount;
+            return _runningRequests.Count + _waitingRequests.Count;
         }
     }
 

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -212,7 +212,13 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         const double Ki = 0.468;
         const double Kd = 0.480;
 
-        var averageWaitingCount = _workers.Count > 0 ? _workers.Average(w => w.WaitingCount) : 0d;
+        var totalWaitingCount = 0L;
+        foreach (var worker in _workers)
+        {
+            totalWaitingCount += worker.GetRequestStatus().WaitingCount;
+        }
+
+        var averageWaitingCount = _workers.Count > 0 ? (double)totalWaitingCount / _workers.Count : 0d;
         var error = -averageWaitingCount; // Our target is 0 waiting count: 0 - avgWC = -avgWC
 
         _integralTerm += error;
@@ -225,7 +231,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
         if (_detectedIdleCyclesCount >= _shared.MinIdleCyclesBeforeRemoval)
         {
-            var inactiveWorkers = _workers.Where(w => w.IsInactive).ToImmutableArray();
+            var inactiveWorkers = _workers.Where(static worker => worker.GetRequestStatus().IsInactive).ToImmutableArray();
             if (inactiveWorkers.Length > 0)
             {
                 var worker = inactiveWorkers[Random.Shared.Next(inactiveWorkers.Length)];
@@ -265,19 +271,21 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                 // of workers spawned
                 for (var i = 0; i < _workers.Count; i++)
                 {
-                    if (_workers[i].IsInactive)
+                    var candidate = _workers[i];
+                    var status = candidate.GetRequestStatus();
+                    if (status.IsInactive)
                     {
-                        worker = _workers[i];
+                        worker = candidate;
                         break;
                     }
                     else
                     {
                         // Track the worker with the lowest value for WaitingCount,
                         // this is used if all workers are busy
-                        if (_workers[i].WaitingCount < minimumWaitingCount)
+                        if (status.WaitingCount < minimumWaitingCount)
                         {
-                            minimumWaitingCount = _workers[i].WaitingCount;
-                            minimumWaitingCountWorker = _workers[i];
+                            minimumWaitingCount = status.WaitingCount;
+                            minimumWaitingCountWorker = candidate;
                         }
                     }
                 }

--- a/test/Orleans.Runtime.Tests/StatelessWorkerActivationTests.cs
+++ b/test/Orleans.Runtime.Tests/StatelessWorkerActivationTests.cs
@@ -67,7 +67,10 @@ public class StatelessWorkerActivationTests : IClassFixture<StatelessWorkerActiv
         for (var i = 0; i < 100; i++)
         {
             await workerGrain.GetActivationCount();
-            await Until(async () => 1 == await managementGrain.GetGrainActivationCount(grainReference), 5_000);
+            await Until(
+                async () => 1 == await managementGrain.GetGrainActivationCount(grainReference),
+                "the activation count to remain at 1",
+                5_000);
         }
     }
 
@@ -89,49 +92,62 @@ public class StatelessWorkerActivationTests : IClassFixture<StatelessWorkerActiv
         const int MaxLocalWorkers = 4;  // Maximum activations per silo
         var waiters = new List<Task>();  // Track blocking calls
         var worker = _fixture.GrainFactory.GetGrain<IStatelessWorkerScalingGrain>(1);
+        var primary = Assert.IsType<InProcessSiloHandle>(_fixture.HostedCluster.Primary);
+        var sharedState = primary.SiloHost.Services.GetRequiredService<StatelessWorkerScalingGrainSharedState>();
+        var grainId = ((GrainReference)worker).GrainId;
 
-        // Initially, only one activation exists
-        var activationCount = await worker.GetActivationCount();
-        Assert.Equal(1, activationCount);
-
-        // First blocking call triggers creation of second activation
-        waiters.Add(worker.Wait());
-        await Until(async () => 2 == await worker.GetActivationCount());
-        activationCount = await worker.GetActivationCount();
-        Assert.Equal(2, activationCount);
-
-        waiters.Add(worker.Wait());
-        await Until(async () => 3 == await worker.GetActivationCount());
-        activationCount = await worker.GetActivationCount();
-        Assert.Equal(3, activationCount);
-
-        waiters.Add(worker.Wait());
-        await Until(async () => 4 == await worker.GetActivationCount());
-        activationCount = await worker.GetActivationCount();
-        Assert.Equal(4, activationCount);
-
-        var waitingCount = await worker.GetWaitingCount();
-        Assert.Equal(3, waitingCount);
-
-        for (var i = 0; i < MaxLocalWorkers; i++)
+        try
         {
+            // Initially, only one activation exists
+            var activationCount = await worker.GetActivationCount();
+            Assert.Equal(1, activationCount);
+
+            // First blocking call triggers creation of second activation
             waiters.Add(worker.Wait());
+            await Until(
+                () => Task.FromResult(1 == sharedState.WaitingActivations[grainId]),
+                "the first activation to enter Wait");
+            activationCount = await worker.GetActivationCount();
+            Assert.Equal(2, activationCount);
+
+            waiters.Add(worker.Wait());
+            await Until(
+                () => Task.FromResult(2 == sharedState.WaitingActivations[grainId]),
+                "the second activation to enter Wait");
+            activationCount = await worker.GetActivationCount();
+            Assert.Equal(3, activationCount);
+
+            waiters.Add(worker.Wait());
+            await Until(
+                () => Task.FromResult(3 == sharedState.WaitingActivations[grainId]),
+                "the third activation to enter Wait");
+            activationCount = await worker.GetActivationCount();
+            Assert.Equal(4, activationCount);
+
+            var waitingCount = sharedState.WaitingActivations[grainId];
+            Assert.Equal(3, waitingCount);
+
+            for (var i = 0; i < MaxLocalWorkers; i++)
+            {
+                waiters.Add(worker.Wait());
+            }
+
+            await Until(
+                () => Task.FromResult(MaxLocalWorkers == sharedState.WaitingActivations[grainId]),
+                $"the waiting count to reach {MaxLocalWorkers}");
+            activationCount = sharedState.ActivationCounts[grainId];
+            Assert.Equal(MaxLocalWorkers, activationCount);
+            waitingCount = sharedState.WaitingActivations[grainId];
+            Assert.Equal(MaxLocalWorkers, waitingCount);
         }
-
-        await Until(async () => MaxLocalWorkers == await worker.GetActivationCount());
-        await Until(async () => MaxLocalWorkers == await worker.GetWaitingCount());
-        activationCount = await worker.GetActivationCount();
-        Assert.Equal(MaxLocalWorkers, activationCount);
-        waitingCount = await worker.GetWaitingCount();
-        Assert.Equal(MaxLocalWorkers, waitingCount);
-
-        // Release all the waiting workers to clean up
-        for (var i = 0; i < waiters.Count; i++)
+        finally
         {
-            await worker.Release();
+            if (waiters.Count > 0)
+            {
+                sharedState.Semaphore.Release(waiters.Count);
+            }
         }
 
-        // Ensure all blocking calls complete properly
         await Task.WhenAll(waiters);
     }
 
@@ -166,6 +182,7 @@ public class StatelessWorkerActivationTests : IClassFixture<StatelessWorkerActiv
         // The activation count for the stateless worker grain should become 0 again
         await Until(
             async () => await mgmt.GetGrainActivationCount((GrainReference)workerGrain) == 0,
+            "the activation count to reach 0",
             5_000
         );
     }
@@ -174,9 +191,21 @@ public class StatelessWorkerActivationTests : IClassFixture<StatelessWorkerActiv
     /// Helper method to wait for an async condition to become true.
     /// Used to handle eventual consistency in activation creation/destruction.
     /// </summary>
-    private static async Task Until(Func<Task<bool>> condition, int maxTimeout = 40_000)
+    private static async Task Until(Func<Task<bool>> condition, string description, int maxTimeout = 40_000)
     {
-        while (!await condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
-        Assert.True(maxTimeout > 0);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(maxTimeout);
+
+        try
+        {
+            while (!await condition().WaitAsync(timeout.Token))
+            {
+                await Task.Delay(10, timeout.Token);
+            }
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested && !TestContext.Current.CancellationToken.IsCancellationRequested)
+        {
+            Assert.Fail($"Timed out after {maxTimeout}ms waiting for {description}.");
+        }
     }
 }


### PR DESCRIPTION
Fixes #10954

Stateless worker dispatch read activation waiting and running request state from a different thread without acquiring the activation lock. Inconsistent observations could classify a busy worker as inactive and route the follow-up request behind a blocked call, preventing scale-out.

Synchronize request-status observations under the activation lock and use one atomic status value for worker selection and idle collection. The regression test now uses explicit Wait-entry phase barriers, observes shared state without perturbing routing, releases blocked calls on every exit path, and reports elapsed-time failures by phase.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10968)