### PR TITLE
fix(test): pass cancellation tokens in handoff tests

### DIFF
--- a/test/Orleans.Runtime.Internal.Tests/GrainDirectoryHandoffManagerTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GrainDirectoryHandoffManagerTests.cs
@@ -823,7 +823,8 @@ public class GrainDirectoryHandoffManagerTests
         catalogA.DeleteActivations(
                 Arg.Any<List<GrainAddress>>(),
                 Arg.Any<DeactivationReasonCode>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
             .Returns(async call =>
             {
                 Interlocked.Increment(ref catalogAInvocationCount);
@@ -837,7 +838,8 @@ public class GrainDirectoryHandoffManagerTests
         catalogB.DeleteActivations(
                 Arg.Any<List<GrainAddress>>(),
                 Arg.Any<DeactivationReasonCode>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
             .Returns(async call =>
             {
                 Interlocked.Increment(ref catalogBInvocationCount);
@@ -1004,7 +1006,8 @@ public class GrainDirectoryHandoffManagerTests
         deadCatalog.DeleteActivations(
                 Arg.Any<List<GrainAddress>>(),
                 Arg.Any<DeactivationReasonCode>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
                 Interlocked.Increment(ref deadDeletionCount);
@@ -1013,7 +1016,8 @@ public class GrainDirectoryHandoffManagerTests
         stoppingCatalog.DeleteActivations(
                 Arg.Any<List<GrainAddress>>(),
                 Arg.Any<DeactivationReasonCode>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
                 Interlocked.Increment(ref stoppingDeletionCount);
@@ -1022,7 +1026,8 @@ public class GrainDirectoryHandoffManagerTests
         activeCatalog.DeleteActivations(
                 Arg.Any<List<GrainAddress>>(),
                 Arg.Any<DeactivationReasonCode>(),
-                Arg.Any<string>())
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
             .Returns(async call =>
             {
                 Interlocked.Increment(ref activeDeletionCount);


### PR DESCRIPTION
Fixes #11038

The grain directory handoff tests configured cancellation-aware `ICatalog.DeleteActivations` substitutes without an explicit cancellation-token matcher, which triggered xUnit1051 during solution builds.

Add cancellation-token matchers at the five affected call sites. This satisfies the analyzer while preserving the tests' existing behavior for production calls which use `CancellationToken.None`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11040)