### PR TITLE
test(reminders): isolate exact-due recovery setup

### DIFF
--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTestKitClusterIntegrationTests.cs
@@ -282,7 +282,13 @@ public sealed class ReminderTestKitClusterIntegrationTests
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
             cancellation.CancelAfter(TimeSpan.FromSeconds(30));
 
-            await grain.RegisterReminderAsync("exact-due-recovery", dueTime, period).WaitAsync(cancellation.Token);
+            await oracle.UpsertRow(new ReminderEntry
+            {
+                GrainId = grainId,
+                ReminderName = "exact-due-recovery",
+                StartAt = firstTickTime,
+                Period = period,
+            }).WaitAsync(cancellation.Token);
             Assert.Equal(0, observer.GetActiveReminderCount(grainId, "exact-due-recovery"));
 
             await using var blockedRead = oracle.BlockNext(ReminderTableOperationKind.ReadRange);
@@ -295,7 +301,11 @@ public sealed class ReminderTestKitClusterIntegrationTests
             blockedRead.Release();
             await activated;
             await observer.WaitForLocalReminderScheduleAsync(grainId, "exact-due-recovery", cancellation.Token);
-            Assert.Equal(["exact-due-recovery"], await grain.GetReminderNamesAsync().WaitAsync(cancellation.Token));
+            var persisted = Assert.Single(oracle.Snapshot());
+            Assert.Equal(grainId, persisted.GrainId);
+            Assert.Equal("exact-due-recovery", persisted.ReminderName);
+            Assert.Equal(firstTickTime, persisted.StartAt);
+            Assert.Equal(period, persisted.Period);
 
             var tick = observer.WaitForReminderTickAsync(grainId, cancellation.Token, "exact-due-recovery");
             await clock.AdvanceAsync(clock.RefreshReminderListPeriod, cancellation.Token);


### PR DESCRIPTION
## Problem

`ReminderTestKit_StorageRecoveryAtExactDueTimeDeliversDueOccurrence` intermittently timed out on macOS net10 and Ubuntu net8 before reaching its storage-recovery interleaving. The Ubuntu recurrence stopped in the initial grain registration round-trip, which exercises cold activation and reminder-service request scheduling outside the exact-due recovery guarantee.

## Solution

Seed the persisted `ReminderEntry` directly in the idealized reminder table and assert its exact durable record after recovery. The scenario still blocks the range read, advances to the persisted `StartAt`, releases recovery, waits for the active owner and armed local schedule, advances fake time, and verifies one delivery on the persisted cadence.

## Rationale

The test now begins from the durable-state boundary it is intended to validate. This removes an unrelated asynchronous prerequisite without adding sleeps, increasing timeouts, weakening assertions, or overlapping the fake-clock, stale-refresh, and topology-startup fixes.

Fixes #10918
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11105)