### PR TITLE
ci: disable macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Setup Node.js


### PR DESCRIPTION
macOS test execution was recently removed from the main CI workflow, while the build matrix continued to schedule a macOS runner. Update the build matrix to run on Ubuntu and Windows so build coverage matches the active CI platforms and avoids unnecessary macOS capacity.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11134)