### PR TITLE
fix: support single-file metadata discovery

### DIFF
--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Orleans</RootNamespace>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <EnableSingleFileAnalyzer Condition="'$(TargetFramework)' == 'net10.0'">true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Core/Runtime/RuntimeVersion.cs
+++ b/src/Orleans.Core/Runtime/RuntimeVersion.cs
@@ -13,10 +13,7 @@ namespace Orleans.Runtime
 
         internal static string GetVersion(Assembly assembly)
         {
-            if (assembly is null)
-            {
-                throw new ArgumentNullException(nameof(assembly));
-            }
+            ArgumentNullException.ThrowIfNull(assembly);
 
             var apiVersion = assembly.GetName().Version!.ToString();
             var productVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;

--- a/src/Orleans.Core/Runtime/RuntimeVersion.cs
+++ b/src/Orleans.Core/Runtime/RuntimeVersion.cs
@@ -6,7 +6,8 @@ namespace Orleans.Runtime
     internal static class RuntimeVersion
     {
         /// <summary>
-        /// The full version string of the Orleans runtime, eg: '2012.5.9.51607 Build:12345 Timestamp: 20120509-185359'
+        /// The informational version of the Orleans runtime and its build configuration,
+        /// or the assembly version when informational version metadata is unavailable.
         /// </summary>
         public static string Current => GetVersion(typeof(RuntimeVersion).Assembly);
 

--- a/src/Orleans.Core/Runtime/RuntimeVersion.cs
+++ b/src/Orleans.Core/Runtime/RuntimeVersion.cs
@@ -8,21 +8,20 @@ namespace Orleans.Runtime
         /// <summary>
         /// The full version string of the Orleans runtime, eg: '2012.5.9.51607 Build:12345 Timestamp: 20120509-185359'
         /// </summary>
-        public static string Current
+        public static string Current => GetVersion(typeof(RuntimeVersion).Assembly);
+
+        internal static string GetVersion(Assembly assembly)
         {
-            get
+            if (assembly is null)
             {
-                Assembly thisProg = typeof(RuntimeVersion).Assembly;
-                var ApiVersion = thisProg.GetName().Version!.ToString();
-                if (string.IsNullOrWhiteSpace(thisProg.Location))
-                {
-                    return ApiVersion;
-                }
-                FileVersionInfo progVersionInfo = FileVersionInfo.GetVersionInfo(thisProg.Location);
-                bool isDebug = IsAssemblyDebugBuild(thisProg);
-                string productVersion = progVersionInfo.ProductVersion + (isDebug ? " (Debug)." : " (Release)."); // progVersionInfo.IsDebug; does not work
-                return string.IsNullOrEmpty(productVersion) ? ApiVersion : productVersion;
+                throw new ArgumentNullException(nameof(assembly));
             }
+
+            var apiVersion = assembly.GetName().Version!.ToString();
+            var productVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            return string.IsNullOrWhiteSpace(productVersion)
+                ? apiVersion
+                : productVersion + (IsAssemblyDebugBuild(assembly) ? " (Debug)." : " (Release).");
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
@@ -212,17 +212,18 @@ namespace Orleans.Serialization.Internal
 #if NET9_0_OR_GREATER
         [FeatureGuard(typeof(RequiresAssemblyFilesAttribute))]
 #endif
+        internal static bool AssemblyFilesAvailable => AreAssemblyFilesAvailable(Assembly.GetEntryAssembly());
+
         [UnconditionalSuppressMessage(
             "SingleFile",
             "IL3000",
             Justification = "Assembly.Location is used only as the documented availability check for bundled assembly files.")]
-        internal static bool AssemblyFilesAvailable
+        internal static bool AreAssemblyFilesAvailable(Assembly? entryAssembly)
         {
-            get
-            {
-                var assembly = Assembly.GetEntryAssembly() ?? typeof(ReferencedAssemblyProvider).Assembly;
-                return !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location);
-            }
+            var assembly = entryAssembly is null || entryAssembly.IsDynamic
+                ? typeof(ReferencedAssemblyProvider).Assembly
+                : entryAssembly;
+            return !string.IsNullOrEmpty(assembly.Location);
         }
 #endif
 

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
@@ -134,9 +134,7 @@ namespace Orleans.Serialization.Internal
         /// <param name="assembly">
         /// The assembly whose dependency context is inspected, or <see langword="null"/> to use the entry assembly.
         /// </param>
-#if NET5_0_OR_GREATER
         [RequiresAssemblyFiles("Dependency-context discovery reads assembly files. Use GetRelevantAssemblies for single-file-compatible discovery.")]
-#endif
         public static void AddFromDependencyContext(HashSet<Assembly> parts, Assembly? assembly = null)
         {
             assembly ??= Assembly.GetEntryAssembly();

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyModel;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -23,8 +24,21 @@ namespace Orleans.Serialization.Internal
         public static IEnumerable<Assembly> GetRelevantAssemblies()
         {
             var parts = new HashSet<Assembly>();
+            var entryAssembly = Assembly.GetEntryAssembly();
 
-            AddFromDependencyContext(parts);
+            if (entryAssembly is not null)
+            {
+                AddAssembly(parts, entryAssembly);
+            }
+
+#if NET5_0_OR_GREATER
+            if (AssemblyFilesAvailable)
+            {
+                AddFromDependencyContext(parts, entryAssembly);
+            }
+#else
+            AddFromDependencyContext(parts, entryAssembly);
+#endif
 
 #if NETCOREAPP3_1_OR_GREATER
             AddFromAssemblyLoadContext(parts);
@@ -120,6 +134,9 @@ namespace Orleans.Serialization.Internal
         /// <param name="assembly">
         /// The assembly whose dependency context is inspected, or <see langword="null"/> to use the entry assembly.
         /// </param>
+#if NET5_0_OR_GREATER
+        [RequiresAssemblyFiles("Dependency-context discovery reads assembly files. Use GetRelevantAssemblies for single-file-compatible discovery.")]
+#endif
         public static void AddFromDependencyContext(HashSet<Assembly> parts, Assembly? assembly = null)
         {
             assembly ??= Assembly.GetEntryAssembly();
@@ -192,6 +209,24 @@ namespace Orleans.Serialization.Internal
                 }
             }
         }
+
+#if NET5_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        [FeatureGuard(typeof(RequiresAssemblyFilesAttribute))]
+#endif
+        [UnconditionalSuppressMessage(
+            "SingleFile",
+            "IL3000",
+            Justification = "Assembly.Location is used only as the documented availability check for bundled assembly files.")]
+        internal static bool AssemblyFilesAvailable
+        {
+            get
+            {
+                var assembly = Assembly.GetEntryAssembly() ?? typeof(ReferencedAssemblyProvider).Assembly;
+                return !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location);
+            }
+        }
+#endif
 
         private static IEnumerable<Assembly> GetApplicationPartAssemblies(Assembly assembly)
         {

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
@@ -31,14 +31,10 @@ namespace Orleans.Serialization.Internal
                 AddAssembly(parts, entryAssembly);
             }
 
-#if NET5_0_OR_GREATER
             if (AssemblyFilesAvailable)
             {
                 AddFromDependencyContext(parts, entryAssembly);
             }
-#else
-            AddFromDependencyContext(parts, entryAssembly);
-#endif
 
 #if NETCOREAPP3_1_OR_GREATER
             AddFromAssemblyLoadContext(parts);
@@ -208,16 +204,17 @@ namespace Orleans.Serialization.Internal
             }
         }
 
