### PR TITLE
fix(testing): preserve deterministic reminder cleanup

### DIFF
--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -33,21 +33,6 @@ public interface IReminderServiceLifecycleHarness
     /// <summary>Gets the currently active silos.</summary>
     IReadOnlyList<SiloAddress> ActiveSilos { get; }
 
-    /// <summary>
-    /// Registers a reminder, directing the request through the specified silo when the harness supports directed
-    /// registration. The default implementation uses the grain-facing API through <see cref="GrainFactory"/>.
-    /// </summary>
-    Task RegisterOnSiloAsync(
-        SiloAddress siloAddress,
-        GrainId grainId,
-        string reminderName,
-        TimeSpan dueTime,
-        TimeSpan period,
-        CancellationToken cancellationToken)
-        => GrainFactory.GetGrain<IReminderServiceTestGrain>(grainId)
-            .RegisterOrUpdateAsync(reminderName, dueTime, period)
-            .WaitAsync(cancellationToken);
-
     /// <summary>Waits until every active reminder service is ready.</summary>
     Task WaitForStartupReadinessAsync(CancellationToken cancellationToken);
 
@@ -110,6 +95,21 @@ public interface IReminderServiceLifecycleHarness
 }
 
 /// <summary>
+/// Adds deterministic reminder registration through a specified silo to a lifecycle harness.
+/// </summary>
+public interface IReminderServiceLifecycleRegistrationTarget
+{
+    /// <summary>Registers a reminder through the reminder service on the specified silo.</summary>
+    Task RegisterOnSiloAsync(
+        SiloAddress siloAddress,
+        GrainId grainId,
+        string reminderName,
+        TimeSpan dueTime,
+        TimeSpan period,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
 /// Shared deterministic conformance scenarios for reminder service lifecycle, ownership, and churn.
 /// </summary>
 /// <remarks>
@@ -119,6 +119,7 @@ public interface IReminderServiceLifecycleHarness
 /// </remarks>
 public abstract class ReminderServiceLifecycleTestRunner
 {
+    private static readonly TimeSpan CleanupPhaseTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan Period = TimeSpan.FromMinutes(2);
     private readonly IReminderServiceLifecycleHarness _harness;
     private readonly int _seed;
@@ -354,6 +355,17 @@ public abstract class ReminderServiceLifecycleTestRunner
         var phase = "join";
         SiloAddress? joined = null;
         SiloAddress? staleOwner = null;
+        Task? registrationTask = null;
+        if (_harness is not IReminderServiceLifecycleRegistrationTarget registrationTarget)
+        {
+            Fail(Guarantee, "harness capability")
+                .WithExpected(
+                    $"{nameof(IReminderServiceLifecycleRegistrationTarget)} for deterministic non-owner registration")
+                .WithObserved(_harness.GetType().FullName ?? _harness.GetType().Name)
+                .Throw();
+            return;
+        }
+
         await ExecuteWithCleanupAsync(
             Guarantee,
             cancellationToken,
@@ -382,13 +394,14 @@ public abstract class ReminderServiceLifecycleTestRunner
                     }
 
                     phase = $"registration through non-owner {staleOwner}";
-                    await _harness.RegisterOnSiloAsync(
+                    registrationTask = registrationTarget.RegisterOnSiloAsync(
                         staleOwner,
                         grainId,
                         Name,
                         TimeSpan.FromSeconds(3),
                         Period,
                         cancellationToken);
+                    await registrationTask.WaitAsync(cancellationToken);
 
                     var ownersBeforeRefresh = _harness.GetOwners(grainId, Name);
                     var startsBeforeRefresh = _harness.GetLocalStartCount(grainId, Name);
@@ -442,45 +455,61 @@ public abstract class ReminderServiceLifecycleTestRunner
                         exception);
                 }
             },
-            async cleanupToken =>
+            async _ =>
             {
-                Exception? topologyFailure = null;
-                try
+                var cleanupFailures = new List<Exception>();
+                if (registrationTask is not null)
                 {
-                    if (joined is not null && _harness.ActiveSilos.Contains(joined))
+                    try
                     {
-                        await _harness.LeaveSiloAsync(joined, cleanupToken);
-                        await _harness.WaitForTopologyReconciliationAsync(cleanupToken);
+                        await registrationTask;
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        // The scheduler observed cancellation before dispatch, so no mutation needs cleanup.
+                    }
+                    catch (Exception exception)
+                    {
+                        cleanupFailures.Add(exception);
                     }
                 }
-                catch (Exception exception)
+
+                using (var topologyCancellation = new CancellationTokenSource(CleanupPhaseTimeout))
                 {
-                    topologyFailure = exception;
+                    try
+                    {
+                        if (joined is not null && _harness.ActiveSilos.Contains(joined))
+                        {
+                            await _harness.LeaveSiloAsync(joined, topologyCancellation.Token);
+                            await _harness.WaitForTopologyReconciliationAsync(topologyCancellation.Token);
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        cleanupFailures.Add(exception);
+                    }
                 }
 
-                Exception? reminderFailure = null;
-                try
+                using (var reminderCancellation = new CancellationTokenSource(CleanupPhaseTimeout))
                 {
-                    await CleanupAsync(Guarantee, reminders, cleanupToken);
-                }
-                catch (Exception exception)
-                {
-                    reminderFailure = exception;
-                }
-
-                if (topologyFailure is not null && reminderFailure is not null)
-                {
-                    throw new AggregateException(topologyFailure, reminderFailure);
+                    try
+                    {
+                        await CleanupAsync(Guarantee, reminders, reminderCancellation.Token);
+                    }
+                    catch (Exception exception)
+                    {
+                        cleanupFailures.Add(exception);
+                    }
                 }
 
-                if (topologyFailure is not null)
+                if (cleanupFailures.Count > 1)
                 {
-                    ExceptionDispatchInfo.Capture(topologyFailure).Throw();
+                    throw new AggregateException(cleanupFailures);
                 }
 
-                if (reminderFailure is not null)
+                if (cleanupFailures.Count == 1)
                 {
-                    ExceptionDispatchInfo.Capture(reminderFailure).Throw();
+                    ExceptionDispatchInfo.Capture(cleanupFailures[0]).Throw();
                 }
             });
     }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -368,11 +368,7 @@ namespace Orleans.Runtime.ReminderService
         }
 
         internal Task TestOnlyRefresh()
