### PR TITLE
fix(aws): use invariant DynamoDB clustering text

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/.editorconfig
+++ b/src/AWS/Orleans.Clustering.DynamoDB/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProvider.cs
@@ -8,6 +8,7 @@ using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -17,7 +18,7 @@ namespace Orleans.Clustering.DynamoDB
     {
         private DynamoDBStorage storage = null!;
         private readonly string clusterId;
-        private readonly string INSTANCE_STATUS_ACTIVE = ((int)SiloStatus.Active).ToString();
+        private readonly string INSTANCE_STATUS_ACTIVE = ((int)SiloStatus.Active).ToString(CultureInfo.InvariantCulture);
         private readonly ILogger logger;
         private readonly DynamoDBGatewayOptions options;
 
@@ -80,8 +81,8 @@ namespace Orleans.Clustering.DynamoDB
                 {
                     return SiloAddress.New(
                             IPAddress.Parse(gateway[SiloInstanceRecord.ADDRESS_PROPERTY_NAME].S),
-                            int.Parse(gateway[SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME].N),
-                            int.Parse(gateway[SiloInstanceRecord.GENERATION_PROPERTY_NAME].N)).ToGatewayUri();
+                                int.Parse(gateway[SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME].N, NumberStyles.Integer, CultureInfo.InvariantCulture),
+                                int.Parse(gateway[SiloInstanceRecord.GENERATION_PROPERTY_NAME].N, NumberStyles.Integer, CultureInfo.InvariantCulture)).ToGatewayUri();
                 });
 
             return records;

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProviderHelper.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBGatewayListProviderHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using Orleans.Configuration;
 