-#if NET5_0_OR_GREATER
 #if NET9_0_OR_GREATER
         [FeatureGuard(typeof(RequiresAssemblyFilesAttribute))]
 #endif
         internal static bool AssemblyFilesAvailable => AreAssemblyFilesAvailable(Assembly.GetEntryAssembly());
 
+#if NET5_0_OR_GREATER
         [UnconditionalSuppressMessage(
             "SingleFile",
             "IL3000",
             Justification = "Assembly.Location is used only as the documented availability check for bundled assembly files.")]
+#endif
         internal static bool AreAssemblyFilesAvailable(Assembly? entryAssembly)
         {
             var assembly = entryAssembly is null || entryAssembly.IsDynamic
@@ -225,7 +222,6 @@ namespace Orleans.Serialization.Internal
                 : entryAssembly;
             return !string.IsNullOrEmpty(assembly.Location);
         }
-#endif
 
         private static IEnumerable<Assembly> GetApplicationPartAssemblies(Assembly assembly)
         {

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
@@ -134,7 +134,7 @@ namespace Orleans.Serialization.Internal
         /// <param name="assembly">
         /// The assembly whose dependency context is inspected, or <see langword="null"/> to use the entry assembly.
         /// </param>
-        [RequiresAssemblyFiles("Dependency-context discovery reads assembly files. Use GetRelevantAssemblies for single-file-compatible discovery.")]
+        [RequiresAssemblyFiles("Dependency-context discovery reads assembly files. Use " + nameof(GetRelevantAssemblies) + " for single-file-compatible discovery.")]
         public static void AddFromDependencyContext(HashSet<Assembly> parts, Assembly? assembly = null)
         {
             assembly ??= Assembly.GetEntryAssembly();

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
@@ -70,8 +70,6 @@ namespace Orleans.Serialization.Internal
                 return;
             }
 
-            AddAssembly(parts, assembly);
-
             // Add all referenced application parts.
             foreach (var referencedAsm in GetApplicationPartAssemblies(assembly))
             {

--- a/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
+++ b/src/Orleans.Serialization/Hosting/ReferencedAssemblyProvider.cs
@@ -220,7 +220,7 @@ namespace Orleans.Serialization.Internal
             var assembly = entryAssembly is null || entryAssembly.IsDynamic
                 ? typeof(ReferencedAssemblyProvider).Assembly
                 : entryAssembly;
-            return !string.IsNullOrEmpty(assembly.Location);
+            return File.Exists(assembly.Location);
         }
 
         private static IEnumerable<Assembly> GetApplicationPartAssemblies(Assembly assembly)

--- a/src/Orleans.Serialization/Orleans.Serialization.csproj
+++ b/src/Orleans.Serialization/Orleans.Serialization.csproj
@@ -8,6 +8,7 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <EnableSingleFileAnalyzer Condition="'$(TargetFramework)' == 'net10.0'">true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Serialization/Properties/RequiresAssemblyFilesAttribute.cs
+++ b/src/Orleans.Serialization/Properties/RequiresAssemblyFilesAttribute.cs
@@ -1,0 +1,23 @@
+#if NETSTANDARD2_1
+namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(
+    AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Property,
+    Inherited = false,
+    AllowMultiple = false)]
+internal sealed class RequiresAssemblyFilesAttribute : Attribute
+{
+    public RequiresAssemblyFilesAttribute()
+    {
+    }
+
+    public RequiresAssemblyFilesAttribute(string message)
+    {
+        Message = message;
+    }
+
+    public string? Message { get; }
+
+    public string? Url { get; set; }
+}
+#endif

