### PR TITLE
test(reminders): stabilize TestKit topology startup

### DIFF
--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -54,7 +54,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellationToken);
+            await DeployAndWaitForStartupReminderTopologyAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var period = TimeSpan.FromMinutes(5);
@@ -100,7 +100,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellationToken);
+            await DeployAndWaitForStartupReminderTopologyAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
             await grain.RegisterReminderAsync("updated-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)).WaitAsync(cancellationToken);
@@ -133,7 +133,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellationToken);
+            await DeployAndWaitForStartupReminderTopologyAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
             oracle.SetAvailable(false);
@@ -178,7 +178,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStartupReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
@@ -222,7 +222,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStartupReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var timerLimit = TimeSpan.FromMilliseconds(0xfffffffe) + TimeSpan.FromMilliseconds(1);
@@ -273,7 +273,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStartupReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = loadingWindow + TimeSpan.FromMinutes(1);
@@ -327,7 +327,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStartupReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
@@ -369,7 +369,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
     public async Task ReminderTestKit_TwoSilosMaintainOneOwnerAndOneDelivery()
     {
         var testCancellationToken = TestContext.Current.CancellationToken;
-        var builder = new InProcessTestClusterBuilder(2);
+        var builder = new InProcessTestClusterBuilder(1);
         builder.ConfigureSilo((_, siloBuilder) =>
             siloBuilder.Configure<ConsistentRingOptions>(options => options.UseVirtualBucketsConsistentRing = false));
         var oracle = builder.UseIdealizedReminderTable();
@@ -382,7 +382,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableTwoSiloReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = TimeSpan.FromMinutes(10);
@@ -478,7 +478,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
         }
     }
 
-    private static async Task DeployAndWaitForStableReminderTopologyAsync(
+    private static async Task DeployAndWaitForStartupReminderTopologyAsync(
         InProcessTestCluster cluster,
         ReminderDiagnosticObserver observer,
         CancellationToken cancellationToken)
@@ -488,10 +488,38 @@ public sealed class ReminderTestKitClusterIntegrationTests
         topologyCancellation.CancelAfter(TimeSpan.FromSeconds(30));
         try
         {
-            await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+            await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
                 cluster,
                 observer,
                 cluster.Silos,
+                topologyCancellation.Token);
+        }
+        catch (OperationCanceledException exception) when (
+            topologyCancellation.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(exception.Message, exception);
+        }
+    }
+
+    private static async Task DeployAndWaitForStableTwoSiloReminderTopologyAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer,
+        CancellationToken cancellationToken)
+    {
+        await cluster.DeployAsync(cancellationToken);
+        var initialSilo = Assert.Single(cluster.Silos);
+        await observer.WaitForReminderServiceStartedAsync(cancellationToken, initialSilo.SiloAddress);
+
+        var joinedSilo = Assert.Single(await cluster.StartSilosAsync(1, cancellationToken));
+        using var topologyCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        topologyCancellation.CancelAfter(TimeSpan.FromSeconds(30));
+        try
+        {
+            await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+                cluster,
+                observer,
+                [initialSilo, joinedSilo],
                 topologyCancellation.Token);
         }
         catch (OperationCanceledException exception) when (

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -54,7 +54,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, cancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var period = TimeSpan.FromMinutes(5);
@@ -100,7 +100,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, cancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
             await grain.RegisterReminderAsync("updated-reminder", TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)).WaitAsync(cancellationToken);
@@ -133,7 +133,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, cancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, cancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
 
             oracle.SetAvailable(false);
@@ -178,7 +178,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
@@ -222,7 +222,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var timerLimit = TimeSpan.FromMilliseconds(0xfffffffe) + TimeSpan.FromMilliseconds(1);
@@ -273,7 +273,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = loadingWindow + TimeSpan.FromMinutes(1);
@@ -327,7 +327,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForReminderServicesAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
@@ -476,19 +476,6 @@ public sealed class ReminderTestKitClusterIntegrationTests
             using var disposeCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
             await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
         }
-    }
-
-    private static async Task DeployAndWaitForReminderServicesAsync(
-        InProcessTestCluster cluster,
-        ReminderDiagnosticObserver observer,
-        CancellationToken cancellationToken)
-    {
-        await cluster.DeployAsync(cancellationToken);
-        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cancellation.CancelAfter(TimeSpan.FromSeconds(30));
-        var started = cluster.Silos.Select(silo =>
-            observer.WaitForReminderServiceStartedAsync(cancellation.Token, silo.SiloAddress));
-        await Task.WhenAll(started);
     }
 
     private static async Task DeployAndWaitForStableReminderTopologyAsync(

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -509,13 +509,16 @@ public sealed class ReminderTestKitClusterIntegrationTests
     {
         await cluster.DeployAsync(cancellationToken);
         var initialSilo = Assert.Single(cluster.Silos);
-        await observer.WaitForReminderServiceStartedAsync(cancellationToken, initialSilo.SiloAddress);
-
-        var joinedSilo = Assert.Single(await cluster.StartSilosAsync(1, cancellationToken));
         using var topologyCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         topologyCancellation.CancelAfter(TimeSpan.FromSeconds(30));
         try
         {
+            await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
+                cluster,
+                observer,
+                [initialSilo],
+                topologyCancellation.Token);
+            var joinedSilo = Assert.Single(await cluster.StartSilosAsync(1, topologyCancellation.Token));
             await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
                 cluster,
                 observer,


### PR DESCRIPTION
## Problem

Reminder TestKit cluster scenarios began issuing reminder operations after observing reminder-service startup. For singleton clusters, startup still needed the completed initial-load topology boundary. For the two-silo scenario, concurrent startup allowed one reminder service to complete a full-ring reconciliation before its queued membership callback applied the joined topology.

## Solution

Use the singleton startup-topology boundary introduced by #11067 before one-silo scenarios issue reminder operations or advance fake time. Start the two-silo scenario with one silo, wait for its reminder service, join the second silo, and then establish the full stable-topology boundary across both silos.

## Rationale

Each scenario now waits for the topology guarantee matching its startup shape: completed initial load for a singleton and completed membership reconciliation after a staged multi-silo join. This keeps reminder operations deterministic while preserving the production runtime path.

Fixes #11024
Fixes #11048
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11064)