### PR TITLE
fix(ci): avoid provider apt refreshes

### DIFF
--- a/.github/actions/setup-coverage/action.yml
+++ b/.github/actions/setup-coverage/action.yml
@@ -1,15 +1,17 @@
 name: Setup code coverage
-description: Install the cross-platform dependencies and tool used to collect CI coverage.
+description: Verify the cross-platform prerequisites and install the tool used to collect CI coverage.
 
 runs:
   using: composite
   steps:
-  - name: Install Linux coverage dependencies
+  - name: Verify Linux coverage dependencies
     if: runner.os == 'Linux'
     shell: bash
     run: |
-      sudo apt-get update
-      sudo apt-get install --yes libxml2
+      if ! dpkg-query --show --showformat='${Status}' libxml2 2>/dev/null | grep --quiet 'ok installed'; then
+        echo "::error::The GitHub-hosted Linux runner must provide libxml2 for dotnet-coverage."
+        exit 1
+      fi
   - name: Install dotnet-coverage
     shell: pwsh
     run: ./.github/scripts/setup-coverage.ps1

--- a/.github/actions/setup-coverage/action.yml
+++ b/.github/actions/setup-coverage/action.yml
@@ -8,8 +8,8 @@ runs:
     if: runner.os == 'Linux'
     shell: bash
     run: |
-      if ! dpkg-query --show --showformat='${Status}' libxml2 2>/dev/null | grep --quiet 'ok installed'; then
-        echo "::error::The GitHub-hosted Linux runner must provide libxml2 for dotnet-coverage."
+      if ! ldconfig -p | grep --fixed-strings 'libxml2.so.2' > /dev/null; then
+        echo "::error::The GitHub-hosted Linux runner must provide libxml2.so.2 for dotnet-coverage."
         exit 1
       fi
   - name: Install dotnet-coverage


### PR DESCRIPTION
`setup-coverage` refreshed every configured apt repository before each Linux test partition so it could install `libxml2`. GitHub-hosted Ubuntu runners already provide that runtime dependency, making provider tests depend unnecessarily on unrelated Microsoft apt feeds; a transient 403 stopped the job before tests began.

Verify the hosted-runner prerequisite directly instead of modifying package state. This removes apt repository access from all Linux test partitions while producing an explicit workflow error if the runner image ever stops providing `libxml2`.

The shared `run-tests` action covers all 16 provider job definitions (36 provider matrix executions), plus the Linux core and Code Generator test partitions.

Fixes #11028
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11085)