--- a/src/api/Orleans.Serialization/Orleans.Serialization.cs
+++ b/src/api/Orleans.Serialization/Orleans.Serialization.cs
@@ -3451,6 +3451,7 @@ namespace Orleans.Serialization.Internal
 
         public static void AddFromAssemblyLoadContext(System.Collections.Generic.HashSet<System.Reflection.Assembly> parts, System.Runtime.Loader.AssemblyLoadContext context) { }
 
+        [System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute("Dependency-context discovery reads assembly files. Use GetRelevantAssemblies for single-file-compatible discovery.")]
         public static void AddFromDependencyContext(System.Collections.Generic.HashSet<System.Reflection.Assembly> parts, System.Reflection.Assembly? assembly = null) { }
 
         public static System.Collections.Generic.IEnumerable<System.Reflection.Assembly> GetRelevantAssemblies() { throw null; }

--- a/test/Orleans.Core.Tests/RuntimeVersionTests.cs
+++ b/test/Orleans.Core.Tests/RuntimeVersionTests.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using Orleans.Runtime;
+using Xunit;
+
+namespace NonSilo.Tests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+public sealed class RuntimeVersionTests
+{
+    [Fact]
+    public void GetVersionUsesInformationalVersionMetadataForFilelessAssembly()
+    {
+        var assembly = CreateAssembly(
+            new Version(1, 2, 3, 4),
+            informationalVersion: "9.8.7+metadata",
+            isDebug: true);
+
+        var result = RuntimeVersion.GetVersion(assembly);
+
+        Assert.Equal("9.8.7+metadata (Debug).", result);
+    }
+
+    [Fact]
+    public void GetVersionUsesAssemblyVersionWhenInformationalVersionIsUnavailable()
+    {
+        var assembly = CreateAssembly(new Version(1, 2, 3, 4));
+
+        var result = RuntimeVersion.GetVersion(assembly);
+
+        Assert.Equal("1.2.3.4", result);
+    }
+
+    private static Assembly CreateAssembly(
+        Version version,
+        string? informationalVersion = null,
+        bool isDebug = false)
+    {
+        var name = new AssemblyName($"RuntimeVersionTests_{Guid.NewGuid():N}") { Version = version };
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run);
+        if (informationalVersion is not null)
+        {
+            var constructor = typeof(AssemblyInformationalVersionAttribute).GetConstructor([typeof(string)])!;
+            assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, [informationalVersion]));
+        }
+
+        if (isDebug)
+        {
+            var constructor = typeof(DebuggableAttribute).GetConstructor([typeof(DebuggableAttribute.DebuggingModes)])!;
+            var modes = DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations;
+            assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, [modes]));
+        }
+
+        return assembly;
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -43,7 +43,7 @@
   <Target
     Name="CopyNetStandardSerializationAsset"
     AfterTargets="Build"
