### PR TITLE
fix(testing): separate reminder refresh barriers

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -367,8 +367,28 @@ namespace Orleans.Runtime.ReminderService
             return task;
         }
 
-        internal Task TestOnlyRefresh()
-            => this.QueueTask(() => TrackReconciliation(ReadAndUpdateReminders));
+        internal Task TestOnlyStartRefresh() => QueueRefresh();
+
+        internal Task TestOnlyRefresh() => QueueRefresh().Unwrap();
+
+        private Task<Task> QueueRefresh()
+        {
+            var refreshStarted = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _ = this.QueueAction(
+                static state =>
+                {
+                    try
+                    {
+                        state.RefreshStarted.SetResult(state.Service.TrackReconciliation(state.Service.ReadAndUpdateReminders));
+                    }
+                    catch (Exception exception)
+                    {
+                        state.RefreshStarted.SetException(exception);
+                    }
+                },
+                (Service: this, RefreshStarted: refreshStarted));
+            return refreshStarted.Task;
+        }
 
         internal Task TestOnlyWaitForSiloStatusListeners(CancellationToken cancellationToken)
             => _siloStatusListenerManager.TestOnlyWaitForCurrentMembershipVersion(cancellationToken);

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -393,6 +393,55 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task RefreshStartBarrier_CompletesBeforeReconciliation()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var readGate = reminderTable.BlockNextRangeRead(cancellation.Token);
+        var schedulerBlocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseScheduler = new ManualResetEventSlim();
+        var blockingTask = new Task(() =>
+        {
+            schedulerBlocked.TrySetResult();
+            releaseScheduler.Wait(cancellation.Token);
+        });
+        reminderService.Scheduler.QueueTask(blockingTask);
+        await schedulerBlocked.Task.WaitAsync(cancellation.Token);
+        try
+        {
+            var refreshStarted = reminderService.TestOnlyStartRefresh();
+            Assert.False(refreshStarted.IsCompleted);
+
+            releaseScheduler.Set();
+            await blockingTask.WaitAsync(cancellation.Token);
+            await readGate.WaitUntilBlockedAsync(cancellation.Token);
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+
+            await refreshStarted.WaitAsync(cancellation.Token);
+            Assert.False(reconciliationTask.IsCompleted);
+
+            readGate.Release();
+            await reconciliationTask.WaitAsync(cancellation.Token);
+        }
+        finally
+        {
+            releaseScheduler.Set();
+            readGate.Release();
+            await blockingTask.WaitAsync(cancellation.Token);
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task RangeChangeBarrier_PropagatesCurrentProviderReadFailure()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);

--- a/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
@@ -80,9 +80,9 @@ public static class ReminderTopologyStabilizer
                 await Task.WhenAll(reminderServices.Select(service =>
                     service.TestOnlyWaitForSiloStatusListeners(cancellationToken)));
 
-                phase = "stable topology refresh";
-                var refreshes = reminderServices.Select(service => service.TestOnlyRefresh()).ToArray();
-                await Task.WhenAll(refreshes).WaitAsync(cancellationToken);
+                phase = "stable topology refresh start";
+                var refreshesStarted = reminderServices.Select(service => service.TestOnlyStartRefresh()).ToArray();
+                await Task.WhenAll(refreshesStarted).WaitAsync(cancellationToken);
 
                 phase = "latest reminder reconciliation";
                 var reconciliations = reminderServices.Select(service =>


### PR DESCRIPTION
## Problem

The reminder topology stabilizer awaited each explicit refresh through an async scheduler work item. Under rare scheduler timing, the tracked reconciliation could already be complete while the refresh wrapper still needed another service-scheduler continuation, leaving startup readiness blocked until the scenario deadline.

## Solution

- Separate the FIFO refresh-start boundary from reconciliation completion.
- Complete refresh admission from a context-clearing synchronous scheduler action with asynchronous external continuations.
- Await the existing scheduler-independent latest-reconciliation barrier after every refresh has started.
- Add coverage proving the start barrier waits for its scheduler turn and completes while reconciliation remains deliberately blocked.

## Rationale

Once the refresh turn starts, all earlier range-change turns have entered the service scheduler in FIFO order and the tracked reconciliation generation represents the latest refresh. Completion is therefore owned by the reconciliation barrier instead of by a second scheduler continuation on the refresh wrapper.

Fixes #10979
Related: #10967