### PR TITLE
chore: enforce analyzer baseline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -49,8 +49,8 @@ csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
 
-# Disallow throw expressions.
-csharp_style_throw_expression = false:suggestion
+# Prefer throw expressions.
+csharp_style_throw_expression = true:suggestion
 
 # Newline settings
 csharp_new_line_before_open_brace = all
@@ -64,9 +64,8 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_style_namespace_declarations = file_scoped
 
 # Brace settings
-csharp_prefer_braces = true # Prefer curly braces even for one line of code
+csharp_prefer_braces = true:suggestion
 
-dotnet_sort_system_directives_first = true
 dotnet_style_coalesce_expression = true : suggestion
 dotnet_style_collection_initializer = true : suggestion
 dotnet_style_explicit_tuple_names = true : suggestion
@@ -76,8 +75,6 @@ dotnet_style_parentheses_in_arithmetic_binary_operators =never_if_unnecessary:su
 dotnet_style_parentheses_in_other_binary_operators =never_if_unnecessary:suggestion
 dotnet_style_parentheses_in_other_operators =never_if_unnecessary:suggestion
 dotnet_style_parentheses_in_relational_binary_operators =never_if_unnecessary:suggestion
-dotnet_style_predefined_type_for_locals_parameters_members = true : suggestion
-dotnet_style_predefined_type_for_member_access = true : suggestion
 dotnet_style_prefer_auto_properties = true : suggestion
 dotnet_style_prefer_compound_assignment = true : suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true : suggestion
@@ -86,9 +83,7 @@ dotnet_style_prefer_inferred_anonymous_type_member_names = true : suggestion
 dotnet_style_prefer_inferred_tuple_names = true : suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true : suggestion
 dotnet_style_qualification_for_event =false:suggestion
-dotnet_style_qualification_for_field =false:suggestion
 dotnet_style_qualification_for_method =false:suggestion
-dotnet_style_qualification_for_property =false:suggestion
 dotnet_style_require_accessibility_modifiers = always : suggestion
 
 # Naming Symbols
@@ -206,19 +201,7 @@ csharp_style_inlined_variable_declaration = true : suggestion
 csharp_style_pattern_local_over_anonymous_function = true : suggestion
 csharp_style_pattern_matching_over_as_with_null_check = true : suggestion
 csharp_style_pattern_matching_over_is_with_cast_check = true : suggestion
-csharp_style_throw_expression = true : suggestion
-csharp_style_var_elsewhere = true : suggestion
-csharp_style_var_for_built_in_types = true : suggestion
-csharp_style_var_when_type_is_apparent = true : suggestion
-csharp_style_namespace_declarations = file_scoped
-
 # New Line Options
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_open_brace = all
 csharp_new_line_between_query_expression_clauses = true
 # Spacing Options
 csharp_space_after_cast = false
@@ -246,8 +229,6 @@ csharp_space_between_square_brackets = false
 # Wrapping Options
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
-# Blocks
-csharp_prefer_braces = true:none
 # Expressions
 csharp_prefer_simple_default_expression = true:suggestion
 
@@ -273,17 +254,66 @@ charset = utf-8-bom
 
 [*.{cs,vb}]
 
+# Parameter documentation completeness remains advisory for this baseline.
+dotnet_diagnostic.CS1573.severity = suggestion
+
+# Existing public API documentation and sealed-type compatibility warnings remain advisory.
+dotnet_diagnostic.CS0628.severity = suggestion
+dotnet_diagnostic.CS1591.severity = suggestion
+
+# Multiple-entry-point compatibility remains advisory.
+dotnet_diagnostic.CS8892.severity = suggestion
+
 # SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 dotnet_diagnostic.SYSLIB1054.severity = suggestion
+
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity = suggestion
+
+# CA1001: Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1001.severity = suggestion
 
 # CA1018: Mark attributes with AttributeUsageAttribute
 dotnet_diagnostic.CA1018.severity = suggestion
 
+# CA1036: Override methods on comparable types
+dotnet_diagnostic.CA1036.severity = suggestion
+
+# CA1041: Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1041.severity = suggestion
+
 # CA1047: Do not declare protected member in sealed type
 dotnet_diagnostic.CA1047.severity = suggestion
 
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = suggestion
+
+# CA1051: Do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = suggestion
+
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.CA1067.severity = suggestion
+
+# CA1068: CancellationToken parameters should come last
+dotnet_diagnostic.CA1068.severity = suggestion
+
+# CA1200: Avoid using cref tags with a prefix
+dotnet_diagnostic.CA1200.severity = suggestion
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = suggestion
+
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = suggestion
+
+# CA1309: Use ordinal string comparison
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = suggestion
+
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = suggestion
 
 # CA1507: Use nameof to express symbol names
 dotnet_diagnostic.CA1507.severity = suggestion
@@ -300,8 +330,32 @@ dotnet_diagnostic.CA1512.severity = suggestion
 # CA1513: Use ObjectDisposedException throw helper
 dotnet_diagnostic.CA1513.severity = suggestion
 
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = suggestion
+
+# CA1708: Identifiers should differ by more than case
+dotnet_diagnostic.CA1708.severity = suggestion
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = suggestion
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = suggestion
+
+# CA1715: Identifiers should have correct prefix
+dotnet_diagnostic.CA1715.severity = suggestion
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = suggestion
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.CA1720.severity = suggestion
+
 # CA1725: Parameter names should match base declaration
 dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA1727: Use PascalCase for named placeholders
+dotnet_diagnostic.CA1727.severity = suggestion
 
 # CA1802: Use literals where appropriate
 dotnet_diagnostic.CA1802.severity = suggestion
@@ -309,8 +363,14 @@ dotnet_diagnostic.CA1802.severity = suggestion
 # CA1805: Do not initialize unnecessarily
 dotnet_diagnostic.CA1805.severity = suggestion
 
