### PR TITLE
fix(zookeeper): validate clustering inputs

### DIFF
--- a/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
+++ b/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
@@ -7,11 +7,13 @@
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <AssemblyName>Orleans.Clustering.ZooKeeper</AssemblyName>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Orleans.Runtime\Orleans.Runtime.csproj" />
     <PackageReference Include="ZooKeeperNetEx" />
+    <InternalsVisibleTo Include="Orleans.Clustering.ZooKeeper.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -63,11 +63,17 @@ namespace Orleans.Runtime.Membership
         /// <param name="logger">The logger.</param>
         /// <param name="membershipTableOptions">The ZooKeeper clustering options.</param>
         /// <param name="clusterOptions">The cluster identity options.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="membershipTableOptions"/> or <paramref name="clusterOptions"/> is <see langword="null"/>.
+        /// </exception>
         public ZooKeeperBasedMembershipTable(
             ILogger<ZooKeeperBasedMembershipTable> logger,
             IOptions<ZooKeeperClusteringSiloOptions> membershipTableOptions,
             IOptions<ClusterOptions> clusterOptions)
         {
+            ArgumentNullException.ThrowIfNull(membershipTableOptions);
+            ArgumentNullException.ThrowIfNull(clusterOptions);
+
             this.logger = logger;
             var options = membershipTableOptions.Value;
             watcher = new ZooKeeperWatcher(logger);
@@ -178,8 +184,14 @@ namespace Orleans.Runtime.Membership
         /// <param name="entry">MembershipEntry to be inserted.</param>
         /// <param name="tableVersion">The new TableVersion for this table, along with its etag.</param>
         /// <returns>True if the insert operation succeeded and false otherwise.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="entry"/> or <paramref name="tableVersion"/> is <see langword="null"/>.
+        /// </exception>
         public Task<bool> InsertRow(MembershipEntry entry, TableVersion tableVersion)
         {
+            ArgumentNullException.ThrowIfNull(entry);
+            ArgumentNullException.ThrowIfNull(tableVersion);
+
             string rowPath = ConvertToRowPath(entry.SiloAddress);
             string rowIAmAlivePath = ConvertToRowIAmAlivePath(entry.SiloAddress);
             byte[] newRowData = Serialize(entry);
@@ -210,8 +222,14 @@ namespace Orleans.Runtime.Membership
         /// <param name="etag">The etag  for the given MembershipEntry.</param>
         /// <param name="tableVersion">The new TableVersion for this table, along with its etag.</param>
         /// <returns>True if the update operation succeeded and false otherwise.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="entry"/> or <paramref name="tableVersion"/> is <see langword="null"/>.
+        /// </exception>
         public Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion)
         {
+            ArgumentNullException.ThrowIfNull(entry);
+            ArgumentNullException.ThrowIfNull(tableVersion);
+
             string rowPath = ConvertToRowPath(entry.SiloAddress);
             string rowIAmAlivePath = ConvertToRowIAmAlivePath(entry.SiloAddress);
             var newRowData = Serialize(entry);
@@ -238,8 +256,11 @@ namespace Orleans.Runtime.Membership
         /// </summary>
         /// <param name="entry">The target MembershipEntry tp update</param>
         /// <returns>Task representing the successful execution of this operation. </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="entry"/> is <see langword="null"/>.</exception>
         public Task UpdateIAmAlive(MembershipEntry entry)
         {
+            ArgumentNullException.ThrowIfNull(entry);
+
             string rowIAmAlivePath = ConvertToRowIAmAlivePath(entry.SiloAddress);
             byte[] newRowIAmAliveData = Serialize(entry.IAmAliveTime);
             //update the data for IAmAlive unconditionally
@@ -327,14 +348,14 @@ namespace Orleans.Runtime.Membership
             return new TableVersion(version, version.ToString(CultureInfo.InvariantCulture));
         }
 
-        private static byte[] Serialize(object obj)
+        internal static byte[] Serialize(object obj)
         {
             return
                 Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(obj, Formatting.None,
                     MembershipSerializerSettings.Instance));
         }
 
-        private static T Deserialize<T>(byte[] data)
+        internal static T Deserialize<T>(byte[] data)
         {
             return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data), MembershipSerializerSettings.Instance)!;
         }

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -64,13 +64,15 @@ namespace Orleans.Runtime.Membership
         /// <param name="membershipTableOptions">The ZooKeeper clustering options.</param>
         /// <param name="clusterOptions">The cluster identity options.</param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="membershipTableOptions"/> or <paramref name="clusterOptions"/> is <see langword="null"/>.
