### PR TITLE
ci: centralize Dashboard asset builds in tests

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -5,6 +5,10 @@ inputs:
   artifact-name:
     description: Test output artifact name.
     required: true
+  build-external-assets:
+    description: Build external assets required by the selected tests.
+    required: false
+    default: 'false'
   filter-query:
     description: Optional Microsoft Testing Platform query filter.
     required: false
@@ -39,6 +43,8 @@ runs:
       framework: ${{ inputs.framework }}
       result-id: ${{ inputs.retry == 'true' && format('{0}-attempt1', inputs.artifact-name) || inputs.artifact-name }}
       static-instrumentation: ${{ inputs.static-instrumentation }}
+    env:
+      BuildExternalAssets: ${{ inputs.build-external-assets }}
   - name: Retry tests
     if: inputs.retry == 'true' && steps.test.outcome == 'failure'
     uses: ./.github/actions/dotnet-test
@@ -48,6 +54,8 @@ runs:
       framework: ${{ inputs.framework }}
       result-id: ${{ format('{0}-attempt2', inputs.artifact-name) }}
       static-instrumentation: ${{ inputs.static-instrumentation }}
+    env:
+      BuildExternalAssets: ${{ inputs.build-external-assets }}
   - name: Archive test results
     if: always()
     uses: ./.github/actions/archive-test-results

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -44,7 +44,7 @@ runs:
       result-id: ${{ inputs.retry == 'true' && format('{0}-attempt1', inputs.artifact-name) || inputs.artifact-name }}
       static-instrumentation: ${{ inputs.static-instrumentation }}
     env:
-      BuildExternalAssets: ${{ inputs.build-external-assets }}
+      BuildExternalAssets: ${{ inputs['build-external-assets'] }}
   - name: Retry tests
     if: inputs.retry == 'true' && steps.test.outcome == 'failure'
     uses: ./.github/actions/dotnet-test
@@ -55,7 +55,7 @@ runs:
       result-id: ${{ format('{0}-attempt2', inputs.artifact-name) }}
       static-instrumentation: ${{ inputs.static-instrumentation }}
     env:
-      BuildExternalAssets: ${{ inputs.build-external-assets }}
+      BuildExternalAssets: ${{ inputs['build-external-assets'] }}
   - name: Archive test results
     if: always()
     uses: ./.github/actions/archive-test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,8 @@ jobs:
   test-sqlite:
     name: SQLite provider tests
     runs-on: ubuntu-latest
+    env:
+      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,6 @@ jobs:
   test-redis:
     name: Redis provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +116,6 @@ jobs:
     name: Cassandra provider tests
     runs-on: ubuntu-latest
     env:
-      BuildExternalAssets: "false"
       CASSANDRA_IMAGE: cassandra:${{ matrix.dbversion }}
     strategy:
       fail-fast: false
@@ -146,7 +143,6 @@ jobs:
     name: PostgreSQL provider tests
     runs-on: ubuntu-latest
     env:
-      BuildExternalAssets: "false"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       POSTGRES_PASSWORD: postgres
     strategy:
@@ -189,7 +185,6 @@ jobs:
     name: MariaDB/MySQL provider tests
     runs-on: ubuntu-latest
     env:
-      BuildExternalAssets: "false"
       # The official MariaDB 10.6 image is not published to GHCR. Prefer Google's Docker Hub
       # mirror, with Docker Hub as a fallback, and pin both references to the same digest.
       MARIADB_IMAGE: mirror.gcr.io/library/mariadb:10.6@sha256:daacc2f260f8ec999daa5e03a017a23a7e6fa3fb982aaf26e8b72f24daf03bc9
@@ -202,10 +197,6 @@ jobs:
         framework: ["net8.0", "net10.0"]
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-    - name: Setup Node.js
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-      with:
-        node-version: '24.x'
     - name: Start MariaDB
       shell: bash
       run: |
@@ -258,7 +249,6 @@ jobs:
     name: Microsoft SQL Server provider tests
     runs-on: ubuntu-latest
     env:
-      BuildExternalAssets: "false"
       ACCEPT_EULA: "Y"
       MSSQL_PID: "Developer"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
@@ -310,8 +300,6 @@ jobs:
   test-sqlite:
     name: SQLite provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -327,8 +315,6 @@ jobs:
   test-azure-storage:
     name: Azure Storage provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -369,8 +355,6 @@ jobs:
   test-azure-eventhubs:
     name: Azure Event Hubs provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -435,8 +419,6 @@ jobs:
   test-azure-cosmosdb:
     name: Azure Cosmos DB provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -493,8 +475,6 @@ jobs:
   test-consul:
     name: Consul provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -517,8 +497,6 @@ jobs:
   test-zookeeper:
     name: ZooKeeper provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -554,7 +532,6 @@ jobs:
     name: AWS DynamoDB provider tests
     runs-on: ubuntu-latest
     env:
