### PR TITLE
perf(durable-jobs): reduce queue wake-ups

### DIFF
--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -15,7 +15,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     private readonly PriorityQueue<JobBucket, DateTimeOffset> _queue = new();
     private readonly Dictionary<string, JobBucket> _jobsIdToBucket = new();
     private readonly Dictionary<DateTimeOffset, JobBucket> _buckets = new();
-    private TaskCompletionSource _queueChanged = CreateQueueChangedSource();
+    private TaskCompletionSource? _queueChangedWaiter;
     private int _jobCount;
     private bool _isComplete;
 #if NET9_0_OR_GREATER
@@ -54,6 +54,8 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             if (_isComplete)
                 throw new InvalidOperationException("Cannot enqueue job to a completed queue.");
 
+            var wakeCheckRequired = _queueChangedWaiter is not null;
+            var previousNextDueTime = wakeCheckRequired ? GetNextDueTime() : null;
             var bucket = GetJobBucket(job.DueTime);
             var isReplacement = _jobsIdToBucket.TryGetValue(job.Id, out var existingBucket);
             if (existingBucket is not null && !ReferenceEquals(existingBucket, bucket))
@@ -68,7 +70,10 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 Volatile.Write(ref _jobCount, _jobCount + 1);
             }
 
-            SignalQueueChanged();
+            if (wakeCheckRequired)
+            {
+                SignalQueueChangedIfNextDueTimeChanged(previousNextDueTime);
+            }
         }
     }
 
@@ -98,6 +103,8 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         lock (_syncLock)
         {
+            var wakeCheckRequired = _queueChangedWaiter is not null;
+            var previousNextDueTime = wakeCheckRequired ? GetNextDueTime() : null;
             if (_jobsIdToBucket.TryGetValue(jobId, out var bucket))
             {
                 // Try to remove from bucket (may already be dequeued)
@@ -105,7 +112,11 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 _jobsIdToBucket.Remove(jobId);
                 Volatile.Write(ref _jobCount, _jobCount - 1);
                 // Note: The bucket remains in the priority queue until processed
-                SignalQueueChanged();
+                if (wakeCheckRequired)
+                {
+                    SignalQueueChangedIfNextDueTimeChanged(previousNextDueTime);
+                }
+
                 return true;
             }
 
@@ -160,6 +171,8 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
 
         lock (_syncLock)
         {
+            var wakeCheckRequired = _queueChangedWaiter is not null;
+            var previousNextDueTime = wakeCheckRequired ? GetNextDueTime() : null;
             if (!_jobsIdToBucket.TryGetValue(jobId, out var oldBucket) || !oldBucket.TryGetJob(jobId, out var existing))
             {
                 return false;
@@ -183,7 +196,11 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             var newBucket = GetJobBucket(newDueTime);
             newBucket.AddJob(newJob, dequeueCount);
             _jobsIdToBucket[jobId] = newBucket;
-            SignalQueueChanged();
+            if (wakeCheckRequired)
+            {
+                SignalQueueChangedIfNextDueTimeChanged(previousNextDueTime);
+            }
+
             return true;
         }
     }
@@ -216,12 +233,17 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     {
         lock (_syncLock)
         {
+            var wakeCheckRequired = _queueChangedWaiter is not null;
+            var previousNextDueTime = wakeCheckRequired ? GetNextDueTime() : null;
             _queue.Clear();
             _jobsIdToBucket.Clear();
             _buckets.Clear();
             Volatile.Write(ref _jobCount, 0);
             _isComplete = false;
-            SignalQueueChanged();
+            if (wakeCheckRequired)
+            {
+                SignalQueueChangedIfNextDueTimeChanged(previousNextDueTime);
+            }
         }
     }
 
@@ -253,7 +275,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                         yield break; // Exit if the queue is frozen and empty
                     }
 
-                    queueChanged = _queueChanged.Task;
+                    queueChanged = GetQueueChangedTask();
                 }
                 else if (_queue.Count > 0)
                 {
@@ -275,13 +297,13 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                     }
                     else
                     {
-                        queueChanged = _queueChanged.Task;
+                        queueChanged = GetQueueChangedTask();
                         delay = nextBucket.DueTime - now;
                     }
                 }
                 else
                 {
-                    queueChanged = _queueChanged.Task;
+                    queueChanged = GetQueueChangedTask();
                 }
             }
 