-    Condition="'$(TargetFramework)' == 'net10.0'">
+    Condition="'$(TargetFramework)' == 'net10.0' and '$(DesignTimeBuild)' != 'true'">
     <MSBuild
       Projects="$(SourceRoot)src\Orleans.Serialization\Orleans.Serialization.csproj"
       Targets="Build"
@@ -51,7 +51,8 @@
       Properties="Configuration=$(Configuration);TargetFramework=netstandard2.1" />
     <Copy
       SourceFiles="$(SourceRoot)src\Orleans.Serialization\bin\$(Configuration)\netstandard2.1\Orleans.Serialization.dll"
-      DestinationFolder="$(TargetDir)TestAssets" />
+      DestinationFolder="$(TargetDir)TestAssets"
+      SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -40,4 +40,18 @@
     <Protobuf Include="protobuf-model.proto" GrpcServices="None" />
   </ItemGroup>
 
+  <Target
+    Name="CopyNetStandardSerializationAsset"
+    AfterTargets="Build"
+    Condition="'$(TargetFramework)' == 'net10.0'">
+    <MSBuild
+      Projects="$(SourceRoot)src\Orleans.Serialization\Orleans.Serialization.csproj"
+      Targets="Build"
+      RemoveProperties="RuntimeIdentifier;SelfContained;TargetFramework"
+      Properties="Configuration=$(Configuration);TargetFramework=netstandard2.1" />
+    <Copy
+      SourceFiles="$(SourceRoot)src\Orleans.Serialization\bin\$(Configuration)\netstandard2.1\Orleans.Serialization.dll"
+      DestinationFolder="$(TargetDir)TestAssets" />
+  </Target>
+
 </Project>

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -38,9 +38,12 @@ public sealed class ReferencedAssemblyProviderTests
     [Fact]
     public void GetRelevantAssembliesIncludesGeneratedEntryAssemblyMetadata()
     {
+        var entryAssembly = Assembly.GetEntryAssembly();
         var result = ReferencedAssemblyProvider.GetRelevantAssemblies().ToHashSet();
 
-        Assert.Contains(typeof(ReferencedAssemblyProviderTests).Assembly, result);
+        Assert.NotNull(entryAssembly);
+        Assert.Same(typeof(ReferencedAssemblyProviderTests).Assembly, entryAssembly);
+        Assert.Contains(entryAssembly, result);
     }
 
     [Fact]

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 #if NET10_0_OR_GREATER
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 #endif
 using Orleans.Serialization.Internal;