+# CA1806: Do not ignore method results
+dotnet_diagnostic.CA1806.severity = suggestion
+
 # CA1810: Do not initialize unnecessarily
 dotnet_diagnostic.CA1810.severity = suggestion
+
+# CA1816: Dispose methods should call SuppressFinalize
+dotnet_diagnostic.CA1816.severity = suggestion
 
 # CA1821: Remove empty Finalizers
 dotnet_diagnostic.CA1821.severity = suggestion
@@ -391,6 +451,9 @@ dotnet_diagnostic.CA1846.severity = suggestion
 # CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
 dotnet_diagnostic.CA1847.severity = suggestion
 
+# CA1848: Use LoggerMessage delegates
+dotnet_diagnostic.CA1848.severity = suggestion
+
 # CA1852: Seal internal types
 dotnet_diagnostic.CA1852.severity = suggestion
 
@@ -401,7 +464,7 @@ dotnet_diagnostic.CA1854.severity = suggestion
 dotnet_diagnostic.CA1855.severity = suggestion
 
 # CA1856: Incorrect usage of ConstantExpected attribute
-dotnet_diagnostic.CA1856.severity = error
+dotnet_diagnostic.CA1856.severity = suggestion
 
 # CA1857: A constant is expected for the parameter
 dotnet_diagnostic.CA1857.severity = suggestion
@@ -409,8 +472,44 @@ dotnet_diagnostic.CA1857.severity = suggestion
 # CA1858: Use 'StartsWith' instead of 'IndexOf'
 dotnet_diagnostic.CA1858.severity = suggestion
 
+# CA1859: Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# CA1860: Avoid using Enumerable.Any()
+dotnet_diagnostic.CA1860.severity = suggestion
+
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = suggestion
+
+# CA1862: Use StringComparison overloads
+dotnet_diagnostic.CA1862.severity = suggestion
+
+# CA1863: Use CompositeFormat
+dotnet_diagnostic.CA1863.severity = suggestion
+
+# CA1864: Prefer IDictionary.TryAdd
+dotnet_diagnostic.CA1864.severity = suggestion
+
+# CA1865: Use char overload
+dotnet_diagnostic.CA1865.severity = suggestion
+
+# CA1866: Use char overload
+dotnet_diagnostic.CA1866.severity = suggestion
+
+# CA1868: Unnecessary call to Contains for sets
+dotnet_diagnostic.CA1868.severity = suggestion
+
+# CA1869: Cache JsonSerializerOptions instances
+dotnet_diagnostic.CA1869.severity = suggestion
+
+# CA1873: Avoid potentially expensive logging evaluation
+dotnet_diagnostic.CA1873.severity = suggestion
+
+# CA1875: Use SearchValues
+dotnet_diagnostic.CA1875.severity = suggestion
+
 # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = silent
+dotnet_diagnostic.CA2007.severity = suggestion
 
 # CA2008: Do not create tasks without passing a TaskScheduler
 dotnet_diagnostic.CA2008.severity = suggestion
@@ -442,6 +541,18 @@ dotnet_diagnostic.CA2201.severity = suggestion
 # CA2208: Instantiate argument exceptions correctly
 dotnet_diagnostic.CA2208.severity = suggestion
 
+# CA2211: Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = suggestion
+
+# CA2215: Dispose methods should call base class dispose
+dotnet_diagnostic.CA2215.severity = suggestion
+
+# CA2219: Do not raise exceptions in finally clauses
+dotnet_diagnostic.CA2219.severity = suggestion
+
+# CA2231: Overload operator equals on overriding ValueType.Equals
+dotnet_diagnostic.CA2231.severity = suggestion
+
 # CA2245: Do not assign a property to itself
 dotnet_diagnostic.CA2245.severity = suggestion
 
@@ -450,6 +561,18 @@ dotnet_diagnostic.CA2246.severity = suggestion
 
 # CA2249: Use string.Contains instead of string.IndexOf to improve readability.
 dotnet_diagnostic.CA2249.severity = suggestion
+
+# CA2251: Use String.Equals over String.Compare
+dotnet_diagnostic.CA2251.severity = suggestion
+
+# CA2253: Named placeholders should not be numeric values
+dotnet_diagnostic.CA2253.severity = suggestion
+
+# CA2254: Logging message templates should not vary between calls
+dotnet_diagnostic.CA2254.severity = suggestion
+
+# CA2263: Prefer generic overload when type is known
+dotnet_diagnostic.CA2263.severity = suggestion
 
 # IDE0005: Remove unnecessary usings
 dotnet_diagnostic.IDE0005.severity = suggestion
@@ -518,107 +641,6 @@ dotnet_diagnostic.IDE0200.severity = suggestion
 dotnet_style_allow_multiple_blank_lines_experimental = false
 dotnet_diagnostic.IDE2000.severity = suggestion
 
