### PR TITLE
test(reminders): stabilize singleton startup topology

### DIFF
--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -607,13 +607,55 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         }
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task StartupTopologyBarrier_UsesCompletedInitialLoadForSingleSilo()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
+            fixture.HostedCluster,
+            fixture.DiagnosticObserver,
+            [silo],
+            cancellation.Token);
+
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var schedulerBlocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseScheduler = new ManualResetEventSlim();
+        var blockingTask = new Task(() =>
+        {
+            schedulerBlocked.TrySetResult();
+            releaseScheduler.Wait(cancellation.Token);
+        });
+        reminderService.Scheduler.QueueTask(blockingTask);
+        await schedulerBlocked.Task.WaitAsync(cancellation.Token);
+
+        try
+        {
+            await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
+                fixture.HostedCluster,
+                fixture.DiagnosticObserver,
+                [silo],
+                cancellation.Token);
+        }
+        finally
+        {
+            releaseScheduler.Set();
+            await blockingTask.WaitAsync(cancellation.Token);
+        }
+    }
+
     public sealed class Fixture : BaseInProcessTestClusterFixture
     {
         public ReminderLifecycleHarness ReminderHarness { get; } = new();
+        public ReminderDiagnosticObserver DiagnosticObserver { get; private set; } = null!;
 
         protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
         {
             builder.Options.InitialSilosCount = 1;
+            DiagnosticObserver = ReminderDiagnosticObserver.Create(builder);
             builder.ConfigureSilo((_, siloBuilder) =>
             {
                 siloBuilder.AddReminders();
@@ -636,6 +678,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             finally
             {
                 ReminderHarness.Dispose();
+                DiagnosticObserver.Dispose();
             }
         }
     }

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -59,7 +59,11 @@ public sealed class ReminderServiceLifecycleHarness
 
     /// <inheritdoc />
     public Task WaitForStartupReadinessAsync(CancellationToken cancellationToken)
-        => StabilizeTopologyAsync(_cluster.GetActiveSilos(), cancellationToken);
+        => ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
+            _cluster,
+            _observer,
+            _cluster.GetActiveSilos(),
+            cancellationToken);
 
     /// <inheritdoc />
     public Task AdvanceAsync(TimeSpan amount, CancellationToken cancellationToken)

--- a/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
@@ -18,6 +18,35 @@ public static class ReminderTopologyStabilizer
         ReminderDiagnosticObserver observer,
         IEnumerable<InProcessSiloHandle> readySilos,
         CancellationToken cancellationToken)
+        => await WaitForStableTopologyAsync(
+            cluster,
+            observer,
+            readySilos,
+            useInitialLoadForSingleSilo: false,
+            cancellationToken);
+
+    /// <summary>
+    /// Waits for the initial reminder topology, using the completed initial load as the refresh boundary for a
+    /// single-silo cluster.
+    /// </summary>
+    public static async Task<IReadOnlyList<InProcessSiloHandle>> WaitForStartupTopologyAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer,
+        IEnumerable<InProcessSiloHandle> readySilos,
+        CancellationToken cancellationToken)
+        => await WaitForStableTopologyAsync(
+            cluster,
+            observer,
+            readySilos,
+            useInitialLoadForSingleSilo: true,
+            cancellationToken);
+
+    private static async Task<IReadOnlyList<InProcessSiloHandle>> WaitForStableTopologyAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer,
+        IEnumerable<InProcessSiloHandle> readySilos,
+        bool useInitialLoadForSingleSilo,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(cluster);
         ArgumentNullException.ThrowIfNull(observer);
@@ -80,9 +109,16 @@ public static class ReminderTopologyStabilizer
                 await Task.WhenAll(reminderServices.Select(service =>
                     service.TestOnlyWaitForSiloStatusListeners(cancellationToken)));
 
-                phase = "stable topology refresh start";
-                var refreshesStarted = reminderServices.Select(service => service.TestOnlyStartRefresh()).ToArray();
-                await Task.WhenAll(refreshesStarted).WaitAsync(cancellationToken);
+                var initialLoadIsRefreshBoundary = useInitialLoadForSingleSilo
+                    && requiredReadySilos.Length == 1
+                    && expectedActiveSilos.Length == 1
+                    && requiredReadySilos[0].SiloAddress.Equals(expectedActiveSilos[0].SiloAddress);
+                if (!initialLoadIsRefreshBoundary)
+                {
+                    phase = "stable topology refresh start";
+                    var refreshesStarted = reminderServices.Select(service => service.TestOnlyStartRefresh()).ToArray();
+                    await Task.WhenAll(refreshesStarted).WaitAsync(cancellationToken);
+                }
 
                 phase = "latest reminder reconciliation";
                 var reconciliations = reminderServices.Select(service =>


### PR DESCRIPTION
## Problem

The reminder lifecycle conformance harness always queued an explicit refresh while establishing startup readiness. For the unchanged single-silo topology, reminder-service startup had already completed the initial table load, so the extra scheduler turn could remain queued under rare CI timing and consume the scenario deadline before the duplicate-owner assertion ran.

## Solution

Use the completed initial load as the startup refresh boundary when the required and active topology is the same single silo. Preserve the explicit refresh-start barrier for multi-silo startup and all later topology reconciliation. Add a regression which holds the reminder-service scheduler after initial convergence and verifies that singleton startup readiness remains available.

## Rationale

A started singleton reminder service has loaded its full ring range. Membership and reconciliation verification still establish the stable startup boundary, while avoiding a redundant scheduler dependency for the topology that cannot transfer ownership.

Fixes #11058
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11067)