### PR TITLE
perf: enforce CA1848 logging diagnostics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -628,9 +628,12 @@ dotnet_diagnostic.RS0026.severity = suggestion
 # RS0027: API with optional parameter(s) should have the most parameters amongst its public overloads
 dotnet_diagnostic.RS0027.severity = suggestion
 
+# CA1848: Use the LoggerMessage delegates
 # CA1849: Call async methods when in an async method
 [src/{Orleans.Core.Abstractions,Orleans.Core}/**.cs]
+dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
 
 [src/Orleans.Runtime/Networking/**.cs]
+dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +12,8 @@ namespace Orleans.Internal
     /// </summary>
     internal static class OrleansTaskExtentions
     {
+        private static readonly ConcurrentDictionary<ErrorCode, Action<ILogger, string, Exception?>> LogExceptionDelegates = new();
+
         public static ConfiguredTaskAwaitable SuppressThrowing(this ValueTask task) => task.AsTask().ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
         public static ConfiguredTaskAwaitable SuppressThrowing(this Task task) => task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
 
@@ -34,8 +37,10 @@ namespace Orleans.Internal
             }
             catch (Exception exc)
             {
-                // TODO: pending on https://github.com/dotnet/runtime/issues/110570
-                logger.LogError((int)errorCode, exc, "{Message}", message);
+                var log = LogExceptionDelegates.GetOrAdd(
+                    errorCode,
+                    static code => LoggerMessage.Define<string>(LogLevel.Error, new EventId((int)code), "{Message}"));
+                log(logger, message, exc);
                 throw;
             }
         }


### PR DESCRIPTION
## Problem

Runtime logging in the core and networking paths can use extension-method APIs which allocate when the corresponding log level is disabled.

## Solution

Enforce CA1848 as a warning for Orleans.Core.Abstractions, Orleans.Core, and Orleans.Runtime networking sources. Cache the `LoggerMessage` delegate used by `OrleansTaskExtentions.LogException`, keyed by `ErrorCode`, while preserving the existing message template, exception, log level, and event ID.

## Rationale

These paths are performance-sensitive and execute frequently. Compile-time enforcement keeps logging allocation-aware, and the cached delegate preserves existing runtime behavior while avoiding repeated message-template processing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11000)