### PR TITLE
fix(test): skip unconfigured ADO.NET fixtures

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/RelationalStorageForTesting.cs
@@ -101,6 +101,10 @@ namespace UnitTests.General
             Assert.SkipWhen(string.IsNullOrEmpty(connectionString), "Connection string not provided.");
         }
 
+        internal static bool IsConnectionStringConfigured(string invariantName)
+            => ConnectionStringsByInvariant.TryGetValue(invariantName, out var connectionString)
+                && !string.IsNullOrEmpty(connectionString);
+
         public static async Task<RelationalStorageForTesting> SetupInstance(
             string invariantName,
             string testDatabaseName,

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
@@ -27,6 +27,11 @@ namespace UnitTests.StorageTests.AdoNet
 
             public async ValueTask InitializeAsync()
             {
+                if (!RelationalStorageForTesting.IsConnectionStringConfigured(AdoNetInvariantName))
+                {
+                    return;
+                }
+
                 Storage = await RelationalStorageForTesting.SetupInstance(
                     AdoNetInvariantName,
                     TestDatabaseName,

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
@@ -24,6 +24,11 @@ namespace UnitTests.StorageTests.AdoNet
 
             public async ValueTask InitializeAsync()
             {
+                if (!RelationalStorageForTesting.IsConnectionStringConfigured(AdoNetInvariantName))
+                {
+                    return;
+                }
+
                 Storage = await RelationalStorageForTesting.SetupInstance(
                     AdoNetInvariantName,
                     TestDatabaseName,

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
@@ -21,26 +21,42 @@ namespace UnitTests.StorageTests.AdoNet
 
         public class Fixture : IAsyncLifetime
         {
+            private readonly Func<bool> _isConnectionStringConfigured;
             private readonly Func<Task<RelationalStorageForTesting>> _storageFactory;
 
             public Fixture() : this(
                 () => RelationalStorageForTesting.SetupInstance(
                     AdoNetInvariantName,
                     TestDatabaseName,
-                    cancellationToken: TestContext.Current.CancellationToken))
+                    cancellationToken: TestContext.Current.CancellationToken),
+                () => RelationalStorageForTesting.IsConnectionStringConfigured(AdoNetInvariantName))
             {
             }
 
             internal Fixture(Func<Task<RelationalStorageForTesting>> storageFactory)
+                : this(storageFactory, static () => true)
+            {
+            }
+
+            internal Fixture(
+                Func<Task<RelationalStorageForTesting>> storageFactory,
+                Func<bool> isConnectionStringConfigured)
             {
                 ArgumentNullException.ThrowIfNull(storageFactory);
+                ArgumentNullException.ThrowIfNull(isConnectionStringConfigured);
                 _storageFactory = storageFactory;
+                _isConnectionStringConfigured = isConnectionStringConfigured;
             }
 
             public RelationalStorageForTesting Storage { get; private set; } = null!;
 
             public async ValueTask InitializeAsync()
             {
+                if (!_isConnectionStringConfigured())
+                {
+                    return;
+                }
+
                 Storage = await _storageFactory();
             }
 
@@ -99,6 +115,23 @@ namespace UnitTests.StorageTests.AdoNet
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await fixture.InitializeAsync());
 
             Assert.Same(expectedException, exception);
+        }
+
+        [Fact]
+        public async Task ProviderConfigurationIsRequiredForInitialization()
+        {
+            var storageFactoryInvoked = false;
+            var fixture = new SqlServerRelationalStoreTests.Fixture(
+                () =>
+                {
+                    storageFactoryInvoked = true;
+                    throw new InvalidOperationException("Storage initialization should not run.");
+                },
+                static () => false);
+
+            await fixture.InitializeAsync();
+
+            Assert.False(storageFactoryInvoked);
         }
 
         [Fact]


### PR DESCRIPTION
## Problem

The SQL Server, PostgreSQL, and MySQL relational-store class fixtures raised provider prerequisite skips from `IAsyncLifetime.InitializeAsync`. xUnit reports fixture initialization exceptions as setup failures, so running the ADO.NET test project without connection strings failed nine tests instead of skipping them.

## Solution

Gate relational-store fixture setup on provider configuration and retain the existing test-constructor prerequisite check as the dynamic-skip boundary. Genuine database initialization failures continue to propagate. A database-independent regression test covers the fixture gate.

## Rationale

Test construction is the supported lifecycle boundary for dynamic skips, while fixture initialization failures represent actual setup errors. This preserves both outcomes without interpreting exception messages or swallowing initialization failures.

Fixes #10990
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11015)