### PR TITLE
perf: enforce CA2000 ownership diagnostics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -652,10 +652,12 @@ dotnet_diagnostic.RS0027.severity = suggestion
 
 # CA1848: Use the LoggerMessage delegates
 # CA1849: Call async methods when in an async method
+# CA2000: Dispose objects before losing scope
 # CA2002: Do not lock on objects with weak identity
 [src/{Orleans.Core.Abstractions,Orleans.Core}/**.cs]
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
+dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2002.severity = warning
 
 # CA1873: Avoid potentially expensive logging
@@ -669,7 +671,11 @@ dotnet_diagnostic.CA1873.severity = warning
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
 dotnet_diagnostic.CA1873.severity = warning
+dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2002.severity = warning
+
+[src/Orleans.Serialization.SystemTextJson/**.cs]
+dotnet_diagnostic.CA2000.severity = warning
 
 # Production source enforces the correctness baseline. Tests, samples, documentation,
 # playgrounds, templates, and tools retain advisory diagnostics during this rollout.

--- a/src/Orleans.Core/Async/AsyncLock.cs
+++ b/src/Orleans.Core/Async/AsyncLock.cs
@@ -61,6 +61,10 @@ namespace Orleans
         /// Acquires the lock asynchronously.
         /// </summary>
         /// <returns>An <see cref="IDisposable"/> which must be used to release the lock.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Ownership of each LockReleaser is transferred to the caller through the returned ValueTask.")]
         public ValueTask<IDisposable> LockAsync()
         {
             Task wait = semaphore.WaitAsync();

--- a/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
@@ -62,6 +62,10 @@ internal sealed partial class ServiceLifecycleNotificationStage(ILogger logger, 
 
     public Task WaitAsync(CancellationToken cancellationToken) => _tcs.Task.WaitAsync(cancellationToken);
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Ownership of the participant is transferred to the lifecycle stage and the returned registration.")]
     public IDisposable Register(Func<object?, CancellationToken, Task> callback, object? state, bool terminateOnError)
     {
         ArgumentNullException.ThrowIfNull(callback);

--- a/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
+++ b/src/Orleans.Core/Networking/Shared/SlabMemoryPool.cs
@@ -104,6 +104,10 @@ namespace Orleans.Networking.Shared
         /// Internal method called when a block is requested and the pool is empty. It allocates one additional slab, creates all of the
         /// block tracking objects, and adds them all to the pool.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "The pool owns the slab and blocks after adding them to its collections and disposes the slabs with the pool.")]
         private MemoryPoolBlock AllocateSlab()
         {
             var slab = MemoryPoolSlab.Create(_slabLength);
@@ -165,6 +169,10 @@ namespace Orleans.Networking.Shared
         }
 
         // This method can ONLY be called from the finalizer of MemoryPoolBlock
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Return transfers ownership of the replacement block back to the pool.")]
         internal void RefreshBlock(MemoryPoolSlab slab, int offset, int length)
         {
             lock (_disposeSync)

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionFactory.cs
@@ -30,45 +30,53 @@ namespace Orleans.Networking.Shared
 
         public async ValueTask<ConnectionContext> ConnectAsync(EndPoint endpoint, CancellationToken cancellationToken)
         {
-            var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+            Socket? socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
                 LingerState = new LingerOption(true, 0),
                 NoDelay = _options.NoDelay,
             };
 
-            if (_options.KeepAlive)
+            try
             {
-                socket.EnableKeepAlive(
-                    timeSeconds: _options.KeepAliveTimeSeconds,
-                    intervalSeconds: _options.KeepAliveIntervalSeconds,
-                    retryCount: _options.KeepAliveRetryCount);
-            }
-
-            socket.EnableFastPath();
-            using var completion = new SingleUseSocketAsyncEventArgs
-            {
-                RemoteEndPoint = endpoint
-            };
-
-            if (socket.ConnectAsync(completion))
-            {
-                using (cancellationToken.Register(s => Socket.CancelConnectAsync((SingleUseSocketAsyncEventArgs)s!), completion))
+                if (_options.KeepAlive)
                 {
-                    await completion.Task;
+                    socket.EnableKeepAlive(
+                        timeSeconds: _options.KeepAliveTimeSeconds,
+                        intervalSeconds: _options.KeepAliveIntervalSeconds,
+                        retryCount: _options.KeepAliveRetryCount);
                 }
-            }
 
-            if (completion.SocketError != SocketError.Success)
+                socket.EnableFastPath();
+                using var completion = new SingleUseSocketAsyncEventArgs
+                {
+                    RemoteEndPoint = endpoint
+                };
+
+                if (socket.ConnectAsync(completion))
+                {
+                    using (cancellationToken.Register(s => Socket.CancelConnectAsync((SingleUseSocketAsyncEventArgs)s!), completion))
+                    {
+                        await completion.Task;
+                    }
+                }
+
+                if (completion.SocketError != SocketError.Success)
+                {
+                    if (completion.SocketError == SocketError.OperationAborted)
+                        cancellationToken.ThrowIfCancellationRequested();
+                    throw new SocketConnectionException($"Unable to connect to {endpoint}. Error: {completion.SocketError}");
+                }
+
+                var scheduler = this.schedulers.GetScheduler();
+                var connection = new SocketConnection(socket, this.memoryPool, scheduler, this.trace);
+                connection.Start();
+                socket = null;
+                return connection;
+            }
+            finally
             {
-                if (completion.SocketError == SocketError.OperationAborted)
-                    cancellationToken.ThrowIfCancellationRequested();
-                throw new SocketConnectionException($"Unable to connect to {endpoint}. Error: {completion.SocketError}");
+                socket?.Dispose();
             }
-
-            var scheduler = this.schedulers.GetScheduler();
-            var connection = new SocketConnection(socket, this.memoryPool, scheduler, this.trace);
-            connection.Start();
-            return connection;
         }
 
         private sealed class SingleUseSocketAsyncEventArgs : SocketAsyncEventArgs

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
@@ -43,43 +43,51 @@ namespace Orleans.Networking.Shared
                 throw new InvalidOperationException("Transport already bound");
             }
 
-            var listenSocket = new Socket(EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+            Socket? listenSocket = new Socket(EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
                 LingerState = new LingerOption(true, 0),
                 NoDelay = true
             };
 
-            listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-            if (_options.KeepAlive)
-            {
-                listenSocket.EnableKeepAlive(
-                    timeSeconds: _options.KeepAliveTimeSeconds,
-                    intervalSeconds: _options.KeepAliveIntervalSeconds,
-                    retryCount: _options.KeepAliveRetryCount);
-            }
-
-            listenSocket.EnableFastPath();
-
-            // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
-            if (EndPoint is IPEndPoint ip && Equals(ip.Address, IPAddress.IPv6Any))
-            {
-                listenSocket.DualMode = true;
-            }
-
             try
             {
-                listenSocket.Bind(EndPoint);
+                listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                if (_options.KeepAlive)
+                {
+                    listenSocket.EnableKeepAlive(
+                        timeSeconds: _options.KeepAliveTimeSeconds,
+                        intervalSeconds: _options.KeepAliveIntervalSeconds,
+                        retryCount: _options.KeepAliveRetryCount);
+                }
+
+                listenSocket.EnableFastPath();
+
+                // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
+                if (EndPoint is IPEndPoint ip && Equals(ip.Address, IPAddress.IPv6Any))
+                {
+                    listenSocket.DualMode = true;
+                }
+
+                try
+                {
+                    listenSocket.Bind(EndPoint);
+                }
+                catch (SocketException e) when (e.SocketErrorCode == SocketError.AddressAlreadyInUse)
+                {
+                    throw new AddressInUseException(e.Message, e);
+                }
+
+                EndPoint = listenSocket.LocalEndPoint!;
+
+                listenSocket.Listen(512);
+
+                _listenSocket = listenSocket;
+                listenSocket = null;
             }
-            catch (SocketException e) when (e.SocketErrorCode == SocketError.AddressAlreadyInUse)
+            finally
             {
-                throw new AddressInUseException(e.Message, e);
+                listenSocket?.Dispose();
             }
-
-            EndPoint = listenSocket.LocalEndPoint!;
-
-            listenSocket.Listen(512);
-
-            _listenSocket = listenSocket;
         }
 
         public async ValueTask<ConnectionContext?> AcceptAsync(CancellationToken cancellationToken = default)
@@ -88,21 +96,29 @@ namespace Orleans.Networking.Shared
             {
                 try
                 {
-                    var acceptSocket = await _listenSocket!.AcceptAsync(cancellationToken);
-                    acceptSocket.NoDelay = _options.NoDelay;
-                    if (_options.KeepAlive)
+                    Socket? acceptSocket = await _listenSocket!.AcceptAsync(cancellationToken);
+                    try
                     {
-                        acceptSocket.EnableKeepAlive(
-                            timeSeconds: _options.KeepAliveTimeSeconds,
-                            intervalSeconds: _options.KeepAliveIntervalSeconds,
-                            retryCount: _options.KeepAliveRetryCount);
+                        acceptSocket.NoDelay = _options.NoDelay;
+                        if (_options.KeepAlive)
+                        {
+                            acceptSocket.EnableKeepAlive(
+                                timeSeconds: _options.KeepAliveTimeSeconds,
+                                intervalSeconds: _options.KeepAliveIntervalSeconds,
+                                retryCount: _options.KeepAliveRetryCount);
+                        }
+
+                        var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);
+
+                        connection.Start();
+                        acceptSocket = null;
+
+                        return connection;
                     }
-
-                    var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers.GetScheduler(), _trace);
-
-                    connection.Start();
-
-                    return connection;
+                    finally
+                    {
+                        acceptSocket?.Dispose();
+                    }
                 }
                 catch (ObjectDisposedException)
                 {

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
@@ -30,7 +30,7 @@ namespace Orleans.Networking.Shared
             this.schedulers = schedulers;
         }
 
-        public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+        public async ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
         {
             if (!(endpoint is IPEndPoint ipEndpoint))
             {
@@ -38,8 +38,16 @@ namespace Orleans.Networking.Shared
             }
 
             var listener = new SocketConnectionListener(ipEndpoint, this.socketConnectionOptions, this.trace, this.schedulers);
-            listener.Bind();
-            return new ValueTask<IConnectionListener>(listener);
+            try
+            {
+                listener.Bind();
+                return listener;
+            }
+            catch
+            {
+                await listener.DisposeAsync();
+                throw;
+            }
         }
     }
 }

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -30,7 +31,11 @@ namespace Orleans.Networking.Shared
             this.schedulers = schedulers;
         }
 
-        public async ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Successful binding transfers ownership to the caller; failed binding transfers the listener to DisposeAndThrowAsync.")]
+        public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(endpoint);
             if (endpoint is not IPEndPoint ipEndpoint)
@@ -42,13 +47,19 @@ namespace Orleans.Networking.Shared
             try
             {
                 listener.Bind();
-                return listener;
+                return new(listener);
             }
-            catch
+            catch (Exception exception)
             {
-                await listener.DisposeAsync();
-                throw;
+                return DisposeAndThrowAsync(listener, exception);
             }
+        }
+
+        private static async ValueTask<IConnectionListener> DisposeAndThrowAsync(SocketConnectionListener listener, Exception exception)
+        {
+            await listener.DisposeAsync();
+            ExceptionDispatchInfo.Throw(exception);
+            return null!;
         }
     }
 }

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
@@ -57,7 +57,15 @@ namespace Orleans.Networking.Shared
 
         private static async ValueTask<IConnectionListener> DisposeAndThrowAsync(SocketConnectionListener listener, Exception exception)
         {
-            await listener.DisposeAsync();
+            try
+            {
+                await listener.DisposeAsync();
+            }
+            catch (Exception disposeException)
+            {
+                exception.Data["Orleans.SocketConnectionListener.DisposeException"] = disposeException;
+            }
+
             ExceptionDispatchInfo.Throw(exception);
             return null!;
         }

--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListenerFactory.cs
@@ -32,9 +32,10 @@ namespace Orleans.Networking.Shared
 
         public async ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
         {
-            if (!(endpoint is IPEndPoint ipEndpoint))
+            ArgumentNullException.ThrowIfNull(endpoint);
+            if (endpoint is not IPEndPoint ipEndpoint)
             {
-                throw new ArgumentNullException(nameof(endpoint));
+                throw new ArgumentException($"The endpoint must be an {nameof(IPEndPoint)}.", nameof(endpoint));
             }
 
             var listener = new SocketConnectionListener(ipEndpoint, this.socketConnectionOptions, this.trace, this.schedulers);

--- a/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
@@ -11,6 +11,7 @@ namespace Orleans.Statistics;
 internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProvider, IDisposable
 {
     private const float OneKiloByte = 1024f;
+    private static readonly IMeterFactory MeterFactory = new DirectMeterFactory();
 
     private long _availableMemoryBytes;
     private long _maximumAvailableMemoryBytes;
@@ -27,7 +28,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
     private readonly DualModeKalmanFilter _memoryUsageFilter = new();
 
     public EnvironmentStatisticsProvider()
-        : this(new OrleansInstruments(new DirectMeterFactory()))
+        : this(new OrleansInstruments(MeterFactory))
     {
     }
 

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -74,7 +74,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         var bufferWriter = new BufferWriterBox<PooledBuffer>(new PooledBuffer());
         try
         {
-            var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
+            using var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
             JsonSerializer.Serialize(jsonWriter, value, _options.SerializerOptions);
             jsonWriter.Flush();
 
@@ -226,7 +226,7 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         var bufferWriter = new BufferWriterBox<PooledBuffer>(new PooledBuffer());
         try
         {
-            var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
+            using var jsonWriter = new Utf8JsonWriter(bufferWriter, _options.WriterOptions);
             JsonSerializer.Serialize(jsonWriter, input!, _options.SerializerOptions);
             jsonWriter.Flush();
 


### PR DESCRIPTION
## Problem

CA2000 was not enforced across the core runtime ownership boundaries, allowing disposable resources to escape without an explicit ownership transfer.

## Solution

Enable CA2000 as a warning for Orleans.Core.Abstractions, Orleans.Core, Orleans.Runtime networking, and the System.Text.Json codec. Dispose sockets and listeners when ownership transfer fails, dispose JSON writers with their operation scope, retain the direct meter factory for process lifetime, and document analyzer-blind ownership transfers with narrow suppressions.

## Rationale

This isolates disposable ownership enforcement from #10997 so the CA2000 behavior and ownership invariants can be reviewed independently. The runtime retains successful socket and listener transfers while cleaning up only failed transfers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11003)