### PR TITLE
ci: run macOS tests daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,7 +756,7 @@ jobs:
       fail-fast: false
       matrix:
         suite: [BVT, SlowBVT, Functional]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         framework: ["net8.0", "net10.0"]
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -778,7 +778,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         framework: ["net8.0", "net10.0"]
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -1,5 +1,6 @@
 name: macOS tests
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 9 * * *'
 permissions:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -1,0 +1,48 @@
+name: macOS tests
+on:
+  schedule:
+    - cron: '0 9 * * *'
+permissions:
+  contents: read
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+jobs:
+  test:
+    name: Test
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [BVT, SlowBVT, Functional]
+        framework: ["net8.0", "net10.0"]
+    steps:
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    - name: Setup Node.js
+      if: matrix.suite == 'BVT'
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      with:
+        node-version: '24.x'
+    - name: Test
+      uses: ./.github/actions/run-tests
+      with:
+        artifact-name: test_output_${{ github.job }}_${{ matrix.suite }}_macos-latest_${{ matrix.framework }}
+        build-external-assets: ${{ matrix.suite == 'BVT' && 'true' || 'false' }}
+        filter-query: /[(Provider=None)&(Suite=${{ matrix.suite }})&(Area!=CodeGen)]
+        framework: ${{ matrix.framework }}
+  test-codegenerator:
+    name: Test Code Generator
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: ["net8.0", "net10.0"]
+    steps:
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    - name: Test Code Generator
+      uses: ./.github/actions/run-tests
+      with:
+        artifact-name: test_output_${{ github.job }}_macos-latest_${{ matrix.framework }}
+        filter-query: /[(Provider=None)&(Area=CodeGen)&((Suite=BVT)|(Suite=SlowBVT)|(Suite=Functional))]
+        framework: ${{ matrix.framework }}
+        static-instrumentation: 'true'


### PR DESCRIPTION
macOS GitHub Actions runners currently have long queue times and significantly extend routine CI completion. Run the macOS test suites once daily from `main` instead of scheduling them for every push, pull request, and merge queue build.

This removes macOS from the general test and code-generator matrices while preserving Linux and Windows test-suite coverage on every build. A dedicated scheduled workflow runs the same BVT, SlowBVT, Functional, and code-generator suites for both supported target frameworks each day at 09:00 UTC, with manual dispatch available for validation and debugging.

The existing macOS compilation build remains part of per-build CI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11112)