### PR TITLE
test: synchronize async enumerable deactivation

### DIFF
--- a/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
@@ -724,15 +724,26 @@ public class AsyncEnumerableGrainCallTests
         var values = new List<string>();
         await Assert.ThrowsAsync<EnumerationAbortedException>(async () =>
         {
-            await foreach (var entry in grain.GetValues(cancellationToken))
+            try
             {
-                values.Add(entry);
-                if (values.Count == 2)
+                await foreach (var entry in grain.GetValues(cancellationToken))
                 {
-                    valuesObserved.TrySetResult();
-                }
+                    values.Add(entry);
+                    if (values.Count == 2)
+                    {
+                        valuesObserved.TrySetResult();
+                    }
 
-                Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
+                    Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
+                }
+            }
+            finally
+            {
+                if (values.Count < 2)
+                {
+                    valuesObserved.TrySetException(
+                        new InvalidOperationException($"Enumeration ended after observing {values.Count} of 2 values."));
+                }
             }
         }).WaitAsync(cancellationToken);
 

--- a/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
@@ -708,15 +708,16 @@ public class AsyncEnumerableGrainCallTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var grain = GrainFactory.GetGrain<IObservableGrain>(Guid.NewGuid());
+        var valuesObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var producer = Task.Run(async () =>
         {
             foreach (var value in Enumerable.Range(0, 2))
             {
-                await Task.Delay(200, cancellationToken);
                 await grain.OnNext(value.ToString());
             }
 
+            await valuesObserved.Task.WaitAsync(cancellationToken);
             await grain.Deactivate();
         }, cancellationToken);
 
@@ -726,10 +727,16 @@ public class AsyncEnumerableGrainCallTests
             await foreach (var entry in grain.GetValues(cancellationToken))
             {
                 values.Add(entry);
+                if (values.Count == 2)
+                {
+                    valuesObserved.TrySetResult();
+                }
+
                 Logger.LogInformation("ObservableGrain_AsyncEnumerable: {Entry}", entry);
             }
         }).WaitAsync(cancellationToken);
 
+        await producer.WaitAsync(cancellationToken);
         Assert.Equal(2, values.Count);
     }
 


### PR DESCRIPTION
Resolves #11073.

`IObservableGrain.OnNext` completes when the value is enqueued in the grain-local channel. The caller observes that value later, when the async-enumerable extension completes a `MoveNext` request. The test previously relied on a 200 ms delay between writes and requested deactivation immediately after the second enqueue, allowing deactivation to dispose the extension before the second value reached the caller.

Replace the timing assumption with an acknowledgement barrier from the consumer. The producer requests deactivation only after the caller has observed both values, preserving the lifecycle invariant that the test is intended to exercise: deactivation aborts the next enumeration request after all produced values have been delivered. Awaiting the producer task also ensures write, synchronization, and deactivation failures are surfaced by the test.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11084)