### PR TITLE
fix(core): make interface mapping trim-safe

### DIFF
--- a/src/Orleans.Core/CodeGeneration/GrainInterfaceUtils.cs
+++ b/src/Orleans.Core/CodeGeneration/GrainInterfaceUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Orleans.Runtime;
@@ -43,7 +44,7 @@ namespace Orleans.CodeGeneration
                 {
                     if (grainType.IsClass)
                     {
-                        var mapping = grainType.GetInterfaceMap(iType);
+                        var mapping = GetInterfaceMap(grainType, iType);
                         foreach (var methodInfo in iType.GetMethods(BindingFlags.Instance | BindingFlags.Public))
                         {
                             foreach (var info in mapping.TargetMethods)
@@ -100,6 +101,12 @@ namespace Orleans.CodeGeneration
                 return typeof(IAddressable).IsAssignableFrom(t);
             }
         }
+
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2067",
+            Justification = "Grain interface methods are statically referenced by generated invokables, which cache their MethodInfo and invoke them through strongly typed calls. Interface types reach this boundary through Type.GetInterfaces() or MethodInfo.DeclaringType, neither of which can propagate DynamicallyAccessedMembers annotations.")]
+        internal static InterfaceMapping GetInterfaceMap(Type implementationType, Type interfaceType) => implementationType.GetInterfaceMap(interfaceType);
 
         public static int GetGrainClassTypeCode(Type grainClass) => (int)StableHash.ComputeHash(RuntimeTypeNameFormatter.Format(grainClass));
 

