### PR TITLE
fix(azure): use invariant clustering text

### DIFF
--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -171,7 +171,7 @@ namespace Orleans.Runtime.MembershipService
                 foreach (var tuple in entries)
                 {
                     var tableEntry = tuple.Entity;
-                    if (tableEntry.RowKey.Equals(SiloInstanceTableEntry.TABLE_VERSION_ROW))
+                    if (tableEntry.RowKey.Equals(SiloInstanceTableEntry.TABLE_VERSION_ROW, StringComparison.Ordinal))
                     {
                         var membershipVersion = tableEntry.MembershipVersion
                             ?? throw new InvalidOperationException("The table version row does not contain a membership version.");
@@ -214,19 +214,19 @@ namespace Orleans.Runtime.MembershipService
             var parse = new MembershipEntry
             {
                 HostName = tableEntry.HostName!,
-                Status = (SiloStatus)Enum.Parse(typeof(SiloStatus), tableEntry.Status!)
+                Status = Enum.Parse<SiloStatus>(tableEntry.Status!, ignoreCase: false)
             };
 
             if (!string.IsNullOrEmpty(tableEntry.ProxyPort))
-                parse.ProxyPort = int.Parse(tableEntry.ProxyPort);
+                parse.ProxyPort = int.Parse(tableEntry.ProxyPort, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
             int port = 0;
             if (!string.IsNullOrEmpty(tableEntry.Port))
-                int.TryParse(tableEntry.Port, out port);
+                int.TryParse(tableEntry.Port, NumberStyles.Integer, CultureInfo.InvariantCulture, out port);
 
             int gen = 0;
             if (!string.IsNullOrEmpty(tableEntry.Generation))
-                int.TryParse(tableEntry.Generation, out gen);
+                int.TryParse(tableEntry.Generation, NumberStyles.Integer, CultureInfo.InvariantCulture, out gen);
 
             parse.SiloAddress = SiloAddress.New(IPAddress.Parse(tableEntry.Address!), port, gen);
 
@@ -242,10 +242,10 @@ namespace Orleans.Runtime.MembershipService
                 parse.SiloName = tableEntry.InstanceName;
             }
             if (!string.IsNullOrEmpty(tableEntry.UpdateZone))
-                parse.UpdateZone = int.Parse(tableEntry.UpdateZone);
+                parse.UpdateZone = int.Parse(tableEntry.UpdateZone, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
             if (!string.IsNullOrEmpty(tableEntry.FaultZone))
-                parse.FaultZone = int.Parse(tableEntry.FaultZone);
+                parse.FaultZone = int.Parse(tableEntry.FaultZone, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
             parse.StartTime = !string.IsNullOrEmpty(tableEntry.StartTime) ?
                 LogFormatter.ParseDate(tableEntry.StartTime) : default;
@@ -273,7 +273,11 @@ namespace Orleans.Runtime.MembershipService
             }
 
             if (suspectingSilos.Count != suspectingTimes.Count)
-                throw new OrleansException(string.Format("SuspectingSilos.Length of {0} as read from Azure table is not equal to SuspectingTimes.Length of {1}", suspectingSilos.Count, suspectingTimes.Count));
+                throw new OrleansException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "SuspectingSilos.Length of {0} as read from Azure table is not equal to SuspectingTimes.Length of {1}",
+                    suspectingSilos.Count,
+                    suspectingTimes.Count));
 
             for (int i = 0; i < suspectingSilos.Count; i++)
                 parse.AddSuspector(suspectingSilos[i], suspectingTimes[i]);

--- a/src/Azure/Orleans.Clustering.AzureStorage/Globalization.globalconfig
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Globalization.globalconfig
@@ -1,0 +1,4 @@
+is_global = true
+
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning

--- a/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)Globalization.globalconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(SourceRoot)src\Orleans.Runtime\Orleans.Runtime.csproj" />
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Data.Tables" />

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -136,11 +136,11 @@ namespace Orleans.AzureUtils
         {
             int proxyPort = 0;
             if (!string.IsNullOrEmpty(gateway.ProxyPort))
-                int.TryParse(gateway.ProxyPort, out proxyPort);
+                int.TryParse(gateway.ProxyPort, NumberStyles.Integer, CultureInfo.InvariantCulture, out proxyPort);
 
             int gen = 0;
             if (!string.IsNullOrEmpty(gateway.Generation))
-                int.TryParse(gateway.Generation, out gen);
+                int.TryParse(gateway.Generation, NumberStyles.Integer, CultureInfo.InvariantCulture, out gen);
 
             SiloAddress address = SiloAddress.New(IPAddress.Parse(gateway.Address!), proxyPort, gen);
             return address.ToGatewayUri();
@@ -174,7 +174,7 @@ namespace Orleans.AzureUtils
             SiloInstanceTableEntry[] entries = queryResults.Select(entry => entry.Item1).ToArray();
 
             var sb = new StringBuilder();
-            sb.Append(string.Format("Deployment {0}. Silos: ", DeploymentId));
+            sb.Append(string.Format(CultureInfo.CurrentCulture, "Deployment {0}. Silos: ", DeploymentId));
 
             // Loop through the results, displaying information about the entity
             Array.Sort(entries,
@@ -188,8 +188,15 @@ namespace Orleans.AzureUtils
                 });
             foreach (SiloInstanceTableEntry entry in entries)
             {
-                sb.AppendLine(string.Format("[IP {0}:{1}:{2}, {3}, Instance={4}, Status={5}]", entry.Address, entry.Port, entry.Generation,
-                    entry.HostName, entry.SiloName, entry.Status));
+                sb.AppendLine(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "[IP {0}:{1}:{2}, {3}, Instance={4}, Status={5}]",
+                    entry.Address,
+                    entry.Port,
+                    entry.Generation,
+                    entry.HostName,
+                    entry.SiloName,
+                    entry.Status));
             }
             return sb.ToString();
         }
