### PR TITLE
ci: fix invalid cfs-npm Dependabot registry configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ registries:
     type: "python-index"
     url: "https://packagefeedproxy.microsoft.io/pypi/simple/"
     replaces-base: true
+# Dependabot reads the checked-in .npmrc files for anonymous CFS npm access.
 updates:
   - package-ecosystem: "dotnet-sdk"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ registries:
     type: "python-index"
     url: "https://packagefeedproxy.microsoft.io/pypi/simple/"
     replaces-base: true
-  cfs-npm:
-    type: "npm-registry"
-    url: "https://packagefeedproxy.microsoft.io/npm/"
-    replaces-base: true
 updates:
   - package-ecosystem: "dotnet-sdk"
     directory: "/"


### PR DESCRIPTION
Fixes #11074

npm dependency resolution continues through the checked-in `.npmrc` files, which route requests through the anonymous CFS proxy. Dependabot reads those files when an npm registry scope is not configured.

The top-level `registries` section represents registry credentials. GitHub currently rejects credential-free `npm-registry` entries ([dependabot-core#15149](https://github.com/dependabot/dependabot-core/issues/15149)), so this removes the invalid `cfs-npm` entry and documents the supported `.npmrc` path. The valid CFS NuGet and PyPI registry entries remain available.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11079)