-        {
-            var refreshTask = new Task<Task>(() => TrackReconciliation(ReadAndUpdateReminders));
-            Scheduler.QueueTask(refreshTask);
-            return refreshTask.Unwrap();
-        }
+            => this.QueueTask(() => TrackReconciliation(ReadAndUpdateReminders));
 
         internal Task TestOnlyWaitForSiloStatusListeners(CancellationToken cancellationToken)
             => _siloStatusListenerManager.TestOnlyWaitForCurrentMembershipVersion(cancellationToken);

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -271,38 +271,6 @@ public sealed class FaultyReminderServiceLifecycleTests
     }
 
     [Fact]
-    public async Task DefaultRegistrationImplementationUsesGrainFacingApi()
-    {
-        var fixture = new ReminderServiceLifecycleFixture();
-        await fixture.InitializeAsync();
-        try
-        {
-            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
-            cancellation.CancelAfter(TimeSpan.FromMinutes(2));
-            var harness = new LegacyLifecycleHarness(fixture.Harness);
-            await harness.WaitForStartupReadinessAsync(cancellation.Token);
-            var grain = harness.GrainFactory.GetGrain<IReminderServiceTestGrain>(
-                Guid.Parse("632db277-28b7-4bd5-a423-35ff4e734f2f"));
-            const string ReminderName = "default-registration";
-
-            await ((IReminderServiceLifecycleHarness)harness).RegisterOnSiloAsync(
-                harness.ActiveSilos[0],
-                grain.GetGrainId(),
-                ReminderName,
-                TimeSpan.FromMinutes(1),
-                TimeSpan.FromMinutes(2),
-                cancellation.Token);
-
-            Assert.Contains(ReminderName, await grain.GetReminderNamesAsync().WaitAsync(cancellation.Token));
-            Assert.True(await grain.UnregisterAsync(ReminderName).WaitAsync(cancellation.Token));
-        }
-        finally
-        {
-            await fixture.DisposeAsync();
-        }
-    }
-
-    [Fact]
     public Task JoinLeaveAdvancesToTheExactRemainingDueTime()
     {
         RecordingAdvanceHarness? recordingHarness = null;
@@ -341,7 +309,8 @@ public sealed class FaultyReminderServiceLifecycleTests
     private sealed class LifecycleRunner(IReminderServiceLifecycleHarness harness, string providerName)
         : ReminderServiceLifecycleTestRunner(harness, providerName);
 
-    private class DelegatingHarness(IReminderServiceLifecycleHarness inner) : IReminderServiceLifecycleHarness
+    private class DelegatingHarness(IReminderServiceLifecycleHarness inner)
+        : IReminderServiceLifecycleHarness, IReminderServiceLifecycleRegistrationTarget
     {
         protected IReminderServiceLifecycleHarness Inner { get; } = inner;
 
@@ -352,7 +321,14 @@ public sealed class FaultyReminderServiceLifecycleTests
         public TimeSpan ReminderRefreshPeriod => Inner.ReminderRefreshPeriod;
         public IReadOnlyList<SiloAddress> ActiveSilos => Inner.ActiveSilos;
         public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => Inner.WaitForStartupReadinessAsync(cancellationToken);
-        public virtual Task RegisterOnSiloAsync(SiloAddress siloAddress, GrainId grainId, string reminderName, TimeSpan dueTime, TimeSpan period, CancellationToken cancellationToken) => Inner.RegisterOnSiloAsync(siloAddress, grainId, reminderName, dueTime, period, cancellationToken);
+        public virtual Task RegisterOnSiloAsync(SiloAddress siloAddress, GrainId grainId, string reminderName, TimeSpan dueTime, TimeSpan period, CancellationToken cancellationToken)
+            => ((IReminderServiceLifecycleRegistrationTarget)Inner).RegisterOnSiloAsync(
+                siloAddress,
+                grainId,
+                reminderName,
+                dueTime,
+                period,
+                cancellationToken);
         public virtual Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => Inner.AdvanceAsync(amount, cancellationToken);
         public virtual Task RefreshAsync(CancellationToken cancellationToken) => Inner.RefreshAsync(cancellationToken);
         public virtual Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => Inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
@@ -393,32 +369,6 @@ public sealed class FaultyReminderServiceLifecycleTests
                 period,
                 cancellationToken);
         }