-# CA1018: Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.CA1018.severity = suggestion
-# CA1507: Use nameof to express symbol names
-dotnet_diagnostic.CA1507.severity = suggestion
-# CA1510: Use ArgumentNullException throw helper
-dotnet_diagnostic.CA1510.severity = suggestion
-# CA1511: Use ArgumentException throw helper
-dotnet_diagnostic.CA1511.severity = suggestion
-# CA1512: Use ArgumentOutOfRangeException throw helper
-dotnet_diagnostic.CA1512.severity = suggestion
-# CA1513: Use ObjectDisposedException throw helper
-dotnet_diagnostic.CA1513.severity = suggestion
-# CA1802: Use literals where appropriate
-dotnet_diagnostic.CA1802.severity = suggestion
-# CA1805: Do not initialize unnecessarily
-dotnet_diagnostic.CA1805.severity = suggestion
-# CA1810: Do not initialize unnecessarily
-dotnet_diagnostic.CA1810.severity = suggestion
-# CA1822: Make member static
-dotnet_diagnostic.CA1822.severity = suggestion
-# CA1823: Avoid zero-length array allocations
-dotnet_diagnostic.CA1825.severity = suggestion
-# CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
-dotnet_diagnostic.CA1826.severity = suggestion
-# CA1827: Do not use Count() or LongCount() when Any() can be used
-dotnet_diagnostic.CA1827.severity = suggestion
-# CA1829: Use Length/Count property instead of Count() when available
-dotnet_diagnostic.CA1829.severity = suggestion
-# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-dotnet_diagnostic.CA1831.severity = suggestion
-# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-dotnet_diagnostic.CA1832.severity = suggestion
-# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-dotnet_diagnostic.CA1833.severity = suggestion
-# CA1834: Consider using 'StringBuilder.Append(char)' when applicable
-dotnet_diagnostic.CA1834.severity = suggestion
-# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-dotnet_diagnostic.CA1835.severity = suggestion
-# CA1837: Use 'Environment.ProcessId'
-dotnet_diagnostic.CA1837.severity = suggestion
-# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
-dotnet_diagnostic.CA1838.severity = suggestion
-# CA1841: Prefer Dictionary.Contains methods
-dotnet_diagnostic.CA1841.severity = suggestion
-# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
-dotnet_diagnostic.CA1844.severity = suggestion
-# CA1845: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1845.severity = suggestion
-# CA1846: Prefer AsSpan over Substring
-dotnet_diagnostic.CA1846.severity = suggestion
-# CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
-dotnet_diagnostic.CA1847.severity = suggestion
-# CA1852: Seal internal types
-dotnet_diagnostic.CA1852.severity = suggestion
-# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
-dotnet_diagnostic.CA1854.severity = suggestion
-# CA1855: Prefer 'Clear' over 'Fill'
-dotnet_diagnostic.CA1855.severity = suggestion
-# CA1856: Incorrect usage of ConstantExpected attribute
-dotnet_diagnostic.CA1856.severity = suggestion
-# CA1857: A constant is expected for the parameter
-dotnet_diagnostic.CA1857.severity = suggestion
-# CA1858: Use 'StartsWith' instead of 'IndexOf'
-dotnet_diagnostic.CA1858.severity = suggestion
-# CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = suggestion
-# CA2008: Do not create tasks without passing a TaskScheduler
-dotnet_diagnostic.CA2008.severity = suggestion
-# CA2012: Use ValueTask correctly
-dotnet_diagnostic.CA2012.severity = suggestion
-# CA2201: Do not raise reserved exception types
-dotnet_diagnostic.CA2201.severity = suggestion
-# CA2249: Use string.Contains instead of string.IndexOf to improve readability.
-dotnet_diagnostic.CA2249.severity = suggestion
-# IDE0005: Remove unnecessary usings
-dotnet_diagnostic.IDE0005.severity = suggestion
-# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
-dotnet_diagnostic.IDE0020.severity = suggestion
-# IDE0029: Use coalesce expression (non-nullable types)
-dotnet_diagnostic.IDE0029.severity = suggestion
-# IDE0030: Use coalesce expression (nullable types)
-dotnet_diagnostic.IDE0030.severity = suggestion
-# IDE0031: Use null propagation
-dotnet_diagnostic.IDE0031.severity = suggestion
-# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
-dotnet_diagnostic.IDE0038.severity = suggestion
-# IDE0044: Make field readonly
-dotnet_diagnostic.IDE0044.severity = suggestion
-# IDE0051: Remove unused private members
-dotnet_diagnostic.IDE0051.severity = suggestion
-# IDE0059: Unnecessary assignment to a value
-dotnet_diagnostic.IDE0059.severity = suggestion
-# IDE0060: Remove unused parameters
-dotnet_diagnostic.IDE0060.severity = suggestion
-# IDE0062: Make local function static
-dotnet_diagnostic.IDE0062.severity = suggestion
-# IDE0200: Lambda expression can be removed
-dotnet_diagnostic.IDE0200.severity = suggestion
-# CA2016: Forward the 'CancellationToken' parameter to methods that take one
-dotnet_diagnostic.CA2016.severity = suggestion
-
 # RS0041: Public members should not use oblivious types
 dotnet_diagnostic.RS0041.severity = suggestion
 
@@ -634,3 +656,18 @@ dotnet_diagnostic.CA1849.severity = warning
 
 [src/Orleans.Runtime/Networking/**.cs]
 dotnet_diagnostic.CA1849.severity = warning
+
+# Production source enforces the correctness baseline. Tests, samples, documentation,
+# playgrounds, templates, and tools retain advisory diagnostics during this rollout.
+[src/**/*.{cs,vb}]
+dotnet_diagnostic.CA1856.severity = warning
+dotnet_diagnostic.CA2011.severity = warning
+dotnet_diagnostic.CA2012.severity = warning
+dotnet_diagnostic.CA2013.severity = warning
+dotnet_diagnostic.CA2014.severity = warning
+dotnet_diagnostic.CA2200.severity = warning
+dotnet_diagnostic.CA2208.severity = warning
+dotnet_diagnostic.CA2245.severity = warning
+dotnet_diagnostic.CA2246.severity = warning
+dotnet_diagnostic.IDE0035.severity = warning
+dotnet_diagnostic.IDE0043.severity = warning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,10 +20,9 @@
     <RepositoryType>git</RepositoryType>
     <LangVersion>preview</LangVersion>
     <Features>strict</Features>
-    <WarningLevel>3</WarningLevel>
-    <AnalysisLevel>preview</AnalysisLevel>
-    <!-- TODO: Uncomment this and fix errors -->
-    <!-- <AnalysisMode>All</AnalysisMode> -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>10.0</AnalysisLevel>
+    <AnalysisMode>Recommended</AnalysisMode>
     <Nullable>enable</Nullable>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -36,6 +35,8 @@
     <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>$(WarningsAsErrors);nullable</WarningsAsErrors>
