### PR TITLE
fix(cosmos): retry transient reminder reads

### DIFF
--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReadRetryPolicy.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReadRetryPolicy.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.Azure.Cosmos;
 
 namespace Orleans.Reminders.Cosmos;
 

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReadRetryPolicy.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReadRetryPolicy.cs
@@ -1,34 +1,80 @@
 using System.Net;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Polly.Retry;
 
 namespace Orleans.Reminders.Cosmos;
 
-internal static class CosmosReadRetryPolicy
+internal static partial class CosmosReadRetryPolicy
 {
-    internal const int MaxRetries = 2;
+    internal const string PipelineKey = "Orleans.Reminders.Cosmos.Read";
+    internal const int MaxRetryAttempts = 2;
     private static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromMilliseconds(100);
 
-    public static async Task<TResult> ExecuteAsync<TResult>(
-        Func<Task<TResult>> operation,
-        Action<CosmosException, int, TimeSpan> onRetry,
-        Func<TimeSpan, Task> delayAsync)
+    internal static IServiceCollection AddCosmosReadRetryPolicy(this IServiceCollection services)
     {
-        var retry = 0;
-        while (true)
+        services.AddResiliencePipeline(PipelineKey, static (builder, context) =>
         {
-            try
-            {
-                return await operation().ConfigureAwait(false);
-            }
-            catch (CosmosException exception) when (
-                exception.StatusCode == HttpStatusCode.RequestTimeout
-                && retry < MaxRetries)
-            {
-                retry++;
-                var delay = DefaultRetryDelay * retry;
-                onRetry(exception, retry, delay);
-                await delayAsync(delay).ConfigureAwait(false);
-            }
-        }
+            builder.TimeProvider = context.ServiceProvider.GetRequiredService<TimeProvider>();
+            Configure(
+                builder,
+                context.ServiceProvider.GetRequiredService<ILogger<CosmosReminderTable>>(),
+                DefaultRetryDelay);
+        });
+
+        return services;
     }