-    }
-
-    private sealed class LegacyLifecycleHarness(IReminderServiceLifecycleHarness inner) : IReminderServiceLifecycleHarness
-    {
-        public IGrainFactory GrainFactory => inner.GrainFactory;
-        public IReminderTable ReminderTable => inner.ReminderTable;
-        public DateTimeOffset UtcNow => inner.UtcNow;
-        public TimeSpan ReminderLoadingWindow => inner.ReminderLoadingWindow;
-        public TimeSpan ReminderRefreshPeriod => inner.ReminderRefreshPeriod;
-        public IReadOnlyList<SiloAddress> ActiveSilos => inner.ActiveSilos;
-        public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken) => inner.WaitForStartupReadinessAsync(cancellationToken);
-        public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken) => inner.AdvanceAsync(amount, cancellationToken);
-        public Task RefreshAsync(CancellationToken cancellationToken) => inner.RefreshAsync(cancellationToken);
-        public Task WaitForOwnerCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => inner.WaitForOwnerCountAsync(grainId, reminderName, count, cancellationToken);
-        public IReadOnlyList<SiloAddress> GetOwners(GrainId grainId, string reminderName) => inner.GetOwners(grainId, reminderName);
-        public bool IsOwner(SiloAddress siloAddress, GrainId grainId) => inner.IsOwner(siloAddress, grainId);
-        public Task WaitForScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken) => inner.WaitForScheduleAsync(grainId, reminderName, cancellationToken);
-        public int GetLocalStartCount(GrainId grainId, string reminderName) => inner.GetLocalStartCount(grainId, reminderName);
-        public int GetLocalStopCount(GrainId grainId, string reminderName) => inner.GetLocalStopCount(grainId, reminderName);
-        public int GetScheduleChangeCount(GrainId grainId, string reminderName) => inner.GetScheduleChangeCount(grainId, reminderName);
-        public Task WaitForScheduleChangeCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => inner.WaitForScheduleChangeCountAsync(grainId, reminderName, count, cancellationToken);
-        public Task WaitForTickCountAsync(GrainId grainId, string reminderName, int count, CancellationToken cancellationToken) => inner.WaitForTickCountAsync(grainId, reminderName, count, cancellationToken);
-        public int GetTickCount(GrainId grainId, string reminderName) => inner.GetTickCount(grainId, reminderName);
-        public Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken) => inner.JoinOneSiloAsync(cancellationToken);
-        public Task LeaveSiloAsync(SiloAddress siloAddress, CancellationToken cancellationToken) => inner.LeaveSiloAsync(siloAddress, cancellationToken);
-        public Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken) => inner.WaitForTopologyReconciliationAsync(cancellationToken);
     }
 
     private sealed class DuplicateOwnerHarness(IReminderServiceLifecycleHarness inner) : DelegatingHarness(inner)

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -379,16 +379,16 @@ public sealed class ReminderTestKitClusterIntegrationTests
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
         var cluster = builder.Build();
         using var observer = ReminderDiagnosticObserver.Create(cluster);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+        cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellation.Token);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = TimeSpan.FromMinutes(10);
             var firstTickTime = clock.UtcNow.UtcDateTime + dueTime;
