### PR TITLE
fix(docs): stabilize validation timeouts

### DIFF
--- a/docs/site/scripts/lib/include-closure.mjs
+++ b/docs/site/scripts/lib/include-closure.mjs
@@ -29,6 +29,7 @@ export async function collectIncludeTargets(markdownFiles, options = {}) {
   const allowedRoot = options.allowedRoot ? await realpath(path.resolve(options.allowedRoot)) : undefined;
   const onIssue = options.onIssue;
   const onTarget = options.onTarget;
+  const readSource = options.readSource ?? ((filePath) => readFile(filePath, 'utf8'));
   const splitFrontmatter = options.splitFrontmatter ?? splitFrontmatterWithoutYaml;
   const targets = new Set();
   const visitedContexts = new Set();
@@ -58,7 +59,7 @@ export async function collectIncludeTargets(markdownFiles, options = {}) {
     }
     visitedContexts.add(context);
 
-    const source = await readFile(logicalPath, 'utf8');
+    const source = await readSource(logicalPath);
     const { body, bodyStartLine } = splitFrontmatter(source);
     const lines = body.replaceAll('\r\n', '\n').split('\n');
     const protectedLineRanges = body.includes('[!INCLUDE')

--- a/docs/site/tests/corpus-links.test.mjs
+++ b/docs/site/tests/corpus-links.test.mjs
@@ -41,16 +41,21 @@ const excludedDirectoryNames = new Set([
   'obj',
 ]);
 
-function filesUnder(directory, extensions) {
-  return readdirSync(directory, { recursive: true })
-    .filter(
-      (file) =>
-        extensions.some((extension) => file.endsWith(extension)) &&
-        !file
-          .split(/[\\/]/)
-          .some((segment) => excludedDirectoryNames.has(segment)),
-    )
-    .map((file) => path.join(directory, file));
+function filesUnder(directory) {
+  const files = [];
+  const pendingDirectories = [directory];
+  for (const currentDirectory of pendingDirectories) {
+    for (const entry of readdirSync(currentDirectory, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!excludedDirectoryNames.has(entry.name)) {
+          pendingDirectories.push(path.join(currentDirectory, entry.name));
+        }
+      } else if (entry.isFile()) {
+        files.push(path.join(currentDirectory, entry.name));
+      }
+    }
+  }
+  return files;
 }
 
 function localTargetExists(sourceFile, url) {
@@ -215,18 +220,34 @@ describe('documentation corpus links', () => {
 
   test('uses fully qualified URLs for Learn content outside Orleans', async () => {
     const failures = [];
-    const documentationFiles = filesUnder(documentationRoot, ['.md']).filter(
+    const documentationCorpus = filesUnder(documentationRoot);
+    const samplesCorpus = filesUnder(samplesRoot);
+    const documentationFiles = documentationCorpus.filter(
       (file) =>
+        file.endsWith('.md') &&
         !isSnippetSupportMarkdown(path.relative(documentationRoot, file)),
     );
-    const includeFiles = await collectIncludeTargets(documentationFiles, sourceRoot);
+    const sourceCache = new Map();
+    function readSource(file) {
+      const resolvedFile = path.resolve(file);
+      let source = sourceCache.get(resolvedFile);
+      if (source === undefined) {
+        source = readFileSync(resolvedFile, 'utf8');
+        sourceCache.set(resolvedFile, source);
+      }
+      return source;
+    }
+    const includeFiles = await collectIncludeTargets(documentationFiles, {
+      allowedRoot: sourceRoot,
+      readSource: async (file) => readSource(file),
+    });
     const auditedMarkdownFiles = new Set([
-      ...filesUnder(documentationRoot, ['.md']),
+      ...documentationCorpus.filter((file) => file.endsWith('.md')),
       ...includeFiles,
-      ...filesUnder(samplesRoot, ['.md']),
+      ...samplesCorpus.filter((file) => file.endsWith('.md')),
     ]);
     for (const file of [...auditedMarkdownFiles].sort()) {
-      for (const item of collectMarkdownUrls(readFileSync(file, 'utf8'), file)) {
+      for (const item of collectMarkdownUrls(readSource(file), file)) {
         failures.push({
           file: path.relative(repositoryRoot, file).replaceAll('\\', '/'),
           line: item.position,
@@ -235,11 +256,15 @@ describe('documentation corpus links', () => {
       }
     }
     const yamlFiles = [
-      ...filesUnder(documentationRoot, ['.yaml', '.yml']),
-      ...filesUnder(samplesRoot, ['.yaml', '.yml']),
+      ...documentationCorpus.filter(
+        (file) => file.endsWith('.yaml') || file.endsWith('.yml'),
+      ),
+      ...samplesCorpus.filter(
+        (file) => file.endsWith('.yaml') || file.endsWith('.yml'),
+      ),
     ];
     for (const file of yamlFiles) {
-      const documents = YAML.parseAllDocuments(readFileSync(file, 'utf8'));
+      const documents = YAML.parseAllDocuments(readSource(file));
       for (const document of documents) {
         if (document.errors.length > 0) {
           throw document.errors[0];

--- a/docs/site/tests/docfx.test.mjs
+++ b/docs/site/tests/docfx.test.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -919,9 +919,17 @@ describe('DocFX conversion', () => {
     await writeFile(nested, 'Active nested guidance.\n');
     await writeFile(path.join(includesRoot, 'inactive.md'), 'Inactive guidance.\n');
 
-    const targets = await collectIncludeTargets([firstPage, secondPage], contentRoot);
+    const reads = [];
+    const targets = await collectIncludeTargets([firstPage, secondPage], {
+      allowedRoot: contentRoot,
+      readSource: async (file) => {
+        reads.push(file);
+        return readFile(file, 'utf8');
+      },
+    });
 
     expect([...targets].sort()).toEqual([nested, shared].sort());
+    expect(reads.sort()).toEqual([firstPage, nested, secondPage, shared].sort());
   });
 
   test('rejects circular include graphs', async () => {

--- a/docs/site/vitest.config.mjs
+++ b/docs/site/vitest.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Give repository-wide parsers and process-backed policy checks a deterministic worker budget.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
Fixes #10949
Fixes #11034

Documentation validation combines repository-wide parsing with process-backed snippet policy checks. Vitest previously ran those files concurrently, so filesystem parsing and repeated PowerShell/MSBuild processes competed for the same worker resources and crossed otherwise healthy timeout budgets. The corpus link test also traversed documentation and samples roots repeatedly and entered excluded build/dependency directories before filtering their contents.

This change prunes excluded directories during corpus discovery, reuses one discovered file inventory and cached source reads across include and link analysis, and runs Vitest files with one deterministic worker. Existing policy assertions and timeout values remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11091)