### PR TITLE
test(runtime): synchronize forwarded cancellation

### DIFF
--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -212,6 +212,7 @@ namespace UnitTests.GrainInterfaces
         [AlwaysInterleave]
         Task LongWaitInterleavingWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken);
         Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, TimeSpan delay, Guid callId);
+        Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, CancellationToken tc, TimeSpan delay, Guid callId);
         Task CallOtherLongRunningTaskGrainCancellation(ILongRunningTaskGrain<T> target, GrainCancellationToken tc, TimeSpan delay, Guid callId);
         Task CallOtherLongRunningTaskWithLocalGrainCancellationToken(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId);
         Task CallOtherLongRunningTaskWithLocalCancellation(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId);

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -754,6 +754,11 @@ namespace UnitTests.Grains
             await target.LongWait(tc, delay, callId);
         }
 
+        public async Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, CancellationToken tc, TimeSpan delay, Guid callId)
+        {
+            await target.LongWaitWithStartNotification(delay, callId, observer, tc);
+        }
+
         public async Task CallOtherLongRunningTaskWithLocalCancellation(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId)
         {
             using var cts = new CancellationTokenSource();

--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -323,12 +323,34 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         var target = grains.Item2;
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
-        var grainTask = grain.CallOtherLongRunningTask(target, cts.Token, TimeSpan.FromSeconds(10), callId);
-        cts.CancelAfter(delay);
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
-        if (delay > 0)
+        if (delay == 0)
         {
+            var grainTask = grain.CallOtherLongRunningTask(target, cts.Token, TimeSpan.FromSeconds(10), callId);
+            cts.CancelAfter(delay);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+            return;
+        }
+
+        var observer = new LongRunningTaskObserver();
+        var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
+        try
+        {
+            var grainTask = grain.CallOtherLongRunningTaskWithStartNotification(
+                target,
+                observerReference,
+                cts.Token,
+                TimeSpan.FromSeconds(10),
+                callId);
+            await observer.WaitForCallToStart(callId);
+
+            cts.CancelAfter(delay);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
             await WaitForCallCancellation(target, callId);
+        }
+        finally
+        {
+            fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
+            GC.KeepAlive(observer);
         }
     }
 


### PR DESCRIPTION
## Problem

`CancellationTokenTests_WaitForAcknowledgement.InSiloClientCancellationTokenPassing(delay: 10)` could cancel the forwarded target request while it was still queued. Orleans legitimately removes a queued request and returns `OperationCanceledException` without invoking the target method, so the test then waited for an application-level cancellation record that could never be produced.

The race has existed since the forwarded cancellation test was introduced. The xUnit v3 migration bounded the resulting wait at five minutes but did not introduce the underlying synchronization gap.

## Solution

Forward the existing call-start observer through the intermediary grain and await its notification before scheduling positive-delay cancellation. This establishes that the target method has initialized and is running before the test expects its cancellation handler to record the call.

The zero-delay path remains unchanged so it continues to cover cancellation before request admission. Observer lifetime is retained through reference cleanup.

Fixes #10773
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11143)