### PR TITLE
ci: capture Linux net8 test coordinator crashes

### DIFF
--- a/.github/actions/dotnet-test/action.yml
+++ b/.github/actions/dotnet-test/action.yml
@@ -26,7 +26,7 @@ runs:
     if: runner.os == 'Linux' && inputs.framework == 'net8.0'
     shell: pwsh
     run: |
-      New-Item -ItemType Directory -Force -Path TestResults | Out-Null
+      New-Item -ItemType Directory -Force -Path '${{ github.workspace }}/TestResults' | Out-Null
       @(
         'DOTNET_DbgEnableMiniDump=1'
         'DOTNET_DbgMiniDumpType=2'

--- a/.github/actions/dotnet-test/action.yml
+++ b/.github/actions/dotnet-test/action.yml
@@ -22,6 +22,17 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Prepare runtime crash diagnostics
+    if: runner.os == 'Linux' && inputs.framework == 'net8.0'
+    shell: pwsh
+    run: |
+      New-Item -ItemType Directory -Force -Path TestResults | Out-Null
+      @(
+        'DOTNET_DbgEnableMiniDump=1'
+        'DOTNET_DbgMiniDumpType=2'
+        'DOTNET_DbgMiniDumpName=${{ github.workspace }}/TestResults/dotnet-test.%p.dmp'
+        'DOTNET_CreateDumpDiagnostics=1'
+      ) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
   - name: Prepare coverage report
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     shell: pwsh

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -649,7 +649,7 @@ try {
             'Runtime crash dumps must include the managed heap.'
         Assert-Matches `
             $dotnetTestAction `
-            "New-Item -ItemType Directory -Force -Path '\$\{\{ github\.workspace \}\}/TestResults'" `
+            'New-Item -ItemType Directory -Force -Path ''\$\{\{ github\.workspace \}\}/TestResults''' `
             'The absolute runtime crash dump directory must exist before test launch.'
         Assert-Matches `
             $dotnetTestAction `

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -631,6 +631,40 @@ try {
             'Coverage file names must include the complete matrix identity.'
     }
 
+    Invoke-Test 'captures Linux net8 runtime crashes' {
+        $dotnetTestAction = Get-Content -Raw -LiteralPath $dotnetTestActionPath
+        $archiveTestResultsAction = Get-Content -Raw -LiteralPath $archiveTestResultsActionPath
+        $runTestsAction = Get-Content -Raw -LiteralPath $runTestsActionPath
+        Assert-Matches `
+            $dotnetTestAction `
+            "if: runner\.os == 'Linux' && inputs\.framework == 'net8\.0'" `
+            'Runtime crash dumps must be scoped to Linux net8 test jobs.'
+        Assert-Matches `
+            $dotnetTestAction `
+            'DOTNET_DbgEnableMiniDump=1' `
+            'Runtime crash dump collection must be enabled.'
+        Assert-Matches `
+            $dotnetTestAction `
+            'DOTNET_DbgMiniDumpType=2' `
+            'Runtime crash dumps must include the managed heap.'
+        Assert-Matches `
+            $dotnetTestAction `
+            'DOTNET_DbgMiniDumpName=\$\{\{ github\.workspace \}\}/TestResults/dotnet-test\.%p\.dmp' `
+            'Runtime crash dumps must flow through the test diagnostics artifact.'
+        Assert-Matches `
+            $dotnetTestAction `
+            'DOTNET_CreateDumpDiagnostics=1' `
+            'Runtime dump creation must emit diagnostics to the job log.'
+        Assert-Matches `
+            $archiveTestResultsAction `
+            '\*\*/TestResults/\*' `
+            'Runtime crash dumps must be retained by the always-run test diagnostics artifact.'
+        Assert-Matches `
+            $runTestsAction `
+            '(?ms)^  - name: Archive test results\r?\n    if: always\(\)' `
+            'Runtime crash dump upload must run after a failed test coordinator.'
+    }
+
     Invoke-Test 'uses external coverage collection for CI builds' {
         $dotnetTestAction = Get-Content -Raw -LiteralPath $dotnetTestActionPath
         $setupTestEnvironmentAction = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot '../actions/setup-test-environment/action.yml')

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -649,6 +649,10 @@ try {
             'Runtime crash dumps must include the managed heap.'
         Assert-Matches `
             $dotnetTestAction `
+            "New-Item -ItemType Directory -Force -Path '\$\{\{ github\.workspace \}\}/TestResults'" `
+            'The absolute runtime crash dump directory must exist before test launch.'
+        Assert-Matches `
+            $dotnetTestAction `
             'DOTNET_DbgMiniDumpName=\$\{\{ github\.workspace \}\}/TestResults/dotnet-test\.%p\.dmp' `
             'Runtime crash dumps must flow through the test diagnostics artifact.'
         Assert-Matches `


### PR DESCRIPTION
## Problem

An Ubuntu .NET 8 test partition can intermittently terminate the top-level `dotnet test --solution` coordinator with `Handle is not initialized` before any TRX, MTP crash dump, or other `TestResults` artifact exists. The existing MTP crash-dump extension observes test applications, so it does not provide evidence when the coordinator itself exits.

## Solution

Prepare `TestResults` before Linux .NET 8 test launch and enable runtime managed-heap dump capture for the coordinator and its descendants. The existing always-run test diagnostics upload retains `dotnet-test.<pid>.dmp` after a failure, and dump creation diagnostics remain visible in the job log.

Add a static workflow contract covering the platform/framework scope, dump settings, destination, and always-run upload path.

## Rationale

The unchanged rerun passed, and no current Microsoft.Testing.Platform release identifies a fix for this signature, so this change preserves the failure instead of retrying or masking it. dotnet/msbuild#12066 records the same aggregate exception with a `Microsoft.NET.StringTools.WeakStringCache` GCHandle stack during SDK solution evaluation; that is an evidence-based hypothesis until a recurrence produces a dump.

Fixes #11094
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11096)