### PR TITLE
ci: diagnose Dashboard npm terminations

### DIFF
--- a/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
+++ b/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
@@ -56,7 +56,29 @@
     <Exec
       Command="npm ci --prefer-offline --no-audit $(NpmFetchRetryArgs)"
       WorkingDirectory="$(NpmAppRootDirectory)"
-      ConsoleToMsBuild="true" />
+      ConsoleToMsBuild="true"
+      IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="NpmInstallExitCode" />
+    </Exec>
+
+    <Message
+      Condition="'$(NpmInstallExitCode)' == '152' and $([MSBuild]::IsOSPlatform('Linux'))"
+      Importance="High"
+      Text="npm ci exit code 152 maps to SIGXCPU (signal 24) on Linux." />
+
+    <Exec
+      Condition="'$(NpmInstallExitCode)' != '0' and $([MSBuild]::IsOSPlatform('Linux'))"
+      Command="echo 'Linux resource snapshot after npm ci failure:'; uname -a; echo 'Process limits:'; cat /proc/self/limits; echo 'CPU cgroup quota and usage:'; if test -r /sys/fs/cgroup/cpu.max; then cat /sys/fs/cgroup/cpu.max; fi; if test -r /sys/fs/cgroup/cpu.stat; then cat /sys/fs/cgroup/cpu.stat; fi; echo 'Memory cgroup limit, usage, peak, and events:'; if test -r /sys/fs/cgroup/memory.max; then cat /sys/fs/cgroup/memory.max; fi; if test -r /sys/fs/cgroup/memory.current; then cat /sys/fs/cgroup/memory.current; fi; if test -r /sys/fs/cgroup/memory.peak; then cat /sys/fs/cgroup/memory.peak; fi; if test -r /sys/fs/cgroup/memory.events; then cat /sys/fs/cgroup/memory.events; fi; echo 'System memory:'; free -h; echo 'Workspace disk:'; df -h .; echo 'Largest processes by resident memory:'; ps -eo pid,ppid,stat,etimes,pcpu,pmem,rss,vsz,comm --sort=-rss | head -n 20"
+      WorkingDirectory="$(NpmAppRootDirectory)"
+      ConsoleToMsBuild="true"
+      StandardOutputImportance="High"
+      StandardErrorImportance="High"
+      IgnoreExitCode="true" />
+
+    <Error
+      Condition="'$(NpmInstallExitCode)' != '0'"
+      Code="MSB3073"
+      Text="The command &quot;npm ci --prefer-offline --no-audit $(NpmFetchRetryArgs)&quot; exited with code $(NpmInstallExitCode)." />
 
     <!-- Build the frontend -->
     <Exec


### PR DESCRIPTION
The Dashboard npm restore can be terminated by a runner-level signal without an npm diagnostic, as seen in the original failure for #11060 where Linux returned exit code 152. The identical commit passed when the workflow was rerun, confirming that the failure was transient rather than dependency-driven.

This preserves the npm process exit code, identifies Linux exit code 152 as SIGXCPU, and emits process limits, cgroup CPU and memory state, system memory, workspace disk usage, and the largest resident processes before failing with MSB3073. A future runner termination will therefore retain the evidence needed to distinguish CPU quota, memory pressure, disk pressure, and other resource causes.

Fixes #11060