@@ -92,10 +93,20 @@ public sealed class ReferencedAssemblyProviderTests
             .Single(method => metadata.GetString(method.Name) == nameof(ReferencedAssemblyProvider.AddFromDependencyContext));
         var attributeNames = method.GetCustomAttributes()
             .Select(handle => GetAttributeTypeName(metadata, metadata.GetCustomAttribute(handle)));
+        var assemblyFilesAvailableGetter = providerType.GetMethods()
+            .Single(handle => metadata.GetString(metadata.GetMethodDefinition(handle).Name) == "get_AssemblyFilesAvailable");
+        var getRelevantAssemblies = providerType.GetMethods()
+            .Select(handle => (Handle: handle, Definition: metadata.GetMethodDefinition(handle)))
+            .Single(method => metadata.GetString(method.Definition.Name) == nameof(ReferencedAssemblyProvider.GetRelevantAssemblies));
+        var methodBody = peReader.GetMethodBody(getRelevantAssemblies.Definition.RelativeVirtualAddress);
+        var expectedCall = new byte[5];
+        expectedCall[0] = 0x28;
+        BitConverter.TryWriteBytes(expectedCall.AsSpan(1), MetadataTokens.GetToken(assemblyFilesAvailableGetter));
 
         Assert.Contains(
             "System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute",
             attributeNames);
+        Assert.True(methodBody.GetILBytes().AsSpan().IndexOf(expectedCall) >= 0);
     }
 #endif
 

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Orleans.Serialization.Internal;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Serialization")]
+public sealed class ReferencedAssemblyProviderTests
+{
+    [Fact]
+    public void AddAssemblyDiscoversGeneratedApplicationPartsWithoutAssemblyFiles()
+    {
+        var referencedAssembly = typeof(ReferencedAssemblyProviderTests).Assembly;
+        var assembly = CreateApplicationPartAssembly(referencedAssembly.GetName().Name!);
+        var result = new HashSet<Assembly>();
+
+        ReferencedAssemblyProvider.AddAssembly(result, assembly);
+
+        Assert.True(assembly.IsDynamic);
+        Assert.Contains(assembly, result);
+        Assert.Contains(referencedAssembly, result);
+    }
+
+    [Fact]
+    public void GetRelevantAssembliesIncludesGeneratedEntryAssemblyMetadata()
+    {
+        var result = ReferencedAssemblyProvider.GetRelevantAssemblies().ToHashSet();
+
+        Assert.Contains(typeof(ReferencedAssemblyProviderTests).Assembly, result);
+    }
+
+    [Fact]
+    public void DependencyContextDiscoveryExposesAssemblyFileRequirement()
+    {
+        var method = typeof(ReferencedAssemblyProvider).GetMethod(
+            nameof(ReferencedAssemblyProvider.AddFromDependencyContext));
+
+        var attribute = method!.GetCustomAttribute<RequiresAssemblyFilesAttribute>();
+
+        Assert.NotNull(attribute);
+        Assert.Contains(nameof(ReferencedAssemblyProvider.GetRelevantAssemblies), attribute!.Message);
+    }
+
+    private static Assembly CreateApplicationPartAssembly(string referencedAssemblyName)
+    {
+        var name = new AssemblyName($"ReferencedAssemblyProviderTests_{Guid.NewGuid():N}");
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run);
+        var constructor = typeof(ApplicationPartAttribute).GetConstructor([typeof(string)])!;
+        assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, [referencedAssemblyName]));
+        assembly.DefineDynamicModule("Main");
+        return assembly;
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -37,14 +37,13 @@ public sealed class ReferencedAssemblyProviderTests
     }
 
     [Fact]