+
+    internal static void Configure(
+        ResiliencePipelineBuilder builder,
+        ILogger<CosmosReminderTable> logger,
+        TimeSpan retryDelay) =>
+        builder.AddRetry(new RetryStrategyOptions
+        {
+            MaxRetryAttempts = MaxRetryAttempts,
+            BackoffType = DelayBackoffType.Linear,
+            Delay = retryDelay,
+            ShouldHandle = new PredicateBuilder().Handle<CosmosException>(
+                static exception => exception.StatusCode == HttpStatusCode.RequestTimeout),
+            OnRetry = args =>
+            {
+                var exception = (CosmosException)args.Outcome.Exception!;
+                LogWarningReadTimedOut(
+                    logger,
+                    exception,
+                    args.AttemptNumber + 1,
+                    MaxRetryAttempts,
+                    args.RetryDelay.TotalMilliseconds,
+                    exception.ActivityId);
+                return default;
+            }
+        });
+
+    internal static ResiliencePipeline CreatePipeline(
+        ILogger<CosmosReminderTable> logger,
+        TimeProvider timeProvider) =>
+        CreatePipeline(logger, timeProvider, DefaultRetryDelay);
+
+    internal static ResiliencePipeline CreatePipeline(
+        ILogger<CosmosReminderTable> logger,
+        TimeProvider timeProvider,
+        TimeSpan retryDelay)
+    {
+        var builder = new ResiliencePipelineBuilder { TimeProvider = timeProvider };
+        Configure(builder, logger, retryDelay);
+        return builder.Build();
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Cosmos DB reminder read timed out. Retrying in {DelayMilliseconds}ms ({Retry}/{MaxRetries}). ActivityId: {ActivityId}"
+    )]
+    private static partial void LogWarningReadTimedOut(
+        ILogger logger,
+        Exception exception,
+        int retry,
+        int maxRetries,
+        double delayMilliseconds,
+        string activityId);
 }

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReadRetryPolicy.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReadRetryPolicy.cs
@@ -1,0 +1,33 @@
+using System.Net;
+
+namespace Orleans.Reminders.Cosmos;
+
+internal static class CosmosReadRetryPolicy
+{
+    internal const int MaxRetries = 2;
+    private static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromMilliseconds(100);
+
+    public static async Task<TResult> ExecuteAsync<TResult>(
+        Func<Task<TResult>> operation,
+        Action<CosmosException, int, TimeSpan> onRetry,
+        Func<TimeSpan, Task> delayAsync)
+    {
+        var retry = 0;
+        while (true)
+        {
+            try
+            {
+                return await operation().ConfigureAwait(false);
+            }
+            catch (CosmosException exception) when (
+                exception.StatusCode == HttpStatusCode.RequestTimeout
+                && retry < MaxRetries)
+            {
+                retry++;
+                var delay = DefaultRetryDelay * retry;
+                onRetry(exception, retry, delay);
+                await delayAsync(delay).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -343,7 +343,7 @@ internal partial class CosmosReminderTable : IReminderTable
 
     private Task<TResult> ExecuteReadOperation<TResult>(Func<Task<TResult>> operation) =>
         _readResiliencePipeline.ExecuteAsync(
-            static async (operation, _) => await operation().ConfigureAwait(false),
+            static (operation, _) => new ValueTask<TResult>(operation()),
             operation,
             CancellationToken.None).AsTask();
 

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Diagnostics;
 using Orleans.Reminders.Cosmos.Models;
+using Polly;
+using Polly.Registry;
 
 namespace Orleans.Reminders.Cosmos;
 
@@ -15,6 +17,7 @@ internal partial class CosmosReminderTable : IReminderTable
     private readonly IServiceProvider _serviceProvider;
     private readonly Func<ReminderEntity, ReminderEntry> _convertEntityToEntry;
     private readonly ICosmosOperationExecutor _executor;
+    private readonly ResiliencePipeline _readResiliencePipeline;
     private CosmosClient _client = default!;
     private Container _container = default!;
 
@@ -22,7 +25,23 @@ internal partial class CosmosReminderTable : IReminderTable
         ILoggerFactory loggerFactory,
         IServiceProvider serviceProvider,
         IOptions<CosmosReminderTableOptions> options,
-        IOptions<ClusterOptions> clusterOptions)
+        IOptions<ClusterOptions> clusterOptions,
+        ResiliencePipelineProvider<string> resiliencePipelineProvider)
+        : this(
+            loggerFactory,
+            serviceProvider,
+            options,
+            clusterOptions,
+            resiliencePipelineProvider.GetPipeline(CosmosReadRetryPolicy.PipelineKey))
+    {
+    }
+
+    internal CosmosReminderTable(
+        ILoggerFactory loggerFactory,
+        IServiceProvider serviceProvider,
+        IOptions<CosmosReminderTableOptions> options,
+        IOptions<ClusterOptions> clusterOptions,
+        ResiliencePipeline readResiliencePipeline)
     {
         _logger = loggerFactory.CreateLogger<CosmosReminderTable>();
         _serviceProvider = serviceProvider;
@@ -30,6 +49,7 @@ internal partial class CosmosReminderTable : IReminderTable
         _clusterOptions = clusterOptions.Value;
         _convertEntityToEntry = FromEntity;
         _executor = options.Value.OperationExecutor;
+        _readResiliencePipeline = readResiliencePipeline;
     }
 
     public async Task Init()
@@ -322,15 +342,10 @@ internal partial class CosmosReminderTable : IReminderTable
     }
 
     private Task<TResult> ExecuteReadOperation<TResult>(Func<Task<TResult>> operation) =>
-        CosmosReadRetryPolicy.ExecuteAsync(operation, LogReadRetry, static delay => Task.Delay(delay));
-
-    private void LogReadRetry(CosmosException exception, int retry, TimeSpan delay) =>
-        LogWarningReadTimedOut(
-            exception,
-            retry,
-            CosmosReadRetryPolicy.MaxRetries,
-            delay.TotalMilliseconds,
-            exception.ActivityId);
+        _readResiliencePipeline.ExecuteAsync(
+            static async (operation, _) => await operation().ConfigureAwait(false),
+            operation,
+            CancellationToken.None).AsTask();
 
     private ReminderEntry FromEntity(ReminderEntity entity)
     {
@@ -430,15 +445,4 @@ internal partial class CosmosReminderTable : IReminderTable
         Message = "Error deleting Azure Cosmos DB database"
     )]
     private partial void LogErrorDeletingAzureCosmosDBDatabase(Exception ex);
