### PR TITLE
docs(streaming): document subscription start positions

### DIFF
--- a/docs/Docs.slnx
+++ b/docs/Docs.slnx
@@ -118,6 +118,9 @@
     <Project Path="site/src/content/docs/streaming/snippets/broadcastchannel/BroadcastChannel.GrainInterfaces/BroadcastChannel.GrainInterfaces.csproj" />
     <Project Path="site/src/content/docs/streaming/snippets/broadcastchannel/BroadcastChannel.Silo/BroadcastChannel.Silo.csproj" />
   </Folder>
+  <Folder Name="/site/src/content/docs/streaming/snippets/subscription-start-positions/">
+    <Project Path="site/src/content/docs/streaming/snippets/subscription-start-positions/subscription-start-positions.csproj" />
+  </Folder>
   <Folder Name="/site/src/content/docs/tutorials-and-samples/" />
   <Folder Name="/site/src/content/docs/tutorials-and-samples/snippets/" />
   <Folder Name="/site/src/content/docs/tutorials-and-samples/snippets/custom-grain-storage/">

--- a/docs/site/src/content/docs/streaming/delivery-semantics.md
+++ b/docs/site/src/content/docs/streaming/delivery-semantics.md
@@ -53,7 +53,7 @@ A rewindable provider can start or resume a subscription from a provider sequenc
 
 Explicit subscriptions can resume from retained positions according to the provider's token semantics. An implicit subscription accepts a recovery token when an activation attaches its observer, then advances monotonically for that attachment. Once a delivery call completes successfully, resuming the active implicit handle with a sequence token throws <xref:System.InvalidOperationException>; passing `null` replaces the observer at its current position.
 