-      BuildExternalAssets: "false"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       AWS_ACCESS_KEY_ID: root
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
@@ -602,7 +579,6 @@ jobs:
     name: AWS SQS provider tests
     runs-on: ubuntu-latest
     env:
-      BuildExternalAssets: "false"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       AWS_ACCESS_KEY_ID: root
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
@@ -664,8 +640,6 @@ jobs:
   test-nats:
     name: NATS stream provider tests
     runs-on: ubuntu-latest
-    env:
-      BuildExternalAssets: "false"
     strategy:
       fail-fast: false
       matrix:
@@ -713,7 +687,6 @@ jobs:
     name: AWS Kinesis provider tests
     runs-on: ubuntu-latest
     env:
-      BuildExternalAssets: "false"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       AWS_ACCESS_KEY_ID: test
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
@@ -785,6 +758,7 @@ jobs:
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Setup Node.js
+      if: matrix.suite == 'BVT'
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '24.x'
@@ -792,6 +766,7 @@ jobs:
       uses: ./.github/actions/run-tests
       with:
         artifact-name: test_output_${{ github.job }}_${{ matrix.suite }}_${{ matrix.os }}_${{ matrix.framework }}
+        build-external-assets: ${{ matrix.suite == 'BVT' && 'true' || 'false' }}
         filter-query: /[(Provider=None)&(Suite=${{ matrix.suite }})&(Area!=CodeGen)]
         framework: ${{ matrix.framework }}
   test-codegenerator:

--- a/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
+++ b/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
@@ -58,6 +58,29 @@
       WorkingDirectory="$(NpmAppRootDirectory)"
       ConsoleToMsBuild="true" />
 
+    <!-- Verify Rolldown's optional native binding before building. A single clean-install
+         retry recovers transient npm optional-dependency omissions. -->
+    <Exec
+      Command="node --input-type=module --eval &quot;import 'rolldown'&quot;"
+      WorkingDirectory="$(NpmAppRootDirectory)"
+      ConsoleToMsBuild="true"
+      IgnoreExitCode="true"
+      StandardOutputImportance="Low"
+      StandardErrorImportance="Low">
+      <Output TaskParameter="ExitCode" PropertyName="RolldownLoadExitCode" />
+    </Exec>
+
+    <Message
+      Condition="'$(RolldownLoadExitCode)' != '0'"
+      Importance="High"
+      Text="Retrying dependency installation once to restore Rolldown's native binding." />
+
+    <Exec
+      Condition="'$(RolldownLoadExitCode)' != '0'"
+      Command="npm ci --prefer-offline --no-audit $(NpmFetchRetryArgs)"
+      WorkingDirectory="$(NpmAppRootDirectory)"
+      ConsoleToMsBuild="true" />
+
     <!-- Build the frontend -->
     <Exec
       Command="npm run build"

--- a/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
+++ b/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
@@ -58,29 +58,6 @@
       WorkingDirectory="$(NpmAppRootDirectory)"
       ConsoleToMsBuild="true" />
 
-    <!-- Verify Rolldown's optional native binding before building. A single clean-install
-         retry recovers transient npm optional-dependency omissions. -->
-    <Exec
-      Command="node --input-type=module --eval &quot;import 'rolldown'&quot;"
-      WorkingDirectory="$(NpmAppRootDirectory)"
-      ConsoleToMsBuild="true"
-      IgnoreExitCode="true"
-      StandardOutputImportance="Low"
-      StandardErrorImportance="Low">
-      <Output TaskParameter="ExitCode" PropertyName="RolldownLoadExitCode" />
-    </Exec>
-
-    <Message
-      Condition="'$(RolldownLoadExitCode)' != '0'"
-      Importance="High"
-      Text="Retrying dependency installation once to restore Rolldown's native binding." />
-
-    <Exec
-      Condition="'$(RolldownLoadExitCode)' != '0'"
-      Command="npm ci --prefer-offline --no-audit $(NpmFetchRetryArgs)"
-      WorkingDirectory="$(NpmAppRootDirectory)"
-      ConsoleToMsBuild="true" />
-
     <!-- Build the frontend -->
     <Exec
       Command="npm run build"


### PR DESCRIPTION
Provider test partitions build the solution before running their selected tests, but none exercise the Dashboard frontend. External asset policy was repeated across individual provider jobs, so the newer SQLite partition missed it and redundantly invoked npm.

This moves the policy into the shared `run-tests` action. Test partitions skip external assets by default, while the general BVT matrix opts in because it contains the Dashboard embedded-asset tests. The workflow no longer carries per-provider `BuildExternalAssets` settings, and Node.js setup runs only in jobs which use it.

Fixes #11045