-
-    [LoggerMessage(
-        Level = LogLevel.Warning,
-        Message = "Cosmos DB reminder read timed out. Retrying in {DelayMilliseconds}ms ({Retry}/{MaxRetries}). ActivityId: {ActivityId}"
-    )]
-    private partial void LogWarningReadTimedOut(
-        Exception ex,
-        int retry,
-        int maxRetries,
-        double delayMilliseconds,
-        string activityId);
 }

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -73,13 +73,14 @@ internal partial class CosmosReminderTable : IReminderTable
         {
             var pk = new PartitionKey(ReminderEntity.ConstructPartitionKey(_clusterOptions.ServiceId, grainId));
             var requestOptions = new QueryRequestOptions { PartitionKey = pk };
-            var response = await _executor.ExecuteOperation(static args =>
-            {
-                var (self, grainId, requestOptions) = args;
-                var iterator = self._container.GetItemLinqQueryable<ReminderEntity>(requestOptions: requestOptions).ToFeedIterator();
-                return iterator.ToListAsync();
-            },
-            (this, grainId, requestOptions)).ConfigureAwait(false);
+            var response = await ExecuteReadOperation(() =>
+                _executor.ExecuteOperation(static args =>
+                {
+                    var (self, grainId, requestOptions) = args;
+                    var iterator = self._container.GetItemLinqQueryable<ReminderEntity>(requestOptions: requestOptions).ToFeedIterator();
+                    return iterator.ToListAsync();
+                },
+                (this, grainId, requestOptions))).ConfigureAwait(false);
 
             return new ReminderTableData(response.Select(_convertEntityToEntry));
         }
@@ -95,19 +96,20 @@ internal partial class CosmosReminderTable : IReminderTable
     {
         try
         {
-            var response = await _executor.ExecuteOperation(static args =>
-            {
-                var (self, begin, end) = args;
-                var query = self._container.GetItemLinqQueryable<ReminderEntity>()
-                    .Where(entity => entity.ServiceId == self._clusterOptions.ServiceId);
+            var response = await ExecuteReadOperation(() =>
+                _executor.ExecuteOperation(static args =>
+                {
+                    var (self, begin, end) = args;
+                    var query = self._container.GetItemLinqQueryable<ReminderEntity>()
+                        .Where(entity => entity.ServiceId == self._clusterOptions.ServiceId);
 
-                query = begin < end
-                    ? query.Where(r => r.GrainHash > begin && r.GrainHash <= end)
-                    : query.Where(r => r.GrainHash > begin || r.GrainHash <= end);
+                    query = begin < end
+                        ? query.Where(r => r.GrainHash > begin && r.GrainHash <= end)
+                        : query.Where(r => r.GrainHash > begin || r.GrainHash <= end);
 
-                return query.ToFeedIterator().ToListAsync();
-            },
-            (this, begin, end)).ConfigureAwait(false);
+                    return query.ToFeedIterator().ToListAsync();
+                },
+                (this, begin, end))).ConfigureAwait(false);
 
             return new ReminderTableData(response.Select(_convertEntityToEntry));
         }
@@ -125,20 +127,21 @@ internal partial class CosmosReminderTable : IReminderTable
         {
             var pk = new PartitionKey(ReminderEntity.ConstructPartitionKey(_clusterOptions.ServiceId, grainId));
             var id = ReminderEntity.ConstructId(grainId, reminderName);
-            var response = await _executor.ExecuteOperation(async args =>
-            {
-                try
+            var response = await ExecuteReadOperation(() =>
+                _executor.ExecuteOperation(async args =>
                 {
-                    var (self, id, pk) = args;
-                    var result = await self._container.ReadItemAsync<ReminderEntity>(id, pk).ConfigureAwait(false);
-                    return result.Resource;
-                }
-                catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return null;
-                }
-            },
-            (this, id, pk)).ConfigureAwait(false);
+                    try
+                    {
+                        var (self, id, pk) = args;
+                        var result = await self._container.ReadItemAsync<ReminderEntity>(id, pk).ConfigureAwait(false);
+                        return result.Resource;
+                    }
+                    catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        return null;
+                    }
+                },
+                (this, id, pk))).ConfigureAwait(false);
 
             return response != null ? FromEntity(response) : default;
         }