--- a/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
+++ b/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
@@ -89,6 +89,11 @@ namespace Orleans
         /// </returns>
         public Dictionary<MethodInfo, Entry> GetOrCreate(Type implementationType, Type interfaceType)
         {
+            if (!interfaceType.IsInterface)
+            {
+                throw new ArgumentException($"Type {interfaceType} is not an interface", nameof(interfaceType));
+            }
+
             if (!interfaceType.IsAssignableFrom(implementationType))
             {
                 throw new InvalidOperationException($"Type {implementationType} does not implement interface {interfaceType}");
@@ -100,11 +105,12 @@ namespace Orleans
         }
 
         /// <summary>
-        /// Maps the provided <paramref name="interfaceType"/> onto <paramref name="implementationType"/>.
+        /// Maps each method from <paramref name="interfaceType"/>, including inherited interface methods,
+        /// to its implementation on <paramref name="implementationType"/>.
         /// </summary>
         /// <param name="implementationType">The implementation type.</param>
         /// <param name="interfaceType">The interface type.</param>
-        /// <returns>The mapped interface.</returns>
+        /// <returns>A mapping from interface methods to implementation methods.</returns>
         private static Dictionary<MethodInfo, Entry> CreateInterfaceToImplementationMap(Type implementationType, Type interfaceType)
         {
             var methods = GrainInterfaceUtils.GetMethods(interfaceType);

--- a/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
+++ b/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
@@ -80,12 +80,13 @@ namespace Orleans
         private readonly ConcurrentDictionary<(Type ImplementationType, Type InterfaceType), Dictionary<MethodInfo, Entry>> mappings = new();
 
         /// <summary>
-        /// Returns a mapping from method id to method info for the provided implementation and interface types.
+        /// Returns a mapping from each interface method to its interface and implementation method metadata
+        /// for the provided implementation and interface types.
         /// </summary>
         /// <param name="implementationType">The implementation type.</param>
         /// <param name="interfaceType">The interface type.</param>
         /// <returns>
-        /// A mapping from method id to method info.
+        /// A mapping from interface methods to interface and implementation method metadata.
         /// </returns>
         public Dictionary<MethodInfo, Entry> GetOrCreate(Type implementationType, Type interfaceType)
         {

--- a/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
+++ b/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
@@ -75,9 +75,9 @@ namespace Orleans
         }
 
         /// <summary>
-        /// The map from implementation types to interface types to map of method to method infos.
+        /// The map from implementation and interface types to method mappings.
         /// </summary>
-        private readonly ConcurrentDictionary<Type, Dictionary<Type, Dictionary<MethodInfo, Entry>>> mappings = new();
+        private readonly ConcurrentDictionary<(Type ImplementationType, Type InterfaceType), Dictionary<MethodInfo, Entry>> mappings = new();
 
         /// <summary>
         /// Returns a mapping from method id to method info for the provided implementation and interface types.
@@ -89,65 +89,50 @@ namespace Orleans
         /// </returns>
         public Dictionary<MethodInfo, Entry> GetOrCreate(Type implementationType, Type interfaceType)
         {
-            // Get or create the mapping between interfaceId and invoker for the provided type.
-            if (!this.mappings.TryGetValue(implementationType, out var invokerMap))
-            {
-                // Generate an the invoker mapping using the provided invoker.
-                invokerMap = mappings.GetOrAdd(implementationType, CreateInterfaceToImplementationMap(implementationType));
-            }
-
-            // Attempt to get the invoker for the provided interfaceId.
-            if (!invokerMap.TryGetValue(interfaceType, out var interfaceToImplementationMap))
+            if (!interfaceType.IsAssignableFrom(implementationType))
             {
                 throw new InvalidOperationException($"Type {implementationType} does not implement interface {interfaceType}");
             }
 
-            return interfaceToImplementationMap;
+            return mappings.GetOrAdd(
+                (implementationType, interfaceType),
+                static key => CreateInterfaceToImplementationMap(key.ImplementationType, key.InterfaceType));
         }
 
         /// <summary>
-        /// Maps the interfaces of the provided <paramref name="implementationType"/>.
+        /// Maps the provided <paramref name="interfaceType"/> onto <paramref name="implementationType"/>.
         /// </summary>
         /// <param name="implementationType">The implementation type.</param>
+        /// <param name="interfaceType">The interface type.</param>
         /// <returns>The mapped interface.</returns>
-        private static Dictionary<Type, Dictionary<MethodInfo, Entry>> CreateInterfaceToImplementationMap(Type implementationType)
+        private static Dictionary<MethodInfo, Entry> CreateInterfaceToImplementationMap(Type implementationType, Type interfaceType)
         {
-            var interfaces = implementationType.GetInterfaces();
+            var methods = GrainInterfaceUtils.GetMethods(interfaceType);
 
-            // Create an invoker for every interface on the provided type.
-            var result = new Dictionary<Type, Dictionary<MethodInfo, Entry>>(interfaces.Length);
-            foreach (var iface in interfaces)
+            // Map every method on this interface from the definition interface onto the implementation class.
+            var result = new Dictionary<MethodInfo, Entry>(methods.Length);
+
+            var mapping = default(InterfaceMapping);
+            for (var i = 0; i < methods.Length; i++)
             {
-                var methods = GrainInterfaceUtils.GetMethods(iface);
+                var method = methods[i];
 
-                // Map every method on this interface from the definition interface onto the implementation class.
-                var methodMap = new Dictionary<MethodInfo, Entry>(methods.Length);
-
-                var mapping = default(InterfaceMapping);
-                for (var i = 0; i < methods.Length; i++)
+                // If this method is not from the expected interface (eg, because it's from a parent interface), then
+                // get the mapping for the interface which it does belong to.
+                if (mapping.InterfaceType != method.DeclaringType)
                 {
-                    var method = methods[i];
-
-                    // If this method is not from the expected interface (eg, because it's from a parent interface), then
-                    // get the mapping for the interface which it does belong to.
-                    if (mapping.InterfaceType != method.DeclaringType)
-                    {
-                        mapping = implementationType.GetInterfaceMap(method.DeclaringType!);
-                    }
-
-                    // Find the index of the interface method and then get the implementation method at that position.
-                    for (var k = 0; k < mapping.InterfaceMethods!.Length; k++)
-                    {
-                        if (mapping.InterfaceMethods[k] != method) continue;
-                        Debug.Assert(method is not null);
-                        methodMap[method] = new Entry(mapping.TargetMethods![k], method);
-
-                        break;
-                    }
+                    mapping = GrainInterfaceUtils.GetInterfaceMap(implementationType, method.DeclaringType!);
                 }
 
-                // Add the resulting map of methodId -> method to the interface map.
-                result[iface] = methodMap;
+                // Find the index of the interface method and then get the implementation method at that position.
+                for (var k = 0; k < mapping.InterfaceMethods!.Length; k++)
+                {
+                    if (mapping.InterfaceMethods[k] != method) continue;
+                    Debug.Assert(method is not null);
+                    result[method] = new Entry(mapping.TargetMethods![k], method);
+
+                    break;
+                }
             }
 
             return result;

--- a/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
+++ b/src/Orleans.Core/Core/InterfaceToImplementationMappingCache.cs
@@ -58,7 +58,8 @@ namespace Orleans
             {
                 internal static readonly TypeArrayComparer Instance = new();
 
-                public bool Equals(Type[]? x, Type[]? y) => ReferenceEquals(x, y) || x is null && y is null || x!.Length != y!.Length || x.AsSpan().SequenceEqual(y.AsSpan());
+                public bool Equals(Type[]? x, Type[]? y) =>
+                    ReferenceEquals(x, y) || x is not null && y is not null && x.AsSpan().SequenceEqual(y);
 
                 public int GetHashCode([DisallowNull] Type[] obj)
                 {

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -9,6 +9,13 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2072</WarningsAsErrors>
+    <!-- Keep the existing trim backlog visible in the compatibility audit while enforcing this bounded IL2072 rollout. -->
+    <NoWarn Condition="'$(EnableCompatibilityAnalyzerAudit)' != 'true'">$(NoWarn);IL2026;IL2055;IL2060;IL2070;IL2075;IL2087;IL2090;IL2091</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="buildMultiTargeting\Microsoft.Orleans.Core.targets">
       <PackagePath>%(Identity)</PackagePath>

--- a/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
+++ b/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using Orleans;
 using Orleans.CodeGeneration;
+using Orleans.Runtime;
 using Xunit;
 
 namespace UnitTests;
@@ -86,5 +88,7 @@ public class InterfaceToImplementationMappingCacheTests
         Task IDerivedInterface.DerivedMethod() => Task.CompletedTask;
     }
 
-    private sealed class UnrelatedImplementation;
+    private sealed class UnrelatedImplementation
+    {
+    }
 }

--- a/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
+++ b/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
@@ -40,6 +40,17 @@ public class InterfaceToImplementationMappingCacheTests
         Assert.Throws<InvalidOperationException>(() => cache.GetOrCreate(typeof(UnrelatedImplementation), typeof(IBaseInterface)));
     }
 
+    [Fact]
+    public void GetOrCreate_NonInterfaceType_ThrowsArgumentException()
+    {
+        var cache = new InterfaceToImplementationMappingCache();
+
+        var exception = Assert.Throws<ArgumentException>(() => cache.GetOrCreate(typeof(UnrelatedImplementation), typeof(object)));
+
+        Assert.Equal("interfaceType", exception.ParamName);
+        Assert.Contains("is not an interface", exception.Message);
+    }
+
     private static void AssertMapping(
         Dictionary<MethodInfo, InterfaceToImplementationMappingCache.Entry> mapping,
         MethodInfo interfaceMethod)

--- a/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
+++ b/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
@@ -53,6 +53,20 @@ public class InterfaceToImplementationMappingCacheTests
         Assert.Contains("is not an interface", exception.Message);
     }
 
+    [Fact]
+    public void TypeArrayComparer_UnequalOrOneSidedNullArrays_AreNotEqual()
+    {
+        var comparerType = typeof(InterfaceToImplementationMappingCache.Entry).GetNestedType("TypeArrayComparer", BindingFlags.NonPublic)!;
+        var comparer = (IEqualityComparer<Type[]>)comparerType
+            .GetField("Instance", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetValue(null)!;
+
+        Assert.False(comparer.Equals([typeof(int)], [typeof(int), typeof(string)]));
+        Assert.False(comparer.Equals(null, []));
+        Assert.False(comparer.Equals([], null));
+        Assert.True(comparer.Equals(null, null));
+    }
+
     private static void AssertMapping(
         Dictionary<MethodInfo, InterfaceToImplementationMappingCache.Entry> mapping,
         MethodInfo interfaceMethod)

--- a/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
+++ b/test/Orleans.Core.Tests/InterfaceToImplementationMappingCacheTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using Orleans.CodeGeneration;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+public class InterfaceToImplementationMappingCacheTests
+{
+    [Fact]
+    public void GetMethods_ClassWithInheritedGrainInterfaces_ReturnsInterfaceMethods()
+    {
+        var methods = GrainInterfaceUtils.GetMethods(typeof(ImplicitImplementation));
+
+        Assert.Contains(typeof(IBaseInterface).GetMethod(nameof(IBaseInterface.BaseMethod))!, methods);
+        Assert.Contains(typeof(IDerivedInterface).GetMethod(nameof(IDerivedInterface.DerivedMethod))!, methods);
+    }
+
+    [Fact]
+    public void GetOrCreate_ExplicitInheritedImplementations_MapsDeclaringInterfaces()
+    {
+        var cache = new InterfaceToImplementationMappingCache();
+        var mapping = cache.GetOrCreate(typeof(ExplicitImplementation), typeof(IDerivedInterface));
+        var baseMethod = typeof(IBaseInterface).GetMethod(nameof(IBaseInterface.BaseMethod))!;
+        var derivedMethod = typeof(IDerivedInterface).GetMethod(nameof(IDerivedInterface.DerivedMethod))!;
+
+        AssertMapping(mapping, baseMethod);
+        AssertMapping(mapping, derivedMethod);
+        Assert.Same(mapping, cache.GetOrCreate(typeof(ExplicitImplementation), typeof(IDerivedInterface)));
+    }
+
+    [Fact]
+    public void GetOrCreate_UnimplementedInterface_ThrowsInvalidOperationException()
+    {
+        var cache = new InterfaceToImplementationMappingCache();
+
+        Assert.Throws<InvalidOperationException>(() => cache.GetOrCreate(typeof(UnrelatedImplementation), typeof(IBaseInterface)));
+    }
+
+    private static void AssertMapping(
+        Dictionary<MethodInfo, InterfaceToImplementationMappingCache.Entry> mapping,
+        MethodInfo interfaceMethod)
+    {
+        var entry = Assert.Contains(interfaceMethod, mapping);
+
+        Assert.Same(interfaceMethod, entry.InterfaceMethod);
+        Assert.Equal(typeof(ExplicitImplementation), entry.ImplementationMethod.DeclaringType);
+        Assert.True(entry.ImplementationMethod.IsPrivate);
+    }
+
+    public interface IBaseInterface : IAddressable
+    {
+        Task BaseMethod();
+    }
+
+    public interface IDerivedInterface : IBaseInterface
+    {
+        Task DerivedMethod();
+    }
+
+    private sealed class ImplicitImplementation : IDerivedInterface
+    {
+        public Task BaseMethod() => Task.CompletedTask;
+
+        public Task DerivedMethod() => Task.CompletedTask;
+    }
+
+    private sealed class ExplicitImplementation : IDerivedInterface
+    {
+        Task IBaseInterface.BaseMethod() => Task.CompletedTask;
+
+        Task IDerivedInterface.DerivedMethod() => Task.CompletedTask;
+    }
+
+    private sealed class UnrelatedImplementation;
+}


### PR DESCRIPTION
## Problem

`Orleans.Core` interface mapping passed interface types from `Type.GetInterfaces()` collections and `MemberInfo.DeclaringType` into `Type.GetInterfaceMap`. Those metadata APIs cannot propagate the required method annotations, producing the two IL2072 findings in the net10 compatibility audit.

## Solution

Centralize `GetInterfaceMap` behind one documented reflection boundary and lazily build mappings only for the requested generated grain interface. Generated invokables statically reference each interface method, cache its `MethodInfo`, and invoke it through a strongly typed call, preserving the interface and implementation methods used by the mapping cache, including explicit non-public implementations.

Enable trim analysis for `Orleans.Core` on net10 and explicitly enforce IL2072. Existing trim diagnostics remain suppressed during regular builds but visible in the compatibility audit, keeping this rollout bounded. Add focused coverage for inherited interfaces, explicit implementations, cache reuse, and invalid implementation/interface pairs.

## Rationale

Mapping only the requested interface aligns the reflection surface with the source-generated preservation mechanism and avoids eagerly reflecting unrelated implementation interfaces. The public API remains unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11055)