### PR TITLE
fix(streaming): preserve prefetched recovery batches

### DIFF
--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -424,13 +424,14 @@ namespace Orleans.Streams
                                     && SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid))
                             {
                                 // Delivery tokens and implicit recovery tokens identify already processed events.
-                                consumerData.Cursor.MoveNext();
+                                consumerData.PendingBatch = AdvanceCursorPastToken(consumerData.Cursor, requestedToken);
                             }
                         }
                         catch (QueueCacheMissException) when (cacheToken is not null)
                         {
                             // A cold stream's triggering batch is the receiver's first available
                             // message, so resume there if the consumer's prior token was evicted.
+                            consumerData.SafeDisposeCursor(logger);
                             consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, cacheToken);
                         }
                     }
@@ -501,6 +502,31 @@ namespace Orleans.Streams
                     || consumerData.LastToken is StartPositionToken startPositionToken
                         && startPositionToken.StartPosition == options.InitialSubscriptionStartPosition);
 
+        private static IBatchContainer? AdvanceCursorPastToken(IQueueCacheCursor cursor, StreamSequenceToken token)
+        {
+            while (cursor.MoveNext())
+            {
+                var batch = cursor.GetCurrent(out var exception);
+                if (exception is not null)
+                {
+                    throw exception;
+                }
+
+                if (batch is null)
+                {
+                    throw new InvalidOperationException("A stream cursor returned no current batch after advancing.");
+                }
+
+                var comparison = batch.SequenceToken.CompareTo(token);
+                if (comparison >= 0)
+                {
+                    return comparison > 0 ? batch : null;
+                }
+            }
+
+            return null;
+        }
+
         private IQueueCacheCursor GetCacheCursorAtStartPosition(
             QualifiedStreamId streamId,
             StartPositionToken startPositionToken,
@@ -517,7 +543,7 @@ namespace Orleans.Streams
                 try
                 {
                     var cursor = queueCache!.GetCacheCursor(consumerData.StreamId, lastProcessedToken);
-                    cursor.MoveNext();
+                    consumerData.PendingBatch = AdvanceCursorPastToken(cursor, lastProcessedToken);
                     return cursor;
                 }
                 catch (QueueCacheMissException)
@@ -540,7 +566,7 @@ namespace Orleans.Streams
                     if (consumerData.LastToken is DeliveryToken
                         || SubscriptionMarker.IsImplicitSubscription(consumerData.SubscriptionId.Guid))
                     {
-                        cursor.MoveNext();
+                        consumerData.PendingBatch = AdvanceCursorPastToken(cursor, handshakeSequenceToken);
                     }
 
                     return cursor;
@@ -1021,7 +1047,7 @@ namespace Orleans.Streams
                     var forceFaultSubscription = false;
                     try
                     {
-                        nextBatch = GetBatchForConsumer(consumerData.Cursor, consumerData.StreamId, consumerData.FilterData);
+                        nextBatch = GetBatchForConsumer(consumerData);
                         if (!nextBatch.HasProgress)
                         {
                             // Only emit cursor-drained when we transitioned from delivering to empty,
@@ -1084,6 +1110,7 @@ namespace Orleans.Streams
                             {
                                 consumerData.LastToken = newToken;
                                 IQueueCacheCursor newCursor;
+                                IBatchContainer? pendingBatch = null;
                                 if (newToken is StartPositionToken startPositionToken)
                                 {
                                     consumerData.LastProcessedToken = null;
@@ -1111,7 +1138,7 @@ namespace Orleans.Streams
                                         {
                                             newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, sequenceToken);
                                             // An implicit recovery token identifies the last event processed by the prior activation.
-                                            newCursor.MoveNext();
+                                            pendingBatch = AdvanceCursorPastToken(newCursor, sequenceToken);
                                         }
                                         catch (QueueCacheMissException)
                                         {
@@ -1135,7 +1162,7 @@ namespace Orleans.Streams
                                     {
                                         newCursor = queueCache!.GetCacheCursor(consumerData.StreamId, sequenceToken); // queueCache must be non-null here: consumerData.Cursor was only ever populated via queueCache.GetCacheCursor.
                                         // The handshake token points to an already processed event, so advance past it.
-                                        newCursor.MoveNext();
+                                        pendingBatch = AdvanceCursorPastToken(newCursor, sequenceToken);
                                     }
                                     catch (QueueCacheMissException)
                                     {
@@ -1152,6 +1179,7 @@ namespace Orleans.Streams
 
                                 consumerData.SafeDisposeCursor(logger);
                                 consumerData.Cursor = newCursor;
+                                consumerData.PendingBatch = pendingBatch;
                             }
                             else
                             {
@@ -1220,16 +1248,30 @@ namespace Orleans.Streams
             public bool HasProgress => ProgressToken is not null;
         }
 
-        private ConsumerBatch GetBatchForConsumer(IQueueCacheCursor cursor, StreamId streamId, string? filterData)
+        private ConsumerBatch GetBatchForConsumer(StreamConsumerData consumerData)
         {
+            var cursor = consumerData.Cursor!;
+            var streamId = consumerData.StreamId.StreamId;
+            var filterData = consumerData.FilterData;
+            var pendingBatch = consumerData.PendingBatch;
+            consumerData.PendingBatch = null;
+
             if (this.options.BatchContainerBatchSize <= 1)
             {
-                if (!cursor.MoveNext())
+                IBatchContainer batchContainer;
+                if (pendingBatch is not null)
+                {
+                    batchContainer = pendingBatch;
+                }
+                else if (cursor.MoveNext())
+                {
+                    batchContainer = cursor.GetCurrent(out _)!; // MoveNext returned true, so GetCurrent is guaranteed non-null here.
+                }
+                else
                 {
                     return default;
                 }
 
-                var batchContainer = cursor.GetCurrent(out _)!; // MoveNext returned true, so GetCurrent is guaranteed non-null here.
                 return ShouldDeliverBatch(streamId, batchContainer, filterData)
                     ? new ConsumerBatch(batchContainer, batchContainer.SequenceToken)
                     : new ConsumerBatch(null, batchContainer.SequenceToken);
@@ -1239,6 +1281,16 @@ namespace Orleans.Streams
                 int i = 0;
                 var batchContainers = new List<IBatchContainer>();
                 StreamSequenceToken? progressToken = null;
+
+                if (pendingBatch is not null)
+                {
+                    progressToken = pendingBatch.SequenceToken;
+                    if (ShouldDeliverBatch(streamId, pendingBatch, filterData))
+                    {
+                        batchContainers.Add(pendingBatch);
+                        i++;
+                    }
+                }
 
                 while (i < this.options.BatchContainerBatchSize)
                 {

--- a/src/Orleans.Streaming/PersistentStreams/QueueStreamDataStructures.cs
+++ b/src/Orleans.Streaming/PersistentStreams/QueueStreamDataStructures.cs
@@ -35,6 +35,8 @@ namespace Orleans.Streams
         [NonSerialized]
         public StreamSequenceToken? PendingStartToken;
         [NonSerialized]
+        public IBatchContainer? PendingBatch;
+        [NonSerialized]
         public bool StartPositionIsProviderDefault;
 
         /// <summary>
@@ -54,6 +56,7 @@ namespace Orleans.Streams
 
         internal void SafeDisposeCursor(ILogger logger)
         {
+            PendingBatch = null;
             if (Cursor is { } cursor)
             {
                 Cursor = null;

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -661,7 +661,17 @@ namespace UnitTests.StreamingTests
 
         private sealed class PurgeablePooledQueueCache : IQueueCache
         {
-            private readonly PooledQueueCache cache = new(new CacheDataAdapter(), NullLogger.Instance, null, null);
+            private readonly PooledQueueCache cache;
+
+            public PurgeablePooledQueueCache(bool retainPurgeMetadata = false)
+            {
+                cache = new(
+                    new CacheDataAdapter(),
+                    NullLogger.Instance,
+                    null,
+                    null,
+                    retainPurgeMetadata ? TimeSpan.FromMinutes(1) : null);
+            }
 
             public int GetMaxAddCount() => 1000;
 
@@ -838,6 +848,37 @@ namespace UnitTests.StreamingTests
                 if (handshakeToken is not StartToken)
                 {
                     return Task.FromResult<StreamHandshakeToken?>(startToken);
+                }
+
+                DeliveredTokens.Add(item.SequenceToken);
+                return Task.FromResult<StreamHandshakeToken?>(null);
+            }
+
+            public Task CompleteStream(GuidId subscriptionId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task ErrorInStream(GuidId subscriptionId, Exception exc, CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task<StreamHandshakeToken?> GetSequenceToken(GuidId subscriptionId, CancellationToken cancellationToken)
+                => Task.FromResult<StreamHandshakeToken?>(null);
+        }
+
+        private sealed class RenegotiatingDeliveryTokenConsumer(StreamSequenceToken token) : IStreamConsumerExtension
+        {
+            private readonly StreamHandshakeToken deliveryToken = StreamHandshakeToken.CreateDeliveyToken(token)!;
+
+            public List<StreamSequenceToken> DeliveredTokens { get; } = new();
+
+            public Task<StreamHandshakeToken?> DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
+            public Task<StreamHandshakeToken?> DeliverMutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
+            public Task<StreamHandshakeToken?> DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, IBatchContainer item, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
+            {
+                if (handshakeToken is not DeliveryToken)
+                {
+                    return Task.FromResult<StreamHandshakeToken?>(deliveryToken);
                 }
 
                 DeliveredTokens.Add(item.SequenceToken);
@@ -1225,6 +1266,47 @@ namespace UnitTests.StreamingTests
         [TestProvider("None")]
         [TestArea("Streaming")]
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task InitialImplicitRecoveryDeliversFirstNewerMessageWhenAcknowledgedMessageWasPurged()
+        {
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var acknowledgedToken = new EventSequenceTokenV2(1);
+            var nextToken = new EventSequenceTokenV2(2);
+            var queueCache = new PurgeablePooledQueueCache(retainPurgeMetadata: true);
+            queueCache.AddToCache([new TestBatchContainer(streamId, acknowledgedToken)]);
+            queueCache.Purge();
+            queueCache.AddToCache([new TestBatchContainer(streamId, nextToken)]);
+
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var agent = CreateAgent(
+                pubSub: Substitute.For<IStreamPubSub>(),
+                QueueId.GetQueueId("queue", 0u, 0u),
+                queueAdapterCache: queueAdapterCache);
+            var accessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            var consumer = new RecordingConsumer(StreamHandshakeToken.CreateStartToken(acknowledgedToken));
+            var consumerData = new StreamConsumerData(
+                GuidId.GetGuidId(SubscriptionMarker.MarkAsImplictSubscriptionId(Guid.NewGuid())),
+                qualifiedStreamId,
+                consumer,
+                filterData: null);
+
+            Assert.True(await accessor.DoHandshakeWithConsumer(consumerData, cacheToken: nextToken));
+            var deliveryTask = accessor.RunConsumerCursor(consumerData);
+            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.Equal(nextToken, Assert.Single(consumer.DeliveredTokens));
+            Assert.Empty(consumer.Errors);
+
+            consumer.ReleaseDelivery();
+            await deliveryTask;
+            await accessor.Shutdown();
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task ReattachmentDeliveryTokenOverridesProviderEarliest()
         {
             var streamId = StreamId.Create("namespace", Guid.NewGuid());
@@ -1433,6 +1515,40 @@ namespace UnitTests.StreamingTests
         [TestProvider("None")]
         [TestArea("Streaming")]
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task DeliveryTokenRenegotiationDeliversFirstNewerMessageWhenAcknowledgedMessageWasPurged()
+        {
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var acknowledgedToken = new EventSequenceTokenV2(1);
+            var attemptedToken = new EventSequenceTokenV2(2);
+            var queueCache = new PurgeablePooledQueueCache(retainPurgeMetadata: true);
+            queueCache.AddToCache([new TestBatchContainer(streamId, acknowledgedToken)]);
+            queueCache.Purge();
+            queueCache.AddToCache([new TestBatchContainer(streamId, attemptedToken)]);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var agent = CreateAgent(pubSub: Substitute.For<IStreamPubSub>(), QueueId.GetQueueId("queue", 0u, 0u), queueAdapterCache: queueAdapterCache);
+            var accessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            var consumer = new RenegotiatingDeliveryTokenConsumer(acknowledgedToken);
+            var consumerData = new StreamConsumerData(
+                GuidId.GetGuidId(SubscriptionMarker.MarkAsExplicitSubscriptionId(Guid.NewGuid())),
+                qualifiedStreamId,
+                consumer,
+                filterData: null)
+            {
+                Cursor = queueCache.GetCacheCursor(streamId, attemptedToken),
+            };
+
+            await accessor.RunConsumerCursor(consumerData);
+
+            Assert.Equal(attemptedToken, Assert.Single(consumer.DeliveredTokens));
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task ImplicitRecoveryStartTokenAdvancesPastAcknowledgedMessage()
         {
             var streamId = StreamId.Create("namespace", Guid.NewGuid());
@@ -1619,6 +1735,8 @@ namespace UnitTests.StreamingTests
 
         private sealed class RewindConsumer(StreamHandshakeToken rewindToken) : IStreamConsumerExtension
         {
+            private bool rewindRequested;
+
             public TaskCompletionSource<bool> Delivered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public Task<StreamHandshakeToken?> DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
@@ -1634,7 +1752,13 @@ namespace UnitTests.StreamingTests
             public Task<StreamHandshakeToken?> DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, IBatchContainer item, StreamHandshakeToken? handshakeToken, CancellationToken cancellationToken)
             {
                 Delivered.TrySetResult(true);
-                return Task.FromResult<StreamHandshakeToken?>(rewindToken);
+                if (!rewindRequested)
+                {
+                    rewindRequested = true;
+                    return Task.FromResult<StreamHandshakeToken?>(rewindToken);
+                }
+
+                return Task.FromResult<StreamHandshakeToken?>(null);
             }
 
             public Task CompleteStream(GuidId subscriptionId, CancellationToken cancellationToken) => Task.CompletedTask;
@@ -1785,7 +1909,7 @@ namespace UnitTests.StreamingTests
         [TestProvider("None")]
         [TestArea("Streaming")]
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task Shutdown_UsesReturnedHandshakeTokenForDeliveryProgress()
+        public async Task Shutdown_UsesAcceptedRedeliveryForDeliveryProgress()
         {
             var pubSub = Substitute.For<IStreamPubSub>();
             pubSub.RegisterProducer(default, default, TestContext.Current.CancellationToken)
@@ -1838,7 +1962,7 @@ namespace UnitTests.StreamingTests
             queueCache.ClearDeliveryProgress();
             await testAccessor.Shutdown();
 
-            Assert.Equal(previousToken, Assert.Single(queueCache.DeliveryProgressTokens));
+            Assert.Equal(attemptedToken, Assert.Single(queueCache.DeliveryProgressTokens));
         }
 
         private static Task InitializeAgent(PersistentStreamPullingAgent agent) =>


### PR DESCRIPTION
## Problem

Persistent stream recovery advances past the consumer's acknowledged token before resuming delivery. When that token has been purged but cache metadata proves no stream item was lost, the cursor's first batch can already be the first newer item. Advancing the cursor consumes that newer batch and leaves the subscriber waiting for unrelated activity.

This is the remaining path behind #11136 after #9711 added recovery for explicit cache-miss exceptions. It is distinct from the phase deadline issue fixed by #10671.

## Solution

Preserve a newer batch encountered while advancing past an acknowledged token and deliver it before reading the cursor again. Apply the same invariant to initial implicit recovery, general cursor recovery, and start/delivery token renegotiation.

Update the shutdown handshake test double to accept the retried batch after returning its requested token, matching the runtime consumer protocol.

Fixes #11136
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11149)