### PR TITLE
fix(benchmarks): register adaptive ping grain types

### DIFF
--- a/test/Benchmarks/Ping/AdaptivePingBenchmark.cs
+++ b/test/Benchmarks/Ping/AdaptivePingBenchmark.cs
@@ -76,11 +76,17 @@ public class AdaptivePingBenchmark : IDisposable
                     gatewayPort: 30000 + i,
                     primarySiloEndpoint: primary);
 
-                // For SiloToSilo mode: remove grains from primary silo to force cross-silo calls
-                if (i == 0 && grainsOnSecondariesOnly)
+                siloBuilder.Configure<GrainTypeOptions>(options =>
                 {
-                    siloBuilder.Configure<GrainTypeOptions>(options => options.Classes.Remove(typeof(PingGrain)));
-                }
+                    options.Interfaces.Add(typeof(IPingGrain));
+                    options.Classes.Add(typeof(PingGrain));
+
+                    // For SiloToSilo mode: remove grains from primary silo to force cross-silo calls
+                    if (i == 0 && grainsOnSecondariesOnly)
+                    {
+                        options.Classes.Remove(typeof(PingGrain));
+                    }
+                });
             });
 
             var host = hostBuilder.Build();


### PR DESCRIPTION
## Problem

AdaptivePing external-client scenarios could construct an `IPingGrain` proxy but could not resolve its grain implementation. External clients build the interface-to-grain map from silo grain manifests, so each silo manifest must contain a `PingGrain` entry with its generated `implemented-interface-*` metadata. The benchmark relied on transitive application-part discovery across the `Benchmarks` -> `BenchmarkGrains` -> `BenchmarkGrainInterfaces` assembly boundary, leaving that mapping unavailable in the failing process configuration.

## Solution

Explicitly register `IPingGrain` and `PingGrain` in each AdaptivePing silo's `GrainTypeOptions`. This makes the silo manifest deterministic without broad assembly scanning and supplies the mapping used by both one-silo and two-silo external clients, including the aggregate AdaptivePing scenario and the deterministic external modes on the performance branch.

The SiloToSilo scenario continues to remove `PingGrain` from the primary silo after registration, preserving forced cross-silo placement while secondary silos advertise the implementation.

Resolves #10912
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11092)