+        /// <paramref name="logger"/>, <paramref name="membershipTableOptions"/>, or <paramref name="clusterOptions"/> is
+        /// <see langword="null"/>.
         /// </exception>
         public ZooKeeperBasedMembershipTable(
             ILogger<ZooKeeperBasedMembershipTable> logger,
             IOptions<ZooKeeperClusteringSiloOptions> membershipTableOptions,
             IOptions<ClusterOptions> clusterOptions)
         {
+            ArgumentNullException.ThrowIfNull(logger);
             ArgumentNullException.ThrowIfNull(membershipTableOptions);
             ArgumentNullException.ThrowIfNull(clusterOptions);
 
@@ -223,11 +225,13 @@ namespace Orleans.Runtime.Membership
         /// <param name="tableVersion">The new TableVersion for this table, along with its etag.</param>
         /// <returns>True if the update operation succeeded and false otherwise.</returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="entry"/> or <paramref name="tableVersion"/> is <see langword="null"/>.
+        /// <paramref name="entry"/>, <paramref name="etag"/>, or <paramref name="tableVersion"/> is
+        /// <see langword="null"/>.
         /// </exception>
         public Task<bool> UpdateRow(MembershipEntry entry, string etag, TableVersion tableVersion)
         {
             ArgumentNullException.ThrowIfNull(entry);
+            ArgumentNullException.ThrowIfNull(etag);
             ArgumentNullException.ThrowIfNull(tableVersion);
 
             string rowPath = ConvertToRowPath(entry.SiloAddress);

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
@@ -35,7 +35,8 @@ namespace Orleans.Runtime.Membership
         /// <param name="gatewayOptions">The gateway discovery refresh options.</param>
         /// <param name="clusterOptions">The cluster identity options.</param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="options"/>, <paramref name="gatewayOptions"/>, or <paramref name="clusterOptions"/> is <see langword="null"/>.
+        /// <paramref name="logger"/>, <paramref name="options"/>, <paramref name="gatewayOptions"/>, or
+        /// <paramref name="clusterOptions"/> is <see langword="null"/>.
         /// </exception>
         public ZooKeeperGatewayListProvider(
             ILogger<ZooKeeperGatewayListProvider> logger,
@@ -43,6 +44,7 @@ namespace Orleans.Runtime.Membership
             IOptions<GatewayOptions> gatewayOptions,
             IOptions<ClusterOptions> clusterOptions)
         {
+            ArgumentNullException.ThrowIfNull(logger);
             ArgumentNullException.ThrowIfNull(options);
             ArgumentNullException.ThrowIfNull(gatewayOptions);
             ArgumentNullException.ThrowIfNull(clusterOptions);

--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperGatewayListProvider.cs
@@ -34,12 +34,19 @@ namespace Orleans.Runtime.Membership
         /// <param name="options">The ZooKeeper gateway discovery options.</param>
         /// <param name="gatewayOptions">The gateway discovery refresh options.</param>
         /// <param name="clusterOptions">The cluster identity options.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="options"/>, <paramref name="gatewayOptions"/>, or <paramref name="clusterOptions"/> is <see langword="null"/>.
+        /// </exception>
         public ZooKeeperGatewayListProvider(
             ILogger<ZooKeeperGatewayListProvider> logger,
             IOptions<ZooKeeperGatewayListProviderOptions> options,
             IOptions<GatewayOptions> gatewayOptions,
             IOptions<ClusterOptions> clusterOptions)
         {
+            ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(gatewayOptions);
+            ArgumentNullException.ThrowIfNull(clusterOptions);
+
             _watcher = new ZooKeeperWatcher(logger);
             _deploymentPath = "/" + clusterOptions.Value.ClusterId;
             _deploymentConnectionString = options.Value.ConnectionString + _deploymentPath;

--- a/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/MembershipSerializerSettingsUnitTests.cs
+++ b/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/MembershipSerializerSettingsUnitTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Orleans.Runtime;
+using Orleans.Runtime.Membership;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.MembershipTests
+{
+    [TestCategory("Membership"), TestCategory("ZooKeeper")]
+    [TestSuite("BVT")]
+    [TestProvider("ZooKeeper")]
+    [TestArea("Membership")]
+    public sealed class MembershipSerializerSettingsUnitTests
+    {
+        private static readonly DateTime StartTime =
+            new(2024, 1, 2, 3, 4, 5, 678, DateTimeKind.Utc);
+
+        private static readonly DateTime IAmAliveTime =
+            new(2024, 1, 2, 3, 5, 6, 789, DateTimeKind.Utc);
+
+        private static readonly DateTime SuspectTime =
+            new(2024, 1, 2, 3, 6, 7, 890, DateTimeKind.Utc);
+
+        [Fact]
+        public void MembershipEntry_Serialization_UsesUtf8NewtonsoftFormattingNoneAndStableSchema()
+        {
+            var payload = Serialize(CreateMembershipEntry());
+            var json = Encoding.UTF8.GetString(payload);
+            var row = JObject.Parse(json);
+
+            Assert.Equal(
+                ["SiloAddress", "HostName", "SiloName", "InstanceName", "Status", "ProxyPort", "StartTime", "SuspectTimes"],
+                row.Properties().Select(property => property.Name));
+            Assert.Equal("Active", row["Status"]!.Value<string>());
+            Assert.Equal(30000, row["ProxyPort"]!.Value<int>());
+            Assert.Equal(StartTime, row["StartTime"]!.Value<DateTime>());
+            Assert.Null(row.Property("IAmAliveTime"));
+            Assert.DoesNotContain("\r", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("\n", json, StringComparison.Ordinal);
+            Assert.True(
+                payload.AsSpan().IndexOf(Encoding.UTF8.GetBytes("ø")) >= 0,
+                "The payload should contain the UTF-8 byte sequence for ø.");
+            Assert.True(
+                payload.AsSpan().IndexOf(Encoding.UTF8.GetBytes("東京")) >= 0,
+                "The payload should contain the UTF-8 byte sequence for 東京.");
+            Assert.Equal("høst-東京", row["HostName"]!.Value<string>());
+        }
+
+        [Fact]
+        public void MembershipEntry_RoundTrip_PreservesPersistedFields()
+        {
+            var original = CreateMembershipEntry();
+
+            var roundTrip = Deserialize<MembershipEntry>(Serialize(original));
+
+            Assert.Equal(original.SiloAddress.ToParsableString(), roundTrip.SiloAddress.ToParsableString());
+            Assert.Equal(original.HostName, roundTrip.HostName);
+            Assert.Equal(original.SiloName, roundTrip.SiloName);
+            Assert.Equal(SiloStatus.Active, roundTrip.Status);
+            Assert.Equal(30000, roundTrip.ProxyPort);
+            Assert.Equal(StartTime, roundTrip.StartTime);
+            var suspect = Assert.Single(roundTrip.SuspectTimes!);
+            Assert.Equal("127.0.0.2:11112@54321", suspect.Item1.ToParsableString());
+            Assert.Equal(SuspectTime, suspect.Item2);
+        }
+
+        [Fact]
+        public void MembershipEntry_Serialization_WritesSiloNameAndLegacyInstanceName()
+        {
+            var row = JObject.Parse(Encoding.UTF8.GetString(Serialize(CreateMembershipEntry())));
+
+            Assert.Equal("silo-modern", row["SiloName"]!.Value<string>());
+            Assert.Equal("silo-modern", row["InstanceName"]!.Value<string>());
+            Assert.NotSame(row.Property("SiloName"), row.Property("InstanceName"));
+        }
+
+        [Fact]
+        public void MembershipEntry_Deserialization_WithOnlyInstanceName_UsesLegacyValue()
+        {
+            var row = CreateSerializedRow();
+            row.Remove("SiloName");
+            row["InstanceName"] = "silo-legacy";
+
+            var entry = Deserialize<MembershipEntry>(Encoding.UTF8.GetBytes(row.ToString(Formatting.None)));
+
+            Assert.Equal("silo-legacy", entry.SiloName);
+            Assert.Equal("127.0.0.1:11111@12345", entry.SiloAddress.ToParsableString());
+        }
+
+        [Fact]
+        public void MembershipEntry_Deserialization_WithBothNames_PrefersSiloName()
+        {
+            var row = CreateSerializedRow();
+            row["SiloName"] = "silo-modern";
+            row["InstanceName"] = "silo-legacy-different";
+
+            var entry = Deserialize<MembershipEntry>(Encoding.UTF8.GetBytes(row.ToString(Formatting.None)));
+
+            Assert.Equal("silo-modern", entry.SiloName);
+            Assert.Equal(SiloStatus.Active, entry.Status);
+        }
+
+        [Fact]
+        public void MembershipEntry_Serialization_OmitsIAmAliveTime()
+        {
+            var first = CreateMembershipEntry(IAmAliveTime);
+            var second = CreateMembershipEntry(IAmAliveTime.AddMinutes(10));
+
+            var firstJson = Encoding.UTF8.GetString(Serialize(first));
+            var secondJson = Encoding.UTF8.GetString(Serialize(second));
+
+            Assert.Null(JObject.Parse(firstJson).Property("IAmAliveTime"));
+            Assert.Equal(firstJson, secondJson);
+        }
+
+        [Fact]
+        public void IAmAliveDateTime_RoundTrip_PreservesSeparatePayload()
+        {
+            var payload = Serialize(IAmAliveTime);
+            var json = Encoding.UTF8.GetString(payload);
+
+            Assert.Equal("\"2024-01-02T03:05:06.789Z\"", json);
+            Assert.Equal(JTokenType.Date, JToken.Parse(json).Type);
+            var roundTrip = Deserialize<DateTime>(payload);
+            Assert.Equal(IAmAliveTime.Ticks, roundTrip.Ticks);
+            Assert.Equal(DateTimeKind.Utc, roundTrip.Kind);
+        }
+
+        [Fact]
+        public void SiloAddress_RoundTrip_PreservesParsableAddress()
+        {
+            var original = CreateSiloAddress("127.0.0.1", 11111, 12345);
+            var payload = Serialize(original);
+            var addressObject = JObject.Parse(Encoding.UTF8.GetString(payload));
+
+            Assert.Equal(["SiloAddress"], addressObject.Properties().Select(property => property.Name));
+            Assert.Equal("127.0.0.1:11111@12345", addressObject["SiloAddress"]!.Value<string>());
+
+            var roundTrip = Deserialize<SiloAddress>(payload);
+            Assert.Equal(IPAddress.Parse("127.0.0.1"), roundTrip.Endpoint.Address);
+            Assert.Equal(11111, roundTrip.Endpoint.Port);
+            Assert.Equal(12345, roundTrip.Generation);
+            Assert.Equal("127.0.0.1:11111@12345", roundTrip.ToParsableString());
+        }
+
+        private static MembershipEntry CreateMembershipEntry(DateTime? iAmAliveTime = null) =>
+            new()
+            {
+                SiloAddress = CreateSiloAddress("127.0.0.1", 11111, 12345),
+                HostName = "høst-東京",
+                SiloName = "silo-modern",
+                Status = SiloStatus.Active,
+                ProxyPort = 30000,
+                StartTime = StartTime,
+                IAmAliveTime = iAmAliveTime ?? IAmAliveTime,
+                SuspectTimes =
+                [
+                    Tuple.Create(
+                        CreateSiloAddress("127.0.0.2", 11112, 54321),
+                        SuspectTime)
+                ]
+            };
+
+        private static JObject CreateSerializedRow() =>
+            JObject.Parse(Encoding.UTF8.GetString(Serialize(CreateMembershipEntry())));
+
+        private static SiloAddress CreateSiloAddress(string address, int port, int generation) =>
+            SiloAddress.New(new IPEndPoint(IPAddress.Parse(address), port), generation);
+
+        private static byte[] Serialize(object value) =>
+            ZooKeeperBasedMembershipTable.Serialize(value);
+
+        private static T Deserialize<T>(byte[] payload) =>
+            ZooKeeperBasedMembershipTable.Deserialize<T>(payload);
+    }
+}

--- a/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperBasedMembershipTableUnitTests.cs
+++ b/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperBasedMembershipTableUnitTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Net;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.Membership;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.MembershipTests
+{
+    [TestCategory("Membership"), TestCategory("ZooKeeper")]
+    [TestSuite("BVT")]
+    [TestProvider("ZooKeeper")]
+    [TestArea("Membership")]
+    public sealed class ZooKeeperBasedMembershipTableUnitTests
+    {
+        [Fact]
+        public void Constructor_NullMembershipTableOptions_ThrowsArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new ZooKeeperBasedMembershipTable(
+                    NullLogger<ZooKeeperBasedMembershipTable>.Instance,
+                    null!,
+                    CreateClusterOptions()));
+
+            Assert.Equal("membershipTableOptions", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_NullClusterOptions_ThrowsArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new ZooKeeperBasedMembershipTable(
+                    NullLogger<ZooKeeperBasedMembershipTable>.Instance,
+                    CreateMembershipTableOptions(),
+                    null!));
+
+            Assert.Equal("clusterOptions", exception.ParamName);
+        }
+
+        [Fact]
+        public void InsertRow_NullEntry_ThrowsArgumentNullException()
+        {
+            var sut = CreateSut();
+            Task<bool>? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.InsertRow(null!, CreateTableVersion());
+            });
+
+            Assert.Equal("entry", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Fact]
+        public void InsertRow_NullTableVersion_ThrowsArgumentNullException()
+        {
+            var sut = CreateSut();
+            Task<bool>? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.InsertRow(CreateMembershipEntry(), null!);
+            });
+
+            Assert.Equal("tableVersion", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Fact]
+        public void InsertRow_NullEntryAndTableVersion_ThrowsForEntryFirst()
+        {
+            var sut = CreateSut();
+            Task<bool>? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.InsertRow(null!, null!);
+            });
+
+            Assert.Equal("entry", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Fact]
+        public void UpdateRow_NullEntry_ThrowsArgumentNullException()
+        {
+            var sut = CreateSut();
+            Task<bool>? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.UpdateRow(null!, "17", CreateTableVersion());
+            });
+
+            Assert.Equal("entry", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Fact]
+        public void UpdateRow_NullTableVersion_ThrowsArgumentNullException()
+        {
+            var sut = CreateSut();
+            Task<bool>? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.UpdateRow(CreateMembershipEntry(), "17", null!);
+            });
+
+            Assert.Equal("tableVersion", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Fact]
+        public void UpdateRow_NullEntryAndTableVersion_ThrowsForEntryFirst()
+        {
+            var sut = CreateSut();
+            Task<bool>? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.UpdateRow(null!, "17", null!);
+            });
+
+            Assert.Equal("entry", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Fact]
+        public void UpdateIAmAlive_NullEntry_ThrowsArgumentNullException()
+        {
+            var sut = CreateSut();
+            Task? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.UpdateIAmAlive(null!);
+            });
+
+            Assert.Equal("entry", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Theory]
+        [InlineData("localhost:2181", "cluster-a", "localhost:2181", "/cluster-a", "localhost:2181/cluster-a")]
+        [InlineData("localhost:2181/", "/cluster-a", "localhost:2181/", "//cluster-a", "localhost:2181///cluster-a")]
+        public void Constructor_ValidOptions_PreservesLiteralConnectionAndClusterPathComposition(
+            string connectionString,
+            string clusterId,
+            string expectedRootConnectionString,
+            string expectedClusterPath,
+            string expectedDeploymentConnectionString)
+        {
+            var sut = CreateSut(connectionString, clusterId);
+
+            Assert.Equal(expectedRootConnectionString, GetPrivateField<string>(sut, "rootConnectionString"));
+            Assert.Equal(expectedClusterPath, GetPrivateField<string>(sut, "clusterPath"));
+            Assert.Equal(expectedDeploymentConnectionString, GetPrivateField<string>(sut, "deploymentConnectionString"));
+        }
+
+        [Fact]
+        public void ConvertToRowPath_ValidAddress_PrefixesParsableAddressWithSlash()
+        {
+            var address = CreateSiloAddress();
+
+            var result = InvokePrivatePathMethod("ConvertToRowPath", address);
+
+            Assert.Equal("/127.0.0.1:11111@12345", result);
+            Assert.EndsWith(address.ToParsableString(), result, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ConvertToRowIAmAlivePath_ValidAddress_AppendsIAmAliveSegment()
+        {
+            var address = CreateSiloAddress();
+
+            var result = InvokePrivatePathMethod("ConvertToRowIAmAlivePath", address);
+
+            Assert.Equal("/127.0.0.1:11111@12345/IAmAlive", result);
+            Assert.Equal(InvokePrivatePathMethod("ConvertToRowPath", address) + "/IAmAlive", result);
+        }
+
+        private static ZooKeeperBasedMembershipTable CreateSut(
+            string connectionString = "sentinel.invalid:2181",
+            string clusterId = "cluster-a") =>
+            new(
+                NullLogger<ZooKeeperBasedMembershipTable>.Instance,
+                CreateMembershipTableOptions(connectionString),
+                CreateClusterOptions(clusterId));
+
+        private static IOptions<ZooKeeperClusteringSiloOptions> CreateMembershipTableOptions(
+            string connectionString = "sentinel.invalid:2181") =>
+            Options.Create(new ZooKeeperClusteringSiloOptions { ConnectionString = connectionString });
+
+        private static IOptions<ClusterOptions> CreateClusterOptions(string clusterId = "cluster-a") =>
+            Options.Create(new ClusterOptions { ClusterId = clusterId });
+
+        private static MembershipEntry CreateMembershipEntry() =>
+            new()
+            {
+                SiloAddress = CreateSiloAddress(),
+                HostName = "host-a",
+                SiloName = "silo-a",
+                Status = SiloStatus.Active,
+                ProxyPort = 30000
+            };
+
+        private static SiloAddress CreateSiloAddress() =>
+            SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11111), 12345);
+
+        private static TableVersion CreateTableVersion() => new(18, "17");
+
+        private static T GetPrivateField<T>(object instance, string fieldName)
+        {
+            var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return Assert.IsType<T>(field.GetValue(instance));
+        }
+
+        private static string InvokePrivatePathMethod(string methodName, SiloAddress address)
+        {
+            var method = typeof(ZooKeeperBasedMembershipTable).GetMethod(
+                methodName,
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            return Assert.IsType<string>(method.Invoke(null, [address]));
+        }
+    }
+}

