### PR TITLE
fix(reminders): order topology reconciliation admission

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -584,6 +584,9 @@ namespace Orleans.Runtime.ReminderService
         {
             CheckRuntimeContext();
 
+            // Observe the ring before loading so readiness covers the current range, including changes during the read.
+            SubscribeToRangeChangeEvents();
+            await this.QueueAction(static _ => { }, state: 0);
             await DoInitialReadAndUpdateReminders();
             this.runTask = RunAsync();
         }
@@ -597,7 +600,15 @@ namespace Orleans.Runtime.ReminderService
                 if (StoppedCancellationTokenSource.IsCancellationRequested) return;
 
                 initialReadCallCount++;
-                await this.ReadAndUpdateReminders();
+                while (true)
+                {
+                    var rangeSerialNumber = RangeSerialNumber;
+                    await this.ReadAndUpdateReminders();
+                    if (rangeSerialNumber == RangeSerialNumber)
+                    {
+                        break;
+                    }
+                }
 
                 Status = GrainServiceStatus.Started;
                 startedTask.TrySetResult(true);

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -16,7 +16,7 @@ using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.ReminderService
 {
-    internal sealed partial class LocalReminderService : GrainService, IReminderService, ILifecycleParticipant<ISiloLifecycle>
+    internal sealed partial class LocalReminderService : GrainService, IReminderService, ILifecycleParticipant<ISiloLifecycle>, IGrainServiceRangeChangeQueue
     {
         private const int InitialReadRetryCountBeforeFastFailForUpdates = 2;
         private static readonly TimeSpan InitialReadMaxWaitTimeForUpdates = TimeSpan.FromSeconds(20);
@@ -392,32 +392,22 @@ namespace Orleans.Runtime.ReminderService
             return task;
         }
 
-        internal Task TestOnlyStartRefresh() => QueueRefresh();
+        internal Task<Task> TestOnlyStartRefresh() => QueueRefresh();
 
         internal Task TestOnlyRefresh() => QueueRefresh().Unwrap();
 
         internal bool TestOnlyIsStarted => Status == GrainServiceStatus.Started;
 
-        internal Task TestOnlyWaitForSchedulerTurn()
-            => this.QueueAction(static _ => { }, state: 0);
-
         private Task<Task> QueueRefresh()
         {
-            var refreshStarted = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _ = this.QueueAction(
-                static state =>
-                {
-                    try
-                    {
-                        state.RefreshStarted.SetResult(state.Service.TrackReconciliation(state.Service.ReadAndUpdateReminders));
-                    }
-                    catch (Exception exception)
-                    {
-                        state.RefreshStarted.SetException(exception);
-                    }
-                },
-                (Service: this, RefreshStarted: refreshStarted));
-            return refreshStarted.Task;
+            try
+            {
+                return Task.FromResult(QueueTrackedReconciliation(ReadAndUpdateReminders));
+            }
+            catch (Exception exception)
+            {
+                return Task.FromException<Task>(exception);
+            }
         }
 
         internal Task TestOnlyWaitForSiloStatusListeners(CancellationToken cancellationToken)
@@ -461,6 +451,18 @@ namespace Orleans.Runtime.ReminderService
         }
 
         public override Task OnRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)