-            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
-            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
             await using var firstRefreshA = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             await using var firstRefreshB = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
@@ -501,7 +501,6 @@ public sealed class ReminderTestKitClusterIntegrationTests
             cluster,
             observer,
             cluster.Silos,
-            TimeSpan.FromSeconds(30),
             cancellationToken);
     }
 

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -1,12 +1,13 @@
 #nullable enable
 
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Reminders.Diagnostics;
 using Orleans.Reminders.TestKit;
 using Orleans.Runtime;
 using Orleans.Runtime.ConsistentRing;
 using Orleans.Runtime.ReminderService;
-using Orleans.Runtime.Services;
+using Orleans.Runtime.Scheduler;
 using Orleans.TestingHost;
 
 namespace Orleans.Testing.Reminders;
@@ -15,8 +16,10 @@ namespace Orleans.Testing.Reminders;
 /// Adapts an in-process cluster, <see cref="ReminderTestClock"/>, and
 /// <see cref="ReminderDiagnosticObserver"/> to the shared service lifecycle conformance runner.
 /// </summary>
-public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleHarness
+public sealed class ReminderServiceLifecycleHarness
+    : IReminderServiceLifecycleHarness, IReminderServiceLifecycleRegistrationTarget
 {
+    private static readonly TimeSpan JoinCleanupTimeout = TimeSpan.FromMinutes(1);
     private readonly InProcessTestCluster _cluster;
     private readonly ReminderTestClock _clock;
     private readonly ReminderDiagnosticObserver _observer;
@@ -72,7 +75,7 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
     }
 
     /// <inheritdoc />
