### PR TITLE
fix(reminders): validate test kit inputs

### DIFF
--- a/src/Orleans.Reminders.TestKit/Orleans.Reminders.TestKit.csproj
+++ b/src/Orleans.Reminders.TestKit/Orleans.Reminders.TestKit.csproj
@@ -15,6 +15,7 @@
   <PropertyGroup>
     <AssemblyName>Orleans.Reminders.TestKit</AssemblyName>
     <RootNamespace>Orleans.Reminders.TestKit</RootNamespace>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Reminders.TestKit/ReminderTableTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableTestRunner.cs
@@ -1294,8 +1294,12 @@ public abstract class ReminderTableTestRunner
     /// <param name="operation">The operation which produced the observation.</param>
     /// <returns>The report.</returns>
     protected ReminderFailureReport Report(string guarantee, string operation)
-        => ReminderFailureReport.Create(ProviderName, guarantee, operation)
+    {
+        ArgumentNullException.ThrowIfNull(guarantee);
+        ArgumentNullException.ThrowIfNull(operation);
+        return ReminderFailureReport.Create(ProviderName, guarantee, operation)
             .WithDetail("seed", Seed.ToString(CultureInfo.InvariantCulture));
+    }
 
     /// <summary>
     /// Creates a grain identifier which is unique to this runner instance.
@@ -1304,6 +1308,7 @@ public abstract class ReminderTableTestRunner
     /// <returns>The grain identifier.</returns>
     protected GrainId NewGrainId(string label)
     {
+        ArgumentNullException.ThrowIfNull(label);
         var ordinal = Interlocked.Increment(ref _grainCounter);
         return GrainId.Create(
             GrainType.Create("reminder-testkit-grain"),
@@ -1320,13 +1325,17 @@ public abstract class ReminderTableTestRunner
     /// <param name="startAt">The start time, or <see langword="null"/> for <see cref="BaseTime"/>.</param>
     /// <param name="period">The period, or <see langword="null"/> for one minute.</param>
     /// <returns>The entry.</returns>
-    protected ReminderEntry NewEntry(GrainId grainId, string reminderName, DateTime? startAt = null, TimeSpan? period = null) => new()
+    protected ReminderEntry NewEntry(GrainId grainId, string reminderName, DateTime? startAt = null, TimeSpan? period = null)
     {
-        GrainId = grainId,
-        ReminderName = reminderName,
-        StartAt = Normalize(startAt ?? BaseTime),
-        Period = period ?? TimeSpan.FromMinutes(1)
-    };
+        ArgumentNullException.ThrowIfNull(reminderName);
+        return new()
+        {
+            GrainId = grainId,
+            ReminderName = reminderName,
+            StartAt = Normalize(startAt ?? BaseTime),
+            Period = period ?? TimeSpan.FromMinutes(1)
+        };
+    }
 
     /// <summary>
     /// Normalizes a timestamp to whole-second UTC precision supported by every built-in provider.
@@ -1347,7 +1356,11 @@ public abstract class ReminderTableTestRunner
     /// <param name="previousETag">The ETag which a replacement must rotate, or <see langword="null"/> for a new row.</param>
     /// <returns>The new ETag.</returns>
     protected Task<string> UpsertAsync(ReminderEntry entry, string guarantee, string? previousETag = null)
-        => UpsertAsync(entry, guarantee, CancellationToken.None, previousETag);
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(guarantee);
+        return UpsertAsync(entry, guarantee, CancellationToken.None, previousETag);
+    }
 
     /// <summary>
     /// Upserts an entry and asserts that a non-empty ETag was returned.
@@ -1363,6 +1376,10 @@ public abstract class ReminderTableTestRunner
         CancellationToken cancellationToken,
         string? previousETag = null)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(guarantee);
