### PR TITLE
perf: enforce CA1849 async diagnostics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -627,3 +627,10 @@ dotnet_diagnostic.RS0026.severity = suggestion
 
 # RS0027: API with optional parameter(s) should have the most parameters amongst its public overloads
 dotnet_diagnostic.RS0027.severity = suggestion
+
+# CA1849: Call async methods when in an async method
+[src/{Orleans.Core.Abstractions,Orleans.Core}/**.cs]
+dotnet_diagnostic.CA1849.severity = warning
+
+[src/Orleans.Runtime/Networking/**.cs]
+dotnet_diagnostic.CA1849.severity = warning

--- a/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
+++ b/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
@@ -86,11 +86,14 @@ namespace Orleans
         /// <returns>
         /// A <see cref="Task"/> representing the operation.
         /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Cancellation callbacks must execute synchronously on the current Orleans scheduler context before remote propagation.")]
         internal Task Cancel()
         {
             if (_cancellationTokenRuntime == null)
             {
-                // Wrap in task
                 try
                 {
                     _cancellationTokenSource.Cancel();
@@ -98,9 +101,7 @@ namespace Orleans
                 }
                 catch (Exception exception)
                 {
-                    var completion = new TaskCompletionSource<object>();
-                    completion.TrySetException(exception);
-                    return completion.Task;
+                    return Task.FromException(exception);
                 }
             }
 

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -610,6 +610,10 @@ namespace Orleans.Runtime
     [SerializerTransparent]
     public abstract class Request : RequestBase
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "GetResult is called only after IsCompleted and must consume a completed ValueTask source without allocating.")]
         public sealed override ValueTask<Response> Invoke()
         {
             try
@@ -749,6 +753,10 @@ namespace Orleans.Runtime
     public abstract class TaskRequest : RequestBase
     {
         /// <inheritdoc/>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "GetResult is called only after IsCompleted, so it observes completion without blocking or allocating.")]
         public sealed override ValueTask<Response> Invoke()
         {
             try

--- a/src/Orleans.Core/Async/TaskExtensions.cs
+++ b/src/Orleans.Core/Async/TaskExtensions.cs
@@ -99,7 +99,7 @@ namespace Orleans.Internal
             // We got done before the timeout, or were able to complete before this code ran, return the result
             if (taskToComplete == completedTask)
             {
-                timeoutCancellationTokenSource.Cancel();
+                await timeoutCancellationTokenSource.CancelAsync();
                 // Await this so as to propagate the exception correctly
                 await taskToComplete;
                 return;
@@ -133,7 +133,7 @@ namespace Orleans.Internal
             // We got done before the timeout, or were able to complete before this code ran, return the result
             if (taskToComplete == completedTask)
             {
-                timeoutCancellationTokenSource.Cancel();
+                await timeoutCancellationTokenSource.CancelAsync();
                 // Await this so as to propagate the exception correctly
                 return await taskToComplete;
             }

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -77,6 +77,10 @@ namespace Orleans.Runtime
             return _initialized.Task;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Shutdown must signal cancellation immediately without awaiting callback completion before observing the host stop token.")]
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             try
@@ -220,6 +224,10 @@ namespace Orleans.Runtime
         }
 
         /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Shutdown must signal cancellation immediately without awaiting callback completion before waiting for the run task.")]
         public async ValueTask DisposeAsync()
         {
             if (_shutdownCts.IsCancellationRequested)

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -356,7 +356,7 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
-                _transport!.Input.Complete();
+                await _transport!.Input.CompleteAsync();
                 this.StartClosing(error);
             }
         }
@@ -421,7 +421,7 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
-                _transport!.Output.Complete();
+                await _transport!.Output.CompleteAsync();
                 this.StartClosing(error);
             }
         }

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -282,6 +282,10 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Shutdown callbacks must complete synchronously before connections are scanned, while aggregating all callback failures.")]
         public async Task Close(CancellationToken ct)
         {
             try

--- a/src/Orleans.Core/Networking/Shared/SocketConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnection.cs
@@ -119,8 +119,8 @@ namespace Orleans.Networking.Shared
         // Only called after connection middleware is complete which means the ConnectionClosed token has fired.
         public override async ValueTask DisposeAsync()
         {
-            Transport.Input.Complete();
-            Transport.Output.Complete();
+            await Transport.Input.CompleteAsync();
+            await Transport.Output.CompleteAsync();
 
             if (_processingTask != null)
             {
@@ -172,7 +172,7 @@ namespace Orleans.Networking.Shared
             finally
             {
                 // If Shutdown() has already bee called, assume that was the reason ProcessReceives() exited.
-                Input.Complete(_shutdownReason ?? error);
+                await Input.CompleteAsync(_shutdownReason ?? error);
 
                 FireConnectionClosed();
 
@@ -259,7 +259,7 @@ namespace Orleans.Networking.Shared
                 Shutdown(shutdownReason);
 
                 // Complete the output after disposing the socket
-                Output.Complete(unexpectedError);
+                await Output.CompleteAsync(unexpectedError);
 
                 // Cancel any pending flushes so that the input loop is un-paused
                 Input.CancelPendingFlush();

--- a/src/Orleans.Core/Runtime/AsyncEnumerableGrainExtension.cs
+++ b/src/Orleans.Core/Runtime/AsyncEnumerableGrainExtension.cs
@@ -331,6 +331,10 @@ internal sealed partial class AsyncEnumerableGrainExtension : IAsyncEnumerableGr
         Timer.Dispose();
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1849:Call async methods when in an async method",
+        Justification = "Cancellation callbacks must run synchronously on the current grain scheduler before awaiting MoveNext completion.")]
     private async ValueTask DisposeEnumeratorAsync(EnumeratorState enumerator)
     {
         try

--- a/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
@@ -17,6 +17,10 @@ namespace Orleans.Runtime
         private readonly Func<Exception, int, bool> _cancelCallRetryExceptionFilter =
             (exception, i) => exception is GrainExtensionNotInstalledException;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance",
+            "CA1849:Call async methods when in an async method",
+            Justification = "Cancellation callbacks must execute synchronously on the current Orleans scheduler context before remote propagation.")]
         public Task Cancel(Guid id, CancellationTokenSource tokenSource, ConcurrentDictionary<GrainId, GrainReference> grainReferences)
         {
             if (tokenSource.IsCancellationRequested)


### PR DESCRIPTION
## Problem

CA1849 was not enforced across the core runtime and networking boundary, allowing synchronous async-compatible operations to regress into blocking execution.

## Solution

Enable CA1849 as a warning for Orleans.Core.Abstractions, Orleans.Core, and Orleans.Runtime networking. Use asynchronous cancellation and pipeline completion where scheduler affinity permits it, and retain synchronous completion only at documented scheduler-affine and already-completed fast paths.

## Rationale

This focused scope makes the async diagnostic independently reviewable while preserving Orleans' cancellation ordering, immediate shutdown signaling, and allocation-free completed-task paths.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11002)