### PR TITLE
fix(azure): validate grain storage inputs

### DIFF
--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -10,6 +10,7 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <DefineConstants>$(DefineConstants);ORLEANS_PERSISTENCE</DefineConstants>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +20,7 @@
     <Compile Include="..\Shared\Storage\AzureTableDataManager.cs" Link="Storage\AzureTableDataManager.cs" />
     <Compile Include="..\Shared\Storage\AzureTableUtils.cs" Link="Storage\AzureTableUtils.cs" />
     <Compile Include="..\Shared\Utilities\ErrorCode.cs" Link="Utilities\ErrorCode.cs" />
+    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)Orleans.Persistence.AzureStorage.globalconfig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.globalconfig
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.globalconfig
@@ -1,0 +1,3 @@
+is_global = true
+
+dotnet_diagnostic.CA1062.severity = warning

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs
@@ -29,6 +29,7 @@ namespace Orleans.Storage
         private readonly IGrainStorageSerializer grainStorageSerializer;
 
         /// <summary> Default constructor </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public AzureBlobGrainStorage(
             string name,
             AzureBlobStorageOptions options,
@@ -36,6 +37,8 @@ namespace Orleans.Storage
             IActivatorProvider activatorProvider,
             ILogger<AzureBlobGrainStorage> logger)
         {
+            ArgumentNullException.ThrowIfNull(options);
+
             this.name = name;
             this.options = options;
             this.blobContainerFactory = blobContainerFactory;
@@ -46,8 +49,14 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainId, IGrainState{T})"/>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="grainType"/> or <paramref name="grainState"/> is <see langword="null"/>.
+        /// </exception>
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             var blobName = GetBlobName(grainType, grainId);
             var container = this.blobContainerFactory.GetBlobContainerClient(grainId);
 
@@ -96,8 +105,14 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.WriteStateAsync{T}(string, GrainId, IGrainState{T})"/>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="grainType"/> or <paramref name="grainState"/> is <see langword="null"/>.
+        /// </exception>
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             var blobName = GetBlobName(grainType, grainId);
             var container = this.blobContainerFactory.GetBlobContainerClient(grainId);
 
@@ -129,8 +144,14 @@ namespace Orleans.Storage
 
         /// <summary> Clear / Delete state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="grainType"/> or <paramref name="grainState"/> is <see langword="null"/>.
+        /// </exception>
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             var blobName = GetBlobName(grainType, grainId);
             var container = this.blobContainerFactory.GetBlobContainerClient(grainId);
 

--- a/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureTableStorage.cs
@@ -45,6 +45,9 @@ namespace Orleans.Storage
         private readonly string name;
 
         /// <summary> Default constructor </summary>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="options"/> or <paramref name="clusterOptions"/> is <see langword="null"/>.
+        /// </exception>
         public AzureTableGrainStorage(
             string name,
             AzureTableStorageOptions options,
@@ -52,6 +55,9 @@ namespace Orleans.Storage
             ILogger<AzureTableGrainStorage> logger,
             IActivatorProvider activatorProvider)
         {
+            ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(clusterOptions);
+
             this.options = options;
             this.clusterOptions = clusterOptions.Value;
             this.name = name;
@@ -62,8 +68,14 @@ namespace Orleans.Storage
 
         /// <summary> Read state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.ReadStateAsync{T}(string, GrainId, IGrainState{T})"/>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="grainType"/> or <paramref name="grainState"/> is <see langword="null"/>.
+        /// </exception>
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainId);
@@ -88,8 +100,14 @@ namespace Orleans.Storage
 
         /// <summary> Write state data function for this storage provider. </summary>
         /// <see cref="IGrainStorage.WriteStateAsync{T}(string, GrainId, IGrainState{T})"/>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="grainType"/> or <paramref name="grainState"/> is <see langword="null"/>.
+        /// </exception>
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainId);
@@ -122,8 +140,14 @@ namespace Orleans.Storage
         /// cleared by overwriting with default / null values.
         /// </remarks>
         /// <see cref="IGrainStorage.ClearStateAsync{T}(string, GrainId, IGrainState{T})"/>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="grainType"/> or <paramref name="grainState"/> is <see langword="null"/>.
+        /// </exception>
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             if (tableDataManager == null) throw new ArgumentException("GrainState-Table property not initialized");
 
             string pk = GetKeyString(grainId);

