### PR TITLE
fix(dashboard): use deterministic text handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -697,6 +697,11 @@ dotnet_diagnostic.CA2246.severity = warning
 dotnet_diagnostic.IDE0035.severity = warning
 dotnet_diagnostic.IDE0043.severity = warning
 
+# Dashboard text handling explicitly distinguishes deterministic identifiers from localized display text.
+[src/Dashboard/Orleans.Dashboard/**/*.cs]
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning
+
 # ActivationData's shared monitor migration is tracked by #10068.
 [src/Orleans.Runtime/Catalog/ActivationData.cs]
 dotnet_diagnostic.CA2002.severity = suggestion

--- a/src/Dashboard/Orleans.Dashboard/Core/Extensions.cs
+++ b/src/Dashboard/Orleans.Dashboard/Core/Extensions.cs
@@ -13,8 +13,9 @@ internal static class Extensions
         if (grainRef.IsPrimaryKeyBasedOnLong()) // Long
         {
             var longKey = grainRef.GetPrimaryKeyLong(out var longExt);
+            var key = longKey.ToString(CultureInfo.InvariantCulture);
 
-            return longExt != null ? $"{longKey} + {longExt}" : longKey.ToString();
+            return longExt != null ? $"{key} + {longExt}" : key;
         }
 
         var stringKey = grainRef.GetPrimaryKeyString();
@@ -29,7 +30,7 @@ internal static class Extensions
         return stringKey;
     }
 
-    public static string ToPeriodString(this DateTime value) => value.ToString("yyyy-MM-ddTHH:mm:ss");
+    public static string ToPeriodString(this DateTime value) => value.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
 
     public static long ToPeriodNumber(this DateTime value) => (long)value.Subtract(UnixStart).TotalSeconds;
 