@@ -22,7 +23,7 @@ namespace Orleans.Clustering.DynamoDB
         {
             var parameters = dataConnectionString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
-            var serviceConfig = Array.Find(parameters, p => p.Contains(ServicePropertyName));
+            var serviceConfig = Array.Find(parameters, p => p.Contains(ServicePropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(serviceConfig))
             {
                 var value = serviceConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
@@ -30,7 +31,7 @@ namespace Orleans.Clustering.DynamoDB
                     options.Service = value[1];
             }
 
-            var secretKeyConfig = Array.Find(parameters, p => p.Contains(SecretKeyPropertyName));
+            var secretKeyConfig = Array.Find(parameters, p => p.Contains(SecretKeyPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(secretKeyConfig))
             {
                 var value = secretKeyConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
@@ -38,7 +39,7 @@ namespace Orleans.Clustering.DynamoDB
                     options.SecretKey = value[1];
             }
 
-            var accessKeyConfig = Array.Find(parameters, p => p.Contains(AccessKeyPropertyName));
+            var accessKeyConfig = Array.Find(parameters, p => p.Contains(AccessKeyPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(accessKeyConfig))
             {
                 var value = accessKeyConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
@@ -46,20 +47,20 @@ namespace Orleans.Clustering.DynamoDB
                     options.AccessKey = value[1];
             }
 
-            var readCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(ReadCapacityUnitsPropertyName));
+            var readCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(ReadCapacityUnitsPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(readCapacityUnitsConfig))
             {
                 var value = readCapacityUnitsConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                 if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
-                    options.ReadCapacityUnits = int.Parse(value[1]);
+                    options.ReadCapacityUnits = int.Parse(value[1], NumberStyles.Integer, CultureInfo.InvariantCulture);
             }
 
-            var writeCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(WriteCapacityUnitsPropertyName));
+            var writeCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(WriteCapacityUnitsPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(writeCapacityUnitsConfig))
             {
                 var value = writeCapacityUnitsConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                 if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
-                    options.WriteCapacityUnits = int.Parse(value[1]);
+                    options.WriteCapacityUnits = int.Parse(value[1], NumberStyles.Integer, CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipHelper.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipHelper.cs
@@ -1,5 +1,6 @@
 using Orleans.Configuration;
 using System;
+using System.Globalization;
 using System.Linq;
 
 namespace Orleans.Clustering.DynamoDB
@@ -23,7 +24,7 @@ namespace Orleans.Clustering.DynamoDB
         {
             var parameters = dataConnectionString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
-            var serviceConfig = Array.Find(parameters, p => p.Contains(ServicePropertyName));
+            var serviceConfig = Array.Find(parameters, p => p.Contains(ServicePropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(serviceConfig))
             {
                 var value = serviceConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
@@ -31,7 +32,7 @@ namespace Orleans.Clustering.DynamoDB
                     options.Service = value[1];
             }
 
-            var tableNameConfig = Array.Find(parameters, p => p.Contains(TableNamePropertyName));
+            var tableNameConfig = Array.Find(parameters, p => p.Contains(TableNamePropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(tableNameConfig))
             {
                 var value = tableNameConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
@@ -39,7 +40,7 @@ namespace Orleans.Clustering.DynamoDB
                     options.TableName = value[1];
             }
 
-            var secretKeyConfig = Array.Find(parameters, p => p.Contains(SecretKeyPropertyName));
+            var secretKeyConfig = Array.Find(parameters, p => p.Contains(SecretKeyPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(secretKeyConfig))
             {
                 var value = secretKeyConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
@@ -47,7 +48,7 @@ namespace Orleans.Clustering.DynamoDB
                     options.SecretKey = value[1];
             }
 
-            var accessKeyConfig = Array.Find(parameters, p => p.Contains(AccessKeyPropertyName));
+            var accessKeyConfig = Array.Find(parameters, p => p.Contains(AccessKeyPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(accessKeyConfig))
             {
                 var value = accessKeyConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
@@ -55,20 +56,20 @@ namespace Orleans.Clustering.DynamoDB
                     options.AccessKey = value[1];
             }
 
-            var readCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(ReadCapacityUnitsPropertyName));
+            var readCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(ReadCapacityUnitsPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(readCapacityUnitsConfig))
             {
                 var value = readCapacityUnitsConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                 if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
-                    options.ReadCapacityUnits = int.Parse(value[1]);
+                    options.ReadCapacityUnits = int.Parse(value[1], NumberStyles.Integer, CultureInfo.InvariantCulture);
             }
 
-            var writeCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(WriteCapacityUnitsPropertyName));
+            var writeCapacityUnitsConfig = Array.Find(parameters, p => p.Contains(WriteCapacityUnitsPropertyName, StringComparison.Ordinal));
             if (!string.IsNullOrWhiteSpace(writeCapacityUnitsConfig))
             {
                 var value = writeCapacityUnitsConfig.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                 if (value.Length == 2 && !string.IsNullOrWhiteSpace(value[1]))
-                    options.WriteCapacityUnits = int.Parse(value[1]);
+                    options.WriteCapacityUnits = int.Parse(value[1], NumberStyles.Integer, CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/DynamoDBMembershipTable.cs
@@ -21,6 +21,7 @@ namespace Orleans.Clustering.DynamoDB
         private static readonly TableVersion NotFoundTableVersion = new TableVersion(0, "0");
 
         private const string CURRENT_ETAG_ALIAS = ":currentETag";
+        private const string MEMBERSHIP_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.fff 'GMT'";
         private const int MAX_BATCH_SIZE = 25;
 
         private readonly ILogger logger;
@@ -119,7 +120,7 @@ namespace Orleans.Clustering.DynamoDB
             }
             else
             {
-                if (!int.TryParse(etag, out etagInt))
+                if (!int.TryParse(etag, NumberStyles.Integer, CultureInfo.InvariantCulture, out etagInt))
                 {
                     entry = default;
                     return false;
@@ -278,7 +279,7 @@ namespace Orleans.Clustering.DynamoDB
                 }
                 catch (TransactionCanceledException canceledException)
                 {
-                    if (canceledException.Message.Contains("ConditionalCheckFailed")) //not a good way to check for this currently
+                    if (canceledException.Message.Contains("ConditionalCheckFailed", StringComparison.Ordinal)) //not a good way to check for this currently
                     {
                         result = false;
                         LogWarningInsertFailedDueToContention(entry);
@@ -304,7 +305,7 @@ namespace Orleans.Clustering.DynamoDB
             {
                 LogDebugUpdateRow(entry, etag);
                 var siloEntry = Convert(entry, tableVersion);
-                if (!int.TryParse(etag, out var currentEtag))
+                if (!int.TryParse(etag, NumberStyles.Integer, CultureInfo.InvariantCulture, out var currentEtag))
                 {
                     LogWarningUpdateFailedInvalidETag(entry, etag);
                     return false;
@@ -352,7 +353,7 @@ namespace Orleans.Clustering.DynamoDB
                 }
                 catch (TransactionCanceledException canceledException)
                 {
-                    if (canceledException.Message.Contains("ConditionalCheckFailed")) //not a good way to check for this currently
+                    if (canceledException.Message.Contains("ConditionalCheckFailed", StringComparison.Ordinal)) //not a good way to check for this currently
                     {
                         result = false;
                         LogWarningUpdateFailedDueToContention(canceledException, entry, etag);
@@ -397,7 +398,7 @@ namespace Orleans.Clustering.DynamoDB
                 var tableVersion = NotFoundTableVersion;
                 foreach (var tableEntry in entries)
                 {
-                    if (tableEntry.SiloIdentity == SiloInstanceRecord.TABLE_VERSION_ROW)
+                    if (string.Equals(tableEntry.SiloIdentity, SiloInstanceRecord.TABLE_VERSION_ROW, StringComparison.Ordinal))
                     {
                         tableVersion = new TableVersion(tableEntry.MembershipVersion, tableEntry.ETag.ToString(CultureInfo.InvariantCulture));
                     }
@@ -561,9 +562,14 @@ namespace Orleans.Clustering.DynamoDB
             }
         }
 
-        private static bool SiloIsDefunct(SiloInstanceRecord silo, DateTimeOffset beforeDate)
+        internal static bool SiloIsDefunct(SiloInstanceRecord silo, DateTimeOffset beforeDate)
         {
-            return DateTimeOffset.TryParse(silo.IAmAliveTime, out var iAmAliveTime)
+            return DateTimeOffset.TryParseExact(
+                        silo.IAmAliveTime,
+                        MEMBERSHIP_DATE_FORMAT,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        out var iAmAliveTime)
                     && iAmAliveTime < beforeDate
                     && silo.Status != (int)SiloStatus.Active;
         }

--- a/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
+++ b/src/AWS/Orleans.Clustering.DynamoDB/Membership/SiloInstanceRecord.cs
@@ -1,6 +1,7 @@
 using Amazon.DynamoDBv2.Model;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Text;
 
@@ -58,22 +59,22 @@ namespace Orleans.Runtime.MembershipService
                 Address = address.S;
 
             if (fields.TryGetValue(PORT_PROPERTY_NAME, out var sPort) &&
-                int.TryParse(sPort.N, out var port))
+                int.TryParse(sPort.N, NumberStyles.Integer, CultureInfo.InvariantCulture, out var port))
                 Port = port;
 
             if (fields.TryGetValue(GENERATION_PROPERTY_NAME, out var sGeneration) &&
-                int.TryParse(sGeneration.N, out var generation))
+                int.TryParse(sGeneration.N, NumberStyles.Integer, CultureInfo.InvariantCulture, out var generation))
                 Generation = generation;
 
             if (fields.TryGetValue(HOSTNAME_PROPERTY_NAME, out var hostName))
                 HostName = hostName.S;
 
             if (fields.TryGetValue(STATUS_PROPERTY_NAME, out var sStatus) &&
-                int.TryParse(sStatus.N, out var status))
+                int.TryParse(sStatus.N, NumberStyles.Integer, CultureInfo.InvariantCulture, out var status))
                 Status = status;
 
             if (fields.TryGetValue(PROXY_PORT_PROPERTY_NAME, out var sProxyPort) &&
-                int.TryParse(sProxyPort.N, out var proxyPort))
+                int.TryParse(sProxyPort.N, NumberStyles.Integer, CultureInfo.InvariantCulture, out var proxyPort))
                 ProxyPort = proxyPort;
 
             if (fields.TryGetValue(SILO_NAME_PROPERTY_NAME, out var siloName))
@@ -92,11 +93,11 @@ namespace Orleans.Runtime.MembershipService
                 IAmAliveTime = aliveTime.S;
 
             if (fields.TryGetValue(ETAG_PROPERTY_NAME, out var sETag) &&
-                int.TryParse(sETag.N, out var etag))
+                int.TryParse(sETag.N, NumberStyles.Integer, CultureInfo.InvariantCulture, out var etag))
                 ETag = etag;
 
             if (fields.TryGetValue(MEMBERSHIP_VERSION_PROPERTY_NAME, out var value) &&
-                int.TryParse(value.N, out var version))
+                int.TryParse(value.N, NumberStyles.Integer, CultureInfo.InvariantCulture, out var version))
                 MembershipVersion = version;
         }
 
@@ -104,15 +105,15 @@ namespace Orleans.Runtime.MembershipService
         {
             try
             {
-                int idx1 = rowKey.IndexOf(Seperator);
+                int idx1 = rowKey.IndexOf(Seperator, StringComparison.Ordinal);
                 int idx2 = rowKey.LastIndexOf(Seperator);
                 ReadOnlySpan<char> rowKeySpan = rowKey.AsSpan();
                 ReadOnlySpan<char> addressStr = rowKeySpan[..idx1];
                 ReadOnlySpan<char> portStr = rowKeySpan.Slice(idx1 + 1, idx2 - idx1 - 1);
                 ReadOnlySpan<char> genStr = rowKeySpan[(idx2 + 1)..];
                 IPAddress address = IPAddress.Parse(addressStr);
-                int port = int.Parse(portStr);
-                int generation = int.Parse(genStr);
+                int port = int.Parse(portStr, NumberStyles.Integer, CultureInfo.InvariantCulture);
+                int generation = int.Parse(genStr, NumberStyles.Integer, CultureInfo.InvariantCulture);
                 return SiloAddress.New(address, port, generation);
             }
             catch (Exception exc)
@@ -146,7 +147,7 @@ namespace Orleans.Runtime.MembershipService
 
         public static string ConstructSiloIdentity(SiloAddress silo)
         {
-            return string.Format("{0}-{1}-{2}", silo.Endpoint.Address, silo.Endpoint.Port, silo.Generation);
+            return string.Format(CultureInfo.InvariantCulture, "{0}-{1}-{2}", silo.Endpoint.Address, silo.Endpoint.Port, silo.Generation);
         }
 
         public Dictionary<string, AttributeValue> GetKeys()
@@ -170,14 +171,14 @@ namespace Orleans.Runtime.MembershipService
             if (!string.IsNullOrWhiteSpace(Address))
                 fields.Add(ADDRESS_PROPERTY_NAME, new AttributeValue(Address));
 
-            fields.Add(PORT_PROPERTY_NAME, new AttributeValue { N = Port.ToString() });
-            fields.Add(GENERATION_PROPERTY_NAME, new AttributeValue { N = Generation.ToString() });
+            fields.Add(PORT_PROPERTY_NAME, new AttributeValue { N = Port.ToString(CultureInfo.InvariantCulture) });
+            fields.Add(GENERATION_PROPERTY_NAME, new AttributeValue { N = Generation.ToString(CultureInfo.InvariantCulture) });
 
             if (!string.IsNullOrWhiteSpace(HostName))
                 fields.Add(HOSTNAME_PROPERTY_NAME, new AttributeValue(HostName));
 
-            fields.Add(STATUS_PROPERTY_NAME, new AttributeValue { N = Status.ToString() });
-            fields.Add(PROXY_PORT_PROPERTY_NAME, new AttributeValue { N = ProxyPort.ToString() });
+            fields.Add(STATUS_PROPERTY_NAME, new AttributeValue { N = Status.ToString(CultureInfo.InvariantCulture) });
+            fields.Add(PROXY_PORT_PROPERTY_NAME, new AttributeValue { N = ProxyPort.ToString(CultureInfo.InvariantCulture) });
 
             if (!string.IsNullOrWhiteSpace(SiloName))
                 fields.Add(SILO_NAME_PROPERTY_NAME, new AttributeValue(SiloName));
@@ -194,9 +195,9 @@ namespace Orleans.Runtime.MembershipService
             if (!string.IsNullOrWhiteSpace(IAmAliveTime))
                 fields.Add(I_AM_ALIVE_TIME_PROPERTY_NAME, new AttributeValue(IAmAliveTime));
 
-            fields.Add(MEMBERSHIP_VERSION_PROPERTY_NAME, new AttributeValue { N = MembershipVersion.ToString() });
+            fields.Add(MEMBERSHIP_VERSION_PROPERTY_NAME, new AttributeValue { N = MembershipVersion.ToString(CultureInfo.InvariantCulture) });
 
-            fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = ETag.ToString() });
+            fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = ETag.ToString(CultureInfo.InvariantCulture) });
             return fields;
         }
     }

--- a/test/Extensions/Orleans.AWS.Tests/MembershipTests/DynamoDBConnectionStringTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/MembershipTests/DynamoDBConnectionStringTests.cs
@@ -1,0 +1,65 @@
+using System.Globalization;
+using Orleans.Clustering.DynamoDB;
+using Orleans.Configuration;
+using Xunit;
+
+namespace AWSUtils.Tests.MembershipTests
+{
+    [TestCategory("Membership"), TestCategory("AWS"), TestCategory("DynamoDb")]
+    [TestSuite("BVT")]
+    [TestProvider("DynamoDB")]
+    [TestArea("Membership")]
+    public class DynamoDBConnectionStringTests
+    {
+        [Fact]
+        public void MembershipOptions_ParseNumericValuesUsingInvariantCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CreateCultureWithNonInvariantPositiveSign();
+                var options = new DynamoDBClusteringOptions();
+
+                DynamoDBMembershipHelper.ParseDataConnectionString(
+                    "ReadCapacityUnits=+12;WriteCapacityUnits=+34",
+                    options);
+
+                Assert.Equal(12, options.ReadCapacityUnits);
+                Assert.Equal(34, options.WriteCapacityUnits);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Fact]
+        public void GatewayOptions_ParseNumericValuesUsingInvariantCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CreateCultureWithNonInvariantPositiveSign();
+                var options = new DynamoDBGatewayOptions();
+
+                DynamoDBGatewayListProviderHelper.ParseDataConnectionString(
+                    "ReadCapacityUnits=+12;WriteCapacityUnits=+34",
+                    options);
+
+                Assert.Equal(12, options.ReadCapacityUnits);
+                Assert.Equal(34, options.WriteCapacityUnits);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        private static CultureInfo CreateCultureWithNonInvariantPositiveSign()
+        {
+            var culture = (CultureInfo)CultureInfo.GetCultureInfo("fr-FR").Clone();
+            culture.NumberFormat.PositiveSign = "!";
+            return culture;
+        }
+    }
+}

