### PR TITLE
fix(serialization): allow well-known generic arguments

### DIFF
--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -576,7 +576,7 @@ public class TypeConverter
         }
 
         // Enums and well-known types carry no user-defined behavior, so allow them absent an explicit opinion.
-        if (result is null && (type.IsEnum || WellKnownRuntimeTypeNames.Contains(type.FullName!)))
+        if (result is null && (type.IsEnum || type.FullName is { } fullName && WellKnownRuntimeTypeNames.Contains(fullName)))
         {
             result = true;
         }

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -54,6 +54,8 @@ public class TypeConverter
         ("DateTimeOffset", "System.DateTimeOffset"),
         ("Type", "System.Type"),
     ];
+    private static readonly HashSet<string> WellKnownRuntimeTypeNames =
+        WellKnownTypeAliases.Select(static alias => alias.RuntimeName).ToHashSet(StringComparer.Ordinal);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TypeConverter"/> class.
@@ -573,8 +575,8 @@ public class TypeConverter
             }
         }
 
-        // Enums carry no behavior and are serialized via their underlying integral type, so allow them absent an explicit opinion.
-        if (result is null && type.IsEnum)
+        // Enums and well-known types carry no user-defined behavior, so allow them absent an explicit opinion.
+        if (result is null && (type.IsEnum || WellKnownRuntimeTypeNames.Contains(type.FullName!)))
         {
             result = true;
         }

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -26,6 +26,17 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_FailsClosed_ForTypesWithoutFullNames()
+        {
+            var converter = CreateConverter();
+            var genericParameter = typeof(TypeConverterTestsGenericTypeAllowedByTypeFilter<>).GetGenericArguments()[0];
+
+            var exception = Assert.Throws<InvalidOperationException>(() => converter.Format(genericParameter));
+
+            Assert.Contains("not allowed", exception.Message);
+        }
+
+        [Fact]
         public void TypeConverter_AllowAllTypes_TakesPrecedenceOverDenyingFilters()
         {
             var converter = CreateConverter(

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -260,6 +260,14 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_AllowsConfiguredAllowedAssemblyTypesAlongsideWellKnownGenericArguments()
+        {
+            var converter = CreateConverter(configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType).Assembly));
+
+            AssertRoundTrips(converter, typeof(IReadOnlyDictionary<TypeConverterTestsAssemblyAllowedType, int>));
+        }
+
+        [Fact]
         public void TypeConverter_RejectsAllowedAssemblyType_WhenTypeNameFilterDeniesIt()
         {
             var converter = CreateConverter(
@@ -340,6 +348,18 @@ namespace Orleans.Serialization.UnitTests
                 ]);
 
             AssertRoundTrips(converter, typeof(List<TypeConverterTestsGenericArgumentAllowedByTypeFilter>));
+        }
+
+        [Fact]
+        public void TypeConverter_UsesTypeFiltersAlongsideWellKnownGenericArguments_WhenNameFiltersHaveNoOpinion()
+        {
+            var converter = CreateConverter(
+                typeFilters:
+                [
+                    new DelegateTypeFilter(type => type == typeof(TypeConverterTestsGenericArgumentAllowedByTypeFilter) ? true : null)
+                ]);
+
+            AssertRoundTrips(converter, typeof(IReadOnlyDictionary<TypeConverterTestsGenericArgumentAllowedByTypeFilter, int>));
         }
 
         [Fact]


### PR DESCRIPTION
`ITypeFilter` and `AddAllowedAssembly` authorization could still reject constructed generic types when another argument was a well-known BCL type such as `int`. Name validation trusted those aliases, but resolved-type inspection returned no opinion and discarded that trust.

Recognize the runtime types represented by Orleans' built-in aliases during resolved-type inspection, using the same fail-closed behavior as enums. Explicit filter denials continue to take precedence. Regression coverage exercises both `ITypeFilter` and `AddAllowedAssembly` with `IReadOnlyDictionary<..., int>`.

Fixes: #10950
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10970)