### PR TITLE
fix(docs): forward async stream cancellation token

### DIFF
--- a/docs/site/src/content/docs/grains/response-streaming.md
+++ b/docs/site/src/content/docs/grains/response-streaming.md
@@ -41,7 +41,7 @@ Batching doesn't cause Orleans to read an unbounded number of elements ahead. Th
 
 ## Cancel response streaming
 
-Pass the caller's token to the grain method and through `WithCancellation` so cancellation reaches both the grain call and the async enumerator. Orleans links distinct tokens so cancellation of either stops the enumeration. Call `WithBatchSize` before `WithCancellation`:
+Pass the caller's token to the grain method either as a method parameter or through `WithCancellation` (or both), so cancellation stops the async enumerator. Orleans links distinct tokens so cancellation of either stops the enumeration. Call `WithBatchSize` before `WithCancellation`:
 
 :::code language="csharp" source="snippets/async-enumerable-results/StreamingConsumer.cs" id="cancel_stream":::
 

--- a/docs/site/src/content/docs/grains/response-streaming.md
+++ b/docs/site/src/content/docs/grains/response-streaming.md
@@ -1,7 +1,7 @@
 ---
 title: Response streaming with IAsyncEnumerable
 description: Stream a grain call's response incrementally using IAsyncEnumerable<T>.
-ms.date: 08/08/2026
+ms.date: 09/04/2026
 ms.topic: concept-article
 ---
 
@@ -41,7 +41,7 @@ Batching doesn't cause Orleans to read an unbounded number of elements ahead. Th
 
 ## Cancel response streaming
 
-Supply a token as a grain method argument, through `WithCancellation`, or both. Orleans links distinct tokens so cancellation of either stops the enumeration. Call `WithBatchSize` first when using both extensions:
+Pass the caller's token to the grain method and through `WithCancellation` so cancellation reaches both the grain call and the async enumerator. Orleans links distinct tokens so cancellation of either stops the enumeration. Call `WithBatchSize` before `WithCancellation`:
 
 :::code language="csharp" source="snippets/async-enumerable-results/StreamingConsumer.cs" id="cancel_stream":::
 

--- a/docs/site/src/content/docs/grains/snippets/async-enumerable-results/StreamingConsumer.cs
+++ b/docs/site/src/content/docs/grains/snippets/async-enumerable-results/StreamingConsumer.cs
@@ -32,7 +32,7 @@ public static class StreamingConsumer
         try
         {
             await foreach (var row in grain
-                .ExportRows()
+                .ExportRows(cancellationToken)
                 .WithBatchSize(25)
                 .WithCancellation(cancellationToken))
             {


### PR DESCRIPTION
Fixes #11044

The response-streaming cancellation snippet omitted the grain method's cancellation-token argument while forwarding the token through `WithCancellation`, causing CA2016 when building the documentation solution.

Pass the caller token to `ExportRows` and clarify that the token reaches both the grain call and the async enumerator.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11072)