### PR TITLE
fix(ci): preserve artifact upload failures

### DIFF
--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -21,24 +21,10 @@ runs:
         !TestResults/*.cobertura.xml
         !TestResults/*.coverage.json
         **/logs/*
-  - name: Wait before retrying test result upload
+  - name: Report test result upload failure
     if: steps.archive-test-results.outcome == 'failure'
     shell: pwsh
-    run: Start-Sleep -Seconds 30
-  - name: Retry test result upload
-    if: steps.archive-test-results.outcome == 'failure'
-    continue-on-error: true
-    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-    with:
-      name: ${{ inputs.name }}
-      if-no-files-found: warn
-      retention-days: 1
-      overwrite: true
-      path: |
-        **/TestResults/*
-        !TestResults/*.cobertura.xml
-        !TestResults/*.coverage.json
-        **/logs/*
+    run: Write-Output '::warning title=Test result artifact upload failed::Test result diagnostics are unavailable. See the preceding upload error.'
   - name: Write coverage metadata
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     shell: pwsh
@@ -53,29 +39,12 @@ runs:
          ConvertTo-Json |
          Set-Content -LiteralPath 'TestResults/${{ inputs.name }}.coverage.json' -Encoding utf8NoBOM
   - name: Archive coverage
-    id: archive-coverage
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
-    continue-on-error: true
     uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     with:
       name: coverage_${{ inputs.name }}
       if-no-files-found: error
       retention-days: ${{ github.event_name == 'push' && 7 || 1 }}
-      path: |
-        TestResults/${{ inputs.name }}.cobertura.xml
-        TestResults/${{ inputs.name }}.coverage.json
-  - name: Wait before retrying coverage upload
-    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
-    shell: pwsh
-    run: Start-Sleep -Seconds 30
-  - name: Retry coverage upload
-    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
-    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-    with:
-      name: coverage_${{ inputs.name }}
-      if-no-files-found: error
-      retention-days: ${{ github.event_name == 'push' && 7 || 1 }}
-      overwrite: true
       path: |
         TestResults/${{ inputs.name }}.cobertura.xml
         TestResults/${{ inputs.name }}.coverage.json

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1186,19 +1186,18 @@ exit 0
             $archiveTestResultsAction `
             '(?s)path:\s*\|.*?TestResults/\$\{\{ inputs\.name \}\}\.cobertura\.xml.*?TestResults/\$\{\{ inputs\.name \}\}\.coverage\.json' `
             'Each test job must publish its exact coverage report.'
-        Assert-Equal 4 ([regex]::Matches($archiveTestResultsAction, 'uses: actions/upload-artifact@')).Count 'Artifact upload attempt count differs.'
-        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'run: Start-Sleep -Seconds 30')).Count 'Artifact upload retry delay count differs.'
-        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact upload retries must replace partial artifacts.'
-        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Both coverage upload attempts must require the report.'
-        Assert-Equal 3 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only the final coverage upload attempt may gate the job.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'uses: actions/upload-artifact@')).Count 'Each artifact must have one immutable upload attempt.'
+        Assert-Equal 0 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact uploads must not replace an ambiguous partial upload.'
+        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Coverage upload must require the report.'
+        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload may remain advisory.'
         Assert-Matches `
             $archiveTestResultsAction `
-            "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Retry test result upload\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
-            'Test result upload attempts must remain non-gating and retry with overwrite.'
+            "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Report test result upload failure\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    shell: pwsh\r?\n    run: Write-Output '::warning title=Test result artifact upload failed::" `
+            'Test result upload failures must remain advisory and explicit.'
         Assert-Matches `
             $archiveTestResultsAction `
-            "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: .*?github\.event_name == 'pull_request'.*?github\.event_name == 'push'.*?\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n.*?^  - name: Retry coverage upload\r?\n    if: .*?steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      overwrite: true\r?$" `
-            'Coverage upload must retry with overwrite and keep the final attempt gating.'
+            "(?ms)^  - name: Archive coverage\r?\n    if: .*?github\.event_name == 'pull_request'.*?github\.event_name == 'push'.*?\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      if-no-files-found: error\r?$" `
+            'Coverage upload must remain directly gating.'
     }
 
     Invoke-Test 'collects coverage from every test job' {

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1181,7 +1181,7 @@ exit 0
             $archiveTestResultsAction `
             "github\.event_name == 'push'.*?github\.event\.repository\.default_branch" `
             'Current-main test jobs must publish the same raw coverage artifacts.'
-        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, "github\.event_name == 'push' && 7 \|\| 1")).Count 'Current-main coverage retention count differs.'
+        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, "github\.event_name == 'push' && 7 \|\| 1")).Count 'Current-main coverage retention count differs.'
         Assert-Matches `
             $archiveTestResultsAction `
             '(?s)path:\s*\|.*?TestResults/\$\{\{ inputs\.name \}\}\.cobertura\.xml.*?TestResults/\$\{\{ inputs\.name \}\}\.coverage\.json' `


### PR DESCRIPTION
Closes #10961.

The artifact service can reserve an immutable artifact name even when `FinalizeArtifact` returns a non-retryable 403. In the reported run, the test-results artifact was published, the coverage artifact was absent from the run artifact API, and the same-name retry still failed with 409. Since the partial reservation is not visible to `overwrite`, the workflow cannot safely delete or reuse it.

Remove the delayed same-name retries and rely on the official action's request handling. Diagnostic upload failures remain advisory but now emit an explicit warning. Coverage uses one directly gating upload, preserving the original authorization/finalization error; a genuine duplicate-name conflict remains visible as 409.

The current upstream reports remain open in actions/upload-artifact#560 and actions/upload-artifact#531. upload-artifact v7.0.1 and @actions/artifact 6.2.0 do not document a finalization or ambiguous-partial-success fix, so this change keeps the existing pinned v6 action instead of introducing an unrelated major-version update.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11086)