@@ -251,7 +258,11 @@ namespace Orleans.AzureUtils
             var filter = TableClient.CreateQueryFilter($"(PartitionKey eq {DeploymentId}) and ((RowKey eq {rowKey}) or (RowKey eq {SiloInstanceTableEntry.TABLE_VERSION_ROW}))");
             var queryResults = await storage.ReadTableEntriesAndEtagsAsync(filter);
             if (queryResults.Count < 1 || queryResults.Count > 2)
-                throw new KeyNotFoundException(string.Format("Could not find table version row or found too many entries. Was looking for key {0}, found = {1}", siloAddress, Utils.EnumerableToString(queryResults)));
+                throw new KeyNotFoundException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Could not find table version row or found too many entries. Was looking for key {0}, found = {1}",
+                    siloAddress,
+                    Utils.EnumerableToString(queryResults)));
 
             var numTableVersionRows = 0;
             foreach (var entry in queryResults)
@@ -263,10 +274,17 @@ namespace Orleans.AzureUtils
             }
 
             if (numTableVersionRows < 1)
-                throw new KeyNotFoundException(string.Format("Did not read table version row. Read = {0}", Utils.EnumerableToString(queryResults)));
+                throw new KeyNotFoundException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Did not read table version row. Read = {0}",
+                    Utils.EnumerableToString(queryResults)));
 
             if (numTableVersionRows > 1)
-                throw new KeyNotFoundException(string.Format("Read {0} table version rows, while was expecting only 1. Read = {1}", numTableVersionRows, Utils.EnumerableToString(queryResults)));
+                throw new KeyNotFoundException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Read {0} table version rows, while was expecting only 1. Read = {1}",
+                    numTableVersionRows,
+                    Utils.EnumerableToString(queryResults)));
 
             return queryResults;
         }
@@ -366,7 +384,10 @@ namespace Orleans.AzureUtils
         private static string? ValidateAllSiloEntries(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
         {
             if (queryResults.Count < 1)
-                throw new KeyNotFoundException(string.Format("Could not find enough rows in the FindAllSiloEntries call. Found = {0}", Utils.EnumerableToString(queryResults)));
+                throw new KeyNotFoundException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Could not find enough rows in the FindAllSiloEntries call. Found = {0}",
+                    Utils.EnumerableToString(queryResults)));
 
             var numTableVersionRows = 0;
             string? tableVersion = null;
@@ -380,9 +401,16 @@ namespace Orleans.AzureUtils
             }
 
             if (numTableVersionRows < 1)
