### PR TITLE
fix(testing): isolate reminder topology timeout

### DIFF
--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -379,16 +379,16 @@ public sealed class ReminderTestKitClusterIntegrationTests
             refreshReminderListPeriod: TimeSpan.FromSeconds(1));
         var cluster = builder.Build();
         using var observer = ReminderDiagnosticObserver.Create(cluster);
-        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
-        cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellation.Token);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = TimeSpan.FromMinutes(10);
             var firstTickTime = clock.UtcNow.UtcDateTime + dueTime;
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
             await using var firstRefreshA = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
             await using var firstRefreshB = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
@@ -497,11 +497,22 @@ public sealed class ReminderTestKitClusterIntegrationTests
         CancellationToken cancellationToken)
     {
         await cluster.DeployAsync(cancellationToken);
-        await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
-            cluster,
-            observer,
-            cluster.Silos,
-            cancellationToken);
+        using var topologyCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        topologyCancellation.CancelAfter(TimeSpan.FromSeconds(30));
+        try
+        {
+            await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+                cluster,
+                observer,
+                cluster.Silos,
+                topologyCancellation.Token);
+        }
+        catch (OperationCanceledException exception) when (
+            topologyCancellation.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(exception.Message, exception);
+        }
     }
 
     private static async Task AdvanceUntilAsync(


### PR DESCRIPTION
## Problem

#10974 started the two-silo reminder scenario's 30-second deadline before cluster deployment. On slower CI agents, deployment and topology stabilization consumed that budget, canceling the stable refresh while the second silo's queued reconciliation was still pending.

## Solution

- let cluster deployment use the test-framework cancellation token
- start a dedicated 30-second topology deadline after deployment
- start the scenario's 30-second deadline after topology stabilization
- preserve `TimeoutException` for a topology deadline while propagating test-framework cancellation

## Rationale

Deployment, topology convergence, and the reminder ownership scenario are separate lifecycle boundaries. Independent deadlines let each boundary complete according to its invariant and keep timeout diagnostics tied to the phase which exceeded its budget.

Fixes #11012
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11017)