--- a/test/Extensions/Orleans.AWS.Tests/MembershipTests/DynamoDBMembershipTableUnitTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/MembershipTests/DynamoDBMembershipTableUnitTests.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using Orleans.Clustering.DynamoDB;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+using Xunit;
+
+namespace AWSUtils.Tests.MembershipTests
+{
+    [TestCategory("Membership"), TestCategory("AWS"), TestCategory("DynamoDb")]
+    [TestSuite("BVT")]
+    [TestProvider("DynamoDB")]
+    [TestArea("Membership")]
+    public class DynamoDBMembershipTableUnitTests
+    {
+        [Fact]
+        public void SiloIsDefunct_ParsesPersistedTimestampUsingInvariantCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ar-SA");
+                var record = new SiloInstanceRecord
+                {
+                    IAmAliveTime = "2026-09-03 20:00:00.000 GMT",
+                    Status = (int)SiloStatus.Dead
+                };
+                var cutoff = new DateTimeOffset(2026, 9, 3, 21, 0, 0, TimeSpan.Zero);
+
+                Assert.True(DynamoDBMembershipTable.SiloIsDefunct(record, cutoff));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+    }
+}

--- a/test/Extensions/Orleans.AWS.Tests/MembershipTests/SiloInstanceRecordTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/MembershipTests/SiloInstanceRecordTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using Amazon.DynamoDBv2.Model;
 using Orleans.Runtime;
