### PR TITLE
test(event-sourcing): cover synchronization and recovery

### DIFF
--- a/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -383,6 +383,9 @@ namespace Orleans.EventSourcing.Common
                 first = false;
             }
 
+            if (first)
+                promise.SetResult(true);
+
             worker.Notify();
 
             return promise.Task;

--- a/src/Orleans.EventSourcing/Orleans.EventSourcing.csproj
+++ b/src/Orleans.EventSourcing/Orleans.EventSourcing.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="LoadTestGrains" />
     <InternalsVisibleTo Include="Orleans.CodeGeneration.Build" />
+    <InternalsVisibleTo Include="Orleans.EventSourcing.Tests" />
     <InternalsVisibleTo Include="Orleans.Runtime" />
     <InternalsVisibleTo Include="Orleans.Runtime.Internal.Tests" />
   </ItemGroup>

--- a/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/StateStorage/LogViewAdaptor.cs
@@ -174,8 +174,6 @@ namespace Orleans.EventSourcing.StateStorage
 
                 if (writebit == GlobalStateCache.StateAndMetaData.GetBit(Services.MyClusterId))
                 {
-                    GlobalStateCache = nextglobalstate;
-
                     Services.Log(LogLevel.Debug, "last write ({0} updates) was actually a success {1}", updates.Length, GlobalStateCache);
 
                     batchsuccessfullywritten = true;

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/CustomStorageLogViewAdaptorTests.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/CustomStorageLogViewAdaptorTests.cs
@@ -1,0 +1,218 @@
+using Orleans.EventSourcing;
+using Orleans.EventSourcing.Common;
+using Orleans.EventSourcing.CustomStorage;
+using Xunit;
+using CustomStorageAdaptor = Orleans.EventSourcing.CustomStorage.CustomStorageAdaptor<Tester.EventSourcingTests.TestLogView, Tester.EventSourcingTests.TestLogEntry>;
+using CustomUpdateNotification = Orleans.EventSourcing.CustomStorage.CustomStorageAdaptor<Tester.EventSourcingTests.TestLogView, Tester.EventSourcingTests.TestLogEntry>.UpdateNotificationMessage;
+
+namespace Tester.EventSourcingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+[TestArea("EventSourcing")]
+public sealed class CustomStorageLogViewAdaptorTests
+{
+    [Fact]
+    public async Task WriteAsync_WhenExpectedVersionMatches_PersistsEntriesInOrder()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppendRange(Entries("one", "two")),
+            "custom storage range to commit");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "custom storage writer to become idle");
+
+        Assert.True(result);
+        Assert.Equal(1, host.ApplyCount);
+        Assert.Equal(0, host.ReadCount);
+        Assert.Equal(0, host.LastExpectedVersion);
+        Assert.Equal(["one", "two"], host.LastUpdates);
+        Assert.Equal(2, host.StoredVersion);
+        Assert.Equal(["one", "two"], host.StoredState.Entries);
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenExpectedVersionConflicts_RereadsAndRejectsConditionalRange()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        host.SetStoredState(["remote"], 1);
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppendRange(Entries("conditional-one", "conditional-two")),
+            "custom storage conflict to resolve");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "custom storage conflict worker to become idle");
+
+        Assert.False(result);
+        Assert.Equal(1, host.ApplyCount);
+        Assert.Equal(1, host.ReadCount);
+        Assert.Equal(0, host.LastExpectedVersion);
+        Assert.Equal(["conditional-one", "conditional-two"], host.LastUpdates);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        Assert.Equal(["remote"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(["remote"], adaptor.TentativeView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Empty(host.ConnectionIssues);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenForwardedStorageFailureOccurs_UnwrapsIssueAndRetriesWithoutDuplication()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        host.NextApplyBehavior = CustomStorageApplyBehavior.ThrowProtocolTransportException;
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("once")),
+            "custom storage retry to commit");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "custom storage retry worker to become idle");
+
+        Assert.True(result);
+        Assert.Equal(2, host.ApplyCount);
+        Assert.Equal(1, host.ReadCount);
+        Assert.Equal(["once"], host.StoredState.Entries);
+        Assert.Equal(1, host.StoredVersion);
+        var issue = Assert.IsType<CustomStorageAdaptor.UpdatePrimaryFailed>(Assert.Single(host.ConnectionIssues));
+        var exception = Assert.IsType<InvalidOperationException>(issue.Exception);
+        Assert.Equal("custom storage unavailable", exception.Message);
+        Assert.Same(issue, Assert.Single(host.ResolvedConnectionIssues));
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenCachedTransitionFails_RereadsPersistedStateAndReportsUserException()
+    {
+        var (adaptor, host, services) = CreateAdaptor();
+        host.ThrowOnNextUpdate();
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("persisted")),
+            "custom storage transition recovery to complete");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "custom storage transition worker to become idle");
+
+        Assert.True(result);
+        Assert.Equal(1, host.ApplyCount);
+        Assert.Equal(1, host.ReadCount);
+        Assert.Equal(["persisted"], host.StoredState.Entries);
+        Assert.Equal(["persisted"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        var exception = Assert.Single(services.UserCodeExceptions);
+        Assert.Equal(("UpdateView", "WriteAsync", "view update failed"), (
+            exception.Callback,
+            exception.Where,
+            exception.Exception.Message));
+        Assert.Empty(host.ConnectionIssues);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithFutureUpdate_QueuesUntilPredecessorAndAppliesInOrder()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+
+        await adaptor.OnProtocolMessageReceived(Notification(2, "two"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "future custom notification to drain");
+
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(host.ViewChanges);
+
+        await adaptor.OnProtocolMessageReceived(Notification(1, "one"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "contiguous custom notifications to drain");
+
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        Assert.Equal([(true, true)], host.ViewChanges);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithStaleUpdate_DiscardsWithoutChangingState()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        await adaptor.OnProtocolMessageReceived(Notification(2, "one", "two"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "initial custom notification to drain");
+        var changeCount = host.ViewChanges.Count;
+
+        await adaptor.OnProtocolMessageReceived(Notification(1, "stale"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "stale custom notification to drain");
+
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(changeCount, host.ViewChanges.Count);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+    }
+
+    [Fact]
+    public async Task ReadAsync_OnFreshAdaptor_RecoversStoredStateWithoutAliasing()
+    {
+        var host = new DeterministicCustomStorageHost();
+        host.SetStoredState(["one", "two"], 2);
+        var (adaptor, _, _) = CreateAdaptor(host);
+
+        await Activate(adaptor, "fresh custom adaptor");
+
+        Assert.Equal(1, host.ReadCount);
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        adaptor.ConfirmedView.Entries.Add("cache-only");
+        Assert.Equal(["one", "two"], host.StoredState.Entries);
+    }
+
+    [Fact]
+    public async Task ClearLogAsync_ResetsStorageAndFreshAdaptorRecoversVersionZero()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        Assert.True(await TestPhase.Await(
+            adaptor.TryAppendRange(Entries("one", "two")),
+            "custom storage setup range to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "custom storage setup writer to become idle");
+
+        await TestPhase.Await(
+            adaptor.ClearLogAsync(CancellationToken.None),
+            "custom storage clear to complete");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "custom storage clear worker to become idle");
+
+        Assert.Equal(1, host.ClearCount);
+        Assert.Equal(0, host.StoredVersion);
+        Assert.Empty(host.StoredState.Entries);
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.TentativeView.Entries);
+
+        var (fresh, _, _) = CreateAdaptor(host);
+        await Activate(fresh, "fresh custom adaptor after clear");
+        Assert.Equal(0, fresh.ConfirmedVersion);
+        Assert.Empty(fresh.ConfirmedView.Entries);
+    }
+
+    private static async Task Activate(CustomStorageAdaptor adaptor, string phase)
+    {
+        await adaptor.PreOnActivate();
+        await adaptor.PostOnActivate();
+        await TestPhase.Await(adaptor.PostOnDeactivate(), $"{phase} activation read to finish");
+    }
+
+    private static (TestCustomStorageAdaptor Adaptor, DeterministicCustomStorageHost Host, RecordingProtocolServices Services)
+        CreateAdaptor(DeterministicCustomStorageHost? host = null)
+    {
+        host ??= new DeterministicCustomStorageHost();
+        var services = new RecordingProtocolServices();
+        return (new TestCustomStorageAdaptor(host, new TestLogView(), services), host, services);
+    }
+
+    private static CustomUpdateNotification Notification(int version, params string[] values) =>
+        new()
+        {
+            Version = version,
+            Updates = Entries(values).ToList(),
+        };
+
+    private static TestLogEntry[] Entries(params string[] values) =>
+        values.Select(value => new TestLogEntry(value)).ToArray();
+}
+
+internal sealed class TestCustomStorageAdaptor(
+    DeterministicCustomStorageHost host,
+    TestLogView initialState,
+    RecordingProtocolServices services)
+    : CustomStorageAdaptor(host, initialState, services, primaryCluster: null);

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/LogStorageLogViewAdaptorTests.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/LogStorageLogViewAdaptorTests.cs
@@ -1,0 +1,542 @@
+using Orleans.EventSourcing;
+using Orleans.EventSourcing.Common;
+using Orleans.EventSourcing.LogStorage;
+using Orleans.EventSourcing.StateStorage;
+using Orleans.Runtime;
+using Orleans.Storage;
+using Xunit;
+using LogStorageAdaptor = Orleans.EventSourcing.LogStorage.LogViewAdaptor<Tester.EventSourcingTests.TestLogView, Tester.EventSourcingTests.TestLogEntry>;
+using LogUpdateNotification = Orleans.EventSourcing.LogStorage.LogViewAdaptor<Tester.EventSourcingTests.TestLogView, Tester.EventSourcingTests.TestLogEntry>.UpdateNotificationMessage;
+
+namespace Tester.EventSourcingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+[TestArea("EventSourcing")]
+public sealed class LogStorageLogViewAdaptorTests
+{
+    [Fact]
+    public void Merge_WithContiguousSameOriginUnderCap_CombinesInOrderWithoutMutatingInputs()
+    {
+        var (adaptor, _, _, _) = CreateAdaptor();
+        var earlier = Notification(2, "remote", "etag-2", "one", "two");
+        var later = Notification(4, "remote", "etag-4", "three", "four");
+
+        var result = Assert.IsType<LogUpdateNotification>(adaptor.MergeForTest(earlier, later));
+
+        Assert.Equal(4, result.Version);
+        Assert.Equal("remote", result.Origin);
+        Assert.Equal("etag-4", result.ETag);
+        Assert.Equal(["one", "two", "three", "four"], result.Updates.Select(entry => entry.Value));
+        Assert.NotSame(earlier.Updates, result.Updates);
+        Assert.NotSame(later.Updates, result.Updates);
+        Assert.Equal(["one", "two"], earlier.Updates.Select(entry => entry.Value));
+        Assert.Equal(["three", "four"], later.Updates.Select(entry => entry.Value));
+        Assert.Equal((2, "etag-2"), (earlier.Version, earlier.ETag));
+        Assert.Equal((4, "etag-4"), (later.Version, later.ETag));
+    }
+
+    [Fact]
+    public void Merge_AtEntryLimit_Merges199ButFallsBackAt200()
+    {
+        var (adaptor, _, _, _) = CreateAdaptor();
+        var first198 = Enumerable.Range(0, 198).Select(index => $"a-{index}").ToArray();
+        var first199 = Enumerable.Range(0, 199).Select(index => $"b-{index}").ToArray();
+        var later199 = Notification(199, "remote", "etag-199", "last-199");
+        var later200 = Notification(200, "remote", "etag-200", "last-200");
+
+        var merged = Assert.IsType<LogUpdateNotification>(
+            adaptor.MergeForTest(Notification(198, "remote", "etag-198", first198), later199));
+        var fallback = Assert.IsType<VersionNotificationMessage>(
+            adaptor.MergeForTest(Notification(199, "remote", "etag-199", first199), later200));
+
+        Assert.Equal(199, merged.Updates.Count);
+        Assert.Equal("a-0", merged.Updates[0].Value);
+        Assert.Equal("a-197", merged.Updates[197].Value);
+        Assert.Equal("last-199", merged.Updates[198].Value);
+        Assert.Equal((199, "etag-199"), (merged.Version, merged.ETag));
+        Assert.Equal(200, fallback.Version);
+        Assert.Equal(["last-199"], later199.Updates.Select(entry => entry.Value));
+        Assert.Equal(["last-200"], later200.Updates.Select(entry => entry.Value));
+    }
+
+    [Theory]
+    [InlineData("different-origin")]
+    [InlineData("gap")]
+    [InlineData("overlap")]
+    [InlineData("wrong-message")]
+    public void Merge_WhenInputsAreIncompatible_ReturnsLaterVersionNotification(string incompatibility)
+    {
+        var (adaptor, _, _, _) = CreateAdaptor();
+        var earlier = Notification(2, "remote", "etag-2", "one", "two");
+        var later = incompatibility switch
+        {
+            "different-origin" => Notification(4, "other", "etag-4", "three", "four"),
+            "gap" => Notification(5, "remote", "etag-5", "three", "four"),
+            "overlap" => Notification(3, "remote", "etag-3", "three", "four"),
+            _ => Notification(4, "remote", "etag-4", "three", "four"),
+        };
+        INotificationMessage earlierInput = incompatibility == "wrong-message"
+            ? new VersionNotificationMessage { Version = earlier.Version }
+            : earlier;
+
+        var result = Assert.IsType<VersionNotificationMessage>(adaptor.MergeForTest(earlierInput, later));
+
+        Assert.Equal(later.Version, result.Version);
+        Assert.Equal(["one", "two"], earlier.Updates.Select(entry => entry.Value));
+        Assert.Equal(["three", "four"], later.Updates.Select(entry => entry.Value));
+        Assert.Equal((2, "remote", "etag-2"), (earlier.Version, earlier.Origin, earlier.ETag));
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithFutureTypedNotification_QueuesUntilPredecessorThenAppliesBothInOrder()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+
+        await adaptor.OnProtocolMessageReceived(Notification(2, "remote", "remote-etag-2", "two"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "future log notification to drain");
+
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(host.ViewChanges);
+
+        await adaptor.OnProtocolMessageReceived(Notification(1, "remote", "remote-etag-1", "one"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "contiguous log notifications to drain");
+
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        Assert.Equal([(true, true)], host.ViewChanges);
+
+        Assert.True(await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("local")),
+            "post-notification log write to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "post-notification log worker to become idle");
+
+        Assert.Equal("remote-etag-2", storage.LastSuppliedETag);
+        Assert.Equal(",test-cluster", storage.LastSuppliedWriteVector);
+        Assert.Equal(["one", "two", "local"], storage.LogSnapshot.StateAndMetaData.Log.Select(entry => entry.Value));
+        Assert.Equal(3, storage.LogSnapshot.StateAndMetaData.GlobalVersion);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithStaleTypedNotification_DiscardsWithoutChangingState()
+    {
+        var (adaptor, host, _, _) = CreateAdaptor();
+        await adaptor.OnProtocolMessageReceived(Notification(2, "remote", "etag-2", "one", "two"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "initial log notification to drain");
+        var changeCount = host.ViewChanges.Count;
+
+        await adaptor.OnProtocolMessageReceived(Notification(1, "remote", "stale-etag", "stale"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "stale log notification to drain");
+
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(changeCount, host.ViewChanges.Count);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+    }
+
+    [Fact]
+    public async Task ReadAsync_OnFreshAdaptor_ReplaysFullPersistedLogAndReturnsDeepCopiedSegment()
+    {
+        var (_, _, storage, _) = CreateAdaptor();
+        var (writer, _, _, _) = CreateAdaptor(storage);
+        Assert.True(await TestPhase.Await(
+            writer.TryAppendRange(Entries("zero", "one", "two", "three")),
+            "persisted log write to commit"));
+        await TestPhase.Await(writer.PostOnDeactivate(), "persisted log writer to become idle");
+
+        var (fresh, host, _, _) = CreateAdaptor(storage);
+        await Activate(fresh, "fresh log adaptor");
+        var segment = await fresh.RetrieveLogSegment(1, 3);
+
+        Assert.Equal(4, fresh.ConfirmedVersion);
+        Assert.Equal(["zero", "one", "two", "three"], fresh.ConfirmedView.Entries);
+        Assert.Equal(["one", "two"], segment.Select(entry => entry.Value));
+        Assert.Equal([(true, true)], host.ViewChanges);
+        var mutableSegment = Assert.IsType<List<TestLogEntry>>(segment);
+        mutableSegment.Clear();
+        Assert.Equal(["zero", "one", "two", "three"], fresh.ConfirmedView.Entries);
+        Assert.Equal(
+            ["zero", "one", "two", "three"],
+            storage.LogSnapshot.StateAndMetaData.Log.Select(entry => entry.Value));
+        Assert.Equal(
+            ["one", "two"],
+            (await fresh.RetrieveLogSegment(1, 3)).Select(entry => entry.Value));
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenPersistenceSucceedsThenThrowsAndWriteBitMatches_ClassifiesSuccessWithoutDuplicate()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+        storage.NextWriteBehavior = StorageWriteBehavior.PersistThenThrow;
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("once")),
+            "ambiguous log write to resolve");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "ambiguous log writer to become idle");
+
+        Assert.True(result);
+        Assert.Equal(1, storage.WriteCount);
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Equal(["once"], storage.LogSnapshot.StateAndMetaData.Log.Select(entry => entry.Value));
+        Assert.Equal(["once"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        var issue = Assert.Single(host.ConnectionIssues);
+        Assert.IsType<LogStorageAdaptor.UpdateLogStorageFailed>(issue);
+        Assert.Equal("persisted write reported failure", ((LogStorageAdaptor.UpdateLogStorageFailed)issue).Exception.Message);
+        Assert.Same(issue, Assert.Single(host.ResolvedConnectionIssues));
+
+        Assert.True(await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("after-recovery")),
+            "log write after ambiguous recovery to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "log writer after ambiguous recovery to become idle");
+        Assert.Equal(2, storage.WriteCount);
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Equal("etag-1", storage.LastSuppliedETag);
+        Assert.Equal(
+            ["once", "after-recovery"],
+            storage.LogSnapshot.StateAndMetaData.Log.Select(entry => entry.Value));
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenETagConflictBelongsToAnotherWriter_RereadsAndRejectsConditionalRange()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+        storage.ConflictNextLogWrite(["remote"], ",remote", "remote-etag");
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppendRange(Entries("conditional-one", "conditional-two")),
+            "conflicting conditional log range to resolve");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "conflicting log writer to become idle");
+
+        Assert.False(result);
+        Assert.Equal(1, storage.WriteCount);
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        Assert.Equal(["remote"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(["remote"], adaptor.TentativeView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Equal(["remote"], storage.LogSnapshot.StateAndMetaData.Log.Select(entry => entry.Value));
+        Assert.IsType<LogStorageAdaptor.UpdateLogStorageFailed>(Assert.Single(host.ConnectionIssues));
+        Assert.Single(host.ResolvedConnectionIssues);
+    }
+
+    [Fact]
+    public async Task ClearLogAsync_WithPendingEntries_ResetsOnceAndFreshAdaptorReadsVersionZero()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+        var blockedWrite = storage.BlockNextWrite();
+        adaptor.Submit(new TestLogEntry("pending-at-clear"));
+        await TestPhase.Await(blockedWrite.Started, "log write before clear to start");
+        var changesBeforeClear = host.ViewChanges.Count;
+
+        var clear = adaptor.ClearLogAsync(CancellationToken.None);
+        Assert.False(clear.IsCompleted);
+        blockedWrite.Complete(true);
+        await TestPhase.Await(clear, "log clear to complete");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "log clear worker to become idle");
+
+        Assert.Equal(1, storage.WriteCount);
+        Assert.Equal(1, storage.ClearCount);
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.TentativeView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Equal(
+            [(false, true), (false, true), (true, true)],
+            host.ViewChanges.Skip(changesBeforeClear));
+        Assert.Empty(storage.LogSnapshot.StateAndMetaData.Log);
+
+        var (fresh, _, _, _) = CreateAdaptor(storage);
+        await Activate(fresh, "fresh log adaptor after clear");
+        Assert.Equal(0, fresh.ConfirmedVersion);
+        Assert.Empty(fresh.ConfirmedView.Entries);
+
+        Assert.True(await TestPhase.Await(
+            fresh.TryAppend(new TestLogEntry("after-clear")),
+            "post-clear log write to commit"));
+        await TestPhase.Await(fresh.PostOnDeactivate(), "post-clear log writer to become idle");
+        Assert.Equal(["after-clear"], storage.LogSnapshot.StateAndMetaData.Log.Select(entry => entry.Value));
+        Assert.Equal(1, fresh.ConfirmedVersion);
+    }
+
+    private static async Task Activate(LogStorageAdaptor adaptor, string phase)
+    {
+        await adaptor.PreOnActivate();
+        await adaptor.PostOnActivate();
+        await TestPhase.Await(adaptor.PostOnDeactivate(), $"{phase} activation read to finish");
+    }
+
+    private static (TestLogStorageAdaptor Adaptor, RecordingLogViewAdaptorHost Host, DeterministicEventSourcingStorage Storage, RecordingProtocolServices Services)
+        CreateAdaptor(DeterministicEventSourcingStorage? storage = null)
+    {
+        var host = new RecordingLogViewAdaptorHost();
+        var services = new RecordingProtocolServices();
+        storage ??= new DeterministicEventSourcingStorage();
+        return (new TestLogStorageAdaptor(host, new TestLogView(), storage, services), host, storage, services);
+    }
+
+    private static LogUpdateNotification Notification(
+        int version,
+        string origin,
+        string etag,
+        params string[] values) =>
+        new()
+        {
+            Version = version,
+            Origin = origin,
+            ETag = etag,
+            Updates = Entries(values).ToList(),
+        };
+
+    private static TestLogEntry[] Entries(params string[] values) =>
+        values.Select(value => new TestLogEntry(value)).ToArray();
+}
+
+internal sealed class TestLogStorageAdaptor(
+    RecordingLogViewAdaptorHost host,
+    TestLogView initialState,
+    IGrainStorage storage,
+    RecordingProtocolServices services)
+    : LogStorageAdaptor(host, initialState, storage, "test-log", services)
+{
+    public INotificationMessage MergeForTest(INotificationMessage earlier, INotificationMessage later) =>
+        Merge(earlier, later);
+}
+
+internal enum StorageWriteBehavior
+{
+    Success,
+    PersistThenThrow,
+    Conflict,
+}
+
+internal sealed class DeterministicEventSourcingStorage : IGrainStorage
+{
+    private LogStateWithMetaDataAndETag<TestLogEntry> _log = new();
+    private GrainStateWithMetaDataAndETag<TestLogView> _state = new(new TestLogView());
+    private LogStateWithMetaDataAndETag<TestLogEntry>? _conflictingLog;
+    private GrainStateWithMetaDataAndETag<TestLogView>? _conflictingState;
+    private ControlledOperation<bool>? _blockedWrite;
+    private int _etag;
+
+    public StorageWriteBehavior NextWriteBehavior { get; set; }
+
+    public int ReadCount { get; private set; }
+
+    public int WriteCount { get; private set; }
+
+    public int ClearCount { get; private set; }
+
+    public string? LastSuppliedETag { get; private set; }
+
+    public string? LastSuppliedWriteVector { get; private set; }
+
+    public LogStateWithMetaDataAndETag<TestLogEntry> LogSnapshot => Clone(_log);
+
+    public GrainStateWithMetaDataAndETag<TestLogView> StateSnapshot => Clone(_state);
+
+    public ControlledOperation<bool> BlockNextWrite()
+    {
+        _blockedWrite = new ControlledOperation<bool>();
+        return _blockedWrite;
+    }
+
+    public void ConflictNextLogWrite(IEnumerable<string> values, string writeVector, string etag)
+    {
+        _conflictingLog = new LogStateWithMetaDataAndETag<TestLogEntry>
+        {
+            ETag = etag,
+            RecordExists = true,
+            StateAndMetaData = new LogStateWithMetaData<TestLogEntry>
+            {
+                Log = values.Select(value => new TestLogEntry(value)).ToList(),
+                WriteVector = writeVector,
+            },
+        };
+        NextWriteBehavior = StorageWriteBehavior.Conflict;
+    }
+
+    public void ConflictNextStateWrite(
+        IEnumerable<string> values,
+        int version,
+        string writeVector,
+        string etag)
+    {
+        _conflictingState = new GrainStateWithMetaDataAndETag<TestLogView>
+        {
+            ETag = etag,
+            RecordExists = true,
+            StateAndMetaData = new GrainStateWithMetaData<TestLogView>
+            {
+                State = new TestLogView(values),
+                GlobalVersion = version,
+                WriteVector = writeVector,
+            },
+        };
+        NextWriteBehavior = StorageWriteBehavior.Conflict;
+    }
+
+    public async Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        ReadCount++;
+        switch ((object)grainState)
+        {
+            case LogStateWithMetaDataAndETag<TestLogEntry> log:
+                Copy(_log, log);
+                break;
+            case GrainStateWithMetaDataAndETag<TestLogView> state:
+                Copy(_state, state);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported state type {typeof(T)}.");
+        }
+
+        await Task.CompletedTask;
+    }
+
+    public async Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        WriteCount++;
+        var blockedWrite = _blockedWrite;
+        _blockedWrite = null;
+
+        switch ((object)grainState)
+        {
+            case LogStateWithMetaDataAndETag<TestLogEntry> log:
+                LastSuppliedETag = log.ETag;
+                LastSuppliedWriteVector = log.StateAndMetaData.WriteVector;
+                if (blockedWrite is not null)
+                {
+                    blockedWrite.SignalStarted();
+                    await blockedWrite.Completion;
+                }
+
+                if (NextWriteBehavior == StorageWriteBehavior.Conflict)
+                {
+                    _log = Clone(_conflictingLog ?? throw new InvalidOperationException("No conflicting log was configured."));
+                    NextWriteBehavior = StorageWriteBehavior.Success;
+                    throw new InvalidOperationException("log etag conflict");
+                }
+
+                var logEtag = $"etag-{++_etag}";
+                if (NextWriteBehavior == StorageWriteBehavior.PersistThenThrow)
+                {
+                    _log = Clone(log);
+                    _log.ETag = logEtag;
+                    _log.RecordExists = true;
+                }
+                else
+                {
+                    log.ETag = logEtag;
+                    log.RecordExists = true;
+                    _log = Clone(log);
+                }
+                break;
+            case GrainStateWithMetaDataAndETag<TestLogView> state:
+                LastSuppliedETag = state.ETag;
+                LastSuppliedWriteVector = state.StateAndMetaData.WriteVector;
+                if (blockedWrite is not null)
+                {
+                    blockedWrite.SignalStarted();
+                    await blockedWrite.Completion;
+                }
+
+                if (NextWriteBehavior == StorageWriteBehavior.Conflict)
+                {
+                    _state = Clone(_conflictingState ?? throw new InvalidOperationException("No conflicting state was configured."));
+                    NextWriteBehavior = StorageWriteBehavior.Success;
+                    throw new InvalidOperationException("state etag conflict");
+                }
+
+                var stateEtag = $"etag-{++_etag}";
+                if (NextWriteBehavior == StorageWriteBehavior.PersistThenThrow)
+                {
+                    _state = Clone(state);
+                    _state.ETag = stateEtag;
+                    _state.RecordExists = true;
+                }
+                else
+                {
+                    state.ETag = stateEtag;
+                    state.RecordExists = true;
+                    _state = Clone(state);
+                }
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported state type {typeof(T)}.");
+        }
+
+        if (NextWriteBehavior == StorageWriteBehavior.PersistThenThrow)
+        {
+            NextWriteBehavior = StorageWriteBehavior.Success;
+            throw new InvalidOperationException("persisted write reported failure");
+        }
+    }
+
+    public Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+    {
+        ClearCount++;
+        switch ((object)grainState)
+        {
+            case LogStateWithMetaDataAndETag<TestLogEntry>:
+                _log = new LogStateWithMetaDataAndETag<TestLogEntry>();
+                break;
+            case GrainStateWithMetaDataAndETag<TestLogView>:
+                _state = new GrainStateWithMetaDataAndETag<TestLogView>(new TestLogView());
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported state type {typeof(T)}.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static LogStateWithMetaDataAndETag<TestLogEntry> Clone(
+        LogStateWithMetaDataAndETag<TestLogEntry> source) =>
+        new()
+        {
+            ETag = source.ETag,
+            RecordExists = source.RecordExists,
+            StateAndMetaData = new LogStateWithMetaData<TestLogEntry>
+            {
+                Log = source.StateAndMetaData.Log.Select(entry => new TestLogEntry(entry.Value)).ToList(),
+                WriteVector = source.StateAndMetaData.WriteVector,
+            },
+        };
+
+    private static GrainStateWithMetaDataAndETag<TestLogView> Clone(
+        GrainStateWithMetaDataAndETag<TestLogView> source) =>
+        new()
+        {
+            ETag = source.ETag,
+            RecordExists = source.RecordExists,
+            StateAndMetaData = new GrainStateWithMetaData<TestLogView>
+            {
+                State = source.StateAndMetaData.State.Copy(),
+                GlobalVersion = source.StateAndMetaData.GlobalVersion,
+                WriteVector = source.StateAndMetaData.WriteVector,
+            },
+        };
+
+    private static void Copy(
+        LogStateWithMetaDataAndETag<TestLogEntry> source,
+        LogStateWithMetaDataAndETag<TestLogEntry> destination)
+    {
+        var copy = Clone(source);
+        destination.StateAndMetaData = copy.StateAndMetaData;
+        destination.ETag = copy.ETag;
+        destination.RecordExists = copy.RecordExists;
+    }
+
+    private static void Copy(
+        GrainStateWithMetaDataAndETag<TestLogView> source,
+        GrainStateWithMetaDataAndETag<TestLogView> destination)
+    {
+        var copy = Clone(source);
+        destination.StateAndMetaData = copy.StateAndMetaData;
+        destination.ETag = copy.ETag;
+        destination.RecordExists = copy.RecordExists;
+    }
+}

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/LogViewAdaptorTestInfrastructure.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/LogViewAdaptorTestInfrastructure.cs
@@ -1,0 +1,470 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Orleans.EventSourcing;
+using Orleans.EventSourcing.Common;
+using Orleans.EventSourcing.CustomStorage;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.EventSourcingTests;
+
+internal sealed class TestLogView
+{
+    public TestLogView()
+    {
+    }
+
+    public TestLogView(IEnumerable<string> entries) => Entries.AddRange(entries);
+
+    public List<string> Entries { get; } = [];
+
+    public TestLogView Copy() => new(Entries);
+}
+
+internal sealed record TestLogEntry(string Value);
+
+internal sealed class TestSubmissionEntry : SubmissionEntry<TestLogEntry>;
+
+internal class RecordingLogViewAdaptorHost : ILogViewAdaptorHost<TestLogView, TestLogEntry>
+{
+    private readonly object _lock = new();
+    private bool _throwOnNextConfirmedChange;
+    private bool _throwOnNextUpdate;
+
+    public List<(bool Tentative, bool Confirmed)> ViewChanges { get; } = [];
+
+    public List<ConnectionIssue> ConnectionIssues { get; } = [];
+
+    public List<ConnectionIssue> ResolvedConnectionIssues { get; } = [];
+
+    public void ThrowOnNextConfirmedChange() => _throwOnNextConfirmedChange = true;
+
+    public void ThrowOnNextUpdate() => _throwOnNextUpdate = true;
+
+    public virtual void UpdateView(TestLogView view, TestLogEntry entry)
+    {
+        if (_throwOnNextUpdate)
+        {
+            _throwOnNextUpdate = false;
+            throw new InvalidOperationException("view update failed");
+        }
+
+        view.Entries.Add(entry.Value);
+    }
+
+    public void OnViewChanged(bool tentative, bool confirmed)
+    {
+        lock (_lock)
+        {
+            ViewChanges.Add((tentative, confirmed));
+        }
+
+        if (confirmed && _throwOnNextConfirmedChange)
+        {
+            _throwOnNextConfirmedChange = false;
+            throw new InvalidOperationException("view-change callback failed");
+        }
+    }
+
+    public void OnConnectionIssue(ConnectionIssue issue)
+    {
+        lock (_lock)
+        {
+            ConnectionIssues.Add(issue);
+        }
+    }
+
+    public void OnConnectionIssueResolved(ConnectionIssue issue)
+    {
+        lock (_lock)
+        {
+            ResolvedConnectionIssues.Add(issue);
+        }
+    }
+}
+
+internal enum CustomStorageApplyBehavior
+{
+    Success,
+    Conflict,
+    ThrowProtocolTransportException,
+}
+
+internal sealed class DeterministicCustomStorageHost
+    : RecordingLogViewAdaptorHost, ICustomStorageInterface<TestLogView, TestLogEntry>
+{
+    private TestLogView _state = new();
+    private int _version;
+
+    public CustomStorageApplyBehavior NextApplyBehavior { get; set; }
+
+    public int ApplyCount { get; private set; }
+
+    public int ReadCount { get; private set; }
+
+    public int ClearCount { get; private set; }
+
+    public int LastExpectedVersion { get; private set; }
+
+    public IReadOnlyList<string> LastUpdates { get; private set; } = [];
+
+    public TestLogView StoredState => _state.Copy();
+
+    public int StoredVersion => _version;
+
+    public void SetStoredState(IEnumerable<string> entries, int version)
+    {
+        _state = new TestLogView(entries);
+        _version = version;
+    }
+
+    public Task<KeyValuePair<int, TestLogView>> ReadStateFromStorage()
+    {
+        ReadCount++;
+        return Task.FromResult(new KeyValuePair<int, TestLogView>(_version, _state.Copy()));
+    }
+
+    public Task<bool> ApplyUpdatesToStorage(IReadOnlyList<TestLogEntry> updates, int expectedVersion)
+    {
+        ApplyCount++;
+        LastExpectedVersion = expectedVersion;
+        LastUpdates = updates.Select(entry => entry.Value).ToArray();
+
+        var behavior = NextApplyBehavior;
+        NextApplyBehavior = CustomStorageApplyBehavior.Success;
+        if (behavior == CustomStorageApplyBehavior.Conflict || expectedVersion != _version)
+        {
+            return Task.FromResult(false);
+        }
+
+        if (behavior == CustomStorageApplyBehavior.ThrowProtocolTransportException)
+        {
+            throw new ProtocolTransportException(
+                "forwarded custom storage failure",
+                new InvalidOperationException("custom storage unavailable"));
+        }
+
+        foreach (var update in updates)
+        {
+            _state.Entries.Add(update.Value);
+        }
+
+        _version += updates.Count;
+        return Task.FromResult(true);
+    }
+
+    public Task ClearStoredState()
+    {
+        ClearCount++;
+        _state = new TestLogView();
+        _version = 0;
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class RecordingProtocolServices : ILogConsistencyProtocolServices
+{
+    private readonly object _lock = new();
+
+    public GrainId GrainId { get; } = GrainId.Create("primary-adaptor-test", "1");
+
+    public string MyClusterId => "test-cluster";
+
+    public List<(string Callback, string Where, Exception Exception)> UserCodeExceptions { get; } = [];
+
+    public List<string> ProtocolErrors { get; } = [];
+
+    public T DeepCopy<T>(T value) => value switch
+    {
+        TestLogView view => (T)(object)view.Copy(),
+        TestLogEntry entry => (T)(object)new TestLogEntry(entry.Value),
+        _ => value,
+    };
+
+    public void ProtocolError(string msg, bool throwexception)
+    {
+        lock (_lock)
+        {
+            ProtocolErrors.Add(msg);
+        }
+    }
+
+    public void CaughtException(string where, Exception e)
+    {
+        lock (_lock)
+        {
+            ProtocolErrors.Add($"{where}: {e.Message}");
+        }
+    }
+
+    public void CaughtUserCodeException(string callback, string where, Exception e)
+    {
+        lock (_lock)
+        {
+            UserCodeExceptions.Add((callback, where, e));
+        }
+    }
+
+    public void Log(LogLevel level, string format, params object[] args)
+    {
+    }
+}
+
+internal sealed class ControlledOperation<T>
+{
+    private readonly TaskCompletionSource<bool> _started =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<T> _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task Started => _started.Task;
+
+    public Task<T> Completion => _completion.Task;
+
+    public void Complete(T result) => _completion.TrySetResult(result);
+
+    public void Fail(Exception exception) => _completion.TrySetException(exception);
+
+    internal void SignalStarted() => _started.TrySetResult(true);
+}
+
+internal sealed record PrimaryReadResult(TestLogView View, int Version);
+
+internal sealed class TestPrimaryBasedLogViewAdaptor
+    : PrimaryBasedLogViewAdaptor<TestLogView, TestLogEntry, TestSubmissionEntry>
+{
+    private readonly object _stateLock = new();
+    private readonly ConcurrentQueue<ControlledOperation<PrimaryReadResult>> _reads = new();
+    private readonly ConcurrentQueue<ControlledOperation<int>> _writes = new();
+    private readonly ConcurrentQueue<ControlledOperation<bool>> _clears = new();
+    private TestLogView _confirmed = new();
+    private int _confirmedVersion;
+    private int _activePrimaryOperations;
+    private int _maximumConcurrentPrimaryOperations;
+
+    public TestPrimaryBasedLogViewAdaptor(
+        RecordingLogViewAdaptorHost host,
+        TestLogView initialState,
+        RecordingProtocolServices services)
+        : base(host, initialState, services)
+    {
+    }
+
+    public List<string> OperationLog { get; } = [];
+
+    public List<(string Type, int Version)> NotificationTrace { get; } = [];
+
+    public int ReadCount { get; private set; }
+
+    public int WriteCount { get; private set; }
+
+    public int ClearCount { get; private set; }
+
+    public int MaximumConcurrentPrimaryOperations => Volatile.Read(ref _maximumConcurrentPrimaryOperations);
+
+    public ControlledOperation<PrimaryReadResult> QueueRead(TestLogView view, int version)
+    {
+        var operation = new ControlledOperation<PrimaryReadResult>();
+        _reads.Enqueue(operation);
+        return operation;
+    }
+
+    public ControlledOperation<int> QueueWrite()
+    {
+        var operation = new ControlledOperation<int>();
+        _writes.Enqueue(operation);
+        return operation;
+    }
+
+    public ControlledOperation<bool> QueueClear()
+    {
+        var operation = new ControlledOperation<bool>();
+        _clears.Enqueue(operation);
+        return operation;
+    }
+
+    protected override void InitializeConfirmedView(TestLogView initialstate)
+    {
+        lock (_stateLock)
+        {
+            _confirmed = initialstate.Copy();
+            _confirmedVersion = 0;
+        }
+    }
+
+    protected override TestLogView LastConfirmedView()
+    {
+        lock (_stateLock)
+        {
+            return _confirmed;
+        }
+    }
+
+    protected override int GetConfirmedVersion()
+    {
+        lock (_stateLock)
+        {
+            return _confirmedVersion;
+        }
+    }
+
+    protected override async Task ReadAsync()
+    {
+        if (!_reads.TryDequeue(out var operation))
+        {
+            throw new InvalidOperationException("No read operation was queued.");
+        }
+
+        EnterPrimaryOperation("read:start");
+        ReadCount++;
+        operation.SignalStarted();
+        try
+        {
+            var result = await operation.Completion;
+            lock (_stateLock)
+            {
+                _confirmed = result.View.Copy();
+                _confirmedVersion = result.Version;
+            }
+        }
+        finally
+        {
+            ExitPrimaryOperation("read:end");
+        }
+    }
+
+    protected override async Task<int> WriteAsync()
+    {
+        if (!_writes.TryDequeue(out var operation))
+        {
+            throw new InvalidOperationException("No write operation was queued.");
+        }
+
+        var updates = GetCurrentBatchOfUpdates();
+        EnterPrimaryOperation("write:start");
+        WriteCount++;
+        operation.SignalStarted();
+        try
+        {
+            var count = await operation.Completion;
+            lock (_stateLock)
+            {
+                for (var index = 0; index < count; index++)
+                {
+                    _confirmed.Entries.Add(updates[index].Entry!.Value);
+                }
+
+                _confirmedVersion += count;
+            }
+
+            return count;
+        }
+        finally
+        {
+            ExitPrimaryOperation("write:end");
+        }
+    }
+
+    protected override TestSubmissionEntry MakeSubmissionEntry(TestLogEntry entry) => new() { Entry = entry };
+
+    protected override async Task ClearPrimaryLogAsync(CancellationToken cancellationToken)
+    {
+        if (!_clears.TryDequeue(out var operation))
+        {
+            throw new InvalidOperationException("No clear operation was queued.");
+        }
+
+        EnterPrimaryOperation("clear:start");
+        ClearCount++;
+        operation.SignalStarted();
+        try
+        {
+            await operation.Completion.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            ExitPrimaryOperation("clear:end");
+        }
+    }
+
+    protected override void OnNotificationReceived(INotificationMessage payload)
+    {
+        NotificationTrace.Add((payload.GetType().Name, payload.Version));
+        base.OnNotificationReceived(payload);
+    }
+
+    private void EnterPrimaryOperation(string operation)
+    {
+        lock (OperationLog)
+        {
+            OperationLog.Add(operation);
+        }
+
+        var active = Interlocked.Increment(ref _activePrimaryOperations);
+        int observed;
+        while (active > (observed = Volatile.Read(ref _maximumConcurrentPrimaryOperations)))
+        {
+            if (Interlocked.CompareExchange(ref _maximumConcurrentPrimaryOperations, active, observed) == observed)
+            {
+                break;
+            }
+        }
+    }
+
+    private void ExitPrimaryOperation(string operation)
+    {
+        Interlocked.Decrement(ref _activePrimaryOperations);
+        lock (OperationLog)
+        {
+            OperationLog.Add(operation);
+        }
+    }
+}
+
+internal sealed class SingleUseEnumerable<T>(IEnumerable<T> values) : IEnumerable<T>
+{
+    public int EnumerationCount { get; private set; }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        EnumerationCount++;
+        if (EnumerationCount != 1)
+        {
+            throw new InvalidOperationException("The enumerable was enumerated more than once.");
+        }
+
+        return values.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal static class TestPhase
+{
+    private static readonly TimeSpan WatchdogTimeout = TimeSpan.FromSeconds(15);
+
+    public static async Task Await(Task task, string phase)
+    {
+        try
+        {
+            await task.WaitAsync(WatchdogTimeout, TestContext.Current.CancellationToken);
+        }
+        catch (TimeoutException exception)
+        {
+            throw new TimeoutException($"Timed out waiting for phase '{phase}'.", exception);
+        }
+    }
+
+    public static async Task<T> Await<T>(Task<T> task, string phase)
+    {
+        try
+        {
+            return await task.WaitAsync(WatchdogTimeout, TestContext.Current.CancellationToken);
+        }
+        catch (TimeoutException exception)
+        {
+            throw new TimeoutException($"Timed out waiting for phase '{phase}'.", exception);
+        }
+    }
+}

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/PrimaryBasedLogViewAdaptorTests.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/PrimaryBasedLogViewAdaptorTests.cs
@@ -1,0 +1,350 @@
+using Orleans.EventSourcing;
+using Orleans.EventSourcing.Common;
+using Xunit;
+
+namespace Tester.EventSourcingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+[TestArea("EventSourcing")]
+public sealed class PrimaryBasedLogViewAdaptorTests
+{
+    [Fact]
+    public async Task TryAppendRange_WithNonEmptyRange_AppendsAtomicallyInOrderAndCompletesTrue()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        var write = adaptor.QueueWrite();
+
+        var append = adaptor.TryAppendRange(Entries("one", "two", "three"));
+        await TestPhase.Await(write.Started, "non-empty conditional range write to start");
+
+        Assert.False(append.IsCompleted);
+        Assert.Equal(["one", "two", "three"], adaptor.TentativeView.Entries);
+        Assert.Equal(["one", "two", "three"], adaptor.UnconfirmedSuffix.Select(entry => entry.Value));
+
+        write.Complete(3);
+        Assert.True(await TestPhase.Await(append, "non-empty conditional range to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "non-empty conditional range worker to become idle");
+
+        Assert.Equal(3, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two", "three"], adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Equal(
+            [(true, false), (true, false), (true, false), (false, true), (false, true)],
+            host.ViewChanges);
+        Assert.Equal(["write:start", "write:end"], adaptor.OperationLog);
+    }
+
+    [Fact]
+    public async Task TryAppendRange_WithEmptyRange_CompletesTrueWithoutSchedulingStorage()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+
+        var append = adaptor.TryAppendRange([]);
+
+        Assert.True(append.IsCompletedSuccessfully);
+        Assert.True(await append);
+        Assert.Equal(0, adaptor.WriteCount);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.TentativeView.Entries);
+        Assert.Empty(host.ViewChanges);
+        Assert.Empty(adaptor.OperationLog);
+    }
+
+    [Fact]
+    public async Task TryAppendRange_WhenActivationReadAdvancesVersion_CompletesFalseAndRemovesWholeRange()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        var read = adaptor.QueueRead(new TestLogView(["remote-one", "remote-two"]), 2);
+        await adaptor.PreOnActivate();
+        await adaptor.PostOnActivate();
+        await TestPhase.Await(read.Started, "activation read to start");
+
+        var append = adaptor.TryAppendRange(Entries("conditional-one", "conditional-two"));
+        Assert.False(append.IsCompleted);
+        Assert.Equal(
+            ["conditional-one", "conditional-two"],
+            adaptor.UnconfirmedSuffix.Select(entry => entry.Value));
+
+        read.Complete(new PrimaryReadResult(new TestLogView(["remote-one", "remote-two"]), 2));
+        Assert.False(await TestPhase.Await(append, "stale conditional range to be rejected"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "conflict worker to become idle");
+
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["remote-one", "remote-two"], adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Equal(["remote-one", "remote-two"], adaptor.TentativeView.Entries);
+        Assert.Equal(0, adaptor.WriteCount);
+        Assert.Equal(
+            [(true, false), (true, false), (true, true), (true, false)],
+            host.ViewChanges);
+    }
+
+    [Fact]
+    public async Task TryAppendRange_WithSingleUseEnumerable_EnumeratesOnceAndPreservesOrder()
+    {
+        var (adaptor, _, _) = CreateAdaptor();
+        var entries = new SingleUseEnumerable<TestLogEntry>(Entries("first", "second", "third"));
+        var write = adaptor.QueueWrite();
+
+        var append = adaptor.TryAppendRange(entries);
+        await TestPhase.Await(write.Started, "single-use range write to start");
+        write.Complete(3);
+
+        Assert.True(await TestPhase.Await(append, "single-use range to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "single-use range worker to become idle");
+        Assert.Equal(1, entries.EnumerationCount);
+        Assert.Equal(["first", "second", "third"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(3, adaptor.ConfirmedVersion);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithVersionNotification_RefreshesToAdvertisedVersion()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        var read = adaptor.QueueRead(new TestLogView(["remote"]), 4);
+
+        var response = await adaptor.OnProtocolMessageReceived(new VersionNotificationMessage { Version = 4 });
+        await TestPhase.Await(read.Started, "version-notification refresh read to start");
+        Assert.Null(response);
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+
+        read.Complete(new PrimaryReadResult(new TestLogView(["remote"]), 4));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "version-notification refresh to finish");
+
+        Assert.Equal(4, adaptor.ConfirmedVersion);
+        Assert.Equal(["remote"], adaptor.ConfirmedView.Entries);
+        Assert.Equal([("VersionNotificationMessage", 4)], adaptor.NotificationTrace);
+        Assert.Equal([(true, true)], host.ViewChanges);
+        Assert.Equal(["read:start", "read:end"], adaptor.OperationLog);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithNestedBatch_ProcessesChildrenInOrder()
+    {
+        var (adaptor, _, _) = CreateAdaptor();
+        var read = adaptor.QueueRead(new TestLogView(["latest"]), 5);
+        var notification = new BatchedNotificationMessage
+        {
+            Notifications =
+            [
+                new VersionNotificationMessage { Version = 2 },
+                new BatchedNotificationMessage
+                {
+                    Notifications =
+                    [
+                        new VersionNotificationMessage { Version = 3 },
+                        new VersionNotificationMessage { Version = 5 },
+                    ],
+                },
+            ],
+        };
+
+        await adaptor.OnProtocolMessageReceived(notification);
+        await TestPhase.Await(read.Started, "nested-batch refresh read to start");
+        read.Complete(new PrimaryReadResult(new TestLogView(["latest"]), 5));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "nested-batch refresh to finish");
+
+        Assert.Equal(
+            [
+                ("BatchedNotificationMessage", 5),
+                ("VersionNotificationMessage", 2),
+                ("BatchedNotificationMessage", 5),
+                ("VersionNotificationMessage", 3),
+                ("VersionNotificationMessage", 5),
+            ],
+            adaptor.NotificationTrace);
+        Assert.Equal(1, adaptor.ReadCount);
+        Assert.Equal(5, adaptor.ConfirmedVersion);
+        Assert.Equal(["latest"], adaptor.ConfirmedView.Entries);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithUnknownMessage_ThrowsProtocolTransportException()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+
+        var exception = await Assert.ThrowsAsync<ProtocolTransportException>(
+            () => adaptor.OnProtocolMessageReceived(new UnknownNotificationMessage(7)));
+
+        Assert.Equal(
+            $"message type {typeof(UnknownNotificationMessage).FullName} not handled by OnNotificationReceived",
+            exception.Message);
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(host.ViewChanges);
+        Assert.Empty(adaptor.OperationLog);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_DuringBlockedWrite_RunsInSubsequentWorkerCycle()
+    {
+        var (adaptor, _, _) = CreateAdaptor();
+        var write = adaptor.QueueWrite();
+        var read = adaptor.QueueRead(new TestLogView(["local", "remote-two", "remote-three", "remote-four"]), 4);
+
+        var append = adaptor.TryAppend(new TestLogEntry("local"));
+        await TestPhase.Await(write.Started, "write to block before notification");
+        await adaptor.OnProtocolMessageReceived(new VersionNotificationMessage { Version = 4 });
+
+        Assert.False(read.Started.IsCompleted);
+        Assert.Equal(1, adaptor.MaximumConcurrentPrimaryOperations);
+
+        write.Complete(1);
+        Assert.True(await TestPhase.Await(append, "blocked write to commit"));
+        await TestPhase.Await(read.Started, "notification refresh to start after write");
+        read.Complete(new PrimaryReadResult(
+            new TestLogView(["local", "remote-two", "remote-three", "remote-four"]),
+            4));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "notification-after-write worker to become idle");
+
+        Assert.Equal(
+            ["write:start", "write:end", "read:start", "read:end"],
+            adaptor.OperationLog);
+        Assert.Equal(1, adaptor.MaximumConcurrentPrimaryOperations);
+        Assert.Equal(4, adaptor.ConfirmedVersion);
+        Assert.Equal(["local", "remote-two", "remote-three", "remote-four"], adaptor.ConfirmedView.Entries);
+    }
+
+    [Fact]
+    public async Task Synchronize_DuringBlockedWrite_SerializesWriteThenRead()
+    {
+        var (adaptor, _, _) = CreateAdaptor();
+        var write = adaptor.QueueWrite();
+        var read = adaptor.QueueRead(new TestLogView(["local", "remote"]), 2);
+
+        var append = adaptor.TryAppend(new TestLogEntry("local"));
+        await TestPhase.Await(write.Started, "write to block before synchronize");
+        var synchronize = adaptor.Synchronize();
+
+        Assert.False(synchronize.IsCompleted);
+        Assert.False(read.Started.IsCompleted);
+        write.Complete(1);
+        Assert.True(await TestPhase.Await(append, "write before synchronize to commit"));
+        await TestPhase.Await(read.Started, "synchronize refresh read to start");
+        Assert.False(synchronize.IsCompleted);
+
+        read.Complete(new PrimaryReadResult(new TestLogView(["local", "remote"]), 2));
+        await TestPhase.Await(synchronize, "synchronize refresh to complete");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "synchronize worker to become idle");
+
+        Assert.Equal(
+            ["write:start", "write:end", "read:start", "read:end"],
+            adaptor.OperationLog);
+        Assert.Equal(1, adaptor.MaximumConcurrentPrimaryOperations);
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["local", "remote"], adaptor.ConfirmedView.Entries);
+    }
+
+    [Fact]
+    public async Task Work_WhenViewChangedCallbackThrows_ReportsCaughtUserCodeException()
+    {
+        var (adaptor, host, services) = CreateAdaptor();
+        var write = adaptor.QueueWrite();
+        host.ThrowOnNextConfirmedChange();
+
+        var append = adaptor.TryAppend(new TestLogEntry("committed"));
+        await TestPhase.Await(write.Started, "write before callback failure");
+        write.Complete(1);
+
+        Assert.True(await TestPhase.Await(append, "write despite callback failure"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "callback-failure worker to become idle");
+        var reported = Assert.Single(services.UserCodeExceptions);
+        Assert.Equal("OnViewChanged", reported.Callback);
+        Assert.Equal("NotifyViewChanges", reported.Where);
+        Assert.Equal("view-change callback failed", reported.Exception.Message);
+        Assert.Empty(services.ProtocolErrors);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        Assert.Equal(["committed"], adaptor.ConfirmedView.Entries);
+    }
+
+    [Fact]
+    public async Task ClearLogAsync_ConcurrentCallers_CoalesceAndResetOnlyAfterRelease()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        await Commit(adaptor, "confirmed");
+        var changesBeforeClear = host.ViewChanges.Count;
+        var clearOperation = adaptor.QueueClear();
+
+        var first = adaptor.ClearLogAsync(CancellationToken.None);
+        await TestPhase.Await(clearOperation.Started, "coalesced clear to start");
+        adaptor.Submit(new TestLogEntry("tentative"));
+        var second = adaptor.ClearLogAsync(CancellationToken.None);
+
+        Assert.Same(first, second);
+        Assert.False(first.IsCompleted);
+        Assert.Equal(["confirmed"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(["confirmed", "tentative"], adaptor.TentativeView.Entries);
+        Assert.Equal(1, adaptor.ClearCount);
+
+        clearOperation.Complete(true);
+        await TestPhase.Await(Task.WhenAll(first, second), "coalesced clear callers to complete");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "coalesced clear worker to become idle");
+
+        Assert.Equal(1, adaptor.ClearCount);
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.TentativeView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Equal([(true, false), (true, true)], host.ViewChanges.Skip(changesBeforeClear));
+        Assert.Equal(["clear:start", "clear:end"], adaptor.OperationLog.TakeLast(2));
+    }
+
+    [Fact]
+    public async Task ClearLogAsync_WhenStorageClearFails_PropagatesAndPreservesConfirmedAndTentativeState()
+    {
+        var (adaptor, host, _) = CreateAdaptor();
+        await Commit(adaptor, "confirmed");
+        var changesBeforeClear = host.ViewChanges.Count;
+        var clearOperation = adaptor.QueueClear();
+        var pendingWrite = adaptor.QueueWrite();
+        var failure = new InvalidOperationException("clear storage failed");
+
+        var clear = adaptor.ClearLogAsync(CancellationToken.None);
+        await TestPhase.Await(clearOperation.Started, "failing clear to start");
+        adaptor.Submit(new TestLogEntry("tentative"));
+        clearOperation.Fail(failure);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => TestPhase.Await(clear, "failing clear to propagate"));
+        await TestPhase.Await(pendingWrite.Started, "pending write after failed clear to start");
+
+        Assert.Same(failure, actual);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        Assert.Equal(["confirmed"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(["confirmed", "tentative"], adaptor.TentativeView.Entries);
+        Assert.Equal(["tentative"], adaptor.UnconfirmedSuffix.Select(entry => entry.Value));
+        Assert.Equal([(true, false)], host.ViewChanges.Skip(changesBeforeClear));
+        Assert.Equal(
+            ["write:start", "write:end", "clear:start", "clear:end", "write:start"],
+            adaptor.OperationLog);
+
+        pendingWrite.Complete(1);
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "failed-clear cleanup write to finish");
+    }
+
+    private static async Task Commit(TestPrimaryBasedLogViewAdaptor adaptor, string value)
+    {
+        var write = adaptor.QueueWrite();
+        var append = adaptor.TryAppend(new TestLogEntry(value));
+        await TestPhase.Await(write.Started, $"setup write '{value}' to start");
+        write.Complete(1);
+        Assert.True(await TestPhase.Await(append, $"setup write '{value}' to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), $"setup write '{value}' worker to become idle");
+    }
+
+    private static (TestPrimaryBasedLogViewAdaptor Adaptor, RecordingLogViewAdaptorHost Host, RecordingProtocolServices Services)
+        CreateAdaptor()
+    {
+        var host = new RecordingLogViewAdaptorHost();
+        var services = new RecordingProtocolServices();
+        return (new TestPrimaryBasedLogViewAdaptor(host, new TestLogView(), services), host, services);
+    }
+
+    private static TestLogEntry[] Entries(params string[] values) =>
+        values.Select(value => new TestLogEntry(value)).ToArray();
+
+    private sealed record UnknownNotificationMessage(int Version) : INotificationMessage;
+}

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/StateStorageLogViewAdaptorTests.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/StateStorageLogViewAdaptorTests.cs
@@ -1,0 +1,312 @@
+using Orleans.EventSourcing;
+using Orleans.EventSourcing.Common;
+using Orleans.EventSourcing.StateStorage;
+using Orleans.Storage;
+using Xunit;
+using StateStorageAdaptor = Orleans.EventSourcing.StateStorage.LogViewAdaptor<Tester.EventSourcingTests.TestLogView, Tester.EventSourcingTests.TestLogEntry>;
+using StateUpdateNotification = Orleans.EventSourcing.StateStorage.LogViewAdaptor<Tester.EventSourcingTests.TestLogView, Tester.EventSourcingTests.TestLogEntry>.UpdateNotificationMessage;
+
+namespace Tester.EventSourcingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+[TestArea("EventSourcing")]
+public sealed class StateStorageLogViewAdaptorTests
+{
+    [Fact]
+    public void Merge_WithContiguousSameOriginUnderCap_CombinesInOrderWithoutMutatingInputs()
+    {
+        var (adaptor, _, _, _) = CreateAdaptor();
+        var earlier = Notification(2, "remote", "etag-2", "one", "two");
+        var later = Notification(4, "remote", "etag-4", "three", "four");
+
+        var result = Assert.IsType<StateUpdateNotification>(adaptor.MergeForTest(earlier, later));
+
+        Assert.Equal(4, result.Version);
+        Assert.Equal("remote", result.Origin);
+        Assert.Equal("etag-4", result.ETag);
+        Assert.Equal(["one", "two", "three", "four"], result.Updates.Select(entry => entry.Value));
+        Assert.NotSame(earlier.Updates, result.Updates);
+        Assert.NotSame(later.Updates, result.Updates);
+        Assert.Equal(["one", "two"], earlier.Updates.Select(entry => entry.Value));
+        Assert.Equal(["three", "four"], later.Updates.Select(entry => entry.Value));
+        Assert.Equal((2, "etag-2"), (earlier.Version, earlier.ETag));
+        Assert.Equal((4, "etag-4"), (later.Version, later.ETag));
+    }
+
+    [Fact]
+    public void Merge_AtEntryLimit_Merges199ButFallsBackAt200()
+    {
+        var (adaptor, _, _, _) = CreateAdaptor();
+        var first198 = Enumerable.Range(0, 198).Select(index => $"a-{index}").ToArray();
+        var first199 = Enumerable.Range(0, 199).Select(index => $"b-{index}").ToArray();
+        var later199 = Notification(199, "remote", "etag-199", "last-199");
+        var later200 = Notification(200, "remote", "etag-200", "last-200");
+
+        var merged = Assert.IsType<StateUpdateNotification>(
+            adaptor.MergeForTest(Notification(198, "remote", "etag-198", first198), later199));
+        var fallback = Assert.IsType<VersionNotificationMessage>(
+            adaptor.MergeForTest(Notification(199, "remote", "etag-199", first199), later200));
+
+        Assert.Equal(199, merged.Updates.Count);
+        Assert.Equal("a-0", merged.Updates[0].Value);
+        Assert.Equal("a-197", merged.Updates[197].Value);
+        Assert.Equal("last-199", merged.Updates[198].Value);
+        Assert.Equal((199, "etag-199"), (merged.Version, merged.ETag));
+        Assert.Equal(200, fallback.Version);
+        Assert.Equal(["last-199"], later199.Updates.Select(entry => entry.Value));
+        Assert.Equal(["last-200"], later200.Updates.Select(entry => entry.Value));
+    }
+
+    [Theory]
+    [InlineData("different-origin")]
+    [InlineData("gap")]
+    [InlineData("overlap")]
+    [InlineData("wrong-message")]
+    public void Merge_WhenInputsAreIncompatible_ReturnsLaterVersionNotification(string incompatibility)
+    {
+        var (adaptor, _, _, _) = CreateAdaptor();
+        var earlier = Notification(2, "remote", "etag-2", "one", "two");
+        var later = incompatibility switch
+        {
+            "different-origin" => Notification(4, "other", "etag-4", "three", "four"),
+            "gap" => Notification(5, "remote", "etag-5", "three", "four"),
+            "overlap" => Notification(3, "remote", "etag-3", "three", "four"),
+            _ => Notification(4, "remote", "etag-4", "three", "four"),
+        };
+        INotificationMessage earlierInput = incompatibility == "wrong-message"
+            ? new VersionNotificationMessage { Version = earlier.Version }
+            : earlier;
+
+        var result = Assert.IsType<VersionNotificationMessage>(adaptor.MergeForTest(earlierInput, later));
+
+        Assert.Equal(later.Version, result.Version);
+        Assert.Equal(["one", "two"], earlier.Updates.Select(entry => entry.Value));
+        Assert.Equal(["three", "four"], later.Updates.Select(entry => entry.Value));
+        Assert.Equal((2, "remote", "etag-2"), (earlier.Version, earlier.Origin, earlier.ETag));
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithFutureTypedNotification_QueuesUntilPredecessorThenAppliesBothInOrder()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+
+        await adaptor.OnProtocolMessageReceived(Notification(2, "remote", "remote-etag-2", "two"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "future state notification to drain");
+
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(host.ViewChanges);
+
+        await adaptor.OnProtocolMessageReceived(Notification(1, "remote", "remote-etag-1", "one"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "contiguous state notifications to drain");
+
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        Assert.Equal([(true, true)], host.ViewChanges);
+
+        Assert.True(await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("local")),
+            "post-notification state write to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "post-notification state worker to become idle");
+
+        Assert.Equal("remote-etag-2", storage.LastSuppliedETag);
+        Assert.Equal(",test-cluster", storage.LastSuppliedWriteVector);
+        Assert.Equal(["one", "two", "local"], storage.StateSnapshot.StateAndMetaData.State.Entries);
+        Assert.Equal(3, storage.StateSnapshot.StateAndMetaData.GlobalVersion);
+    }
+
+    [Fact]
+    public async Task OnNotificationReceived_WithStaleTypedNotification_DiscardsWithoutChangingState()
+    {
+        var (adaptor, host, _, _) = CreateAdaptor();
+        await adaptor.OnProtocolMessageReceived(Notification(2, "remote", "etag-2", "one", "two"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "initial state notification to drain");
+        var changeCount = host.ViewChanges.Count;
+
+        await adaptor.OnProtocolMessageReceived(Notification(1, "remote", "stale-etag", "stale"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "stale state notification to drain");
+
+        Assert.Equal(2, adaptor.ConfirmedVersion);
+        Assert.Equal(["one", "two"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(changeCount, host.ViewChanges.Count);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+    }
+
+    [Fact]
+    public async Task ReadAsync_OnFreshAdaptor_LoadsMaterializedSnapshotAndAllMetadata()
+    {
+        var (_, _, storage, _) = CreateAdaptor();
+        var (writer, _, _, _) = CreateAdaptor(storage);
+        Assert.True(await TestPhase.Await(
+            writer.TryAppendRange(Entries("one", "two")),
+            "materialized state write to commit"));
+        await TestPhase.Await(writer.PostOnDeactivate(), "materialized state writer to become idle");
+        var persisted = storage.StateSnapshot;
+
+        var (fresh, host, _, _) = CreateAdaptor(storage);
+        await Activate(fresh, "fresh state adaptor");
+
+        Assert.Equal(2, fresh.ConfirmedVersion);
+        Assert.Equal(["one", "two"], fresh.ConfirmedView.Entries);
+        Assert.Equal(",test-cluster", persisted.StateAndMetaData.WriteVector);
+        Assert.Equal("etag-1", persisted.ETag);
+        Assert.True(persisted.RecordExists);
+        Assert.Equal([(true, true)], host.ViewChanges);
+
+        fresh.ConfirmedView.Entries.Add("cache-only");
+        Assert.Equal(["one", "two"], storage.StateSnapshot.StateAndMetaData.State.Entries);
+
+        var (metadataReader, _, _, _) = CreateAdaptor(storage);
+        await Activate(metadataReader, "state metadata reader");
+        Assert.True(await TestPhase.Await(
+            metadataReader.TryAppend(new TestLogEntry("three")),
+            "state metadata continuation write to commit"));
+        await TestPhase.Await(metadataReader.PostOnDeactivate(), "state metadata writer to become idle");
+        Assert.Equal("etag-1", storage.LastSuppliedETag);
+        Assert.Equal("", storage.LastSuppliedWriteVector);
+        Assert.Equal(["one", "two", "three"], storage.StateSnapshot.StateAndMetaData.State.Entries);
+        Assert.Equal(3, storage.StateSnapshot.StateAndMetaData.GlobalVersion);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenPersistenceSucceedsThenThrowsAndWriteBitMatches_ClassifiesSuccessWithoutDuplicate()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+        storage.NextWriteBehavior = StorageWriteBehavior.PersistThenThrow;
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("once")),
+            "ambiguous state write to resolve");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "ambiguous state writer to become idle");
+
+        Assert.True(result);
+        Assert.Equal(1, storage.WriteCount);
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Equal(["once"], storage.StateSnapshot.StateAndMetaData.State.Entries);
+        Assert.Equal(["once"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        var issue = Assert.Single(host.ConnectionIssues);
+        Assert.IsType<StateStorageAdaptor.UpdateStateStorageFailed>(issue);
+        Assert.Equal("persisted write reported failure", ((StateStorageAdaptor.UpdateStateStorageFailed)issue).Exception.Message);
+        Assert.Same(issue, Assert.Single(host.ResolvedConnectionIssues));
+
+        Assert.True(await TestPhase.Await(
+            adaptor.TryAppend(new TestLogEntry("after-recovery")),
+            "state write after ambiguous recovery to commit"));
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "state writer after ambiguous recovery to become idle");
+        Assert.Equal(2, storage.WriteCount);
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Equal("etag-1", storage.LastSuppliedETag);
+        Assert.Equal(
+            ["once", "after-recovery"],
+            storage.StateSnapshot.StateAndMetaData.State.Entries);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WhenETagConflictBelongsToAnotherWriter_RereadsAndRejectsConditionalRange()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+        storage.ConflictNextStateWrite(["remote"], 1, ",remote", "remote-etag");
+
+        var result = await TestPhase.Await(
+            adaptor.TryAppendRange(Entries("conditional-one", "conditional-two")),
+            "conflicting conditional state range to resolve");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "conflicting state writer to become idle");
+
+        Assert.False(result);
+        Assert.Equal(1, storage.WriteCount);
+        Assert.Equal(1, storage.ReadCount);
+        Assert.Equal(1, adaptor.ConfirmedVersion);
+        Assert.Equal(["remote"], adaptor.ConfirmedView.Entries);
+        Assert.Equal(["remote"], adaptor.TentativeView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Equal(["remote"], storage.StateSnapshot.StateAndMetaData.State.Entries);
+        Assert.IsType<StateStorageAdaptor.UpdateStateStorageFailed>(Assert.Single(host.ConnectionIssues));
+        Assert.Single(host.ResolvedConnectionIssues);
+    }
+
+    [Fact]
+    public async Task ClearLogAsync_WithPendingEntries_ResetsOnceAndFreshAdaptorReadsVersionZero()
+    {
+        var (adaptor, host, storage, _) = CreateAdaptor();
+        var blockedWrite = storage.BlockNextWrite();
+        adaptor.Submit(new TestLogEntry("pending-at-clear"));
+        await TestPhase.Await(blockedWrite.Started, "state write before clear to start");
+        var changesBeforeClear = host.ViewChanges.Count;
+
+        var clear = adaptor.ClearLogAsync(CancellationToken.None);
+        Assert.False(clear.IsCompleted);
+        blockedWrite.Complete(true);
+        await TestPhase.Await(clear, "state clear to complete");
+        await TestPhase.Await(adaptor.PostOnDeactivate(), "state clear worker to become idle");
+
+        Assert.Equal(1, storage.WriteCount);
+        Assert.Equal(1, storage.ClearCount);
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Empty(adaptor.ConfirmedView.Entries);
+        Assert.Empty(adaptor.TentativeView.Entries);
+        Assert.Empty(adaptor.UnconfirmedSuffix);
+        Assert.Equal(
+            [(false, true), (false, true), (true, true)],
+            host.ViewChanges.Skip(changesBeforeClear));
+        Assert.Empty(storage.StateSnapshot.StateAndMetaData.State.Entries);
+        Assert.Equal(0, storage.StateSnapshot.StateAndMetaData.GlobalVersion);
+
+        var (fresh, _, _, _) = CreateAdaptor(storage);
+        await Activate(fresh, "fresh state adaptor after clear");
+        Assert.Equal(0, fresh.ConfirmedVersion);
+        Assert.Empty(fresh.ConfirmedView.Entries);
+
+        Assert.True(await TestPhase.Await(
+            fresh.TryAppend(new TestLogEntry("after-clear")),
+            "post-clear state write to commit"));
+        await TestPhase.Await(fresh.PostOnDeactivate(), "post-clear state writer to become idle");
+        Assert.Equal(["after-clear"], storage.StateSnapshot.StateAndMetaData.State.Entries);
+        Assert.Equal(1, fresh.ConfirmedVersion);
+    }
+
+    private static async Task Activate(StateStorageAdaptor adaptor, string phase)
+    {
+        await adaptor.PreOnActivate();
+        await adaptor.PostOnActivate();
+        await TestPhase.Await(adaptor.PostOnDeactivate(), $"{phase} activation read to finish");
+    }
+
+    private static (TestStateStorageAdaptor Adaptor, RecordingLogViewAdaptorHost Host, DeterministicEventSourcingStorage Storage, RecordingProtocolServices Services)
+        CreateAdaptor(DeterministicEventSourcingStorage? storage = null)
+    {
+        var host = new RecordingLogViewAdaptorHost();
+        var services = new RecordingProtocolServices();
+        storage ??= new DeterministicEventSourcingStorage();
+        return (new TestStateStorageAdaptor(host, new TestLogView(), storage, services), host, storage, services);
+    }
+
+    private static StateUpdateNotification Notification(
+        int version,
+        string origin,
+        string etag,
+        params string[] values) =>
+        new()
+        {
+            Version = version,
+            Origin = origin,
+            ETag = etag,
+            Updates = Entries(values).ToList(),
+        };
+
+    private static TestLogEntry[] Entries(params string[] values) =>
+        values.Select(value => new TestLogEntry(value)).ToArray();
+}
+
+internal sealed class TestStateStorageAdaptor(
+    RecordingLogViewAdaptorHost host,
+    TestLogView initialState,
+    IGrainStorage storage,
+    RecordingProtocolServices services)
+    : StateStorageAdaptor(host, initialState, storage, "test-state", services)
+{
+    public INotificationMessage MergeForTest(INotificationMessage earlier, INotificationMessage later) =>
+        Merge(earlier, later);
+}

--- a/test/Orleans.EventSourcing.Tests/Orleans.EventSourcing.Tests.csproj
+++ b/test/Orleans.EventSourcing.Tests/Orleans.EventSourcing.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(SourceRoot)src\Orleans.EventSourcing\Orleans.EventSourcing.csproj" />
     <ProjectReference Include="$(SourceRoot)test\Orleans.Runtime.Tests\Orleans.Runtime.Tests.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Problem

Event-sourcing synchronization, notification ordering, conflict recovery, and clear-log paths had limited direct coverage. The storage adaptors' merge methods were entirely uncovered, and ambiguous state-storage writes could replace an authoritative reread with stale cached metadata.

## Solution

- add deterministic, barrier-controlled tests for primary, log-storage, state-storage, and custom-storage adaptors
- verify persistence order, deep-copy isolation, notification sequencing, conflict rejection, ambiguous-write recovery, callback/storage failures, snapshots, and clear/recovery behavior
- make an empty atomic append complete immediately without scheduling storage work
- retain authoritative state and ETag metadata after an ambiguous state-storage write is confirmed by rereading

## Rationale

The focused suite raises `Orleans.EventSourcing` from 55.3% line / 48% branch coverage to 77.3% line / 78% branch coverage. Methods above CRAP 30 fall from 10 to 0, both storage `Merge` methods reach 100% line coverage, and custom-storage `WriteAsync` reaches 85.7% with CRAP 23.41.

Part of #10863.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11009)