### PR TITLE
fix(cosmos): validate clustering setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -682,7 +682,7 @@ dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 
 # CA1062: Validate arguments of public methods
-[src/Azure/Orleans.Reminders.Cosmos/**.cs]
+[src/Azure/Orleans.{Clustering,Reminders}.Cosmos/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
 # Production source enforces the correctness baseline. Tests, samples, documentation,

--- a/src/Azure/Orleans.Clustering.Cosmos/HostingExtensions.cs
+++ b/src/Azure/Orleans.Clustering.Cosmos/HostingExtensions.cs
@@ -19,6 +19,9 @@ public static class HostingExtensions
         this ISiloBuilder builder,
         Action<CosmosClusteringOptions> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         builder.Services.UseCosmosClustering(configureOptions);
         return builder;
     }
@@ -33,6 +36,9 @@ public static class HostingExtensions
         this ISiloBuilder builder,
         Action<OptionsBuilder<CosmosClusteringOptions>> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         builder.Services.UseCosmosClustering(configureOptions);
         return builder;
     }
@@ -44,6 +50,8 @@ public static class HostingExtensions
     /// <returns>The provided <paramref name="builder"/>.</returns>
     public static ISiloBuilder UseCosmosClustering(this ISiloBuilder builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.Services.AddOptions<CosmosClusteringOptions>();
         builder.Services.AddSingleton<IMembershipTable, CosmosMembershipTable>();
         return builder;
@@ -59,6 +67,9 @@ public static class HostingExtensions
         this IClientBuilder builder,
         Action<CosmosClusteringOptions> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         builder.Services.UseCosmosGatewayListProvider(configureOptions);
         return builder;
     }
@@ -70,6 +81,8 @@ public static class HostingExtensions
     /// <returns>The provided <paramref name="builder"/>.</returns>
     public static IClientBuilder UseCosmosGatewayListProvider(this IClientBuilder builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.Services.AddOptions<CosmosClusteringOptions>();
         builder.Services.AddSingleton<IGatewayListProvider, CosmosGatewayListProvider>();
         return builder;
@@ -85,6 +98,9 @@ public static class HostingExtensions
         this IClientBuilder builder,
         Action<OptionsBuilder<CosmosClusteringOptions>> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         builder.Services.UseCosmosGatewayListProvider(configureOptions);
         return builder;
     }
@@ -100,6 +116,9 @@ public static class HostingExtensions
         this IServiceCollection services,
         Action<CosmosClusteringOptions> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         return services.UseCosmosClustering(ob => ob.Configure(configureOptions));
     }
 
@@ -113,7 +132,10 @@ public static class HostingExtensions
         this IServiceCollection services,
         Action<OptionsBuilder<CosmosClusteringOptions>> configureOptions)
     {
-        configureOptions?.Invoke(services.AddOptions<CosmosClusteringOptions>());
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        configureOptions(services.AddOptions<CosmosClusteringOptions>());
         return services.AddSingleton<IMembershipTable, CosmosMembershipTable>();
     }
 
@@ -127,6 +149,9 @@ public static class HostingExtensions
         this IServiceCollection services,
         Action<CosmosClusteringOptions> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         return services.UseCosmosGatewayListProvider(ob => ob.Configure(configureOptions));
     }
 
@@ -140,7 +165,10 @@ public static class HostingExtensions
         this IServiceCollection services,
         Action<OptionsBuilder<CosmosClusteringOptions>> configureOptions)
     {
-        configureOptions?.Invoke(services.AddOptions<CosmosClusteringOptions>());
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        configureOptions(services.AddOptions<CosmosClusteringOptions>());
         services.AddTransient<IConfigurationValidator>(
             sp => new CosmosOptionsValidator<CosmosClusteringOptions>(
                 sp.GetRequiredService<IOptionsMonitor<CosmosClusteringOptions>>().CurrentValue,

--- a/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.csproj
+++ b/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.csproj
@@ -10,6 +10,7 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <DefineConstants>$(DefineConstants);ORLEANS_CLUSTERING</DefineConstants>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.globalconfig
+++ b/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.globalconfig
@@ -1,3 +1,0 @@
-is_global = true
-
-dotnet_diagnostic.CA1062.severity = warning

--- a/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.globalconfig
+++ b/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.globalconfig
@@ -1,0 +1,3 @@
+is_global = true
+
+dotnet_diagnostic.CA1062.severity = warning

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosClusteringHostingExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosClusteringHostingExtensionsTests.cs
@@ -1,0 +1,232 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Clustering.Cosmos;
+using Orleans.Hosting;
+
+namespace Tester.Cosmos.Clustering;
+
+[TestCategory("Cosmos"), TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("Cosmos")]
+[TestArea("Clustering")]
+public class CosmosClusteringHostingExtensionsTests
+{
+    [Fact]
+    public void UseCosmosClustering_NullBuilderWithOptionsCallback_Throws()
+    {
+        ISiloBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosClustering((CosmosClusteringOptions _) => { }));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullOptionsCallbackWithBuilder_ThrowsBeforeRegisteringServices()
+    {
+        var builder = new TestSiloBuilder();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosClustering((Action<CosmosClusteringOptions>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(builder.Services);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullBuilderWithOptionsBuilderCallback_Throws()
+    {
+        ISiloBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosClustering((OptionsBuilder<CosmosClusteringOptions> _) => { }));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullOptionsBuilderCallbackWithBuilder_ThrowsBeforeRegisteringServices()
+    {
+        var builder = new TestSiloBuilder();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosClustering((Action<OptionsBuilder<CosmosClusteringOptions>>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(builder.Services);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullBuilderWithoutCallback_Throws()
+    {
+        ISiloBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => builder.UseCosmosClustering());
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullBuilderWithOptionsCallback_Throws()
+    {
+        IClientBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosGatewayListProvider((CosmosClusteringOptions _) => { }));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullOptionsCallbackWithBuilder_ThrowsBeforeRegisteringServices()
+    {
+        var builder = new TestClientBuilder();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosGatewayListProvider((Action<CosmosClusteringOptions>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(builder.Services);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullBuilderWithOptionsBuilderCallback_Throws()
+    {
+        IClientBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosGatewayListProvider((OptionsBuilder<CosmosClusteringOptions> _) => { }));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullOptionsBuilderCallbackWithBuilder_ThrowsBeforeRegisteringServices()
+    {
+        var builder = new TestClientBuilder();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.UseCosmosGatewayListProvider((Action<OptionsBuilder<CosmosClusteringOptions>>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(builder.Services);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullBuilderWithoutCallback_Throws()
+    {
+        IClientBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => builder.UseCosmosGatewayListProvider());
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullServicesWithOptionsCallback_Throws()
+    {
+        IServiceCollection services = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosClustering((CosmosClusteringOptions _) => { }));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullOptionsCallback_ThrowsBeforeRegisteringServices()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosClustering((Action<CosmosClusteringOptions>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(services);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullServicesWithOptionsBuilderCallback_Throws()
+    {
+        IServiceCollection services = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosClustering((OptionsBuilder<CosmosClusteringOptions> _) => { }));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosClustering_NullOptionsBuilderCallback_ThrowsBeforeRegisteringServices()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosClustering((Action<OptionsBuilder<CosmosClusteringOptions>>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(services);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullServicesWithOptionsCallback_Throws()
+    {
+        IServiceCollection services = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosGatewayListProvider((CosmosClusteringOptions _) => { }));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullOptionsCallback_ThrowsBeforeRegisteringServices()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosGatewayListProvider((Action<CosmosClusteringOptions>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(services);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullServicesWithOptionsBuilderCallback_Throws()
+    {
+        IServiceCollection services = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosGatewayListProvider((OptionsBuilder<CosmosClusteringOptions> _) => { }));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseCosmosGatewayListProvider_NullOptionsBuilderCallback_ThrowsBeforeRegisteringServices()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            services.UseCosmosGatewayListProvider((Action<OptionsBuilder<CosmosClusteringOptions>>)null!));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Empty(services);
+    }
+
+    private sealed class TestSiloBuilder : ISiloBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = new ConfigurationBuilder().Build();
+    }
+
+    private sealed class TestClientBuilder : IClientBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = new ConfigurationBuilder().Build();
+    }
+}


### PR DESCRIPTION
Addresses the six CA1062 findings for Cosmos clustering hosting extensions reported by analyzer audit run 33941973157.

Validates caller-controlled silo builder, client builder, service collection, and configuration callback inputs at the public extension boundaries. Configuration callbacks now fail before options or provider services are registered, while the existing Cosmos membership/gateway registrations, options validation, provider naming, and exception parameter names remain intact.

Enables CA1062 as an error across `Orleans.Clustering.Cosmos` and adds service-independent contract coverage for every overload family, including zero-registration guarantees on callback validation failures.

The change has no exact-file overlap with #10174 and was also validated against a merged tree containing current `main`, #10174, and this patch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11122)