@@ -30,6 +31,76 @@ namespace AWSUtils.Tests.MembershipTests
             Assert.Equal(2, keys.Count);
             Assert.Equal(instanceRecord.DeploymentId, keys[SiloInstanceRecord.DEPLOYMENT_ID_PROPERTY_NAME].S);
             Assert.Equal(instanceRecord.SiloIdentity, keys[SiloInstanceRecord.SILO_IDENTITY_PROPERTY_NAME].S);
+        }
+
+        [Fact]
+        public void NumericFields_RoundTripUsingInvariantCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CreateCultureWithNonInvariantNegativeSign();
+                var instanceRecord = new SiloInstanceRecord
+                {
+                    DeploymentId = "deploymentID",
+                    SiloIdentity = "siloIdentity",
+                    Port = -12345,
+                    Generation = -67890,
+                    Status = -1,
+                    ProxyPort = -23456,
+                    MembershipVersion = -2,
+                    ETag = -3
+                };
+
+                var fields = instanceRecord.GetFields();
+
+                Assert.Equal("-12345", fields[SiloInstanceRecord.PORT_PROPERTY_NAME].N);
+                Assert.Equal("-67890", fields[SiloInstanceRecord.GENERATION_PROPERTY_NAME].N);
+                Assert.Equal("-1", fields[SiloInstanceRecord.STATUS_PROPERTY_NAME].N);
+                Assert.Equal("-23456", fields[SiloInstanceRecord.PROXY_PORT_PROPERTY_NAME].N);
+                Assert.Equal("-2", fields[SiloInstanceRecord.MEMBERSHIP_VERSION_PROPERTY_NAME].N);
+                Assert.Equal("-3", fields[SiloInstanceRecord.ETAG_PROPERTY_NAME].N);
+
+                var roundTripped = new SiloInstanceRecord(fields);
+
+                Assert.Equal(instanceRecord.Port, roundTripped.Port);
+                Assert.Equal(instanceRecord.Generation, roundTripped.Generation);
+                Assert.Equal(instanceRecord.Status, roundTripped.Status);
+                Assert.Equal(instanceRecord.ProxyPort, roundTripped.ProxyPort);
+                Assert.Equal(instanceRecord.MembershipVersion, roundTripped.MembershipVersion);
+                Assert.Equal(instanceRecord.ETag, roundTripped.ETag);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Fact]
+        public void SiloIdentity_RoundTripsUsingInvariantCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CreateCultureWithNonInvariantNegativeSign();
+                var address = SiloAddress.New(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12345), 67890);
+
+                var identity = SiloInstanceRecord.ConstructSiloIdentity(address);
+
+                Assert.Equal("127.0.0.1-12345-67890", identity);
+                Assert.Equal(address, SiloInstanceRecord.UnpackRowKey(identity));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        private static CultureInfo CreateCultureWithNonInvariantNegativeSign()
+        {
+            var culture = (CultureInfo)CultureInfo.GetCultureInfo("fr-FR").Clone();
+            culture.NumberFormat.NegativeSign = "~";
+            return culture;
         }
     }
 }


### PR DESCRIPTION
## Problem

DynamoDB clustering persisted and parsed numeric membership fields, silo identity keys, and timestamps through culture-sensitive APIs. Connection-string and protocol-marker checks also relied on implicit string comparison semantics, leaving 30 CA1305/CA1307 findings in clustering-owned source.

## Solution

Use invariant integer formatting and parsing for DynamoDB numeric attributes, status values, ETags, versions, connection-string capacities, and silo identity keys. Parse the fixed membership timestamp representation exactly, and use explicit ordinal semantics for connection-string tokens, version-row markers, and DynamoDB conditional-failure markers. Enable CA1305 and CA1307 for clustering-owned C# files through a nested editorconfig, leaving linked shared sources under their separate rollout.

Add focused non-invariant-culture coverage for numeric field round-tripping, silo identity keys, connection-string capacities, and defunct-silo timestamp parsing.

## Rationale

DynamoDB membership rows and keys form a cross-process compatibility boundary. Their textual representations must remain stable across host cultures, and protocol identifiers require deterministic ordinal comparisons. Path-scoped analyzer enforcement keeps that invariant active without overlapping the shared DynamoDB or reminder work owned by other changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11051)