### PR TITLE
build: modernize Roslyn analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Connections.Abstractions" Version="8.0.24" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.57.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.10.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />

--- a/src/Orleans.Analyzers.Contracts/Orleans.Analyzers.Contracts.csproj
+++ b/src/Orleans.Analyzers.Contracts/Orleans.Analyzers.Contracts.csproj
@@ -11,10 +11,12 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- The contracts package includes its analyzer and code fix together; the code fix requires Roslyn Workspaces. -->
     <NoWarn>$(NoWarn);RS1038</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
     <ProjectReference Include="..\Orleans.Analyzers\Orleans.Analyzers.csproj"

--- a/src/Orleans.Analyzers/Orleans.Analyzers.csproj
+++ b/src/Orleans.Analyzers/Orleans.Analyzers.csproj
@@ -4,10 +4,12 @@
     <IsPackable>false</IsPackable>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Analyzers and code fixes share this assembly so the packaged component exposes both; code fixes require Roslyn Workspaces. -->
     <NoWarn>$(NoWarn);RS1038</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
+++ b/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
@@ -11,7 +11,6 @@
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
-    <NoWarn>$(NoWarn);RS1038;RS1042</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

The Orleans analyzer and source-generator projects used Microsoft.CodeAnalysis.Analyzers 3.11.0, and only the code generator referenced the package directly. Their RS1038 and RS1042 suppressions also predated the current Roslyn analyzer behavior.

## Solution

- Upgrade Microsoft.CodeAnalysis.Analyzers to the current stable 5.9.0 release.
- Reference it consistently with `PrivateAssets="all"` from Orleans.Analyzers, Orleans.Analyzers.Contracts, and Orleans.CodeGenerator.
- Remove the obsolete RS1038 and RS1042 suppressions from Orleans.CodeGenerator.
- Retain RS1038 only in the two analyzer/code-fix assemblies, with project-local justification for their intentional Roslyn Workspaces dependency.

## Rationale

All compiler-extension projects now run the same current analyzer rules without changing their Roslyn API dependency versions or package layout. The remaining RS1038 suppressions describe the existing packaging boundary: analyzers and code fixes ship together, and the code fixes require Roslyn Workspaces.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10991)