-See the [provider matrix](stream-providers.md#provider-matrix) for provider capabilities.
+New explicit subscriptions to rewindable persistent streams can also select [a cache-relative start position](subscription-start-positions.md). See the [provider matrix](stream-providers.md#provider-matrix) for provider capabilities.
 
 ## Recovery checklist
 

--- a/docs/site/src/content/docs/streaming/index.md
+++ b/docs/site/src/content/docs/streaming/index.md
@@ -33,6 +33,7 @@ Use streams when events should fan out to independently managed consumers, when 
 
 1. Follow the [streaming quickstart](streams-quick-start.md) with the in-memory provider.
 1. Learn stream [identity, production, consumption, and subscription APIs](streams-programming-apis.md).
+1. Choose how new persistent-stream subscriptions [begin with live or locally cached messages](subscription-start-positions.md).
 1. Choose a [provider](stream-providers.md) for the required durability and replay behavior.
 1. Plan for [delivery, ordering, replay, and recovery](delivery-semantics.md).
 1. Configure [PubSub storage](pubsub-storage.md) and [operations](streaming-operations.md) for production.

--- a/docs/site/src/content/docs/streaming/snippets/subscription-start-positions/SubscriptionStartPositions.cs
+++ b/docs/site/src/content/docs/streaming/snippets/subscription-start-positions/SubscriptionStartPositions.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Streams;
+
+namespace Orleans.Docs.Snippets.Streaming;
+
+public static class SubscriptionStartPositions
+{
+    // <subscribe_earliest_available>
+    public static Task<StreamSubscriptionHandle<T>> SubscribeFromCacheStart<T>(
+        IAsyncStream<T> stream,
+        IAsyncObserver<T> observer) =>
+        stream.SubscribeAsync(
+            observer,
+            StreamSubscriptionStartPosition.EarliestAvailable);
+    // </subscribe_earliest_available>
+
+    // <subscribe_batch_earliest_available>
+    public static Task<StreamSubscriptionHandle<T>> SubscribeBatchFromCacheStart<T>(
+        IAsyncBatchObservable<T> stream,
+        IAsyncBatchObserver<T> observer) =>
+        stream.SubscribeAsync(
+            observer,
+            StreamSubscriptionStartPosition.EarliestAvailable);
+    // </subscribe_batch_earliest_available>
+
+    // <configure_default_start_position>
+    public static void ConfigureDefaultStartPosition(
+        ISiloPersistentStreamConfigurator streams)
+    {
+        streams.ConfigurePullingAgent(optionsBuilder =>
+            optionsBuilder.Configure(options =>
+                options.InitialSubscriptionStartPosition =
+                    StreamSubscriptionStartPosition.EarliestAvailable));
+    }
+    // </configure_default_start_position>
+}
+

--- a/docs/site/src/content/docs/streaming/snippets/subscription-start-positions/subscription-start-positions.csproj
+++ b/docs/site/src/content/docs/streaming/snippets/subscription-start-positions/subscription-start-positions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RepositoryRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\..\..\..\..\'))</RepositoryRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepositoryRoot)src\Orleans.Streaming\Orleans.Streaming.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/docs/site/src/content/docs/streaming/stream-providers.md
+++ b/docs/site/src/content/docs/streaming/stream-providers.md
@@ -54,6 +54,8 @@ The examples use durable Azure Table Storage for `PubSubStore`; queue durability
 
 Register [Azure Event Hubs](https://learn.microsoft.com/azure/event-hubs/event-hubs-about) with <xref:Orleans.Hosting.SiloBuilderExtensions.AddEventHubStreams*>. Event Hubs retention and partition positions make this provider rewindable. Configure a consumer group dedicated to the Orleans application and durable checkpoint storage. Partition count bounds physical read parallelism, and retention bounds how far recovery can rewind.
 
+New subscriptions can [begin with messages retained in the pulling agent's local cache](subscription-start-positions.md). This cache-local replay keeps the Event Hubs partition receiver and checkpoint at their current positions.
+
 The Event Hubs provider supports a custom data adapter for provider-specific wire formats. See [Integrate external stream producers and consumers](external-streams.md) when a non-Orleans application must publish to or consume from the same Event Hub.
 
 ## Amazon Kinesis

--- a/docs/site/src/content/docs/streaming/streams-programming-apis.md
+++ b/docs/site/src/content/docs/streaming/streams-programming-apis.md
@@ -80,6 +80,8 @@ The subscription belongs to the grain identity, not one activation. After deacti
 
 This lifecycle is durable across cluster restarts only when the configured [`PubSubStore` is durable](pubsub-storage.md). A memory `PubSubStore` preserves records only while that cluster state remains available.
 
+For a rewindable persistent provider, [choose a subscription start position](subscription-start-positions.md) to begin with new messages or replay matching messages retained in the pulling agent's local queue cache.
+
 #### End an explicit subscription
 
 End a subscription by awaiting <xref:Orleans.Streams.StreamSubscriptionHandle`1.UnsubscribeAsync*> for every handle. The streaming runtime removes each subscription from pub/sub storage and notifies active producers before the operation completes. The example's `UnsubscribeAsync` method follows this sequence.

--- a/docs/site/src/content/docs/streaming/subscription-start-positions.md
+++ b/docs/site/src/content/docs/streaming/subscription-start-positions.md
@@ -63,8 +63,4 @@ The default queue-cache interface behavior maps `Latest` to the existing tokenle
 
 A custom <xref:Orleans.Streams.IAsyncObservable`1> implementation receives equivalent extension-overload compatibility: `Latest` uses its tokenless subscription path, and `EarliestAvailable` reports <xref:System.NotSupportedException> until the observable implements Orleans start-position subscriptions.
 
-## Roll out start-position subscriptions
-
-During a rolling upgrade, first deploy the supporting Orleans version to every silo eligible to host persistent-stream pulling agents. Keep tokenless subscriptions at `Latest` until those silos are upgraded. Then deploy consumers which create subscriptions with explicit start positions and change `InitialSubscriptionStartPosition` as required. This sequence ensures that every pulling agent which receives the subscription understands and applies its requested position.
-
 For delivery guarantees and sequence-token recovery, continue to [Stream delivery, ordering, replay, and recovery](delivery-semantics.md).

--- a/docs/site/src/content/docs/streaming/subscription-start-positions.md
+++ b/docs/site/src/content/docs/streaming/subscription-start-positions.md
@@ -1,0 +1,70 @@
+---
+title: Choose a persistent-stream subscription start position
+description: Start an Orleans persistent-stream subscription with new messages or replay messages retained in the local queue cache.
+ms.date: 09/03/2026
+ms.topic: how-to
+---
+
+# Choose a persistent-stream subscription start position
+
+A rewindable persistent-stream subscription can start with newly published messages or replay messages already retained by its pulling agent. Choose the start position when application behavior creates the subscription, or configure a provider-wide default for subscriptions which omit a position. After delivery begins, sequence-token progress defines the subscription's position.
+
+For the broader subscription model, see [Orleans streaming APIs](streams-programming-apis.md). Provider durability and rewindability are described in [Orleans stream providers](stream-providers.md).
+
+## Choose a position for one subscription
+
+Pass a <xref:Orleans.Streams.StreamSubscriptionStartPosition> to <xref:Orleans.Streams.AsyncObservableExtensions.SubscribeAsync*>:
+
+:::code language="csharp" source="snippets/subscription-start-positions/SubscriptionStartPositions.cs" id="subscribe_earliest_available":::
+
+The batch-observer overload accepts the same position:
+
+:::code language="csharp" source="snippets/subscription-start-positions/SubscriptionStartPositions.cs" id="subscribe_batch_earliest_available":::
+
+The values have these semantics:
+
+| Position | Initial delivery |
+|---|---|
+| <xref:Orleans.Streams.StreamSubscriptionStartPosition.Latest> | Messages published after the subscription is established. Messages already retained in the queue cache are skipped. This value preserves the default behavior of a tokenless `SubscribeAsync` call. |
+| <xref:Orleans.Streams.StreamSubscriptionStartPosition.EarliestAvailable> | The earliest matching message currently retained in the pulling agent's local queue cache, included in delivery. When the cache has no matching message, delivery begins with the stream's first future message. |
+
+The position applies when the subscription is created. Resume an existing subscription handle to continue from its established progress; resume APIs use sequence tokens rather than a new start position.
+
+## Configure the provider default
+
+Configure <xref:Orleans.Configuration.StreamPullingAgentOptions.InitialSubscriptionStartPosition> on the silo-side persistent-stream provider:
+
+:::code language="csharp" source="snippets/subscription-start-positions/SubscriptionStartPositions.cs" id="configure_default_start_position":::
+
+This setting controls initial subscriptions which omit both a concrete sequence token and an explicit start position. It applies to tokenless explicit subscriptions and initial implicit-subscription attachments which have no delivery progress. <xref:Orleans.Streams.StreamSubscriptionStartPosition.Latest> is the default.
+
+Orleans chooses an initial position in this order:
+
+1. A concrete <xref:Orleans.Streams.StreamSequenceToken> supplied by the caller.
+1. An explicit <xref:Orleans.Streams.StreamSubscriptionStartPosition> supplied to `SubscribeAsync`.
+1. <xref:Orleans.Configuration.StreamPullingAgentOptions.InitialSubscriptionStartPosition>.
+1. <xref:Orleans.Streams.StreamSubscriptionStartPosition.Latest>.
+
+An explicit choice therefore overrides the provider default in either direction. Explicit `Latest` skips retained messages when the provider default is `EarliestAvailable`, and explicit `EarliestAvailable` replays the local cache when the provider default is `Latest`. Configure the option consistently on every silo eligible to host a pulling agent for the named provider.
+
+## Understand the available replay window
+
+`EarliestAvailable` searches one pulling agent's local queue cache for the target <xref:Orleans.Runtime.StreamId>. The cache's current contents define the available replay window. Cache eviction, memory pressure, queue assignment, silo restarts, and the time since the pulling agent began reading can all move its earliest available position forward.
+
+For Azure Event Hubs, `EarliestAvailable` keeps the partition receiver and its checkpoint at their current positions. It replays matching messages which the Orleans Event Hubs pulling agent has already read and still retains in its silo-side cache. The local cache window is therefore the replay window for this API, while Event Hubs retention remains the upstream recovery window.
+
+<xref:Orleans.Configuration.StreamCacheEvictionOptions.DataMinTimeInCache> and <xref:Orleans.Configuration.StreamCacheEvictionOptions.DataMaxAgeInCache> control time-based eviction, while cache pressure can advance the earliest retained position. Size Event Hubs retention for upstream recovery and size the Orleans cache for the replay interval required by new subscriptions. See [Protect a slow Event Hubs consumer](streaming-operations.md#protect-a-slow-event-hubs-consumer) for cache eviction and pressure behavior.
+
+## Handle queue cache support
+
+The built-in pooled, simple, memory, generator, and Event Hubs queue caches support `EarliestAvailable`. A custom persistent-stream cache participates by implementing <xref:Orleans.Streams.IQueueCache.GetCacheCursorAtPosition*>.
+
+The default queue-cache interface behavior maps `Latest` to the existing tokenless cursor path and reports <xref:System.NotSupportedException> for `EarliestAvailable`. An explicit subscription which requests the unsupported position receives the error and is faulted. When `EarliestAvailable` is the provider default for an implicit subscription, Orleans reports the error to the consumer and keeps the implicit subscription live at its current position.
+
+A custom <xref:Orleans.Streams.IAsyncObservable`1> implementation receives equivalent extension-overload compatibility: `Latest` uses its tokenless subscription path, and `EarliestAvailable` reports <xref:System.NotSupportedException> until the observable implements Orleans start-position subscriptions.
+
+## Roll out start-position subscriptions
+
+During a rolling upgrade, first deploy the supporting Orleans version to every silo eligible to host persistent-stream pulling agents. Keep tokenless subscriptions at `Latest` until those silos are upgraded. Then deploy consumers which create subscriptions with explicit start positions and change `InitialSubscriptionStartPosition` as required. This sequence ensures that every pulling agent which receives the subscription understands and applies its requested position.
+
+For delivery guarantees and sequence-token recovery, continue to [Stream delivery, ordering, replay, and recovery](delivery-semantics.md).

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -138,6 +138,8 @@ items:
         href: streaming/streams-why.md
       - name: Programming APIs
         href: streaming/streams-programming-apis.md
+      - name: Subscription start positions
+        href: streaming/subscription-start-positions.md
       - name: Stream providers
         href: streaming/stream-providers.md
       - name: External producers and consumers


### PR DESCRIPTION
## Problem

Persistent-stream users need clear guidance for choosing between live delivery and replay from the pulling agent's retained queue cache, especially for Event Hubs.

## Solution

Document per-subscription and provider-default start positions, precedence, cache-local replay semantics, and unsupported-cache behavior. Add source-backed compiled examples for item, batch, and provider configuration APIs and cross-link the streaming conceptual pages.

## Rationale

The guidance makes the runtime boundary explicit: `EarliestAvailable` replays the pulling agent's current local cache and leaves upstream receiver checkpoints unchanged.

Closes #11005
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11025)