### PR TITLE
fix(test): update MTP to 2.4.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,11 +80,11 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.3.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.4.0" />
     <PackageVersion Include="MySql.Data" Version="8.0.31" />
     <PackageVersion Include="NATS.Net" Version="2.7.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/docs/site/src/content/docs/grains/snippets/testing/orleans-testing/Sample.OrleansTesting/Sample.OrleansTesting.csproj
+++ b/docs/site/src/content/docs/grains/snippets/testing/orleans-testing/Sample.OrleansTesting/Sample.OrleansTesting.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.2.2" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.3.3" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="OrleansTestKit" Version="10.0.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />


### PR DESCRIPTION
## Problem

Filtered solution runs intentionally launch modules with zero selected tests. Under Microsoft.Testing.Platform 2.3.3, the out-of-process TRX lifetime handler created its named-pipe server asynchronously, allowing a fast zero-selection test host to race pipe creation under solution-scale thread-pool contention. On Windows this surfaced as exit code 7 after the xUnit foreground-thread shutdown watchdog; on Linux it surfaced as a TRX named-pipe timeout and exit code 134.

`Orleans.Persistence.TestKit.Tests` contains Persistence/MemoryStore tests and correctly has zero matches in the BVT partition. Its intermittent 71-second exit-code-7 failure in #10853 therefore matches the same lifecycle defect tracked in #10754, rather than a test discovery or solution assembly-selection defect.

## Solution

Update Microsoft.Testing.Platform, its MSBuild integration, and the TRX/CrashDump/HangDump extensions together from 2.3.3 to 2.4.0. Align the standalone Orleans testing documentation sample with the same MTP MSBuild version.

MTP 2.4.0 includes microsoft/testfx#10682, which creates and configures the TRX named-pipe server synchronously before scheduling the connection wait. The upstream regression coverage exercises zero selected tests with TRX and crash-dump reporting on both net8.0 and net10.0.

## Rationale

The normal zero-test result remains accepted through the existing `--ignore-exit-code 8` configuration, while abnormal host shutdown continues to fail. This adopts the upstream lifetime guarantee without suppressing exit code 7, duplicating project-selection rules, retrying failures, or weakening TRX/crash diagnostics.

microsoft/testfx#11040 tracks a 2.4 cancellation regression caused by enabling controller-backed TRX for plain `--report-trx` runs. Orleans already passes `--crashdump` with every CI test command, which selected controller mode in 2.3.3, so this update does not newly activate that cancellation path.

#11096 addresses a distinct boundary: Linux net8 coordinator crashes before test applications produce artifacts. Its coordinator dump capture remains complementary to this test-application/TRX handshake fix.

Fixes #10853
Fixes #10754