### PR TITLE
test(placement): fix state preservation flake

### DIFF
--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/StatePreservationRebalancingTests.cs
@@ -68,6 +68,7 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
 
         (var rebalancerHost, var rebalancerHostNum) = await FindRebalancerHost(Silo1);
         var reportBeforeStop = await rebalancer.GetReport(cancellationToken);
+        Assert.NotEmpty(reportBeforeStop.Statistics);
 
         OutputHelper.WriteLine($"Now stopping Silo{rebalancerHostNum}, which is the host of the rebalancer\n");
 
@@ -83,13 +84,6 @@ public class StatePreservationRebalancingTests(SPFixture fixture, ITestOutputHel
         Assert.NotEqual(rebalancerHost, newHost);
         Assert.Equal(reportBeforeStop.ClusterImbalance, reportAfterStop.ClusterImbalance);
         Assert.Equal(reportBeforeStop.Status, reportAfterStop.Status);
-        Assert.Equal(
-            reportBeforeStop.Statistics
-                .Single(statistic => statistic.SiloAddress.Equals(newHost))
-                .AcquiredActivations,
-            reportAfterStop.Statistics
-                .Single(statistic => statistic.SiloAddress.Equals(newHost))
-                .AcquiredActivations);
         Assert.Equal(
             reportBeforeStop.Statistics
                 .Where(statistic => !statistic.SiloAddress.Equals(rebalancerHost))


### PR DESCRIPTION
## Problem

The state-preservation rebalancing test assumed that the silo selected to host the migrated rebalancer had participated in an earlier activation migration. When it had not, the report legitimately contained no statistic for that silo and `Single(...)` failed intermittently.

## Solution

Remove the destination-specific statistic lookup and compare the complete set of surviving pre-stop statistics with the post-migration report. Require the pre-stop report to contain statistics so the preservation assertion remains meaningful.

## Rationale

Rebalancing statistics are created only for silos involved in activation migration. Rebalancer placement is independent of those migrations, while the full sequence comparison already verifies every statistic which the runtime promises to preserve.

Fixes #11088
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11114)