### PR TITLE
test(runtime): stabilize manual activation collection

### DIFF
--- a/test/Grains/TestInternalGrainInterfaces/ActivationGCTestGrainInterfaces.cs
+++ b/test/Grains/TestInternalGrainInterfaces/ActivationGCTestGrainInterfaces.cs
@@ -13,6 +13,7 @@ namespace UnitTests.GrainInterfaces
     public interface IBusyActivationGcTestGrain1 : IGrainWithGuidKey
     {
         Task Nop();
+        Task BlockUntilReleased();
         Task Delay(TimeSpan dt);
         Task<string> IdentifyActivation();
     }

--- a/test/Grains/TestInternalGrains/ActivationGCTestGrains.cs
+++ b/test/Grains/TestInternalGrains/ActivationGCTestGrains.cs
@@ -22,6 +22,7 @@ namespace UnitTests.Grains
 
     internal class BusyActivationGcTestGrain1 : Grain, IBusyActivationGcTestGrain1
     {
+        private static BlockingCallBarrier? _blockingCallBarrier;
         private readonly string _id = Guid.NewGuid().ToString();
         private readonly ActivationCollector activationCollector;
         private readonly IGrainContext _grainContext;
@@ -37,6 +38,13 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
+        public Task BlockUntilReleased()
+        {
+            var barrier = Volatile.Read(ref _blockingCallBarrier)
+                ?? throw new InvalidOperationException("The blocking call barrier is not armed.");
+            return barrier.SignalAndWaitAsync();
+        }
+
         public Task Delay(TimeSpan dt)
         {
             return Task.Delay(dt);
@@ -45,6 +53,78 @@ namespace UnitTests.Grains
         public Task<string> IdentifyActivation()
         {
             return Task.FromResult(_id);
+        }
+
+        public static BlockingCallBarrier ArmBlockingCallBarrier(int participantCount)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(participantCount, 1);
+
+            var barrier = new BlockingCallBarrier(participantCount);
+            if (Interlocked.CompareExchange(ref _blockingCallBarrier, barrier, null) is not null)
+            {
+                throw new InvalidOperationException("A blocking call barrier is already armed.");
+            }
+
+            return barrier;
+        }
+
+        public sealed class BlockingCallBarrier : IDisposable
+        {
+            private readonly TaskCompletionSource _participantsReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly int _participantCount;
+            private int _remainingParticipants;
+            private int _disposed;
+
+            internal BlockingCallBarrier(int participantCount)
+            {
+                _participantCount = participantCount;
+                _remainingParticipants = participantCount;
+            }
+
+            public async Task WaitForParticipantsAsync(TimeSpan timeout, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await _participantsReady.Task.WaitAsync(timeout, cancellationToken);
+                }
+                catch (TimeoutException exception)
+                {
+                    var arrived = _participantCount - Volatile.Read(ref _remainingParticipants);
+                    throw new TimeoutException(
+                        $"Timed out waiting for busy activation calls: {arrived} of {_participantCount} calls reached the barrier.",
+                        exception);
+                }
+            }
+
+            public void Release() => _release.TrySetResult();
+
+            internal async Task SignalAndWaitAsync()
+            {
+                var remaining = Interlocked.Decrement(ref _remainingParticipants);
+                if (remaining < 0)
+                {
+                    throw new InvalidOperationException($"More than {_participantCount} calls reached the blocking call barrier.");
+                }
+
+                if (remaining == 0)
+                {
+                    _participantsReady.TrySetResult();
+                }
+
+                await _release.Task;
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+
+                Release();
+                Interlocked.CompareExchange(ref _blockingCallBarrier, null, this);
+            }
         }
     }
 

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -249,9 +249,9 @@ namespace UnitTests.ActivationsLifeCycleTests
         public async Task ManualCollectionShouldNotCollectBusyActivations()
         {
             var cancellationToken = TestContext.Current.CancellationToken;
-            await Initialize(DEFAULT_IDLE_TIMEOUT, cancellationToken);
+            await Initialize(TimeSpan.FromHours(1), cancellationToken);
 
-            TimeSpan shortIdleTimeout = FORCED_COLLECTION_WAIT_TIME;
+            var manualCollectionWaitTime = FORCED_COLLECTION_WAIT_TIME;
             const int idleGrainCount = 500;
             const int busyGrainCount = 500;
             var idleGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(IdleActivationGcTestGrain1));
