### PR TITLE
fix(durable-jobs): prevent duplicate queue entries

### DIFF
--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +16,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     private readonly Dictionary<string, JobBucket> _jobsIdToBucket = new();
     private readonly Dictionary<DateTimeOffset, JobBucket> _buckets = new();
     private TaskCompletionSource _queueChanged = CreateQueueChangedSource();
+    private int _jobCount;
     private bool _isComplete;
 #if NET9_0_OR_GREATER
     private readonly Lock _syncLock = new();
@@ -32,7 +32,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     /// <summary>
     /// Gets the total number of jobs currently in the queue.
     /// </summary>
-    public int Count => _jobsIdToBucket.Count;
+    public int Count => Volatile.Read(ref _jobCount);
 
     /// <summary>
     /// Adds a durable job to the queue with the specified dequeue count.
@@ -55,8 +55,19 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 throw new InvalidOperationException("Cannot enqueue job to a completed queue.");
 
             var bucket = GetJobBucket(job.DueTime);
+            var isReplacement = _jobsIdToBucket.TryGetValue(job.Id, out var existingBucket);
+            if (existingBucket is not null && !ReferenceEquals(existingBucket, bucket))
+            {
+                existingBucket.RemoveJob(job.Id);
+            }
+
             bucket.AddJob(job, dequeueCount);
             _jobsIdToBucket[job.Id] = bucket;
+            if (!isReplacement)
+            {
+                Volatile.Write(ref _jobCount, _jobCount + 1);
+            }
+
             SignalQueueChanged();
         }
     }
@@ -92,6 +103,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 // Try to remove from bucket (may already be dequeued)
                 bucket.RemoveJob(jobId);
                 _jobsIdToBucket.Remove(jobId);
+                Volatile.Write(ref _jobCount, _jobCount - 1);
                 // Note: The bucket remains in the priority queue until processed
                 SignalQueueChanged();
                 return true;
@@ -207,6 +219,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             _queue.Clear();
             _jobsIdToBucket.Clear();
             _buckets.Clear();
+            Volatile.Write(ref _jobCount, 0);
             _isComplete = false;
             SignalQueueChanged();
         }
@@ -225,6 +238,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
         while (true)
         {
             List<(DurableJob Job, int DequeueCount)>? jobsToYield = null;
+            JobBucket? bucketBeingProcessed = null;
             Task? queueChanged = null;
             TimeSpan? delay = null;
 
@@ -252,6 +266,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                         // GetJobBucket would find the bucket still in _buckets and add to it,
                         // but the bucket is no longer in _queue, so the new job would be stranded.
                         var bucketToProcess = _queue.Dequeue();
+                        bucketBeingProcessed = bucketToProcess;
                         _buckets.Remove(bucketToProcess.DueTime);
 
                         // Snapshot the jobs under the lock so concurrent Cancel/Retry mutations
@@ -279,7 +294,10 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                     bool shouldYield;
                     lock (_syncLock)
                     {
-                        shouldYield = _jobsIdToBucket.ContainsKey(job.Id);
+                        shouldYield = bucketBeingProcessed is not null
+                            && _jobsIdToBucket.TryGetValue(job.Id, out var currentBucket)
+                            && ReferenceEquals(currentBucket, bucketBeingProcessed)
+                            && bucketBeingProcessed.ContainsJob(job);
                         // Keep job in _jobsIdToBucket for explicit removal via CancelJob/RetryJobLater
                     }
 
@@ -377,4 +395,7 @@ internal sealed class JobBucket
     {
         return _jobs.TryGetValue(jobId, out job);
     }
+
+    public bool ContainsJob(DurableJob job)
+        => _jobs.TryGetValue(job.Id, out var current) && ReferenceEquals(current.Job, job);
 }

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -79,6 +79,59 @@ public class InMemoryJobQueueTests
     }
 
     [Fact]
