### PR TITLE
fix(runtime): retain observer cancellation until dispatch

### DIFF
--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -83,9 +83,11 @@ namespace Orleans
 
         public sealed partial class LocalObjectData : IGrainContext, IGrainCallCancellationExtension
         {
+            private const int MaxPendingCancellations = 1_024;
             private static readonly Func<object?, Task> HandleFunc = self => ((LocalObjectData)self!).LocalObjectMessagePumpAsync();
             private readonly InvokableObjectManager _manager;
-            private readonly HashSet<(GrainId SenderGrainId, CorrelationId MessageId)> _pendingCancellations = [];
+            private readonly Dictionary<(GrainId SenderGrainId, CorrelationId MessageId), LinkedListNode<(GrainId, CorrelationId)>> _pendingCancellations = [];
+            private readonly LinkedList<(GrainId SenderGrainId, CorrelationId MessageId)> _pendingCancellationOrder = [];
             private readonly Dictionary<Message, Task?> _runningRequests = [];
             private Task? _messagePumpTask;
 
@@ -168,7 +170,7 @@ namespace Orleans
                     bool wasCancelled;
                     lock (Messages)
                     {
-                        wasCancelled = _pendingCancellations.Remove((message.SendingGrain, message.Id));
+                        wasCancelled = RemovePendingCancellation((message.SendingGrain, message.Id));
                         if (!wasCancelled)
                         {
                             // Track the running request so it can be cancelled.
@@ -198,7 +200,7 @@ namespace Orleans
                 bool wasWaitingCancellation;
                 lock (this.Messages)
                 {
-                    wasWaitingCancellation = _pendingCancellations.Remove((message.SendingGrain, message.Id));
+                    wasWaitingCancellation = RemovePendingCancellation((message.SendingGrain, message.Id));
                     if (wasWaitingCancellation)
                     {
                         start = false;
@@ -363,6 +365,7 @@ namespace Orleans
                 lock (Messages)
                 {
                     _pendingCancellations.Clear();
+                    _pendingCancellationOrder.Clear();
                 }
             }
 
@@ -370,7 +373,7 @@ namespace Orleans
             {
                 lock (Messages)
                 {
-                    return _pendingCancellations.Remove((message.SendingGrain, message.Id));
+                    return RemovePendingCancellation((message.SendingGrain, message.Id));
                 }
             }
 
@@ -521,7 +524,7 @@ namespace Orleans
                         {
                             // Cancellation and invocation are delivered independently. Retain cancellation
                             // until the matching invocation is admitted or has initialized its local token.
-                            _pendingCancellations.Add(key);
+                            RetainPendingCancellation(key);
                         }
                     }
 
@@ -550,10 +553,38 @@ namespace Orleans
                     {
                         lock (Messages)
                         {
-                            _pendingCancellations.Remove(key);
+                            RemovePendingCancellation(key);
                         }
                     }
                 }
+            }
+
+            private void RetainPendingCancellation((GrainId SenderGrainId, CorrelationId MessageId) key)
+            {
+                if (_pendingCancellations.ContainsKey(key))
+                {
+                    return;
+                }
+
+                if (_pendingCancellations.Count >= MaxPendingCancellations)
+                {
+                    var oldest = _pendingCancellationOrder.First!;
+                    _pendingCancellationOrder.RemoveFirst();
+                    _pendingCancellations.Remove(oldest.Value);
+                }
+
+                _pendingCancellations.Add(key, _pendingCancellationOrder.AddLast(key));
+            }
+
+            private bool RemovePendingCancellation((GrainId SenderGrainId, CorrelationId MessageId) key)
+            {
+                if (!_pendingCancellations.Remove(key, out var node))
+                {
+                    return false;
+                }
+
+                _pendingCancellationOrder.Remove(node);
+                return true;
             }
 
             [LoggerMessage(

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -54,7 +54,13 @@ namespace Orleans
 
         public bool TryDeregister(ObserverGrainId objectId)
         {
-            return this.localObjects.TryRemove(objectId, out _);
+            if (!this.localObjects.TryRemove(objectId, out var objectData))
+            {
+                return false;
+            }
+
+            objectData.OnDeregistered();
+            return true;
         }
 
         public void Dispatch(Message message)
@@ -79,6 +85,7 @@ namespace Orleans
         {
             private static readonly Func<object?, Task> HandleFunc = self => ((LocalObjectData)self!).LocalObjectMessagePumpAsync();
             private readonly InvokableObjectManager _manager;
+            private readonly HashSet<(GrainId SenderGrainId, CorrelationId MessageId)> _pendingCancellations = [];
             private readonly Dictionary<Message, Task?> _runningRequests = [];
             private Task? _messagePumpTask;
 
@@ -158,31 +165,56 @@ namespace Orleans
                 // These messages need to be processed right away, even if another request is currently running.
                 if (message.IsAlwaysInterleave)
                 {
-                    // Track the running request so it can be cancelled.
+                    bool wasCancelled;
                     lock (Messages)
                     {
-                        var task = Task.Factory.StartNew(
-                            static state =>
-                            {
-                                var (self, msg) = ((LocalObjectData, Message))state!;
-                                return self.ProcessMessageAsync(msg);
-                            },
-                            (this, message),
-                            CancellationToken.None,
-                            TaskCreationOptions.DenyChildAttach,
-                            TaskScheduler.Default).Unwrap();
-                        _runningRequests.Add(message, task);
+                        wasCancelled = _pendingCancellations.Remove((message.SendingGrain, message.Id));
+                        if (!wasCancelled)
+                        {
+                            // Track the running request so it can be cancelled.
+                            var task = Task.Factory.StartNew(
+                                static state =>
+                                {
+                                    var (self, msg) = ((LocalObjectData, Message))state!;
+                                    return self.ProcessMessageAsync(msg);
+                                },
+                                (this, message),
+                                CancellationToken.None,
+                                TaskCreationOptions.DenyChildAttach,
+                                TaskScheduler.Default).Unwrap();
+                            _runningRequests.Add(message, task);
+                        }
+                    }
+
+                    if (wasCancelled)
+                    {
+                        SendCanceledResponse(message);
                     }
 
                     return;
                 }
 
                 bool start;
+                bool wasWaitingCancellation;
                 lock (this.Messages)
                 {
-                    this.Messages.Enqueue(message);
-                    start = !this.Running;
-                    this.Running = true;
+                    wasWaitingCancellation = _pendingCancellations.Remove((message.SendingGrain, message.Id));
+                    if (wasWaitingCancellation)
+                    {
+                        start = false;
+                    }
+                    else
+                    {
+                        this.Messages.Enqueue(message);
+                        start = !this.Running;
+                        this.Running = true;
+                    }
+                }
+
+                if (wasWaitingCancellation)
+                {
+                    SendCanceledResponse(message);
+                    return;
                 }
 
                 LogInvokeLocalObjectAsync(_manager.logger, message, start);
@@ -281,6 +313,11 @@ namespace Orleans
                     try
                     {
                         request.SetTarget(this);
+                        if (TryTakePendingCancellation(message))
+                        {
+                            TryCancelInvokable(request);
+                        }
+
                         var filters = _manager.GrainCallFilters;
                         Response response;
                         if (filters is { Count: > 0 } || LocalObject is IIncomingGrainCallFilter)
@@ -320,6 +357,38 @@ namespace Orleans
                     LogErrorProcessingMessage(_manager.logger, outerException, message);
                 }
             }
+
+            internal void OnDeregistered()
+            {
+                lock (Messages)
+                {
+                    _pendingCancellations.Clear();
+                }
+            }
+
+            private bool TryTakePendingCancellation(Message message)
+            {
+                lock (Messages)
+                {
+                    return _pendingCancellations.Remove((message.SendingGrain, message.Id));
+                }
+            }
+
+            private bool TryCancelInvokable(IInvokable request)
+            {
+                try
+                {
+                    return request.TryCancel();
+                }
+                catch (Exception exception)
+                {
+                    LogErrorCancellationCallbackFailed(_manager.logger, exception);
+                    return true;
+                }
+            }
+
+            private void SendCanceledResponse(Message message) =>
+                _manager.runtimeClient.SendResponse(message, Response.FromException(new OperationCanceledException()));
 
             private void SendResponseAsync(Message message, Response resultObject)
             {
@@ -401,33 +470,14 @@ namespace Orleans
                 CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (!TryCancelRequest())
-                {
-                    // The message being canceled may not have arrived yet, so retry a few times.
-                    return RetryCancellationAfterDelay();
-                }
-
+                TryCancelRequest();
                 return ValueTask.CompletedTask;
 
-                async ValueTask RetryCancellationAfterDelay()
-                {
-                    var attemptsRemaining = 3;
-                    do
-                    {
-                        await Task.Delay(1_000, cancellationToken);
-
-                        if (TryCancelRequest())
-                        {
-                            return;
-                        }
-
-                    } while (--attemptsRemaining > 0);
-                }
-
-                bool TryCancelRequest()
+                void TryCancelRequest()
                 {
                     Message? message = null;
                     var wasWaiting = false;
+                    var key = (senderGrainId, messageId);
                     lock (Messages)
                     {
                         // Check the running requests.
@@ -466,6 +516,13 @@ namespace Orleans
                                 }
                             }
                         }
+
+                        if (!wasWaiting)
+                        {
+                            // Cancellation and invocation are delivered independently. Retain cancellation
+                            // until the matching invocation is admitted or has initialized its local token.
+                            _pendingCancellations.Add(key);
+                        }
                     }
 
                     var didCancel = false;
@@ -475,7 +532,7 @@ namespace Orleans
                         // If the message did begin executing, wait for it to observe the cancellation token and respond itself.
                         if (wasWaiting)
                         {
-                            _manager.runtimeClient.SendResponse(message, Response.FromException(new OperationCanceledException()));
+                            SendCanceledResponse(message);
                             didCancel = true;
                         }
                         else if (message.BodyObject is IInvokable invokableRequest)
@@ -489,19 +546,12 @@ namespace Orleans
                         }
                     }
 