+
         var etag = (await ReminderTableRetryPolicy.MutateUntilAsync(
             () => ReminderTable.UpsertRow(entry),
             etag => !string.IsNullOrEmpty(etag),
@@ -1394,19 +1411,23 @@ public abstract class ReminderTableTestRunner
     /// <param name="reminderName">The reminder name.</param>
     /// <param name="guarantee">The guarantee being verified.</param>
     /// <returns>The reminder entry.</returns>
-    protected async Task<ReminderEntry> ReadRequiredAsync(
+    protected Task<ReminderEntry> ReadRequiredAsync(
         GrainId grainId,
         string reminderName,
         string guarantee,
         ReminderEntry? expected = null,
         string? expectedETag = null)
-        => await ReadRequiredAsync(
+    {
+        ArgumentNullException.ThrowIfNull(reminderName);
+        ArgumentNullException.ThrowIfNull(guarantee);
+        return ReadRequiredAsync(
             grainId,
             reminderName,
             guarantee,
             CancellationToken.None,
             expected,
             expectedETag);
+    }
 
     /// <summary>
     /// Reads a reminder which the guarantee requires to be present.
@@ -1426,6 +1447,10 @@ public abstract class ReminderTableTestRunner
         ReminderEntry? expected = null,
         string? expectedETag = null)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(reminderName);
+        ArgumentNullException.ThrowIfNull(guarantee);
+
         var read = await ReadUntilAsync(
             () => ReminderTable.ReadRow(grainId, reminderName),
             value => value is not null && (expected is null || EntryMatches(expected, expectedETag, value)),
@@ -1485,7 +1510,11 @@ public abstract class ReminderTableTestRunner
     /// <param name="etag">The current ETag.</param>
     /// <returns>A task which represents the asynchronous operation.</returns>
     protected Task RemoveAsync(GrainId grainId, string reminderName, string etag)
-        => RemoveAsync(grainId, reminderName, etag, CancellationToken.None);
+    {
+        ArgumentNullException.ThrowIfNull(reminderName);
+        ArgumentNullException.ThrowIfNull(etag);
+        return RemoveAsync(grainId, reminderName, etag, CancellationToken.None);
+    }
 
     /// <summary>
     /// Removes a reminder during test cleanup.
@@ -1501,6 +1530,10 @@ public abstract class ReminderTableTestRunner
         string etag,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(reminderName);
+        ArgumentNullException.ThrowIfNull(etag);
+
         await ReminderTable.RemoveRow(grainId, reminderName, etag, cancellationToken).WaitAsync(cancellationToken);
     }
 
@@ -1513,6 +1546,9 @@ public abstract class ReminderTableTestRunner
     /// <returns>The non-null result.</returns>
     protected ReminderTableData RequireRows(string guarantee, string operation, ReminderTableData? rows)
     {
+        ArgumentNullException.ThrowIfNull(guarantee);
+        ArgumentNullException.ThrowIfNull(operation);
+
         if (rows is null)
         {
             Report(guarantee, operation)
@@ -1586,6 +1622,12 @@ public abstract class ReminderTableTestRunner
     /// <param name="actual">The observed entry.</param>
     protected void AssertEntry(string guarantee, string operation, ReminderEntry expected, string expectedETag, ReminderEntry actual)
     {
+        ArgumentNullException.ThrowIfNull(guarantee);
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(expected);
+        ArgumentNullException.ThrowIfNull(expectedETag);
+        ArgumentNullException.ThrowIfNull(actual);
+
         if (!actual.GrainId.Equals(expected.GrainId) || !string.Equals(actual.ReminderName, expected.ReminderName, StringComparison.Ordinal))
         {
             Report(guarantee, operation)
@@ -1648,7 +1690,10 @@ public abstract class ReminderTableTestRunner
     /// <param name="entry">The entry.</param>
     /// <returns>The rendered entry.</returns>
     protected static string Describe(ReminderEntry entry)
-        => $"(GrainId={entry.GrainId}, ReminderName='{entry.ReminderName}', StartAt={entry.StartAt:O}, Period={entry.Period}, ETag={FormatETag(entry.ETag)})";
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return $"(GrainId={entry.GrainId}, ReminderName='{entry.ReminderName}', StartAt={entry.StartAt:O}, Period={entry.Period}, ETag={FormatETag(entry.ETag)})";
+    }
 
     /// <summary>
     /// Renders an ETag for diagnostics.

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTableTestRunnerInputValidationTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTableTestRunnerInputValidationTests.cs
@@ -1,0 +1,355 @@
+using Orleans.Reminders.TestKit;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Orleans.Reminders.TestKit.Tests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "xUnit",
+    "xUnit1051",
+    Justification = "These tests intentionally exercise both protected overloads and explicit cancellation precedence.")]
+public class ReminderTableTestRunnerInputValidationTests
+{
+    private const string ETag = "etag";
+    private const string Guarantee = "Guarantee";
+    private const string Operation = "Operation";
+    private const string ReminderName = "reminder";
+
+    public static TheoryData<ProtectedStringParameter, string> ProtectedStringParameters { get; } = new()
+    {
+        { ProtectedStringParameter.ReportGuarantee, "guarantee" },
+        { ProtectedStringParameter.ReportOperation, "operation" },
+        { ProtectedStringParameter.NewGrainIdLabel, "label" },
+        { ProtectedStringParameter.NewEntryReminderName, "reminderName" },
+        { ProtectedStringParameter.UpsertGuarantee, "guarantee" },
+        { ProtectedStringParameter.UpsertGuaranteeWithCancellation, "guarantee" },
+        { ProtectedStringParameter.ReadRequiredReminderName, "reminderName" },
+        { ProtectedStringParameter.ReadRequiredReminderNameWithCancellation, "reminderName" },
+        { ProtectedStringParameter.ReadRequiredGuarantee, "guarantee" },
+        { ProtectedStringParameter.ReadRequiredGuaranteeWithCancellation, "guarantee" },
+        { ProtectedStringParameter.RemoveReminderName, "reminderName" },
+        { ProtectedStringParameter.RemoveReminderNameWithCancellation, "reminderName" },
+        { ProtectedStringParameter.RemoveETag, "etag" },
+        { ProtectedStringParameter.RemoveETagWithCancellation, "etag" },
+        { ProtectedStringParameter.RequireRowsGuarantee, "guarantee" },
+        { ProtectedStringParameter.RequireRowsOperation, "operation" },
+        { ProtectedStringParameter.AssertEntryGuarantee, "guarantee" },
+        { ProtectedStringParameter.AssertEntryOperation, "operation" },
+        { ProtectedStringParameter.AssertEntryExpectedETag, "expectedETag" },
+    };
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UpsertAsync_NullEntry_ThrowsBeforeTableOperation(bool useCancellationOverload)
+    {
+        var table = new RecordingReminderTable();
+        var runner = new TestRunner(table);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            useCancellationOverload
+                ? runner.InvokeUpsertAsync(null!, Guarantee, TestContext.Current.CancellationToken)
+                : runner.InvokeUpsertAsync(null!, Guarantee));
+
+        Assert.Equal("entry", exception.ParamName);
+        Assert.Equal(0, table.OperationCount);
+    }
+
+    [Theory]
+    [InlineData(EntryParameter.Expected, "expected")]
+    [InlineData(EntryParameter.Actual, "actual")]
+    public void AssertEntry_NullEntry_ThrowsBeforeComparisonOrTableOperation(
+        EntryParameter parameter,
+        string expectedParamName)
+    {
+        var table = new RecordingReminderTable();
+        var runner = new TestRunner(table);
+        var entry = CreateEntry();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => runner.InvokeAssertEntry(
+            Guarantee,
+            Operation,
+            parameter == EntryParameter.Expected ? null! : entry,
+            ETag,
+            parameter == EntryParameter.Actual ? null! : entry));
+
+        Assert.Equal(expectedParamName, exception.ParamName);
+        Assert.Equal(0, table.OperationCount);
+    }
+
+    [Fact]
+    public void Describe_NullEntry_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => TestRunner.InvokeDescribe(null!));
+
+        Assert.Equal("entry", exception.ParamName);
+    }
+
+    [Theory]
+    [MemberData(nameof(ProtectedStringParameters))]
+    public async Task ProtectedStringBoundary_NullInput_ThrowsBeforeTableOperation(
+        ProtectedStringParameter parameter,
+        string expectedParamName)
+    {
+        var table = new RecordingReminderTable();
+        var runner = new TestRunner(table);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeNullStringBoundaryAsync(runner, parameter));
+
+        Assert.Equal(expectedParamName, exception.ParamName);
+        Assert.Equal(0, table.OperationCount);
+    }
+
+    [Theory]
+    [InlineData(CancellationAwareOperation.Upsert)]
+    [InlineData(CancellationAwareOperation.ReadRequired)]
+    [InlineData(CancellationAwareOperation.Remove)]
+    public async Task CancellationAwareBoundary_CanceledToken_TakesPrecedenceOverNullInput(
+        CancellationAwareOperation operation)
+    {
+        var table = new RecordingReminderTable();
+        var runner = new TestRunner(table);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeCanceledBoundaryAsync(runner, operation, cancellation.Token));
+
+        Assert.Equal(0, table.OperationCount);
+    }
+
+    private static async Task InvokeNullStringBoundaryAsync(
+        TestRunner runner,
+        ProtectedStringParameter parameter)
+    {
+        var entry = CreateEntry();
+        switch (parameter)
+        {
+            case ProtectedStringParameter.ReportGuarantee:
+                runner.InvokeReport(null!, Operation);
+                return;
+            case ProtectedStringParameter.ReportOperation:
+                runner.InvokeReport(Guarantee, null!);
+                return;
+            case ProtectedStringParameter.NewGrainIdLabel:
+                runner.InvokeNewGrainId(null!);
+                return;
+            case ProtectedStringParameter.NewEntryReminderName:
+                runner.InvokeNewEntry(null!);
+                return;
+            case ProtectedStringParameter.UpsertGuarantee:
+                await runner.InvokeUpsertAsync(entry, null!);
+                return;
+            case ProtectedStringParameter.UpsertGuaranteeWithCancellation:
+                await runner.InvokeUpsertAsync(entry, null!, CancellationToken.None);
+                return;
+            case ProtectedStringParameter.ReadRequiredReminderName:
+                await runner.InvokeReadRequiredAsync(null!, Guarantee);
+                return;
+            case ProtectedStringParameter.ReadRequiredReminderNameWithCancellation:
+                await runner.InvokeReadRequiredAsync(null!, Guarantee, CancellationToken.None);
+                return;
+            case ProtectedStringParameter.ReadRequiredGuarantee:
+                await runner.InvokeReadRequiredAsync(ReminderName, null!);
+                return;
+            case ProtectedStringParameter.ReadRequiredGuaranteeWithCancellation:
+                await runner.InvokeReadRequiredAsync(ReminderName, null!, CancellationToken.None);
+                return;
+            case ProtectedStringParameter.RemoveReminderName:
+                await runner.InvokeRemoveAsync(null!, ETag);
+                return;
+            case ProtectedStringParameter.RemoveReminderNameWithCancellation:
+                await runner.InvokeRemoveAsync(null!, ETag, CancellationToken.None);
+                return;
+            case ProtectedStringParameter.RemoveETag:
+                await runner.InvokeRemoveAsync(ReminderName, null!);
+                return;
+            case ProtectedStringParameter.RemoveETagWithCancellation:
+                await runner.InvokeRemoveAsync(ReminderName, null!, CancellationToken.None);
+                return;
+            case ProtectedStringParameter.RequireRowsGuarantee:
+                runner.InvokeRequireRows(null!, Operation, new ReminderTableData([]));
+                return;
+            case ProtectedStringParameter.RequireRowsOperation:
+                runner.InvokeRequireRows(Guarantee, null!, new ReminderTableData([]));
+                return;
+            case ProtectedStringParameter.AssertEntryGuarantee:
+                runner.InvokeAssertEntry(null!, Operation, entry, ETag, entry);
+                return;
+            case ProtectedStringParameter.AssertEntryOperation:
+                runner.InvokeAssertEntry(Guarantee, null!, entry, ETag, entry);
+                return;
+            case ProtectedStringParameter.AssertEntryExpectedETag:
+                runner.InvokeAssertEntry(Guarantee, Operation, entry, null!, entry);
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(parameter));
+        }
+    }
+
+    private static Task InvokeCanceledBoundaryAsync(
+        TestRunner runner,
+        CancellationAwareOperation operation,
+        CancellationToken cancellationToken)
+        => operation switch
+        {
+            CancellationAwareOperation.Upsert => runner.InvokeUpsertAsync(null!, Guarantee, cancellationToken),
+            CancellationAwareOperation.ReadRequired => runner.InvokeReadRequiredAsync(null!, Guarantee, cancellationToken),
+            CancellationAwareOperation.Remove => runner.InvokeRemoveAsync(null!, ETag, cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
+
+    private static ReminderEntry CreateEntry() => new()
+    {
+        GrainId = GrainId.Create("test", "key"),
+        ReminderName = ReminderName,
+        StartAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Period = TimeSpan.FromMinutes(1),
+        ETag = ETag,
+    };
+
+    public enum EntryParameter
+    {
+        Expected,
+        Actual,
+    }
+
+    public enum ProtectedStringParameter
+    {
+        ReportGuarantee,
+        ReportOperation,
+        NewGrainIdLabel,
+        NewEntryReminderName,
+        UpsertGuarantee,
+        UpsertGuaranteeWithCancellation,
+        ReadRequiredReminderName,
+        ReadRequiredReminderNameWithCancellation,
+        ReadRequiredGuarantee,
+        ReadRequiredGuaranteeWithCancellation,
+        RemoveReminderName,
+        RemoveReminderNameWithCancellation,
+        RemoveETag,
+        RemoveETagWithCancellation,
+        RequireRowsGuarantee,
+        RequireRowsOperation,
+        AssertEntryGuarantee,
+        AssertEntryOperation,
+        AssertEntryExpectedETag,
+    }
+
+    public enum CancellationAwareOperation
+    {
+        Upsert,
+        ReadRequired,
+        Remove,
+    }
+
+    private sealed class TestRunner(IReminderTable table)
+        : ReminderTableTestRunner(table, nameof(RecordingReminderTable))
+    {
+        public ReminderFailureReport InvokeReport(string guarantee, string operation)
+            => Report(guarantee, operation);
+
+        public GrainId InvokeNewGrainId(string label) => NewGrainId(label);
+
+        public ReminderEntry InvokeNewEntry(string reminderName)
+            => NewEntry(GrainId.Create("test", "key"), reminderName);
+
+        public Task<string> InvokeUpsertAsync(ReminderEntry entry, string guarantee)
+            => UpsertAsync(entry, guarantee);
+
+        public Task<string> InvokeUpsertAsync(
+            ReminderEntry entry,
+            string guarantee,
+            CancellationToken cancellationToken)
+            => UpsertAsync(entry, guarantee, cancellationToken);
+
+        public Task<ReminderEntry> InvokeReadRequiredAsync(string reminderName, string guarantee)
+            => ReadRequiredAsync(GrainId.Create("test", "key"), reminderName, guarantee);
+
+        public Task<ReminderEntry> InvokeReadRequiredAsync(
+            string reminderName,
+            string guarantee,
+            CancellationToken cancellationToken)
+            => ReadRequiredAsync(GrainId.Create("test", "key"), reminderName, guarantee, cancellationToken);
+
+        public Task InvokeRemoveAsync(string reminderName, string etag)
+            => RemoveAsync(GrainId.Create("test", "key"), reminderName, etag);
+
+        public Task InvokeRemoveAsync(
+            string reminderName,
+            string etag,
+            CancellationToken cancellationToken)
+            => RemoveAsync(GrainId.Create("test", "key"), reminderName, etag, cancellationToken);
+
+        public ReminderTableData InvokeRequireRows(
+            string guarantee,
+            string operation,
+            ReminderTableData? rows)
+            => RequireRows(guarantee, operation, rows);
+
+        public void InvokeAssertEntry(
+            string guarantee,
+            string operation,
+            ReminderEntry expected,
+            string expectedETag,
+            ReminderEntry actual)
+            => AssertEntry(guarantee, operation, expected, expectedETag, actual);
+
+        public static string InvokeDescribe(ReminderEntry entry) => Describe(entry);
+    }
+
+    private sealed class RecordingReminderTable : IReminderTable
+    {
+        public int OperationCount { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            OperationCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            OperationCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<ReminderEntry?> ReadRow(GrainId grainId, string reminderName)
+        {
+            OperationCount++;
+            return Task.FromResult<ReminderEntry?>(null);
+        }
+
+        public Task<ReminderTableData> ReadRows(GrainId grainId)
+        {
+            OperationCount++;
+            return Task.FromResult(new ReminderTableData([]));
+        }
+
+        public Task<ReminderTableData> ReadRows(uint begin, uint end)
+        {
+            OperationCount++;
+            return Task.FromResult(new ReminderTableData([]));
+        }
+
+        public Task<string?> UpsertRow(ReminderEntry entry)
+        {
+            OperationCount++;
+            return Task.FromResult<string?>(ETag);
+        }
+
+        public Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag)
+        {
+            OperationCount++;
+            return Task.FromResult(true);
+        }
+
+        public Task TestOnlyClearTable()
+        {
+            OperationCount++;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Analyzer audit run [33948903771](https://github.com/dotnet/orleans/actions/runs/33948903771) reports four CA1062 findings in `ReminderTableTestRunner`.

This change validates non-nullable caller-controlled inputs at the protected TestKit runner boundaries before any reminder-table operation. Cancellation-aware helpers retain cancellation precedence, while nullable observation and expectation values keep their existing semantics. Private harness delegates continue through the retry policy's established validation.

CA1062 is enforced as an error across `Orleans.Reminders.TestKit`, and focused contract tests pin exact parameter names plus zero table operations before rejection. The change does not overlap the TestKit files modified by #10911.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11137)