### PR TITLE
fix(testing): avoid redundant reminder topology refresh

### DIFF
--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -189,6 +189,33 @@ public sealed class FaultyReminderServiceLifecycleTests
     }
 
     [Fact]
+    public async Task TopologyReconciliationDoesNotRequestRefresh()
+    {
+        var fixture = new ReminderServiceLifecycleFixture();
+        await fixture.InitializeAsync();
+        try
+        {
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            cancellation.CancelAfter(TimeSpan.FromMinutes(2));
+            await fixture.Harness.WaitForStartupReadinessAsync(cancellation.Token);
+            var table = Assert.IsType<IdealizedReminderTable>(fixture.Harness.ReminderTable);
+            var rangeReads = table.Operations.Count(operation =>
+                operation.Kind == ReminderTableOperationKind.ReadRange);
+
+            await fixture.Harness.WaitForTopologyReconciliationAsync(cancellation.Token);
+
+            Assert.Equal(
+                rangeReads,
+                table.Operations.Count(operation => operation.Kind == ReminderTableOperationKind.ReadRange));
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [Fact]
     public Task DuplicateOwnerImplementationIsRejected()
         => RunFaultAsync(
             harness => new LifecycleRunner(new DuplicateOwnerHarness(harness), "DuplicateOwner"),

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderServiceLifecycleConformanceTests.cs
@@ -200,14 +200,11 @@ public sealed class FaultyReminderServiceLifecycleTests
             cancellation.CancelAfter(TimeSpan.FromMinutes(2));
             await fixture.Harness.WaitForStartupReadinessAsync(cancellation.Token);
             var table = Assert.IsType<IdealizedReminderTable>(fixture.Harness.ReminderTable);
-            var rangeReads = table.Operations.Count(operation =>
-                operation.Kind == ReminderTableOperationKind.ReadRange);
+            var rangeReads = table.OperationCount(ReminderTableOperationKind.ReadRange);
 
             await fixture.Harness.WaitForTopologyReconciliationAsync(cancellation.Token);
 
-            Assert.Equal(
-                rangeReads,
-                table.Operations.Count(operation => operation.Kind == ReminderTableOperationKind.ReadRange));
+            Assert.Equal(rangeReads, table.OperationCount(ReminderTableOperationKind.ReadRange));
         }
         finally
         {

--- a/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
+++ b/test/Orleans.Testing.Reminders/ReminderServiceLifecycleHarness.cs
@@ -171,7 +171,7 @@ public sealed class ReminderServiceLifecycleHarness
         try
         {
             var silo = AssertSingle(await _cluster.StartSilosAsync(1, cancellationToken));
-            await StabilizeTopologyAsync([silo], cancellationToken);
+            await WaitForReconciledTopologyAsync([silo], cancellationToken);
             return silo.SiloAddress;
         }
         catch (Exception joinFailure)
@@ -225,12 +225,12 @@ public sealed class ReminderServiceLifecycleHarness
 
     /// <inheritdoc />
     public Task WaitForTopologyReconciliationAsync(CancellationToken cancellationToken)
-        => StabilizeTopologyAsync(_cluster.GetActiveSilos(), cancellationToken);
+        => WaitForReconciledTopologyAsync(_cluster.GetActiveSilos(), cancellationToken);
 
-    private async Task StabilizeTopologyAsync(
+    private async Task WaitForReconciledTopologyAsync(
         IEnumerable<InProcessSiloHandle> readySilos,
         CancellationToken cancellationToken)
-        => await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+        => await ReminderTopologyStabilizer.WaitForReconciledTopologyAsync(
             _cluster,
             _observer,
             readySilos,


### PR DESCRIPTION
## Problem

The Reminder TestKit lifecycle harness used the explicit-refresh topology barrier for join readiness and reconciliation-only waits. The join/leave scenario therefore requested consecutive refresh admissions after membership and reminder reconciliation had already converged, allowing the scenario deadline to expire while a redundant refresh-start work item remained queued.

## Solution

Route lifecycle join readiness and `WaitForTopologyReconciliationAsync` through the existing reconciliation-only topology barrier. This preserves reminder-service readiness, liveness and manifest convergence, membership-listener delivery, FIFO scheduler ordering, latest-generation reconciliation, and final topology verification while leaving scenario-driven provider refreshes under `RefreshAsync`.

Add a deterministic contract test which proves a topology reconciliation wait does not issue another reminder-table range read.

## Rationale

Topology changes already trigger range reconciliation. The scheduler-turn and latest-generation barriers establish completion of that work, so an additional provider refresh is outside the reconciliation contract and adds an independent scheduler dependency after convergence.

Fixes #11108
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11116)