-                    return didCancel;
-                }
-
-                bool TryCancelInvokable(IInvokable request)
-                {
-                    try
+                    if (didCancel)
                     {
-                        return request.TryCancel();
-                    }
-                    catch (Exception exception)
-                    {
-                        LogErrorCancellationCallbackFailed(_manager.logger, exception);
-                        return true;
+                        lock (Messages)
+                        {
+                            _pendingCancellations.Remove(key);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

Observer invocation messages and their cancellation control messages are delivered independently. When cancellation reached a client observer before the invocation was visible, or before `SetTarget` initialized the generated local cancellation source, `LocalObjectData` retried for three seconds and then silently abandoned cancellation. A delayed observer callback could subsequently execute and complete normally after the caller had requested acknowledged cancellation.

The observer target lifetime race was already addressed by #10897; this is the remaining cancellation-admission race tracked by #10902.

## Solution

Retain cancellation by sender and message identity within the local observer reference until the matching invocation reaches an actionable boundary:

- consume retained cancellation atomically before admitting the invocation to the observer queue;
- consume it after `SetTarget` when cancellation raced request initialization;
- cancel queued requests with an immediate canceled response;
- clear retained state when the observer reference is deregistered.

This removes the fixed-delay retries and establishes the invariant that acknowledged cancellation either prevents observer dispatch or is observed by the initialized invocation before it responds. The exact multi-observer cancellation assertions remain unchanged.

Fixes #10902

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11111)