### PR TITLE
fix(firestore): validate grain directory inputs

### DIFF
--- a/src/Google/Orleans.GrainDirectory.Firestore/FirestoreGrainDirectory.cs
+++ b/src/Google/Orleans.GrainDirectory.Firestore/FirestoreGrainDirectory.cs
@@ -34,6 +34,9 @@ public partial class FirestoreGrainDirectory : IGrainDirectory, ILifecyclePartic
         IOptions<FirestoreOptions> firestoreOptions,
         ILoggerFactory loggerFactory)
     {
+        ArgumentNullException.ThrowIfNull(clusterOptions);
+        ArgumentNullException.ThrowIfNull(firestoreOptions);
+
         this._clusterId = clusterOptions.Value.ClusterId;
         this._logger = loggerFactory.CreateLogger<FirestoreGrainDirectory>();
 
@@ -93,6 +96,8 @@ public partial class FirestoreGrainDirectory : IGrainDirectory, ILifecyclePartic
         GrainAddress? previousAddress,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(address);
+
         if (previousAddress is not null)
         {
             await Unregister(previousAddress, cancellationToken).ConfigureAwait(false);
@@ -128,6 +133,8 @@ public partial class FirestoreGrainDirectory : IGrainDirectory, ILifecyclePartic
 
     private async Task Unregister(GrainAddress address, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(address);
+
         try
         {
             var found = await this._dataManager

--- a/src/Google/Orleans.GrainDirectory.Firestore/FirestoreGrainDirectory.cs
+++ b/src/Google/Orleans.GrainDirectory.Firestore/FirestoreGrainDirectory.cs
@@ -85,6 +85,9 @@ public partial class FirestoreGrainDirectory : IGrainDirectory, ILifecyclePartic
     Task<GrainAddress?> IGrainDirectory.Register(GrainAddress address, CancellationToken cancellationToken) =>
         Register(address, previousAddress: null, cancellationToken: cancellationToken);
 
+    Task<GrainAddress?> IGrainDirectory.Register(GrainAddress address, GrainAddress? previousAddress) =>
+        Register(address, previousAddress, CancellationToken.None);
+
     Task<GrainAddress?> IGrainDirectory.Register(
         GrainAddress address,
         GrainAddress? previousAddress,

--- a/src/Google/Orleans.GrainDirectory.Firestore/FirestoreGrainDirectory.cs
+++ b/src/Google/Orleans.GrainDirectory.Firestore/FirestoreGrainDirectory.cs
@@ -36,6 +36,7 @@ public partial class FirestoreGrainDirectory : IGrainDirectory, ILifecyclePartic
     {
         ArgumentNullException.ThrowIfNull(clusterOptions);
         ArgumentNullException.ThrowIfNull(firestoreOptions);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
 
         this._clusterId = clusterOptions.Value.ClusterId;
         this._logger = loggerFactory.CreateLogger<FirestoreGrainDirectory>();

--- a/src/Google/Orleans.GrainDirectory.Firestore/Orleans.GrainDirectory.Firestore.csproj
+++ b/src/Google/Orleans.GrainDirectory.Firestore/Orleans.GrainDirectory.Firestore.csproj
@@ -10,6 +10,7 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <DefineConstants>$(DefineConstants);ORLEANS_DIRECTORY</DefineConstants>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/api/Google/Orleans.GrainDirectory.Firestore/Orleans.GrainDirectory.Firestore.cs
+++ b/src/api/Google/Orleans.GrainDirectory.Firestore/Orleans.GrainDirectory.Firestore.cs
@@ -18,6 +18,8 @@ namespace Orleans.GrainDirectory.Firestore
 
         System.Threading.Tasks.Task<Runtime.GrainAddress?> IGrainDirectory.Register(Runtime.GrainAddress address, Runtime.GrainAddress? previousAddress, System.Threading.CancellationToken cancellationToken) { throw null; }
 
+        System.Threading.Tasks.Task<Runtime.GrainAddress?> IGrainDirectory.Register(Runtime.GrainAddress address, Runtime.GrainAddress? previousAddress) { throw null; }
+
         System.Threading.Tasks.Task<Runtime.GrainAddress?> IGrainDirectory.Register(Runtime.GrainAddress address, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         System.Threading.Tasks.Task IGrainDirectory.Unregister(Runtime.GrainAddress address, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
+++ b/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
@@ -67,6 +67,24 @@ public class FirestoreGrainDirectoryNullTests
     }
 
     [Fact]
+    public async Task RegisterWithPreviousAddress_NullAddress_ThrowsBeforeUnregistering()
+    {
+        IGrainDirectory directory = CreateGrainDirectory();
+        var previousAddress = new GrainAddress
+        {
+            ActivationId = ActivationId.NewId(),
+            GrainId = GrainId.Parse("user/previous"),
+            SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+            MembershipVersion = new MembershipVersion(51),
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RegisterWithoutCancellation(directory, null!, previousAddress));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
     public async Task Unregister_NullAddress_ThrowsArgumentNullException()
     {
         var directory = CreateGrainDirectory();
@@ -89,6 +107,12 @@ public class FirestoreGrainDirectoryNullTests
 
     private static FirestoreGrainDirectory CreateGrainDirectory() =>
         new(CreateClusterOptions(), CreateFirestoreOptions(), NullLoggerFactory.Instance);
+
+    private static Task<GrainAddress?> RegisterWithoutCancellation(
+        IGrainDirectory directory,
+        GrainAddress address,
+        GrainAddress? previousAddress) =>
+        directory.Register(address, previousAddress);
 
     private static IOptions<ClusterOptions> CreateClusterOptions() =>
         Options.Create(new ClusterOptions

--- a/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
+++ b/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
@@ -35,6 +35,17 @@ public class FirestoreGrainDirectoryNullTests
     }
 
     [Fact]
+    public void Constructor_NullLoggerFactory_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new FirestoreGrainDirectory(
+            CreateClusterOptions(),
+            CreateFirestoreOptions(),
+            null!));
+
+        Assert.Equal("loggerFactory", exception.ParamName);
+    }
+
+    [Fact]
     public async Task Register_NullAddress_ThrowsArgumentNullException()
     {
         var directory = CreateGrainDirectory();

--- a/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
+++ b/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
@@ -67,7 +67,7 @@ public class FirestoreGrainDirectoryNullTests
     }
 
     [Fact]
-    public async Task RegisterWithPreviousAddress_NullAddress_ThrowsBeforeUnregistering()
+    public async Task RegisterWithoutCancellation_NullAddress_ThrowsArgumentNullException()
     {
         IGrainDirectory directory = CreateGrainDirectory();
         var previousAddress = new GrainAddress

--- a/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
+++ b/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryNullTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Orleans.GrainDirectory.Firestore.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("GoogleCloud")]
+[TestArea("GrainDirectory")]
+[TestCategory("GrainDirectory"), TestCategory("BVT"), TestCategory("Firestore"), TestCategory("GoogleCloud")]
+public class FirestoreGrainDirectoryNullTests
+{
+    [Fact]
+    public void Constructor_NullClusterOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new FirestoreGrainDirectory(
+            null!,
+            CreateFirestoreOptions(),
+            NullLoggerFactory.Instance));
+
+        Assert.Equal("clusterOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullFirestoreOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new FirestoreGrainDirectory(
+            CreateClusterOptions(),
+            null!,
+            NullLoggerFactory.Instance));
+
+        Assert.Equal("firestoreOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Register_NullAddress_ThrowsArgumentNullException()
+    {
+        var directory = CreateGrainDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => directory.Register(null!));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task RegisterWithCancellation_NullAddress_ThrowsArgumentNullException()
+    {
+        IGrainDirectory directory = CreateGrainDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => directory.Register(null!, TestContext.Current.CancellationToken));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task RegisterWithPreviousAddress_NullAddress_ThrowsArgumentNullException()
+    {
+        IGrainDirectory directory = CreateGrainDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => directory.Register(null!, previousAddress: null, TestContext.Current.CancellationToken));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Unregister_NullAddress_ThrowsArgumentNullException()
+    {
+        var directory = CreateGrainDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => directory.Unregister(null!));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task UnregisterWithCancellation_NullAddress_ThrowsArgumentNullException()
+    {
+        IGrainDirectory directory = CreateGrainDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => directory.Unregister(null!, TestContext.Current.CancellationToken));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    private static FirestoreGrainDirectory CreateGrainDirectory() =>
+        new(CreateClusterOptions(), CreateFirestoreOptions(), NullLoggerFactory.Instance);
+
+    private static IOptions<ClusterOptions> CreateClusterOptions() =>
+        Options.Create(new ClusterOptions
+        {
+            ClusterId = "cluster-id",
+            ServiceId = "service-id",
+        });
+
+    private static IOptions<FirestoreOptions> CreateFirestoreOptions() =>
+        Options.Create(new FirestoreOptions
+        {
+            ProjectId = "project-id",
+            EmulatorHost = "localhost:8080",
+        });
+}

--- a/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryTests.cs
+++ b/test/Extensions/Orleans.GrainDirectory.Firestore.Tests/FirestoreGrainDirectoryTests.cs
@@ -69,6 +69,26 @@ public class FirestoreGrainDirectoryTests : GrainDirectoryTests<FirestoreGrainDi
         Assert.Null(await GrainDirectory.Lookup(address.GrainId));
     }
 
+    [Fact]
+    public async Task RegisterNullReplacementPreservesPreviousRegistration()
+    {
+        var previousAddress = new GrainAddress
+        {
+            ActivationId = ActivationId.NewId(),
+            GrainId = GrainId.Parse($"user/{Guid.NewGuid():N}"),
+            SiloAddress = SiloAddress.FromParsableString("10.0.23.12:1000@5678"),
+            MembershipVersion = new MembershipVersion(51),
+        };
+        await GrainDirectory.Register(previousAddress);
+        IGrainDirectory directory = GrainDirectory;
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RegisterWithoutCancellation(directory, null!, previousAddress));
+
+        Assert.Equal("address", exception.ParamName);
+        Assert.Equal(previousAddress, await GrainDirectory.Lookup(previousAddress.GrainId));
+    }
+
     public async ValueTask InitializeAsync()
     {
         var clusterOptions = new ClusterOptions
@@ -91,4 +111,10 @@ public class FirestoreGrainDirectoryTests : GrainDirectoryTests<FirestoreGrainDi
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static Task<GrainAddress?> RegisterWithoutCancellation(
+        IGrainDirectory directory,
+        GrainAddress address,
+        GrainAddress? previousAddress) =>
+        directory.Register(address, previousAddress);
 }


### PR DESCRIPTION
## Summary
- validate the Firestore grain directory's public options and grain-address boundaries
- preserve the shared registration and unregistration paths for all `IGrainDirectory` overloads
- add service-independent null-contract coverage and enforce CA1062 for the complete provider project

## Rationale
Analyzer audit run 33941973157 identified four CA1062 findings in `FirestoreGrainDirectory.cs`. The checks are limited to externally supplied options and addresses. Internal Firestore client state, grain-address members, cancellation flow, document keys, optimistic concurrency, and transaction behavior continue to rely on their existing initialization and runtime guarantees.

The existing normal behavior and concurrent-cleanup coverage remains emulator-backed and requires the Firestore emulator at `127.0.0.1:8080`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11121)