### PR TITLE
fix(streaming): release Azure Queue messages during handoff

### DIFF
--- a/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Queue stream implementation
 description: Understand the Orleans Azure Queue adapter, receiver acknowledgement, queue mapping, and configuration surfaces.
-ms.date: 08/18/2026
+ms.date: 09/05/2026
 ms.topic: concept-article
 ---
 
@@ -46,7 +46,9 @@ sequenceDiagram
     Receiver->>Queue: Delete with pop receipt
 ```
 
-If the receiver, agent, or silo fails before delete, the visibility timeout eventually expires and Azure can return the message again. Consumers must tolerate redelivery. If visibility expires while a message is still being processed, delete can fail because the pop receipt is no longer current.
+During graceful queue ownership transfer, the previous receiver uses the [Update Message operation](https://learn.microsoft.com/rest/api/storageservices/update-message) to make every prefetched, unacknowledged message visible immediately. The replacement receiver can therefore resume delivery without waiting for the visibility timeout. Credentials must authorize that operation; a queue service SAS includes the `u` permission. When an update fails, Orleans logs the release failure and Azure makes the message available when its existing visibility lease expires.
+
+If the receiver, agent, or silo fails before this handoff completes, the visibility timeout eventually expires and Azure can return the message again. Consumers must tolerate redelivery. If visibility expires while a message is still being processed, delete can fail because the pop receipt is no longer current.
 
 Source: [`AzureQueueAdapterReceiver`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs).
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Orleans.Azure.Tests" />
     <InternalsVisibleTo Include="Orleans.Runtime.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -163,9 +163,12 @@ namespace Orleans.Providers.Streams.AzureQueue
                         pendingDeliveries.Clear();
                     }
 
-                    foreach (var delivery in pendingDeliveries)
+                    if (pendingDeliveries.Count > 0)
                     {
-                        pending.RemoveAll(item => string.Equals(item.Message.MessageId, delivery.Message.MessageId, StringComparison.Ordinal));
+                        var messageIds = pendingDeliveries
+                            .Select(static item => item.Message.MessageId)
+                            .ToHashSet(StringComparer.Ordinal);
+                        pending.RemoveAll(item => messageIds.Contains(item.Message.MessageId));
                     }
 
                     pending.AddRange(pendingDeliveries);

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -289,11 +289,23 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         private async Task ConfirmMessagesDeliveredAsync(IAzureQueueDataManager queueRef, HashSet<PendingDelivery> delivered)
         {
-            await Task.WhenAll(delivered.Select(item => queueRef.DeleteQueueMessage(item.Message)));
-
-            lock (pendingLock)
+            var deletions = delivered.ToDictionary(
+                static item => item,
+                async item => await queueRef.DeleteQueueMessage(item.Message));
+            try
             {
-                pending.RemoveAll(delivered.Contains);
+                await Task.WhenAll(deletions.Values);
+            }
+            finally
+            {
+                var confirmed = deletions
+                    .Where(static item => item.Value.IsCompletedSuccessfully)
+                    .Select(static item => item.Key)
+                    .ToHashSet();
+                lock (pendingLock)
+                {
+                    pending.RemoveAll(confirmed.Contains);
+                }
             }
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -25,6 +25,7 @@ namespace Orleans.Providers.Streams.AzureQueue
         private readonly object pendingLock = new();
         private int activeOperations;
         private TaskCompletionSource? operationsCompleted;
+        private bool shutdownCompleted;
 
         private readonly string azureQueueName;
 
@@ -116,6 +117,7 @@ namespace Orleans.Providers.Streams.AzureQueue
                 lock (pendingLock)
                 {
                     pending.Clear();
+                    shutdownCompleted = true;
                 }
             }
         }
@@ -152,9 +154,11 @@ namespace Orleans.Providers.Streams.AzureQueue
                     pendingDeliveries.Add(new PendingDelivery(container, message));
                 }
 
+                var shutdownStarted = false;
                 lock (pendingLock)
                 {
-                    if (!ReferenceEquals(queue, queueRef))
+                    shutdownStarted = !ReferenceEquals(queue, queueRef);
+                    if (shutdownStarted && shutdownCompleted)
                     {
                         pendingDeliveries.Clear();
                     }
@@ -167,17 +171,8 @@ namespace Orleans.Providers.Streams.AzureQueue
                     pending.AddRange(pendingDeliveries);
                 }
 
-                if (pendingDeliveries.Count == 0 && messages.Length > 0)
+                if (shutdownStarted)
                 {
-                    try
-                    {
-                        await ReleaseMessagesAsync(queueRef, messages, CancellationToken.None);
-                    }
-                    catch (Exception exception)
-                    {
-                        LogWarningReleaseQueueMessage(exception, azureQueueName, messages.Length);
-                    }
-
                     return Array.Empty<IBatchContainer>();
                 }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs
@@ -16,12 +16,15 @@ namespace Orleans.Providers.Streams.AzureQueue
     /// </summary>
     internal partial class AzureQueueAdapterReceiver : IQueueAdapterReceiver
     {
-        private AzureQueueDataManager? queue;
+        private const int MaxConcurrentReleases = 32;
+        private IAzureQueueDataManager? queue;
         private long lastReadMessage;
-        private Task? outstandingTask;
         private readonly ILogger logger;
         private readonly IQueueDataAdapter<string, IBatchContainer> dataAdapter;
         private readonly List<PendingDelivery> pending;
+        private readonly object pendingLock = new();
+        private int activeOperations;
+        private TaskCompletionSource? operationsCompleted;
 
         private readonly string azureQueueName;
 
@@ -35,7 +38,7 @@ namespace Orleans.Providers.Streams.AzureQueue
             return new AzureQueueAdapterReceiver(azureQueueName, loggerFactory, queue, dataAdapter);
         }
 
-        private AzureQueueAdapterReceiver(string azureQueueName, ILoggerFactory loggerFactory, AzureQueueDataManager queue, IQueueDataAdapter<string, IBatchContainer> dataAdapter)
+        internal AzureQueueAdapterReceiver(string azureQueueName, ILoggerFactory loggerFactory, IAzureQueueDataManager queue, IQueueDataAdapter<string, IBatchContainer> dataAdapter)
         {
             this.azureQueueName = azureQueueName ?? throw new ArgumentNullException(nameof(azureQueueName));
             this.queue = queue ?? throw new ArgumentNullException(nameof(queue));
@@ -55,79 +58,166 @@ namespace Orleans.Providers.Streams.AzureQueue
 
         public async Task Shutdown(TimeSpan timeout)
         {
+            using var timeoutCancellation = new CancellationTokenSource(timeout);
+            IAzureQueueDataManager? queueRef;
+            Task? pendingOperations;
+
+            lock (pendingLock)
+            {
+                queueRef = queue;
+                queue = null;
+                pendingOperations = operationsCompleted?.Task;
+            }
+
             try
             {
-                // await the last storage operation, so after we shutdown and stop this receiver we don't get async operation completions from pending storage operations.
-                if (outstandingTask != null)
-                    await outstandingTask;
+                if (pendingOperations != null)
+                {
+                    try
+                    {
+                        await pendingOperations.WaitAsync(timeoutCancellation.Token);
+                    }
+                    catch (OperationCanceledException exception) when (timeoutCancellation.IsCancellationRequested)
+                    {
+                        LogWarningPendingOperationException(exception, azureQueueName);
+                    }
+                    catch (Exception exception)
+                    {
+                        LogWarningPendingOperationException(exception, azureQueueName);
+                    }
+                }
+
+                QueueMessage[] pendingMessages;
+                lock (pendingLock)
+                {
+                    pendingMessages = pending.Select(static item => item.Message).ToArray();
+                }
+
+                if (queueRef is not null && pendingMessages.Length > 0)
+                {
+                    var releaseTask = ReleaseMessagesAsync(queueRef, pendingMessages, timeoutCancellation.Token);
+                    try
+                    {
+                        await releaseTask.WaitAsync(timeoutCancellation.Token);
+                    }
+                    catch (OperationCanceledException exception) when (timeoutCancellation.IsCancellationRequested)
+                    {
+                        releaseTask.Ignore();
+                        LogWarningReleaseQueueMessage(exception, azureQueueName, pendingMessages.Length);
+                    }
+                    catch (Exception exception)
+                    {
+                        LogWarningReleaseQueueMessage(exception, azureQueueName, pendingMessages.Length);
+                    }
+                }
             }
             finally
             {
-                // remember that we shut down so we never try to read from the queue again.
-                queue = null;
+                lock (pendingLock)
+                {
+                    pending.Clear();
+                }
             }
         }
 
         public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
         {
+            IAzureQueueDataManager? queueRef;
+            lock (pendingLock)
+            {
+                queueRef = queue;
+                if (queueRef is null)
+                {
+                    return Array.Empty<IBatchContainer>();
+                }
+
+                BeginOperation();
+            }
+
             const int MaxNumberOfMessagesToPeek = 32;
 
             try
             {
-                var queueRef = queue; // store direct ref, in case we are somehow asked to shutdown while we are receiving.
-                if (queueRef == null) return new List<IBatchContainer>();
-
                 int count = maxCount < 0 || maxCount == QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG ?
                     MaxNumberOfMessagesToPeek : Math.Min(maxCount, MaxNumberOfMessagesToPeek);
 
-                var task = queueRef.GetQueueMessages(count);
-                outstandingTask = task;
-                IEnumerable<QueueMessage> messages = await task;
+                var messages = (await queueRef.GetQueueMessages(count)).ToArray();
 
                 List<IBatchContainer> azureQueueMessages = new List<IBatchContainer>();
+                List<PendingDelivery> pendingDeliveries = new List<PendingDelivery>();
                 foreach (var message in messages)
                 {
                     IBatchContainer container = this.dataAdapter.FromQueueMessage(message.MessageText, lastReadMessage++);
                     azureQueueMessages.Add(container);
-                    this.pending.Add(new PendingDelivery(container.SequenceToken, message));
+                    pendingDeliveries.Add(new PendingDelivery(container, message));
+                }
+
+                lock (pendingLock)
+                {
+                    if (!ReferenceEquals(queue, queueRef))
+                    {
+                        pendingDeliveries.Clear();
+                    }
+
+                    foreach (var delivery in pendingDeliveries)
+                    {
+                        pending.RemoveAll(item => string.Equals(item.Message.MessageId, delivery.Message.MessageId, StringComparison.Ordinal));
+                    }
+
+                    pending.AddRange(pendingDeliveries);
+                }
+
+                if (pendingDeliveries.Count == 0 && messages.Length > 0)
+                {
+                    try
+                    {
+                        await ReleaseMessagesAsync(queueRef, messages, CancellationToken.None);
+                    }
+                    catch (Exception exception)
+                    {
+                        LogWarningReleaseQueueMessage(exception, azureQueueName, messages.Length);
+                    }
+
+                    return Array.Empty<IBatchContainer>();
                 }
 
                 return azureQueueMessages;
             }
             finally
             {
-                outstandingTask = null;
+                EndOperation();
             }
         }
 
         public async Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
         {
+            IAzureQueueDataManager? queueRef;
+            lock (pendingLock)
+            {
+                queueRef = queue;
+                if (messages.Count == 0 || queueRef is null)
+                {
+                    return;
+                }
+
+                BeginOperation();
+            }
+
             try
             {
-                var queueRef = queue; // store direct ref, in case we are somehow asked to shutdown while we are receiving.
-                if (messages.Count == 0 || queueRef == null) return;
-                // get sequence tokens of delivered messages
-                List<StreamSequenceToken> deliveredTokens = messages.Select(message => message.SequenceToken!).ToList();
-                // find oldest delivered message
-                StreamSequenceToken oldest = deliveredTokens.Max()!;
-                // finalize all pending messages at or befor the oldest
-                List<PendingDelivery> finalizedDeliveries = pending
-                    .Where(pendingDelivery => !pendingDelivery.Token.Newer(oldest))
-                    .ToList();
-                if (finalizedDeliveries.Count == 0) return;
-                // remove all finalized deliveries from pending, regardless of if it was delivered or not.
-                pending.RemoveRange(0, finalizedDeliveries.Count);
-                // get the queue messages for all finalized deliveries that were delivered.
-                List<QueueMessage> deliveredCloudQueueMessages = finalizedDeliveries
-                    .Where(finalized => deliveredTokens.Contains(finalized.Token))
-                    .Select(finalized => finalized.Message)
-                    .ToList();
-                if (deliveredCloudQueueMessages.Count == 0) return;
-                // delete all delivered queue messages from the queue.  Anything finalized but not delivered will show back up later
-                outstandingTask = Task.WhenAll(deliveredCloudQueueMessages.Select(queueRef.DeleteQueueMessage));
+                HashSet<PendingDelivery> delivered;
+                lock (pendingLock)
+                {
+                    delivered = messages
+                        .Select(message => pending.Find(item => ReferenceEquals(item.Batch, message)))
+                        .OfType<PendingDelivery>()
+                        .ToHashSet();
+                }
+                if (delivered.Count == 0) return;
+
                 try
                 {
-                    await outstandingTask;
+                    await ConfirmMessagesDeliveredAsync(queueRef, delivered);
                 }
                 catch (Exception exc)
                 {
@@ -136,7 +226,76 @@ namespace Orleans.Providers.Streams.AzureQueue
             }
             finally
             {
-                outstandingTask = null;
+                EndOperation();
+            }
+        }
+
+        private void BeginOperation()
+        {
+            if (activeOperations++ == 0)
+            {
+                operationsCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        private void EndOperation()
+        {
+            TaskCompletionSource? completed = null;
+            lock (pendingLock)
+            {
+                if (--activeOperations == 0)
+                {
+                    completed = operationsCompleted;
+                    operationsCompleted = null;
+                }
+            }
+
+            completed?.TrySetResult();
+        }
+
+        private static async Task ReleaseMessagesAsync(
+            IAzureQueueDataManager queueRef,
+            IEnumerable<QueueMessage> messages,
+            CancellationToken cancellationToken)
+        {
+            List<Exception>? failures = null;
+            foreach (var batch in messages.Chunk(MaxConcurrentReleases))
+            {
+                var results = await Task.WhenAll(batch.Select(ReleaseMessage));
+                foreach (var failure in results.OfType<Exception>())
+                {
+                    (failures ??= []).Add(failure);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            if (failures is not null)
+            {
+                throw new AggregateException("One or more Azure Queue messages could not be released.", failures);
+            }
+
+            async Task<Exception?> ReleaseMessage(QueueMessage message)
+            {
+                try
+                {
+                    await queueRef.ReleaseQueueMessage(message, cancellationToken);
+                    return null;
+                }
+                catch (Exception exception)
+                {
+                    return exception;
+                }
+            }
+        }
+
+        private async Task ConfirmMessagesDeliveredAsync(IAzureQueueDataManager queueRef, HashSet<PendingDelivery> delivered)
+        {
+            await Task.WhenAll(delivered.Select(item => queueRef.DeleteQueueMessage(item.Message)));
+
+            lock (pendingLock)
+            {
+                pending.RemoveAll(delivered.Contains);
             }
         }
 
@@ -147,17 +306,31 @@ namespace Orleans.Providers.Streams.AzureQueue
         )]
         private partial void LogWarningOnDeleteQueueMessage(Exception exception, string queueName);
 
-        private class PendingDelivery
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            EventId = (int)AzureQueueErrorCode.AzureQueue_17,
+            Message = "Exception while awaiting a pending operation for Azure queue {QueueName}. Continuing shutdown cleanup."
+        )]
+        private partial void LogWarningPendingOperationException(Exception exception, string queueName);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            EventId = (int)AzureQueueErrorCode.AzureQueue_18,
+            Message = "An error occurred while releasing up to {MessageCount} pending messages for Azure queue {QueueName}."
+        )]
+        private partial void LogWarningReleaseQueueMessage(Exception exception, string queueName, int messageCount);
+
+        private sealed class PendingDelivery
         {
-            public PendingDelivery(StreamSequenceToken token, QueueMessage message)
+            public PendingDelivery(IBatchContainer batch, QueueMessage message)
             {
-                this.Token = token;
+                this.Batch = batch;
                 this.Message = message;
             }
 
-            public QueueMessage Message { get; }
+            public IBatchContainer Batch { get; }
 
-            public StreamSequenceToken Token { get; }
+            public QueueMessage Message { get; }
         }
     }
 }

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -12,6 +12,17 @@ using Orleans.Configuration;
 
 namespace Orleans.AzureUtils
 {
+    internal interface IAzureQueueDataManager
+    {
+        Task InitQueueAsync();
+
+        Task<IEnumerable<QueueMessage>> GetQueueMessages(int? count = null);
+
+        Task DeleteQueueMessage(QueueMessage message);
+
+        Task ReleaseQueueMessage(QueueMessage message, CancellationToken cancellationToken);
+    }
+
     /// <summary>
     /// How to use the Queue Storage Service: http://www.windowsazure.com/en-us/develop/net/how-to-guides/queue-service/
     /// Windows Azure Storage Abstractions and their Scalability Targets: http://blogs.msdn.com/b/windowsazurestorage/archive/2010/05/10/windows-azure-storage-abstractions-and-their-scalability-targets.aspx
@@ -44,7 +55,7 @@ namespace Orleans.AzureUtils
     /// <remarks>
     /// Used by Azure queue streaming provider.
     /// </remarks>
-    public partial class AzureQueueDataManager
+    public partial class AzureQueueDataManager : IAzureQueueDataManager
     {
         /// <summary> Name of the table queue instance is managing. </summary>
         public string QueueName { get; private set; }
@@ -322,6 +333,34 @@ namespace Orleans.AzureUtils
                 CheckAlertSlowAccess(startTime, "DeleteQueueMessage");
             }
         }
+
+        internal async Task ReleaseQueueMessage(QueueMessage message, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+
+            var startTime = DateTime.UtcNow;
+            try
+            {
+                var client = await GetQueueClient();
+                await client.UpdateMessageAsync(
+                    message.MessageId,
+                    message.PopReceipt,
+                    message.Body,
+                    TimeSpan.Zero,
+                    cancellationToken);
+            }
+            catch (Exception exc)
+            {
+                ReportErrorAndRethrow(exc, "ReleaseQueueMessage", AzureQueueErrorCode.AzureQueue_16);
+            }
+            finally
+            {
+                CheckAlertSlowAccess(startTime, "ReleaseQueueMessage");
+            }
+        }
+
+        Task IAzureQueueDataManager.ReleaseQueueMessage(QueueMessage message, CancellationToken cancellationToken) =>
+            ReleaseQueueMessage(message, cancellationToken);
 
         internal async Task GetAndDeleteQueueMessage()
         {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Utilities/AzureQueueErrorCode.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Utilities/AzureQueueErrorCode.cs
@@ -23,5 +23,8 @@ namespace Orleans.AzureUtils.Utilities
         AzureQueue_13 = AzureQueueBase + 13,
         AzureQueue_14 = AzureQueueBase + 14,
         AzureQueue_15 = AzureQueueBase + 15,
+        AzureQueue_16 = AzureQueueBase + 16,
+        AzureQueue_17 = AzureQueueBase + 17,
+        AzureQueue_18 = AzureQueueBase + 18,
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
@@ -91,7 +91,7 @@ public class AzureQueueAdapterReceiverTests
         var message = CreateMessage();
         var queue = new TestQueueDataManager(message)
         {
-            DeleteException = new InvalidOperationException("delete failed")
+            OnDelete = _ => Task.FromException(new InvalidOperationException("delete failed"))
         };
         var receiver = new AzureQueueAdapterReceiver(
             "test-queue",
@@ -108,11 +108,49 @@ public class AzureQueueAdapterReceiverTests
         Assert.Same(message, Assert.Single(queue.ReleasedMessages));
     }
 
-    private static QueueMessage CreateMessage()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PartialDeleteFailureReleasesOnlyUnconfirmedMessages(bool throwSynchronously)
+    {
+        var failed = CreateMessage("failed");
+        var confirmed = CreateMessage("confirmed");
+        var unacknowledged = CreateMessage("unacknowledged");
+        var queue = new TestQueueDataManager(failed, confirmed, unacknowledged)
+        {
+            OnDelete = message =>
+            {
+                if (!ReferenceEquals(message, failed))
+                {
+                    return Task.CompletedTask;
+                }
+
+                var exception = new InvalidOperationException("delete failed");
+                return throwSynchronously ? throw exception : Task.FromException(exception);
+            }
+        };
+        var receiver = new AzureQueueAdapterReceiver(
+            "test-queue",
+            NullLoggerFactory.Instance,
+            queue,
+            new TestQueueDataAdapter());
+        await receiver.Initialize(TimeSpan.FromSeconds(1));
+        var received = await receiver.GetQueueMessagesAsync(3);
+        Assert.Equal(3, received.Count);
+
+        await receiver.MessagesDeliveredAsync([received[0], received[1]]);
+        await receiver.MessagesDeliveredAsync([received[1]]);
+        await receiver.Shutdown(TimeSpan.FromSeconds(1));
+
+        Assert.Equal([failed, confirmed], queue.DeletedMessages);
+        Assert.Equal([failed, unacknowledged], queue.ReleasedMessages);
+    }
+
+    private static QueueMessage CreateMessage(string messageId = "message-id")
     {
         var now = DateTimeOffset.UtcNow;
         return QueuesModelFactory.QueueMessage(
-            "message-id",
+            messageId,
             "pop-receipt",
             "payload",
             dequeueCount: 1,
@@ -121,32 +159,33 @@ public class AzureQueueAdapterReceiverTests
             expiresOn: now.AddDays(1));
     }
 
-    private sealed class TestQueueDataManager(QueueMessage message) : IAzureQueueDataManager
+    private sealed class TestQueueDataManager(params QueueMessage[] messages) : IAzureQueueDataManager
     {
-        private readonly Queue<QueueMessage> _messages = new([message]);
+        private readonly Queue<QueueMessage> _messages = new(messages);
 
         public List<QueueMessage> DeletedMessages { get; } = [];
 
         public List<QueueMessage> ReleasedMessages { get; } = [];
 
-        public Exception? DeleteException { get; init; }
+        public Func<QueueMessage, Task> OnDelete { get; init; } = _ => Task.CompletedTask;
 
         public Task InitQueueAsync() => Task.CompletedTask;
 
         public Task<IEnumerable<QueueMessage>> GetQueueMessages(int? count = null)
         {
-            if (_messages.TryDequeue(out var message))
+            List<QueueMessage> result = [];
+            while (result.Count < (count ?? 1) && _messages.TryDequeue(out var message))
             {
-                return Task.FromResult<IEnumerable<QueueMessage>>([message]);
+                result.Add(message);
             }
 
-            return Task.FromResult<IEnumerable<QueueMessage>>([]);
+            return Task.FromResult<IEnumerable<QueueMessage>>(result);
         }
 
         public Task DeleteQueueMessage(QueueMessage message)
         {
             DeletedMessages.Add(message);
-            return DeleteException is null ? Task.CompletedTask : Task.FromException(DeleteException);
+            return OnDelete(message);
         }
 
         public Task ReleaseQueueMessage(QueueMessage message, CancellationToken cancellationToken)

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
@@ -65,6 +65,29 @@ public class AzureQueueAdapterReceiverTests
     }
 
     [Fact]
+    public async Task ShutdownCancelsPendingReleaseAtDeadline()
+    {
+        var message = CreateMessage();
+        var queue = new DelayedQueueDataManager(message);
+        var receiver = new AzureQueueAdapterReceiver(
+            "test-queue",
+            NullLoggerFactory.Instance,
+            queue,
+            new TestQueueDataAdapter());
+        await receiver.Initialize(TimeSpan.FromSeconds(1));
+
+        var receiveTask = receiver.GetQueueMessagesAsync(1);
+        await queue.ReceiveStarted.Task;
+        var shutdownTask = receiver.Shutdown(TimeSpan.FromMilliseconds(100));
+        queue.CompleteReceive();
+
+        await queue.ReleaseStarted.Task;
+        await shutdownTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await queue.ReleaseCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Assert.Empty(await receiveTask);
+    }
+
+    [Fact]
     public async Task DeliveredMessagesAreDeletedInsteadOfReleased()
     {
         var message = CreateMessage();
@@ -169,6 +192,9 @@ public class AzureQueueAdapterReceiverTests
         public TaskCompletionSource ReleaseStarted { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public TaskCompletionSource ReleaseCanceled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public List<QueueMessage> ReleasedMessages { get; } = [];
 
         public Task InitQueueAsync() => Task.CompletedTask;
@@ -185,7 +211,15 @@ public class AzureQueueAdapterReceiverTests
         {
             ReleasedMessages.Add(message);
             ReleaseStarted.TrySetResult();
-            await _release.Task.WaitAsync(cancellationToken);
+            try
+            {
+                await _release.Task.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                ReleaseCanceled.TrySetResult();
+                throw;
+            }
         }
 
         public void CompleteReceive() => _receive.TrySetResult([message]);

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
@@ -1,0 +1,220 @@
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.AzureUtils;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace Tester.AzureUtils.Streaming;
+
+[TestCategory("Streaming")]
+[TestSuite("BVT")]
+[TestProvider("AzureStorage")]
+[TestArea("Streaming")]
+public class AzureQueueAdapterReceiverTests
+{
+    [Fact]
+    public async Task ShutdownReleasesPendingMessagesForReplacementReceiver()
+    {
+        var message = CreateMessage();
+        var queue = new TestQueueDataManager(message);
+        var adapter = new TestQueueDataAdapter();
+
+        var receiver = new AzureQueueAdapterReceiver("test-queue", NullLoggerFactory.Instance, queue, adapter);
+        await receiver.Initialize(TimeSpan.FromSeconds(1));
+        var received = Assert.Single(await receiver.GetQueueMessagesAsync(1));
+
+        await receiver.Shutdown(TimeSpan.FromSeconds(1));
+
+        Assert.Same(message, Assert.Single(queue.ReleasedMessages));
+
+        var replacement = new AzureQueueAdapterReceiver("test-queue", NullLoggerFactory.Instance, queue, adapter);
+        await replacement.Initialize(TimeSpan.FromSeconds(1));
+        var redelivered = Assert.Single(await replacement.GetQueueMessagesAsync(1));
+
+        Assert.Equal("payload", Assert.IsType<TestBatchContainer>(received).Payload);
+        Assert.Equal("payload", Assert.IsType<TestBatchContainer>(redelivered).Payload);
+    }
+
+    [Fact]
+    public async Task ShutdownReleasesMessageReceivedAfterShutdownBegins()
+    {
+        var message = CreateMessage();
+        var queue = new DelayedQueueDataManager(message);
+        var receiver = new AzureQueueAdapterReceiver(
+            "test-queue",
+            NullLoggerFactory.Instance,
+            queue,
+            new TestQueueDataAdapter());
+        await receiver.Initialize(TimeSpan.FromSeconds(1));
+
+        var receiveTask = receiver.GetQueueMessagesAsync(1);
+        await queue.ReceiveStarted.Task;
+        var shutdownTask = receiver.Shutdown(TimeSpan.FromSeconds(1));
+        queue.CompleteReceive();
+
+        await queue.ReleaseStarted.Task;
+        Assert.False(shutdownTask.IsCompleted);
+        queue.CompleteRelease();
+
+        await Task.WhenAll(receiveTask, shutdownTask);
+        Assert.Empty(await receiveTask);
+        Assert.Same(message, Assert.Single(queue.ReleasedMessages));
+    }
+
+    [Fact]
+    public async Task DeliveredMessagesAreDeletedInsteadOfReleased()
+    {
+        var message = CreateMessage();
+        var queue = new TestQueueDataManager(message);
+        var receiver = new AzureQueueAdapterReceiver(
+            "test-queue",
+            NullLoggerFactory.Instance,
+            queue,
+            new TestQueueDataAdapter());
+        await receiver.Initialize(TimeSpan.FromSeconds(1));
+        var received = Assert.Single(await receiver.GetQueueMessagesAsync(1));
+
+        await receiver.MessagesDeliveredAsync([received]);
+        await receiver.Shutdown(TimeSpan.FromSeconds(1));
+
+        Assert.Same(message, Assert.Single(queue.DeletedMessages));
+        Assert.Empty(queue.ReleasedMessages);
+    }
+
+    [Fact]
+    public async Task DeleteFailureLeavesMessagePendingForShutdownRelease()
+    {
+        var message = CreateMessage();
+        var queue = new TestQueueDataManager(message)
+        {
+            DeleteException = new InvalidOperationException("delete failed")
+        };
+        var receiver = new AzureQueueAdapterReceiver(
+            "test-queue",
+            NullLoggerFactory.Instance,
+            queue,
+            new TestQueueDataAdapter());
+        await receiver.Initialize(TimeSpan.FromSeconds(1));
+        var received = Assert.Single(await receiver.GetQueueMessagesAsync(1));
+
+        await receiver.MessagesDeliveredAsync([received]);
+        await receiver.Shutdown(TimeSpan.FromSeconds(1));
+
+        Assert.Same(message, Assert.Single(queue.DeletedMessages));
+        Assert.Same(message, Assert.Single(queue.ReleasedMessages));
+    }
+
+    private static QueueMessage CreateMessage()
+    {
+        var now = DateTimeOffset.UtcNow;
+        return QueuesModelFactory.QueueMessage(
+            "message-id",
+            "pop-receipt",
+            "payload",
+            dequeueCount: 1,
+            nextVisibleOn: now.AddMinutes(1),
+            insertedOn: now,
+            expiresOn: now.AddDays(1));
+    }
+
+    private sealed class TestQueueDataManager(QueueMessage message) : IAzureQueueDataManager
+    {
+        private readonly Queue<QueueMessage> _messages = new([message]);
+
+        public List<QueueMessage> DeletedMessages { get; } = [];
+
+        public List<QueueMessage> ReleasedMessages { get; } = [];
+
+        public Exception? DeleteException { get; init; }
+
+        public Task InitQueueAsync() => Task.CompletedTask;
+
+        public Task<IEnumerable<QueueMessage>> GetQueueMessages(int? count = null)
+        {
+            if (_messages.TryDequeue(out var message))
+            {
+                return Task.FromResult<IEnumerable<QueueMessage>>([message]);
+            }
+
+            return Task.FromResult<IEnumerable<QueueMessage>>([]);
+        }
+
+        public Task DeleteQueueMessage(QueueMessage message)
+        {
+            DeletedMessages.Add(message);
+            return DeleteException is null ? Task.CompletedTask : Task.FromException(DeleteException);
+        }
+
+        public Task ReleaseQueueMessage(QueueMessage message, CancellationToken cancellationToken)
+        {
+            ReleasedMessages.Add(message);
+            _messages.Enqueue(message);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class DelayedQueueDataManager(QueueMessage message) : IAzureQueueDataManager
+    {
+        private readonly TaskCompletionSource<IEnumerable<QueueMessage>> _receive =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReceiveStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<QueueMessage> ReleasedMessages { get; } = [];
+
+        public Task InitQueueAsync() => Task.CompletedTask;
+
+        public Task<IEnumerable<QueueMessage>> GetQueueMessages(int? count = null)
+        {
+            ReceiveStarted.TrySetResult();
+            return _receive.Task;
+        }
+
+        public Task DeleteQueueMessage(QueueMessage message) => Task.CompletedTask;
+
+        public async Task ReleaseQueueMessage(QueueMessage message, CancellationToken cancellationToken)
+        {
+            ReleasedMessages.Add(message);
+            ReleaseStarted.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+        }
+
+        public void CompleteReceive() => _receive.TrySetResult([message]);
+
+        public void CompleteRelease() => _release.TrySetResult();
+    }
+
+    private sealed class TestQueueDataAdapter : IQueueDataAdapter<string, IBatchContainer>
+    {
+        public string ToQueueMessage<T>(
+            StreamId streamId,
+            IEnumerable<T> events,
+            StreamSequenceToken? token,
+            Dictionary<string, object>? requestContext) => throw new NotSupportedException();
+
+        public IBatchContainer FromQueueMessage(string queueMessage, long sequenceId) =>
+            new TestBatchContainer(queueMessage, sequenceId);
+    }
+
+    private sealed class TestBatchContainer(string payload, long sequenceId) : IBatchContainer
+    {
+        public string Payload { get; } = payload;
+
+        public StreamId StreamId { get; } = StreamId.Create("test", Guid.Empty);
+
+        public StreamSequenceToken SequenceToken { get; } = new EventSequenceTokenV2(sequenceId);
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() => [];
+
+        public bool ImportRequestContext() => false;
+    }
+}

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
@@ -56,35 +56,13 @@ public class AzureQueueAdapterReceiverTests
         queue.CompleteReceive();
 
         await queue.ReleaseStarted.Task;
+        Assert.True(queue.ReleaseCancellationToken.CanBeCanceled);
         Assert.False(shutdownTask.IsCompleted);
         queue.CompleteRelease();
 
         await Task.WhenAll(receiveTask, shutdownTask);
         Assert.Empty(await receiveTask);
         Assert.Same(message, Assert.Single(queue.ReleasedMessages));
-    }
-
-    [Fact]
-    public async Task ShutdownCancelsPendingReleaseAtDeadline()
-    {
-        var message = CreateMessage();
-        var queue = new DelayedQueueDataManager(message);
-        var receiver = new AzureQueueAdapterReceiver(
-            "test-queue",
-            NullLoggerFactory.Instance,
-            queue,
-            new TestQueueDataAdapter());
-        await receiver.Initialize(TimeSpan.FromSeconds(1));
-
-        var receiveTask = receiver.GetQueueMessagesAsync(1);
-        await queue.ReceiveStarted.Task;
-        var shutdownTask = receiver.Shutdown(TimeSpan.FromMilliseconds(100));
-        queue.CompleteReceive();
-
-        await queue.ReleaseStarted.Task;
-        await shutdownTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-        await queue.ReleaseCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
-        Assert.Empty(await receiveTask);
     }
 
     [Fact]
@@ -192,10 +170,9 @@ public class AzureQueueAdapterReceiverTests
         public TaskCompletionSource ReleaseStarted { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public TaskCompletionSource ReleaseCanceled { get; } =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-
         public List<QueueMessage> ReleasedMessages { get; } = [];
+
+        public CancellationToken ReleaseCancellationToken { get; private set; }
 
         public Task InitQueueAsync() => Task.CompletedTask;
 
@@ -210,16 +187,9 @@ public class AzureQueueAdapterReceiverTests
         public async Task ReleaseQueueMessage(QueueMessage message, CancellationToken cancellationToken)
         {
             ReleasedMessages.Add(message);
+            ReleaseCancellationToken = cancellationToken;
             ReleaseStarted.TrySetResult();
-            try
-            {
-                await _release.Task.WaitAsync(cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                ReleaseCanceled.TrySetResult();
-                throw;
-            }
+            await _release.Task.WaitAsync(cancellationToken);
         }
 
         public void CompleteReceive() => _receive.TrySetResult([message]);

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterReceiverTests.cs
@@ -142,8 +142,8 @@ public class AzureQueueAdapterReceiverTests
         await receiver.MessagesDeliveredAsync([received[1]]);
         await receiver.Shutdown(TimeSpan.FromSeconds(1));
 
-        Assert.Equal([failed, confirmed], queue.DeletedMessages);
-        Assert.Equal([failed, unacknowledged], queue.ReleasedMessages);
+        Assert.Equal([confirmed, failed], queue.DeletedMessages.OrderBy(message => message.MessageId, StringComparer.Ordinal));
+        Assert.Equal([failed, unacknowledged], queue.ReleasedMessages.OrderBy(message => message.MessageId, StringComparer.Ordinal));
     }
 
     private static QueueMessage CreateMessage(string messageId = "message-id")

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
@@ -90,7 +90,7 @@ namespace Tester.AzureUtils.Streaming
             adapterFactory.Init();
 
             var cancellationToken = TestContext.Current.CancellationToken;
-            var adapter = await adapterFactory.CreateAdapter();
+            var adapter = await ((IQueueAdapterFactory)adapterFactory).CreateAdapter(cancellationToken);
             var queueId = Assert.Single(adapterFactory.GetStreamQueueMapper().GetAllQueues());
             var receiver = adapter.CreateReceiver(queueId);
             await receiver.Initialize(TimeSpan.FromSeconds(10), cancellationToken);

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
@@ -71,6 +71,67 @@ namespace Tester.AzureUtils.Streaming
                 TestContext.Current.CancellationToken);
         }
 
+        [Fact, TestCategory("Functional")]
+        public async Task ShutdownReleasesPendingMessages()
+        {
+            var options = new AzureQueueOptions
+            {
+                MessageVisibilityTimeout = TimeSpan.FromMinutes(1),
+                QueueNames = [azureQueueNames[0]]
+            };
+            options.ConfigureTestDefaults();
+            var serializer = this.fixture.Services.GetRequiredService<Serializer>();
+            var adapterFactory = new AzureQueueAdapterFactory(
+                AZURE_QUEUE_STREAM_PROVIDER_NAME,
+                options,
+                new SimpleQueueCacheOptions(),
+                new AzureQueueDataAdapterV2(serializer),
+                loggerFactory);
+            adapterFactory.Init();
+
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var adapter = await adapterFactory.CreateAdapter();
+            var queueId = Assert.Single(adapterFactory.GetStreamQueueMapper().GetAllQueues());
+            var receiver = adapter.CreateReceiver(queueId);
+            await receiver.Initialize(TimeSpan.FromSeconds(10), cancellationToken);
+
+            var streamId = StreamId.Create("handoff", Guid.NewGuid());
+            await adapter.QueueMessageBatchAsync(streamId, [42], null, null);
+            var received = await WaitForMessage(receiver, "the initial receiver", cancellationToken);
+            Assert.Equal(42, Assert.Single(received.GetEvents<int>()).Item1);
+
+            await receiver.Shutdown(TimeSpan.FromSeconds(10), cancellationToken);
+
+            var replacement = adapter.CreateReceiver(queueId);
+            await replacement.Initialize(TimeSpan.FromSeconds(10), cancellationToken);
+            var redelivered = await WaitForMessage(replacement, "the replacement receiver after handoff", cancellationToken);
+            Assert.Equal(42, Assert.Single(redelivered.GetEvents<int>()).Item1);
+
+            await replacement.MessagesDeliveredAsync([redelivered], cancellationToken);
+            await replacement.Shutdown(TimeSpan.FromSeconds(10), cancellationToken);
+        }
+
+        private static async Task<IBatchContainer> WaitForMessage(
+            IQueueAdapterReceiver receiver,
+            string phase,
+            CancellationToken cancellationToken)
+        {
+            var timeout = TimeSpan.FromSeconds(10);
+            var started = DateTime.UtcNow;
+            while (DateTime.UtcNow - started < timeout)
+            {
+                var messages = await receiver.GetQueueMessagesAsync(1, cancellationToken);
+                if (messages.Count > 0)
+                {
+                    return Assert.Single(messages);
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+            }
+
+            throw new TimeoutException($"Timed out after {timeout} waiting for one Azure Queue message during {phase}; observed 0.");
+        }
+
         private async Task SendAndReceiveFromQueueAdapter(
             IQueueAdapterFactory adapterFactory,
             CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #11119.

## Problem

When Azure Queue ownership moves to another silo, the previous receiver can shut down with prefetched, unacknowledged messages still hidden by their visibility timeout. The replacement pulling agent cannot receive those messages until the lease expires, which caused the multi-stream join test to observe 9 of 10 deliveries for its full 30-second deadline.

## Solution

- Track complete receiver operations so shutdown waits for receive, acknowledgement, and late-message release work.
- Retain pending receipts until Azure confirms deletion.
- Reset remaining message visibility to zero during graceful handoff, with bounded concurrency and the shutdown cancellation budget.
- Release messages returned after shutdown begins instead of exposing them to the stopped receiver.
- Add deterministic coverage for replacement delivery, late receive races, successful acknowledgement, and deletion failure, plus an Azurite-backed adapter regression.
- Document graceful handoff behavior and the Azure Queue `Update Message` permission requirement.

## Rationale

Graceful ownership transfer preserves at-least-once delivery while making unconfirmed work immediately available to the replacement receiver. Azure's existing visibility lease remains the recovery path for process failure or authorization/transport errors during release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11144)