### PR TITLE
test(reminders): isolate local owner update path

### DIFF
--- a/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderServiceLifecycleTestRunner.cs
@@ -209,14 +209,31 @@ public abstract class ReminderServiceLifecycleTestRunner
         const string Guarantee = nameof(ReminderService_UpdateDoesNotRestartLocalOwner);
         const string Name = "in-place-update";
         var grain = CreateGrain(Guarantee);
+        if (_harness is not IReminderServiceLifecycleRegistrationTarget registrationTarget)
+        {
+            Fail(Guarantee, "harness capability")
+                .WithExpected(
+                    $"{nameof(IReminderServiceLifecycleRegistrationTarget)} for owner-targeted registration")
+                .WithObserved(_harness.GetType().FullName ?? _harness.GetType().Name)
+                .Throw();
+            return;
+        }
+
         await ExecuteWithCleanupAsync(
             Guarantee,
             cancellationToken,
             async () =>
             {
+                var owner = _harness.ActiveSilos.Single(silo => _harness.IsOwner(silo, grain.GetGrainId()));
                 var initialDue = TimeSpan.FromSeconds(3);
                 var originalExpectedStart = _harness.UtcNow.UtcDateTime + initialDue;
-                await grain.RegisterOrUpdateAsync(Name, initialDue, Period).WaitAsync(cancellationToken);
+                await registrationTarget.RegisterOnSiloAsync(
+                    owner,
+                    grain.GetGrainId(),
+                    Name,
+                    initialDue,
+                    Period,
+                    cancellationToken).WaitAsync(cancellationToken);
                 await WaitForOwnersAfterRefreshAsync([(grain, Name)], cancellationToken);
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);
                 var original = await AssertPersistedAsync(
@@ -238,7 +255,13 @@ public abstract class ReminderServiceLifecycleTestRunner
                     Name,
                     scheduleChanges + 1,
                     cancellationToken);
-                await grain.RegisterOrUpdateAsync(Name, due, Period + TimeSpan.FromMinutes(1)).WaitAsync(cancellationToken);
+                await registrationTarget.RegisterOnSiloAsync(
+                    owner,
+                    grain.GetGrainId(),
+                    Name,
+                    due,
+                    Period + TimeSpan.FromMinutes(1),
+                    cancellationToken).WaitAsync(cancellationToken);
                 await _harness.RefreshAsync(cancellationToken);
                 await changed;
                 await _harness.WaitForScheduleAsync(grain.GetGrainId(), Name, cancellationToken);

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -94,7 +94,12 @@ public sealed class ReminderServiceLifecycleHarness
         return reminderService.QueueTask(async () =>
         {
             cancellationToken.ThrowIfCancellationRequested();
-            _ = await reminderService.RegisterOrUpdateReminder(grainId, reminderName, dueTime, period);
+            _ = await reminderService.RegisterOrUpdateReminder(
+                grainId,
+                reminderName,
+                dueTime,
+                period,
+                cancellationToken);
         });
     }
 


### PR DESCRIPTION
## Problem

`ReminderService_UpdateDoesNotRestartLocalOwner` timed out in its initial setup `RegisterOrUpdateAsync` call. Activation diagnostics showed that the valid test-grain activation had processed all queued work and remained suspended on its nested reminder-service system-target request until the 30-second response deadline.

That setup call occurs before the scenario reaches the local-owner update and schedule-version replacement which the test is intended to verify. The public grain RPC remains covered by the registration and other lifecycle scenarios.

## Solution

Run this scenario's initial registration and update through the harness's existing owner-targeted `LocalReminderService.QueueTask` path. This directly awaits the same reminder-service registration implementation, including the reminder-table upsert, local owner creation/update, and schedule-version replacement, while excluding the unrelated nested grain response acknowledgement.

Propagate the scenario cancellation token into the reminder-service registration so the table operation remains bounded. Preserve the exact owner, start/stop count, schedule-change, `StartAt`, period, and ETag assertions.

## Rationale

The scenario now depends only on the runtime boundaries required by its local-owner update guarantee. This is distinct from #10921 and #11067, which established singleton startup readiness by removing a redundant startup refresh.

Fixes #11106
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11109)