+            => TrackReconciliation(() => ApplyRangeChange(oldRange, newRange, increased));
+
+        void IGrainServiceRangeChangeQueue.QueueRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)
+            => QueueTrackedRangeChange(oldRange, newRange, increased).Ignore();
+
+        private Task QueueTrackedRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)
+            => QueueTrackedReconciliation(() => ApplyRangeChange(oldRange, newRange, increased));
+
+        private Task QueueTrackedReconciliation(Func<Task> reconciliation)
+            => TrackReconciliation(() => this.QueueTask(reconciliation));
+
+        private Task ApplyRangeChange(IRingRange oldRange, IRingRange newRange, bool increased)
         {
             CheckRuntimeContext();
 
@@ -468,7 +470,7 @@ namespace Orleans.Runtime.ReminderService
             var status = Status;
             if (status == GrainServiceStatus.Started)
             {
-                return TrackReconciliation(ReadAndUpdateReminders);
+                return ReadAndUpdateReminders();
             }
 
             LogIgnoringRangeChange(status);
@@ -478,26 +480,32 @@ namespace Orleans.Runtime.ReminderService
         private Task TrackReconciliation(Func<Task> reconciliation)
         {
             var reconciliationTaskSource = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
-            TaskCompletionSource previousGenerationChanged;
-            lock (_reconciliationLock)
-            {
-                previousGenerationChanged = reconciliationGenerationChanged;
-                reconciliationGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
-                reconciliationGeneration++;
-                reconciliationTask = reconciliationTaskSource.Task.Unwrap();
-            }
-
-            previousGenerationChanged.TrySetResult();
+            TaskCompletionSource? previousGenerationChanged = null;
             try
             {
-                var task = reconciliation();
-                reconciliationTaskSource.SetResult(task);
-                return task;
+                lock (_reconciliationLock)
+                {
+                    previousGenerationChanged = reconciliationGenerationChanged;
+                    reconciliationGenerationChanged = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                    reconciliationGeneration++;
+                    reconciliationTask = reconciliationTaskSource.Task.Unwrap();
+
+                    try
+                    {
+                        var task = reconciliation();
+                        reconciliationTaskSource.SetResult(task);
+                        return task;
+                    }
+                    catch (Exception exception)
+                    {
+                        reconciliationTaskSource.SetException(exception);
+                        throw;
+                    }
+                }
             }
-            catch (Exception exception)
+            finally
             {
-                reconciliationTaskSource.SetException(exception);
-                throw;
+                previousGenerationChanged?.TrySetResult();
             }
         }
 
@@ -535,11 +543,10 @@ namespace Orleans.Runtime.ReminderService
         }
 
         internal Task TestOnlyChangeRange(IRingRange oldRange, IRingRange newRange, bool increased)
-            => this.QueueTask(() => OnRangeChange(oldRange, newRange, increased));
+            => QueueTrackedRangeChange(oldRange, newRange, increased);
 
         private async Task RunAsync()
         {
-            await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
             var initialRefreshStagger = reminderOptions.RefreshReminderListPeriod < InitialReadRetryPeriod
                 ? reminderOptions.RefreshReminderListPeriod
                 : InitialReadRetryPeriod;
@@ -549,21 +556,8 @@ namespace Orleans.Runtime.ReminderService
             {
                 try
                 {
-                    CheckRuntimeContext();
-
                     overrideDelay = null;
-                    switch (Status)
-                    {
-                        case GrainServiceStatus.Booting:
-                            await DoInitialReadAndUpdateReminders();
-                            break;
-                        case GrainServiceStatus.Started:
-                            await TrackReconciliation(ReadAndUpdateReminders);
-                            break;
-                        default:
-                            listRefreshTimer.Dispose();
-                            return;
-                    }
+                    await QueueTrackedReconciliation(ProcessRefreshTick);
 
                     consecutiveFailures = 0;
                 }
@@ -578,6 +572,24 @@ namespace Orleans.Runtime.ReminderService
                         cap: TimeSpan.FromSeconds(80));
                 }
             }
+
+            async Task ProcessRefreshTick()
+            {
+                CheckRuntimeContext();
+
+                switch (Status)
+                {
+                    case GrainServiceStatus.Booting:
+                        await DoInitialReadAndUpdateReminders();
+                        break;
+                    case GrainServiceStatus.Started:
+                        await ReadAndUpdateReminders();
+                        break;
+                    default:
+                        listRefreshTimer.Dispose();
+                        break;
+                }
+            }
         }
 
         protected override async Task StartInBackground()
@@ -588,7 +600,8 @@ namespace Orleans.Runtime.ReminderService
             SubscribeToRangeChangeEvents();
             await this.QueueAction(static _ => { }, state: 0);
             await DoInitialReadAndUpdateReminders();
-            this.runTask = RunAsync();
+            using var suppressExecutionContext = new ExecutionContextSuppressor();
+            this.runTask = Task.Run(RunAsync);
         }
 
         private async Task DoInitialReadAndUpdateReminders()

--- a/src/Orleans.Runtime/Services/GrainService.cs
+++ b/src/Orleans.Runtime/Services/GrainService.cs
@@ -77,13 +77,15 @@ namespace Orleans.Runtime
         {
             if (oldStatus != GrainServiceStatus.Started && newStatus == GrainServiceStatus.Started)
             {
-                ring.SubscribeToRangeChangeEvents(this);
+                SubscribeToRangeChangeEvents();
             }
             if (oldStatus != GrainServiceStatus.Stopped && newStatus == GrainServiceStatus.Stopped)
             {
                 ring.UnSubscribeFromRangeChangeEvents(this);
             }
         }
