### PR TITLE
fix(cosmos): validate reminder options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -681,6 +681,10 @@ dotnet_diagnostic.CA2000.severity = warning
 [src/Orleans.Serialization.SystemTextJson/**.cs]
 dotnet_diagnostic.CA2000.severity = warning
 
+# CA1062: Validate arguments of public methods
+[src/Azure/Orleans.Reminders.Cosmos/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
 # Production source enforces the correctness baseline. Tests, samples, documentation,
 # playgrounds, templates, and tools retain advisory diagnostics during this rollout.
 [src/**/*.{cs,vb}]

--- a/src/Azure/Orleans.Reminders.Cosmos/HostingExtensions.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/HostingExtensions.cs
@@ -23,6 +23,9 @@ public static class HostingExtensions
     /// </returns>
     public static ISiloBuilder UseCosmosReminderService(this ISiloBuilder builder, Action<CosmosReminderTableOptions> configure)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
         builder.Services.UseCosmosReminderService(configure);
         return builder;
     }
@@ -41,6 +44,9 @@ public static class HostingExtensions
     /// </returns>
     public static ISiloBuilder UseCosmosReminderService(this ISiloBuilder builder, Action<OptionsBuilder<CosmosReminderTableOptions>> configure)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
         builder.Services.UseCosmosReminderService(configure);
         return builder;
     }
@@ -58,7 +64,12 @@ public static class HostingExtensions
     /// The provided <see cref="IServiceCollection"/>, for chaining.
     /// </returns>
     public static IServiceCollection UseCosmosReminderService(this IServiceCollection services, Action<CosmosReminderTableOptions> configure)
-        => services.UseCosmosReminderService(optionsBuilder => optionsBuilder.Configure(configure));
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        return services.UseCosmosReminderService(optionsBuilder => optionsBuilder.Configure(configure));
+    }
 
     /// <summary>
     /// Adds reminder storage backed by Azure Cosmos DB.
@@ -74,6 +85,9 @@ public static class HostingExtensions
     /// </returns>
     public static IServiceCollection UseCosmosReminderService(this IServiceCollection services, Action<OptionsBuilder<CosmosReminderTableOptions>> configure)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
         services.AddReminders();
         services.AddCosmosReadRetryPolicy();
         services.AddSingleton<IReminderTable, CosmosReminderTable>();

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosReminderHostingExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosReminderHostingExtensionsTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Hosting;
+using Orleans.Reminders.Cosmos;
+
+namespace Tester.Cosmos.Reminders;
+
+[TestCategory("Cosmos"), TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("Cosmos")]
+[TestArea("Reminders")]
+public class CosmosReminderHostingExtensionsTests
+{
+    [Fact]
+    public void UseCosmosReminderService_NullBuilderWithOptionsCallback_Throws()
+    {
+        ISiloBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosReminderService((CosmosReminderTableOptions _) => { }));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosReminderService_NullOptionsCallbackWithBuilder_Throws()
+    {
+        var builder = new TestSiloBuilder();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosReminderService((Action<CosmosReminderTableOptions>)null!));
+
+        Assert.Equal("configure", exception.ParamName);
+        Assert.Empty(builder.Services);
+    }
+
+    [Fact]
+    public void UseCosmosReminderService_NullBuilderWithOptionsBuilderCallback_Throws()
+    {
+        ISiloBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosReminderService((OptionsBuilder<CosmosReminderTableOptions> _) => { }));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosReminderService_NullOptionsBuilderCallbackWithBuilder_Throws()
+    {
+        var builder = new TestSiloBuilder();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosReminderService((Action<OptionsBuilder<CosmosReminderTableOptions>>)null!));
+
+        Assert.Equal("configure", exception.ParamName);
+        Assert.Empty(builder.Services);
+    }
+
+    [Fact]
+    public void UseCosmosReminderService_NullOptionsCallback_ThrowsBeforeRegisteringServices()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosReminderService((Action<CosmosReminderTableOptions>)null!));
+
+        Assert.Equal("configure", exception.ParamName);
+        Assert.Empty(services);
+    }
+
+    [Fact]
+    public void UseCosmosReminderService_NullServicesWithOptionsCallback_Throws()
+    {
+        IServiceCollection services = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosReminderService((CosmosReminderTableOptions _) => { }));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosReminderService_NullOptionsBuilderCallback_ThrowsBeforeRegisteringServices()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosReminderService((Action<OptionsBuilder<CosmosReminderTableOptions>>)null!));
+
+        Assert.Equal("configure", exception.ParamName);
+        Assert.Empty(services);
+    }
+
+    [Fact]
+    public void UseCosmosReminderService_NullServicesWithOptionsBuilderCallback_Throws()
+    {
+        IServiceCollection services = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosReminderService((OptionsBuilder<CosmosReminderTableOptions> _) => { }));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    private sealed class TestSiloBuilder : ISiloBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = new ConfigurationBuilder().Build();
+    }
+}


### PR DESCRIPTION
## Problem

Analyzer audit run 33921307978 reports three CA1062 findings in the Cosmos reminder hosting extensions, leaving caller-controlled null inputs to fail after dereference or after service registration begins.

## Solution

Validate both public silo-builder entry points before accessing `Services`, validate the options-builder callback before registering reminder services, add service-independent contract coverage for the exception parameter names and registration ordering, and enable CA1062 for the Orleans.Reminders.Cosmos source tree.

## Rationale

The checks stay at externally visible boundaries. After those checks, the implementation relies on the silo builder's service collection, the options infrastructure, configuration validation, and DI construction guarantees, preserving Cosmos reminder registration and runtime behavior for valid configurations.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11099)