+    <!-- CA1824 is part of the separate performance-diagnostic rollout. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1824</WarningsNotAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <!--<NoWarn>$(NoWarn);2003</NoWarn>-->
     <!-- TODO: Disable and ensure all public members are documented: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1591 -->

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -371,7 +371,7 @@ namespace Orleans.Storage
             if ((pkSize + rkSize + versionSize + dataSize) > MAX_DATA_SIZE)
             {
                 var msg = $"Data too large to write to DynamoDB table. Size={dataSize} MaxSize={MAX_DATA_SIZE}";
-                throw new ArgumentOutOfRangeException("GrainState.Size", msg);
+                throw new ArgumentOutOfRangeException(nameof(grainState), dataSize, msg);
             }
         }
 

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -371,7 +371,7 @@ namespace Orleans.Storage
             if ((pkSize + rkSize + versionSize + dataSize) > MAX_DATA_SIZE)
             {
                 var msg = $"Data too large to write to DynamoDB table. Size={dataSize} MaxSize={MAX_DATA_SIZE}";
-                throw new ArgumentOutOfRangeException(nameof(grainState), dataSize, msg);
+                throw new ArgumentOutOfRangeException(nameof(grainState), msg);
             }
         }
 

--- a/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
+++ b/src/AWS/Orleans.Streaming.SQS/Storage/SQSStorage.cs
@@ -296,7 +296,7 @@ namespace OrleansAWSUtils.Storage
                     throw new ArgumentNullException(nameof(message));
 
                 if (string.IsNullOrWhiteSpace(message.ReceiptHandle))
-                    throw new ArgumentNullException(nameof(message.ReceiptHandle));
+                    throw new ArgumentException("The message must have a receipt handle.", nameof(message));
 
                 if (string.IsNullOrWhiteSpace(queueUrl))
                     throw new InvalidOperationException("Queue not initialized");
@@ -368,7 +368,7 @@ namespace OrleansAWSUtils.Storage
                 throw new ArgumentNullException(nameof(message));
 
             if (string.IsNullOrWhiteSpace(message.ReceiptHandle))
-                throw new ArgumentNullException(nameof(message.ReceiptHandle));
+                throw new ArgumentException("The message must have a receipt handle.", nameof(message));
         }
 
         private void ReportErrorAndRethrow(Exception exc, string operation)

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureTableJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureTableJournalStorageOptions.cs
@@ -131,18 +131,22 @@ public sealed class AzureTableJournalStorageOptions
     {
         if (tableName is not { Length: >= 3 and <= 63 } || !IsAsciiLetter(tableName[0]))
         {
+#pragma warning disable CA2208 // Validation reports the public configuration property rather than this helper parameter.
             throw new ArgumentException(
                 "Azure Table names must contain 3 to 63 alphanumeric characters and begin with a letter.",
-                nameof(tableName));
+                nameof(TableName));
+#pragma warning restore CA2208
         }
 
         foreach (var character in tableName)
         {
             if (!IsAsciiLetter(character) && character is not (>= '0' and <= '9'))
             {
+#pragma warning disable CA2208 // Validation reports the public configuration property rather than this helper parameter.
                 throw new ArgumentException(
                     "Azure Table names must contain 3 to 63 alphanumeric characters and begin with a letter.",
-                    nameof(tableName));
+                    nameof(TableName));
+#pragma warning restore CA2208
             }
         }
     }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureTableJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureTableJournalStorageOptions.cs
@@ -106,7 +106,7 @@ public sealed class AzureTableJournalStorageOptions
             throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
         }
 
-        var mapper = GetPartitionKey ?? throw new ArgumentNullException(nameof(GetPartitionKey));
+        var mapper = GetPartitionKey ?? throw new InvalidOperationException("A partition key mapper must be configured.");
         var partitionKey = mapper(journalId);
         ArgumentException.ThrowIfNullOrWhiteSpace(partitionKey);
         ValidatePartitionKey(partitionKey, nameof(partitionKey));
@@ -133,7 +133,7 @@ public sealed class AzureTableJournalStorageOptions
         {
             throw new ArgumentException(
                 "Azure Table names must contain 3 to 63 alphanumeric characters and begin with a letter.",
-                nameof(TableName));
+                nameof(tableName));
         }
 
         foreach (var character in tableName)
@@ -142,7 +142,7 @@ public sealed class AzureTableJournalStorageOptions
             {
                 throw new ArgumentException(
                     "Azure Table names must contain 3 to 63 alphanumeric characters and begin with a letter.",
-                    nameof(TableName));
+                    nameof(tableName));
             }
         }
     }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -215,7 +215,7 @@ namespace Orleans.Storage
             {
                 var msg = string.Format("Data too large to write to Azure table. Size={0} MaxSize={1}", dataSize, maxDataSize);
                 LogErrorDataTooLarge(dataSize, maxDataSize);
-                throw new ArgumentOutOfRangeException("GrainState.Size", msg);
+                throw new ArgumentOutOfRangeException(nameof(dataSize), dataSize, msg);
             }
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
@@ -37,7 +37,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
             }
             if (string.IsNullOrEmpty(azureStorageOptions.TableName))
             {
-                throw new ArgumentNullException(nameof(azureStorageOptions.TableName));
+                throw new ArgumentException("A table name must be configured.", nameof(azureStorageOptions));
             }
 
             this.serializer = serializer;

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorage.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorage.cs
@@ -132,7 +132,7 @@ namespace Orleans.Transactions.AzureStorage
             var keyETag = key.ETag.ToString();
             if ((!string.IsNullOrWhiteSpace(keyETag) || !string.IsNullOrWhiteSpace(expectedETag)) && keyETag != expectedETag)
             {
-                throw new ArgumentException(nameof(expectedETag), "Etag does not match");
+                throw new ArgumentException("Etag does not match", nameof(expectedETag));
             }
 
             try

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/StateEntity.cs
@@ -153,7 +153,7 @@ namespace Orleans.Transactions.AzureStorage
             if (dataSize > maxDataSize)
             {
                 var msg = string.Format("Data too large to write to table. Size={0} MaxSize={1}", dataSize, maxDataSize);
-                throw new ArgumentOutOfRangeException("state", msg);
+                throw new ArgumentOutOfRangeException(nameof(dataSize), dataSize, msg);
             }
         }
 

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -62,8 +62,8 @@ namespace Orleans.GrainDirectory.AzureStorage
             this.options = options ?? throw new ArgumentNullException(nameof(options));
 
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            TableName = options.TableName ?? throw new ArgumentNullException(nameof(options.TableName));
-            StoragePolicyOptions = options.StoragePolicyOptions ?? throw new ArgumentNullException(nameof(options.StoragePolicyOptions));
+            TableName = options.TableName ?? throw new ArgumentException("A table name must be configured.", nameof(options));
+            StoragePolicyOptions = options.StoragePolicyOptions ?? throw new ArgumentException("Storage policy options must be configured.", nameof(options));
 
             AzureTableUtils.ValidateTableName(TableName);
         }