+
+        private protected void SubscribeToRangeChangeEvents() => ring.SubscribeToRangeChangeEvents(this);
 
         /// <summary>Invoked when service is being started</summary>
         /// <returns>A <see cref="Task"/> representing the work performed.</returns>

--- a/src/Orleans.Runtime/Services/GrainService.cs
+++ b/src/Orleans.Runtime/Services/GrainService.cs
@@ -124,7 +124,14 @@ namespace Orleans.Runtime
         /// <inheritdoc/>
         void IRingRangeListener.RangeChangeNotification(IRingRange oldRange, IRingRange newRange, bool increased)
         {
-            this.WorkItemGroup.QueueTask(() => OnRangeChange(oldRange, newRange, increased), this).Ignore();
+            if (this is IGrainServiceRangeChangeQueue rangeChangeQueue)
+            {
+                rangeChangeQueue.QueueRangeChange(oldRange, newRange, increased);
+            }
+            else
+            {
+                this.WorkItemGroup.QueueTask(() => OnRangeChange(oldRange, newRange, increased), this).Ignore();
+            }
         }
 
         /// <summary>
@@ -179,5 +186,10 @@ namespace Orleans.Runtime
             /// <summary>Service has been stopped</summary>
             Stopped,
         }
+    }
+
+    internal interface IGrainServiceRangeChangeQueue
+    {
+        void QueueRangeChange(IRingRange oldRange, IRingRange newRange, bool increased);
     }
 }

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -418,23 +418,80 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         try
         {
             var refreshStarted = reminderService.TestOnlyStartRefresh();
-            Assert.False(refreshStarted.IsCompleted);
+            var refresh = await refreshStarted.WaitAsync(cancellation.Token);
+            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+            Assert.False(refresh.IsCompleted);
+            Assert.False(reconciliationTask.IsCompleted);
 
             releaseScheduler.Set();
             await blockingTask.WaitAsync(cancellation.Token);
             await readGate.WaitUntilBlockedAsync(cancellation.Token);
-            var reconciliationTask = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
-
-            await refreshStarted.WaitAsync(cancellation.Token);
             Assert.False(reconciliationTask.IsCompleted);
 
             readGate.Release();
-            await reconciliationTask.WaitAsync(cancellation.Token);
+            await Task.WhenAll(refresh, reconciliationTask).WaitAsync(cancellation.Token);
         }
         finally
         {
             releaseScheduler.Set();
             readGate.Release();
+            await blockingTask.WaitAsync(cancellation.Token);
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task RangeChangeBarrier_PreservesRefreshThenRangeOrder()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        _ = await fixture.ReminderHarness.WaitForServicesReadyAsync(
+            [silo],
+            TestConstants.InitTimeout,
+            cancellation.Token);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = silo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var oldRange = RangeFactory.CreateRange(0, uint.MaxValue / 2);
+        var newRange = RangeFactory.CreateRange(0, uint.MaxValue / 4);
+        var schedulerBlocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseScheduler = new ManualResetEventSlim();
+        var blockingTask = new Task(() =>
+        {
+            schedulerBlocked.TrySetResult();
+            releaseScheduler.Wait(cancellation.Token);
+        });
+        reminderService.Scheduler.QueueTask(blockingTask);
+        await schedulerBlocked.Task.WaitAsync(cancellation.Token);
+
+        var refreshRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+        RangeReadGate? rangeChangeRead = null;
+        try
+        {
+            var refresh = reminderService.TestOnlyRefresh();
+            var rangeChange = reminderService.TestOnlyChangeRange(oldRange, newRange, increased: false);
+            var reconciliation = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
+            Assert.False(reconciliation.IsCompleted);
+
+            releaseScheduler.Set();
+            await blockingTask.WaitAsync(cancellation.Token);
+            await refreshRead.WaitUntilBlockedAsync(cancellation.Token);
+
+            rangeChangeRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+            refreshRead.Release();
+            await rangeChangeRead.WaitUntilBlockedAsync(cancellation.Token);
+            Assert.False(reconciliation.IsCompleted);
+
+            rangeChangeRead.Release();
+            await Task.WhenAll(refresh, rangeChange, reconciliation).WaitAsync(cancellation.Token);
+        }
+        finally
+        {
+            releaseScheduler.Set();
+            refreshRead.Release();
+            rangeChangeRead?.Release();
             await blockingTask.WaitAsync(cancellation.Token);
         }
     }
