### PR TITLE
fix(redis): validate grain directory inputs

### DIFF
--- a/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
@@ -36,8 +36,12 @@ namespace Orleans.Configuration
         /// </summary>
         /// <param name="options">The Redis grain directory options.</param>
         /// <returns>A task which returns a provider-owned connection multiplexer.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options)
-            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
+        }
     }
 
     internal class RedactRedisConfigurationOptions : RedactAttribute

--- a/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
@@ -8,6 +8,7 @@
     <PackageTags>$(PackageTags) Redis Grain Directory</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,4 +29,3 @@
     <InternalsVisibleTo Include="Orleans.Redis.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using System.Text;
@@ -38,6 +39,7 @@ namespace Orleans.GrainDirectory.Redis
         /// <param name="directoryOptions">The Redis grain directory options.</param>
         /// <param name="clusterOptions">The cluster options.</param>
         /// <param name="logger">The logger.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivatorUtilities supplies the options and services from dependency injection.")]
         public RedisGrainDirectory(
             RedisGrainDirectoryOptions directoryOptions,
             IOptions<ClusterOptions> clusterOptions,
@@ -84,6 +86,7 @@ namespace Orleans.GrainDirectory.Redis
         /// </summary>
         /// <param name="address">The grain address to register.</param>
         /// <returns>The grain address registered in the directory.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
         public Task<GrainAddress?> Register(GrainAddress address) => Register(address, null);
 
         /// <summary>
@@ -92,8 +95,11 @@ namespace Orleans.GrainDirectory.Redis
         /// <param name="address">The grain address to register.</param>
         /// <param name="previousAddress">The previous registration to replace, or <see langword="null"/> to require an empty entry.</param>
         /// <returns>The grain address registered in the directory.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
         public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress)
         {
+            ArgumentNullException.ThrowIfNull(address);
+
             const string RegisterScript =
                 """
                 local cur = redis.call('GET', KEYS[1])
@@ -159,8 +165,11 @@ namespace Orleans.GrainDirectory.Redis
         /// </summary>
         /// <param name="address">The grain address to remove.</param>
         /// <returns>A task representing the operation.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
         public async Task Unregister(GrainAddress address)
         {
+            ArgumentNullException.ThrowIfNull(address);
+
             const string DeleteScript =
                 """
                 local cur = redis.call('GET', KEYS[1])
@@ -289,7 +298,7 @@ namespace Orleans.GrainDirectory.Redis
             }
         }
 
-        private RedisKey GetKey(GrainId grainId) => _keyPrefix.Append(grainId.ToString());
+        internal RedisKey GetKey(GrainId grainId) => _keyPrefix.Append(grainId.ToString());
 
         #region Logging
         private void LogConnectionRestored(object? sender, ConnectionFailedEventArgs e)

--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using System.Text;
@@ -39,12 +38,18 @@ namespace Orleans.GrainDirectory.Redis
         /// <param name="directoryOptions">The Redis grain directory options.</param>
         /// <param name="clusterOptions">The cluster options.</param>
         /// <param name="logger">The logger.</param>
