### PR TITLE
test(reminders): stabilize two-silo topology startup

### DIFF
--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -369,7 +369,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
     public async Task ReminderTestKit_TwoSilosMaintainOneOwnerAndOneDelivery()
     {
         var testCancellationToken = TestContext.Current.CancellationToken;
-        var builder = new InProcessTestClusterBuilder(2);
+        var builder = new InProcessTestClusterBuilder(1);
         builder.ConfigureSilo((_, siloBuilder) =>
             siloBuilder.Configure<ConsistentRingOptions>(options => options.UseVirtualBucketsConsistentRing = false));
         var oracle = builder.UseIdealizedReminderTable();
@@ -382,7 +382,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
 
         try
         {
-            await DeployAndWaitForStableReminderTopologyAsync(cluster, observer, testCancellationToken);
+            await DeployAndWaitForStableTwoSiloReminderTopologyAsync(cluster, observer, testCancellationToken);
             var grain = cluster.Client.GetGrain<IReminderTestKitGrain>(Guid.NewGuid());
             var grainId = grain.GetGrainId();
             var dueTime = TimeSpan.FromMinutes(10);
@@ -497,6 +497,15 @@ public sealed class ReminderTestKitClusterIntegrationTests
         CancellationToken cancellationToken)
     {
         await cluster.DeployAsync(cancellationToken);
+        await WaitForStableReminderTopologyAsync(cluster, observer, cluster.Silos, cancellationToken);
+    }
+
+    private static async Task WaitForStableReminderTopologyAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer,
+        IEnumerable<InProcessSiloHandle> readySilos,
+        CancellationToken cancellationToken)
+    {
         using var topologyCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         topologyCancellation.CancelAfter(TimeSpan.FromSeconds(30));
         try
@@ -504,7 +513,7 @@ public sealed class ReminderTestKitClusterIntegrationTests
             await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
                 cluster,
                 observer,
-                cluster.Silos,
+                readySilos,
                 topologyCancellation.Token);
         }
         catch (OperationCanceledException exception) when (
@@ -513,6 +522,19 @@ public sealed class ReminderTestKitClusterIntegrationTests
         {
             throw new TimeoutException(exception.Message, exception);
         }
+    }
+
+    private static async Task DeployAndWaitForStableTwoSiloReminderTopologyAsync(
+        InProcessTestCluster cluster,
+        ReminderDiagnosticObserver observer,
+        CancellationToken cancellationToken)
+    {
+        await cluster.DeployAsync(cancellationToken);
+        var initialSilo = Assert.Single(cluster.Silos);
+        await observer.WaitForReminderServiceStartedAsync(cancellationToken, initialSilo.SiloAddress);
+
+        var joinedSilo = Assert.Single(await cluster.StartSilosAsync(1, cancellationToken));
+        await WaitForStableReminderTopologyAsync(cluster, observer, [initialSilo, joinedSilo], cancellationToken);
     }
 
     private static async Task AdvanceUntilAsync(


### PR DESCRIPTION
## Problem

The two-silo Reminder TestKit scenario started both silos concurrently. A reminder service could complete its initial full-ring reconciliation before its queued membership callback applied the two-silo range, leaving topology stabilization waiting on the service scheduler until timeout.

## Solution

Start the first silo and wait for its reminder service before joining the second silo. Then apply the existing stable-topology barrier to both silos before registering reminders or advancing fake time.

## Rationale

The scenario validates single ownership and delivery after a two-silo topology is established. Sequencing the join makes that topology transition explicit while preserving the production runtime path and the full reconciliation invariant.

Fixes #11048
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11071)