+    public async Task Enqueue_ReplacingJobInSameBucketPreservesOrderAndCount()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var queue = new InMemoryJobQueue();
+        var job1 = CreateJob("job1", now.AddSeconds(-1));
+        var job2 = CreateJob("job2", job1.DueTime);
+
+        queue.Enqueue(job1, 0);
+        queue.Enqueue(job2, 0);
+        queue.Enqueue(job1, 7);
+        queue.MarkAsComplete();
+
+        Assert.Equal(2, queue.Count);
+
+        await using var enumerator = queue.GetAsyncEnumerator(TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(job1.Id, enumerator.Current.Job.Id);
+        Assert.Equal(8, enumerator.Current.DequeueCount);
+        Assert.True(queue.RemoveJob(job1.Id));
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(job2.Id, enumerator.Current.Job.Id);
+        Assert.True(queue.RemoveJob(job2.Id));
+
+        Assert.False(await enumerator.MoveNextAsync());
+        Assert.Equal(0, queue.Count);
+    }
+
+    [Fact]
+    public async Task Enqueue_ReplacingJobInAnotherBucketYieldsOnlyReplacement()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var queue = new InMemoryJobQueue();
+        var stale = CreateJob("job1", now.AddSeconds(-2));
+        var replacement = CreateJob("job1", now.AddSeconds(-1));
+
+        queue.Enqueue(stale, 0);
+        queue.Enqueue(replacement, 4);
+        queue.MarkAsComplete();
+
+        Assert.Equal(1, queue.Count);
+
+        await using var enumerator = queue.GetAsyncEnumerator(TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Same(replacement, enumerator.Current.Job);
+        Assert.Equal(5, enumerator.Current.DequeueCount);
+        Assert.True(queue.RemoveJob(replacement.Id));
+
+        Assert.False(await enumerator.MoveNextAsync());
+        Assert.Equal(0, queue.Count);
+    }
+
+    [Fact]
     public async Task GetAsyncEnumerator_IncrementsDequeueCount()
     {
         var queue = new InMemoryJobQueue();
@@ -458,6 +511,37 @@ public class InMemoryJobQueueTests
         queue.RemoveJob(enumerator.Current.Job.Id);
 
         Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Enqueue_SameJobIdMovedDuringBucketDrain_YieldsOnlyReplacement()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 10, 0, TimeSpan.Zero));
+        var queue = new InMemoryJobQueue(timeProvider);
+        var staleDueTime = timeProvider.GetUtcNow().AddMinutes(-2);
+        var replacementDueTime = timeProvider.GetUtcNow().AddMinutes(-1);
+        var sentinel = CreateJob("sentinel", staleDueTime);
+        var stale = CreateJob("replaced-job", staleDueTime);
+        var replacement = CreateJob("replaced-job", replacementDueTime);
+
+        queue.Enqueue(sentinel, 0);
+        queue.Enqueue(stale, 0);
+
+        await using var enumerator = queue.GetAsyncEnumerator(TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(sentinel.Id, enumerator.Current.Job.Id);
+        Assert.True(queue.RemoveJob(sentinel.Id));
+
+        queue.Enqueue(replacement, 7);
+        queue.MarkAsComplete();
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Same(replacement, enumerator.Current.Job);
+        Assert.Equal(8, enumerator.Current.DequeueCount);
+        Assert.True(queue.RemoveJob(replacement.Id));
+
+        Assert.False(await enumerator.MoveNextAsync());
+        Assert.Equal(0, queue.Count);
     }
 
     private static DurableJob CreateJob(string id, DateTimeOffset dueTime, string? traceParent = null, string? traceState = null)


### PR DESCRIPTION
Durable job replay or update can move an existing job ID to a different due-time bucket while leaving the old bucket entry live. A detached bucket snapshot can then yield the stale job before the replacement, causing outdated or duplicate execution.

Remove the previous bucket membership when replacing a job ID, track the unique live-job count independently, and validate detached entries against both their bucket and job identity before yielding. This preserves existing same-bucket ordering and notification behavior while enforcing one live queue entry per job ID.