--- a/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperBasedMembershipTableUnitTests.cs
+++ b/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperBasedMembershipTableUnitTests.cs
@@ -19,6 +19,18 @@ namespace UnitTests.MembershipTests
     public sealed class ZooKeeperBasedMembershipTableUnitTests
     {
         [Fact]
+        public void Constructor_NullLogger_ThrowsArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new ZooKeeperBasedMembershipTable(
+                    null!,
+                    CreateMembershipTableOptions(),
+                    CreateClusterOptions()));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
         public void Constructor_NullMembershipTableOptions_ThrowsArgumentNullException()
         {
             var exception = Assert.Throws<ArgumentNullException>(() =>
@@ -114,6 +126,21 @@ namespace UnitTests.MembershipTests
             });
 
             Assert.Equal("tableVersion", exception.ParamName);
+            Assert.Null(returnedTask);
+        }
+
+        [Fact]
+        public void UpdateRow_NullEtag_ThrowsArgumentNullException()
+        {
+            var sut = CreateSut();
+            Task<bool>? returnedTask = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                returnedTask = sut.UpdateRow(CreateMembershipEntry(), null!, CreateTableVersion());
+            });
+
+            Assert.Equal("etag", exception.ParamName);
             Assert.Null(returnedTask);
         }
 

--- a/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperGatewayListProviderUnitTests.cs
+++ b/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperGatewayListProviderUnitTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime.Membership;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.MembershipTests
+{
+    [TestCategory("Membership"), TestCategory("ZooKeeper")]
+    [TestSuite("BVT")]
+    [TestProvider("ZooKeeper")]
+    [TestArea("Membership")]
+    public sealed class ZooKeeperGatewayListProviderUnitTests
+    {
+        [Fact]
+        public void Constructor_NullOptions_ThrowsArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new ZooKeeperGatewayListProvider(
+                    NullLogger<ZooKeeperGatewayListProvider>.Instance,
+                    null!,
+                    CreateGatewayOptions(),
+                    CreateClusterOptions()));
+
+            Assert.Equal("options", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_NullGatewayOptions_ThrowsArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new ZooKeeperGatewayListProvider(
+                    NullLogger<ZooKeeperGatewayListProvider>.Instance,
+                    CreateProviderOptions(),
+                    null!,
+                    CreateClusterOptions()));
+
+            Assert.Equal("gatewayOptions", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_NullClusterOptions_ThrowsArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new ZooKeeperGatewayListProvider(
+                    NullLogger<ZooKeeperGatewayListProvider>.Instance,
+                    CreateProviderOptions(),
+                    CreateGatewayOptions(),
+                    null!));
+
+            Assert.Equal("clusterOptions", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData("localhost:2181", "cluster-a", "localhost:2181/cluster-a")]
+        [InlineData("localhost:2181/", "/cluster-a", "localhost:2181///cluster-a")]
+        public void Constructor_ValidOptions_PreservesLiteralConnectionAndClusterPathComposition(
+            string connectionString,
+            string clusterId,
+            string expectedDeploymentConnectionString)
+        {
+            var sut = CreateSut(connectionString, clusterId, TimeSpan.FromSeconds(37));
+
+            Assert.Equal(expectedDeploymentConnectionString, GetPrivateField<string>(sut, "_deploymentConnectionString"));
+            Assert.Equal("/" + clusterId, GetPrivateField<string>(sut, "_deploymentPath"));
+        }
+
+        [Fact]
+        public void Constructor_ValidGatewayOptions_CopiesMaxStaleness()
+        {
+            var sut = CreateSut("sentinel.invalid:2181", "cluster-a", TimeSpan.FromSeconds(37));
+
+            Assert.Equal(TimeSpan.FromSeconds(37), sut.MaxStaleness);
+            Assert.True(sut.IsUpdatable);
+        }
+
+        private static ZooKeeperGatewayListProvider CreateSut(
+            string connectionString,
+            string clusterId,
+            TimeSpan refreshPeriod) =>
+            new(
+                NullLogger<ZooKeeperGatewayListProvider>.Instance,
+                CreateProviderOptions(connectionString),
+                CreateGatewayOptions(refreshPeriod),
+                CreateClusterOptions(clusterId));
+
+        private static IOptions<ZooKeeperGatewayListProviderOptions> CreateProviderOptions(
+            string connectionString = "sentinel.invalid:2181") =>
+            Options.Create(new ZooKeeperGatewayListProviderOptions { ConnectionString = connectionString });
+
+        private static IOptions<GatewayOptions> CreateGatewayOptions(TimeSpan? refreshPeriod = null) =>
+            Options.Create(new GatewayOptions
+            {
+                GatewayListRefreshPeriod = refreshPeriod ?? TimeSpan.FromSeconds(37)
+            });
+
+        private static IOptions<ClusterOptions> CreateClusterOptions(string clusterId = "cluster-a") =>
+            Options.Create(new ClusterOptions { ClusterId = clusterId });
+
+        private static T GetPrivateField<T>(object instance, string fieldName)
+        {
+            var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return Assert.IsType<T>(field.GetValue(instance));
+        }
+    }
+}

