### PR TITLE
fix(azure): validate transaction storage inputs

### DIFF
--- a/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Orleans.Transactions.AzureStorage</RootNamespace>
     <DefineConstants>$(DefineConstants);ORLEANS_TRANSACTIONS</DefineConstants>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorage.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorage.cs
@@ -135,8 +135,11 @@ namespace Orleans.Transactions.AzureStorage
         }
 
         /// <inheritdoc />
+        /// <exception cref="ArgumentNullException"><paramref name="metadata"/> is <see langword="null"/>.</exception>
         public async Task<string> Store(string? expectedETag, TransactionalStateMetaData metadata, List<PendingTransactionState<TState>>? statesToPrepare, long? commitUpTo, long? abortAfter)
         {
+            ArgumentNullException.ThrowIfNull(metadata);
+
             if (_storeRequiresLoad)
             {
                 throw new InvalidOperationException("Load must complete successfully before Store can be called again after a failed Store operation.");

--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorageFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
@@ -44,6 +45,7 @@ namespace Orleans.Transactions.AzureStorage
         /// <param name="clusterOptions">The cluster options.</param>
         /// <param name="services">The service provider.</param>
         /// <param name="loggerFactory">The logger factory.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivatorUtilities resolves the non-null IOptions<ClusterOptions> instance from dependency injection.")]
         public AzureTableTransactionalStateStorageFactory(string name, AzureTableTransactionalStateOptions options, IOptions<ClusterOptions> clusterOptions, IServiceProvider services, ILoggerFactory loggerFactory)
         {
             this.name = name;
@@ -54,6 +56,7 @@ namespace Orleans.Transactions.AzureStorage
         }
 
         /// <inheritdoc />
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Orleans invokes transactional state storage factories with the current non-null grain context.")]
         public ITransactionalStateStorage<TState> Create<TState>(string stateName, IGrainContext context) where TState : class, new()
         {
             string partitionKey = MakePartitionKey(context, stateName);

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -265,6 +265,44 @@ namespace Orleans.Transactions.Azure.Tests
         private static readonly string MetadataJson = JsonConvert.SerializeObject(new TransactionalStateMetaData());
 
         [Fact]
+        public async Task Store_NullMetadata_ThrowsBeforeWritingAndStorageRemainsUsable()
+        {
+            var table = new ScriptedTableClient { PersistTransactions = true };
+            var storage = CreateStorage(table);
+            var initial = await storage.Load();
+
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => storage.Store(initial.ETag, null!, [], null, null));
+
+            Assert.Equal("metadata", exception.ParamName);
+            Assert.Empty(table.SubmittedTransactions);
+
+            var etag = await storage.Store(initial.ETag, initial.Metadata, [], null, null);
+
+            Assert.Equal(new ETag("batch-1").ToString(), etag);
+            Assert.Single(table.SubmittedTransactions);
+        }
+
+        [Fact]
+        public async Task Store_ValidMetadata_PersistsAndLoadsNormally()
+        {
+            var table = new ScriptedTableClient { PersistTransactions = true };
+            var storage = CreateStorage(table);
+            var initial = await storage.Load();
+            var timestamp = DateTime.UtcNow;
+            var metadata = new TransactionalStateMetaData { TimeStamp = timestamp };
+
+            var etag = await storage.Store(initial.ETag, metadata, [], null, null);
+            var loaded = await CreateStorage(table).Load();
+
+            Assert.Equal(etag, loaded.ETag);
+            Assert.Equal(timestamp, loaded.Metadata.TimeStamp);
+            Assert.Equal(0, loaded.CommittedSequenceId);
+            Assert.Equal(0, loaded.CommittedState.State);
+            Assert.Empty(loaded.PendingStates);
+        }
+
+        [Fact]
         public async Task Load_WhenBoundaryChangesDuringStateRead_RetriesAndReturnsCoherentSnapshot()
         {
             var table = new ScriptedTableClient { StorageVersion = "old" };


### PR DESCRIPTION
## Problem

Analyzer audit run 33941973157 reports three CA1062 diagnostics in `Orleans.Transactions.AzureStorage`, leaving transaction storage input handling and analyzer enforcement inconsistent.

## Solution

- Validate non-null transaction metadata at the public storage boundary before any storage operation or instance-state transition.
- Document and narrowly suppress the constructor diagnostic where `ActivatorUtilities` resolves `IOptions<ClusterOptions>` from dependency injection.
- Document and narrowly suppress the factory diagnostic where Orleans supplies the current grain context through `NamedTransactionalStateStorageFactory`.
- Promote CA1062 to an error for the complete `Orleans.Transactions.AzureStorage` project.
- Add service-independent scripted-table coverage for the null contract, post-rejection reuse, and normal metadata persistence/load semantics.

This preserves table initialization, serializer configuration, partition/key construction, cancellation behavior, ETag handling, and transactional state semantics for valid calls.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11125)