-        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivatorUtilities supplies the options and services from dependency injection.")]
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="directoryOptions"/>, <paramref name="clusterOptions"/>, or <paramref name="logger"/> is <see langword="null"/>.
+        /// </exception>
         public RedisGrainDirectory(
             RedisGrainDirectoryOptions directoryOptions,
             IOptions<ClusterOptions> clusterOptions,
             ILogger<RedisGrainDirectory> logger)
         {
+            ArgumentNullException.ThrowIfNull(directoryOptions);
+            ArgumentNullException.ThrowIfNull(clusterOptions);
+            ArgumentNullException.ThrowIfNull(logger);
+
             _directoryOptions = directoryOptions;
             _logger = logger;
             _clusterOptions = clusterOptions.Value;

--- a/test/Extensions/Orleans.Redis.Tests/GrainDirectory/RedisGrainDirectoryUnitTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/GrainDirectory/RedisGrainDirectoryUnitTests.cs
@@ -15,6 +15,42 @@ namespace Tester.Redis.GrainDirectory;
 public sealed class RedisGrainDirectoryUnitTests
 {
     [Fact]
+    public void Constructor_NullDirectoryOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new RedisGrainDirectory(
+                null!,
+                CreateClusterOptions(),
+                NullLogger<RedisGrainDirectory>.Instance));
+
+        Assert.Equal("directoryOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullClusterOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new RedisGrainDirectory(
+                new RedisGrainDirectoryOptions(),
+                null!,
+                NullLogger<RedisGrainDirectory>.Instance));
+
+        Assert.Equal("clusterOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new RedisGrainDirectory(
+                new RedisGrainDirectoryOptions(),
+                CreateClusterOptions(),
+                null!));
+
+        Assert.Equal("logger", exception.ParamName);
+    }
+
+    [Fact]
     public async Task DefaultCreateMultiplexer_NullOptions_ThrowsArgumentNullException()
     {
         var exception = await Assert.ThrowsAsync<ArgumentNullException>(
@@ -69,10 +105,13 @@ public sealed class RedisGrainDirectoryUnitTests
     private static RedisGrainDirectory CreateDirectory(string serviceId = "service") =>
         new(
             new RedisGrainDirectoryOptions(),
-            Options.Create(new ClusterOptions
-            {
-                ServiceId = serviceId,
-                ClusterId = "cluster",
-            }),
+            CreateClusterOptions(serviceId),
             NullLogger<RedisGrainDirectory>.Instance);
+
+    private static IOptions<ClusterOptions> CreateClusterOptions(string serviceId = "service") =>
+        Options.Create(new ClusterOptions
+        {
+            ServiceId = serviceId,
+            ClusterId = "cluster",
+        });
 }

--- a/test/Extensions/Orleans.Redis.Tests/GrainDirectory/RedisGrainDirectoryUnitTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/GrainDirectory/RedisGrainDirectoryUnitTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.GrainDirectory.Redis;
+using Orleans.Runtime;
+using StackExchange.Redis;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.Redis.GrainDirectory;
+
+[TestSuite("BVT")]
+[TestProvider("Redis")]
+[TestCategory("BVT")]
+public sealed class RedisGrainDirectoryUnitTests
+{
+    [Fact]
+    public async Task DefaultCreateMultiplexer_NullOptions_ThrowsArgumentNullException()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RedisGrainDirectoryOptions.DefaultCreateMultiplexer(null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Register_NullAddress_ThrowsArgumentNullException()
+    {
+        using var directory = CreateDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => directory.Register(null!));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task RegisterWithPreviousAddress_NullAddress_ThrowsArgumentNullException()
+    {
+        using var directory = CreateDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => directory.Register(null!, previousAddress: null));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Unregister_NullAddress_ThrowsArgumentNullException()
+    {
+        using var directory = CreateDirectory();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => directory.Unregister(null!));
+
+        Assert.Equal("address", exception.ParamName);
+    }
+
+    [Fact]
+    public void GetKey_TypeAndKey_ReturnsExactClusterDirectoryKey()
+    {
+        using var directory = CreateDirectory(serviceId: "service-must-not-appear");
+
+        var result = directory.GetKey(GrainId.Create("type", "key"));
+
+        Assert.Equal((RedisKey)"cluster/directory/type/key", result);
+    }
+
+    private static RedisGrainDirectory CreateDirectory(string serviceId = "service") =>
+        new(
+            new RedisGrainDirectoryOptions(),
+            Options.Create(new ClusterOptions
+            {
+                ServiceId = serviceId,
+                ClusterId = "cluster",
+            }),
+            NullLogger<RedisGrainDirectory>.Instance);
+}


### PR DESCRIPTION
## Problem

Analyzer audit run 33941973157 reports five CA1062 findings in `Orleans.GrainDirectory.Redis`. Public constructor and operation inputs can currently fail through incidental dereferences instead of stable argument contracts.

## Solution

- Validate all public constructor dependencies before assignment or dereference, with exact `directoryOptions`, `clusterOptions`, and `logger` parameter names.
- Validate the public multiplexer options and registration/unregistration addresses with exact `ArgumentNullException` parameter names.
- Enforce CA1062 as an error across the complete project.
- Add service-independent BVT coverage for constructor and operation null contracts plus the exact `cluster/directory/type/key` format, including exclusion of `ServiceId`.

The Redis key and hash formats, Lua scripts, registration conflict/version semantics, expiry behavior, cancellation behavior, and exception wrapping remain unchanged. Existing live Redis coverage remains in `RedisGrainDirectoryTests` and `RedisMultipleGrainDirectoriesTests`.

The changes do not overlap the active #10798 Redis provider-builder or test-project edits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11127)