### PR TITLE
test(runtime): make one-way deactivation setup deterministic

### DIFF
--- a/test/Grains/TestGrainInterfaces/ITestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITestGrain.cs
@@ -71,7 +71,7 @@ namespace UnitTests.GrainInterfaces
 
         Task<bool> NotifyOtherGrainValueTask(IOneWayGrain otherGrain);
 
-        Task<IOneWayGrain> GetOtherGrain();
+        Task<IOneWayGrain> GetOtherGrain(SiloAddress targetSilo, SiloAddress directorySilo);
 
         Task NotifyOtherGrain();
 

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -209,6 +209,7 @@ namespace UnitTests.Grains
 
     internal class OneWayGrain : Grain, IOneWayGrain, ISimpleGrainObserver
     {
+        private const int MaxTopologyCandidateCount = 1_000;
         private readonly string _id = Guid.NewGuid().ToString();
         private int count;
         private TaskCompletionSource<int> countChanged = CreateCountChangedSource();
@@ -258,30 +259,66 @@ namespace UnitTests.Grains
             return completedSynchronously;
         }
 
-        public async Task<IOneWayGrain> GetOtherGrain()
+        public async Task<IOneWayGrain> GetOtherGrain(SiloAddress targetSilo, SiloAddress directorySilo)
         {
-            return this.other ?? (this.other = await GetGrainOnOtherSilo());
-
-            async Task<IOneWayGrain> GetGrainOnOtherSilo()
+            if (this.other is not null)
             {
-                var silos = ServiceProvider.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members.Where(kv => kv.Value.Status == SiloStatus.Active).Select(kv => kv.Key).ToHashSet();
-                var thisSilo = await this.GetSiloAddress();
-                silos.Remove(thisSilo);
-                while (true)
+                return this.other;
+            }
+
+            var thisSilo = this.LocalSiloDetails.SiloAddress;
+            var activeSilos = ServiceProvider.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members
+                .Where(member => member.Value.Status == SiloStatus.Active)
+                .Select(member => member.Key)
+                .ToHashSet();
+            if (targetSilo.Equals(thisSilo)
+                || directorySilo.Equals(thisSilo)
+                || targetSilo.Equals(directorySilo)
+                || !activeSilos.Contains(targetSilo)
+                || !activeSilos.Contains(directorySilo))
+            {
+                throw new InvalidOperationException(
+                    $"The one-way test topology requires three distinct active silos. "
+                    + $"Caller: {thisSilo}, target: {targetSilo}, directory: {directorySilo}, "
+                    + $"active silos: {string.Join(", ", activeSilos.Order())}.");
+            }
+
+            for (var candidateIndex = 0; candidateIndex < MaxTopologyCandidateCount; candidateIndex++)
+            {
+                var candidate = this.GrainFactory.GetGrain<IOneWayGrain>(CreateTopologyCandidateKey(candidateIndex));
+                var grainId = ((GrainReference)candidate).GrainId;
+                if (!directorySilo.Equals(this.LocalGrainDirectory.GetPrimaryForGrain(grainId)))
                 {
-                    RequestContext.Set(IPlacementDirector.PlacementHintKey, silos.First());
-                    var candidate = this.GrainFactory.GetGrain<IOneWayGrain>(Guid.NewGuid());
-                    var directorySilo = await candidate.GetPrimaryForGrain();
-                    var candidateSilo = await candidate.GetSiloAddress();
-                    if (!directorySilo.Equals(candidateSilo)
-                        && !directorySilo.Equals(thisSilo)
-                        && !candidateSilo.Equals(thisSilo))
+                    continue;
+                }
+
+                RequestContext.Set(IPlacementDirector.PlacementHintKey, targetSilo);
+                try
+                {
+                    var actualTargetSilo = await candidate.GetSiloAddress();
+                    if (!targetSilo.Equals(actualTargetSilo))
                     {
-                        return candidate;
+                        throw new InvalidOperationException(
+                            $"The one-way target grain was placed on {actualTargetSilo} instead of {targetSilo}. "
+                            + $"Caller: {thisSilo}, directory: {directorySilo}, grain: {grainId}.");
                     }
+
+                    return this.other = candidate;
+                }
+                finally
+                {
+                    RequestContext.Remove(IPlacementDirector.PlacementHintKey);
                 }
             }
+
+            throw new InvalidOperationException(
+                $"Could not select a one-way target grain owned by directory silo {directorySilo} "
+                + $"after checking {MaxTopologyCandidateCount} deterministic grain ids. "
+                + $"Caller: {thisSilo}, target: {targetSilo}.");
         }
+
+        private static Guid CreateTopologyCandidateKey(int candidateIndex) =>
+            new(candidateIndex, 0x1133, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
         public Task<string> GetActivationId()
         {

--- a/test/Orleans.Runtime.Tests/OneWayDeactivationTests.cs
+++ b/test/Orleans.Runtime.Tests/OneWayDeactivationTests.cs
@@ -55,21 +55,26 @@ namespace UnitTests.General
         public async Task OneWay_Deactivation_CacheInvalidated()
         {
             var directoryCache = ((InProcessSiloHandle)_fixture.HostedCluster.Primary!).SiloHost.Services.GetRequiredService<TestDirectoryCache>();
-            IOneWayGrain grainToCallFrom;
-            while (true)
+            var callerSilo = _fixture.HostedCluster.Primary.SiloAddress;
+            var targetSilo = _fixture.HostedCluster.SecondarySilos[0].SiloAddress;
+            var directorySilo = _fixture.HostedCluster.SecondarySilos[1].SiloAddress;
+            var grainToCallFrom = _fixture.Client.GetGrain<IOneWayGrain>(new Guid("9e773e45-24e0-4e99-b630-6523f5f53b68"));
+
+            RequestContext.Set(IPlacementDirector.PlacementHintKey, callerSilo);
+            try
             {
-                RequestContext.Set(IPlacementDirector.PlacementHintKey, _fixture.HostedCluster.Primary.SiloAddress);
-                grainToCallFrom = _fixture.Client.GetGrain<IOneWayGrain>(Guid.NewGuid());
                 var grainHost = await grainToCallFrom.GetSiloAddress();
-                if (grainHost.Equals(_fixture.HostedCluster.Primary.SiloAddress))
-                {
-                    break;
-                }
+                Assert.Equal(callerSilo, grainHost);
+            }
+            finally
+            {
+                RequestContext.Remove(IPlacementDirector.PlacementHintKey);
             }
 
             // Activate the grain & record its address.
-            RequestContext.Remove(IPlacementDirector.PlacementHintKey);
-            var grainToDeactivate = await grainToCallFrom.GetOtherGrain();
+            var grainToDeactivate = await grainToCallFrom.GetOtherGrain(targetSilo, directorySilo);
+            Assert.Equal(targetSilo, await grainToDeactivate.GetSiloAddress());
+            Assert.Equal(directorySilo, await grainToDeactivate.GetPrimaryForGrain());
             var initialActivationId = await grainToDeactivate.GetActivationId();
             var grainId = grainToDeactivate.GetGrainId();
             var activationAddress = directoryCache.Operations


### PR DESCRIPTION
The one-way deactivation test selected random grain candidates by activating each candidate before checking whether the caller, activation, and directory owner occupied distinct silos. That open-ended network loop could consume the response timeout before the deactivation behavior was exercised.

This change assigns the three topology roles from the fixture, checks a bounded deterministic sequence of grain IDs against the local directory map, and activates one matching target on the designated silo. The test asserts the resulting topology before preserving its one-way deactivation, reactivation, and cache-update assertions.

Fixes #11133
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11147)