-                throw new KeyNotFoundException(string.Format("Did not find table version row. Read = {0}", Utils.EnumerableToString(queryResults)));
+                throw new KeyNotFoundException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Did not find table version row. Read = {0}",
+                    Utils.EnumerableToString(queryResults)));
             if (numTableVersionRows > 1)
-                throw new KeyNotFoundException(string.Format("Read {0} table version rows, while was expecting only 1. Read = {1}", numTableVersionRows, Utils.EnumerableToString(queryResults)));
+                throw new KeyNotFoundException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Read {0} table version rows, while was expecting only 1. Read = {1}",
+                    numTableVersionRows,
+                    Utils.EnumerableToString(queryResults)));
 
             return tableVersion;
         }

--- a/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Text;
 using Azure;
@@ -48,7 +49,12 @@ namespace Orleans.AzureUtils
 
         public static string ConstructRowKey(SiloAddress silo)
         {
-            return string.Format("{0}-{1}-{2}", silo.Endpoint.Address, silo.Endpoint.Port, silo.Generation);
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}-{1}-{2}",
+                silo.Endpoint.Address,
+                silo.Endpoint.Port,
+                silo.Generation);
         }
         internal static SiloAddress UnpackRowKey(string rowKey)
         {
@@ -56,27 +62,37 @@ namespace Orleans.AzureUtils
             try
             {
 #if DEBUG
-                debugInfo = string.Format("UnpackRowKey: RowKey={0}", rowKey);
+                debugInfo = string.Format(CultureInfo.CurrentCulture, "UnpackRowKey: RowKey={0}", rowKey);
                 Trace.TraceInformation(debugInfo);
 #endif
-                int idx1 = rowKey.IndexOf(Seperator);
+                int idx1 = rowKey.IndexOf(Seperator, StringComparison.Ordinal);
                 int idx2 = rowKey.LastIndexOf(Seperator);
 #if DEBUG
-                debugInfo = string.Format("UnpackRowKey: RowKey={0} Idx1={1} Idx2={2}", rowKey, idx1, idx2);
+                debugInfo = string.Format(
+                    CultureInfo.CurrentCulture,
+                    "UnpackRowKey: RowKey={0} Idx1={1} Idx2={2}",
+                    rowKey,
+                    idx1,
+                    idx2);
 #endif
                 ReadOnlySpan<char> rowKeySpan = rowKey.AsSpan();
                 ReadOnlySpan<char> addressStr = rowKeySpan[..idx1];
                 ReadOnlySpan<char> portStr = rowKeySpan.Slice(idx1 + 1, idx2 - idx1 - 1);
                 ReadOnlySpan<char> genStr = rowKeySpan[(idx2 + 1)..];
 #if DEBUG
-                debugInfo = string.Format("UnpackRowKey: RowKey={0} -> Address={1} Port={2} Generation={3}",
-                    rowKey, addressStr.ToString(), portStr.ToString(), genStr.ToString());
+                debugInfo = string.Format(
+                    CultureInfo.CurrentCulture,
+                    "UnpackRowKey: RowKey={0} -> Address={1} Port={2} Generation={3}",
+                    rowKey,
+                    addressStr.ToString(),
+                    portStr.ToString(),
+                    genStr.ToString());
 
                 Trace.TraceInformation(debugInfo);
 #endif
                 IPAddress address = IPAddress.Parse(addressStr);
-                int port = int.Parse(portStr);
-                int generation = int.Parse(genStr);
+                int port = int.Parse(portStr, NumberStyles.Integer, CultureInfo.InvariantCulture);
+                int generation = int.Parse(genStr, NumberStyles.Integer, CultureInfo.InvariantCulture);
                 return SiloAddress.New(address, port, generation);
             }
             catch (Exception exc)

--- a/src/Azure/Shared/Storage/AzureTableUtils.cs
+++ b/src/Azure/Shared/Storage/AzureTableUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Net;
 using System.Text.RegularExpressions;
 using Azure;
@@ -214,7 +215,11 @@ namespace Orleans.GrainDirectory.AzureStorage
                 .Replace('?', '_');       // Question mark
 
             if (key.Length >= 1024)
-                throw new ArgumentException(string.Format("Key length {0} is too long to be an Azure table key. Key={1}", key.Length, key));
+                throw new ArgumentException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Key length {0} is too long to be an Azure table key. Key={1}",
+                    key.Length,
+                    key));
 
             return key;
         }

