### PR TITLE
fix(serialization): validate test kit inputs

### DIFF
--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -24,7 +24,8 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Initializes a new <see cref="CopierTester{TValue, TCopier}"/> instance.
         /// </summary>
-        protected CopierTester(ITestOutputHelper output) : base(output)
+        /// <exception cref="ArgumentNullException"><paramref name="output"/> is <see langword="null"/>.</exception>
+        protected CopierTester(ITestOutputHelper output) : base(output ?? throw new ArgumentNullException(nameof(output)))
         {
             output.WriteLine($"Random seed: {RandomSeed}");
             _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();
@@ -33,7 +34,8 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Initializes a new <see cref="CopierTester{TValue, TCopier}"/> instance.
         /// </summary>
-        protected CopierTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
+        /// <exception cref="ArgumentNullException"><paramref name="output"/> or <paramref name="fixture"/> is <see langword="null"/>.</exception>
+        protected CopierTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output ?? throw new ArgumentNullException(nameof(output)), fixture)
         {
             output.WriteLine($"Random seed: {RandomSeed}");
             _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -32,7 +32,8 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldCodecTester{TValue, TCodec}"/> class.
         /// </summary>
-        protected FieldCodecTester(ITestOutputHelper output) : base(output)
+        /// <exception cref="ArgumentNullException"><paramref name="output"/> is <see langword="null"/>.</exception>
+        protected FieldCodecTester(ITestOutputHelper output) : base(output ?? throw new ArgumentNullException(nameof(output)))
         {
             output.WriteLine($"Random seed: {RandomSeed}");
             _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();
@@ -41,7 +42,8 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldCodecTester{TValue, TCodec}"/> class.
         /// </summary>
-        protected FieldCodecTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
+        /// <exception cref="ArgumentNullException"><paramref name="output"/> or <paramref name="fixture"/> is <see langword="null"/>.</exception>
+        protected FieldCodecTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output ?? throw new ArgumentNullException(nameof(output)), fixture)
         {
             output.WriteLine($"Random seed: {RandomSeed}");
             _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();

--- a/src/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.csproj
+++ b/src/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.csproj
@@ -7,6 +7,7 @@
     <PackageDescription>Test kit for projects using Orleans.Serialization</PackageDescription>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <IsTestProject>false</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Serialization.TestKit/ReadOnlySequenceHelper.cs
+++ b/src/Orleans.Serialization.TestKit/ReadOnlySequenceHelper.cs
@@ -18,23 +18,34 @@ namespace Orleans.Serialization.TestKit
         /// <param name="sequence">The sequence to divide into batches.</param>
         /// <param name="batchSize">The maximum number of bytes in each batch.</param>
         /// <returns>A sequence of byte arrays containing the source bytes in order.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="sequence"/> is <see langword="null"/>.</exception>
         public static IEnumerable<byte[]> Batch(this IEnumerable<byte> sequence, int batchSize)
         {
-            var batch = new List<byte>(batchSize);
-            foreach (var item in sequence)
+            if (sequence is null)
             {
-                batch.Add(item);
-
-                if (batch.Count >= batchSize)
-                {
-                    yield return batch.ToArray();
-                    batch = new List<byte>(batchSize);
-                }
+                throw new ArgumentNullException(nameof(sequence));
             }
 
-            if (batch.Count > 0)
+            return BatchCore(sequence, batchSize);
+
+            static IEnumerable<byte[]> BatchCore(IEnumerable<byte> sequence, int batchSize)
             {
-                yield return batch.ToArray();
+                var batch = new List<byte>(batchSize);
+                foreach (var item in sequence)
+                {
+                    batch.Add(item);
+
+                    if (batch.Count >= batchSize)
+                    {
+                        yield return batch.ToArray();
+                        batch = new List<byte>(batchSize);
+                    }
+                }
+
+                if (batch.Count > 0)
+                {
+                    yield return batch.ToArray();
+                }
             }
         }
 
@@ -43,22 +54,46 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         /// <param name="buffers">The buffers to include as sequence segments.</param>
         /// <returns>A read-only sequence containing the provided buffers in order.</returns>
-        public static ReadOnlySequence<byte> ToReadOnlySequence(this IEnumerable<byte[]> buffers) => CreateReadOnlySequence(buffers.ToArray());
+        /// <exception cref="ArgumentNullException"><paramref name="buffers"/> is <see langword="null"/>.</exception>
+        public static ReadOnlySequence<byte> ToReadOnlySequence(this IEnumerable<byte[]> buffers)
+        {
+            if (buffers is null)
+            {
+                throw new ArgumentNullException(nameof(buffers));
+            }
+
+            return CreateReadOnlySequence(buffers.ToArray());
+        }
 
         /// <summary>
         /// Creates a read-only sequence whose segments are backed by the provided memory regions.
         /// </summary>
         /// <param name="buffers">The memory regions to include as sequence segments.</param>
         /// <returns>A read-only sequence containing the provided memory regions in order.</returns>
-        public static ReadOnlySequence<byte> ToReadOnlySequence(this IEnumerable<Memory<byte>> buffers) => ReadOnlyBufferSegment.Create(buffers);
+        /// <exception cref="ArgumentNullException"><paramref name="buffers"/> is <see langword="null"/>.</exception>
+        public static ReadOnlySequence<byte> ToReadOnlySequence(this IEnumerable<Memory<byte>> buffers)
+        {
+            if (buffers is null)
+            {
+                throw new ArgumentNullException(nameof(buffers));
+            }
+
+            return ReadOnlyBufferSegment.Create(buffers);
+        }
 
         /// <summary>
         /// Creates a read-only sequence whose segments are backed by the provided byte arrays.
         /// </summary>
         /// <param name="buffers">The buffers to include as sequence segments.</param>
         /// <returns>A read-only sequence containing the provided buffers in order.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="buffers"/> is <see langword="null"/>.</exception>
         public static ReadOnlySequence<byte> CreateReadOnlySequence(params byte[][] buffers)
         {
+            if (buffers is null)
+            {
+                throw new ArgumentNullException(nameof(buffers));
+            }
+
             if (buffers.Length == 1)
             {
                 return new ReadOnlySequence<byte>(buffers[0]);

--- a/src/Orleans.Serialization.TestKit/SerializationTester.cs
+++ b/src/Orleans.Serialization.TestKit/SerializationTester.cs
@@ -15,9 +15,14 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Initializes a new <see cref="SerializationTester"/> instance.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="output"/> is <see langword="null"/>.</exception>
         protected SerializationTester(ITestOutputHelper output)
         {
-            _ = output;
+            if (output is null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
             RandomSeed = CreateRandomSeed();
             Random = new(RandomSeed);
             ServiceProvider = CreateServiceProvider();
@@ -27,9 +32,14 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Initializes a new <see cref="SerializationTester"/> instance.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="output"/> or <paramref name="fixture"/> is <see langword="null"/>.</exception>
         protected SerializationTester(ITestOutputHelper output, SerializationTesterFixture fixture)
         {
-            _ = output;
+            if (output is null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
             if (fixture is null)
             {
                 throw new ArgumentNullException(nameof(fixture));

--- a/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.TestKit;
+using Orleans.Serialization.WireProtocol;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Serialization")]
+public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void SerializationTester_NullOutput_ThrowsWithExactParamNameWithoutCreatingServices()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new SerializationTesterHarness(null!));
+
+        Assert.Equal("output", exception.ParamName);
+        Assert.Equal(0, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
+    public void SerializationTester_NullFixture_ThrowsWithExactParamNameWithoutCreatingServices()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new SerializationTesterHarness(output, null!));
+
+        Assert.Equal("fixture", exception.ParamName);
+        Assert.Equal(0, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
+    public void FieldCodecTester_FirstConstructor_NullOutput_ThrowsWithExactParamNameWithoutInvokingDependencies()
+    {
+        var probe = new ConstructionProbe();
+        FieldCodecTesterHarness<object>.Probe = probe;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new FieldCodecTesterHarness<object>(null!));
+
+        Assert.Equal("output", exception.ParamName);
+        AssertNoFieldCodecDependenciesWereInvoked(probe);
+    }
+
+    [Fact]
+    public void FieldCodecTester_FixtureConstructor_NullOutput_ThrowsWithExactParamNameWithoutInvokingDependencies()
+    {
+        var probe = new ConstructionProbe();
+        FieldCodecTesterHarness<object>.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new FieldCodecTesterHarness<object>(null!, fixture));
+
+        Assert.Equal("output", exception.ParamName);
+        AssertNoFieldCodecDependenciesWereInvoked(probe);
+    }
+
+    [Fact]
+    public void FieldCodecTester_FixtureConstructor_NullFixture_ThrowsWithExactParamNameWithoutInvokingDependencies()
+    {
+        var probe = new ConstructionProbe();
+        FieldCodecTesterHarness<object>.Probe = probe;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new FieldCodecTesterHarness<object>(output, null!));
+
+        Assert.Equal("fixture", exception.ParamName);
+        AssertNoFieldCodecDependenciesWereInvoked(probe);
+    }
+
+    [Fact]
+    public void CopierTester_FirstConstructor_NullOutput_ThrowsWithExactParamNameWithoutInvokingDependencies()
+    {
+        var probe = new ConstructionProbe();
+        CopierTesterHarness<object>.Probe = probe;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new CopierTesterHarness<object>(null!));
+
+        Assert.Equal("output", exception.ParamName);
+        AssertNoCopierDependenciesWereInvoked(probe);
+    }
+
+    [Fact]
+    public void CopierTester_FixtureConstructor_NullOutput_ThrowsWithExactParamNameWithoutInvokingDependencies()
+    {
+        var probe = new ConstructionProbe();
+        CopierTesterHarness<object>.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new CopierTesterHarness<object>(null!, fixture));
+
+        Assert.Equal("output", exception.ParamName);
+        AssertNoCopierDependenciesWereInvoked(probe);
+    }
+
+    [Fact]
+    public void CopierTester_FixtureConstructor_NullFixture_ThrowsWithExactParamNameWithoutInvokingDependencies()
+    {
+        var probe = new ConstructionProbe();
+        CopierTesterHarness<object>.Probe = probe;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new CopierTesterHarness<object>(output, null!));
+
+        Assert.Equal("fixture", exception.ParamName);
+        AssertNoCopierDependenciesWereInvoked(probe);
+    }
+
+    [Fact]
+    public void Batch_NullSequence_ThrowsWithExactParamNameAtCall()
+    {
+        IEnumerable<byte> sequence = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sequence.Batch(batchSize: 2));
+
+        Assert.Equal("sequence", exception.ParamName);
+    }
+
+    [Fact]
+    public void ToReadOnlySequence_NullByteBuffers_ThrowsWithExactParamName()
+    {
+        IEnumerable<byte[]> buffers = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => buffers.ToReadOnlySequence());
+
+        Assert.Equal("buffers", exception.ParamName);
+    }
+
+    [Fact]
+    public void ToReadOnlySequence_NullMemoryBuffers_ThrowsWithExactParamName()
+    {
+        IEnumerable<Memory<byte>> buffers = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => buffers.ToReadOnlySequence());
+
+        Assert.Equal("buffers", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateReadOnlySequence_NullBuffers_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => ReadOnlySequenceHelper.CreateReadOnlySequence((byte[][])null!));
+
+        Assert.Equal("buffers", exception.ParamName);
+    }
+
+    private static void AssertNoFieldCodecDependenciesWereInvoked(ConstructionProbe probe)
+    {
+        Assert.Equal(0, probe.ServiceProviderFactoryCount);
+        Assert.Equal(0, probe.ConfigureCount);
+        Assert.Equal(0, probe.CodecCreationCount);
+        Assert.Equal(0, probe.CodecWriteCount);
+        Assert.Equal(0, probe.CodecReadCount);
+    }
+
+    private static void AssertNoCopierDependenciesWereInvoked(ConstructionProbe probe)
+    {
+        Assert.Equal(0, probe.ServiceProviderFactoryCount);
+        Assert.Equal(0, probe.ConfigureCount);
+        Assert.Equal(0, probe.CopierCreationCount);
+        Assert.Equal(0, probe.CopyCount);
+    }
+
+    private sealed class ConstructionProbe
+    {
+        public int ServiceProviderFactoryCount { get; set; }
+
+        public int ConfigureCount { get; set; }
+
+        public int CodecCreationCount { get; set; }
+
+        public int CodecWriteCount { get; set; }
+
+        public int CodecReadCount { get; set; }
+
+        public int CopierCreationCount { get; set; }
+
+        public int CopyCount { get; set; }
+    }
+
+    private sealed class SerializationTesterHarness : SerializationTester
+    {
+        public SerializationTesterHarness(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public SerializationTesterHarness(ITestOutputHelper output, SerializationTesterFixture fixture)
+            : base(output, fixture)
+        {
+        }
+
+        public static ConstructionProbe Probe { get; set; } = null!;
+
+        protected override IServiceProvider CreateServiceProvider()
+        {
+            Probe.ServiceProviderFactoryCount++;
+            return new EmptyServiceProvider();
+        }
+    }
+
+    private sealed class FieldCodecTesterHarness<TMarker> : FieldCodecTester<int, CountingInt32Codec>
+    {
+        public FieldCodecTesterHarness(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public FieldCodecTesterHarness(ITestOutputHelper output, SerializationTesterFixture fixture)
+            : base(output, fixture)
+        {
+        }
+
+        public static ConstructionProbe Probe { get; set; } = null!;
+
+        protected override IServiceProvider CreateServiceProvider()
+        {
+            Probe.ServiceProviderFactoryCount++;
+            return base.CreateServiceProvider();
+        }
+
+        protected override void Configure(ISerializerBuilder builder) => Probe.ConfigureCount++;
+
+        protected override CountingInt32Codec CreateCodec()
+        {
+            Probe.CodecCreationCount++;
+            return new CountingInt32Codec();
+        }
+
+        protected override int CreateValue() => 42;
+
+        protected override int[] TestValues => [42];
+    }
+
+    private sealed class CopierTesterHarness<TMarker> : CopierTester<int, CountingInt32Copier>
+    {
+        public CopierTesterHarness(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public CopierTesterHarness(ITestOutputHelper output, SerializationTesterFixture fixture)
+            : base(output, fixture)
+        {
+        }
+
+        public static ConstructionProbe Probe { get; set; } = null!;
+
+        protected override IServiceProvider CreateServiceProvider()
+        {
+            Probe.ServiceProviderFactoryCount++;
+            return base.CreateServiceProvider();
+        }
+
+        protected override void Configure(ISerializerBuilder builder) => Probe.ConfigureCount++;
+
+        protected override CountingInt32Copier CreateCopier()
+        {
+            Probe.CopierCreationCount++;
+            return new CountingInt32Copier();
+        }
+
+        protected override int CreateValue() => 42;
+
+        protected override int[] TestValues => [42];
+    }
+
+    private sealed class CountingInt32Codec : IFieldCodec<int>
+    {
+        public void WriteField<TBufferWriter>(
+            ref Writer<TBufferWriter> writer,
+            uint fieldIdDelta,
+            [AllowNull] Type expectedType,
+            int value)
+            where TBufferWriter : IBufferWriter<byte>
+        {
+            FieldCodecTesterHarness<object>.Probe.CodecWriteCount++;
+            throw new InvalidOperationException("The counting codec must not be invoked during constructor validation.");
+        }
+
+        public int ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+        {
+            FieldCodecTesterHarness<object>.Probe.CodecReadCount++;
+            throw new InvalidOperationException("The counting codec must not be invoked during constructor validation.");
+        }
+    }
+
+    private sealed class CountingInt32Copier : IDeepCopier<int>
+    {
+        public int DeepCopy(int input, CopyContext context)
+        {
+            CopierTesterHarness<object>.Probe.CopyCount++;
+            throw new InvalidOperationException("The counting copier must not be invoked during constructor validation.");
+        }
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+}


### PR DESCRIPTION
The analyzer audit reported seven CA1062 findings in `Orleans.Serialization.TestKit`, covering tester output helpers and read-only sequence inputs.

Validate tester constructor inputs before serializer service creation, preserve nullable serialized values and generic/value-type behavior, and make `Batch` reject a null source at call time rather than deferred enumeration. The public sequence helper overloads now provide consistent `ArgumentNullException` parameter names.

Enable CA1062 as an error for the complete TestKit project and add focused contract tests which verify exact parameter names and prove serializer, codec, and copier dependencies are not invoked when construction is rejected.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11140)