### PR TITLE
fix(testing): support single-file standalone silos

### DIFF
--- a/src/Orleans.TestingHost/StandaloneSiloHandle.cs
+++ b/src/Orleans.TestingHost/StandaloneSiloHandle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -176,7 +177,22 @@ namespace Orleans.TestingHost
         /// <param name="assembly">The entry point for spawned silos. If the provided assembly is a library (dll), then its executable sibling assembly will be invoked instead.</param>
         public static Func<string, IConfiguration, Task<SiloHandle>> CreateForAssembly(Assembly assembly)
         {
-            var executablePath = assembly.Location;
+            var executablePath = GetExecutablePath(
+                assembly,
+                GetAssemblyLocation(assembly),
+                ReferenceEquals(assembly, Assembly.GetEntryAssembly()),
+                Environment.ProcessPath);
+            return CreateDelegate(executablePath);
+        }
+
+        internal static string GetExecutablePath(Assembly assembly, string assemblyLocation, bool isEntryAssembly, string? processPath)
+        {
+            var executablePath = string.IsNullOrEmpty(assemblyLocation) && isEntryAssembly ? processPath : assemblyLocation;
+            if (string.IsNullOrEmpty(executablePath))
+            {
+                throw new FileNotFoundException($"Cannot find assembly location for assembly {assembly}");
+            }
+
             var originalFileInfo = new FileInfo(executablePath);
             if (!originalFileInfo.Exists)
             {
@@ -206,8 +222,14 @@ namespace Orleans.TestingHost
                 throw new FileNotFoundException($"Target assembly \"{target.FullName}\" does not exist");
             }
 
-            return CreateDelegate(target.FullName);
+            return target.FullName;
         }
+
+        [UnconditionalSuppressMessage(
+            "SingleFile",
+            "IL3000:Avoid accessing Assembly file path when publishing as a single file",
+            Justification = "CreateForAssembly handles the empty location of a bundled entry assembly using the current process path.")]
+        private static string GetAssemblyLocation(Assembly assembly) => assembly.Location;
 
         private async Task StartAsync()
         {

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/StandaloneSiloHandleTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/StandaloneSiloHandleTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace Orleans.TestingHost.Tests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("TestingHost")]
+public sealed class StandaloneSiloHandleTests
+{
+    [Fact]
+    public void GetExecutablePath_BundledEntryAssembly_UsesProcessPath()
+    {
+        var processPath = Path.GetTempFileName();
+
+        try
+        {
+            var result = StandaloneSiloHandle.GetExecutablePath(
+                typeof(StandaloneSiloHandleTests).Assembly,
+                assemblyLocation: string.Empty,
+                isEntryAssembly: true,
+                processPath);
+
+            Assert.Equal(processPath, result);
+        }
+        finally
+        {
+            File.Delete(processPath);
+        }
+    }
+}


### PR DESCRIPTION
`StandaloneSiloHandle.CreateForAssembly` relied on `Assembly.Location`, which is empty for assemblies embedded in a single-file application.

Resolve bundled entry assemblies through `Environment.ProcessPath` while preserving the existing assembly-location and sibling-apphost behavior for regular deployments. Add focused coverage for the bundled-entry resolution path and keep the IL3000 suppression scoped to the validated `Assembly.Location` access.

Fixes #11053
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11068)