-    public void GetRelevantAssembliesIncludesGeneratedEntryAssemblyMetadata()
+    public void GetRelevantAssembliesIncludesLoadedGeneratedAssembly()
     {
-        var entryAssembly = Assembly.GetEntryAssembly();
+        var assembly = typeof(ReferencedAssemblyProviderTests).Assembly;
         var result = ReferencedAssemblyProvider.GetRelevantAssemblies().ToHashSet();
 
-        Assert.NotNull(entryAssembly);
-        Assert.Same(typeof(ReferencedAssemblyProviderTests).Assembly, entryAssembly);
-        Assert.Contains(entryAssembly, result);
+        Assert.True(assembly.IsDefined(typeof(ApplicationPartAttribute)));
+        Assert.Contains(assembly, result);
     }
 
     [Fact]

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -55,6 +55,19 @@ public sealed class ReferencedAssemblyProviderTests
         Assert.Contains(nameof(ReferencedAssemblyProvider.GetRelevantAssemblies), attribute!.Message);
     }
 
+    [Fact]
+    public void AssemblyFileAvailabilityUsesProviderAssemblyForDynamicEntryAssembly()
+    {
+        var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"DynamicEntryAssembly_{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.Run);
+
+        Assert.True(ReferencedAssemblyProvider.AreAssemblyFilesAvailable(null));
+        Assert.Equal(
+            ReferencedAssemblyProvider.AreAssemblyFilesAvailable(null),
+            ReferencedAssemblyProvider.AreAssemblyFilesAvailable(dynamicAssembly));
+    }
+
 #if NET10_0_OR_GREATER
     [Fact]
     public void NetStandardAssetDependencyContextDiscoveryExposesAssemblyFileRequirement()

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -75,7 +75,7 @@ public sealed class ReferencedAssemblyProviderTests
     [Fact]
     public void AssemblyFileAvailabilityIsFalseForMemoryLoadedAssembly()
     {
-        var assembly = Assembly.Load(File.ReadAllBytes(typeof(ReferencedAssemblyProviderTests).Assembly.Location));
+        var assembly = Assembly.Load(File.ReadAllBytes(typeof(Enumerable).Assembly.Location));
 
         Assert.Empty(assembly.Location);
         Assert.False(ReferencedAssemblyProvider.AreAssemblyFilesAvailable(assembly));

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -4,9 +4,7 @@ using System.Buffers.Binary;
 #endif
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-#if NET10_0_OR_GREATER
 using System.IO;
-#endif
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -72,6 +70,15 @@ public sealed class ReferencedAssemblyProviderTests
         Assert.Equal(
             ReferencedAssemblyProvider.AreAssemblyFilesAvailable(null),
             ReferencedAssemblyProvider.AreAssemblyFilesAvailable(dynamicAssembly));
+    }
+
+    [Fact]
+    public void AssemblyFileAvailabilityIsFalseForMemoryLoadedAssembly()
+    {
+        var assembly = Assembly.Load(File.ReadAllBytes(typeof(ReferencedAssemblyProviderTests).Assembly.Location));
+
+        Assert.Empty(assembly.Location);
+        Assert.False(ReferencedAssemblyProvider.AreAssemblyFilesAvailable(assembly));
     }
 
 #if NET10_0_OR_GREATER

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -1,9 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+#if NET10_0_OR_GREATER
+using System.IO;
+#endif
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+#if NET10_0_OR_GREATER
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+#endif
 using Orleans.Serialization.Internal;
 
 namespace Orleans.Serialization.UnitTests;
@@ -48,6 +55,34 @@ public sealed class ReferencedAssemblyProviderTests
         Assert.Contains(nameof(ReferencedAssemblyProvider.GetRelevantAssemblies), attribute!.Message);
     }
 
+#if NET10_0_OR_GREATER
+    [Fact]
+    public void NetStandardAssetDependencyContextDiscoveryExposesAssemblyFileRequirement()
+    {
+        var assemblyPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "TestAssets",
+            "Orleans.Serialization.dll");
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+        var providerType = metadata.TypeDefinitions
+            .Select(metadata.GetTypeDefinition)
+            .Single(type =>
+                metadata.GetString(type.Namespace) == "Orleans.Serialization.Internal"
+                && metadata.GetString(type.Name) == nameof(ReferencedAssemblyProvider));
+        var method = providerType.GetMethods()
+            .Select(metadata.GetMethodDefinition)
+            .Single(method => metadata.GetString(method.Name) == nameof(ReferencedAssemblyProvider.AddFromDependencyContext));
+        var attributeNames = method.GetCustomAttributes()
+            .Select(handle => GetAttributeTypeName(metadata, metadata.GetCustomAttribute(handle)));
+
+        Assert.Contains(
+            "System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute",
+            attributeNames);
+    }
+#endif
+
     private static Assembly CreateApplicationPartAssembly(string referencedAssemblyName)
     {
         var name = new AssemblyName($"ReferencedAssemblyProviderTests_{Guid.NewGuid():N}");
@@ -57,4 +92,29 @@ public sealed class ReferencedAssemblyProviderTests
         assembly.DefineDynamicModule("Main");
         return assembly;
     }