--- a/src/Dashboard/Orleans.Dashboard/Implementation/Grains/DashboardGrain.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/Grains/DashboardGrain.cs
@@ -305,7 +305,7 @@ internal sealed class DashboardGrain : Grain, IDashboardGrain
         try
         {
             var implementationType = _typeManifestOptions.InterfaceImplementations
-                .FirstOrDefault(w => w.FullName!.Equals(grainType))!;
+                .FirstOrDefault(w => string.Equals(w.FullName, grainType, StringComparison.Ordinal))!;
 
             var mappedGrainId = GrainStateHelper.GetGrainId(id!, implementationType);
             object? grainId = mappedGrainId.Item1;

--- a/src/Dashboard/Orleans.Dashboard/Implementation/Grains/DashboardGrain.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/Grains/DashboardGrain.cs
@@ -304,10 +304,14 @@ internal sealed class DashboardGrain : Grain, IDashboardGrain
 
         try
         {
-            var implementationType = _typeManifestOptions.InterfaceImplementations
-                .FirstOrDefault(w => string.Equals(w.FullName, grainType, StringComparison.Ordinal))!;
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            ArgumentException.ThrowIfNullOrWhiteSpace(grainType);
 
-            var mappedGrainId = GrainStateHelper.GetGrainId(id!, implementationType);
+            var implementationType = _typeManifestOptions.InterfaceImplementations
+                .FirstOrDefault(w => string.Equals(w.FullName, grainType, StringComparison.Ordinal))
+                ?? throw new ArgumentException($"Unknown grain type '{grainType}'.", nameof(grainType));
+
+            var mappedGrainId = GrainStateHelper.GetGrainId(id, implementationType);
             object? grainId = mappedGrainId.Item1;
             string keyExtension = mappedGrainId.Item2;
 
@@ -381,7 +385,10 @@ internal sealed class DashboardGrain : Grain, IDashboardGrain
         }
         catch (Exception ex)
         {
-            result.TryAdd("error", string.Concat(ex.Message, " - ", ex?.InnerException!.Message));
+            var error = ex.InnerException is { } innerException
+                ? string.Concat(ex.Message, " - ", innerException.Message)
+                : ex.Message;
+            result.TryAdd("error", error);
         }
 
         return JsonSerializer.Serialize(result, options: new JsonSerializerOptions()

--- a/src/Dashboard/Orleans.Dashboard/Implementation/Helpers/GrainStateHelper.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/Helpers/GrainStateHelper.cs
@@ -1,8 +1,9 @@
-using Orleans.Core;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Orleans.Core;
 
 namespace Orleans.Dashboard.Implementation.Helpers;
 
@@ -29,12 +30,12 @@ internal static class GrainStateHelper
                 if (splitedGrainId.Length != 2)
                     throw new InvalidOperationException("Inform grain id in format {id},{additionalKey}");
 
-                grainId = Convert.ToInt64(splitedGrainId.First());
+                grainId = Convert.ToInt64(splitedGrainId.First(), CultureInfo.InvariantCulture);
                 keyExtension = splitedGrainId.Last();
             }
             else if (implementationType.IsAssignableTo(typeof(IGrainWithIntegerKey)))
             {
-                grainId = Convert.ToInt64(id);
+                grainId = Convert.ToInt64(id, CultureInfo.InvariantCulture);
             }
             else if (implementationType.IsAssignableTo(typeof(IGrainWithGuidKey)))
             {

--- a/src/Dashboard/Orleans.Dashboard/Implementation/LifecycleStageInspector.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/LifecycleStageInspector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -64,7 +65,8 @@ internal static class LifecycleStageInspector
             .Select(group => new LifecycleStageInfo
             {
                 Stage = group.Key,
-                StageName = group.Select(e => e.StageName).FirstOrDefault(s => !string.IsNullOrEmpty(s)) ?? group.Key.ToString(),
+                StageName = group.Select(e => e.StageName).FirstOrDefault(s => !string.IsNullOrEmpty(s))
+                    ?? group.Key.ToString(CultureInfo.CurrentCulture),
                 IsNamedStage = NamedStageValues.Contains(group.Key),
                 Observers = group.Select(e => BuildObserver(e.Name, e.InnerObserver)).ToArray(),
             })
@@ -168,7 +170,7 @@ internal static class LifecycleStageInspector
         if (d is null) return true;
         if (ReferenceEquals(d, NoOpStart) || ReferenceEquals(d, NoOpStop)) return true;
         var method = d.Method;
-        if (method.DeclaringType is { } declaring && declaring.Name.Contains("<>c"))
+        if (method.DeclaringType is { } declaring && declaring.Name.Contains("<>c", StringComparison.Ordinal))
         {
             // Lambda. Without analyzing the IL we can't be sure, but it's
             // almost always a no-op when used in lifecycle wiring.
@@ -307,7 +309,7 @@ internal static class LifecycleStageInspector
         if (!type.IsGenericType) return type.FullName ?? type.Name;
         var genericArgs = string.Join(", ", type.GetGenericArguments().Select(FormatType));
         var name = type.Namespace is null ? type.Name : $"{type.Namespace}.{type.Name}";
-        var tickIndex = name.IndexOf('`');
+        var tickIndex = name.IndexOf('`', StringComparison.Ordinal);
         if (tickIndex >= 0) name = name[..tickIndex];
         return $"{name}<{genericArgs}>";
     }

--- a/src/Dashboard/Orleans.Dashboard/Metrics/History/GrainTraceEntryEqualityComparer.cs
+++ b/src/Dashboard/Orleans.Dashboard/Metrics/History/GrainTraceEntryEqualityComparer.cs
@@ -1,6 +1,6 @@
-using Orleans.Dashboard.Model;
 using System;
 using System.Collections.Generic;
+using Orleans.Dashboard.Model;
 
 namespace Orleans.Dashboard.Metrics.History;
 
@@ -50,19 +50,19 @@ internal sealed class GrainTraceEqualityComparer : IEqualityComparer<GrainTraceE
 
         var hashCode = 17;
 
-        if (obj.Grain != null)
+        if (obj.Grain is { } grain)
         {
-            hashCode = hashCode * 23 + (obj.Grain?.GetHashCode() ?? 0);
+            hashCode = hashCode * 23 + grain.GetHashCode(StringComparison.OrdinalIgnoreCase);
         }
 
-        if (obj.Grain != null)
+        if (obj.Method is { } method)
         {
-            hashCode = hashCode * 23 + (obj.Method?.GetHashCode() ?? 0);
+            hashCode = hashCode * 23 + method.GetHashCode(StringComparison.OrdinalIgnoreCase);
         }
 
-        if (obj.Grain != null && _withSiloAddress)
+        if (_withSiloAddress && obj.SiloAddress is { } siloAddress)
         {
-            hashCode = hashCode * 23 + (obj.SiloAddress?.GetHashCode() ?? 0);
+            hashCode = hashCode * 23 + siloAddress.GetHashCode(StringComparison.OrdinalIgnoreCase);
         }
 
         return hashCode;

--- a/src/Dashboard/Orleans.Dashboard/Metrics/TypeFormatting/TypeFormatter.cs
+++ b/src/Dashboard/Orleans.Dashboard/Metrics/TypeFormatting/TypeFormatter.cs
@@ -1,6 +1,7 @@
-using Orleans.Serialization.TypeSystem;
+using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using Orleans.Serialization.TypeSystem;
 
 namespace Orleans.Dashboard.Metrics.TypeFormatting;
 
@@ -30,12 +31,12 @@ internal sealed class TypeFormatter
 
                 const string SystemPrefix = "System.";
 
-                if (name.StartsWith(SystemPrefix))
+                if (name.StartsWith(SystemPrefix, StringComparison.Ordinal))
                 {
                     name = name[SystemPrefix.Length..];
                 }
 
-                var genericCardinalityIndex = name.IndexOf('`');
+                var genericCardinalityIndex = name.IndexOf('`', StringComparison.Ordinal);
 
                 if (genericCardinalityIndex > 0)
                 {

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/DashboardTextHandlingTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/DashboardTextHandlingTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Globalization;
+using Orleans.Dashboard.Core;
+using Orleans.Dashboard.Implementation.Helpers;
+using Orleans.Dashboard.Metrics.History;
+using Orleans.Dashboard.Model;
+using TestGrains;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Dashboard")]
+public class DashboardTextHandlingTests
+{
+    [Fact]
+    public void ToPeriodString_UsesInvariantCalendar()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ar-SA");
+            var period = new DateTime(2024, 1, 2, 3, 4, 5);
+
+            var result = period.ToPeriodString();
+
+            Assert.Equal("2024-01-02T03:04:05", result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Theory]
+    [InlineData(typeof(TestStateGrain), "-42", "")]
+    [InlineData(typeof(TestStateCompoundKeyGrain), "-42,tenant", "tenant")]
+    public void GetGrainId_ParsesIntegerKeysUsingInvariantCulture(Type implementationType, string id, string expectedKeyExtension)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NegativeSign = "~";
+            CultureInfo.CurrentCulture = culture;
+
+            var (grainId, keyExtension) = GrainStateHelper.GetGrainId(id, implementationType);
+
+            Assert.Equal(-42L, grainId);
+            Assert.Equal(expectedKeyExtension, keyExtension);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void GrainTraceEqualityComparer_UsesCaseInsensitiveOrdinalHashCodes()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("tr-TR");
+            var upper = new GrainTraceEntry
+            {
+                Grain = "GRAIN-I",
+                Method = "METHOD-I",
+                SiloAddress = "SILO-I",
+            };
+            var lower = new GrainTraceEntry
+            {
+                Grain = "grain-i",
+                Method = "method-i",
+                SiloAddress = "silo-i",
+            };
+
+            AssertComparerContract(GrainTraceEqualityComparer.ByGrainAndMethod, upper, lower);
+            AssertComparerContract(GrainTraceEqualityComparer.ByGrainAndMethodAndSilo, upper, lower);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    private static void AssertComparerContract(
+        GrainTraceEqualityComparer comparer,
+        GrainTraceEntry first,
+        GrainTraceEntry second)
+    {
+        Assert.True(comparer.Equals(first, second));
+        Assert.Equal(comparer.GetHashCode(first), comparer.GetHashCode(second));
+    }
+}

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/GrainStateTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/GrainStateTests.cs
@@ -82,6 +82,25 @@ namespace UnitTests
             Assert.Equal(stateFromGrain.Counter, counter);
         }
 
+        [Theory]
+        [InlineData(null, "TestGrains.TestStateGrain", "id")]
+        [InlineData("", "TestGrains.TestStateGrain", "id")]
+        [InlineData("123", null, "grainType")]
+        [InlineData("123", "", "grainType")]
+        [InlineData("123", "TestGrains.UnknownGrain", "Unknown grain type")]
+        public async Task GetGrainState_InvalidRequest_ReturnsErrorPayload(string? id, string? grainType, string expectedError)
+        {
+            var dashboardGrain = _cluster.GrainFactory!.GetGrain<IDashboardGrain>(1); // This fixture deploys the client.
+
+            var immutableState = await dashboardGrain.GetGrainState(
+                id,
+                grainType,
+                TestContext.Current.CancellationToken);
+
+            var state = JObject.Parse(immutableState.Value);
+            Assert.Contains(expectedError, (string)state["error"]!, StringComparison.Ordinal);
+        }
+
 
         public class TestSiloConfigurations : ISiloConfigurator
         {

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/LifecycleStageInspectorTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/LifecycleStageInspectorTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -112,6 +113,29 @@ public class LifecycleStageInspectorTests
         Assert.Contains("<lambda in", observer.OnStartMethod ?? string.Empty, System.StringComparison.Ordinal);
         Assert.Contains("<lambda in", observer.OnStopMethod ?? string.Empty, System.StringComparison.Ordinal);
         Assert.DoesNotContain("b__", observer.OnStartMethod ?? string.Empty, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetStages_FormatsNumericStageUsingCurrentCulture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NegativeSign = "~";
+            CultureInfo.CurrentCulture = culture;
+            var subject = new SiloLifecycleSubject(NullLogger<SiloLifecycleSubject>.Instance);
+            subject.Subscribe("CustomStage", -4242, Start, Stop);
+
+            var stage = Assert.Single(LifecycleStageInspector.GetStages(subject));
+
+            Assert.Equal("~4242", stage.StageName);
+            Assert.False(stage.IsNamedStage);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     private static Task Start(CancellationToken ct) => Task.CompletedTask;

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/TypeFormatterTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/TypeFormatterTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Orleans.Dashboard.Metrics.TypeFormatting;
 using Xunit;
 
@@ -67,6 +68,24 @@ namespace UnitTests
             var name = TypeFormatter.Parse(example);
 
             Assert.Equal(".Program.Progress", name);
+        }
+
+        [Fact]
+        public void Parse_FormatsTypeSyntaxIndependentlyOfCurrentCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("tr-TR");
+
+                var name = TypeFormatter.Parse("CultureTests.GenericGrain`1[[System.String,mscorlib]]");
+
+                Assert.Equal("CultureTests.GenericGrain<String>", name);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem
Orleans.Dashboard relied on ambient culture and implicit string comparison semantics for grain keys, history period keys, type syntax, lifecycle inspection, and trace identity. The static analyzer audit reported 5 CA1305 and 7 CA1307 findings in these paths.

## Solution
Use invariant formatting and parsing for grain keys and history period keys, ordinal comparison for type and metric identities, and matching ordinal-ignore-case hash codes for trace entries. Keep numeric lifecycle stage labels explicitly formatted with the current culture as user-facing dashboard text. Enable CA1305 and CA1307 as warnings across the Orleans.Dashboard project and add culture-switch coverage for the affected behavior.

## Rationale
These choices preserve existing dashboard payload shapes and type-name parsing while making machine identities deterministic across server cultures. The trace comparer now satisfies the equality/hash-code contract, and localized lifecycle labels retain their presentation behavior intentionally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11100)