### PR TITLE
fix(storage): validate memory storage inputs

### DIFF
--- a/src/Orleans.Persistence.Memory/Orleans.Persistence.Memory.csproj
+++ b/src/Orleans.Persistence.Memory/Orleans.Persistence.Memory.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Orleans.Persistence.Memory</AssemblyName>
     <RootNamespace>Orleans.Persistence.Memory</RootNamespace>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,6 +46,7 @@ namespace Orleans.Storage
         /// <param name="grainFactory">The grain factory.</param>
         /// <param name="defaultGrainStorageSerializer">The default grain storage serializer.</param>
         /// <param name="activatorProvider">The provider used to create grain state instances.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Microsoft.Extensions.DependencyInjection supplies the resolved options instance.")]
         public MemoryGrainStorage(
             string name,
             MemoryGrainStorageOptions options,
@@ -74,7 +76,11 @@ namespace Orleans.Storage
 
         /// <inheritdoc/>
         public virtual Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
-            => ReadStateCoreAsync(grainType, grainId, grainState, CancellationToken.None);
+        {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+            return ReadStateCoreAsync(grainType, grainId, grainState, CancellationToken.None);
+        }
 
         /// <inheritdoc/>
         public virtual async Task ReadStateAsync<T>(
@@ -84,6 +90,8 @@ namespace Orleans.Storage
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
             if (_overridesLegacyReadState)
             {
                 await ReadStateAsync(grainType, grainId, grainState).WaitAsync(cancellationToken);
@@ -121,7 +129,11 @@ namespace Orleans.Storage
 
         /// <inheritdoc/>
         public virtual Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
-            => WriteStateCoreAsync(grainType, grainId, grainState, CancellationToken.None);
+        {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+            return WriteStateCoreAsync(grainType, grainId, grainState, CancellationToken.None);
+        }
 
         /// <inheritdoc/>
         public virtual async Task WriteStateAsync<T>(
@@ -131,6 +143,8 @@ namespace Orleans.Storage
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
             if (_overridesLegacyWriteState)
             {
                 await WriteStateAsync(grainType, grainId, grainState).WaitAsync(cancellationToken);
@@ -167,7 +181,11 @@ namespace Orleans.Storage
 
         /// <inheritdoc/>
         public virtual Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
-            => ClearStateCoreAsync(grainType, grainId, grainState, CancellationToken.None);
+        {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+            return ClearStateCoreAsync(grainType, grainId, grainState, CancellationToken.None);
+        }
 
         /// <inheritdoc/>
         public virtual async Task ClearStateAsync<T>(
@@ -177,6 +195,8 @@ namespace Orleans.Storage
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
             if (_overridesLegacyClearState)
             {
                 await ClearStateAsync(grainType, grainId, grainState).WaitAsync(cancellationToken);

--- a/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageInputValidationTests.cs
+++ b/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageInputValidationTests.cs
@@ -1,0 +1,242 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Serialization.Activators;
+using Orleans.Serialization.Serializers;
+using Orleans.Storage;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Persistence.Memory.Tests;
+
+[TestCategory("BVT"), TestCategory("Persistence")]
+public class MemoryGrainStorageInputValidationTests
+{
+    public static TheoryData<StorageOperation, bool> StorageOperations { get; } = new()
+    {
+        { StorageOperation.Read, false },
+        { StorageOperation.Read, true },
+        { StorageOperation.Write, false },
+        { StorageOperation.Write, true },
+        { StorageOperation.Clear, false },
+        { StorageOperation.Clear, true },
+    };
+
+    [Theory]
+    [MemberData(nameof(StorageOperations))]
+    public async Task StorageOperation_NullGrainType_ThrowsWithoutMutatingStateOrAccessingStorage(
+        StorageOperation operation,
+        bool useCancellationOverload)
+    {
+        var (storage, storageGrain) = CreateStorage();
+        var value = new TestState { Value = 42 };
+        var state = new GrainState<TestState>(value, "initial-etag") { RecordExists = true };
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeStorageOperation(
+                storage,
+                operation,
+                useCancellationOverload,
+                null!,
+                state,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainType", exception.ParamName);
+        Assert.Same(value, state.State);
+        Assert.Equal("initial-etag", state.ETag);
+        Assert.True(state.RecordExists);
+        Assert.Equal(0, storageGrain.OperationCount);
+    }
+
+    [Theory]
+    [MemberData(nameof(StorageOperations))]
+    public async Task StorageOperation_NullGrainState_ThrowsBeforeAccessingStorage(
+        StorageOperation operation,
+        bool useCancellationOverload)
+    {
+        var (storage, storageGrain) = CreateStorage();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeStorageOperation(
+                storage,
+                operation,
+                useCancellationOverload,
+                "state",
+                null!,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        Assert.Equal(0, storageGrain.OperationCount);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task StorageOperation_CanceledToken_TakesPrecedenceWithoutMutatingStateOrAccessingStorage(
+        StorageOperation operation)
+    {
+        var (storage, storageGrain) = CreateStorage();
+        var value = new TestState { Value = 42 };
+        var state = new GrainState<TestState>(value, "initial-etag") { RecordExists = true };
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeStorageOperation(storage, operation, true, null!, state, cancellation.Token));
+
+        Assert.Same(value, state.State);
+        Assert.Equal("initial-etag", state.ETag);
+        Assert.True(state.RecordExists);
+        Assert.Equal(0, storageGrain.OperationCount);
+    }
+
+    [Fact]
+    public async Task StorageOperations_ValidInputs_PreserveKeySerializationAndStateLifecycle()
+    {
+        var (storage, storageGrain) = CreateStorage();
+        var grainId = GrainId.Create("test", "key");
+        var originalState = new TestState { Value = 42 };
+        var writtenState = new GrainState<TestState>(originalState);
+
+        await storage.WriteStateAsync("state", grainId, writtenState);
+
+        Assert.Equal($"state/{grainId}", storageGrain.LastKey);
+        Assert.Equal("etag-1", writtenState.ETag);
+        Assert.True(writtenState.RecordExists);
+
+        originalState.Value = 99;
+        var readState = new GrainState<TestState>(new());
+
+        await storage.ReadStateAsync("state", grainId, readState);
+
+        Assert.NotSame(originalState, readState.State);
+        Assert.Equal(42, Assert.IsType<TestState>(readState.State).Value);
+        Assert.Equal("etag-1", readState.ETag);
+        Assert.True(readState.RecordExists);
+
+        await storage.ClearStateAsync("state", grainId, readState);
+
+        Assert.Null(readState.ETag);
+        Assert.False(readState.RecordExists);
+        Assert.Equal(0, readState.State.Value);
+
+        var stateAfterClear = new GrainState<TestState>(new() { Value = -1 });
+        await storage.ReadStateAsync("state", grainId, stateAfterClear);
+
+        Assert.Null(stateAfterClear.ETag);
+        Assert.False(stateAfterClear.RecordExists);
+        Assert.Equal(0, Assert.IsType<TestState>(stateAfterClear.State).Value);
+    }
+
+    private static Task InvokeStorageOperation(
+        MemoryGrainStorage storage,
+        StorageOperation operation,
+        bool useCancellationOverload,
+        string grainType,
+        IGrainState<TestState> grainState,
+        CancellationToken cancellationToken = default)
+    {
+        var grainId = GrainId.Create("test", "key");
+        return (operation, useCancellationOverload) switch
+        {
+            (StorageOperation.Read, false) => storage.ReadStateAsync(grainType, grainId, grainState),
+            (StorageOperation.Read, true) => storage.ReadStateAsync(grainType, grainId, grainState, cancellationToken),
+            (StorageOperation.Write, false) => storage.WriteStateAsync(grainType, grainId, grainState),
+            (StorageOperation.Write, true) => storage.WriteStateAsync(grainType, grainId, grainState, cancellationToken),
+            (StorageOperation.Clear, false) => storage.ClearStateAsync(grainType, grainId, grainState),
+            (StorageOperation.Clear, true) => storage.ClearStateAsync(grainType, grainId, grainState, cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
+    }
+
+    private static (MemoryGrainStorage Storage, RecordingMemoryStorageGrain StorageGrain) CreateStorage()
+    {
+        var storageGrain = new RecordingMemoryStorageGrain();
+        var grainFactory = DispatchProxy.Create<IGrainFactory, GrainFactoryProxy>();
+        ((GrainFactoryProxy)(object)grainFactory).Grain = storageGrain;
+        var storage = new MemoryGrainStorage(
+            "MemoryStore",
+            new MemoryGrainStorageOptions { NumStorageGrains = 1 },
+            NullLogger<MemoryGrainStorage>.Instance,
+            grainFactory,
+            new JsonStorageSerializer(),
+            new ActivatorProvider());
+        return (storage, storageGrain);
+    }
+
+    public enum StorageOperation
+    {
+        Read,
+        Write,
+        Clear,
+    }
+
+    private class GrainFactoryProxy : DispatchProxy
+    {
+        public object Grain { get; set; } = null!;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => targetMethod?.Name == nameof(IGrainFactory.GetGrain) ? Grain : throw new NotSupportedException();
+    }
+
+    private sealed class RecordingMemoryStorageGrain : IMemoryStorageGrain
+    {
+        private readonly Dictionary<string, object?> _store = [];
+        private int _etag;
+
+        public int OperationCount { get; private set; }
+
+        public string? LastKey { get; private set; }
+
+        public Task<IGrainState<T>?> ReadStateAsync<T>(string grainStoreKey)
+        {
+            OperationCount++;
+            LastKey = grainStoreKey;
+            _store.TryGetValue(grainStoreKey, out var state);
+            return Task.FromResult((IGrainState<T>?)state);
+        }
+
+        public Task<string> WriteStateAsync<T>(string grainStoreKey, IGrainState<T> grainState)
+        {
+            OperationCount++;
+            LastKey = grainStoreKey;
+            var etag = $"etag-{++_etag}";
+            grainState.ETag = etag;
+            _store[grainStoreKey] = grainState;
+            return Task.FromResult(etag);
+        }
+
+        public Task DeleteStateAsync<T>(string grainStoreKey, string? eTag)
+        {
+            OperationCount++;
+            LastKey = grainStoreKey;
+            _store[grainStoreKey] = null;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ActivatorProvider : IActivatorProvider
+    {
+        public IActivator<T> GetActivator<T>() => new DefaultActivator<T>();
+    }
+
+    private sealed class DefaultActivator<T> : IActivator<T>
+    {
+        public T Create() => Activator.CreateInstance<T>();
+    }
+
+    private sealed class JsonStorageSerializer : IGrainStorageSerializer
+    {
+        public BinaryData Serialize<T>(T? input) => new(JsonSerializer.SerializeToUtf8Bytes(input));
+
+        public T? Deserialize<T>(BinaryData input) => JsonSerializer.Deserialize<T>(input.ToMemory().Span);
+    }
+
+    private sealed class TestState
+    {
+        public int Value { get; set; }
+    }
+}


### PR DESCRIPTION
## Problem

Analyzer audit run 33941973157 reports seven CA1062 findings in `Orleans.Persistence.Memory`, all in `MemoryStorage.cs`. Public storage operations accepted null caller-owned inputs until they were dereferenced, potentially after state or storage work had begun.

## Solution

- Validate `grainType` and `grainState` at every legacy and cancellation-aware read, write, and clear entry point.
- Preserve cancellation precedence and the existing key, serialization, ETag, concurrency, read/write/clear, and subclass-override behavior.
- Document the constructor options value as a dependency-injection invariant using the established analyzer suppression pattern.
- Enforce CA1062 as an error across `Orleans.Persistence.Memory`.
- Add focused tests for exact parameter names, cancellation ordering, failure atomicity, key formatting, serialization isolation, and the normal storage lifecycle.

## Rationale

`grainType` and `IGrainState<T>` cross the public grain-storage boundary and are controlled by callers, so they are validated before storage access or mutation. `GrainId` is a non-nullable value type. Logger, factory, serializer, activator, and options dependencies are resolved by the Orleans service graph and retain their existing lifecycle guarantees.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11124)