### PR TITLE
perf: enforce CA2002 lock diagnostics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -652,9 +652,11 @@ dotnet_diagnostic.RS0027.severity = suggestion
 
 # CA1848: Use the LoggerMessage delegates
 # CA1849: Call async methods when in an async method
+# CA2002: Do not lock on objects with weak identity
 [src/{Orleans.Core.Abstractions,Orleans.Core}/**.cs]
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA2002.severity = warning
 
 # CA1873: Avoid potentially expensive logging
 [src/Orleans.Core.Abstractions/**.cs]
@@ -667,6 +669,7 @@ dotnet_diagnostic.CA1873.severity = warning
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
 dotnet_diagnostic.CA1873.severity = warning
+dotnet_diagnostic.CA2002.severity = warning
 
 # Production source enforces the correctness baseline. Tests, samples, documentation,
 # playgrounds, templates, and tools retain advisory diagnostics during this rollout.

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -11,6 +11,11 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly IConnectionFactory connectionFactory;
         private readonly IServiceProvider serviceProvider;
+#if NET9_0_OR_GREATER
+        private readonly Lock connectionDelegateLock = new();
+#else
+        private readonly object connectionDelegateLock = new();
+#endif
         private ConnectionDelegate? connectionDelegate;
 
         protected ConnectionFactory(
@@ -31,7 +36,7 @@ namespace Orleans.Runtime.Messaging
             {
                 if (this.connectionDelegate != null) return this.connectionDelegate;
 
-                lock (this)
+                lock (this.connectionDelegateLock)
                 {
                     if (this.connectionDelegate != null) return this.connectionDelegate;
 

--- a/src/Orleans.Runtime/Networking/ConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/ConnectionListener.cs
@@ -21,6 +21,11 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionCommon connectionShared;
         private Task? acceptLoopTask;
         private IConnectionListener? listener;
+#if NET9_0_OR_GREATER
+        private readonly Lock connectionDelegateLock = new();
+#else
+        private readonly object connectionDelegateLock = new();
+#endif
         private ConnectionDelegate? connectionDelegate;
 
         protected ConnectionListener(
@@ -51,7 +56,7 @@ namespace Orleans.Runtime.Messaging
             {
                 if (this.connectionDelegate != null) return this.connectionDelegate;
 
-                lock (this)
+                lock (this.connectionDelegateLock)
                 {
                     if (this.connectionDelegate != null) return this.connectionDelegate;
 


### PR DESCRIPTION
## Problem
Core networking lazily initializes connection delegates using the containing instance as the monitor. Dedicated private synchronization identities make monitor ownership explicit and prevent external contention. The relevant source scopes currently keep CA2002 below warning severity.

## Solution
Set CA2002 to warning for Orleans.Core.Abstractions, Orleans.Core, and Orleans.Runtime networking sources. Use a private `System.Threading.Lock` on .NET 9 and later, with a private `object` monitor on earlier target frameworks, for connection delegate initialization.

## Rationale
This preserves synchronization behavior across supported target frameworks while using the optimized lock implementation where available. It separates the CA2002 portion of #10997 so the diagnostic and its required lock changes can be reviewed independently.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11001)