### PR TITLE
ci: retain failed test diagnostics

### DIFF
--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -19,7 +19,7 @@ runs:
     with:
       name: ${{ inputs.name }}
       if-no-files-found: warn
-      retention-days: ${{ inputs.retention-days }}
+      retention-days: ${{ inputs['retention-days'] }}
       path: |
         **/TestResults/*
         !TestResults/*.cobertura.xml

--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -5,6 +5,10 @@ inputs:
   name:
     description: Artifact name.
     required: true
+  retention-days:
+    description: Number of days to retain test diagnostics.
+    required: false
+    default: '1'
 
 runs:
   using: composite
@@ -15,7 +19,7 @@ runs:
     with:
       name: ${{ inputs.name }}
       if-no-files-found: warn
-      retention-days: 1
+      retention-days: ${{ inputs.retention-days }}
       path: |
         **/TestResults/*
         !TestResults/*.cobertura.xml

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -61,3 +61,4 @@ runs:
     uses: ./.github/actions/archive-test-results
     with:
       name: ${{ inputs.artifact-name }}
+      retention-days: ${{ steps.test.outcome == 'failure' && 14 || 1 }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -46,6 +46,7 @@ runs:
     env:
       BuildExternalAssets: ${{ inputs['build-external-assets'] }}
   - name: Retry tests
+    id: retry
     if: inputs.retry == 'true' && steps.test.outcome == 'failure'
     uses: ./.github/actions/dotnet-test
     with:
@@ -61,4 +62,4 @@ runs:
     uses: ./.github/actions/archive-test-results
     with:
       name: ${{ inputs.artifact-name }}
-      retention-days: ${{ steps.test.outcome == 'failure' && 14 || 1 }}
+      retention-days: ${{ steps.test.outcome == 'failure' && steps.retry.outcome != 'success' && 14 || 1 }}

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1192,7 +1192,7 @@ exit 0
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Coverage upload must require the report.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload may remain advisory.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'retention-days: \$\{\{ inputs\.retention-days \}\}')).Count 'Diagnostic upload must use the requested retention period.'
-        Assert-Equal 1 ([regex]::Matches($runTestsAction, '(?m)^    id: retry$')).Count 'The retry outcome must be available to diagnostic retention policy.'
+        Assert-Equal 1 ([regex]::Matches($runTestsAction, '(?m)^    id: retry\r?$')).Count 'The retry outcome must be available to diagnostic retention policy.'
         Assert-Equal 1 ([regex]::Matches($runTestsAction, 'retention-days: \$\{\{ steps\.test\.outcome == ''failure'' && steps\.retry\.outcome != ''success'' && 14 \|\| 1 \}\}')).Count 'Only unrecovered test failures may retain diagnostics for 14 days.'
         Assert-Matches `
             $archiveTestResultsAction `

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1191,7 +1191,7 @@ exit 0
         Assert-Equal 0 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact uploads must not replace an ambiguous partial upload.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Coverage upload must require the report.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload may remain advisory.'
-        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'retention-days: \$\{\{ inputs\.retention-days \}\}')).Count 'Diagnostic upload must use the requested retention period.'
+        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'retention-days: \$\{\{ inputs\[''retention-days''\] \}\}')).Count 'Diagnostic upload must use the requested retention period.'
         Assert-Equal 1 ([regex]::Matches($runTestsAction, '(?m)^    id: retry\r?$')).Count 'The retry outcome must be available to diagnostic retention policy.'
         Assert-Equal 1 ([regex]::Matches($runTestsAction, 'retention-days: \$\{\{ steps\.test\.outcome == ''failure'' && steps\.retry\.outcome != ''success'' && 14 \|\| 1 \}\}')).Count 'Only unrecovered test failures may retain diagnostics for 14 days.'
         Assert-Matches `

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1192,7 +1192,8 @@ exit 0
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Coverage upload must require the report.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload may remain advisory.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'retention-days: \$\{\{ inputs\.retention-days \}\}')).Count 'Diagnostic upload must use the requested retention period.'
-        Assert-Equal 1 ([regex]::Matches($runTestsAction, 'retention-days: \$\{\{ steps\.test\.outcome == ''failure'' && 14 \|\| 1 \}\}')).Count 'Failed test diagnostics must remain available for 14 days.'
+        Assert-Equal 1 ([regex]::Matches($runTestsAction, '(?m)^    id: retry$')).Count 'The retry outcome must be available to diagnostic retention policy.'
+        Assert-Equal 1 ([regex]::Matches($runTestsAction, 'retention-days: \$\{\{ steps\.test\.outcome == ''failure'' && steps\.retry\.outcome != ''success'' && 14 \|\| 1 \}\}')).Count 'Only unrecovered test failures may retain diagnostics for 14 days.'
         Assert-Matches `
             $archiveTestResultsAction `
             "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Report test result upload failure\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    shell: pwsh\r?\n    run: Write-Output '::warning title=Test result artifact upload failed::" `

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -1173,6 +1173,7 @@ exit 0
 
     Invoke-Test 'requires every successful test job to upload coverage' {
         $archiveTestResultsAction = Get-Content -Raw -LiteralPath $archiveTestResultsActionPath
+        $runTestsAction = Get-Content -Raw -LiteralPath $runTestsActionPath
         Assert-Matches `
             $archiveTestResultsAction `
             'if-no-files-found: error' `
@@ -1190,6 +1191,8 @@ exit 0
         Assert-Equal 0 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact uploads must not replace an ambiguous partial upload.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Coverage upload must require the report.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload may remain advisory.'
+        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'retention-days: \$\{\{ inputs\.retention-days \}\}')).Count 'Diagnostic upload must use the requested retention period.'
+        Assert-Equal 1 ([regex]::Matches($runTestsAction, 'retention-days: \$\{\{ steps\.test\.outcome == ''failure'' && 14 \|\| 1 \}\}')).Count 'Failed test diagnostics must remain available for 14 days.'
         Assert-Matches `
             $archiveTestResultsAction `
             "(?ms)^  - id: archive-test-results\r?\n    uses: actions/upload-artifact@.*?\r?\n    continue-on-error: true\r?\n.*?^  - name: Report test result upload failure\r?\n    if: steps\.archive-test-results\.outcome == 'failure'\r?\n    shell: pwsh\r?\n    run: Write-Output '::warning title=Test result artifact upload failed::" `


### PR DESCRIPTION
## Problem

The Linux .NET 10 BVT coverage job in #10888 terminated `Orleans.Core.Tests` with SIGSEGV and produced a 551.59 MiB full dump plus a crash sequence log. Those diagnostics were stored in an 85.07 MiB artifact with one-day retention and expired before the investigation began.

The available evidence points toward the dynamic code-coverage profiler rather than an Orleans product change: the identical rerun passed, the failing process was collected by `dotnet-coverage` 18.5.2, and `Orleans.Core.Tests` exercises a collectible `AssemblyLoadContext` pattern matching the trigger described in microsoft/codecoverage#238. The expired dump prevents definitive native stack attribution.

## Solution

- let the test-result archive action accept an explicit retention period
- retain diagnostics from failed test partitions for 14 days while successful artifacts remain at one day
- extend the static workflow contract to enforce the retention policy and preserve advisory artifact upload behavior

## Rationale

Failure-only retention keeps future dumps and sequence logs available long enough for native analysis without extending storage for successful test runs. This change improves the investigation boundary and does not claim to fix the external profiler crash.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11102)