@@ -208,13 +211,14 @@ internal partial class CosmosReminderTable : IReminderTable
     {
         try
         {
-            var entities = await _executor.ExecuteOperation(static self =>
-            {
-                var iterator = self._container.GetItemLinqQueryable<ReminderEntity>()
-                    .Where(entity => entity.ServiceId == self._clusterOptions.ServiceId)
-                    .ToFeedIterator();
-                return iterator.ToListAsync();
-            }, this).ConfigureAwait(false);
+            var entities = await ExecuteReadOperation(() =>
+                _executor.ExecuteOperation(static self =>
+                {
+                    var iterator = self._container.GetItemLinqQueryable<ReminderEntity>()
+                        .Where(entity => entity.ServiceId == self._clusterOptions.ServiceId)
+                        .ToFeedIterator();
+                    return iterator.ToListAsync();
+                }, this)).ConfigureAwait(false);
 
             var deleteTasks = new List<Task>();
             foreach (var entity in entities)
@@ -317,6 +321,17 @@ internal partial class CosmosReminderTable : IReminderTable
         }
     }
 
+    private Task<TResult> ExecuteReadOperation<TResult>(Func<Task<TResult>> operation) =>
+        CosmosReadRetryPolicy.ExecuteAsync(operation, LogReadRetry, static delay => Task.Delay(delay));
+
+    private void LogReadRetry(CosmosException exception, int retry, TimeSpan delay) =>
+        LogWarningReadTimedOut(
+            exception,
+            retry,
+            CosmosReadRetryPolicy.MaxRetries,
+            delay.TotalMilliseconds,
+            exception.ActivityId);
+
     private ReminderEntry FromEntity(ReminderEntity entity)
     {
         return new ReminderEntry
@@ -415,4 +430,15 @@ internal partial class CosmosReminderTable : IReminderTable
         Message = "Error deleting Azure Cosmos DB database"
     )]
     private partial void LogErrorDeletingAzureCosmosDBDatabase(Exception ex);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Cosmos DB reminder read timed out. Retrying in {DelayMilliseconds}ms ({Retry}/{MaxRetries}). ActivityId: {ActivityId}"
+    )]
+    private partial void LogWarningReadTimedOut(
+        Exception ex,
+        int retry,
+        int maxRetries,
+        double delayMilliseconds,
+        string activityId);
 }

