### PR TITLE
fix(azure): validate reminder options

### DIFF
--- a/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
@@ -18,6 +18,7 @@
     <Compile Include="..\Shared\Utilities\ErrorCode.cs" Link="Utilities\ErrorCode.cs" />
     <Compile Include="..\Shared\Storage\AzureStorageOperationOptions.cs" Link="Storage\AzureStorageOperationOptions.cs" />
     <Compile Include="..\Shared\Storage\AzureStoragePolicyOptions.cs" Link="Storage\AzureStoragePolicyOptions.cs" />
+    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)Orleans.Reminders.AzureStorage.globalconfig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.globalconfig
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.globalconfig
@@ -1,0 +1,3 @@
+is_global = true
+
+dotnet_diagnostic.CA1062.severity = warning

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -30,6 +30,9 @@ namespace Orleans.Runtime.ReminderService
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="clusterOptions">The cluster identity options used to scope reminder entries.</param>
         /// <param name="storageOptions">The Azure Table Storage reminder options.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="clusterOptions"/> or <paramref name="storageOptions"/> is <see langword="null"/>.
+        /// </exception>
         public AzureBasedReminderTable(
             ILoggerFactory loggerFactory,
             IOptions<ClusterOptions> clusterOptions,
@@ -37,6 +40,8 @@ namespace Orleans.Runtime.ReminderService
         {
             this.logger = loggerFactory.CreateLogger<AzureBasedReminderTable>();
             this.loggerFactory = loggerFactory;
+            ArgumentNullException.ThrowIfNull(clusterOptions);
+            ArgumentNullException.ThrowIfNull(storageOptions);
             this.clusterOptions = clusterOptions.Value;
             this.storageOptions = storageOptions.Value;
             this.remTableManager = new RemindersTableManager(
@@ -284,8 +289,11 @@ namespace Orleans.Runtime.ReminderService
         /// </summary>
         /// <param name="entry">The reminder entry to store.</param>
         /// <returns>The new entity tag when the write succeeds; otherwise, <see langword="null"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="entry"/> is <see langword="null"/>.</exception>
         public async Task<string?> UpsertRow(ReminderEntry entry)
         {
+            ArgumentNullException.ThrowIfNull(entry);
+
             try
             {
                 await Volatile.Read(ref _initializationTask).Task;

--- a/test/Extensions/Orleans.Azure.Tests/AzureBasedReminderTableTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureBasedReminderTableTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Reminders.AzureStorage;
+using Orleans.Runtime.ReminderService;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.RemindersTest;
+
+[TestCategory("AzureStorage"), TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("AzureStorage")]
+[TestArea("Reminders")]
+public class AzureBasedReminderTableTests
+{
+    [Fact]
+    public void Constructor_NullClusterOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AzureBasedReminderTable(
+            NullLoggerFactory.Instance,
+            null!,
+            Options.Create(new AzureTableReminderStorageOptions())));
+
+        Assert.Equal("clusterOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullStorageOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AzureBasedReminderTable(
+            NullLoggerFactory.Instance,
+            Options.Create(new ClusterOptions()),
+            null!));
+
+        Assert.Equal("storageOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task UpsertRow_NullEntry_ThrowsArgumentNullException()
+    {
+        var table = new AzureBasedReminderTable(
+            NullLoggerFactory.Instance,
+            Options.Create(new ClusterOptions
+            {
+                ServiceId = "service-id",
+                ClusterId = "cluster-id",
+            }),
+            Options.Create(new AzureTableReminderStorageOptions()));
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => table.UpsertRow(null!));
+
+        Assert.Equal("entry", exception.ParamName);
+    }
+}


### PR DESCRIPTION
## Problem
Analyzer audit run 33921307978 reports three CA1062 findings in `Orleans.Reminders.AzureStorage`: the public reminder table constructor dereferences null option wrappers, and `UpsertRow` dereferences a null reminder entry after entering the lifecycle path.

## Solution
Validate the caller-controlled `clusterOptions`, `storageOptions`, and `entry` parameters at their public boundaries, preserving exact parameter names. Add service-independent contract tests and enable CA1062 for every source file compiled by the project, including linked shared Azure sources.

## Rationale
Hosting supplies valid logger and options dependencies, and the reminder lifecycle gates storage operations after initialization. Keeping validation at the public boundaries makes those contracts explicit without duplicating checks inside guaranteed internal paths or changing Azure reminder configuration behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11101)