### PR TITLE
test(durable-jobs): stabilize shard start timing assertion

### DIFF
--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -222,25 +222,32 @@ public class ShardExecutorTests
     [Fact]
     public async Task RunShardAsync_WaitsForShardStartTime_BeforeProcessing()
     {
+        var timeProvider = new TimerTrackingFakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var startDelay = TimeSpan.FromMinutes(1);
         var options = CreateOptions(maxConcurrentJobs: 10);
         var overloadDetector = CreateOverloadDetector(isOverloaded: false);
-        var jobs = CreateJobs(1);
-        var futureStartTime = DateTimeOffset.UtcNow.AddMilliseconds(200);
-        var shard = CreateJobShard(jobs, startTime: futureStartTime);
+        var jobs = CreateJobs(1, timeProvider.GetUtcNow().AddSeconds(-1));
+        var shard = CreateJobShard(jobs, startTime: timeProvider.GetUtcNow().Add(startDelay));
         var grainFactory = CreateGrainFactory();
-        var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance);
+        var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance, timeProvider);
 
         var completedJobs = new List<string>();
         ConfigureGrainFactoryToTrackCompletions(grainFactory, completedJobs);
+        var timerCreated = timeProvider.TimerCreated.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        var startTime = DateTimeOffset.UtcNow;
+        var runTask = executor.RunShardAsync(shard, CancellationToken.None);
 
-        await executor.RunShardAsync(shard, CancellationToken.None);
+        await timerCreated;
+        Assert.False(runTask.IsCompleted);
+        Assert.Empty(completedJobs);
 
-        // Verify executor waited for shard start time before processing
-        var elapsed = DateTimeOffset.UtcNow - startTime;
-        Assert.True(elapsed.TotalMilliseconds >= 150,
-            $"Expected to wait for shard start time, but elapsed only {elapsed.TotalMilliseconds}ms");
+        timeProvider.Advance(startDelay - TimeSpan.FromTicks(1));
+        Assert.False(runTask.IsCompleted);
+        Assert.Empty(completedJobs);
+
+        timeProvider.Advance(TimeSpan.FromTicks(1));
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.Single(completedJobs);
     }
 


### PR DESCRIPTION
## Problem

`RunShardAsync_WaitsForShardStartTime_BeforeProcessing` measured a 200 ms system-clock delay and accepted a 150 ms threshold. Host clock and scheduling behavior could make the elapsed observation shorter on macOS arm64 even though the executor respected the shard start time.

## Solution

Run the executor with the existing timer-tracking fake time provider, wait until its shard-start timer is armed, and verify processing remains blocked one tick before the configured start time. Advance the final tick and verify the shard completes.

## Rationale

The assertion now observes the executor's configured time boundary directly, preserving the intended behavior without depending on host wall-clock precision.

Fixes #11059
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11065)