### PR TITLE
test(placement): synchronize static rebalancing observations

### DIFF
--- a/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
@@ -50,11 +50,80 @@ public class DiagnosticInfrastructureRegressionTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task GrainDiagnosticObserver_WaitForAnyGrainDeactivatedAsync_ObservesMatchingEvent()
+    {
+        using var observer = GrainDiagnosticObserver.CreateForAllSilos();
+        var expectedContext = Substitute.For<IGrainContext>();
+        expectedContext.GrainId.Returns(GrainId.Create("test", "expected"));
+        var otherContext = Substitute.For<IGrainContext>();
+        otherContext.GrainId.Returns(GrainId.Create("test", "other"));
+
+        var waitTask = observer.WaitForAnyGrainDeactivatedAsync(
+            deactivated => deactivated.GrainContext.GrainId == expectedContext.GrainId,
+            TimeSpan.FromSeconds(1));
+
+        GrainLifecycleEvents.EmitDeactivated(
+            otherContext,
+            new(DeactivationReasonCode.ApplicationRequested, "other"));
+        Assert.False(waitTask.IsCompleted);
+
+        GrainLifecycleEvents.EmitDeactivated(
+            expectedContext,
+            new(DeactivationReasonCode.Migrating, "expected"));
+
+        var result = await waitTask;
+        Assert.Same(expectedContext, result.GrainContext);
+        Assert.Equal(DeactivationReasonCode.Migrating, result.Reason.ReasonCode);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task GrainDiagnosticObserver_WaitForAnyGrainDeactivatedAsync_TimesOut()
     {
         using var observer = GrainDiagnosticObserver.CreateForAllSilos();
 
-        await Assert.ThrowsAsync<TimeoutException>(() => observer.WaitForAnyGrainDeactivatedAsync(_ => false, TimeSpan.FromMilliseconds(100)));
+        await Assert.ThrowsAsync<TimeoutException>(
+            () => observer.WaitForAnyGrainDeactivatedAsync(_ => false, TimeSpan.FromMilliseconds(100)));
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task GrainDiagnosticObserver_PredicateException_DoesNotBlockOtherWaiters()
+    {
+        using var observer = GrainDiagnosticObserver.CreateForAllSilos();
+        var grainContext = Substitute.For<IGrainContext>();
+        grainContext.GrainId.Returns(GrainId.Create("test", "predicate"));
+
+        var throwingWait = observer.WaitForAnyGrainDeactivatedAsync(
+            _ => throw new InvalidOperationException("predicate failed"),
+            TimeSpan.FromSeconds(1));
+        var matchingWait = observer.WaitForAnyGrainDeactivatedAsync(
+            deactivated => deactivated.GrainContext.GrainId == grainContext.GrainId,
+            TimeSpan.FromSeconds(1));
+
+        GrainLifecycleEvents.EmitDeactivated(
+            grainContext,
+            new(DeactivationReasonCode.ApplicationRequested, "test"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => throwingWait);
+        Assert.Same(grainContext, (await matchingWait).GrainContext);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task GrainDiagnosticObserver_Dispose_CompletesPredicateWaiters()
+    {
+        var observer = GrainDiagnosticObserver.CreateForAllSilos();
+        var waitTask = observer.WaitForAnyGrainDeactivatedAsync(_ => false, TimeSpan.FromSeconds(1));
+
+        observer.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => waitTask);
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => observer.WaitForAnyGrainDeactivatedAsync(_ => true, TimeSpan.FromSeconds(1)));
     }
 
     [TestSuite("BVT")]

--- a/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
@@ -114,6 +114,44 @@ public class DiagnosticInfrastructureRegressionTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task GrainDiagnosticObserver_BlockedPredicate_DoesNotBlockDisposal()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var observer = GrainDiagnosticObserver.CreateForAllSilos();
+        var grainContext = Substitute.For<IGrainContext>();
+        grainContext.GrainId.Returns(GrainId.Create("test", "blocking-predicate"));
+        var predicateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePredicate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var waitTask = observer.WaitForAnyGrainDeactivatedAsync(
+            _ =>
+            {
+                predicateEntered.TrySetResult();
+                releasePredicate.Task.GetAwaiter().GetResult();
+                return false;
+            },
+            TimeSpan.FromSeconds(5));
+
+        var emitTask = Task.Run(() => GrainLifecycleEvents.EmitDeactivated(
+            grainContext,
+            new(DeactivationReasonCode.ApplicationRequested, "test")), cancellationToken);
+        await predicateEntered.Task.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken);
+
+        try
+        {
+            await Task.Run(observer.Dispose, cancellationToken).WaitAsync(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+        finally
+        {
+            releasePredicate.TrySetResult();
+        }
+
+        await emitTask.WaitAsync(cancellationToken);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => waitTask);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task GrainDiagnosticObserver_Dispose_CompletesPredicateWaiters()
     {
         var observer = GrainDiagnosticObserver.CreateForAllSilos();

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/RebalancingTestBase.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/RebalancingTestBase.cs
@@ -37,6 +37,12 @@ public abstract class RebalancingTestBase<TFixture>
     protected static int GetActivationCount(DetailedGrainStatistic[] stats, SiloAddress silo) =>
         stats.Count(x => x.SiloAddress.Equals(silo));
 
+    protected static int GetActivationCount(
+        DetailedGrainStatistic[] stats,
+        SiloAddress silo,
+        GrainType grainType) =>
+        stats.Count(x => x.SiloAddress.Equals(silo) && x.GrainId.Type.Equals(grainType));
+
     protected void AddTestActivations(List<Task> tasks, SiloAddress silo, int count)
     {
         RequestContext.Set(IPlacementDirector.PlacementHintKey, silo);

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
@@ -14,6 +14,8 @@ namespace UnitTests.ActivationRebalancingTests;
 public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper output)
     : RebalancingTestBase<RebalancerFixture>(fixture, output), IClassFixture<RebalancerFixture>
 {
+    private static readonly TimeSpan RebalancerSuspensionDuration = TimeSpan.FromMinutes(2);
+
     [Fact]
     public async Task Should_Move_Activations_From_Silo1_And_Silo3_To_Silo2_And_Silo4()
     {
@@ -23,7 +25,7 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
         using var grainEvents = GrainDiagnosticObserver.Create(Cluster);
         var rebalancer = Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0);
         var rebalancerHost = (await rebalancer.GetReport(cancellationToken)).Host;
-        await rebalancer.SuspendRebalancing(null, cancellationToken);
+        await rebalancer.SuspendRebalancing(RebalancerSuspensionDuration, cancellationToken);
 
         AddTestActivations(tasks, Silo1, 300);
         AddTestActivations(tasks, Silo2, 30);

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
@@ -53,6 +53,7 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
         var silo3Activations = initialSilo3Activations;
         var silo4Activations = initialSilo4Activations;
 
+        await MgmtGrain.ForceRuntimeStatisticsCollection([rebalancerHost], cancellationToken);
         grainEvents.Clear();
         var silo1Migration = grainEvents.WaitForAnyGrainDeactivatedAsync(
             deactivated =>

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StaticRebalancingTests.cs
@@ -20,8 +20,10 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
         var cancellationToken = TestContext.Current.CancellationToken;
         var tasks = new List<Task>();
         using var rebalancerEvents = RebalancerDiagnosticObserver.Create(Cluster);
+        using var grainEvents = GrainDiagnosticObserver.Create(Cluster);
         var rebalancer = Cluster.Client!.GetGrain<IActivationRebalancerWorker>(0);
         var rebalancerHost = (await rebalancer.GetReport(cancellationToken)).Host;
+        await rebalancer.SuspendRebalancing(null, cancellationToken);
 
         AddTestActivations(tasks, Silo1, 300);
         AddTestActivations(tasks, Silo2, 30);
@@ -31,12 +33,13 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
         await Task.WhenAll(tasks);
         rebalancerEvents.Clear();
 
+        var testGrainType = GrainFactory.GetGrain<IRebalancingTestGrain>(Guid.Empty).GetGrainId().Type;
         var stats = await MgmtGrain.GetDetailedGrainStatistics(null, null, cancellationToken);
 
-        var initialSilo1Activations = GetActivationCount(stats, Silo1);
-        var initialSilo2Activations = GetActivationCount(stats, Silo2);
-        var initialSilo3Activations = GetActivationCount(stats, Silo3);
-        var initialSilo4Activations = GetActivationCount(stats, Silo4);
+        var initialSilo1Activations = GetActivationCount(stats, Silo1, testGrainType);
+        var initialSilo2Activations = GetActivationCount(stats, Silo2, testGrainType);
+        var initialSilo3Activations = GetActivationCount(stats, Silo3, testGrainType);
+        var initialSilo4Activations = GetActivationCount(stats, Silo4, testGrainType);
 
         OutputHelper.WriteLine(
            $"Pre-rebalancing activations:\n" +
@@ -50,16 +53,28 @@ public class StaticRebalancingTests(RebalancerFixture fixture, ITestOutputHelper
         var silo3Activations = initialSilo3Activations;
         var silo4Activations = initialSilo4Activations;
 
+        grainEvents.Clear();
+        var silo1Migration = grainEvents.WaitForAnyGrainDeactivatedAsync(
+            deactivated =>
+                deactivated.Reason.ReasonCode is DeactivationReasonCode.Migrating &&
+                deactivated.GrainContext.GrainId.Type.Equals(testGrainType) &&
+                Silo1.Equals(deactivated.GrainContext.Address.SiloAddress));
+        var silo3Migration = grainEvents.WaitForAnyGrainDeactivatedAsync(
+            deactivated =>
+                deactivated.Reason.ReasonCode is DeactivationReasonCode.Migrating &&
+                deactivated.GrainContext.GrainId.Type.Equals(testGrainType) &&
+                Silo3.Equals(deactivated.GrainContext.Address.SiloAddress));
+
         const int observedCycles = 3;
-        await rebalancerEvents
-            .WaitForCycleCountAsync(rebalancerHost, observedCycles)
-            .WaitAsync(cancellationToken);
+        var observedRebalancing = rebalancerEvents.WaitForCycleCountAsync(rebalancerHost, observedCycles);
+        await rebalancer.ResumeRebalancing(cancellationToken);
+        await Task.WhenAll(observedRebalancing, silo1Migration, silo3Migration).WaitAsync(cancellationToken);
 
         stats = await MgmtGrain.GetDetailedGrainStatistics(null, null, cancellationToken);
-        silo1Activations = GetActivationCount(stats, Silo1);
-        silo2Activations = GetActivationCount(stats, Silo2);
-        silo3Activations = GetActivationCount(stats, Silo3);
-        silo4Activations = GetActivationCount(stats, Silo4);
+        silo1Activations = GetActivationCount(stats, Silo1, testGrainType);
+        silo2Activations = GetActivationCount(stats, Silo2, testGrainType);
+        silo3Activations = GetActivationCount(stats, Silo3, testGrainType);
+        silo4Activations = GetActivationCount(stats, Silo4, testGrainType);
 
         Assert.True(silo1Activations < initialSilo1Activations,
             $"Did not expect Silo1 to have more activations than what it started with: " +

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/GrainDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/GrainDiagnosticObserver.cs
@@ -435,14 +435,31 @@ public sealed class GrainDiagnosticObserver : IDisposable, IObserver<GrainLifecy
 
     private void SignalDeactivationWaiters(GrainLifecycleEvents.Deactivated deactivated)
     {
+        DeactivationWaiter[] waiters;
         lock (_deactivationWaitersLock)
         {
-            for (var i = _deactivationWaiters.Count - 1; i >= 0; i--)
+            waiters = [.. _deactivationWaiters];
+        }
+
+        List<DeactivationWaiter>? completedWaiters = null;
+        foreach (var waiter in waiters)
+        {
+            if (waiter.TryComplete(deactivated))
             {
-                if (_deactivationWaiters[i].TryComplete(deactivated))
-                {
-                    _deactivationWaiters.RemoveAt(i);
-                }
+                (completedWaiters ??= []).Add(waiter);
+            }
+        }
+
+        if (completedWaiters is null)
+        {
+            return;
+        }
+
+        lock (_deactivationWaitersLock)
+        {
+            foreach (var waiter in completedWaiters)
+            {
+                _deactivationWaiters.Remove(waiter);
             }
         }
     }

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/GrainDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/GrainDiagnosticObserver.cs
@@ -21,8 +21,11 @@ public sealed class GrainDiagnosticObserver : IDisposable, IObserver<GrainLifecy
     private readonly ConcurrentBag<GrainLifecycleEvents.Activated> _activatedEvents = new();
     private readonly ConcurrentBag<GrainLifecycleEvents.Deactivating> _deactivatingEvents = new();
     private readonly ConcurrentBag<GrainLifecycleEvents.Deactivated> _deactivatedEvents = new();
+    private readonly object _deactivationWaitersLock = new();
+    private readonly List<DeactivationWaiter> _deactivationWaiters = [];
     private IDisposable? _subscription;
     private int _listenerSubscriptionCount;
+    private bool _disposed;
 
     /// <summary>
     /// Gets the number of Orleans.Grains listeners that have been subscribed to.
@@ -128,38 +131,37 @@ public sealed class GrainDiagnosticObserver : IDisposable, IObserver<GrainLifecy
     /// <param name="predicate">A predicate to match the grain.</param>
     /// <param name="timeout">Maximum time to wait. Defaults to 30 seconds.</param>
     /// <returns>The deactivated event payload.</returns>
-    public async Task<GrainLifecycleEvents.Deactivated> WaitForAnyGrainDeactivatedAsync(Func<GrainLifecycleEvents.Deactivated, bool> predicate, TimeSpan? timeout = null)
+    public async Task<GrainLifecycleEvents.Deactivated> WaitForAnyGrainDeactivatedAsync(
+        Func<GrainLifecycleEvents.Deactivated, bool> predicate,
+        TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
-        using var cts = new CancellationTokenSource(effectiveTimeout);
-
-        // Check if we already have a matching event
-        var existingMatch = _deactivatedEvents.FirstOrDefault(predicate);
-        if (existingMatch != null)
+        DeactivationWaiter waiter;
+        lock (_deactivationWaitersLock)
         {
-            return existingMatch;
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            var existingMatch = _deactivatedEvents.FirstOrDefault(predicate);
+            if (existingMatch is not null)
+            {
+                return existingMatch;
+            }
+
+            waiter = new(predicate);
+            _deactivationWaiters.Add(waiter);
         }
 
-        // Poll for new events (this is a fallback; the event-driven approach is preferred)
-        while (!cts.Token.IsCancellationRequested)
+        try
         {
-            try
+            return await waiter.Task.WaitAsync(effectiveTimeout).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_deactivationWaitersLock)
             {
-                await Task.Delay(10, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-
-            var match = _deactivatedEvents.FirstOrDefault(predicate);
-            if (match != null)
-            {
-                return match;
+                _deactivationWaiters.Remove(waiter);
             }
         }
-
-        throw new TimeoutException($"Timed out waiting for grain deactivation matching predicate after {effectiveTimeout}");
     }
 
     /// <summary>
@@ -399,6 +401,7 @@ public sealed class GrainDiagnosticObserver : IDisposable, IObserver<GrainLifecy
             case GrainLifecycleEvents.Deactivated deactivated:
                 _deactivatedEvents.Add(deactivated);
                 SignalWaiters(deactivated.GrainContext.GrainId, nameof(GrainLifecycleEvents.Deactivated), deactivated);
+                SignalDeactivationWaiters(deactivated);
                 break;
         }
     }
@@ -411,10 +414,63 @@ public sealed class GrainDiagnosticObserver : IDisposable, IObserver<GrainLifecy
     /// </summary>
     public void Dispose()
     {
-        _subscription?.Dispose();
+        Interlocked.Exchange(ref _subscription, null)?.Dispose();
+
+        lock (_deactivationWaitersLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            foreach (var waiter in _deactivationWaiters)
+            {
+                waiter.TrySetException(new ObjectDisposedException(nameof(GrainDiagnosticObserver)));
+            }
+
+            _deactivationWaiters.Clear();
+        }
+    }
+
+    private void SignalDeactivationWaiters(GrainLifecycleEvents.Deactivated deactivated)
+    {
+        lock (_deactivationWaitersLock)
+        {
+            for (var i = _deactivationWaiters.Count - 1; i >= 0; i--)
+            {
+                if (_deactivationWaiters[i].TryComplete(deactivated))
+                {
+                    _deactivationWaiters.RemoveAt(i);
+                }
+            }
+        }
     }
 
     private static string GetGrainTypeName(IGrainContext grainContext) => grainContext.GrainId.Type.ToString();
+
+    private sealed class DeactivationWaiter(Func<GrainLifecycleEvents.Deactivated, bool> predicate)
+    {
+        private readonly TaskCompletionSource<GrainLifecycleEvents.Deactivated> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<GrainLifecycleEvents.Deactivated> Task => _completion.Task;
+
+        public bool TryComplete(GrainLifecycleEvents.Deactivated value)
+        {
+            try
+            {
+                return predicate(value) && _completion.TrySetResult(value);
+            }
+            catch (Exception exception)
+            {
+                _completion.TrySetException(exception);
+                return true;
+            }
+        }
+
+        public bool TrySetException(Exception exception) => _completion.TrySetException(exception);
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Problem

`StaticRebalancingTests` could establish its baseline while the rebalancer held a mixed-age runtime-statistics snapshot, then count cycle completions which did not prove that the test activations had completed migration. Its assertions also counted unrelated runtime activations, allowing incidental activation churn to obscure the test grain movement.

## Solution

Suspend rebalancing while creating and measuring the activation distribution, refresh the rebalancer host's full cluster statistics, then arm grain lifecycle barriers before resuming. The test now observes completed migration deactivations from both configured source silos and counts only `IRebalancingTestGrain` activations when comparing the distribution.

Replace predicate-based deactivation polling in `GrainDiagnosticObserver` with event-driven waiters, including timeout, predicate-fault, and disposal handling.

## Rationale

The runtime rebalancer admits migrations during its cycles, while grain lifecycle events establish when source activations have completed deactivation. Synchronizing those boundaries gives the assertion a stable post-migration snapshot without delays, retries, or weaker expectations.

Fixes #10941
Fixes #11083
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11113)