--- a/test/Extensions/Orleans.Azure.Tests/AzureStorageMembershipGlobalizationTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureStorageMembershipGlobalizationTests.cs
@@ -1,0 +1,347 @@
+using System.Globalization;
+using System.Net;
+using System.Reflection;
+using Azure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.AzureUtils;
+using Orleans.Clustering.AzureStorage;
+using Orleans.Configuration;
+using Orleans.Runtime.MembershipService;
+using Xunit;
+
+namespace Tester.AzureUtils;
+
+[TestCategory("AzureStorage"), TestCategory("Membership"), TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestArea("Membership")]
+public class AzureStorageMembershipGlobalizationTests
+{
+    private const string ClusterId = "Cluster-Ii-'Exact";
+
+    public static TheoryData<CultureInfo> Cultures => new()
+    {
+        CultureInfo.InvariantCulture,
+        CultureInfo.GetCultureInfo("tr-TR"),
+        CreateCultureWithNonInvariantSigns(),
+    };
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void RowKey_RoundTripsInvariantSchema_AcrossCultures(CultureInfo culture)
+    {
+        using var cultureScope = new CultureScope(culture);
+        var siloAddress = SiloAddress.New(
+            new IPEndPoint(IPAddress.Parse("2001:db8::1"), 22222),
+            42);
+
+        var rowKey = SiloInstanceTableEntry.ConstructRowKey(siloAddress);
+        var unpacked = SiloInstanceTableEntry.UnpackRowKey(rowKey);
+
+        Assert.Equal("2001:db8::1-22222-42", rowKey);
+        Assert.Equal(siloAddress, unpacked);
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void MembershipEntry_ConvertsToInvariantPersistedSchema_AcrossCultures(CultureInfo culture)
+    {
+        using var cultureScope = new CultureScope(culture);
+        var membershipEntry = CreateMembershipEntry();
+
+        var tableEntry = MembershipCodec.Convert(membershipEntry, ClusterId);
+
+        Assert.Equal(ClusterId, tableEntry.DeploymentId, StringComparer.Ordinal);
+        Assert.Equal(ClusterId, tableEntry.PartitionKey, StringComparer.Ordinal);
+        Assert.Equal("2001:db8::1-22222-42", tableEntry.RowKey, StringComparer.Ordinal);
+        Assert.Equal("22222", tableEntry.Port, StringComparer.Ordinal);
+        Assert.Equal("42", tableEntry.Generation, StringComparer.Ordinal);
+        Assert.Equal("Active", tableEntry.Status, StringComparer.Ordinal);
+        Assert.Equal("30000", tableEntry.ProxyPort, StringComparer.Ordinal);
+        Assert.Equal("-12", tableEntry.UpdateZone, StringComparer.Ordinal);
+        Assert.Equal("34", tableEntry.FaultZone, StringComparer.Ordinal);
+        Assert.Equal("2024-02-29 23:59:58.123 GMT", tableEntry.StartTime, StringComparer.Ordinal);
+        Assert.Equal("2024-03-01 00:00:01.456 GMT", tableEntry.IAmAliveTime, StringComparer.Ordinal);
+        Assert.Equal(
+            "192.0.2.10:12345@17|2001:db8::2:23456@18",
+            tableEntry.SuspectingSilos,
+            StringComparer.Ordinal);
+        Assert.Equal(
+            "2024-02-29 23:58:57.012 GMT|2024-02-29 23:58:58.345 GMT",
+            tableEntry.SuspectingTimes,
+            StringComparer.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void LegacyRow_RoundTripsInvariantSchema_AcrossCultures(CultureInfo culture)
+    {
+        using var cultureScope = new CultureScope(culture);
+        var legacyRow = CreateLegacyRow();
+        var originalTimestamp = legacyRow.Timestamp;
+        var originalETag = legacyRow.ETag;
+
+        var parsed = MembershipCodec.Parse(legacyRow);
+        var converted = MembershipCodec.Convert(parsed, ClusterId);
+
+        Assert.Equal(IPAddress.Parse("2001:db8::1"), parsed.SiloAddress.Endpoint.Address);
+        Assert.Equal(22222, parsed.SiloAddress.Endpoint.Port);
+        Assert.Equal(42, parsed.SiloAddress.Generation);
+        Assert.Equal(SiloStatus.Active, parsed.Status);
+        Assert.Equal(30000, parsed.ProxyPort);
+        Assert.Equal(-12, parsed.UpdateZone);
+        Assert.Equal(34, parsed.FaultZone);
+        Assert.Equal("Legacy-Silo-Ii", parsed.SiloName, StringComparer.Ordinal);
+        Assert.Equal(new DateTime(2024, 2, 29, 23, 59, 58, 123), parsed.StartTime);
+        Assert.Equal(new DateTime(2024, 3, 1, 0, 0, 1, 456), parsed.IAmAliveTime);
+        Assert.Collection(
+            parsed.SuspectTimes!,
+            item =>
+            {
+                Assert.Equal("192.0.2.10:12345@17", item.Item1.ToParsableString());
+                Assert.Equal(new DateTime(2024, 2, 29, 23, 58, 57, 12), item.Item2);
+            },
+            item =>
+            {
+                Assert.Equal("2001:db8::2:23456@18", item.Item1.ToParsableString());
+                Assert.Equal(new DateTime(2024, 2, 29, 23, 58, 58, 345), item.Item2);
+            });
+
+        Assert.Equal("2001:db8::1-22222-42", converted.RowKey, StringComparer.Ordinal);
+        Assert.Equal("-12", converted.UpdateZone, StringComparer.Ordinal);
+        Assert.Equal("34", converted.FaultZone, StringComparer.Ordinal);
+        Assert.Equal("2024-02-29 23:59:58.123 GMT", converted.StartTime, StringComparer.Ordinal);
+        Assert.Equal("2024-03-01 00:00:01.456 GMT", converted.IAmAliveTime, StringComparer.Ordinal);
+
+        Assert.Equal("+0007", legacyRow.MembershipVersion, StringComparer.Ordinal);
+        Assert.Equal(originalTimestamp, legacyRow.Timestamp);
+        Assert.Equal(originalETag, legacyRow.ETag);
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void GatewayRow_ParsesInvariantPortAndGeneration_AcrossCultures(CultureInfo culture)
+    {
+        using var cultureScope = new CultureScope(culture);
+        var gatewayRow = new SiloInstanceTableEntry
+        {
+            Address = "2001:db8::1",
+            ProxyPort = "30000",
+            Generation = "42",
+        };
+
+        var gatewayUri = MembershipCodec.ConvertToGatewayUri(gatewayRow);
+
+        Assert.Equal("gwy.tcp://[2001:db8::1]:30000/42", gatewayUri.ToString());
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void MembershipSnapshot_AcceptsLegacyVersionAndPreservesOpaqueEtags_AcrossCultures(CultureInfo culture)
+    {
+        using var cultureScope = new CultureScope(culture);
+        var membershipTable = new AzureBasedMembershipTable(
+            NullLoggerFactory.Instance,
+            Options.Create(new AzureStorageClusteringOptions()),
+            Options.Create(new ClusterOptions { ClusterId = ClusterId, ServiceId = "Service" }));
+        var versionRow = new SiloInstanceTableEntry
+        {
+            PartitionKey = ClusterId,
+            RowKey = SiloInstanceTableEntry.TABLE_VERSION_ROW,
+            MembershipVersion = "+0007",
+            ETag = new ETag("entity-version-etag"),
+        };
+        var siloRow = CreateLegacyRow();
+
+        var result = MembershipCodec.Convert(
+            membershipTable,
+            [(versionRow, "opaque-version-etag"), (siloRow, "opaque-silo-etag")]);
+
+        Assert.Equal(7, result.Version.Version);
+        Assert.Equal("opaque-version-etag", result.Version.VersionEtag, StringComparer.Ordinal);
+        var member = Assert.Single(result.Members);
+        Assert.Equal("opaque-silo-etag", member.Item2, StringComparer.Ordinal);
+        Assert.Equal("Legacy-Silo-Ii", member.Item1.SiloName, StringComparer.Ordinal);
+        Assert.Equal("+0007", versionRow.MembershipVersion, StringComparer.Ordinal);
+        Assert.Equal("entity-version-etag", versionRow.ETag.ToString(), StringComparer.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(Cultures))]
+    public void SchemaIdentifiersAndQueries_RemainExact_AcrossCultures(CultureInfo culture)
+    {
+        using var cultureScope = new CultureScope(culture);
+        var manager = new OrleansSiloInstanceManager(
+            ClusterId,
+            NullLoggerFactory.Instance,
+            new AzureStorageClusteringOptions(),
+            membershipTableReadStorage: null);
+
+        var versionRow = manager.CreateTableVersionEntry(7);
+        var pointQuery = AzureTableUtils.PointQuery(ClusterId, "Row-Ii-'Exact");
+        var rangeQuery = AzureTableUtils.RangeQuery(
+            ClusterId,
+            SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN,
+            SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX);
+
+        Assert.Equal("VersionRow", versionRow.RowKey, StringComparer.Ordinal);
+        Assert.Equal("7", versionRow.MembershipVersion, StringComparer.Ordinal);
+        Assert.True(SiloInstanceTableEntry.IsVersionRow("VersionRow"));
+        Assert.False(SiloInstanceTableEntry.IsVersionRow("versionrow"));
+        var caseChangedStatus = CreateLegacyRow();
+        caseChangedStatus.Status = "active";
+        Assert.Throws<ArgumentException>(() => MembershipCodec.Parse(caseChangedStatus));
+        Assert.Equal(
+            "(PartitionKey eq 'Cluster-Ii-''Exact') and (RowKey eq 'Row-Ii-''Exact')",
+            pointQuery,
+            StringComparer.Ordinal);
+        Assert.Equal(
+            "((PartitionKey eq 'Cluster-Ii-''Exact') and (RowKey ge '!Start')) and (RowKey le '~End')",
+            rangeQuery,
+            StringComparer.Ordinal);
+    }
+
+    private static MembershipEntry CreateMembershipEntry() => new()
+    {
+        SiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 22222), 42),
+        HostName = "Host-Ii",
+        Status = SiloStatus.Active,
+        ProxyPort = 30000,
+        RoleName = "Primary",
+        SiloName = "Silo-Ii",
+        UpdateZone = -12,
+        FaultZone = 34,
+        StartTime = new DateTime(2024, 2, 29, 23, 59, 58, 123, DateTimeKind.Utc),
+        IAmAliveTime = new DateTime(2024, 3, 1, 0, 0, 1, 456, DateTimeKind.Utc),
+        SuspectTimes =
+        [
+            Tuple.Create(
+                SiloAddress.New(new IPEndPoint(IPAddress.Parse("192.0.2.10"), 12345), 17),
+                new DateTime(2024, 2, 29, 23, 58, 57, 12, DateTimeKind.Utc)),
+            Tuple.Create(
+                SiloAddress.New(new IPEndPoint(IPAddress.Parse("2001:db8::2"), 23456), 18),
+                new DateTime(2024, 2, 29, 23, 58, 58, 345, DateTimeKind.Utc)),
+        ],
+    };
+
+    private static SiloInstanceTableEntry CreateLegacyRow() => new()
+    {
+        DeploymentId = ClusterId,
+        PartitionKey = ClusterId,
+        RowKey = "2001:db8::1-22222-42",
+        Address = "2001:db8::1",
+        Port = "22222",
+        Generation = "42",
+        HostName = "Legacy-Host-Ii",
+        Status = "Active",
+        ProxyPort = "30000",
+        RoleName = "Legacy-Primary",
+        InstanceName = "Legacy-Silo-Ii",
+        UpdateZone = "-12",
+        FaultZone = "34",
+        SuspectingSilos = "192.0.2.10:12345@17|2001:db8::2:23456@18",
+        SuspectingTimes = "2024-02-29 23:58:57.012 GMT|2024-02-29 23:58:58.345 GMT",
+        StartTime = "2024-02-29 23:59:58.123 GMT",
+        IAmAliveTime = "2024-03-01 00:00:01.456 GMT",
+        MembershipVersion = "+0007",
+        Timestamp = new DateTimeOffset(2024, 3, 1, 0, 0, 2, 789, TimeSpan.Zero),
+        ETag = new ETag("opaque-entity-etag"),
+    };
+
+    private static CultureInfo CreateCultureWithNonInvariantSigns()
+    {
+        var culture = (CultureInfo)CultureInfo.GetCultureInfo("en-US").Clone();
+        culture.NumberFormat.NegativeSign = "~";
+        culture.NumberFormat.PositiveSign = "!";
+        return culture;
+    }
+
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        private readonly CultureInfo originalUICulture = CultureInfo.CurrentUICulture;
+
+        public CultureScope(CultureInfo culture)
+        {
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+
+        public void Dispose()
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
+        }
+    }
+
+    private static class MembershipCodec
+    {
+        private static readonly Type CodecType = typeof(AzureBasedMembershipTable);
+        private static readonly MethodInfo ConvertEntryMethod = BindStatic(
+            "Convert",
+            typeof(SiloInstanceTableEntry),
+            typeof(MembershipEntry),
+            typeof(string));
+        private static readonly MethodInfo ParseMethod = BindStatic(
+            "Parse",
+            typeof(MembershipEntry),
+            typeof(SiloInstanceTableEntry));
+        private static readonly MethodInfo ConvertEntriesMethod = CodecType.GetMethod(
+            "Convert",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(List<(SiloInstanceTableEntry Entity, string ETag)>)],
+            modifiers: null)
+            ?? throw new MissingMethodException(CodecType.FullName, "Convert");
+        private static readonly MethodInfo ConvertToGatewayUriMethod =
+            typeof(OrleansSiloInstanceManager).GetMethod(
+                "ConvertToGatewayUri",
+                BindingFlags.Static | BindingFlags.NonPublic,
+                binder: null,
+                types: [typeof(SiloInstanceTableEntry)],
+                modifiers: null)
+            ?? throw new MissingMethodException(
+                typeof(OrleansSiloInstanceManager).FullName,
+                "ConvertToGatewayUri");
+
+        public static SiloInstanceTableEntry Convert(MembershipEntry entry, string deploymentId)
+            => Invoke<SiloInstanceTableEntry>(ConvertEntryMethod, null, entry, deploymentId);
+
+        public static MembershipEntry Parse(SiloInstanceTableEntry entity)
+            => Invoke<MembershipEntry>(ParseMethod, null, entity);
+
+        public static MembershipTableData Convert(
+            AzureBasedMembershipTable table,
+            List<(SiloInstanceTableEntry Entity, string ETag)> entries)
+            => Invoke<MembershipTableData>(ConvertEntriesMethod, table, entries);
+
+        public static Uri ConvertToGatewayUri(SiloInstanceTableEntry gatewayRow)
+            => Invoke<Uri>(ConvertToGatewayUriMethod, null, gatewayRow);
+
+        private static MethodInfo BindStatic(string name, Type returnType, params Type[] parameterTypes)
+        {
+            var method = CodecType.GetMethod(
+                name,
+                BindingFlags.Static | BindingFlags.NonPublic,
+                binder: null,
+                types: parameterTypes,
+                modifiers: null);
+            return method is { ReturnType: var actualReturnType } && actualReturnType == returnType
+                ? method
+                : throw new MissingMethodException(CodecType.FullName, name);
+        }
+
+        private static TResult Invoke<TResult>(MethodInfo method, object? instance, params object?[] arguments)
+        {
+            try
+            {
+                return (TResult)method.Invoke(instance, arguments)!;
+            }
+            catch (TargetInvocationException exception) when (exception.InnerException is not null)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Azure Table clustering persisted and parsed membership values through ambient culture in several paths, and the project did not continuously enforce CA1305/CA1307. This could make schema text and protocol identifiers vary by process culture.

## Solution
Use invariant integer formatting and parsing for membership rows, exact ordinal comparison for schema identifiers, and current culture for diagnostic text. Enable CA1305/CA1307 across the full clustering project compilation, including linked Azure Table utilities, and add service-free culture and legacy-row coverage.

## Rationale
Azure Table membership rows are a cross-version persistence contract. Keeping numeric, timestamp, key, status, version, and ETag semantics stable preserves rolling-upgrade compatibility, including legacy signed and zero-padded version text, while diagnostics remain natural for the current user culture.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11107)