### PR TITLE
fix(aws): use invariant DynamoDB state serialization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -698,3 +698,7 @@ dotnet_diagnostic.CA2002.severity = suggestion
 # DynamoDB persistence and transactional state use stable wire representations.
 [src/AWS/{Orleans.Persistence.DynamoDB,Orleans.Transactions.DynamoDB}/**.cs]
 dotnet_diagnostic.CA1305.severity = warning
+
+# Shared linked sources are separately owned and remain advisory for this rollout.
+[src/AWS/Shared/{AWSUtils.cs,Storage/DynamoDBStorage.cs}]
+dotnet_diagnostic.CA1305.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -695,19 +695,6 @@ dotnet_diagnostic.IDE0043.severity = warning
 [src/Orleans.Runtime/Catalog/ActivationData.cs]
 dotnet_diagnostic.CA2002.severity = suggestion
 
-# DynamoDB persistence and transactional state use stable wire representations
-# for numbers, timestamps, ETags, and keys.
-[src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs]
-dotnet_diagnostic.CA1305.severity = warning
-
-[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs]
-dotnet_diagnostic.CA1305.severity = warning
-
-[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorageFactory.cs]
-dotnet_diagnostic.CA1305.severity = warning
-
-[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/KeyEntity.cs]
-dotnet_diagnostic.CA1305.severity = warning
-[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/StateEntity.cs]
-dotnet_diagnostic.CA1305.severity = warning
+# DynamoDB persistence and transactional state use stable wire representations.
+[src/AWS/{Orleans.Persistence.DynamoDB,Orleans.Transactions.DynamoDB}/**.cs]
 dotnet_diagnostic.CA1305.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -694,3 +694,20 @@ dotnet_diagnostic.IDE0043.severity = warning
 # ActivationData's shared monitor migration is tracked by #10068.
 [src/Orleans.Runtime/Catalog/ActivationData.cs]
 dotnet_diagnostic.CA2002.severity = suggestion
+
+# DynamoDB persistence and transactional state use stable wire representations
+# for numbers, timestamps, ETags, and keys.
+[src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs]
+dotnet_diagnostic.CA1305.severity = warning
+
+[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs]
+dotnet_diagnostic.CA1305.severity = warning
+
+[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorageFactory.cs]
+dotnet_diagnostic.CA1305.severity = warning
+
+[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/KeyEntity.cs]
+dotnet_diagnostic.CA1305.severity = warning
+[src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/StateEntity.cs]
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1305.severity = warning

--- a/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
+++ b/src/AWS/Orleans.Persistence.DynamoDB/Provider/DynamoDBGrainStorage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -66,7 +67,7 @@ namespace Orleans.Storage
 
             try
             {
-                var initMsg = string.Format("Init: Name={0} ServiceId={1} Table={2} DeleteStateOnClear={3}",
+                var initMsg = string.Format(CultureInfo.CurrentCulture, "Init: Name={0} ServiceId={1} Table={2} DeleteStateOnClear={3}",
                         this.name, this.options.ServiceId, this.options.TableName, this.options.DeleteStateOnClear);
 
                 LogInformationInitializingDynamoDBGrainStorage(logger, this.name, initMsg);
@@ -139,7 +140,7 @@ namespace Orleans.Storage
                     {
                         GrainType = fields[GRAIN_TYPE_PROPERTY_NAME].S,
                         GrainReference = fields[GRAIN_REFERENCE_PROPERTY_NAME].S,
-                        ETag = int.Parse(fields[ETAG_PROPERTY_NAME].N),
+                        ETag = int.Parse(fields[ETAG_PROPERTY_NAME].N, NumberStyles.Integer, CultureInfo.InvariantCulture),
                         State = fields.TryGetValue(BINARY_STATE_PROPERTY_NAME, out var propertyName) ? propertyName.B?.ToArray() : null,
                     };
                 }).ConfigureAwait(false);
@@ -149,7 +150,7 @@ namespace Orleans.Storage
                 var loadedState = ConvertFromStorageFormat<T>(record);
                 grainState.RecordExists = loadedState != null;
                 grainState.State = loadedState ?? CreateInstance<T>();
-                grainState.ETag = record.ETag.ToString();
+                grainState.ETag = record.ETag.ToString(CultureInfo.InvariantCulture);
             }
             else
             {
@@ -189,7 +190,7 @@ namespace Orleans.Storage
             var fields = new Dictionary<string, AttributeValue>();
             if (this.options.TimeToLive.HasValue)
             {
-                fields.Add(GRAIN_TTL_PROPERTY_NAME, new AttributeValue { N = ((DateTimeOffset)DateTime.UtcNow.Add(this.options.TimeToLive.Value)).ToUnixTimeSeconds().ToString() });
+                fields.Add(GRAIN_TTL_PROPERTY_NAME, new AttributeValue { N = ((DateTimeOffset)DateTime.UtcNow.Add(this.options.TimeToLive.Value)).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) });
             }
 
             if (record.State != null && record.State.Length > 0)
@@ -205,10 +206,10 @@ namespace Orleans.Storage
             if (clear)
             {
                 int currentEtag;
-                int.TryParse(grainState.ETag, out currentEtag);
+                int.TryParse(grainState.ETag, NumberStyles.Integer, CultureInfo.InvariantCulture, out currentEtag);
                 newEtag = currentEtag;
                 newEtag++;
-                fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = newEtag.ToString() });
+                fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = newEtag.ToString(CultureInfo.InvariantCulture) });
 
                 if (string.IsNullOrWhiteSpace(grainState.ETag))
                 {
@@ -224,7 +225,7 @@ namespace Orleans.Storage
                         { GRAIN_REFERENCE_PROPERTY_NAME, new AttributeValue(record.GrainReference) },
                         { GRAIN_TYPE_PROPERTY_NAME, new AttributeValue(record.GrainType) }
                     };
-                    var conditionalValues = new Dictionary<string, AttributeValue> { { CURRENT_ETAG_ALIAS, new AttributeValue { N = currentEtag.ToString() } } };
+                    var conditionalValues = new Dictionary<string, AttributeValue> { { CURRENT_ETAG_ALIAS, new AttributeValue { N = currentEtag.ToString(CultureInfo.InvariantCulture) } } };
                     var expression = $"{ETAG_PROPERTY_NAME} = {CURRENT_ETAG_ALIAS}";
                     await this.storage.UpsertEntryAsync(this.options.TableName, keys, fields, expression, conditionalValues).ConfigureAwait(false);
                 }
@@ -245,17 +246,17 @@ namespace Orleans.Storage
                 keys.Add(GRAIN_TYPE_PROPERTY_NAME, new AttributeValue(record.GrainType));
 
                 int currentEtag;
-                int.TryParse(grainState.ETag, out currentEtag);
+                int.TryParse(grainState.ETag, NumberStyles.Integer, CultureInfo.InvariantCulture, out currentEtag);
                 newEtag = currentEtag;
                 newEtag++;
-                fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = newEtag.ToString() });
+                fields.Add(ETAG_PROPERTY_NAME, new AttributeValue { N = newEtag.ToString(CultureInfo.InvariantCulture) });
 
-                var conditionalValues = new Dictionary<string, AttributeValue> { { CURRENT_ETAG_ALIAS, new AttributeValue { N = currentEtag.ToString() } } };
+                var conditionalValues = new Dictionary<string, AttributeValue> { { CURRENT_ETAG_ALIAS, new AttributeValue { N = currentEtag.ToString(CultureInfo.InvariantCulture) } } };
                 var expression = $"{ETAG_PROPERTY_NAME} = {CURRENT_ETAG_ALIAS}";
                 await this.storage.UpsertEntryAsync(this.options.TableName, keys, fields, expression, conditionalValues).ConfigureAwait(false);
             }
 
-            grainState.ETag = newEtag.ToString();
+            grainState.ETag = newEtag.ToString(CultureInfo.InvariantCulture);
             grainState.RecordExists = !clear;
         }
 
@@ -274,7 +275,14 @@ namespace Orleans.Storage
             LogTraceClearingGrainState(logger, grainType, partitionKey, grainId, grainState.ETag, this.options.DeleteStateOnClear, this.options.TableName);
 
             string rowKey = AWSUtils.ValidateDynamoDBRowKey(grainType);
-            var record = new GrainStateRecord { GrainReference = partitionKey, ETag = string.IsNullOrWhiteSpace(grainState.ETag) ? 0 : int.Parse(grainState.ETag), GrainType = rowKey };
+            var record = new GrainStateRecord
+            {
+                GrainReference = partitionKey,
+                ETag = string.IsNullOrWhiteSpace(grainState.ETag)
+                    ? 0
+                    : int.Parse(grainState.ETag, NumberStyles.Integer, CultureInfo.InvariantCulture),
+                GrainType = rowKey
+            };
 
             var operation = "Clearing";
             try
@@ -291,7 +299,7 @@ namespace Orleans.Storage
                     Dictionary<string, AttributeValue>? conditionalValues = null;
                     if (!string.IsNullOrWhiteSpace(grainState.ETag))
                     {
-                        conditionalValues = new Dictionary<string, AttributeValue> { { CURRENT_ETAG_ALIAS, new AttributeValue { N = record.ETag.ToString() } } };
+                        conditionalValues = new Dictionary<string, AttributeValue> { { CURRENT_ETAG_ALIAS, new AttributeValue { N = record.ETag.ToString(CultureInfo.InvariantCulture) } } };
                         expression = $"{ETAG_PROPERTY_NAME} = {CURRENT_ETAG_ALIAS}";
                     }
 
@@ -341,11 +349,11 @@ namespace Orleans.Storage
             catch (Exception exc)
             {
                 var sb = new StringBuilder();
-                sb.AppendFormat("Unable to convert from storage format GrainStateEntity.Data={0}", entity.State);
+                sb.AppendFormat(CultureInfo.CurrentCulture, "Unable to convert from storage format GrainStateEntity.Data={0}", entity.State);
 
                 if (dataValue != null)
                 {
-                    sb.Append($"Data Value={dataValue} Type={dataValue.GetType()}");
+                    sb.AppendFormat(CultureInfo.CurrentCulture, "Data Value={0} Type={1}", dataValue, dataValue.GetType());
                 }
 
                 var message = sb.ToString();
@@ -367,7 +375,7 @@ namespace Orleans.Storage
 
             var pkSize = GRAIN_REFERENCE_PROPERTY_NAME.Length + entity.GrainReference.Length;
             var rkSize = GRAIN_TYPE_PROPERTY_NAME.Length + entity.GrainType.Length;
-            var versionSize = ETAG_PROPERTY_NAME.Length + entity.ETag.ToString().Length;
+            var versionSize = ETAG_PROPERTY_NAME.Length + entity.ETag.ToString(CultureInfo.InvariantCulture).Length;
 
             if ((pkSize + rkSize + versionSize + dataSize) > MAX_DATA_SIZE)
             {

--- a/src/AWS/Orleans.Transactions.DynamoDB/Properties/AssemblyInfo.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Orleans.Transactions.DynamoDB.Tests")]

--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
@@ -188,7 +188,10 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                         ConditionExpression = $"{DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME} = {DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS}",
                         ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                         {
-                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = entity.ETag!.Value.ToString(CultureInfo.InvariantCulture) }
+                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue
+                            {
+                                N = GetRequiredETag(entity.ETag, entity.PartitionKey, entity.RowKey).ToString(CultureInfo.InvariantCulture)
+                            }
                         }
                     };
 
@@ -214,12 +217,12 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                         {
                             // overwrite with new pending state
                             StateEntity existing = states[pos].Value;
-                            var currentETag = existing.ETag!.Value.ToString(CultureInfo.InvariantCulture);
+                            var currentETag = GetRequiredETag(existing.ETag, existing.PartitionKey, existing.RowKey);
                             existing.TransactionId = s.TransactionId;
                             existing.TransactionTimestamp = s.TimeStamp;
                             existing.TransactionManager = this.ConvertToStorageFormat(s.TransactionManager);
                             existing.SetState(s.State, this.serializer);
-                            existing.ETag = existing.ETag + 1;
+                            existing.ETag = currentETag + 1;
 
                             await batchOperation.Add(new TransactWriteItem
                             {
@@ -231,7 +234,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                                         $"{DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME} = {DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS}",
                                     ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                                     {
-                                        [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = currentETag }
+                                        [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = currentETag.ToString(CultureInfo.InvariantCulture) }
                                     }
                                 }
                             }, existing.PartitionKey, existing.RowKey).ConfigureAwait(false);
@@ -289,7 +292,10 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                         ConditionExpression = $"ETag = {DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS}",
                         ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                         {
-                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = stateToDelete.Value.ETag!.Value.ToString(CultureInfo.InvariantCulture) }
+                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue
+                            {
+                                N = GetRequiredETag(stateToDelete.Value.ETag, stateToDelete.Value.PartitionKey, stateToDelete.Value.RowKey).ToString(CultureInfo.InvariantCulture)
+                            }
                         }
                     };
                     await batchOperation.Add(
@@ -308,7 +314,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
 
             this.requiresReload = false;
             LogDebugStoredETag(this.partitionKey, this.key.CommittedSequenceId, this.key.ETag);
-            return key.ETag!.Value.ToString(CultureInfo.InvariantCulture);
+            return GetRequiredETag(key.ETag, key.PartitionKey, key.RowKey).ToString(CultureInfo.InvariantCulture);
         }
         catch (InconsistentStateException)
         {
@@ -328,6 +334,17 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
             [DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME] = new AttributeValue { S = partition },
             [DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME] = new AttributeValue { S = rowKey }
         };
+    }
+
+    private static long GetRequiredETag(long? etag, string partitionKey, string rowKey)
+    {
+        if (etag is not { } value)
+        {
+            throw new InconsistentStateException(
+                $"DynamoDB transactional state record is missing its required ETag. PartitionKey={partitionKey} RowKey={rowKey}.");
+        }
+
+        return value;
     }
 
     /// <summary>

--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.Model;
@@ -66,7 +67,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
         {
             (key, states) = await LoadSnapshotAsync().ConfigureAwait(false);
 
-            if (string.IsNullOrEmpty(key.ETag.ToString()))
+            if (!key.ETag.HasValue)
             {
                 LogDebugLoadedV0Fresh(this.partitionKey);
                 this.requiresReload = false;
@@ -130,7 +131,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                 ? this.ConvertFromStorageFormat<TransactionalStateMetaData>(this.key.Metadata)
                 : new TransactionalStateMetaData();
             this.requiresReload = false;
-            return new TransactionalStorageLoadResponse<TState>(this.key.ETag.ToString(), committedState, this.key.CommittedSequenceId, metadata, PrepareRecordsToRecover);
+            return new TransactionalStorageLoadResponse<TState>(this.key.ETag.Value.ToString(CultureInfo.InvariantCulture), committedState, this.key.CommittedSequenceId, metadata, PrepareRecordsToRecover);
         }
         catch (Exception ex)
         {
@@ -152,7 +153,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
 
         try
         {
-            var keyETag = key.ETag?.ToString();
+            var keyETag = key.ETag?.ToString(CultureInfo.InvariantCulture);
             if ((!string.IsNullOrWhiteSpace(keyETag) || !string.IsNullOrWhiteSpace(expectedETag)) &&
                 keyETag != expectedETag)
             {
@@ -187,7 +188,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                         ConditionExpression = $"{DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME} = {DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS}",
                         ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                         {
-                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = entity.ETag.ToString() }
+                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = entity.ETag!.Value.ToString(CultureInfo.InvariantCulture) }
                         }
                     };
 
@@ -213,7 +214,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                         {
                             // overwrite with new pending state
                             StateEntity existing = states[pos].Value;
-                            var currentETag = existing.ETag.ToString();
+                            var currentETag = existing.ETag!.Value.ToString(CultureInfo.InvariantCulture);
                             existing.TransactionId = s.TransactionId;
                             existing.TransactionTimestamp = s.TimeStamp;
                             existing.TransactionManager = this.ConvertToStorageFormat(s.TransactionManager);
@@ -288,7 +289,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                         ConditionExpression = $"ETag = {DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS}",
                         ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                         {
-                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = stateToDelete.Value.ETag.ToString() }
+                            [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = stateToDelete.Value.ETag!.Value.ToString(CultureInfo.InvariantCulture) }
                         }
                     };
                     await batchOperation.Add(
@@ -307,7 +308,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
 
             this.requiresReload = false;
             LogDebugStoredETag(this.partitionKey, this.key.CommittedSequenceId, this.key.ETag);
-            return key.ETag!.Value.ToString();
+            return key.ETag!.Value.ToString(CultureInfo.InvariantCulture);
         }
         catch (InconsistentStateException)
         {
@@ -364,8 +365,8 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
 
         throw new InconsistentStateException(
             "Could not load a consistent DynamoDB transactional state snapshot.",
-            storedEtag: keyBefore.ETag?.ToString() ?? "null",
-            currentEtag: keyAfter.ETag?.ToString() ?? "null");
+            storedEtag: keyBefore.ETag?.ToString(CultureInfo.InvariantCulture) ?? "null",
+            currentEtag: keyAfter.ETag?.ToString(CultureInfo.InvariantCulture) ?? "null");
     }
 
     /// <summary>
@@ -551,7 +552,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                     $"{DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME} = {DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS}";
                 keyPut.ExpressionAttributeValues = new Dictionary<string, AttributeValue>
                 {
-                    [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = currentETag.Value.ToString() }
+                    [DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS] = new AttributeValue { N = currentETag.Value.ToString(CultureInfo.InvariantCulture) }
                 };
             }
             else
@@ -591,7 +592,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                 throw new InconsistentStateException(
                     conflictMessage,
                     storedEtag: "Unknown",
-                    currentEtag: currentETag?.ToString() ?? "null",
+                    currentEtag: currentETag?.ToString(CultureInfo.InvariantCulture) ?? "null",
                     exception);
             }
             catch
@@ -708,7 +709,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
 
     private readonly struct StatesLogRecord(List<KeyValuePair<long, StateEntity>> states)
     {
-        public override string ToString() => string.Join(",", states.Select(s => s.Key.ToString("x16")));
+        public override string ToString() => string.Join(",", states.Select(s => s.Key.ToString("x16", CultureInfo.InvariantCulture)));
     }
 
     [LoggerMessage(

--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorageFactory.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorageFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
@@ -98,7 +99,7 @@ public partial class DynamoDBTransactionalStateStorageFactory : ITransactionalSt
 
         try
         {
-            var initMsg = string.Format("Init: Name={0} ServiceId={1} Table={2}", this.name, this.options.ServiceId, this.options.TableName);
+            var initMsg = string.Format(CultureInfo.CurrentCulture, "Init: Name={0} ServiceId={1} Table={2}", this.name, this.options.ServiceId, this.options.TableName);
 
             LogInformationInitializingDynamoDBGrainStorage(logger, this.name, initMsg);
 

--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/KeyEntity.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/KeyEntity.cs
@@ -2,10 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 using Amazon.DynamoDBv2.Model;
-
-[assembly: InternalsVisibleTo("Orleans.Transactions.DynamoDB.Tests")]
 
 namespace Orleans.Transactions.DynamoDB.TransactionalState;
 

--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/KeyEntity.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/KeyEntity.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Amazon.DynamoDBv2.Model;
+
+[assembly: InternalsVisibleTo("Orleans.Transactions.DynamoDB.Tests")]
 
 namespace Orleans.Transactions.DynamoDB.TransactionalState;
 
@@ -18,16 +22,16 @@ internal class KeyEntity
             this.PartitionKey = partitionKey.S;
 
         if (fields.TryGetValue(COMITTED_SEQUENCE_ID_PROPERTY_NAME, out var committedSequenceId))
-            this.CommittedSequenceId = long.Parse(committedSequenceId.N);
+            this.CommittedSequenceId = long.Parse(committedSequenceId.N, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
         if (fields.TryGetValue(METADATA_PROPERTY_NAME, out var metadata))
             this.Metadata = metadata.B.ToArray();
 
         if (fields.TryGetValue(DynamoDBTransactionalStateConstants.TIMESTAMP_PROPERTY_NAME, out var timestamp))
-            this.Timestamp = DateTimeOffset.FromUnixTimeSeconds(long.Parse(timestamp.N));
+            this.Timestamp = DateTimeOffset.FromUnixTimeSeconds(long.Parse(timestamp.N, NumberStyles.Integer, CultureInfo.InvariantCulture));
 
         if (fields.TryGetValue(DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME, out var etag))
-            this.ETag = long.Parse(etag.N);
+            this.ETag = long.Parse(etag.N, NumberStyles.Integer, CultureInfo.InvariantCulture);
     }
 
     public KeyEntity(string partitionKey)
@@ -56,7 +60,7 @@ internal class KeyEntity
         {
             { DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME, new AttributeValue { S = this.PartitionKey } },
             { DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME, new AttributeValue { S = this.RowKey } },
-            { COMITTED_SEQUENCE_ID_PROPERTY_NAME, new AttributeValue { N = this.CommittedSequenceId.ToString() } },
+            { COMITTED_SEQUENCE_ID_PROPERTY_NAME, new AttributeValue { N = this.CommittedSequenceId.ToString(CultureInfo.InvariantCulture) } },
         };
 
         if (this.Metadata is { Length: > 0 })
@@ -66,12 +70,12 @@ internal class KeyEntity
 
         if (this.Timestamp != default)
         {
-            item[DynamoDBTransactionalStateConstants.TIMESTAMP_PROPERTY_NAME] = new AttributeValue { N = this.Timestamp.ToUnixTimeSeconds().ToString() };
+            item[DynamoDBTransactionalStateConstants.TIMESTAMP_PROPERTY_NAME] = new AttributeValue { N = this.Timestamp.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) };
         }
 
         if (this.ETag.HasValue)
         {
-            item[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME] = new AttributeValue { N = this.ETag.Value.ToString() };
+            item[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME] = new AttributeValue { N = this.ETag.Value.ToString(CultureInfo.InvariantCulture) };
         }
 
         return item;

--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/StateEntity.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/StateEntity.cs
@@ -36,7 +36,7 @@ internal class StateEntity
             this.TransactionId = transactionId.S;
 
         if (fields.TryGetValue(TRANSACTION_TIMESTAMP_PROPERTY_NAME, out var timestamp))
-            this.TransactionTimestamp = DateTime.Parse(timestamp.S, null, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+            this.TransactionTimestamp = DateTime.Parse(timestamp.S, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
 
         if (fields.TryGetValue(TRANSACTION_MANAGER_PROPERTY_NAME, out var transactionManager))
             this.TransactionManager = transactionManager.B.ToArray();
@@ -45,14 +45,14 @@ internal class StateEntity
             this.State = state.B.ToArray();
 
         if (fields.TryGetValue(DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME, out var etag))
-            this.ETag = long.Parse(etag.N);
+            this.ETag = long.Parse(etag.N, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
         this.StorageSize = GetItemSize(fields);
     }
 
     public static string MakeRowKey(long sequenceId)
     {
-        return $"{ROW_KEY_PREFIX}{sequenceId.ToString("x16")}";
+        return $"{ROW_KEY_PREFIX}{sequenceId.ToString("x16", CultureInfo.InvariantCulture)}";
     }
 
     public static StateEntity Create<TState>(
@@ -78,7 +78,7 @@ internal class StateEntity
 
     public string RowKey { get; set; } = null!;
 
-    public long SequenceId => long.Parse(this.RowKey.Substring(ROW_KEY_PREFIX.Length), NumberStyles.AllowHexSpecifier);
+    public long SequenceId => long.Parse(this.RowKey.Substring(ROW_KEY_PREFIX.Length), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
 
     public string TransactionId { get; set; } = string.Empty;
 
@@ -112,13 +112,13 @@ internal class StateEntity
             item[TRANSACTION_ID_PROPERTY_NAME] = new AttributeValue { S = this.TransactionId };
 
         if (this.TransactionTimestamp != default)
-            item[TRANSACTION_TIMESTAMP_PROPERTY_NAME] = new AttributeValue { S = this.TransactionTimestamp.ToUniversalTime().ToString("o") };
+            item[TRANSACTION_TIMESTAMP_PROPERTY_NAME] = new AttributeValue { S = this.TransactionTimestamp.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture) };
 
         if (this.TransactionManager is { Length: > 0 })
             item[TRANSACTION_MANAGER_PROPERTY_NAME] = new AttributeValue { B = new MemoryStream(this.TransactionManager) };
 
         if (this.ETag.HasValue)
-            item[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME] = new AttributeValue { N = this.ETag.Value.ToString() };
+            item[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME] = new AttributeValue { N = this.ETag.Value.ToString(CultureInfo.InvariantCulture) };
 
         this.StorageSize = GetItemSize(item);
         return item;

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateCultureTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateCultureTests.cs
@@ -1,0 +1,154 @@
+using System.Globalization;
+using Amazon.DynamoDBv2.Model;
+using Orleans.Transactions.DynamoDB.TransactionalState;
+using Xunit;
+
+namespace Orleans.Transactions.DynamoDB.Tests;
+
+public class DynamoDBTransactionalStateCultureTests
+{
+    [Fact]
+    public void KeyEntity_ToStorageFormat_UsesInvariantNumbersAndLegacyValuesRoundTripUnderCustomCulture()
+    {
+        RunWithCustomCulture(() =>
+        {
+            const long committedSequenceId = -1_234_567_890_123_456_789;
+            const long timestampSeconds = -123_456_789;
+            const long etag = -9_876_543_210;
+            byte[] metadata = [1, 2, 3, 4];
+
+            var entity = new KeyEntity("partition")
+            {
+                CommittedSequenceId = committedSequenceId,
+                Metadata = metadata,
+                Timestamp = DateTimeOffset.FromUnixTimeSeconds(timestampSeconds),
+                ETag = etag
+            };
+
+            var stored = entity.ToStorageFormat();
+
+            Assert.Equal("-1234567890123456789", stored[nameof(KeyEntity.CommittedSequenceId)].N);
+            Assert.Equal("-123456789", stored[DynamoDBTransactionalStateConstants.TIMESTAMP_PROPERTY_NAME].N);
+            Assert.Equal("-9876543210", stored[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N);
+
+            var legacy = new Dictionary<string, AttributeValue>
+            {
+                [DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME] = new() { S = "legacy-partition" },
+                [DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME] = new() { S = KeyEntity.RK },
+                [nameof(KeyEntity.CommittedSequenceId)] = new() { N = "-1234567890123456789" },
+                [nameof(KeyEntity.Metadata)] = new() { B = new MemoryStream(metadata) },
+                [DynamoDBTransactionalStateConstants.TIMESTAMP_PROPERTY_NAME] = new() { N = "-123456789" },
+                [DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME] = new() { N = "-9876543210" }
+            };
+
+            var roundTripped = new KeyEntity(legacy);
+            var reserialized = roundTripped.ToStorageFormat();
+
+            Assert.Equal("legacy-partition", roundTripped.PartitionKey);
+            Assert.Equal(KeyEntity.RK, roundTripped.RowKey);
+            Assert.Equal(committedSequenceId, roundTripped.CommittedSequenceId);
+            Assert.Equal(metadata, roundTripped.Metadata);
+            Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(timestampSeconds), roundTripped.Timestamp);
+            Assert.Equal(etag, roundTripped.ETag);
+            Assert.Equal(legacy[nameof(KeyEntity.CommittedSequenceId)].N, reserialized[nameof(KeyEntity.CommittedSequenceId)].N);
+            Assert.Equal(legacy[DynamoDBTransactionalStateConstants.TIMESTAMP_PROPERTY_NAME].N, reserialized[DynamoDBTransactionalStateConstants.TIMESTAMP_PROPERTY_NAME].N);
+            Assert.Equal(legacy[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N, reserialized[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N);
+            Assert.Equal(metadata, reserialized[nameof(KeyEntity.Metadata)].B.ToArray());
+        });
+    }
+
+    [Fact]
+    public void StateEntity_RowKeyAndSequenceId_UseInvariantLowercaseFixedWidthHexUnderCustomCulture()
+    {
+        RunWithCustomCulture(() =>
+        {
+            const long sequenceId = 0x0123456789ABCDEF;
+
+            var rowKey = StateEntity.MakeRowKey(sequenceId);
+            var entity = new StateEntity { RowKey = rowKey };
+
+            Assert.Equal("state_0123456789abcdef", rowKey);
+            Assert.Equal(16, rowKey[StateEntity.ROW_KEY_PREFIX.Length..].Length);
+            Assert.Equal(sequenceId, entity.SequenceId);
+        });
+    }
+
+    [Fact]
+    public void StateEntity_ToStorageFormat_UsesInvariantTimestampAndETagAndLegacyValuesRoundTripUnderCustomCulture()
+    {
+        RunWithCustomCulture(() =>
+        {
+            var timestamp = new DateTime(2024, 2, 29, 12, 34, 56, DateTimeKind.Utc).AddTicks(7_891_234);
+            const long etag = -9_876_543_210;
+            byte[] transactionManager = [5, 6, 7];
+            byte[] state = [8, 9, 10, 11];
+            var rowKey = StateEntity.MakeRowKey(0x0123456789ABCDEF);
+
+            var entity = new StateEntity
+            {
+                PartitionKey = "partition",
+                RowKey = rowKey,
+                TransactionId = "transaction",
+                TransactionTimestamp = timestamp,
+                TransactionManager = transactionManager,
+                State = state,
+                ETag = etag
+            };
+
+            var stored = entity.ToStorageFormat();
+
+            Assert.Equal("2024-02-29T12:34:56.7891234Z", stored[StateEntity.TRANSACTION_TIMESTAMP_PROPERTY_NAME].S);
+            Assert.Equal("-9876543210", stored[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N);
+
+            var legacy = new Dictionary<string, AttributeValue>
+            {
+                [DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME] = new() { S = "legacy-partition" },
+                [DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME] = new() { S = rowKey },
+                [StateEntity.TRANSACTION_ID_PROPERTY_NAME] = new() { S = "legacy-transaction" },
+                [StateEntity.TRANSACTION_TIMESTAMP_PROPERTY_NAME] = new() { S = "2024-02-29T12:34:56.7891234Z" },
+                [StateEntity.TRANSACTION_MANAGER_PROPERTY_NAME] = new() { B = new MemoryStream(transactionManager) },
+                [DynamoDBTransactionalStateConstants.BINARY_STATE_PROPERTY_NAME] = new() { B = new MemoryStream(state) },
+                [DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME] = new() { N = "-9876543210" }
+            };
+
+            var roundTripped = new StateEntity(legacy);
+            var reserialized = roundTripped.ToStorageFormat();
+
+            Assert.Equal("legacy-partition", roundTripped.PartitionKey);
+            Assert.Equal(rowKey, roundTripped.RowKey);
+            Assert.Equal(0x0123456789ABCDEF, roundTripped.SequenceId);
+            Assert.Equal("legacy-transaction", roundTripped.TransactionId);
+            Assert.Equal(timestamp.Ticks, roundTripped.TransactionTimestamp.Ticks);
+            Assert.Equal(DateTimeKind.Utc, roundTripped.TransactionTimestamp.Kind);
+            Assert.Equal(transactionManager, roundTripped.TransactionManager);
+            Assert.Equal(state, roundTripped.State);
+            Assert.Equal(etag, roundTripped.ETag);
+            Assert.Equal(legacy[StateEntity.TRANSACTION_TIMESTAMP_PROPERTY_NAME].S, reserialized[StateEntity.TRANSACTION_TIMESTAMP_PROPERTY_NAME].S);
+            Assert.Equal(legacy[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N, reserialized[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N);
+            Assert.Equal(transactionManager, reserialized[StateEntity.TRANSACTION_MANAGER_PROPERTY_NAME].B.ToArray());
+            Assert.Equal(state, reserialized[DynamoDBTransactionalStateConstants.BINARY_STATE_PROPERTY_NAME].B.ToArray());
+        });
+    }
+
+    private static void RunWithCustomCulture(Action action)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUICulture = CultureInfo.CurrentUICulture;
+        var culture = (CultureInfo)CultureInfo.GetCultureInfo("fr-FR").Clone();
+        culture.NumberFormat.NegativeSign = "NEG";
+        culture.NumberFormat.NumberGroupSeparator = "_";
+        culture.NumberFormat.NumberGroupSizes = [2];
+
+        try
+        {
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+            action();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

DynamoDB persistence and transactional state serialization relied on the ambient culture for numeric values, timestamps, ETags, and row keys. That makes persisted representations and conditional expressions dependent on process locale and leaves CA1305 advisory in this state-storage boundary.

## Solution

- Use invariant decimal, Unix timestamp, round-trip timestamp, ETag, and fixed-width hexadecimal key conversions while retaining current-culture formatting for initialization and conversion diagnostics.
- Enforce CA1305 as a warning across the complete `Orleans.Persistence.DynamoDB` and `Orleans.Transactions.DynamoDB` projects.
- Add service-free culture-switch tests which verify exact stored strings and round-trip legacy invariant records on net8.0 and net10.0.
- Leave `AWSUtils.cs` and shared `DynamoDBStorage.cs` unchanged because active reminder/provider PRs already own those files.

## Rationale

DynamoDB attribute values and keys are wire/storage contracts, so their representation must remain stable across host cultures. Explicit invariant parsing continues to read the ASCII decimal, ISO round-trip, and lowercase hexadecimal forms already stored by existing deployments, while explicit current-culture formatting keeps human-readable diagnostics locale-aware.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11056)