--- a/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperGatewayListProviderUnitTests.cs
+++ b/test/Extensions/Orleans.Clustering.ZooKeeper.Tests/ZooKeeperGatewayListProviderUnitTests.cs
@@ -16,6 +16,19 @@ namespace UnitTests.MembershipTests
     public sealed class ZooKeeperGatewayListProviderUnitTests
     {
         [Fact]
+        public void Constructor_NullLogger_ThrowsArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new ZooKeeperGatewayListProvider(
+                    null!,
+                    CreateProviderOptions(),
+                    CreateGatewayOptions(),
+                    CreateClusterOptions()));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
         public void Constructor_NullOptions_ThrowsArgumentNullException()
         {
             var exception = Assert.Throws<ArgumentNullException>(() =>


### PR DESCRIPTION
## Problem
The ZooKeeper clustering provider had ten CA1062 findings across its membership and gateway option boundaries. Invalid inputs could fail after path composition or serialization instead of at the public boundary.

## Solution
- Validate the ten analyzer-reported inputs with exact `ArgumentNullException.ParamName` values.
- Enforce CA1062 for the complete `Orleans.Clustering.ZooKeeper` project.
- Add service-independent tests covering synchronous null contracts, literal ZooKeeper path composition, gateway settings, and the persisted membership JSON schema and legacy `InstanceName` compatibility.

The ZooKeeper transaction ordering, version checks, gateway filtering, connection behavior, and nullable hosting configuration delegate behavior remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11138)