### PR TITLE
fix(testing): await reminder startup topology

### DIFF
--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -50,11 +50,11 @@ namespace UnitTests.TimerTests
         public class Fixture : BaseInProcessTestClusterFixture
         {
             private ReminderTestClock? _reminderClock;
-            private IReadOnlyList<SiloAddress>? _stableReminderServices;
+            private IReadOnlyList<SiloAddress>? _startedReminderServices;
             internal ReminderTestClock ReminderClock => _reminderClock ?? throw new InvalidOperationException($"{nameof(ReminderTestClock)} has not been configured.");
             internal ReminderTableReadController ReadController { get; } = new();
-            internal IReadOnlyList<SiloAddress> StableReminderServices => _stableReminderServices
-                ?? throw new InvalidOperationException("Reminder services have not reached stable topology.");
+            internal IReadOnlyList<SiloAddress> StartedReminderServices => _startedReminderServices
+                ?? throw new InvalidOperationException("Reminder services have not reached startup topology.");
 
             protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
             {
@@ -88,12 +88,12 @@ namespace UnitTests.TimerTests
                 topologyCancellation.CancelAfter(TestConstants.InitTimeout);
                 try
                 {
-                    var stableSilos = await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+                    var startedSilos = await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
                         HostedCluster,
                         ReminderClock.DiagnosticObserver,
                         HostedCluster.Silos,
                         topologyCancellation.Token);
-                    _stableReminderServices = stableSilos.Select(static silo => silo.SiloAddress).ToArray();
+                    _startedReminderServices = startedSilos.Select(static silo => silo.SiloAddress).ToArray();
                 }
                 catch (OperationCanceledException exception) when (
                     topologyCancellation.IsCancellationRequested
@@ -136,11 +136,11 @@ namespace UnitTests.TimerTests
         // Basic tests
 
         [Fact]
-        public async Task Fixture_WaitsForStableReminderTopologyBeforeGrainCalls()
+        public async Task Fixture_WaitsForReminderStartupTopologyBeforeGrainCalls()
         {
             Assert.All(
                 HostedCluster.Silos,
-                silo => Assert.Contains(silo.SiloAddress, _fixture.StableReminderServices));
+                silo => Assert.Contains(silo.SiloAddress, _fixture.StartedReminderServices));
 
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
             cancellation.CancelAfter(TestConstants.InitTimeout);

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -99,7 +99,9 @@ namespace UnitTests.TimerTests
                     topologyCancellation.IsCancellationRequested
                     && !TestContext.Current.CancellationToken.IsCancellationRequested)
                 {
-                    throw new TimeoutException(exception.Message, exception);
+                    throw new TimeoutException(
+                        $"Reminder startup topology stabilization timed out within {TestConstants.InitTimeout}. Diagnostics: {exception.Message}",
+                        exception);
                 }
             }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -50,12 +50,11 @@ namespace UnitTests.TimerTests
         public class Fixture : BaseInProcessTestClusterFixture
         {
             private ReminderTestClock? _reminderClock;
-            private readonly ReminderLifecycleHarness _startupHarness = new();
-            private IReadOnlyList<SiloAddress>? _startedReminderServices;
+            private IReadOnlyList<SiloAddress>? _stableReminderServices;
             internal ReminderTestClock ReminderClock => _reminderClock ?? throw new InvalidOperationException($"{nameof(ReminderTestClock)} has not been configured.");
             internal ReminderTableReadController ReadController { get; } = new();
-            internal IReadOnlyList<SiloAddress> StartedReminderServices => _startedReminderServices
-                ?? throw new InvalidOperationException("Reminder services have not completed startup.");
+            internal IReadOnlyList<SiloAddress> StableReminderServices => _stableReminderServices
+                ?? throw new InvalidOperationException("Reminder services have not reached stable topology.");
 
             protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
             {
@@ -85,10 +84,23 @@ namespace UnitTests.TimerTests
                     return;
                 }
 
-                _startedReminderServices = await _startupHarness.WaitForServicesReadyAsync(
-                    HostedCluster.Silos,
-                    TestConstants.InitTimeout,
-                    TestContext.Current.CancellationToken);
+                using var topologyCancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+                topologyCancellation.CancelAfter(TestConstants.InitTimeout);
+                try
+                {
+                    var stableSilos = await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+                        HostedCluster,
+                        ReminderClock.DiagnosticObserver,
+                        HostedCluster.Silos,
+                        topologyCancellation.Token);
+                    _stableReminderServices = stableSilos.Select(static silo => silo.SiloAddress).ToArray();
+                }
+                catch (OperationCanceledException exception) when (
+                    topologyCancellation.IsCancellationRequested
+                    && !TestContext.Current.CancellationToken.IsCancellationRequested)
+                {
+                    throw new TimeoutException(exception.Message, exception);
+                }
             }
 
             public override async ValueTask DisposeAsync()
@@ -101,7 +113,6 @@ namespace UnitTests.TimerTests
                 finally
                 {
                     _reminderClock?.Dispose();
-                    _startupHarness.Dispose();
                 }
 
             }
@@ -125,11 +136,15 @@ namespace UnitTests.TimerTests
         // Basic tests
 
         [Fact]
-        public void Fixture_WaitsForReminderServicesToStart()
+        public async Task Fixture_WaitsForStableReminderTopologyBeforeGrainCalls()
         {
             Assert.All(
                 HostedCluster.Silos,
-                silo => Assert.Contains(silo.SiloAddress, _fixture.StartedReminderServices));
+                silo => Assert.Contains(silo.SiloAddress, _fixture.StableReminderServices));
+
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TestConstants.InitTimeout);
+            await ClearReminderTableAsync(cancellation.Token);
         }
 
         [Fact]


### PR DESCRIPTION
## Problem

The in-memory reminder fixture considered startup complete after the reminder-service-started event. The initial membership range-change reconciliation can still be in progress, so the fixture could activate its table-control grain before the singleton reminder service was ready for grain calls. That activation waits for GetReminders, and a stalled service scheduler caused the table cleanup request and every subsequent test initializer to time out.

## Solution

- establish the single-silo fixture through `ReminderTopologyStabilizer.WaitForStartupTopologyAsync`, covering service readiness, membership delivery, and completion of the initial reminder reconciliation
- retain phase-specific topology diagnostics when the fixture startup deadline expires
- verify that a fresh control grain can clear the reminder table after the startup-topology boundary

## Rationale

For a singleton cluster, the completed initial load is the required refresh boundary. Waiting for startup topology makes that guarantee explicit without requesting a redundant singleton refresh, while keeping this fix scoped to the older `Orleans.Reminders.Tests` fixture.

Fixes #11032

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11063)