### PR TITLE
fix(build): resolve analyzer enforcement blockers

### DIFF
--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/AzureTableGrainDirectory.cs
@@ -228,7 +228,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// <remarks>This method is invoked by the silo lifecycle and can also be used by tests.</remarks>
         public async Task InitializeIfNeeded(CancellationToken ct = default)
         {
-            await this.tableDataManager.InitTableAsync();
+            await this.tableDataManager.InitTableAsync(ct);
         }
 
         /// <summary>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -377,9 +377,9 @@ namespace Orleans.Storage
                 tableManager = new AzureTableDataManager<TableEntity>(options, logger);
             }
 
-            public Task InitTableAsync()
+            public Task InitTableAsync(CancellationToken cancellationToken)
             {
-                return tableManager.InitTableAsync();
+                return tableManager.InitTableAsync(cancellationToken);
             }
 
             public async Task<TableEntity?> Read(string partitionKey, string rowKey)
@@ -496,7 +496,7 @@ namespace Orleans.Storage
             {
                 LogDebugStorageInitializing(name, this.options.TableName);
                 this.tableDataManager = new GrainStateTableDataManager(this.options, this.logger);
-                await this.tableDataManager.InitTableAsync();
+                await this.tableDataManager.InitTableAsync(ct);
                 stopWatch.Stop();
                 LogInfoInitializingProvider(this.name, this.GetType().Name, this.options.InitStage, stopWatch.ElapsedMilliseconds);
             }

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -71,7 +71,7 @@ namespace Orleans.Runtime.ReminderService
                 {
                     try
                     {
-                        await remTableManager.InitTableAsync();
+                        await remTableManager.InitTableAsync(cancellationToken);
                         initialization.TrySetResult();
                         return;
                     }

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
@@ -73,18 +73,18 @@ namespace Orleans.Transactions.AzureStorage
             return AzureTableUtils.SanitizeTableProperty(key);
         }
 
-        private async Task CreateTable()
+        private async Task CreateTable(CancellationToken cancellationToken)
         {
             var tableManager = new AzureTableDataManager<TableEntity>(
                 this.options,
                 this.loggerFactory.CreateLogger<AzureTableDataManager<TableEntity>>());
-            await tableManager.InitTableAsync();
+            await tableManager.InitTableAsync(cancellationToken);
             this.table = tableManager.Table;
         }
 
         private Task Init(CancellationToken cancellationToken)
         {
-            return CreateTable();
+            return CreateTable(cancellationToken);
         }
     }
 }

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -71,8 +71,9 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// <summary>
         /// Connects to, or creates and initializes a new Azure table if it does not already exist.
         /// </summary>
+        /// <param name="cancellationToken">The token used to cancel table creation.</param>
         /// <returns>Completion promise for this operation.</returns>
-        public async Task InitTableAsync()
+        public async Task InitTableAsync(CancellationToken cancellationToken = default)
         {
             const string operation = "InitTable";
             var startTime = DateTime.UtcNow;
@@ -81,7 +82,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             {
                 TableServiceClient tableCreationClient = await GetCloudTableCreationClientAsync();
                 var table = tableCreationClient.GetTableClient(TableName);
-                var response = await table.CreateIfNotExistsAsync();
+                var response = await table.CreateIfNotExistsAsync(cancellationToken);
                 var alreadyExisted = response.GetRawResponse().Status == (int)HttpStatusCode.Conflict;
 
                 LogInfoTableCreation(Logger, alreadyExisted ? "Attached to" : "Created", TableName);

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -88,6 +88,10 @@ namespace Orleans.GrainDirectory.AzureStorage
                 LogInfoTableCreation(Logger, alreadyExisted ? "Attached to" : "Created", TableName);
                 Table = table;
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (TimeoutException te)
             {
                 LogErrorTableCreationInTimeout(Logger, te, StoragePolicyOptions.CreationTimeout);

--- a/src/Orleans.Analyzers.Contracts/Orleans.Analyzers.Contracts.csproj
+++ b/src/Orleans.Analyzers.Contracts/Orleans.Analyzers.Contracts.csproj
@@ -10,6 +10,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
+    <NeutralLanguage>en-US</NeutralLanguage>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- The contracts package includes its analyzer and code fix together; the code fix requires Roslyn Workspaces. -->
     <NoWarn>$(NoWarn);RS1038</NoWarn>

--- a/src/Orleans.Analyzers/Orleans.Analyzers.csproj
+++ b/src/Orleans.Analyzers/Orleans.Analyzers.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
+    <NeutralLanguage>en-US</NeutralLanguage>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- Analyzers and code fixes share this assembly so the packaged component exposes both; code fixes require Roslyn Workspaces. -->
     <NoWarn>$(NoWarn);RS1038</NoWarn>

--- a/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
+++ b/src/Orleans.CodeGenerator/Orleans.CodeGenerator.csproj
@@ -9,6 +9,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
+    <NeutralLanguage>en-US</NeutralLanguage>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>

--- a/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
+++ b/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
@@ -58,7 +58,7 @@ namespace Tester.AzureUtils
             : base(new AzureStorageOperationOptions { TableName = INSTANCE_TABLE_NAME }.ConfigureTestDefaults(),
                   NullLoggerFactory.Instance.CreateLogger<UnitTestAzureTableDataManager>())
         {
-            InitTableAsync()
+            InitTableAsync(cancellationToken)
                 .WaitAsync(new AzureStoragePolicyOptions().CreationTimeout, cancellationToken)
                 .GetAwaiter()
                 .GetResult();

--- a/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
+++ b/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
@@ -58,10 +58,9 @@ namespace Tester.AzureUtils
             : base(new AzureStorageOperationOptions { TableName = INSTANCE_TABLE_NAME }.ConfigureTestDefaults(),
                   NullLoggerFactory.Instance.CreateLogger<UnitTestAzureTableDataManager>())
         {
-            InitTableAsync(cancellationToken)
-                .WaitAsync(new AzureStoragePolicyOptions().CreationTimeout, cancellationToken)
-                .GetAwaiter()
-                .GetResult();
+            using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellationSource.CancelAfter(StoragePolicyOptions.CreationTimeout);
+            InitTableAsync(cancellationSource.Token).GetAwaiter().GetResult();
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
+++ b/test/Extensions/Orleans.Azure.Tests/UnitTestAzureTableDataManager.cs
@@ -59,8 +59,18 @@ namespace Tester.AzureUtils
                   NullLoggerFactory.Instance.CreateLogger<UnitTestAzureTableDataManager>())
         {
             using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cancellationSource.CancelAfter(StoragePolicyOptions.CreationTimeout);
-            InitTableAsync(cancellationSource.Token).GetAwaiter().GetResult();
+            var creationTimeout = StoragePolicyOptions.CreationTimeout;
+            cancellationSource.CancelAfter(creationTimeout);
+            try
+            {
+                InitTableAsync(cancellationSource.Token).GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException exception) when (
+                cancellationSource.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException($"Azure Table initialization timed out after {creationTimeout}.", exception);
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

The analyzer baseline leaves current `main` with two warnings-as-errors build blockers: Azure Table grain-directory initialization does not forward lifecycle cancellation, and the analyzer assemblies do not declare their neutral resource language.

## Solution

- Propagate lifecycle cancellation through shared Azure Table initialization and the affected lifecycle entry points.
- Declare `en-US` as the neutral language for `Orleans.Analyzers` and `Orleans.CodeGenerator`.

PR #11040 already resolved the xUnit1051 failures reported by #11035, #11036, #11037, #11039, and #11043. This PR does not include or claim those fixes.

Closes #11041
Closes #11042
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11080)