### PR TITLE
test(analyzers): stabilize temporary directory cleanup

### DIFF
--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -2924,11 +2924,13 @@ interface Outer.IInnerGrain [Version(1)]
             }
             catch (IOException) when (attempt < maxAttempts)
             {
-                await Task.Delay(retryDelay, cancellationToken);
+                await Task.Delay(retryDelay, cancellationToken)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             }
             catch (UnauthorizedAccessException) when (attempt < maxAttempts)
             {
-                await Task.Delay(retryDelay, cancellationToken);
+                await Task.Delay(retryDelay, cancellationToken)
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             }
         }
     }

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -2922,12 +2922,7 @@ interface Outer.IInnerGrain [Version(1)]
                 Directory.Delete(path, recursive: true);
                 return;
             }
-            catch (IOException) when (attempt < maxAttempts)
-            {
-                await Task.Delay(retryDelay, cancellationToken)
-                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-            }
-            catch (UnauthorizedAccessException) when (attempt < maxAttempts)
+            catch (Exception exception) when (attempt < maxAttempts && (exception is IOException or UnauthorizedAccessException))
             {
                 await Task.Delay(retryDelay, cancellationToken)
                     .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -2902,11 +2902,15 @@ interface Outer.IInnerGrain [Version(1)]
         }
         finally
         {
-            await DeleteDirectoryWithRetriesAsync(tempDirectory);
+            await DeleteDirectoryWithRetriesAsync(
+                tempDirectory,
+                TestContext.Current.CancellationToken);
         }
     }
 
-    private static async Task DeleteDirectoryWithRetriesAsync(string path)
+    private static async Task DeleteDirectoryWithRetriesAsync(
+        string path,
+        CancellationToken cancellationToken)
     {
         const int maxAttempts = 10;
         var retryDelay = TimeSpan.FromMilliseconds(100);
@@ -2920,11 +2924,11 @@ interface Outer.IInnerGrain [Version(1)]
             }
             catch (IOException) when (attempt < maxAttempts)
             {
-                await Task.Delay(retryDelay, TestContext.Current.CancellationToken);
+                await Task.Delay(retryDelay, cancellationToken);
             }
             catch (UnauthorizedAccessException) when (attempt < maxAttempts)
             {
-                await Task.Delay(retryDelay, TestContext.Current.CancellationToken);
+                await Task.Delay(retryDelay, cancellationToken);
             }
         }
     }

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -2902,7 +2902,30 @@ interface Outer.IInnerGrain [Version(1)]
         }
         finally
         {
-            Directory.Delete(tempDirectory, recursive: true);
+            await DeleteDirectoryWithRetriesAsync(tempDirectory);
+        }
+    }
+
+    private static async Task DeleteDirectoryWithRetriesAsync(string path)
+    {
+        const int maxAttempts = 10;
+        var retryDelay = TimeSpan.FromMilliseconds(100);
+
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (attempt < maxAttempts)
+            {
+                await Task.Delay(retryDelay, TestContext.Current.CancellationToken);
+            }
+            catch (UnauthorizedAccessException) when (attempt < maxAttempts)
+            {
+                await Task.Delay(retryDelay, TestContext.Current.CancellationToken);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The analyzer CLI tests can leave transient Windows file handles after `dotnet` exits, causing successful tests to fail while deleting their temporary directory.

## Solution

Retry temporary-directory deletion for bounded `IOException` and `UnauthorizedAccessException` failures. The final deletion attempt remains unhandled so persistent cleanup failures retain their filesystem exception and stack trace.

## Rationale

A short bounded retry accommodates Windows compiler-server and filesystem handle release timing without hiding durable cleanup problems.

Fixes #11047
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11069)