### PR TITLE
fix(runtime): harden lifecycle lock identity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -674,6 +674,12 @@ dotnet_diagnostic.CA1873.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2002.severity = warning
 
+[src/Orleans.Runtime/Catalog/GrainLifecycle.cs]
+dotnet_diagnostic.CA2002.severity = warning
+
+[src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs]
+dotnet_diagnostic.CA2002.severity = warning
+
 [src/Orleans.Serialization.SystemTextJson/**.cs]
 dotnet_diagnostic.CA2000.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -672,13 +672,13 @@ dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
 dotnet_diagnostic.CA1873.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
+
+[src/Orleans.Runtime/**.cs]
 dotnet_diagnostic.CA2002.severity = warning
 
-[src/Orleans.Runtime/Catalog/GrainLifecycle.cs]
-dotnet_diagnostic.CA2002.severity = warning
-
-[src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs]
-dotnet_diagnostic.CA2002.severity = warning
+# ActivationData's shared monitor migration is tracked by #10068.
+[src/Orleans.Runtime/Catalog/ActivationData.cs]
+dotnet_diagnostic.CA2002.severity = suggestion
 
 [src/Orleans.Serialization.SystemTextJson/**.cs]
 dotnet_diagnostic.CA2000.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -658,7 +658,6 @@ dotnet_diagnostic.RS0027.severity = suggestion
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
-dotnet_diagnostic.CA2002.severity = warning
 
 # CA1873: Avoid potentially expensive logging
 [src/Orleans.Core.Abstractions/**.cs]
@@ -673,13 +672,6 @@ dotnet_diagnostic.CA1849.severity = warning
 dotnet_diagnostic.CA1873.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 
-[src/Orleans.Runtime/**.cs]
-dotnet_diagnostic.CA2002.severity = warning
-
-# ActivationData's shared monitor migration is tracked by #10068.
-[src/Orleans.Runtime/Catalog/ActivationData.cs]
-dotnet_diagnostic.CA2002.severity = suggestion
-
 [src/Orleans.Serialization.SystemTextJson/**.cs]
 dotnet_diagnostic.CA2000.severity = warning
 
@@ -687,6 +679,7 @@ dotnet_diagnostic.CA2000.severity = warning
 # playgrounds, templates, and tools retain advisory diagnostics during this rollout.
 [src/**/*.{cs,vb}]
 dotnet_diagnostic.CA1856.severity = warning
+dotnet_diagnostic.CA2002.severity = warning
 dotnet_diagnostic.CA2011.severity = warning
 dotnet_diagnostic.CA2012.severity = warning
 dotnet_diagnostic.CA2013.severity = warning
@@ -697,3 +690,7 @@ dotnet_diagnostic.CA2245.severity = warning
 dotnet_diagnostic.CA2246.severity = warning
 dotnet_diagnostic.IDE0035.severity = warning
 dotnet_diagnostic.IDE0043.severity = warning
+
+# ActivationData's shared monitor migration is tracked by #10068.
+[src/Orleans.Runtime/Catalog/ActivationData.cs]
+dotnet_diagnostic.CA2002.severity = suggestion

--- a/src/Orleans.Runtime/Catalog/GrainLifecycle.cs
+++ b/src/Orleans.Runtime/Catalog/GrainLifecycle.cs
@@ -9,13 +9,14 @@ namespace Orleans.Runtime
     internal class GrainLifecycle(ILogger logger) : LifecycleSubject(logger), IGrainLifecycle
     {
         private static readonly ImmutableDictionary<int, string> StageNames = GetStageNames(typeof(GrainLifecycleStage));
+        private readonly object _lock = new();
         private List<IGrainMigrationParticipant>? _migrationParticipants;
 
         public IEnumerable<IGrainMigrationParticipant> GetMigrationParticipants() => _migrationParticipants ?? (IEnumerable<IGrainMigrationParticipant>)[];
 
         public void AddMigrationParticipant(IGrainMigrationParticipant participant)
         {
-            lock (this)
+            lock (_lock)
             {
                 _migrationParticipants ??= [];
                 _migrationParticipants.Add(participant);
@@ -24,7 +25,7 @@ namespace Orleans.Runtime
 
         public void RemoveMigrationParticipant(IGrainMigrationParticipant participant)
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_migrationParticipants is null) return;
                 _migrationParticipants.Remove(participant);

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -21,6 +21,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IClusterMembershipService clusterMembershipService;
         private readonly IInternalGrainFactory grainFactory;
         private readonly ILogger logger;
+        private readonly object _lock = new();
         private readonly Queue<(string name, object state, Func<GrainDirectoryHandoffManager, object, Task> action)> pendingOperations = new();
         private readonly AsyncLock executorLock = new AsyncLock();
 
@@ -40,7 +41,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         internal void ProcessSiloAddEvent(SiloAddress addedSilo)
         {
-            lock (this)
+            lock (_lock)
             {
                 LogDebugProcessingSiloAddEvent(logger, addedSilo);
 
@@ -218,7 +219,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         private void EnqueueOperation(string name, object state, Func<GrainDirectoryHandoffManager, object, Task> action)
         {
-            lock (this)
+            lock (_lock)
             {
                 this.pendingOperations.Enqueue((name, state, action));
                 if (this.pendingOperations.Count <= 2)
@@ -236,7 +237,7 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     // Get the next operation, or exit if there are none.
                     (string Name, object State, Func<GrainDirectoryHandoffManager, object, Task> Action) op;
-                    lock (this)
+                    lock (_lock)
                     {
                         if (this.pendingOperations.Count == 0) break;
 
@@ -246,7 +247,7 @@ namespace Orleans.Runtime.GrainDirectory
                     try
                     {
                         await op.Action(this, op.State);
-                        lock (this)
+                        lock (_lock)
                         {
                             this.pendingOperations.Dequeue();
                         }
@@ -266,7 +267,7 @@ namespace Orleans.Runtime.GrainDirectory
                         }
 
                         // Keep retrying failed handoff work, but let later queued operations make progress.
-                        lock (this)
+                        lock (_lock)
                         {
                             this.pendingOperations.Dequeue();
                             this.pendingOperations.Enqueue(op);


### PR DESCRIPTION
## Problem
The successful main analyzer audit reported CA2002 findings where production synchronization used externally visible object identities. All 50 production findings were concentrated in three Orleans.Runtime files: the seven addressed here and 43 in `ActivationData`, whose shared monitor migration is owned by #10068 and overlaps #10830.

## Solution
`GrainLifecycle` now uses one private, lifetime-bound monitor for migration participant mutation. `GrainDirectoryHandoffManager` now uses one private, lifetime-bound monitor across silo-add processing and all pending-operation queue access. CA2002 is enforced across all production source under `src/**/*.{cs,vb}`, while `ActivationData` remains advisory until #10068 lands.

## Rationale
Source-wide enforcement gives production code a stable analyzer boundary and prevents new weak-identity locks anywhere in the codebase. The single temporary `ActivationData` exception preserves clear ownership of its existing shared monitor contract. Each lock replacement in this change preserves the existing synchronization domain and monitor reentrancy, and the handoff execution and cancellation-aware RPC behavior remain unchanged.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11050)