### PR TITLE
fix(ci): preserve retry policy across nested test actions

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -33,7 +33,7 @@ runs:
       coverage: ${{ runner.os == 'Linux' && inputs.framework == 'net10.0' }}
   - name: Test
     id: test
-    continue-on-error: ${{ inputs.retry == 'true' }}
+    continue-on-error: ${{ env.ORLEANS_TEST_RETRY == 'true' }}
     uses: ./.github/actions/dotnet-test
     with:
       coverage-id: ${{ inputs.artifact-name }}
@@ -42,6 +42,8 @@ runs:
       result-id: ${{ inputs.retry == 'true' && format('{0}-attempt1', inputs.artifact-name) || inputs.artifact-name }}
       coverage: ${{ runner.os == 'Linux' && inputs.framework == 'net10.0' }}
     env:
+      # The nested composite action supplies its own inputs context when continue-on-error is evaluated.
+      ORLEANS_TEST_RETRY: ${{ inputs.retry }}
       BuildExternalAssets: ${{ inputs['build-external-assets'] }}
   - name: Retry tests
     id: retry

--- a/.github/actions/run-tests/test-fixture/action.yml
+++ b/.github/actions/run-tests/test-fixture/action.yml
@@ -1,0 +1,50 @@
+name: Test retry fixture
+description: Record test attempts and artifact retention for the run-tests retry contract.
+
+inputs:
+  coverage:
+    description: Coverage selection forwarded by run-tests.
+  coverage-id:
+    description: Coverage report identifier forwarded by run-tests.
+  filter-query:
+    description: Test filter forwarded by run-tests.
+  framework:
+    description: Target framework forwarded by run-tests.
+  result-id:
+    description: Test result identifier for this attempt.
+  name:
+    description: Test result artifact name.
+  retention-days:
+    description: Test result artifact retention.
+
+runs:
+  using: composite
+  steps:
+  - shell: pwsh
+    run: |
+      $action = Split-Path '${{ github.action_path }}' -Leaf
+      switch ($action) {
+        'setup-test-environment' {
+          'TEST_RETRY_ATTEMPTS=0' >> $env:GITHUB_ENV
+          'TEST_RETRY_RESULT_IDS=' >> $env:GITHUB_ENV
+        }
+        'dotnet-test' {
+          $attempt = [int] $env:TEST_RETRY_ATTEMPTS + 1
+          "TEST_RETRY_ATTEMPTS=$attempt" >> $env:GITHUB_ENV
+          $resultIds = @($env:TEST_RETRY_RESULT_IDS, '${{ inputs.result-id }}') |
+            Where-Object { $_ }
+          "TEST_RETRY_RESULT_IDS=$($resultIds -join ',')" >> $env:GITHUB_ENV
+          Write-Output "Test attempt $attempt (${{ inputs.result-id }})"
+          if ($env:TEST_RETRY_FAILURE_MODE -eq 'always' -or
+              ($env:TEST_RETRY_FAILURE_MODE -eq 'first' -and $attempt -eq 1)) {
+            Write-Output 'Simulating a failed test partition.'
+            exit 1
+          }
+        }
+        'archive-test-results' {
+          'TEST_RETRY_RETENTION=${{ inputs.retention-days }}' >> $env:GITHUB_ENV
+        }
+        default {
+          throw "Unexpected fixture action: $action"
+        }
+      }