@@ -267,51 +267,34 @@ namespace UnitTests.ActivationsLifeCycleTests
                 tasks0.Add(g.Nop());
             }
             await Task.WhenAll(tasks0);
-            using var workerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            async Task busyWorker(CancellationToken cancellationToken)
+
+            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
+            tasks0.Clear();
+            for (var i = 0; i < idleGrainCount; ++i)
             {
-                logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: busyWorker started");
-                while (true)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    List<Task> tasks1 = new List<Task>(busyGrains.Count);
-                    foreach (var g in busyGrains)
-                        tasks1.Add(g.Nop());
-                    await Task.WhenAll(tasks1);
-                }
+                IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
+                tasks0.Add(g.Nop());
             }
-            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token), cancellationToken);
+            await Task.WhenAll(tasks0);
+
+            int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
+            Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
+
+            logger.LogInformation(
+                "ManualCollectionShouldNotCollectBusyActivations: grains activated; waiting {TotalSeconds} sec before manual collection.",
+                manualCollectionWaitTime.TotalSeconds);
+            await Task.Delay(manualCollectionWaitTime, cancellationToken);
+
+            using var callBarrier = BusyActivationGcTestGrain1.ArmBlockingCallBarrier(busyGrainCount);
+            var busyCalls = busyGrains.Select(grain => grain.BlockUntilReleased()).ToArray();
             try
             {
-                logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
-                tasks0.Clear();
-                for (var i = 0; i < idleGrainCount; ++i)
-                {
-                    IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
-                    tasks0.Add(g.Nop());
-                }
-                await Task.WhenAll(tasks0);
+                await callBarrier.WaitForParticipantsAsync(TestConstants.InitTimeout, cancellationToken);
 
-                int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
-                Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
-
-                logger.LogInformation(
-                    "ManualCollectionShouldNotCollectBusyActivations: grains activated; waiting {TotalSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
-                    shortIdleTimeout.TotalSeconds,
-                    DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-                await Task.Delay(shortIdleTimeout, cancellationToken);
-
-                TimeSpan everything = TimeSpan.FromMinutes(10);
-                logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (timespan is {TotalSeconds} sec).", everything.TotalSeconds);
+                logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (age limit is {TotalSeconds} sec).", FORCED_COLLECTION_AGE_LIMIT.TotalSeconds);
                 IManagementGrain mgmtGrain = this.testCluster.GrainFactory!.GetGrain<IManagementGrain>(0);
-                await mgmtGrain.ForceActivationCollection(everything, cancellationToken);
+                await mgmtGrain.ForceActivationCollection(FORCED_COLLECTION_AGE_LIMIT, cancellationToken);
 
-                logger.LogInformation(
-                    "ManualCollectionShouldNotCollectBusyActivations: waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
-                    DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0, cancellationToken);
-
-                // we should have only collected grains from the idle category (IdleActivationGcTestGrain).
                 int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
                 int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
                 Assert.Equal(0, idleActivationsNotCollected);
@@ -319,7 +302,8 @@ namespace UnitTests.ActivationsLifeCycleTests
             }
             finally
             {
-                await CancelWorkerAsync(workerCancellation, workerTask);
+                callBarrier.Release();
+                await Task.WhenAll(busyCalls).WaitAsync(TestConstants.InitTimeout, cancellationToken);
             }
         }
 


### PR DESCRIPTION
## Problem

`ManualCollectionShouldNotCollectBusyActivations` used rapid `Nop` calls to represent busy activations. Activations were legitimately inactive between calls, so collection could remove most of them. The test also used a ten-minute age limit after only 1.25 seconds, leaving the manual collection with no eligible idle activations.

## Solution

- Hold one executing request on each of the 500 busy activations using a test barrier.
- Trigger manual collection only after every busy call reaches the barrier.
- Collect activations idle for one second after a 1.25-second wait.
- Configure the normal collection age to one hour so the manual operation produces the observed result.
- Release and await all blocked calls during cleanup.

## Rationale

An activation with an executing request is ineligible for collection. Synchronizing on that lifecycle guarantee makes both exact outcomes deterministic: 500 idle activations are collected and 500 executing activations remain.

Fixes #11089
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11117)