### PR TITLE
perf: enforce CA1873 logging guards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -652,10 +652,15 @@ dotnet_diagnostic.RS0027.severity = suggestion
 
 # CA1848: Use the LoggerMessage delegates
 # CA1849: Call async methods when in an async method
-# CA1873: Avoid potentially expensive logging
 [src/{Orleans.Core.Abstractions,Orleans.Core}/**.cs]
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
+
+# CA1873: Avoid potentially expensive logging
+[src/Orleans.Core.Abstractions/**.cs]
+dotnet_diagnostic.CA1873.severity = warning
+
+[src/Orleans.Core/**.cs]
 dotnet_diagnostic.CA1873.severity = warning
 
 [src/Orleans.Runtime/Networking/**.cs]

--- a/.editorconfig
+++ b/.editorconfig
@@ -652,13 +652,16 @@ dotnet_diagnostic.RS0027.severity = suggestion
 
 # CA1848: Use the LoggerMessage delegates
 # CA1849: Call async methods when in an async method
+# CA1873: Avoid potentially expensive logging
 [src/{Orleans.Core.Abstractions,Orleans.Core}/**.cs]
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA1873.severity = warning
 
 [src/Orleans.Runtime/Networking/**.cs]
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA1873.severity = warning
 
 # Production source enforces the correctness baseline. Tests, samples, documentation,
 # playgrounds, templates, and tools retain advisory diagnostics during this rollout.

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -96,6 +96,11 @@ namespace Orleans
         /// <param name="formatter">The options formatter.</param>
         public void LogOption(IOptionFormatter formatter)
         {
+            if (!logger.IsEnabled(LogLevel.Information))
+            {
+                return;
+            }
+
             try
             {
                 var stringBuilder = new StringBuilder();
@@ -103,9 +108,11 @@ namespace Orleans
                 {
                     stringBuilder.AppendLine($"{setting}");
                 }
-                LogInformationOptions(logger, formatter.Name, stringBuilder.ToString());
+
+                var options = stringBuilder.ToString();
+                LogInformationOptions(logger, formatter.Name, options);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 LogErrorOptions(logger, ex, formatter.Name);
                 throw;
@@ -114,6 +121,7 @@ namespace Orleans
 
         [LoggerMessage(
             Level = LogLevel.Information,
+            SkipEnabledCheck = true,
             Message = "Configuration {Name}:\n{Options}"
         )]
         private static partial void LogInformationOptions(ILogger logger, string name, string options);

--- a/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
+++ b/src/Orleans.Core/Lifecycle/LifecycleSubject.cs
@@ -86,7 +86,11 @@ namespace Orleans
         /// <param name="elapsed">The period of time which elapsed before <see cref="OnStart"/> completed once it was initiated.</param>
         protected virtual void PerfMeasureOnStart(int stage, TimeSpan elapsed)
         {
-            LogLifecycleStageStarted(Logger, GetStageName(stage), elapsed);
+            if (Logger.IsEnabled(LogLevel.Trace))
+            {
+                var stageName = GetStageName(stage);
+                LogLifecycleStageStarted(Logger, stageName, elapsed);
+            }
         }
 
         /// <inheritdoc />
@@ -146,7 +150,11 @@ namespace Orleans
         /// <param name="elapsed">The period of time which elapsed before <see cref="OnStop"/> completed once it was initiated.</param>
         protected virtual void PerfMeasureOnStop(int stage, TimeSpan elapsed)
         {
-            LogLifecycleStageStopped(Logger, GetStageName(stage), elapsed);
+            if (Logger.IsEnabled(LogLevel.Trace))
+            {
+                var stageName = GetStageName(stage);
+                LogLifecycleStageStopped(Logger, stageName, elapsed);
+            }
         }
 
         /// <inheritdoc />
@@ -266,6 +274,7 @@ namespace Orleans
         [LoggerMessage(
             EventId = (int)ErrorCode.SiloStartPerfMeasure,
             Level = LogLevel.Trace,
+            SkipEnabledCheck = true,
             Message = "Starting lifecycle stage '{Stage}' took '{Elapsed}'."
         )]
         private static partial void LogLifecycleStageStarted(ILogger logger, string stage, TimeSpan elapsed);
@@ -273,6 +282,7 @@ namespace Orleans
         [LoggerMessage(
             EventId = (int)ErrorCode.SiloStartPerfMeasure,
             Level = LogLevel.Trace,
+            SkipEnabledCheck = true,
             Message = "Stopping lifecycle stage '{Stage}' took '{Elapsed}'."
         )]
         private static partial void LogLifecycleStageStopped(ILogger logger, string stage, TimeSpan elapsed);

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -77,7 +77,11 @@ namespace Orleans.Runtime.Messaging
                     });
 
                 var preamble = await connectionPreambleHelper.Read(this.Context);
-                LogInformationEstablishedConnection(this.Log, preamble.SiloAddress, preamble.NetworkProtocolVersion.ToString());
+                if (this.Log.IsEnabled(LogLevel.Information))
+                {
+                    var protocolVersion = preamble.NetworkProtocolVersion.ToString();
+                    LogInformationEstablishedConnection(this.Log, preamble.SiloAddress, protocolVersion);
+                }
 
                 if (preamble.ClusterId != myClusterId)
                 {
@@ -170,6 +174,7 @@ namespace Orleans.Runtime.Messaging
 
         [LoggerMessage(
             Level = LogLevel.Information,
+            SkipEnabledCheck = true,
             Message = "Established connection to {Silo} with protocol version {ProtocolVersion}"
         )]
         private static partial void LogInformationEstablishedConnection(ILogger logger, SiloAddress? silo, string protocolVersion);

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -138,7 +138,12 @@ namespace Orleans.Runtime.Messaging
 
                 this.Send(rejection);
 
-                LogDebugRejectingObsoleteRequest(this.Log, msg.TargetSilo?.ToString() ?? "null", this.LocalSiloAddress.ToString(), msg);
+                if (this.Log.IsEnabled(LogLevel.Debug))
+                {
+                    var targetSilo = msg.TargetSilo?.ToString() ?? "null";
+                    var siloAddress = this.LocalSiloAddress.ToString();
+                    LogDebugRejectingObsoleteRequest(this.Log, targetSilo, siloAddress, msg);
+                }
             }
         }
 
@@ -319,6 +324,7 @@ namespace Orleans.Runtime.Messaging
 
         [LoggerMessage(
             Level = LogLevel.Debug,
+            SkipEnabledCheck = true,
             Message = "Rejecting an obsolete request; target was {TargetSilo}, but this silo is {SiloAddress}. The rejected message is {Message}."
         )]
         private static partial void LogDebugRejectingObsoleteRequest(ILogger logger, string targetSilo, string siloAddress, Message message);


### PR DESCRIPTION
## Problem

CA1873 was not enforced in the core runtime and networking boundaries, allowing expensive log argument construction to occur even when the matching log level was disabled.

## Solution

Enable CA1873 as a warning for Orleans.Core.Abstractions, Orleans.Core, and Orleans.Runtime networking. Guard the affected option, lifecycle, client connection, and silo connection log values with the matching `IsEnabled` check, and set `SkipEnabledCheck` only on logger methods invoked behind those guards.

## Rationale

These paths can format options, lifecycle stage names, protocol versions, and silo addresses on runtime hot paths. Constructing those values only when they will be logged preserves rendered log output while avoiding unnecessary work and makes the analyzer enforce that behavior for future changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10999)