--- a/src/Orleans.BroadcastChannel/IdMapping/DefaultChannelIdMapper.cs
+++ b/src/Orleans.BroadcastChannel/IdMapping/DefaultChannelIdMapper.cs
@@ -50,7 +50,7 @@ namespace Orleans.BroadcastChannel
         private static IdSpan GetGuidKey(ChannelId streamId, bool includeNamespaceInGrainId)
         {
             var key = streamId.Key.Span;
-            if (!Utf8Parser.TryParse(key, out Guid guidKey, out var len, 'N') || len < key.Length) throw new ArgumentException(nameof(streamId));
+            if (!Utf8Parser.TryParse(key, out Guid guidKey, out var len, 'N') || len < key.Length) throw new ArgumentException("The channel key is not a valid GUID.", nameof(streamId));
 
             if (!includeNamespaceInGrainId)
                 return streamId.GetKeyIdSpan();
@@ -62,7 +62,7 @@ namespace Orleans.BroadcastChannel
         private static IdSpan GetIntegerKey(ChannelId streamId, bool includeNamespaceInGrainId)
         {
             var key = streamId.Key.Span;
-            if (!Utf8Parser.TryParse(key, out int intKey, out var len) || len < key.Length) throw new ArgumentException(nameof(streamId));
+            if (!Utf8Parser.TryParse(key, out int intKey, out var len) || len < key.Length) throw new ArgumentException("The channel key is not a valid integer.", nameof(streamId));
 
             return includeNamespaceInGrainId
                 ? GrainIdKeyExtensions.CreateIntegerKey(intKey, streamId.Namespace.Span)

--- a/src/Orleans.Core.Abstractions/Manifest/MajorMinorVersion.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/MajorMinorVersion.cs
@@ -73,7 +73,7 @@ namespace Orleans.Metadata
             if (string.IsNullOrWhiteSpace(value)) throw new ArgumentNullException(nameof(value));
 
             var i = value.IndexOf('.');
-            if (i < 0) throw new ArgumentException(nameof(value));
+            if (i < 0) throw new ArgumentException("The value must contain a major and minor version separated by a period.", nameof(value));
             return new MajorMinorVersion(long.Parse(value[..i]), long.Parse(value[(i + 1)..]));
         }
 

--- a/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
+++ b/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
@@ -69,7 +69,7 @@ namespace Orleans.Networking.Shared
         {
             if (size > _blockSize)
             {
-                ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_blockSize);
+                ThrowArgumentOutOfRangeException_BufferRequestTooLarge(size, _blockSize);
             }
 
             var block = Lease();
@@ -207,9 +207,9 @@ namespace Orleans.Networking.Shared
             }
         }
 
-        private static void ThrowArgumentOutOfRangeException_BufferRequestTooLarge(int maxSize)
+        private static void ThrowArgumentOutOfRangeException_BufferRequestTooLarge(int size, int maxSize)
         {
-            throw new ArgumentOutOfRangeException("size", $"Cannot allocate more than {maxSize} bytes in a single buffer");
+            throw new ArgumentOutOfRangeException(nameof(size), size, $"Cannot allocate more than {maxSize} bytes in a single buffer");
         }
 
         private static void ThrowObjectDisposedException() => throw new ObjectDisposedException("MemoryPool");

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -406,7 +406,7 @@ namespace Orleans
 
             if (!localObjects!.TryRegister(obj, observerId))
             {
-                throw new ArgumentException($"Failed to add new observer {reference} to localObjects collection.", "reference");
+                throw new ArgumentException($"Failed to add new observer {reference} to localObjects collection.", nameof(obj));
             }
 
             return reference;
@@ -426,7 +426,7 @@ namespace Orleans
 
             if (!localObjects!.TryDeregister(observerId))
             {
-                throw new ArgumentException("Reference is not associated with a local object.", "reference");
+                throw new ArgumentException("Reference is not associated with a local object.", nameof(obj));
             }
         }
 

--- a/src/Orleans.Core/Runtime/RingRange.cs
+++ b/src/Orleans.Core/Runtime/RingRange.cs
@@ -331,7 +331,7 @@ namespace Orleans.Runtime
                     return new SingleRange(start, end);
                 start = end; // nextStart
             }
-            throw new ArgumentException(nameof(mySubRangeIndex));
+            throw new ArgumentException("The subrange index must identify one of the divided ranges.", nameof(mySubRangeIndex));
         }
 
         // Takes a range and divides it into numSubRanges equal ranges and returns the subrange at mySubRangeIndex.
@@ -364,4 +364,3 @@ namespace Orleans.Runtime
         }
     }
 }