-    public async Task RegisterOnSiloAsync(
+    public Task RegisterOnSiloAsync(
         SiloAddress siloAddress,
         GrainId grainId,
         string reminderName,
@@ -82,10 +85,13 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
     {
         var silo = _cluster.GetSiloForAddress(siloAddress)
             ?? throw new InvalidOperationException($"Silo {siloAddress} is not active.");
-        var client = new DirectedReminderServiceClient(silo.ServiceProvider);
-        await client.GetReminderService(siloAddress)
-            .RegisterOrUpdateReminder(grainId, reminderName, dueTime, period)
-            .WaitAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        return reminderService.QueueTask(async () =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _ = await reminderService.RegisterOrUpdateReminder(grainId, reminderName, dueTime, period);
+        });
     }
 
     /// <inheritdoc />
@@ -157,9 +163,49 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
     /// <inheritdoc />
     public async Task<SiloAddress> JoinOneSiloAsync(CancellationToken cancellationToken)
     {
-        var silo = AssertSingle(await _cluster.StartSilosAsync(1).WaitAsync(cancellationToken));
-        await StabilizeTopologyAsync([silo], cancellationToken);
-        return silo.SiloAddress;
+        var initialSilos = _cluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToHashSet();
+        try
+        {
+            var silo = AssertSingle(await _cluster.StartSilosAsync(1, cancellationToken));
+            await StabilizeTopologyAsync([silo], cancellationToken);
+            return silo.SiloAddress;
+        }
+        catch (Exception joinFailure)
+        {
+            Exception? cleanupFailure = null;
+            using (var cleanupCancellation = new CancellationTokenSource(JoinCleanupTimeout))
+            {
+                try
+                {
+                    var addedSilos = _cluster.GetActiveSilos()
+                        .Where(silo => !initialSilos.Contains(silo.SiloAddress))
+                        .ToArray();
+                    foreach (var addedSilo in addedSilos)
+                    {
+                        await _cluster.StopSiloAsync(addedSilo, cleanupCancellation.Token);
+                    }
+
+                    if (addedSilos.Length > 0)
+                    {
+                        await Task.WhenAll(
+                            _cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cleanupCancellation.Token),
+                            _cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cleanupCancellation.Token));
+                    }
+                }
+                catch (Exception exception)
+                {
+                    cleanupFailure = exception;
+                }
+            }
+
+            if (cleanupFailure is not null)
+            {
+                joinFailure.Data["ReminderServiceLifecycleJoinCleanupFailure"] = cleanupFailure.ToString();
+            }
+
+            ExceptionDispatchInfo.Capture(joinFailure).Throw();
+            throw;
+        }
     }
 
     /// <inheritdoc />
@@ -184,7 +230,6 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
             _cluster,
             _observer,
             readySilos,
-            Timeout.InfiniteTimeSpan,
             cancellationToken);
 
     private static InProcessSiloHandle AssertSingle(IReadOnlyList<InProcessSiloHandle> silos)
@@ -214,9 +259,4 @@ public sealed class ReminderServiceLifecycleHarness : IReminderServiceLifecycleH
             ReminderEvents.LocalReminderStopReason.Unregistered,
             ActiveSilos.First());
 
-    private sealed class DirectedReminderServiceClient(IServiceProvider serviceProvider)
-        : GrainServiceClient<IReminderService>(serviceProvider)
-    {
-        public IReminderService GetReminderService(SiloAddress siloAddress) => GetGrainService(siloAddress);
-    }
 }

--- a/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
@@ -17,7 +17,6 @@ public static class ReminderTopologyStabilizer
         InProcessTestCluster cluster,
         ReminderDiagnosticObserver observer,
         IEnumerable<InProcessSiloHandle> readySilos,
-        TimeSpan timeout,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(cluster);
@@ -30,15 +29,11 @@ public static class ReminderTopologyStabilizer
             .ToArray();
         var expectedActiveSilos = Array.Empty<InProcessSiloHandle>();
         var phase = "reminder service readiness";
-        using var timeoutCancellation = new CancellationTokenSource(timeout);
-        using var phaseCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-            timeoutCancellation.Token,
-            cancellationToken);
         try
         {
             var ready = requiredReadySilos
                 .Select(silo => observer.WaitForReminderServiceStartedAsync(
-                    phaseCancellation.Token,
+                    cancellationToken,
                     silo.SiloAddress))
                 .ToArray();
             await Task.WhenAll(ready);
@@ -47,8 +42,8 @@ public static class ReminderTopologyStabilizer
             {
                 phase = "liveness and manifest convergence";
                 await Task.WhenAll(
-                    cluster.WaitForLivenessToStabilizeAsync().WaitAsync(phaseCancellation.Token),
-                    cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(phaseCancellation.Token));
+                    cluster.WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken),
+                    cluster.WaitForClusterManifestToStabilizeAsync().WaitAsync(cancellationToken));
 
                 phase = "active silo selection";
                 expectedActiveSilos = cluster.GetActiveSilos()
@@ -69,7 +64,7 @@ public static class ReminderTopologyStabilizer
                 phase = "selected active reminder service readiness";
                 var activeServicesReady = expectedActiveSilos
                     .Select(silo => observer.WaitForReminderServiceStartedAsync(
-                        phaseCancellation.Token,
+                        cancellationToken,
                         silo.SiloAddress))
                     .ToArray();
                 await Task.WhenAll(activeServicesReady);
