### PR TITLE
test: stabilize Cosmos reminder manifest convergence

### DIFF
--- a/src/Orleans.TestingHost/ClusterManifestStabilizationHelper.cs
+++ b/src/Orleans.TestingHost/ClusterManifestStabilizationHelper.cs
@@ -17,6 +17,20 @@ internal static class ClusterManifestStabilizationHelper
         ArgumentNullException.ThrowIfNull(activeSilos);
         ArgumentNullException.ThrowIfNull(testHooks);
 
+        return await WaitForExpectedClusterManifestAsync(
+            activeSilos,
+            testHooks.Select(static hooks => new Func<SiloAddress[], TimeSpan, Task<bool>>(hooks.WaitForClusterManifest)).ToArray(),
+            timeout);
+    }
+
+    internal static async Task<bool> WaitForExpectedClusterManifestAsync(
+        IReadOnlyCollection<SiloHandle> activeSilos,
+        IReadOnlyCollection<Func<SiloAddress[], TimeSpan, Task<bool>>> waitForClusterManifest,
+        TimeSpan timeout)
+    {
+        ArgumentNullException.ThrowIfNull(activeSilos);
+        ArgumentNullException.ThrowIfNull(waitForClusterManifest);
+
         if (activeSilos.Count == 0)
         {
             await Task.Delay(timeout);
@@ -26,8 +40,8 @@ internal static class ClusterManifestStabilizationHelper
         var expectedSilos = activeSilos.Select(static silo => silo.SiloAddress).ToArray();
         try
         {
-            var waitTasks = testHooks.Select(hooks => hooks.WaitForClusterManifest(expectedSilos, timeout));
-            var results = await Task.WhenAll(waitTasks).WaitAsync(timeout);
+            var waitTasks = waitForClusterManifest.Select(wait => wait(expectedSilos, timeout));
+            var results = await Task.WhenAll(waitTasks);
             return results.All(static result => result);
         }
         catch (TimeoutException)

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/ClusterManifestStabilizationHelperTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/ClusterManifestStabilizationHelperTests.cs
@@ -37,6 +37,28 @@ public sealed class ClusterManifestStabilizationHelperTests
         Assert.Equal("testHooks", exception.ParamName);
     }
 
+    [Fact]
+    public async Task WaitForExpectedClusterManifestAsync_WaitsForHookFinalResult()
+    {
+        using var silo = CreateSilo(port: 11111, generation: 7);
+        TimeSpan? observedTimeout = null;
+
+        var result = await ClusterManifestStabilizationHelper.WaitForExpectedClusterManifestAsync(
+            activeSilos: [silo],
+            waitForClusterManifest: [WaitForClusterManifest],
+            timeout: TimeSpan.Zero);
+
+        Assert.True(result);
+        Assert.Equal(TimeSpan.Zero, observedTimeout);
+
+        async Task<bool> WaitForClusterManifest(SiloAddress[] expectedSilos, TimeSpan timeout)
+        {
+            observedTimeout = timeout;
+            await Task.Yield();
+            return expectedSilos.SequenceEqual([silo.SiloAddress]);
+        }
+    }
+
     private static TestSiloHandle CreateSilo(int port, int generation) =>
         new()
         {


### PR DESCRIPTION
## Problem

Cluster manifest stabilization applied the same timeout twice: once inside each silo test hook and again around their aggregate task. The outer deadline could win at the five-second boundary before a hook completed its final manifest snapshot check, which surfaced as the Cosmos reminder fixture flake after the rest of the topology had converged.

## Solution

Let each silo hook own its bounded manifest wait and final state check, then aggregate the completed results without a competing deadline. Add focused regression coverage for a final check which completes asynchronously at the timeout boundary.

## Rationale

The manifest provider retries failed fetches on a five-second cadence, matching the test stabilization budget. Preserving the hook result allows convergence observed at that boundary to satisfy the barrier without extending the timeout or weakening the topology invariant.

Fixes #10983
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11029)