### PR TITLE
perf: enforce runtime analyzer diagnostics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -627,3 +627,23 @@ dotnet_diagnostic.RS0026.severity = suggestion
 
 # RS0027: API with optional parameter(s) should have the most parameters amongst its public overloads
 dotnet_diagnostic.RS0027.severity = suggestion
+
+# Core runtime performance and reliability diagnostics.
+[src/{Orleans.Core.Abstractions,Orleans.Core}/**.cs]
+dotnet_diagnostic.CA1848.severity = warning
+dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA1873.severity = warning
+dotnet_diagnostic.CA2000.severity = warning
+dotnet_diagnostic.CA2002.severity = warning
+
+# Networking is the synchronization and transport boundary in Orleans.Runtime.
+[src/Orleans.Runtime/Networking/**.cs]
+dotnet_diagnostic.CA1848.severity = warning
+dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA1873.severity = warning
+dotnet_diagnostic.CA2000.severity = warning
+dotnet_diagnostic.CA2002.severity = warning
+
+# The System.Text.Json codec directly owns disposable writer resources.
+[src/Orleans.Serialization.SystemTextJson/**.cs]
+dotnet_diagnostic.CA2000.severity = warning

--- a/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
+++ b/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
@@ -86,11 +86,14 @@ namespace Orleans
         /// <returns>
         /// A <see cref="Task"/> representing the operation.
         /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Cancellation callbacks must execute synchronously on the current Orleans scheduler context before remote propagation.")]
         internal Task Cancel()
         {
             if (_cancellationTokenRuntime == null)
             {
-                // Wrap in task
                 try
                 {
                     _cancellationTokenSource.Cancel();
@@ -98,9 +101,7 @@ namespace Orleans
                 }
                 catch (Exception exception)
                 {
-                    var completion = new TaskCompletionSource<object>();
-                    completion.TrySetException(exception);
-                    return completion.Task;
+                    return Task.FromException(exception);
                 }
             }
 

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -610,6 +610,10 @@ namespace Orleans.Runtime
     [SerializerTransparent]
     public abstract class Request : RequestBase
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "GetResult is called only after IsCompleted and must consume a completed ValueTask source without allocating.")]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -749,6 +753,10 @@ namespace Orleans.Runtime
     public abstract class TaskRequest : RequestBase
     {
         /// <inheritdoc/>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "GetResult is called only after IsCompleted, so it observes completion without blocking or allocating.")]
         public sealed override ValueTask<Response> Invoke()
         {
             try

--- a/src/Orleans.Core/Async/AsyncLock.cs
+++ b/src/Orleans.Core/Async/AsyncLock.cs
@@ -61,6 +61,10 @@ namespace Orleans
         /// Acquires the lock asynchronously.
         /// </summary>
         /// <returns>An <see cref="IDisposable"/> which must be used to release the lock.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownership of each LockReleaser is transferred to the caller through the returned ValueTask.")]
         public ValueTask<IDisposable> LockAsync()
         {
             Task wait = semaphore.WaitAsync();

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +12,8 @@ namespace Orleans.Internal
     /// </summary>
     internal static class OrleansTaskExtentions
     {
+        private static readonly ConcurrentDictionary<ErrorCode, Action<ILogger, string, Exception?>> LogExceptionDelegates = new();
+
         public static ConfiguredTaskAwaitable SuppressThrowing(this ValueTask task) => task.AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
         public static ConfiguredTaskAwaitable SuppressThrowing(this Task task) => task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
 
@@ -34,8 +37,10 @@ namespace Orleans.Internal
             }
             catch (Exception exc)
             {
-                // TODO: pending on https://github.com/dotnet/runtime/issues/110570
-                logger.LogError((int)errorCode, exc, "{Message}", message);
+                var log = LogExceptionDelegates.GetOrAdd(
+                    errorCode,
+                    static code => LoggerMessage.Define<string>(LogLevel.Error, new EventId((int)code), "{Message}"));
+                log(logger, message, exc);
                 throw;
             }
         }
@@ -99,7 +104,7 @@ namespace Orleans.Internal
             // We got done before the timeout, or were able to complete before this code ran, return the result
             if (taskToComplete == completedTask)
             {
-                timeoutCancellationTokenSource.Cancel();
+                await timeoutCancellationTokenSource.CancelAsync();
                 // Await this so as to propagate the exception correctly
                 await taskToComplete;
                 return;
@@ -133,7 +138,7 @@ namespace Orleans.Internal
             // We got done before the timeout, or were able to complete before this code ran, return the result
             if (taskToComplete == completedTask)
             {
-                timeoutCancellationTokenSource.Cancel();
+                await timeoutCancellationTokenSource.CancelAsync();
                 // Await this so as to propagate the exception correctly
                 return await taskToComplete;
             }

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -96,6 +96,11 @@ namespace Orleans
         /// <param name="formatter">The options formatter.</param>
         public void LogOption(IOptionFormatter formatter)
         {
+            if (!logger.IsEnabled(LogLevel.Information))
+            {
+                return;
+            }
+
             try
             {
                 var stringBuilder = new StringBuilder();
@@ -103,9 +108,11 @@ namespace Orleans
                 {
                     stringBuilder.AppendLine($"{setting}");
                 }
-                LogInformationOptions(logger, formatter.Name, stringBuilder.ToString());
+
+                var options = stringBuilder.ToString();
+                LogInformationOptions(logger, formatter.Name, options);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 LogErrorOptions(logger, ex, formatter.Name);
                 throw;
@@ -114,6 +121,7 @@ namespace Orleans
 
         [LoggerMessage(
             Level = LogLevel.Information,
+            SkipEnabledCheck = true,
             Message = "Configuration {Name}:\n{Options}"
         )]
         private static partial void LogInformationOptions(ILogger logger, string name, string options);

--- a/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
@@ -86,7 +86,11 @@ namespace Orleans
         /// <param name="elapsed">The period of time which elapsed before <see cref="OnStart"/> completed once it was initiated.</param>
         protected virtual void PerfMeasureOnStart(int stage, TimeSpan elapsed)
         {
-            LogLifecycleStageStarted(Logger, GetStageName(stage), elapsed);
+            if (Logger.IsEnabled(LogLevel.Trace))
+            {
+                var stageName = GetStageName(stage);
+                LogLifecycleStageStarted(Logger, stageName, elapsed);
+            }
         }
 
         /// <inheritdoc />
@@ -146,7 +150,11 @@ namespace Orleans
         /// <param name="elapsed">The period of time which elapsed before <see cref="OnStop"/> completed once it was initiated.</param>
         protected virtual void PerfMeasureOnStop(int stage, TimeSpan elapsed)
         {
-            LogLifecycleStageStopped(Logger, GetStageName(stage), elapsed);
+            if (Logger.IsEnabled(LogLevel.Trace))
+            {
+                var stageName = GetStageName(stage);
+                LogLifecycleStageStopped(Logger, stageName, elapsed);
+            }
         }
 
         /// <inheritdoc />
@@ -266,6 +274,7 @@ namespace Orleans
         [LoggerMessage(
             EventId = (int)ErrorCode.SiloStartPerfMeasure,
             Level = LogLevel.Trace,
+            SkipEnabledCheck = true,
             Message = "Starting lifecycle stage '{Stage}' took '{Elapsed}'."
         )]
         private static partial void LogLifecycleStageStarted(ILogger logger, string stage, TimeSpan elapsed);
@@ -273,6 +282,7 @@ namespace Orleans
         [LoggerMessage(
             EventId = (int)ErrorCode.SiloStartPerfMeasure,
             Level = LogLevel.Trace,
+            SkipEnabledCheck = true,
             Message = "Stopping lifecycle stage '{Stage}' took '{Elapsed}'."
         )]
         private static partial void LogLifecycleStageStopped(ILogger logger, string stage, TimeSpan elapsed);

--- a/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
@@ -62,6 +62,10 @@ internal sealed partial class ServiceLifecycleNotificationStage(ILogger logger, 
 
     public Task WaitAsync(CancellationToken cancellationToken) => _tcs.Task.WaitAsync(cancellationToken);
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Ownership of the participant is transferred to the lifecycle stage and the returned registration.")]
     public IDisposable Register(Func<object?, CancellationToken, Task> callback, object? state, bool terminateOnError)
     {
         ArgumentNullException.ThrowIfNull(callback);

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -77,11 +77,15 @@ namespace Orleans.Runtime
             return _initialized.Task;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Shutdown must signal cancellation immediately without awaiting callback completion before observing the host stop token.")]
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             try
             {
-                await _shutdownCts.CancelAsync();
+                _shutdownCts.Cancel();
 
                 if (_runTask is { } task)
                 {
@@ -220,6 +224,10 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Shutdown must signal cancellation immediately without awaiting callback completion before waiting for the run task.")]
         public async ValueTask DisposeAsync()
         {
             if (_shutdownCts.IsCancellationRequested)
@@ -227,7 +235,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            await _shutdownCts.CancelAsync();
+            _shutdownCts.Cancel();
             if (_runTask is Task task)
             {
                 await task.SuppressThrowing();

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -81,7 +81,7 @@ namespace Orleans.Runtime
         {
             try
             {
-                _shutdownCts.Cancel();
+                await _shutdownCts.CancelAsync();
 
                 if (_runTask is { } task)
                 {
@@ -227,7 +227,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            _shutdownCts.Cancel();
+            await _shutdownCts.CancelAsync();
             if (_runTask is Task task)
             {
                 await task.SuppressThrowing();

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -77,7 +77,11 @@ namespace Orleans.Runtime.Messaging
                     });
 
                 var preamble = await connectionPreambleHelper.Read(this.Context);
-                LogInformationEstablishedConnection(this.Log, preamble.SiloAddress, preamble.NetworkProtocolVersion.ToString());
+                if (this.Log.IsEnabled(LogLevel.Information))
+                {
+                    var protocolVersion = preamble.NetworkProtocolVersion.ToString();
+                    LogInformationEstablishedConnection(this.Log, preamble.SiloAddress, protocolVersion);
+                }
 
                 if (preamble.ClusterId != myClusterId)
                 {
@@ -170,6 +174,7 @@ namespace Orleans.Runtime.Messaging
 
         [LoggerMessage(
             Level = LogLevel.Information,
+            SkipEnabledCheck = true,
             Message = "Established connection to {Silo} with protocol version {ProtocolVersion}"
         )]
         private static partial void LogInformationEstablishedConnection(ILogger logger, SiloAddress? silo, string protocolVersion);

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -356,7 +356,7 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
-                _transport!.Input.Complete();
+                await _transport!.Input.CompleteAsync();
                 this.StartClosing(error);
             }
         }
@@ -421,7 +421,7 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
-                _transport!.Output.Complete();
+                await _transport!.Output.CompleteAsync();
                 this.StartClosing(error);
             }
         }

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -11,6 +11,11 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly IConnectionFactory connectionFactory;
         private readonly IServiceProvider serviceProvider;
+#if NET9_0_OR_GREATER
+        private readonly Lock connectionDelegateLock = new();
+#else
+        private readonly object connectionDelegateLock = new();
+#endif
         private ConnectionDelegate? connectionDelegate;
 
         protected ConnectionFactory(
@@ -31,7 +36,7 @@ namespace Orleans.Runtime.Messaging
             {
                 if (this.connectionDelegate != null) return this.connectionDelegate;
 
-                lock (this)
+                lock (this.connectionDelegateLock)
                 {
                     if (this.connectionDelegate != null) return this.connectionDelegate;
 

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -282,6 +282,10 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Shutdown callbacks must complete synchronously before connections are scanned, while aggregating all callback failures.")]
         public async Task Close(CancellationToken ct)
         {
             try

--- a/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
+++ b/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
@@ -104,6 +104,10 @@ namespace Orleans.Networking.Shared
         /// Internal method called when a block is requested and the pool is empty. It allocates one additional slab, creates all of the
         /// block tracking objects, and adds them all to the pool.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "The pool owns the slab and blocks after adding them to its collections and disposes the slabs with the pool.")]
         private MemoryPoolBlock AllocateSlab()
         {
             var slab = MemoryPoolSlab.Create(_slabLength);
@@ -165,6 +169,10 @@ namespace Orleans.Networking.Shared
         }
 
         // This method can ONLY be called from the finalizer of MemoryPoolBlock
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Return transfers ownership of the replacement block back to the pool.")]
         internal void RefreshBlock(MemoryPoolSlab slab, int offset, int length)
         {
             lock (_disposeSync)

--- a/src/Orleans.Core/Networking/Shared/SocketConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnection.cs
@@ -119,8 +119,8 @@ namespace Orleans.Networking.Shared
         // Only called after connection middleware is complete which means the ConnectionClosed token has fired.
         public override async ValueTask DisposeAsync()
         {
-            Transport.Input.Complete();
-            Transport.Output.Complete();
+            await Transport.Input.CompleteAsync();
+            await Transport.Output.CompleteAsync();
 
             if (_processingTask != null)
             {
@@ -172,7 +172,7 @@ namespace Orleans.Networking.Shared
             finally
             {
                 // If Shutdown() has already bee called, assume that was the reason ProcessReceives() exited.
-                Input.Complete(_shutdownReason ?? error);
+                await Input.CompleteAsync(_shutdownReason ?? error);
 
                 FireConnectionClosed();
 
@@ -259,7 +259,7 @@ namespace Orleans.Networking.Shared
                 Shutdown(shutdownReason);
 
                 // Complete the output after disposing the socket
-                Output.Complete(unexpectedError);
+                await Output.CompleteAsync(unexpectedError);
 
                 // Cancel any pending flushes so that the input loop is un-paused
                 Input.CancelPendingFlush();

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionFactory.cs
@@ -30,45 +30,53 @@ namespace Orleans.Networking.Shared
 
         public async ValueTask<ConnectionContext> ConnectAsync(EndPoint endpoint, CancellationToken cancellationToken)
         {
-            var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+            Socket? socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
                 LingerState = new LingerOption(true, 0),
                 NoDelay = _options.NoDelay,
             };
 
-            if (_options.KeepAlive)
+            try
             {
-                socket.EnableKeepAlive(
-                    timeSeconds: _options.KeepAliveTimeSeconds,
-                    intervalSeconds: _options.KeepAliveIntervalSeconds,
-                    retryCount: _options.KeepAliveRetryCount);
-            }
-
-            socket.EnableFastPath();
-            using var completion = new SingleUseSocketAsyncEventArgs
-            {
-                RemoteEndPoint = endpoint
-            };
-
-            if (socket.ConnectAsync(completion))
-            {
-                using (cancellationToken.Register(s => Socket.CancelConnectAsync((SingleUseSocketAsyncEventArgs)s!), completion))
+                if (_options.KeepAlive)
                 {
-                    await completion.Task;
+                    socket.EnableKeepAlive(
+                        timeSeconds: _options.KeepAliveTimeSeconds,
+                        intervalSeconds: _options.KeepAliveIntervalSeconds,
+                        retryCount: _options.KeepAliveRetryCount);
                 }
-            }
 
-            if (completion.SocketError != SocketError.Success)
+                socket.EnableFastPath();
+                using var completion = new SingleUseSocketAsyncEventArgs
+                {
+                    RemoteEndPoint = endpoint
+                };
+
+                if (socket.ConnectAsync(completion))
+                {
+                    using (cancellationToken.Register(s => Socket.CancelConnectAsync((SingleUseSocketAsyncEventArgs)s!), completion))
+                    {
+                        await completion.Task;
+                    }
+                }
+
+                if (completion.SocketError != SocketError.Success)
+                {
+                    if (completion.SocketError == SocketError.OperationAborted)
+                        cancellationToken.ThrowIfCancellationRequested();
+                    throw new SocketConnectionException($"Unable to connect to {endpoint}. Error: {completion.SocketError}");
+                }
+
+                var scheduler = this.schedulers.GetScheduler();
+                var connection = new SocketConnection(socket, this.memoryPool, scheduler, this.trace);
+                connection.Start();
+                socket = null;
+                return connection;
+            }
+            finally
             {
-                if (completion.SocketError == SocketError.OperationAborted)
-                    cancellationToken.ThrowIfCancellationRequested();
-                throw new SocketConnectionException($"Unable to connect to {endpoint}. Error: {completion.SocketError}");
+                socket?.Dispose();
             }
-
-            var scheduler = this.schedulers.GetScheduler();
-            var connection = new SocketConnection(socket, this.memoryPool, scheduler, this.trace);
-            connection.Start();
-            return connection;
         }
 
         private sealed class SingleUseSocketAsyncEventArgs : SocketAsyncEventArgs

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
@@ -43,43 +43,51 @@ namespace Orleans.Networking.Shared
                 throw new InvalidOperationException("Transport already bound");
             }
 
-            var listenSocket = new Socket(EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+            Socket? listenSocket = new Socket(EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
                 LingerState = new LingerOption(true, 0),
                 NoDelay = true
             };
 
-            listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-            if (_options.KeepAlive)
-            {
-                listenSocket.EnableKeepAlive(
-                    timeSeconds: _options.KeepAliveTimeSeconds,
-                    intervalSeconds: _options.KeepAliveIntervalSeconds,
-                    retryCount: _options.KeepAliveRetryCount);
-            }
-
-            listenSocket.EnableFastPath();
-
-            // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
-            if (EndPoint is IPEndPoint ip && Equals(ip.Address, IPAddress.IPv6Any))
-            {
-                listenSocket.DualMode = true;
-            }
-
             try
             {
-                listenSocket.Bind(EndPoint);
+                listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                if (_options.KeepAlive)
+                {
+                    listenSocket.EnableKeepAlive(
+                        timeSeconds: _options.KeepAliveTimeSeconds,
+                        intervalSeconds: _options.KeepAliveIntervalSeconds,
+                        retryCount: _options.KeepAliveRetryCount);
+                }
+
+                listenSocket.EnableFastPath();
+
+                // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
+                if (EndPoint is IPEndPoint ip && Equals(ip.Address, IPAddress.IPv6Any))
+                {
+                    listenSocket.DualMode = true;
+                }
+
+                try
+                {
+                    listenSocket.Bind(EndPoint);
+                }
+                catch (SocketException e) when (e.SocketErrorCode == SocketError.AddressAlreadyInUse)
+                {
+                    throw new AddressInUseException(e.Message, e);
+                }
+
+                EndPoint = listenSocket.LocalEndPoint!;
+
+                listenSocket.Listen(512);
+
+                _listenSocket = listenSocket;
+                listenSocket = null;
             }
-            catch (SocketException e) when (e.SocketErrorCode == SocketError.AddressAlreadyInUse)
+            finally
             {
-                throw new AddressInUseException(e.Message, e);
+                listenSocket?.Dispose();
             }
-
-            EndPoint = listenSocket.LocalEndPoint!;
-
-            listenSocket.Listen(512);
-
-            _listenSocket = listenSocket;
         }
 
         public async ValueTask<ConnectionContext?> AcceptAsync(CancellationToken cancellationToken = default)
@@ -88,21 +96,29 @@ namespace Orleans.Networking.Shared
             {
                 try
                 {
-                    var acceptSocket = await _listenSocket!.AcceptAsync();
-                    acceptSocket.NoDelay = _options.NoDelay;
-                    if (_options.KeepAlive)
+                    Socket? acceptSocket = await _listenSocket!.AcceptAsync();
+                    try
                     {
-                        acceptSocket.EnableKeepAlive(
-                            timeSeconds: _options.KeepAliveTimeSeconds,
-                            intervalSeconds: _options.KeepAliveIntervalSeconds,
-                            retryCount: _options.KeepAliveRetryCount);
+                        acceptSocket.NoDelay = _options.NoDelay;
+                        if (_options.KeepAlive)
+                        {
+                            acceptSocket.EnableKeepAlive(
+                                timeSeconds: _options.KeepAliveTimeSeconds,
+                                intervalSeconds: _options.KeepAliveIntervalSeconds,
+                                retryCount: _options.KeepAliveRetryCount);
+                        }
+
+                        var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);
+
+                        connection.Start();
+                        acceptSocket = null;
+
+                        return connection;
                     }
-
-                    var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);
-
-                    connection.Start();
-
-                    return connection;
+                    finally
+                    {
+                        acceptSocket?.Dispose();
+                    }
                 }
                 catch (ObjectDisposedException)
                 {

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
@@ -30,7 +30,7 @@ namespace Orleans.Networking.Shared
             this.schedulers = schedulers;
         }
 
-        public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+        public async ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
         {
             if (!(endpoint is IPEndPoint ipEndpoint))
             {
@@ -38,8 +38,16 @@ namespace Orleans.Networking.Shared
             }
 
             var listener = new SocketConnectionListener(ipEndpoint, this.socketConnectionOptions, this.trace, this.schedulers);
-            listener.Bind();
-            return new ValueTask<IConnectionListener>(listener);
+            try
+            {
+                listener.Bind();
+                return listener;
+            }
+            catch
+            {
+                await listener.DisposeAsync();
+                throw;
+            }
         }
     }
 }

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
@@ -32,9 +32,10 @@ namespace Orleans.Networking.Shared
 
         public async ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
         {
-            if (!(endpoint is IPEndPoint ipEndpoint))
+            ArgumentNullException.ThrowIfNull(endpoint);
+            if (endpoint is not IPEndPoint ipEndpoint)
             {
-                throw new ArgumentNullException(nameof(endpoint));
+                throw new ArgumentException($"The endpoint must be an {nameof(IPEndPoint)}.", nameof(endpoint));
             }
 
             var listener = new SocketConnectionListener(ipEndpoint, this.socketConnectionOptions, this.trace, this.schedulers);

--- a/src/Orleans.Core/Runtime/AsyncEnumerableGrainExtension.cs
+++ b/src/Orleans.Core/Runtime/AsyncEnumerableGrainExtension.cs
@@ -331,6 +331,10 @@ internal sealed partial class AsyncEnumerableGrainExtension : IAsyncEnumerableGr
         Timer.Dispose();
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1849:Call async methods when in an async method",
+        Justification = "Cancellation callbacks must run synchronously on the current grain scheduler before awaiting MoveNext completion.")]
     private async ValueTask DisposeEnumeratorAsync(EnumeratorState enumerator)
     {
         try

--- a/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
@@ -17,6 +17,10 @@ namespace Orleans.Runtime
         private readonly Func<Exception, int, bool> _cancelCallRetryExceptionFilter =
             (exception, i) => exception is GrainExtensionNotInstalledException;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Cancellation callbacks must execute synchronously on the current Orleans scheduler context before remote propagation.")]
         public Task Cancel(Guid id, CancellationTokenSource tokenSource, ConcurrentDictionary<GrainId, GrainReference> grainReferences)
         {
             if (tokenSource.IsCancellationRequested)

--- a/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
@@ -11,6 +11,7 @@ namespace Orleans.Statistics;
 internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProvider, IDisposable
 {
     private const float OneKiloByte = 1024f;
+    private static readonly IMeterFactory MeterFactory = new DirectMeterFactory();
 
     private long _availableMemoryBytes;
     private long _maximumAvailableMemoryBytes;
@@ -27,7 +28,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
     private readonly DualModeKalmanFilter _memoryUsageFilter = new();
 
     public EnvironmentStatisticsProvider()
-        : this(new OrleansInstruments(new DirectMeterFactory()))
+        : this(new OrleansInstruments(MeterFactory))
     {
     }
 

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -21,6 +21,11 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionCommon connectionShared;
         private Task? acceptLoopTask;
         private IConnectionListener? listener;
+#if NET9_0_OR_GREATER
+        private readonly Lock connectionDelegateLock = new();
+#else
+        private readonly object connectionDelegateLock = new();
+#endif
         private ConnectionDelegate? connectionDelegate;
 
         protected ConnectionListener(
@@ -51,7 +56,7 @@ namespace Orleans.Runtime.Messaging
             {
                 if (this.connectionDelegate != null) return this.connectionDelegate;
 
-                lock (this)
+                lock (this.connectionDelegateLock)
                 {
                     if (this.connectionDelegate != null) return this.connectionDelegate;
 

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -138,7 +138,12 @@ namespace Orleans.Runtime.Messaging
 
                 this.Send(rejection);
 
-                LogDebugRejectingObsoleteRequest(this.Log, msg.TargetSilo?.ToString() ?? "null", this.LocalSiloAddress.ToString(), msg);
+                if (this.Log.IsEnabled(LogLevel.Debug))
+                {
+                    var targetSilo = msg.TargetSilo?.ToString() ?? "null";
+                    var siloAddress = this.LocalSiloAddress.ToString();
+                    LogDebugRejectingObsoleteRequest(this.Log, targetSilo, siloAddress, msg);
+                }
             }
         }
 
@@ -319,6 +324,7 @@ namespace Orleans.Runtime.Messaging
 
         [LoggerMessage(
             Level = LogLevel.Debug,
+            SkipEnabledCheck = true,
             Message = "Rejecting an obsolete request; target was {TargetSilo}, but this silo is {SiloAddress}. The rejected message is {Message}."
         )]
         private static partial void LogDebugRejectingObsoleteRequest(ILogger logger, string targetSilo, string siloAddress, Message message);

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -74,7 +74,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         var bufferWriter = new BufferWriterBox<PooledBuffer>(new PooledBuffer());
         try
         {
-            var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
+            using var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
             JsonSerializer.Serialize(jsonWriter, value, _options.SerializerOptions);
             jsonWriter.Flush();
 
@@ -226,7 +226,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         var bufferWriter = new BufferWriterBox<PooledBuffer>(new PooledBuffer());
         try
         {
-            var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
+            using var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
             JsonSerializer.Serialize(jsonWriter, input!, _options.SerializerOptions);
             jsonWriter.Flush();
 


### PR DESCRIPTION
## Problem

High-value runtime performance and reliability diagnostics were not enforced in the core runtime boundary, allowing blocking async calls, eager logging allocations, disposable ownership mistakes, and weak lock identities to regress unnoticed.

## Solution

Enable CA1848, CA1849, CA1873, CA2000, and CA2002 as warnings for Orleans.Core.Abstractions, Orleans.Core, and Orleans.Runtime networking, with CA2000 additionally enabled for the System.Text.Json codec. Resolve the resulting findings using cached logging delegates, guarded expensive log values, asynchronous completion where scheduler affinity permits it, explicit socket and writer lifetime handling, and private synchronization objects.

## Rationale

The scope targets the highest-value runtime and transport boundaries while keeping the change reviewable and separate from the broader analyzer baseline. Narrow suppressions document ownership transfers and synchronous scheduler guarantees where the analyzer cannot model Orleans' runtime invariants.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10997)