@@ -671,6 +728,70 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             cancellation.Token);
 
         Assert.Equal(rangeReadCount, reminderTable.RangeReadCount);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task StartupTopologyBarrier_DoesNotRefreshStableMultiSiloTopology()
+    {
+        var builder = new InProcessTestClusterBuilder(2);
+        var clock = builder.AddReminderTestClock();
+        builder.ConfigureSilo((_, siloBuilder) =>
+        {
+            siloBuilder.AddReminders();
+            siloBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton<NullReturningReminderTable>();
+                services.AddSingleton<IReminderTable>(
+                    static provider => provider.GetRequiredService<NullReturningReminderTable>());
+            });
+        });
+
+        var cluster = builder.Build();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        try
+        {
+            await cluster.DeployAsync(cancellation.Token);
+            await ReminderTopologyStabilizer.WaitForReconciledTopologyAsync(
+                cluster,
+                clock.DiagnosticObserver,
+                cluster.Silos,
+                cancellation.Token);
+            var reminderTables = cluster.Silos
+                .Select(silo => silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>())
+                .ToArray();
+            var rangeReadCounts = reminderTables.Select(table => table.RangeReadCount).ToArray();
+
+            await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
+                cluster,
+                clock.DiagnosticObserver,
+                cluster.Silos,
+                cancellation.Token);
+
+            Assert.Equal(rangeReadCounts, reminderTables.Select(table => table.RangeReadCount));
+        }
+        finally
+        {
+            try
+            {
+                using var cleanupCancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+                await cluster.StopAllSilosAsync(cleanupCancellation.Token);
+            }
+            finally
+            {
+                try
+                {
+                    using var disposeCancellation = new CancellationTokenSource(TestConstants.InitTimeout);
+                    await cluster.DisposeAsync().AsTask().WaitAsync(disposeCancellation.Token);
+                }
+                finally
+                {
+                    clock.Dispose();
+                }
+            }
+        }
     }
 
     [TestSuite("BVT")]

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -650,6 +650,93 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public async Task StableTopologyBarrier_DoesNotStartAnExtraRefresh()
+    {
+        var silo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
+            fixture.HostedCluster,
+            fixture.DiagnosticObserver,
+            [silo],
+            cancellation.Token);
+
+        var reminderTable = silo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var rangeReadCount = reminderTable.RangeReadCount;
+
+        await ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+            fixture.HostedCluster,
+            fixture.DiagnosticObserver,
+            [silo],
+            cancellation.Token);
+
+        Assert.Equal(rangeReadCount, reminderTable.RangeReadCount);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task StableTopologyBarrier_WaitsForMembershipRangeReconciliation()
+    {
+        var initialSilo = Assert.Single(fixture.HostedCluster.Silos);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TestConstants.InitTimeout);
+        await ReminderTopologyStabilizer.WaitForStartupTopologyAsync(
+            fixture.HostedCluster,
+            fixture.DiagnosticObserver,
+            [initialSilo],
+            cancellation.Token);
+
+        var reminderTable = initialSilo.ServiceProvider.GetRequiredService<NullReturningReminderTable>();
+        var reminderService = initialSilo.ServiceProvider.GetRequiredService<LocalReminderService>();
+        var rangeRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+        var schedulerBlocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseScheduler = new ManualResetEventSlim();
+        var blockingTask = new Task(() =>
+        {
+            schedulerBlocked.TrySetResult();
+            releaseScheduler.Wait(cancellation.Token);
+        });
+        reminderService.Scheduler.QueueTask(blockingTask);
+        await schedulerBlocked.Task.WaitAsync(cancellation.Token);
+        InProcessSiloHandle? joinedSilo = null;
+        try
+        {
+            joinedSilo = Assert.Single(await fixture.HostedCluster.StartSilosAsync(1, cancellation.Token));
+            await reminderService.TestOnlyWaitForSiloStatusListeners(cancellation.Token);
+
+            var barrier = ReminderTopologyStabilizer.WaitForStableTopologyAsync(
+                fixture.HostedCluster,
+                fixture.DiagnosticObserver,
+                [joinedSilo],
+                cancellation.Token);
+            Assert.False(barrier.IsCompleted);
+
+            releaseScheduler.Set();
+            await blockingTask.WaitAsync(cancellation.Token);
+            await rangeRead.WaitUntilBlockedAsync(cancellation.Token);
+            Assert.False(barrier.IsCompleted);
+
+            rangeRead.Release();
+            await barrier;
+        }
+        finally
+        {
+            releaseScheduler.Set();
+            rangeRead.Release();
+            await blockingTask.WaitAsync(cancellation.Token);
+            if (joinedSilo is not null)
+            {
+                using var siloCleanup = new CancellationTokenSource(TestConstants.InitTimeout);
+                await fixture.HostedCluster.StopSiloAsync(joinedSilo, siloCleanup.Token);
+                await fixture.HostedCluster.WaitForLivenessToStabilizeAsync();
+            }
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public async Task ReconciledTopologyBarrier_WaitsForQueuedRangeChange()
     {
         var silo = Assert.Single(fixture.HostedCluster.Silos);
@@ -712,13 +799,16 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
 
     public sealed class Fixture : BaseInProcessTestClusterFixture
     {
+        private ReminderTestClock? _clock;
+
         public ReminderLifecycleHarness ReminderHarness { get; } = new();
         public ReminderDiagnosticObserver DiagnosticObserver { get; private set; } = null!;
 
         protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
         {
             builder.Options.InitialSilosCount = 1;
-            DiagnosticObserver = ReminderDiagnosticObserver.Create(builder);
+            _clock = builder.AddReminderTestClock();
+            DiagnosticObserver = _clock.DiagnosticObserver;
             builder.ConfigureSilo((_, siloBuilder) =>
             {
                 siloBuilder.AddReminders();
@@ -741,7 +831,7 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             finally
             {
                 ReminderHarness.Dispose();
-                DiagnosticObserver.Dispose();
+                _clock?.Dispose();
             }
         }
     }

--- a/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
@@ -23,7 +23,6 @@ public static class ReminderTopologyStabilizer
             observer,
             readySilos,
             useInitialLoadForSingleSilo: false,
-            requestRefresh: true,
             cancellationToken);
 
     /// <summary>
@@ -39,7 +38,6 @@ public static class ReminderTopologyStabilizer
             observer,
             readySilos,
             useInitialLoadForSingleSilo: false,
-            requestRefresh: false,
             cancellationToken);
 
     /// <summary>
@@ -56,7 +54,6 @@ public static class ReminderTopologyStabilizer
             observer,
             readySilos,
             useInitialLoadForSingleSilo: true,
-            requestRefresh: true,
             cancellationToken);
 
     private static async Task<IReadOnlyList<InProcessSiloHandle>> WaitForStableTopologyAsync(
@@ -64,7 +61,6 @@ public static class ReminderTopologyStabilizer
         ReminderDiagnosticObserver observer,
         IEnumerable<InProcessSiloHandle> readySilos,
         bool useInitialLoadForSingleSilo,
-        bool requestRefresh,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(cluster);
@@ -134,14 +130,10 @@ public static class ReminderTopologyStabilizer
                     && requiredReadySilos.Length == 1
                     && expectedActiveSilos.Length == 1
                     && requiredReadySilos[0].SiloAddress.Equals(expectedActiveSilos[0].SiloAddress);
-                if (!initialLoadIsRefreshBoundary && requestRefresh)
+                if (!initialLoadIsRefreshBoundary)
                 {
-                    phase = "stable topology refresh start";
-                    var refreshesStarted = reminderServices.Select(service => service.TestOnlyStartRefresh()).ToArray();
-                    await Task.WhenAll(refreshesStarted).WaitAsync(cancellationToken);
-                }
-                else if (!initialLoadIsRefreshBoundary)
-                {
+                    // Membership listener delivery enqueues ring changes before it reports the version as processed.
+                    // This FIFO turn ensures those changes have published their reconciliation generations.
                     phase = "reminder scheduler topology boundary";
                     var schedulerTurns = reminderServices.Select(service => service.TestOnlyWaitForSchedulerTurn()).ToArray();
                     await Task.WhenAll(schedulerTurns).WaitAsync(cancellationToken);

--- a/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
+++ b/test/Orleans.Testing.Reminders/ReminderTopologyStabilizer.cs
@@ -18,11 +18,10 @@ public static class ReminderTopologyStabilizer
         ReminderDiagnosticObserver observer,
         IEnumerable<InProcessSiloHandle> readySilos,
         CancellationToken cancellationToken)
-        => await WaitForStableTopologyAsync(
+        => await WaitForTopologyAsync(
             cluster,
             observer,
             readySilos,
-            useInitialLoadForSingleSilo: false,
             cancellationToken);
 
     /// <summary>
@@ -33,34 +32,30 @@ public static class ReminderTopologyStabilizer
         ReminderDiagnosticObserver observer,
         IEnumerable<InProcessSiloHandle> readySilos,
         CancellationToken cancellationToken)
-        => await WaitForStableTopologyAsync(
+        => await WaitForTopologyAsync(
             cluster,
             observer,
             readySilos,
-            useInitialLoadForSingleSilo: false,
             cancellationToken);
 
     /// <summary>
-    /// Waits for the initial reminder topology, using the completed initial load as the refresh boundary for a
-    /// single-silo cluster.
+    /// Waits for the initial reminder topology and its current range reconciliation.
     /// </summary>
     public static async Task<IReadOnlyList<InProcessSiloHandle>> WaitForStartupTopologyAsync(
         InProcessTestCluster cluster,
         ReminderDiagnosticObserver observer,
         IEnumerable<InProcessSiloHandle> readySilos,
         CancellationToken cancellationToken)
-        => await WaitForStableTopologyAsync(
+        => await WaitForTopologyAsync(
             cluster,
             observer,
             readySilos,
-            useInitialLoadForSingleSilo: true,
             cancellationToken);
 
-    private static async Task<IReadOnlyList<InProcessSiloHandle>> WaitForStableTopologyAsync(
+    private static async Task<IReadOnlyList<InProcessSiloHandle>> WaitForTopologyAsync(
         InProcessTestCluster cluster,
         ReminderDiagnosticObserver observer,
         IEnumerable<InProcessSiloHandle> readySilos,
-        bool useInitialLoadForSingleSilo,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(cluster);
@@ -125,19 +120,6 @@ public static class ReminderTopologyStabilizer
                 phase = "silo status listener delivery";
                 await Task.WhenAll(reminderServices.Select(service =>
                     service.TestOnlyWaitForSiloStatusListeners(cancellationToken)));
-
-                var initialLoadIsRefreshBoundary = useInitialLoadForSingleSilo
-                    && requiredReadySilos.Length == 1
-                    && expectedActiveSilos.Length == 1
-                    && requiredReadySilos[0].SiloAddress.Equals(expectedActiveSilos[0].SiloAddress);
-                if (!initialLoadIsRefreshBoundary)
-                {
-                    // Membership listener delivery enqueues ring changes before it reports the version as processed.
-                    // This FIFO turn ensures those changes have published their reconciliation generations.
-                    phase = "reminder scheduler topology boundary";
-                    var schedulerTurns = reminderServices.Select(service => service.TestOnlyWaitForSchedulerTurn()).ToArray();
-                    await Task.WhenAll(schedulerTurns).WaitAsync(cancellationToken);
-                }
 
                 phase = "latest reminder reconciliation";
                 var reconciliations = reminderServices.Select(service =>


### PR DESCRIPTION
## Problem

Reminder lifecycle topology stabilization enqueued an explicit refresh on every active silo after membership listeners had already processed the current version. That redundant provider work could stall at refresh admission or reconciliation under provider load, even though membership, manifests, and ring ownership had converged.

Replacing the refresh with a separate scheduler turn retained the same admission dependency. Publishing reconciliation generations only when scheduler callbacks executed also allowed queued refreshes and range changes to be observed in a different order from their scheduler execution order.

A topology change during reminder-service startup could additionally invalidate the initial range read before the service subscribed to ring notifications.

## Solution

Subscribe the local reminder service to ring changes before its initial read and repeat the load whenever its range changes during the read, so startup readiness covers a stable current range.

Publish and enqueue every range change, explicit refresh, and periodic refresh through one ordered reconciliation-admission path. Generation publication and scheduler FIFO enqueue now occur atomically, and previous-generation waiters are signaled only after the new generation and its exact task are installed. The periodic timer waits outside the grain scheduler and queues the actual refresh turn through this path.

Topology stabilization waits for membership listener processing and then directly awaits the latest published reconciliation generation. It no longer creates unrelated provider work or depends on a separate scheduler no-op.

Add deterministic coverage for stable multi-silo startup, membership-triggered range reconciliation, and both refresh-before-range and range-before-refresh ordering.

## Rationale

Membership processing synchronously queues the associated ring changes before publishing its processed version. Using the same admission path for every reconciliation operation preserves that causal order through scheduler execution, so the topology barrier awaits the work caused by the topology itself.

Fixes #11023

Related: #11016, #11108