### PR TITLE
test(analyzers): stabilize repository target contract

### DIFF
--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -25,6 +25,12 @@ namespace Analyzers.Tests;
 [TestCategory("BVT"), TestCategory("Analyzer")]
 public class GrainInterfaceVersionAnalyzerTest
 {
+    private enum ContractsTargetsContract
+    {
+        PackageBuildRoundTrip,
+        RepositoryDotNetFormat,
+    }
+
     private const string OrleansContractsFileName = "OrleansContracts.txt";
     private const string RegenerateCodeActionTitle = "Regenerate OrleansContracts.txt";
     private const string RegenerateCodeActionEquivalenceKey = "RegenerateOrleansContractsFileAsync";
@@ -2783,11 +2789,11 @@ interface Outer.IInnerGrain [Version(1)]
     public Task DotNetFormat_CreatesMissingContractsFileUsingRepositoryBuildTargets()
         => VerifyDotNetFormatCreatesMissingContractsFileAsync(
             configuredContractsPath: null,
-            useRepositoryBuildTargets: true);
+            targetsContract: ContractsTargetsContract.RepositoryDotNetFormat);
 
     private static async Task VerifyDotNetFormatCreatesMissingContractsFileAsync(
         string? configuredContractsPath,
-        bool useRepositoryBuildTargets = false)
+        ContractsTargetsContract targetsContract = ContractsTargetsContract.PackageBuildRoundTrip)
     {
         var repositoryRoot = GetRepositoryRoot();
         var tempDirectory = Path.Combine(
@@ -2810,7 +2816,7 @@ interface Outer.IInnerGrain [Version(1)]
                 "Orleans.Analyzers",
                 "build",
                 "Microsoft.Orleans.Analyzers.props");
-            var targetsPath = useRepositoryBuildTargets
+            var targetsPath = targetsContract == ContractsTargetsContract.RepositoryDotNetFormat
                 ? Path.Combine(repositoryRoot, "src", "Directory.Build.targets")
                 : Path.Combine(
                     repositoryRoot,
@@ -2836,6 +2842,19 @@ interface Outer.IInnerGrain [Version(1)]
                     <Reference Include="Orleans.Core.Abstractions" HintPath="{EscapeXml(abstractionsPath)}" />
                 {analyzerItem}  </ItemGroup>
                   <Import Project="{EscapeXml(targetsPath)}" />
+                  <Target Name="VerifyOrleansContractsTargetState">
+                    <ItemGroup>
+                      <_OrleansContractsFile Include="@(AdditionalFiles->WithMetadataValue('OrleansContractsFile', 'true'))" />
+                    </ItemGroup>
+                    <Error Condition="'$(ExpectedOrleansContractsFileExists)' != 'true' and '$(ExpectedOrleansContractsFileExists)' != 'false'"
+                           Text="ExpectedOrleansContractsFileExists must be true or false." />
+                    <Error Condition="'$(ExpectedOrleansContractsFileExists)' == 'false' and '@(_OrleansContractsFile)' != ''"
+                           Text="The missing contracts file was included in the regular build." />
+                    <Error Condition="'$(ExpectedOrleansContractsFileExists)' == 'true' and '@(_OrleansContractsFile)' != '$(OrleansContractsPath)'"
+                           Text="The repository targets did not include the configured contracts file." />
+                    <Error Condition="'$(ExpectedOrleansContractsFileExists)' == 'true' and '@(_OrleansContractsFile->Metadata('OrleansContractsFileExists'))' != 'true'"
+                           Text="The repository targets did not mark the configured contracts file as existing." />
+                  </Target>
                 </Project>
                 """,
                 TestContext.Current.CancellationToken);
@@ -2856,14 +2875,24 @@ interface Outer.IInnerGrain [Version(1)]
             Assert.True(restore.ExitCode == 0, restore.Output);
             Assert.False(File.Exists(contractsPath));
 
-            var missingManifestBuild = await RunDotNetAsync(
-                repositoryRoot,
-                "build",
-                projectPath,
-                "--no-restore",
-                "--nologo");
-            Assert.True(missingManifestBuild.ExitCode == 0, missingManifestBuild.Output);
-            Assert.False(File.Exists(contractsPath));
+            if (targetsContract == ContractsTargetsContract.PackageBuildRoundTrip)
+            {
+                var missingManifestBuild = await RunDotNetAsync(
+                    repositoryRoot,
+                    "build",
+                    projectPath,
+                    "--no-restore",
+                    "--nologo");
+                Assert.True(missingManifestBuild.ExitCode == 0, missingManifestBuild.Output);
+                Assert.False(File.Exists(contractsPath));
+            }
+            else
+            {
+                await VerifyRepositoryContractsTargetStateAsync(
+                    repositoryRoot,
+                    projectPath,
+                    contractsFileExists: false);
+            }
 
             var format = await RunDotNetAsync(
                 repositoryRoot,
@@ -2892,13 +2921,23 @@ interface Outer.IInnerGrain [Version(1)]
                 "interface [GrainInterfaceType(\"IMyGrain\")] IMyGrain [Version(0)]",
                 content);
 
-            var build = await RunDotNetAsync(
-                repositoryRoot,
-                "build",
-                projectPath,
-                "--no-restore",
-                "--nologo");
-            Assert.True(build.ExitCode == 0, build.Output);
+            if (targetsContract == ContractsTargetsContract.PackageBuildRoundTrip)
+            {
+                var build = await RunDotNetAsync(
+                    repositoryRoot,
+                    "build",
+                    projectPath,
+                    "--no-restore",
+                    "--nologo");
+                Assert.True(build.ExitCode == 0, build.Output);
+            }
+            else
+            {
+                await VerifyRepositoryContractsTargetStateAsync(
+                    repositoryRoot,
+                    projectPath,
+                    contractsFileExists: true);
+            }
         }
         finally
         {
@@ -2906,6 +2945,21 @@ interface Outer.IInnerGrain [Version(1)]
                 tempDirectory,
                 TestContext.Current.CancellationToken);
         }
+    }
+
+    private static async Task VerifyRepositoryContractsTargetStateAsync(
+        string repositoryRoot,
+        string projectPath,
+        bool contractsFileExists)
+    {
+        var result = await RunDotNetAsync(
+            repositoryRoot,
+            "msbuild",
+            projectPath,
+            "-nologo",
+            "-target:VerifyOrleansContractsTargetState",
+            $"-property:ExpectedOrleansContractsFileExists={contractsFileExists.ToString().ToLowerInvariant()}");
+        Assert.True(result.ExitCode == 0, result.Output);
     }
 
     private static async Task DeleteDirectoryWithRetriesAsync(
@@ -2950,25 +3004,49 @@ interface Outer.IInnerGrain [Version(1)]
         Assert.NotNull(process);
         var standardOutput = process!.StandardOutput.ReadToEndAsync();
         var standardError = process.StandardError.ReadToEndAsync();
+        var completion = Task.WhenAll(
+            process.WaitForExitAsync(CancellationToken.None),
+            standardOutput,
+            standardError);
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
             TestContext.Current.CancellationToken);
         timeout.CancelAfter(TimeSpan.FromMinutes(2));
         try
         {
-            await process.WaitForExitAsync(timeout.Token);
+            await completion.WaitAsync(timeout.Token);
         }
-        catch (OperationCanceledException) when (!TestContext.Current.CancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            process.Kill(entireProcessTree: true);
+            if (!process.HasExited)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException) when (process.HasExited)
+                {
+                }
+            }
+
+            await completion;
+            if (TestContext.Current.CancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+
             throw new TimeoutException(
-                $"dotnet {string.Join(' ', arguments)} exceeded the two-minute test timeout.");
+                $"dotnet {string.Join(' ', arguments)} exceeded the two-minute test timeout."
+                + Environment.NewLine
+                + await ReadOutputAsync());
         }
 
-        var output = string.Concat(
-            await standardOutput,
-            Environment.NewLine,
-            await standardError);
-        return (process.ExitCode, output);
+        return (process.ExitCode, await ReadOutputAsync());
+
+        async Task<string> ReadOutputAsync()
+            => string.Concat(
+                await standardOutput,
+                Environment.NewLine,
+                await standardError);
     }
 
     private static string EscapeXml(string value)


### PR DESCRIPTION
## Problem

`DotNetFormat_CreatesMissingContractsFileUsingRepositoryBuildTargets` repeated the package-target tests' complete build round trip around `dotnet format`. Its final compilation could exceed the two-minute inner timeout during loaded Windows runs even though the repository-target-specific behavior had already completed.

The process helper also bounded only top-level process exit. Output completion and cancellation cleanup remained outside that boundary, reducing failure diagnostics and leaving process-tree termination incomplete when cancellation won the race.

## Solution

- Keep the complete missing-manifest build, `dotnet format`, and generated-manifest build round trips in the package-target cases.
- Give the repository-target case a focused MSBuild target which verifies the regular-build `AdditionalFiles` state before and after format: the missing file is excluded, then the generated file is included with `OrleansContractsFileExists=true`.
- Continue running `dotnet format` against the temporary project importing `src/Directory.Build.targets`, so successful file creation proves the repository design-time wiring supplies the missing contracts document and metadata.
- Bound process exit together with stdout/stderr completion, terminate and drain the process tree on timeout or test cancellation, and include captured output in timeout failures.

## Rationale

The repository-target case now validates its unique build-target contract without two redundant compilations. The package-target cases retain end-to-end compiler validation, while the shared process helper has a deterministic completion boundary and preserves actionable timeout output.

Closes #10980
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11104)