@@ -83,15 +78,15 @@ public static class ReminderTopologyStabilizer
 
                 phase = "silo status listener delivery";
                 await Task.WhenAll(reminderServices.Select(service =>
-                    service.TestOnlyWaitForSiloStatusListeners(phaseCancellation.Token)));
+                    service.TestOnlyWaitForSiloStatusListeners(cancellationToken)));
 
                 phase = "stable topology refresh";
                 var refreshes = reminderServices.Select(service => service.TestOnlyRefresh()).ToArray();
-                await Task.WhenAll(refreshes).WaitAsync(phaseCancellation.Token);
+                await Task.WhenAll(refreshes).WaitAsync(cancellationToken);
 
                 phase = "latest reminder reconciliation";
                 var reconciliations = reminderServices.Select(service =>
-                    service.TestOnlyWaitForRangeChangeReconciliation(phaseCancellation.Token)).ToArray();
+                    service.TestOnlyWaitForRangeChangeReconciliation(cancellationToken)).ToArray();
                 await Task.WhenAll(reconciliations);
 
                 phase = "active silo and membership version verification";
@@ -120,16 +115,10 @@ public static class ReminderTopologyStabilizer
                 }
             }
         }
-        catch (OperationCanceledException exception) when (
-            timeoutCancellation.IsCancellationRequested
-            && !cancellationToken.IsCancellationRequested)
-        {
-            throw new TimeoutException(DescribeFailure(cluster, expectedActiveSilos, phase, timeout), exception);
-        }
         catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {
             throw new OperationCanceledException(
-                DescribeFailure(cluster, expectedActiveSilos, phase, timeout),
+                DescribeFailure(cluster, expectedActiveSilos, phase),
                 exception,
                 cancellationToken);
         }
@@ -138,8 +127,7 @@ public static class ReminderTopologyStabilizer
     private static string DescribeFailure(
         InProcessTestCluster cluster,
         IReadOnlyList<InProcessSiloHandle> expectedActiveSilos,
-        string phase,
-        TimeSpan timeout)
+        string phase)
     {
         var expected = expectedActiveSilos.Select(silo => silo.SiloAddress.ToString());
         var observed = cluster.GetActiveSilos()
@@ -147,7 +135,7 @@ public static class ReminderTopologyStabilizer
             .ToArray();
         var states = observed.Select(silo =>
             silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyDescribeTopologyState());
-        return $"Reminder topology did not stabilize during '{phase}' within {timeout}. "
+        return $"Reminder topology stabilization was canceled during '{phase}'. "
             + $"Expected active silos: [{string.Join(", ", expected)}]. "
             + $"Observed active silos: [{string.Join(", ", observed.Select(silo => silo.SiloAddress.ToString()))}]. "
             + $"States: [{string.Join("; ", states)}].";


### PR DESCRIPTION
## Problem

PR #10933 stabilized reminder topology convergence, but its compatibility follow-up left three correctness gaps: the default directed-registration method ignored its target silo, join cancellation could leave a temporary silo running, and a response timeout could let reminder persistence continue after cleanup. Explicit test refreshes also used a different scheduler queue from range-change callbacks, weakening the intended FIFO boundary.

## Solution

- Add a separate directed-registration capability so existing lifecycle harness implementations remain compatible while the stale-owner scenario explicitly requires exact target semantics.
- Queue the actual in-process reminder-service mutation on the selected silo, retain its task, and drain it before persisted-row cleanup.
- Pass caller cancellation into silo startup and clean every newly added silo with an independent cleanup budget when startup or stabilization fails.
- Use caller-owned topology deadlines, independent topology and row-cleanup budgets, and the same WorkItemGroup FIFO queue for range-change callbacks and explicit refreshes.

## Rationale

The stale-owner scenario must prove that registration through a known non-owner persists without starting a local schedule. Cleanup must also complete after all dispatched mutations and topology changes have settled, preventing delayed writes or temporary silos from contaminating later shared-fixture tests.

Follow-up to #10933.

Related: #10928, #10934, #10938, #10940, #10943, #10955, #10962
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10974)