--- a/.github/workflows/test-action-retry.yml
+++ b/.github/workflows/test-action-retry.yml
@@ -1,0 +1,104 @@
+name: Test action retry
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/actions/run-tests/**
+      - .github/actions/dotnet-test/**
+      - .github/workflows/test-action-retry.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/actions/run-tests/**
+      - .github/actions/dotnet-test/**
+      - .github/workflows/test-action-retry.yml
+permissions:
+  contents: read
+jobs:
+  retry-contract:
+    name: Retry contract (${{ matrix.scenario }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scenario: first attempt succeeds
+            retry: 'true'
+            failure-mode: none
+            outcome: success
+            attempts: 1
+            result-ids: retry-contract-attempt1
+            retention: 1
+          - scenario: second attempt succeeds
+            retry: 'true'
+            failure-mode: first
+            outcome: success
+            attempts: 2
+            result-ids: retry-contract-attempt1,retry-contract-attempt2
+            retention: 1
+          - scenario: both attempts fail
+            retry: 'true'
+            failure-mode: always
+            outcome: failure
+            attempts: 2
+            result-ids: retry-contract-attempt1,retry-contract-attempt2
+            retention: 14
+          - scenario: succeeds with retry disabled
+            retry: 'false'
+            failure-mode: none
+            outcome: success
+            attempts: 1
+            result-ids: retry-contract
+            retention: 1
+          - scenario: fails with retry disabled
+            retry: 'false'
+            failure-mode: always
+            outcome: failure
+            attempts: 1
+            result-ids: retry-contract
+            retention: 14
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Replace test infrastructure with recording fixtures
+        shell: pwsh
+        run: |
+          foreach ($action in 'setup-test-environment', 'dotnet-test', 'archive-test-results') {
+            Copy-Item .github/actions/run-tests/test-fixture/action.yml ".github/actions/$action/action.yml"
+          }
+      - name: Run test partition
+        id: partition
+        continue-on-error: true
+        uses: ./.github/actions/run-tests
+        with:
+          artifact-name: retry-contract
+          framework: net10.0
+          provider: Cosmos
+          retry: ${{ matrix.retry }}
+        env:
+          TEST_RETRY_FAILURE_MODE: ${{ matrix.failure-mode }}
+      - name: Assert retry outcome and diagnostics
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          $expected = @{
+            Outcome = '${{ matrix.outcome }}'
+            Attempts = '${{ matrix.attempts }}'
+            ResultIds = '${{ matrix.result-ids }}'
+            Retention = '${{ matrix.retention }}'
+          }
+          $actual = @{
+            Outcome = '${{ steps.partition.outcome }}'
+            Attempts = $env:TEST_RETRY_ATTEMPTS
+            ResultIds = $env:TEST_RETRY_RESULT_IDS
+            Retention = $env:TEST_RETRY_RETENTION
+          }
+          foreach ($key in $expected.Keys) {
+            if ($actual[$key] -cne $expected[$key]) {
+              throw "$key expected '$($expected[$key])', actual '$($actual[$key])'."
+            }
+          }
+          Write-Output 'PASS ${{ matrix.scenario }}'


### PR DESCRIPTION
## Problem

The Cosmos DB partition enables one retry, but a failed first attempt currently fails the enclosing action and skips the retry. The caller's `continue-on-error` expression reads `inputs.retry` after the nested composite action has installed its own inputs context, where `retry` is absent. This matches actions/runner#2418.

Observed on #11127: https://github.com/dotnet/orleans/actions/runs/33945375871/job/101250384425. The first action reports `outcome=failure;conclusion=failure`, followed by a skipped `Retry tests` step despite the `attempt1` result identifier.

## Solution

Resolve the caller's retry setting into the first attempt's environment and evaluate `continue-on-error` from that preserved value. Retry-enabled partitions get their configured second attempt; non-retry failures and failed second attempts continue to fail the job. Existing attempt identifiers and diagnostic retention remain intact.

Add a lightweight GitHub-runner contract workflow which exercises the actual `run-tests` action with recording fixtures for its setup, test, and archive dependencies. The scenarios cover first-attempt success, retry recovery, persistent failure, and success/failure with retries disabled, including exact attempt counts, result identifiers, and retention periods.

## Related CI findings

The five newest PRs also expose independent problems: the shared SQS documentation HTTP 403 is fixed on main by merged #11129, reminder reconciliation failures are addressed by open #11118, and duplicate stream publisher registration by open #10532. Runtime remediation remains in those existing PRs. This branch includes the merged documentation correction.

Fixes #11130.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11131)