+
+#if NET10_0_OR_GREATER
+    private static string GetAttributeTypeName(MetadataReader metadata, CustomAttribute attribute)
+    {
+        var typeHandle = attribute.Constructor.Kind switch
+        {
+            HandleKind.MemberReference => metadata.GetMemberReference((MemberReferenceHandle)attribute.Constructor).Parent,
+            HandleKind.MethodDefinition => metadata.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor).GetDeclaringType(),
+            _ => throw new InvalidOperationException($"Unsupported attribute constructor handle: {attribute.Constructor.Kind}."),
+        };
+
+        return typeHandle.Kind switch
+        {
+            HandleKind.TypeDefinition => GetTypeName(metadata, metadata.GetTypeDefinition((TypeDefinitionHandle)typeHandle)),
+            HandleKind.TypeReference => GetTypeName(metadata, metadata.GetTypeReference((TypeReferenceHandle)typeHandle)),
+            _ => throw new InvalidOperationException($"Unsupported attribute type handle: {typeHandle.Kind}."),
+        };
+    }
+
+    private static string GetTypeName(MetadataReader metadata, TypeDefinition type)
+        => $"{metadata.GetString(type.Namespace)}.{metadata.GetString(type.Name)}";
+
+    private static string GetTypeName(MetadataReader metadata, TypeReference type)
+        => $"{metadata.GetString(type.Namespace)}.{metadata.GetString(type.Name)}";
+#endif
 }

--- a/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReferencedAssemblyProviderTests.cs
@@ -1,4 +1,7 @@
 using System;
+#if NET10_0_OR_GREATER
+using System.Buffers.Binary;
+#endif
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 #if NET10_0_OR_GREATER
@@ -100,7 +103,9 @@ public sealed class ReferencedAssemblyProviderTests
         var methodBody = peReader.GetMethodBody(getRelevantAssemblies.Definition.RelativeVirtualAddress);
         var expectedCall = new byte[5];
         expectedCall[0] = 0x28;
-        BitConverter.TryWriteBytes(expectedCall.AsSpan(1), MetadataTokens.GetToken(assemblyFilesAvailableGetter));
+        BinaryPrimitives.WriteInt32LittleEndian(
+            expectedCall.AsSpan(1),
+            MetadataTokens.GetToken(assemblyFilesAvailableGetter));
 
         Assert.Contains(
             "System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute",


### PR DESCRIPTION
## Problem

The .NET single-file analyzer reported file-based metadata access in runtime version reporting and serializer application-part discovery. Bundled assemblies have no `Assembly.Location`, and `DependencyContext` discovery requires physical assembly files.

## Solution

Read the runtime product version from `AssemblyInformationalVersionAttribute`, preserving the assembly-version fallback and build-configuration suffix. Serializer discovery now starts from generated `ApplicationPartAttribute` metadata and loaded assemblies, while dependency-context discovery runs only when assembly files are available. The public file-based API is annotated with `RequiresAssemblyFiles`, and the single-file analyzer is enabled for the affected net10 projects. Focused tests cover fileless version metadata, generated application-part traversal, entry-assembly discovery, and the public assembly-file contract.

## Rationale

Assembly attributes and generated application-part registrations are available from memory-loaded assemblies, so they provide stable metadata and discovery in bundled apps. Framework-dependent deployments retain dependency-context scanning for assemblies which have not yet loaded, while callers of the explicit file-based API receive an accurate compatibility contract.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11054)