-

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -73,7 +73,7 @@ namespace Orleans.Hosting.Kubernetes
             _options = options;
             _clusterOptions = clusterOptions.Value;
             _clusterMembershipService = clusterMembershipService;
-            _config = _options.CurrentValue.GetClientConfiguration?.Invoke() ?? throw new ArgumentNullException(nameof(KubernetesHostingOptions) + "." + nameof(KubernetesHostingOptions.GetClientConfiguration));
+            _config = _options.CurrentValue.GetClientConfiguration?.Invoke() ?? throw new ArgumentException("A Kubernetes client configuration must be provided.", nameof(options));
             _client = new k8s.Kubernetes(_config);
             _podLabelSelector = $"{KubernetesHostingOptions.ServiceIdLabel}={_clusterOptions.ServiceId},{KubernetesHostingOptions.ClusterIdLabel}={_clusterOptions.ClusterId}";
             _podNamespace = _options.CurrentValue.Namespace!;

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1483,7 +1483,7 @@ internal sealed partial class ActivationData :
             OnCompletedRequest(message);
         }
 
-        static async ValueTask OnCompleteAsync(ActivationData activation, Message message, Task task)
+        static async Task OnCompleteAsync(ActivationData activation, Message message, Task task)
         {
             try
             {

--- a/src/Orleans.Runtime/Core/GrainRuntime.cs
+++ b/src/Orleans.Runtime/Core/GrainRuntime.cs
@@ -81,7 +81,7 @@ internal class GrainRuntime : IGrainRuntime
     public IStorage<TGrainState> GetStorage<TGrainState>(IGrainContext grainContext)
     {
         ArgumentNullException.ThrowIfNull(grainContext);
-        var grainType = grainContext.GrainInstance?.GetType() ?? throw new ArgumentNullException(nameof(IGrainContext.GrainInstance));
+        var grainType = grainContext.GrainInstance?.GetType() ?? throw new ArgumentException("The grain context must have a grain instance.", nameof(grainContext));
         IGrainStorage grainStorage = GrainStorageHelpers.GetGrainStorage(grainType, ServiceProvider);
         return new StateStorageBridge<TGrainState>("state", grainContext, grainStorage);
     }

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -116,7 +116,7 @@ namespace Orleans.Runtime
             {
                 throw new ArgumentException(
                     string.Format("Failed to add new observer {0} to localObjects collection.", grainReference),
-                    nameof(grainReference));
+                    nameof(obj));
             }
 
             return grainReference;
@@ -137,7 +137,7 @@ namespace Orleans.Runtime
 
             if (!invokableObjects.TryDeregister(observerId))
             {
-                throw new ArgumentException("Reference is not associated with a local object.", "reference");
+                throw new ArgumentException("Reference is not associated with a local object.", nameof(obj));
             }
         }
 

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -30,8 +30,12 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
 
     public async ValueTask<DirectoryMembershipSnapshot> RefreshViewAsync(MembershipVersion version, CancellationToken cancellationToken)
     {
-        await ClusterMembershipService.Refresh(version, cancellationToken);
-        if (CurrentView.Version <= version)
+        if (version == default || CurrentView.Version < version)
+        {
+            await ClusterMembershipService.Refresh(version, cancellationToken);
+        }
+
+        if (CurrentView.Version < version)
         {
             await foreach (var view in _viewUpdates.WithCancellation(cancellationToken))
             {

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -30,7 +30,7 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
 
     public async ValueTask<DirectoryMembershipSnapshot> RefreshViewAsync(MembershipVersion version, CancellationToken cancellationToken)
     {
-        _ = ClusterMembershipService.Refresh(version, cancellationToken);
+        await ClusterMembershipService.Refresh(version, cancellationToken);
         if (CurrentView.Version <= version)
         {
             await foreach (var view in _viewUpdates.WithCancellation(cancellationToken))

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -83,7 +83,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     public async ValueTask<DirectoryMembershipSnapshot> RefreshViewAsync(MembershipVersion version, CancellationToken cancellationToken)
     {
-        _ = _owner.RefreshViewAsync(version, cancellationToken);
+        await _owner.RefreshViewAsync(version, cancellationToken);
         if (CurrentView.Version <= version)
         {
             await foreach (var view in _viewUpdates.WithCancellation(cancellationToken))

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -83,8 +83,12 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     public async ValueTask<DirectoryMembershipSnapshot> RefreshViewAsync(MembershipVersion version, CancellationToken cancellationToken)
     {
-        await _owner.RefreshViewAsync(version, cancellationToken);
-        if (CurrentView.Version <= version)
+        if (version == default || CurrentView.Version < version)
+        {
+            await _owner.RefreshViewAsync(version, cancellationToken);
+        }
+
+        if (CurrentView.Version < version)
         {
             await foreach (var view in _viewUpdates.WithCancellation(cancellationToken))
             {

--- a/src/Orleans.Serialization/Buffers/ArcBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/ArcBufferWriter.cs
@@ -1399,7 +1399,7 @@ public struct ArcBuffer(ArcBufferPage first, int token, int offset, int length) 
 #else
         if (length < 0) throw new ArgumentOutOfRangeException(nameof(length), "Length must be greater than or equal to 0.");
         if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset), "Offset must be greater than or equal to 0.");
-        if (length + offset > Length) throw new ArgumentOutOfRangeException($"{nameof(length)} + {nameof(offset)}", "Length plus offset must be less than or equal to the length of the buffer.");
+        if (length + offset > Length) throw new ArgumentOutOfRangeException(nameof(length), "Length plus offset must be less than or equal to the length of the buffer.");
 #endif
 
         CheckValidity();

--- a/src/Orleans.Serialization/Buffers/ArcBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/ArcBufferWriter.cs
@@ -1395,17 +1395,19 @@ public struct ArcBuffer(ArcBufferPage first, int token, int offset, int length) 
 #if NET6_0_OR_GREATER
         ArgumentOutOfRangeException.ThrowIfLessThan(length, 0);
         ArgumentOutOfRangeException.ThrowIfLessThan(offset, 0);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(length + offset, Length);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, Length);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, Length - offset);
 #else
         if (length < 0) throw new ArgumentOutOfRangeException(nameof(length), "Length must be greater than or equal to 0.");
         if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset), "Offset must be greater than or equal to 0.");
-        if (length + offset > Length) throw new ArgumentOutOfRangeException(nameof(length), "Length plus offset must be less than or equal to the length of the buffer.");
+        if (offset > Length) throw new ArgumentOutOfRangeException(nameof(offset), "Offset must be less than or equal to the length of the buffer.");
+        if (length > Length - offset) throw new ArgumentOutOfRangeException(nameof(length), "Length plus offset must be less than or equal to the length of the buffer.");
 #endif
 
         CheckValidity();
         Debug.Assert(offset >= 0);
         Debug.Assert(length >= 0); 
-        Debug.Assert(offset + length <= Length);
+        Debug.Assert(length <= Length - offset);
         ArcBuffer result;
 
         // Navigate to the offset page & calculate the offset into the page.

--- a/src/Orleans.Streaming/Common/PooledCache/ChronologicalEvictionStrategy.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/ChronologicalEvictionStrategy.cs
@@ -30,8 +30,8 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="monitorWriteInterval">"Interval to write periodic statistics. Only triggered for active caches.</param>
         public ChronologicalEvictionStrategy(ILogger logger, TimePurgePredicate timePurage, ICacheMonitor? cacheMonitor, TimeSpan? monitorWriteInterval)
         {
-            if (logger == null) throw new ArgumentException(nameof(logger));
-            if (timePurage == null) throw new ArgumentException(nameof(timePurage));
+            if (logger == null) throw new ArgumentNullException(nameof(logger));
+            if (timePurage == null) throw new ArgumentNullException(nameof(timePurage));
             this.logger = logger;
             this.timePurge = timePurage;
             this.inUseBuffers = new Queue<FixedSizeBuffer>();

--- a/src/Orleans.Streaming/Core/DefaultStreamIdMapper.cs
+++ b/src/Orleans.Streaming/Core/DefaultStreamIdMapper.cs
@@ -50,7 +50,7 @@ namespace Orleans.Streams
         private static IdSpan GetGuidKey(StreamId streamId, bool includeNamespaceInGrainId)
         {
             var key = streamId.Key.Span;
-            if (!Utf8Parser.TryParse(key, out Guid guidKey, out var len, 'N') || len < key.Length) throw new ArgumentException(nameof(streamId));
+            if (!Utf8Parser.TryParse(key, out Guid guidKey, out var len, 'N') || len < key.Length) throw new ArgumentException("The stream key is not a valid GUID.", nameof(streamId));
 
             if (!includeNamespaceInGrainId)
                 return streamId.GetKeyIdSpan();
@@ -62,7 +62,7 @@ namespace Orleans.Streams
         private static IdSpan GetIntegerKey(StreamId streamId, bool includeNamespaceInGrainId)
         {
             var key = streamId.Key.Span;
-            if (!Utf8Parser.TryParse(key, out long intKey, out var len) || len < key.Length) throw new ArgumentException(nameof(streamId));
+            if (!Utf8Parser.TryParse(key, out long intKey, out var len) || len < key.Length) throw new ArgumentException("The stream key is not a valid integer.", nameof(streamId));
 
             return includeNamespaceInGrainId
                 ? GrainIdKeyExtensions.CreateIntegerKey(intKey, streamId.Namespace.Span)

--- a/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
@@ -86,7 +86,7 @@ namespace Orleans.Providers
             this.Name = providerName;
             this.queueMapperOptions = queueMapperOptions ?? throw new ArgumentNullException(nameof(queueMapperOptions));
             this.cacheOptions = cacheOptions ?? throw new ArgumentNullException(nameof(cacheOptions));
-            this.statisticOptions = statisticOptions ?? throw new ArgumentException(nameof(statisticOptions));
+            this.statisticOptions = statisticOptions ?? throw new ArgumentNullException(nameof(statisticOptions));
             this.grainFactory = grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.logger = loggerFactory.CreateLogger<ILogger<MemoryAdapterFactory<TSerializer>>>();

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -74,7 +74,7 @@ namespace Orleans.Streams
             StreamInstruments? streamInstruments = null)
             : base(id, shared)
         {
-            if (strProviderName == null) throw new ArgumentNullException("runtime", "PersistentStreamPullingAgent: strProviderName should not be null");
+            if (strProviderName == null) throw new ArgumentNullException(nameof(strProviderName), "PersistentStreamPullingAgent: strProviderName should not be null");
 
             QueueId = queueId;
             streamProviderName = strProviderName;

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -112,9 +112,9 @@ namespace Orleans.Runtime.Providers
         {
             try
             {
-                var balancer = this.ServiceProvider.GetKeyedService<IStreamQueueBalancer>(streamProviderName) ??this.ServiceProvider.GetService<IStreamQueueBalancer>();
+                var balancer = this.ServiceProvider.GetKeyedService<IStreamQueueBalancer>(streamProviderName) ?? this.ServiceProvider.GetService<IStreamQueueBalancer>();
                 if (balancer == null)
-                    throw new ArgumentOutOfRangeException(nameof(streamProviderName), streamProviderName, $"Cannot create stream queue balancer for StreamProvider: {streamProviderName}.Please configure your stream provider with a queue balancer.");
+                    throw new ArgumentOutOfRangeException(nameof(streamProviderName), streamProviderName, $"Cannot create stream queue balancer for StreamProvider: {streamProviderName}. Please configure your stream provider with a queue balancer.");
                 LogInfoSuccessfullyCreatedQueueBalancer(balancer.GetType(), streamProviderName);
                 return balancer;
             }

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -114,14 +114,14 @@ namespace Orleans.Runtime.Providers
             {
                 var balancer = this.ServiceProvider.GetKeyedService<IStreamQueueBalancer>(streamProviderName) ??this.ServiceProvider.GetService<IStreamQueueBalancer>();
                 if (balancer == null)
-                    throw new ArgumentOutOfRangeException("balancerType", $"Cannot create stream queue balancer for StreamProvider: {streamProviderName}.Please configure your stream provider with a queue balancer.");
+                    throw new ArgumentOutOfRangeException(nameof(streamProviderName), streamProviderName, $"Cannot create stream queue balancer for StreamProvider: {streamProviderName}.Please configure your stream provider with a queue balancer.");
                 LogInfoSuccessfullyCreatedQueueBalancer(balancer.GetType(), streamProviderName);
                 return balancer;
             }
             catch (Exception e)
             {
                 string error = $"Cannot create stream queue balancer for StreamProvider: {streamProviderName}, Exception: {e}. Please configure your stream provider with a queue balancer.";
-                throw new ArgumentOutOfRangeException("balancerType", error);
+                throw new ArgumentOutOfRangeException(nameof(streamProviderName), streamProviderName, error);
             }
         }
 

--- a/src/Orleans.Streaming/QueueBalancer/ConsistentRingQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/ConsistentRingQueueBalancer.cs
@@ -23,7 +23,7 @@ namespace Orleans.Streams
         {
             if (consistentRingProvider == null)
             {
-                throw new ArgumentNullException("streamProviderRuntime");
+                throw new ArgumentNullException(nameof(consistentRingProvider));
             }
 
             _myRange = consistentRingProvider.GetMyRange();

--- a/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
+++ b/src/Orleans.Transactions/State/TransactionalStateStorageProviderWrapper.cs
@@ -37,7 +37,7 @@ namespace Orleans.Transactions
         public async Task<string> Store(string? expectedETag, TransactionalStateMetaData metadata, List<PendingTransactionState<TState>>? statesToPrepare, long? commitUpTo, long? abortAfter)
         {
             if (this.StateStorage.Etag != expectedETag)
-                throw new ArgumentException(nameof(expectedETag), "Etag does not match");
+                throw new ArgumentException("Etag does not match", nameof(expectedETag));
             var storedState = stateStorage!.State!; // StateStorage access above initializes the field and ReadStateAsync has populated its state.
             var storedETag = stateStorage.Etag;
             var state = new TransactionalStateRecord<TState>

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/DistributedGrainDirectoryTests.cs
@@ -77,6 +77,12 @@ public sealed class DistributedGrainDirectoryMembershipTests
             controlledMembership.ReleaseActiveUpdate();
 
             Assert.Equal(siloAddress, await primaryTask);
+
+            var refreshCount = controlledMembership.RefreshCount;
+            var currentView = await membership.RefreshViewAsync(membership.CurrentView.Version, timeout.Token);
+
+            Assert.Equal(membership.CurrentView, currentView);
+            Assert.Equal(refreshCount, controlledMembership.RefreshCount);
         }
         finally
         {
@@ -90,6 +96,7 @@ public sealed class DistributedGrainDirectoryMembershipTests
         private readonly TaskCompletionSource _activeUpdateBlocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource _releaseActiveUpdate = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _hasBlockedActiveUpdate;
+        private int _refreshCount;
 
         public ClusterMembershipSnapshot CurrentSnapshot => inner.CurrentSnapshot;
 
@@ -97,8 +104,13 @@ public sealed class DistributedGrainDirectoryMembershipTests
 
         public Task ActiveUpdateBlocked => _activeUpdateBlocked.Task;
 
-        public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) =>
-            inner.Refresh(minimumVersion, cancellationToken);
+        public int RefreshCount => Volatile.Read(ref _refreshCount);
+
+        public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _refreshCount);
+            return inner.Refresh(minimumVersion, cancellationToken);
+        }
 
         public Task<bool> TryKill(SiloAddress siloAddress) => inner.TryKill(siloAddress);
 

--- a/test/Orleans.Journaling.Tests/AzureTableJournalStorageOptionsTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureTableJournalStorageOptionsTests.cs
@@ -131,10 +131,10 @@ public sealed class AzureTableJournalStorageOptionsTests
     {
         var options = new AzureTableJournalStorageOptions { GetPartitionKey = null! };
 
-        var exception = Assert.Throws<ArgumentNullException>(
+        var exception = Assert.Throws<InvalidOperationException>(
             () => options.GetPartitionKeyForJournal(new JournalId("journal")));
 
-        Assert.Equal(nameof(AzureTableJournalStorageOptions.GetPartitionKey), exception.ParamName);
+        Assert.Equal("A partition key mapper must be configured.", exception.Message);
     }
 
     [Theory]


### PR DESCRIPTION
## Problem

The repository lowers compiler warnings to level 3, does not explicitly enable the .NET analyzers, and contains duplicated `.editorconfig` entries whose later overrides make analyzer and style policy ambiguous.

## Solution

Enable the .NET analyzers with the stable .NET 10 analysis level and Recommended mode, remove the warning-level downgrade, consolidate the duplicated style and diagnostic configuration, and enforce the selected correctness diagnostics for production source. Fix the resulting CA2012 and CA2208 findings in source while keeping existing tests, samples, docs, playgrounds, templates, and broader Recommended-mode debt advisory.

## Rationale

The source-scoped baseline makes correctness enforcement immediately actionable without coupling this PR to the separate performance rollout or the larger non-production backlog. CA2016 remains advisory because its enforcement is owned by the existing rollout branch. CA1824 and the other pre-existing Recommended/performance findings remain visible without failing the build. The full external-assets build is independently blocked by the Dashboard npm mirror failure addressed by #10981; the remaining solution builds successfully with external assets disabled.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10996)