### PR TITLE
fix(core): enforce disposable ownership

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -668,17 +668,9 @@ dotnet_diagnostic.CA1873.severity = warning
 
 # CA1001: Types that own disposable fields should be disposable
 # CA2213: Disposable fields should be disposed
-[src/Orleans.Core/{Lifecycle/ServiceLifecycle,Lifecycle/ServiceLifecycleNotificationStage,Manifest/ClientClusterManifestProvider,Networking/ConnectionManager,Runtime/InvokableObjectManager,Runtime/OutsideRuntimeClient}.cs]
+[src/Orleans.Core/**.cs]
 dotnet_diagnostic.CA1001.severity = warning
 dotnet_diagnostic.CA2213.severity = warning
-
-# The message-oriented transport replacement in #10846 removes MessageSerializer's
-# reusable PrefixingBufferWriter and deletes SocketConnection.
-[src/Orleans.Core/Messaging/MessageSerializer.cs]
-dotnet_diagnostic.CA1001.severity = suggestion
-
-[src/Orleans.Core/Networking/Shared/SocketConnection.cs]
-dotnet_diagnostic.CA2213.severity = suggestion
 
 [src/Orleans.Runtime/Networking/**.cs]
 dotnet_diagnostic.CA1848.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -666,6 +666,20 @@ dotnet_diagnostic.CA1873.severity = warning
 [src/Orleans.Core/**.cs]
 dotnet_diagnostic.CA1873.severity = warning
 
+# CA1001: Types that own disposable fields should be disposable
+# CA2213: Disposable fields should be disposed
+[src/Orleans.Core/{Lifecycle/ServiceLifecycle,Lifecycle/ServiceLifecycleNotificationStage,Manifest/ClientClusterManifestProvider,Networking/ConnectionManager,Runtime/InvokableObjectManager,Runtime/OutsideRuntimeClient}.cs]
+dotnet_diagnostic.CA1001.severity = warning
+dotnet_diagnostic.CA2213.severity = warning
+
+# The message-oriented transport replacement in #10846 removes MessageSerializer's
+# reusable PrefixingBufferWriter and deletes SocketConnection.
+[src/Orleans.Core/Messaging/MessageSerializer.cs]
+dotnet_diagnostic.CA1001.severity = suggestion
+
+[src/Orleans.Core/Networking/Shared/SocketConnection.cs]
+dotnet_diagnostic.CA2213.severity = suggestion
+
 [src/Orleans.Runtime/Networking/**.cs]
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning

--- a/src/Orleans.Core/Async/AsyncLock.cs
+++ b/src/Orleans.Core/Async/AsyncLock.cs
@@ -44,7 +44,10 @@ namespace Orleans
     /// 3) LockReleaser is IDisposable to implement the "using" pattern.
     /// 4) LockReleaser does NOT have to implement the Finalizer function. If users forget to Dispose the LockReleaser (analogous to forgetting to release a mutex)
     /// the AsyncLock will remain locked, which may potentially cause deadlock. This is OK, since these are the exact regular mutex semantics - if one forgets to unlock the mutex, it stays locked.
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1001:Types that own disposable fields should be disposable",
+        Justification = "AsyncLock has mutex lifetime semantics: the semaphore remains available for every outstanding releaser and is reclaimed with the lock.")]
     internal class AsyncLock
     {
         private readonly SemaphoreSlim semaphore;

--- a/src/Orleans.Core/Lifecycle/ServiceLifecycle.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycle.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +26,7 @@ public interface IServiceLifecycle
 }
 
 internal sealed class ServiceLifecycle<TLifecycleObservable>(ILogger<ServiceLifecycle<TLifecycleObservable>> logger) :
-    IServiceLifecycle, ILifecycleParticipant<TLifecycleObservable>
+    IServiceLifecycle, ILifecycleParticipant<TLifecycleObservable>, IDisposable
         where TLifecycleObservable : ILifecycleObservable
 {
     private readonly ServiceLifecycleNotificationStage _started = new(logger, "Started");
@@ -35,6 +36,13 @@ internal sealed class ServiceLifecycle<TLifecycleObservable>(ILogger<ServiceLife
     public IServiceLifecycleStage Started => _started;
     public IServiceLifecycleStage Stopping => _stopping;
     public IServiceLifecycleStage Stopped => _stopped;
+
+    public void Dispose()
+    {
+        _started.Dispose();
+        _stopping.Dispose();
+        _stopped.Dispose();
+    }
 
     public void Participate(TLifecycleObservable lifecycle)
     {

--- a/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
@@ -46,7 +46,7 @@ public interface IServiceLifecycleStage
     IDisposable Register(Func<object?, CancellationToken, Task> callback, object? state = null, bool terminateOnError = true);
 }
 
-internal sealed partial class ServiceLifecycleNotificationStage(ILogger logger, string name) : IServiceLifecycleStage
+internal sealed partial class ServiceLifecycleNotificationStage(ILogger logger, string name) : IServiceLifecycleStage, IDisposable
 {
     // We use this so that late registrations can still be executed, otherwise
     // we'd need to rely on the TCS which means we'd need to set it *before* the callbacks
@@ -189,6 +189,8 @@ internal sealed partial class ServiceLifecycleNotificationStage(ILogger logger, 
             LogCancellationCallbackError(logger, ex, name);
         }
     }
+
+    public void Dispose() => _cts.Dispose();
 
     private async Task ExecuteParticipantAsync(StageParticipant participant, CancellationToken cancellationToken)
     {

--- a/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientClusterManifestProvider.cs
@@ -29,6 +29,7 @@ namespace Orleans.Runtime
         private readonly GatewayManager _gatewayManager;
         private readonly AsyncEnumerable<ClusterManifest> _updates;
         private readonly CancellationTokenSource _shutdownCts = new CancellationTokenSource();
+        private int _disposeState;
         private ClusterManifest _current;
         private Task? _runTask;
 
@@ -237,22 +238,46 @@ namespace Orleans.Runtime
             Justification = "Shutdown must signal cancellation immediately without awaiting callback completion before waiting for the run task.")]
         public async ValueTask DisposeAsync()
         {
-            if (_shutdownCts.IsCancellationRequested)
+            if (Interlocked.Exchange(ref _disposeState, 1) != 0)
             {
                 return;
             }
 
-            _shutdownCts.Cancel();
-            if (_runTask is Task task)
+            try
             {
-                await task.SuppressThrowing();
+                if (!_shutdownCts.IsCancellationRequested)
+                {
+                    _shutdownCts.Cancel();
+                }
+
+                if (_runTask is Task task)
+                {
+                    await task.SuppressThrowing();
+                }
+            }
+            finally
+            {
+                _shutdownCts.Dispose();
             }
         }
 
         /// <inheritdoc />
         public void Dispose()
         {
-            _shutdownCts.Cancel();
+            if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                _shutdownCts.Cancel();
+                _runTask?.SuppressThrowing().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                _shutdownCts.Dispose();
+            }
         }
 
         [LoggerMessage(

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -19,6 +19,10 @@ using static Orleans.Runtime.Message;
 
 namespace Orleans.Runtime.Messaging
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1001:Types that own disposable fields should be disposable",
+        Justification = "Each write resets the reusable buffer writer and releases any rented buffers. Making the transient serializer disposable would extend its lifetime through container tracking; the transport replacement in #10846 removes this field.")]
     internal sealed class MessageSerializer
     {
         private const int FramingLength = Message.LENGTH_HEADER_SIZE;

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -19,11 +19,7 @@ using static Orleans.Runtime.Message;
 
 namespace Orleans.Runtime.Messaging
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Design",
-        "CA1001:Types that own disposable fields should be disposable",
-        Justification = "Each write resets the reusable buffer writer and releases any rented buffers. Making the transient serializer disposable would extend its lifetime through container tracking; the transport replacement in #10846 removes this field.")]
-    internal sealed class MessageSerializer
+    internal sealed class MessageSerializer : IDisposable
     {
         private const int FramingLength = Message.LENGTH_HEADER_SIZE;
         private const int MessageSizeHint = 4096;
@@ -40,6 +36,7 @@ namespace Orleans.Runtime.Messaging
         private readonly int _maxBodyLength;
         private readonly DictionaryCodec<string, object> _requestContextCodec;
         private readonly PrefixingBufferWriter _bufferWriter;
+        private bool _disposed;
 
         public MessageSerializer(
             SerializerSessionPool sessionPool,
@@ -54,6 +51,19 @@ namespace Orleans.Runtime.Messaging
             _requestContextCodec = OrleansGeneratedCodeHelper.GetService<DictionaryCodec<string, object>>(this, sessionPool.CodecProvider);
             _grainAddressCacheUpdateCodec = OrleansGeneratedCodeHelper.GetService<IFieldCodec<GrainAddressCacheUpdate>>(this, sessionPool.CodecProvider);
             _bufferWriter = new(FramingLength, MessageSizeHint, memoryPool.Pool);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _bufferWriter.Dispose();
+            _serializationSession.Dispose();
+            _deserializationSession.Dispose();
         }
 
         public (int RequiredBytes, int HeaderLength, int BodyLength) TryRead(ref ReadOnlySequence<byte> input, out Message? message)

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -291,7 +291,8 @@ namespace Orleans.Runtime.Messaging
             await Task.Yield();
 
             Exception? error = default;
-            var serializer = this.shared.ServiceProvider.GetRequiredService<MessageSerializer>();
+            using var serializerScope = this.shared.ServiceProvider.CreateScope();
+            var serializer = serializerScope.ServiceProvider.GetRequiredService<MessageSerializer>();
             var prevBufferLength = 0L;
             try
             {
@@ -366,7 +367,8 @@ namespace Orleans.Runtime.Messaging
             await Task.Yield();
 
             Exception? error = default;
-            var serializer = this.shared.ServiceProvider.GetRequiredService<MessageSerializer>();
+            using var serializerScope = this.shared.ServiceProvider.CreateScope();
+            var serializer = serializerScope.ServiceProvider.GetRequiredService<MessageSerializer>();
             var messageObserver = this.shared.MessageStatisticsSink.GetMessageObserver();
             try
             {

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -321,7 +321,11 @@ namespace Orleans.Runtime.Messaging
                     if (closeTasks.Count > 0)
                     {
                         await Task.WhenAll(closeTasks).WaitAsync(ct).SuppressThrowing();
-                        if (ct.IsCancellationRequested) break;
+                        if (ct.IsCancellationRequested)
+                        {
+                            shutdownCompleted = IsQuiescent();
+                            break;
+                        }
                     }
                     else if (!pendingConnections)
                     {
@@ -330,7 +334,12 @@ namespace Orleans.Runtime.Messaging
                     }
 
                     await Task.Delay(10, ct).SuppressThrowing();
-                    if (ct.IsCancellationRequested) break;
+                    if (ct.IsCancellationRequested)
+                    {
+                        shutdownCompleted = IsQuiescent();
+                        break;
+                    }
+
                     if (++cycles > 100 && cycles % 500 == 0 && this.ConnectionCount is var remaining and > 0)
                     {
                         LogWarningWaitingForConnectionsToTerminate(this.logger, remaining);
@@ -349,6 +358,19 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 this.closedTaskCompletionSource.TrySetResult(0);
+            }
+
+            bool IsQuiescent()
+            {
+                foreach (var entry in connections.Values)
+                {
+                    if (entry.PendingConnection is not null || !entry.Connections.IsEmpty)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
         }
 

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -14,6 +14,10 @@ using Orleans.Internal;
 
 namespace Orleans.Runtime.Messaging
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1001:Types that own disposable fields should be disposable",
+        Justification = "The lifecycle adapter invokes the terminal asynchronous Close method, which disposes the cancellation source after all connections quiesce. A canceled host stop preserves it for remaining connection operations.")]
     internal sealed partial class ConnectionManager
     {
         [ThreadStatic]
@@ -288,6 +292,7 @@ namespace Orleans.Runtime.Messaging
             Justification = "Shutdown callbacks must complete synchronously before connections are scanned, while aggregating all callback failures.")]
         public async Task Close(CancellationToken ct)
         {
+            var shutdownCompleted = false;
             try
             {
                 LogDebugShuttingDownConnections(this.logger);
@@ -318,7 +323,11 @@ namespace Orleans.Runtime.Messaging
                         await Task.WhenAll(closeTasks).WaitAsync(ct).SuppressThrowing();
                         if (ct.IsCancellationRequested) break;
                     }
-                    else if (!pendingConnections) break;
+                    else if (!pendingConnections)
+                    {
+                        shutdownCompleted = true;
+                        break;
+                    }
 
                     await Task.Delay(10, ct).SuppressThrowing();
                     if (ct.IsCancellationRequested) break;
@@ -334,6 +343,11 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
+                if (shutdownCompleted)
+                {
+                    this.shutdownCancellation.Dispose();
+                }
+
                 this.closedTaskCompletionSource.TrySetResult(0);
             }
         }

--- a/src/Orleans.Core/Networking/Shared/SocketConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnection.cs
@@ -22,12 +22,12 @@ namespace Orleans.Networking.Shared
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Usage",
             "CA2213:Disposable fields should be disposed",
-            Justification = "The receive helper remains active for the connection processing lifetime and is disposed after both I/O loops complete.")]
+            Justification = "StartAsync joins both I/O loops and unconditionally disposes the receive helper in its finally block.")]
         private readonly SocketReceiver _receiver;
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Usage",
             "CA2213:Disposable fields should be disposed",
-            Justification = "The send helper remains active for the connection processing lifetime and is disposed after both I/O loops complete.")]
+            Justification = "StartAsync joins both I/O loops and unconditionally disposes the send helper in its finally block.")]
         private readonly SocketSender _sender;
         private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
 
@@ -96,22 +96,20 @@ namespace Orleans.Networking.Shared
 
         private async Task StartAsync()
         {
+            var receiveTask = DoReceive();
+            var sendTask = DoSend();
             try
             {
-                // Spawn send and receive logic
-                var receiveTask = DoReceive();
-                var sendTask = DoSend();
-
-                // Now wait for both to complete
-                await receiveTask;
-                await sendTask;
-
-                _receiver.Dispose();
-                _sender.Dispose();
+                await Task.WhenAll(receiveTask, sendTask);
             }
             catch (Exception ex)
             {
                 LogErrorUnexpectedExceptionInStartAsync(_trace, ex);
+            }
+            finally
+            {
+                _receiver.Dispose();
+                _sender.Dispose();
             }
         }
 

--- a/src/Orleans.Core/Networking/Shared/SocketConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnection.cs
@@ -19,7 +19,15 @@ namespace Orleans.Networking.Shared
 
         private readonly Socket _socket;
         private readonly ISocketsTrace _trace;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "The receive helper remains active for the connection processing lifetime and is disposed after both I/O loops complete.")]
         private readonly SocketReceiver _receiver;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "The send helper remains active for the connection processing lifetime and is disposed after both I/O loops complete.")]
         private readonly SocketSender _sender;
         private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
 

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -13,9 +13,8 @@ using Orleans.Serialization.Invocation;
 
 namespace Orleans
 {
-    internal sealed partial class InvokableObjectManager : IDisposable
+    internal sealed partial class InvokableObjectManager
     {
-        private readonly CancellationTokenSource disposed = new CancellationTokenSource();
         private readonly ConcurrentDictionary<ObserverGrainId, LocalObjectData> localObjects = new ConcurrentDictionary<ObserverGrainId, LocalObjectData>();
 
         private readonly InterfaceToImplementationMappingCache _interfaceToImplementationMapping;
@@ -74,13 +73,6 @@ namespace Orleans
             {
                 LogUnexpectedTargetInRequest(logger, message.TargetGrain, message);
             }
-        }
-
-        public void Dispose()
-        {
-            var tokenSource = this.disposed;
-            Utils.SafeExecute(() => tokenSource?.Cancel(false));
-            Utils.SafeExecute(() => tokenSource?.Dispose());
         }
 
         public sealed partial class LocalObjectData : IGrainContext, IGrainCallCancellationExtension

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -39,6 +39,10 @@ namespace Orleans
 
         public IInternalGrainFactory InternalGrainFactory { get; private set; } = null!;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "This field is a non-owning view of the singleton registered in the service provider. The client coordinates StopAsync, and the service provider owns disposal.")]
         private ClientClusterManifestProvider? _manifestProvider;
         private MessageFactory? messageFactory;
         private readonly LocalClientDetails _localClientDetails;
@@ -436,7 +440,7 @@ namespace Orleans
             this.disposing = true;
             Volatile.Write(ref _isStopping, 1);
 
-            Utils.SafeExecute(() => this.callbackTimer.Dispose());
+            this.callbackTimer.Dispose();
             BreakOutstandingMessages();
 
             Utils.SafeExecute(() => MessageCenter?.Dispose());


### PR DESCRIPTION
## Problem

The latest main analyzer audit reports ambiguous disposable ownership in Orleans.Core. CA1001 and CA2213 need project-wide enforcement with explicit ownership decisions for intentional lifetime patterns.

## Solution

- Enforce CA1001 and CA2213 for every source file in `Orleans.Core`.
- Dispose service lifecycle stages through their DI-owned parent, and dispose connection cancellation state after quiescent shutdown, including the final timeout-cancellation check.
- Make client manifest disposal idempotent and wait for its refresh loop before releasing cancellation state.
- Remove the unused disposable state from `InvokableObjectManager`, directly dispose the callback timer, and document the manifest provider field as a non-owning singleton view.
- Give each connection I/O loop a DI scope so its `MessageSerializer` deterministically returns pooled serializer sessions and releases its reusable buffer writer.
- Keep the intentional `AsyncLock` and socket I/O helper lifetimes as exact code-level suppressions with ownership rationale.
- Join both socket I/O loops and unconditionally dispose their helpers on exceptional processing exits.

## Rationale

Project-wide enforcement ensures new disposable ownership issues fail the Orleans.Core build. Explicit lifecycle boundaries and code-local suppressions keep exceptional lifetime guarantees reviewable beside their implementations while preserving shutdown ordering, pooling behavior, socket ownership, and asynchronous cleanup.