### PR TITLE
ci: expand scheduled CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          queries: ${{ github.event_name == 'schedule' && 'security-extended' || '' }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,12 +40,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Initialize CodeQL
+      - name: Initialize CodeQL with extended queries
+        if: github.event_name == 'schedule'
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          queries: ${{ github.event_name == 'schedule' && 'security-extended' || '' }}
+          queries: +security-extended
+
+      - name: Initialize CodeQL
+        if: github.event_name != 'schedule'
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4


### PR DESCRIPTION
Scheduled CodeQL scans currently use the same default query suite as required push and pull request analysis. This limits periodic analysis to the highest-precision security queries.

Configure scheduled runs to add the maintained `security-extended` suite while leaving push, pull request, and merge queue runs on the default suite. This broadens weekly security coverage while avoiding the additional runtime and alert noise of `security-and-quality` on every required analysis.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10984)