### PR TITLE
fix(redis): validate clustering options

### DIFF
--- a/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
+++ b/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
@@ -8,6 +8,7 @@
     <PackageTags>$(PackageTags) Redis Clustering</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,4 +30,3 @@
     <InternalsVisibleTo Include="Orleans.Redis.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 using StackExchange.Redis;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading.Tasks;
 using Orleans.Configuration;
@@ -41,17 +42,24 @@ namespace Orleans.Clustering.Redis
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
+        /// <param name="options">The Redis clustering options.</param>
+        /// <returns>A task containing the created multiplexer and an indication that the provider owns it.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisClusteringOptions options)
         {
+            ArgumentNullException.ThrowIfNull(options);
             return (await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), false);
         }
 
         /// <summary>
-        /// The default multiplexer creation redis key for RedisMembershipTable.
+        /// Creates the default Redis key for <see cref="RedisMembershipTable"/>.
         /// </summary>
-        /// <returns></returns>
+        /// <param name="clusterOptions">The cluster identity options.</param>
+        /// <returns>The Redis membership table key.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="clusterOptions"/> is <see langword="null"/>.</exception>
         public static RedisKey DefaultCreateRedisKey(ClusterOptions clusterOptions)
         {
+            ArgumentNullException.ThrowIfNull(clusterOptions);
             return Encoding.UTF8.GetBytes($"{clusterOptions.ServiceId}/members/{clusterOptions.ClusterId}");
         }
     }
@@ -72,6 +80,7 @@ namespace Orleans.Clustering.Redis
         /// Initializes a new instance of the <see cref="RedisClusteringOptionsValidator"/> class.
         /// </summary>
         /// <param name="options">The options to validate.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Microsoft.Extensions.DependencyInjection supplies the resolved options instance.")]
         public RedisClusteringOptionsValidator(IOptions<RedisClusteringOptions> options)
         {
             _options = options.Value;

--- a/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
@@ -43,7 +43,7 @@ namespace Orleans.Clustering.Redis
         /// The default multiplexer creation delegate.
         /// </summary>
         /// <param name="options">The Redis clustering options.</param>
-        /// <returns>A task containing the created multiplexer and an indication that the provider owns it.</returns>
+        /// <returns>A task containing the created multiplexer and a value indicating whether it is shared.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisClusteringOptions options)
         {

--- a/test/Extensions/Orleans.Redis.Tests/Clustering/RedisClusteringOptionsTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Clustering/RedisClusteringOptionsTests.cs
@@ -1,0 +1,44 @@
+using Orleans.Clustering.Redis;
+using Orleans.Configuration;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.Redis.Clustering;
+
+[TestSuite("BVT")]
+[TestProvider("Redis")]
+[TestCategory("BVT")]
+public sealed class RedisClusteringOptionsTests
+{
+    [Fact]
+    public async Task DefaultCreateMultiplexer_NullOptions_ThrowsArgumentNullException()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RedisClusteringOptions.DefaultCreateMultiplexer(null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void DefaultCreateRedisKey_NullClusterOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => RedisClusteringOptions.DefaultCreateRedisKey(null!));
+
+        Assert.Equal("clusterOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public void DefaultCreateRedisKey_ClusterIdentity_ReturnsMembershipTableKey()
+    {
+        var clusterOptions = new ClusterOptions
+        {
+            ServiceId = "service",
+            ClusterId = "cluster",
+        };
+
+        var result = RedisClusteringOptions.DefaultCreateRedisKey(clusterOptions);
+
+        Assert.Equal("service/members/cluster", result);
+    }
+}

--- a/test/Extensions/Orleans.Redis.Tests/Clustering/RedisClusteringOptionsTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Clustering/RedisClusteringOptionsTests.cs
@@ -1,5 +1,6 @@
 using Orleans.Clustering.Redis;
 using Orleans.Configuration;
+using StackExchange.Redis;
 using TestExtensions;
 using Xunit;
 
@@ -39,6 +40,6 @@ public sealed class RedisClusteringOptionsTests
 
         var result = RedisClusteringOptions.DefaultCreateRedisKey(clusterOptions);
 
-        Assert.Equal("service/members/cluster", result);
+        Assert.Equal((RedisKey)"service/members/cluster", result);
     }
 }


### PR DESCRIPTION
## Problem
The stable analyzer audit reports three CA1062 findings in `RedisClusteringOptions.cs`, including two public delegate defaults and a validator constructor activated through dependency injection.

## Solution
Validate the public default delegate parameters, document their null contracts, and enforce CA1062 for the Orleans.Clustering.Redis project. Retain the DI-backed validator contract with a focused analyzer suppression and add BVT coverage for the null contracts and normal membership key configuration.

## Rationale
The public delegates can be invoked directly and therefore validate caller input. Microsoft.Extensions.DependencyInjection supplies the validator's resolved options instance, so the constructor relies on that framework guarantee without duplicating validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11098)