--- a/src/Azure/Orleans.Reminders.Cosmos/HostingExtensions.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/HostingExtensions.cs
@@ -75,6 +75,7 @@ public static class HostingExtensions
     public static IServiceCollection UseCosmosReminderService(this IServiceCollection services, Action<OptionsBuilder<CosmosReminderTableOptions>> configure)
     {
         services.AddReminders();
+        services.AddCosmosReadRetryPolicy();
         services.AddSingleton<IReminderTable, CosmosReminderTable>();
         configure(services.AddOptions<CosmosReminderTableOptions>());
         services.ConfigureFormatter<CosmosReminderTableOptions>();

--- a/src/Azure/Orleans.Reminders.Cosmos/Orleans.Reminders.Cosmos.csproj
+++ b/src/Azure/Orleans.Reminders.Cosmos/Orleans.Reminders.Cosmos.csproj
@@ -25,6 +25,8 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Reminders\Orleans.Reminders.csproj" />
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
+    <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosReadRetryPolicyTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosReadRetryPolicyTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Orleans.Reminders.Cosmos;
 using Polly;
 using Xunit;
@@ -48,6 +49,48 @@ public class CosmosReadRetryPolicyTests
 
         Assert.Same(exception, actual);
         Assert.Equal(CosmosReadRetryPolicy.MaxRetryAttempts + 1, attempts);
+    }
+
+    [Fact]
+    public async Task Pipeline_PersistentRequestTimeout_UsesDefaultLinearBackoff()
+    {
+        var exception = CreateCosmosException(HttpStatusCode.RequestTimeout);
+        var timeProvider = new FakeTimeProvider();
+        var attemptTimes = new List<DateTimeOffset>();
+        var attempts = Enumerable.Range(0, CosmosReadRetryPolicy.MaxRetryAttempts + 1)
+            .Select(_ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var pipeline = CosmosReadRetryPolicy.CreatePipeline(
+            NullLogger<CosmosReminderTable>.Instance,
+            timeProvider);
+
+        var execution = pipeline.ExecuteAsync<int>(
+            _ =>
+            {
+                var attempt = attemptTimes.Count;
+                attemptTimes.Add(timeProvider.GetUtcNow());
+                attempts[attempt].SetResult();
+                return ValueTask.FromException<int>(exception);
+            },
+            TestContext.Current.CancellationToken).AsTask();
+
+        await attempts[0].Task.WaitAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(99));
+        Assert.False(attempts[1].Task.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+        await attempts[1].Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        timeProvider.Advance(TimeSpan.FromMilliseconds(199));
+        Assert.False(attempts[2].Task.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+        await attempts[2].Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        var actual = await Assert.ThrowsAsync<CosmosException>(() => execution);
+
+        Assert.Same(exception, actual);
+        Assert.Equal(
+            [TimeSpan.Zero, TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(300)],
+            attemptTimes.Select(time => time - attemptTimes[0]));
     }
 
     [Fact]

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosReadRetryPolicyTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosReadRetryPolicyTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Reminders.Cosmos;
+using Polly;
 using Xunit;
 
 namespace Tester.Cosmos.Reminders;
@@ -8,74 +10,71 @@ namespace Tester.Cosmos.Reminders;
 public class CosmosReadRetryPolicyTests
 {
     [Fact]
-    public async Task ExecuteAsync_RequestTimeoutThenSuccess_RetriesRead()
+    public async Task Pipeline_RequestTimeoutThenSuccess_RetriesRead()
     {
         var exception = CreateCosmosException(HttpStatusCode.RequestTimeout);
         var attempts = 0;
-        var retries = new List<(CosmosException Exception, int Retry, TimeSpan Delay)>();
+        var pipeline = CreatePipeline();
 
-        var result = await CosmosReadRetryPolicy.ExecuteAsync(
-            () =>
+        var result = await pipeline.ExecuteAsync(
+            _ =>
             {
                 attempts++;
-                return attempts == 1 ? Task.FromException<int>(exception) : Task.FromResult(42);
+                return attempts == 1
+                    ? ValueTask.FromException<int>(exception)
+                    : ValueTask.FromResult(42);
             },
-            (exception, retry, delay) => retries.Add((exception, retry, delay)),
-            static _ => Task.CompletedTask);
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(42, result);
         Assert.Equal(2, attempts);
-        var retry = Assert.Single(retries);
-        Assert.Same(exception, retry.Exception);
-        Assert.Equal(1, retry.Retry);
-        Assert.Equal(TimeSpan.FromMilliseconds(100), retry.Delay);
     }
 
     [Fact]
-    public async Task ExecuteAsync_PersistentRequestTimeout_StopsAfterMaximumRetries()
+    public async Task Pipeline_PersistentRequestTimeout_StopsAfterMaximumRetries()
     {
         var exception = CreateCosmosException(HttpStatusCode.RequestTimeout);
         var attempts = 0;
-        var retryDelays = new List<TimeSpan>();
+        var pipeline = CreatePipeline();
 
         var actual = await Assert.ThrowsAsync<CosmosException>(() =>
-            CosmosReadRetryPolicy.ExecuteAsync<int>(
-                () =>
+            pipeline.ExecuteAsync<int>(
+                _ =>
                 {
                     attempts++;
-                    return Task.FromException<int>(exception);
+                    return ValueTask.FromException<int>(exception);
                 },
-                (_, _, delay) => retryDelays.Add(delay),
-                static _ => Task.CompletedTask));
+                TestContext.Current.CancellationToken).AsTask());
 
         Assert.Same(exception, actual);
-        Assert.Equal(CosmosReadRetryPolicy.MaxRetries + 1, attempts);
-        Assert.Equal(
-            [TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(200)],
-            retryDelays);
+        Assert.Equal(CosmosReadRetryPolicy.MaxRetryAttempts + 1, attempts);
     }
 
     [Fact]
-    public async Task ExecuteAsync_NonTimeoutFailure_DoesNotRetry()
+    public async Task Pipeline_NonTimeoutFailure_DoesNotRetry()
     {
         var exception = CreateCosmosException(HttpStatusCode.InternalServerError);
         var attempts = 0;
-        var retryCount = 0;
+        var pipeline = CreatePipeline();
 
         var actual = await Assert.ThrowsAsync<CosmosException>(() =>
-            CosmosReadRetryPolicy.ExecuteAsync<int>(
-                () =>
+            pipeline.ExecuteAsync<int>(
+                _ =>
                 {
                     attempts++;
-                    return Task.FromException<int>(exception);
+                    return ValueTask.FromException<int>(exception);
                 },
-                (_, _, _) => retryCount++,
-                static _ => Task.CompletedTask));
+                TestContext.Current.CancellationToken).AsTask());
 
         Assert.Same(exception, actual);
         Assert.Equal(1, attempts);
-        Assert.Equal(0, retryCount);
     }
+
+    private static ResiliencePipeline CreatePipeline() =>
+        CosmosReadRetryPolicy.CreatePipeline(
+            NullLogger<CosmosReminderTable>.Instance,
+            TimeProvider.System,
+            TimeSpan.Zero);
 
     private static CosmosException CreateCosmosException(HttpStatusCode statusCode) =>
         new("Test failure", statusCode, 0, "test-activity", 0);

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosReadRetryPolicyTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosReadRetryPolicyTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Orleans.Reminders.Cosmos;
+using Xunit;
+
+namespace Tester.Cosmos.Reminders;
+
+public class CosmosReadRetryPolicyTests
+{
+    [Fact]
+    public async Task ExecuteAsync_RequestTimeoutThenSuccess_RetriesRead()
+    {
+        var exception = CreateCosmosException(HttpStatusCode.RequestTimeout);
+        var attempts = 0;
+        var retries = new List<(CosmosException Exception, int Retry, TimeSpan Delay)>();
+
+        var result = await CosmosReadRetryPolicy.ExecuteAsync(
+            () =>
+            {
+                attempts++;
+                return attempts == 1 ? Task.FromException<int>(exception) : Task.FromResult(42);
+            },
+            (exception, retry, delay) => retries.Add((exception, retry, delay)),
+            static _ => Task.CompletedTask);
+
+        Assert.Equal(42, result);
+        Assert.Equal(2, attempts);
+        var retry = Assert.Single(retries);
+        Assert.Same(exception, retry.Exception);
+        Assert.Equal(1, retry.Retry);
+        Assert.Equal(TimeSpan.FromMilliseconds(100), retry.Delay);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PersistentRequestTimeout_StopsAfterMaximumRetries()
+    {
+        var exception = CreateCosmosException(HttpStatusCode.RequestTimeout);
+        var attempts = 0;
+        var retryDelays = new List<TimeSpan>();
+
+        var actual = await Assert.ThrowsAsync<CosmosException>(() =>
+            CosmosReadRetryPolicy.ExecuteAsync<int>(
+                () =>
+                {
+                    attempts++;
+                    return Task.FromException<int>(exception);
+                },
+                (_, _, delay) => retryDelays.Add(delay),
+                static _ => Task.CompletedTask));
+
+        Assert.Same(exception, actual);
+        Assert.Equal(CosmosReadRetryPolicy.MaxRetries + 1, attempts);
+        Assert.Equal(
+            [TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(200)],
+            retryDelays);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonTimeoutFailure_DoesNotRetry()
+    {
+        var exception = CreateCosmosException(HttpStatusCode.InternalServerError);
+        var attempts = 0;
+        var retryCount = 0;
+
+        var actual = await Assert.ThrowsAsync<CosmosException>(() =>
+            CosmosReadRetryPolicy.ExecuteAsync<int>(
+                () =>
+                {
+                    attempts++;
+                    return Task.FromException<int>(exception);
+                },
+                (_, _, _) => retryCount++,
+                static _ => Task.CompletedTask));
+
+        Assert.Same(exception, actual);
+        Assert.Equal(1, attempts);
+        Assert.Equal(0, retryCount);
+    }
+
+    private static CosmosException CreateCosmosException(HttpStatusCode statusCode) =>
+        new("Test failure", statusCode, 0, "test-activity", 0);
+}

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosRemindersTableTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosRemindersTableTests.cs
@@ -36,7 +36,15 @@ public class CosmosRemindersTableTests : ReminderTableTestsBase
 
         var options = new CosmosReminderTableOptions();
         options.ConfigureTestDefaults();
-        return new CosmosReminderTable(loggerFactory, this.ClusterFixture.Services, Options.Create(options), this.clusterOptions);
+        var retryPipeline = CosmosReadRetryPolicy.CreatePipeline(
+            loggerFactory.CreateLogger<CosmosReminderTable>(),
+            TimeProvider.System);
+        return new CosmosReminderTable(
+            loggerFactory,
+            this.ClusterFixture.Services,
+            Options.Create(options),
+            this.clusterOptions,
+            retryPipeline);
     }
 
     protected override Task<string> GetConnectionString()

--- a/test/Extensions/Orleans.Cosmos.Tests/Orleans.Cosmos.Tests.csproj
+++ b/test/Extensions/Orleans.Cosmos.Tests/Orleans.Cosmos.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
   </ItemGroup>
 

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
@@ -45,8 +45,16 @@ public class ReminderTests_Cosmos_Standalone
         var clusterOptions = Options.Create(new ClusterOptions { ClusterId = "TMSLocalTesting", ServiceId = _serviceId });
         var storageOptions = Options.Create(new CosmosReminderTableOptions());
         storageOptions.Value.ConfigureTestDefaults();
+        var retryPipeline = CosmosReadRetryPolicy.CreatePipeline(
+            _loggerFactory.CreateLogger<CosmosReminderTable>(),
+            TimeProvider.System);
 
-        IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
+        IReminderTable table = new CosmosReminderTable(
+            _loggerFactory,
+            _fixture.Services,
+            storageOptions,
+            clusterOptions,
+            retryPipeline);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(new ReminderOptions().InitializationTimeout);
         await table.StartAsync(cancellation.Token);
@@ -63,7 +71,15 @@ public class ReminderTests_Cosmos_Standalone
         var clusterOptions = Options.Create(new ClusterOptions { ClusterId = clusterId, ServiceId = _serviceId });
         var storageOptions = Options.Create(new CosmosReminderTableOptions());
         storageOptions.Value.ConfigureTestDefaults();
-        IReminderTable table = new CosmosReminderTable(_loggerFactory, _fixture.Services, storageOptions, clusterOptions);
+        var retryPipeline = CosmosReadRetryPolicy.CreatePipeline(
+            _loggerFactory.CreateLogger<CosmosReminderTable>(),
+            TimeProvider.System);
+        IReminderTable table = new CosmosReminderTable(
+            _loggerFactory,
+            _fixture.Services,
+            storageOptions,
+            clusterOptions,
+            retryPipeline);
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cancellation.CancelAfter(new ReminderOptions().InitializationTimeout);
         await table.StartAsync(cancellation.Token);


### PR DESCRIPTION
## Problem

The Cosmos emulator can return transient HTTP 408 responses for reminder GET queries. Earlier fixture load controls and reminder reconciliation fixes preserve test ordering but do not make an individual Cosmos read reliable.

## Solution

Retry reminder reads only, with two bounded 100ms/200ms delays, and log each retry with its Cosmos activity ID. Writes retain their existing behavior because a timed-out write can have an ambiguous server-side outcome.

Focused coverage verifies transient recovery, the retry bound and backoff, and immediate propagation of non-timeout failures.

Fixes #11020
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11031)