### PR TITLE
fix(docs): allowlist SQS permissions reference

### DIFF
--- a/docs/site/src/data/external-link-allowlist.json
+++ b/docs/site/src/data/external-link-allowlist.json
@@ -2,6 +2,7 @@
   "description": "Exact external URLs which cannot be probed reliably. Every entry requires a narrow reason.",
   "urls": {
     "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html": "AWS serves this public ECS task-networking page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
+    "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-permissions-reference.html": "AWS serves this public SQS API permissions reference to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html": "AWS serves this public SQS visibility-timeout page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html": "AWS serves this public SQS message-quotas page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",
     "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues-at-least-once-delivery.html": "AWS serves this public SQS delivery-semantics page to browsers but rejects the bounded automated HEAD/GET probe with HTTP 403.",


### PR DESCRIPTION
## Problem

The documentation `Build site` job fails on `main` and unrelated PRs, including #11121, because AWS returns HTTP 403 to the bounded automated probe for the public SQS API permissions reference. Site generation completes; the subsequent external-link audit reports this URL as its sole failure.

Failing job: https://github.com/dotnet/orleans/actions/runs/33944016585/job/101246704614

## Solution

Add a reasoned exact-URL entry for the SQS API permissions reference to the existing external-link allowlist, consistent with the other public AWS documentation references. Preserve the authoritative permissions guidance and continue probing the URL with a diagnostic warning for AWS's rejection. Existing destination-safety, reason, reference, and recovered-target checks remain active, along with validation of all other links.

Fixes #11128.
Fixes #11123.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11129)