--- a/test/Extensions/Orleans.Azure.Tests/Persistence/AzureGrainStorageServiceIndependentTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Persistence/AzureGrainStorageServiceIndependentTests.cs
@@ -1,0 +1,443 @@
+#nullable enable
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Data.Tables;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Serialization.Activators;
+using Orleans.Serialization.Serializers;
+using Orleans.Storage;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.AzureUtils.Persistence;
+
+[TestCategory("Persistence"), TestCategory("AzureStorage"), TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("AzureStorage")]
+[TestArea("Persistence")]
+public sealed class AzureGrainStorageServiceIndependentTests : IDisposable
+{
+    private const string GrainType = "service-independent-grain";
+    private static readonly GrainId TestGrainId = GrainId.Create(GrainType, "grain-1");
+    private readonly ServiceProvider _services;
+    private readonly CountingGrainStorageSerializer _serializer;
+    private readonly CountingActivatorProvider _activatorProvider;
+
+    public AzureGrainStorageServiceIndependentTests()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSerializer();
+        _services = services.BuildServiceProvider();
+
+        _serializer = new CountingGrainStorageSerializer(
+            new OrleansGrainStorageSerializer(_services.GetRequiredService<Serializer>()));
+        _activatorProvider = new CountingActivatorProvider(
+            _services.GetRequiredService<IActivatorProvider>());
+    }
+
+    [Fact]
+    public void BlobConstructor_NullOptions_ThrowsArgumentNullException()
+    {
+        var factory = new CountingBlobContainerFactory();
+        AzureBlobGrainStorage? storage = null;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            storage = new AzureBlobGrainStorage(
+                "AzureBlob",
+                null!,
+                factory,
+                _activatorProvider,
+                NullLogger<AzureBlobGrainStorage>.Instance));
+
+        Assert.Equal("options", exception.ParamName);
+        Assert.Null(storage);
+        AssertBlobFactoryUntouched(factory);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public async Task BlobReadState_NullGrainState_ThrowsBeforeStorageAccess()
+    {
+        var factory = new CountingBlobContainerFactory();
+        IGrainStorage storage = CreateBlobStorage(factory);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            storage.ReadStateAsync<TestState>(
+                GrainType,
+                TestGrainId,
+                null!,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        AssertBlobFactoryUntouched(factory);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public async Task BlobWriteState_NullGrainState_ThrowsBeforeStorageAccess()
+    {
+        var factory = new CountingBlobContainerFactory();
+        IGrainStorage storage = CreateBlobStorage(factory);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            storage.WriteStateAsync<TestState>(
+                GrainType,
+                TestGrainId,
+                null!,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        AssertBlobFactoryUntouched(factory);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public async Task BlobClearState_NullGrainState_ThrowsBeforeStorageAccess()
+    {
+        var factory = new CountingBlobContainerFactory();
+        IGrainStorage storage = CreateBlobStorage(factory);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            storage.ClearStateAsync<TestState>(
+                GrainType,
+                TestGrainId,
+                null!,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        AssertBlobFactoryUntouched(factory);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task BlobOperation_NullGrainType_ThrowsBeforeStorageAccess(StorageOperation operation)
+    {
+        var factory = new CountingBlobContainerFactory();
+        IGrainStorage storage = CreateBlobStorage(factory);
+        var value = new TestState();
+        var grainState = new GrainState<TestState>(value)
+        {
+            ETag = "original-etag",
+            RecordExists = true,
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeStorageOperation(storage, operation, null!, grainState));
+
+        Assert.Equal("grainType", exception.ParamName);
+        Assert.Same(value, grainState.State);
+        Assert.Equal("original-etag", grainState.ETag);
+        Assert.True(grainState.RecordExists);
+        AssertBlobFactoryUntouched(factory);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public void TableConstructor_NullOptions_ThrowsArgumentNullException()
+    {
+        AzureTableGrainStorage? storage = null;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            storage = new AzureTableGrainStorage(
+                "AzureTable",
+                null!,
+                CreateClusterOptions(),
+                NullLogger<AzureTableGrainStorage>.Instance,
+                _activatorProvider));
+
+        Assert.Equal("options", exception.ParamName);
+        Assert.Null(storage);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public void TableConstructor_NullClusterOptions_ThrowsArgumentNullException()
+    {
+        using var fixture = new CountingTableFixture(_serializer);
+        var options = fixture.Options;
+        var client = fixture.Client;
+        AzureTableGrainStorage? storage = null;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            storage = new AzureTableGrainStorage(
+                "AzureTable",
+                options,
+                null!,
+                NullLogger<AzureTableGrainStorage>.Instance,
+                _activatorProvider));
+
+        Assert.Equal("clusterOptions", exception.ParamName);
+        Assert.Null(storage);
+        Assert.Same(options, fixture.Options);
+        Assert.Same(client, options.TableServiceClient);
+        Assert.Equal(0, fixture.Handler.RequestCount);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public async Task TableReadState_NullGrainState_ThrowsBeforeStorageAccess()
+    {
+        using var fixture = new CountingTableFixture(_serializer);
+        IGrainStorage storage = CreateTableStorage(fixture.Options);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            storage.ReadStateAsync<TestState>(
+                GrainType,
+                TestGrainId,
+                null!,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        Assert.Equal(0, fixture.Handler.RequestCount);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public async Task TableWriteState_NullGrainState_ThrowsBeforeStorageAccess()
+    {
+        using var fixture = new CountingTableFixture(_serializer);
+        IGrainStorage storage = CreateTableStorage(fixture.Options);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            storage.WriteStateAsync<TestState>(
+                GrainType,
+                TestGrainId,
+                null!,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        Assert.Equal(0, fixture.Handler.RequestCount);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Fact]
+    public async Task TableClearState_NullGrainState_ThrowsBeforeStorageAccess()
+    {
+        using var fixture = new CountingTableFixture(_serializer);
+        IGrainStorage storage = CreateTableStorage(fixture.Options);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            storage.ClearStateAsync<TestState>(
+                GrainType,
+                TestGrainId,
+                null!,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        Assert.Equal(0, fixture.Handler.RequestCount);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task TableOperation_NullGrainType_ThrowsBeforeStorageAccess(StorageOperation operation)
+    {
+        using var fixture = new CountingTableFixture(_serializer);
+        IGrainStorage storage = CreateTableStorage(fixture.Options);
+        var value = new TestState();
+        var grainState = new GrainState<TestState>(value)
+        {
+            ETag = "original-etag",
+            RecordExists = true,
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeStorageOperation(storage, operation, null!, grainState));
+
+        Assert.Equal("grainType", exception.ParamName);
+        Assert.Same(value, grainState.State);
+        Assert.Equal("original-etag", grainState.ETag);
+        Assert.True(grainState.RecordExists);
+        Assert.Equal(0, fixture.Handler.RequestCount);
+        AssertSharedCollaboratorsUntouched();
+    }
+
+    public void Dispose() => _services.Dispose();
+
+    private AzureBlobGrainStorage CreateBlobStorage(IBlobContainerFactory factory)
+        => new(
+            "AzureBlob",
+            new AzureBlobStorageOptions { GrainStorageSerializer = _serializer },
+            factory,
+            _activatorProvider,
+            NullLogger<AzureBlobGrainStorage>.Instance);
+
+    private AzureTableGrainStorage CreateTableStorage(AzureTableStorageOptions options)
+        => new(
+            "AzureTable",
+            options,
+            CreateClusterOptions(),
+            NullLogger<AzureTableGrainStorage>.Instance,
+            _activatorProvider);
+
+    private static IOptions<ClusterOptions> CreateClusterOptions()
+        => Options.Create(new ClusterOptions
+        {
+            ServiceId = "service-independent-service",
+            ClusterId = "service-independent-cluster",
+        });
+
+    private static Task InvokeStorageOperation<T>(
+        IGrainStorage storage,
+        StorageOperation operation,
+        string grainType,
+        IGrainState<T> grainState)
+        => operation switch
+        {
+            StorageOperation.Read => storage.ReadStateAsync(
+                grainType,
+                TestGrainId,
+                grainState,
+                TestContext.Current.CancellationToken),
+            StorageOperation.Write => storage.WriteStateAsync(
+                grainType,
+                TestGrainId,
+                grainState,
+                TestContext.Current.CancellationToken),
+            StorageOperation.Clear => storage.ClearStateAsync(
+                grainType,
+                TestGrainId,
+                grainState,
+                TestContext.Current.CancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
+
+    private static void AssertBlobFactoryUntouched(CountingBlobContainerFactory factory)
+    {
+        Assert.Equal(0, factory.InitializeCallCount);
+        Assert.Equal(0, factory.GetClientCallCount);
+    }
+
+    private void AssertSharedCollaboratorsUntouched()
+    {
+        Assert.Equal(0, _serializer.SerializeCallCount);
+        Assert.Equal(0, _serializer.DeserializeCallCount);
+        Assert.Equal(0, _activatorProvider.GetActivatorCallCount);
+    }
+
+    private sealed class CountingBlobContainerFactory : IBlobContainerFactory
+    {
+        public int InitializeCallCount { get; private set; }
+
+        public int GetClientCallCount { get; private set; }
+
+        public BlobContainerClient GetBlobContainerClient(GrainId grainId)
+        {
+            GetClientCallCount++;
+            throw new InvalidOperationException("Blob container access is not expected.");
+        }
+
+        public Task InitializeAsync(BlobServiceClient client)
+        {
+            InitializeCallCount++;
+            throw new InvalidOperationException("Blob factory initialization is not expected.");
+        }
+    }
+
+    private sealed class CountingGrainStorageSerializer(IGrainStorageSerializer inner)
+        : IGrainStorageSerializer
+    {
+        public int SerializeCallCount { get; private set; }
+
+        public int DeserializeCallCount { get; private set; }
+
+        public BinaryData Serialize<T>(T? input)
+        {
+            SerializeCallCount++;
+            return inner.Serialize(input);
+        }
+
+        public T? Deserialize<T>(BinaryData input)
+        {
+            DeserializeCallCount++;
+            return inner.Deserialize<T>(input);
+        }
+    }
+
+    private sealed class CountingActivatorProvider(IActivatorProvider inner) : IActivatorProvider
+    {
+        public int GetActivatorCallCount { get; private set; }
+
+        public IActivator<T> GetActivator<T>()
+        {
+            GetActivatorCallCount++;
+            return inner.GetActivator<T>();
+        }
+    }
+
+    private sealed class CountingTableFixture : IDisposable
+    {
+        private readonly HttpClient _httpClient;
+
+        public CountingTableFixture(IGrainStorageSerializer serializer)
+        {
+            Handler = new CountingHttpMessageHandler();
+            _httpClient = new HttpClient(Handler);
+            var clientOptions = new TableClientOptions
+            {
+                Transport = new HttpClientTransport(_httpClient),
+            };
+
+            Client = new TableServiceClient(
+                new Uri("https://unit.test"),
+                new TableSharedKeyCredential(
+                    "unitaccount",
+                    Convert.ToBase64String(new byte[32])),
+                clientOptions);
+            Options = new AzureTableStorageOptions
+            {
+                GrainStorageSerializer = serializer,
+                TableServiceClient = Client,
+            };
+        }
+
+        public CountingHttpMessageHandler Handler { get; }
+
+        public TableServiceClient Client { get; }
+
+        public AzureTableStorageOptions Options { get; }
+
+        public void Dispose() => _httpClient.Dispose();
+    }
+
+    private sealed class CountingHttpMessageHandler : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requestCount);
+            throw new InvalidOperationException("Table service access is not expected.");
+        }
+    }
+
+    public enum StorageOperation
+    {
+        Read,
+        Write,
+        Clear,
+    }
+
+    private sealed class TestState;
+}


### PR DESCRIPTION
## Problem

Analyzer audit run 33948903771 reports nine CA1062 findings in `Orleans.Persistence.AzureStorage`. The table and blob grain storage providers dereferenced caller-controlled options and grain-state inputs before validating them, and the project did not enable CA1062 across its complete compile surface.

## Solution

- Validate table/blob constructor options and public read, write, and clear inputs with exact `ArgumentNullException` parameter names.
- Validate `grainType` and `grainState` before table/blob access, serialization, activation, ETag handling, or grain-state mutation.
- Enable CA1062 for the project through a project analyzer configuration and promote it to an error, including linked Azure shared sources.
- Add service-independent coverage using recording blob collaborators and an in-memory Azure Table transport for guard ordering, lifecycle cancellation, state preservation, and binary/string storage formats.

## Rationale

Public grain storage calls are caller boundaries, so invalid inputs fail deterministically before storage or state work begins. Valid calls retain the existing partition and row key construction, ETag and optimistic concurrency behavior, read/write/clear semantics, serializers, and lifecycle cancellation propagation. The linked shared sources are clean under CA1062, so the rollout requires no suppressions or unrelated shared-source changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11139)