### PR TITLE
test: centralize NSubstitute analyzers

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -5,5 +5,12 @@
   </PropertyGroup>
   
   <Import Project="$(_ParentDirectoryBuildTargetsPath)" Condition="Exists('$(_ParentDirectoryBuildTargetsPath)')"/>
-  
-  </Project>
+
+  <ItemGroup Condition="'@(PackageReference->WithMetadataValue('Identity', 'NSubstitute'))' != ''">
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/test/Extensions/Orleans.AdoNet.Tests/Orleans.AdoNet.Tests.csproj
+++ b/test/Extensions/Orleans.AdoNet.Tests/Orleans.AdoNet.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Npgsql" />
     <PackageReference Include="MySql.Data" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="System.Drawing.Common" /> <!-- For some reason it's a dependency of MySql.Data. We want to force it to a specific version -->
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
   </ItemGroup>

--- a/test/Orleans.Core.Tests/Orleans.Core.Tests.csproj
+++ b/test/Orleans.Core.Tests/Orleans.Core.Tests.csproj
@@ -17,10 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="CsCheck" />
   </ItemGroup>
 

--- a/test/Orleans.Streaming.Tests/Orleans.Streaming.Tests.csproj
+++ b/test/Orleans.Streaming.Tests/Orleans.Streaming.Tests.csproj
@@ -9,10 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

NSubstitute analyzer coverage was inconsistent across tests. Core and Streaming carried duplicate project-level analyzer references, while Kinesis and ADO.NET compiled NSubstitute usage without the same analyzer enforcement. ADO.NET also relied on a transitive NSubstitute dependency.

## Solution

Add `NSubstitute.Analyzers.CSharp` from the shared test build targets whenever a project directly references `NSubstitute`, preserving private and included asset metadata. Remove the duplicate Core and Streaming analyzer references and make ADO.NET's NSubstitute dependency explicit.

## Rationale

Evaluating the condition after project items are declared applies one consistent analyzer policy to every direct consumer while keeping the analyzer private from downstream projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10993)