@@ -335,12 +357,29 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
         }
     }
 
+    private DateTimeOffset? GetNextDueTime()
+    {
+        RemoveEmptyBuckets();
+        return _queue.Count == 0 ? null : _queue.Peek().DueTime;
+    }
+
+    private void SignalQueueChangedIfNextDueTimeChanged(DateTimeOffset? previousNextDueTime)
+    {
+        if ((_isComplete && _jobCount == 0) || previousNextDueTime != GetNextDueTime())
+        {
+            SignalQueueChanged();
+        }
+    }
+
     private void SignalQueueChanged()
     {
-        var previous = _queueChanged;
-        _queueChanged = CreateQueueChangedSource();
-        previous.TrySetResult();
+        var waiter = _queueChangedWaiter;
+        _queueChangedWaiter = null;
+        waiter?.TrySetResult();
     }
+
+    private Task GetQueueChangedTask()
+        => (_queueChangedWaiter ??= CreateQueueChangedSource()).Task;
 
     private async Task WaitForQueueChangeOrDelayAsync(Task queueChanged, TimeSpan? delay, CancellationToken cancellationToken)
     {

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -203,6 +203,25 @@ public class InMemoryJobQueueTests
     }
 
     [Fact]
+    public async Task RetryJobLater_WhenNextDueTimeMovesEarlier_WakesWaitingEnumerator()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var queue = new InMemoryJobQueue(timeProvider);
+        var job = CreateJob("job1", timeProvider.GetUtcNow().AddHours(1));
+        queue.Enqueue(job, 0);
+
+        await using var enumerator = queue.GetAsyncEnumerator(TestContext.Current.CancellationToken);
+        var moveNextTask = enumerator.MoveNextAsync().AsTask();
+        Assert.False(moveNextTask.IsCompleted);
+
+        Assert.True(queue.RetryJobLater(job.Id, timeProvider.GetUtcNow(), 3));
+
+        Assert.True(await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        Assert.Equal(job.Id, enumerator.Current.Job.Id);
+        Assert.Equal(4, enumerator.Current.DequeueCount);
+    }
+
+    [Fact]
     public async Task GetAsyncEnumerator_CompletesWhenQueueIsMarkedComplete()
     {
         var queue = new InMemoryJobQueue();
@@ -541,6 +560,27 @@ public class InMemoryJobQueueTests
         Assert.True(queue.RemoveJob(replacement.Id));
 
         Assert.False(await enumerator.MoveNextAsync());
+        Assert.Equal(0, queue.Count);
+    }
+
+    [Fact]
+    public async Task RemoveLastDequeuedJob_AfterCompletion_WakesWaitingEnumerator()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 8, 16, 0, 0, 0, TimeSpan.Zero));
+        var queue = new InMemoryJobQueue(timeProvider);
+        var job = CreateJob("in-flight", timeProvider.GetUtcNow().AddMilliseconds(-100));
+        queue.Enqueue(job, 0);
+
+        await using var enumerator = queue.GetAsyncEnumerator(TestContext.Current.CancellationToken);
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(1, queue.Count);
+
+        queue.MarkAsComplete();
+        var completion = enumerator.MoveNextAsync().AsTask();
+        Assert.False(completion.IsCompleted);
+
+        Assert.True(queue.RemoveJob(job.Id));
+        Assert.False(await completion.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
         Assert.Equal(0, queue.Count);
     }
 


### PR DESCRIPTION
## Problem
Queue mutations wake the durable job queue enumerator even when its currently observed next due time is unchanged. This creates avoidable wake-ups and timer recreation under queue activity.

## Solution
Track the queue-change waiter lazily and signal it only when a mutation changes the next observable due time. Preserve completion by also signaling when removal of the final already-dequeued job empties a completed queue.

## Rationale
The enumerator only needs to reconsider its wait when the queue head changes or completion becomes observable. Keeping waiter creation and signaling aligned with those transitions reduces scheduling churn without losing wake-ups.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11103)