### PR TITLE
fix(analyzers): enforce ordinal string comparisons

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -307,13 +307,13 @@ dotnet_diagnostic.CA1304.severity = suggestion
 dotnet_diagnostic.CA1305.severity = suggestion
 
 # CA1309: Use ordinal string comparison
-dotnet_diagnostic.CA1309.severity = suggestion
+dotnet_diagnostic.CA1309.severity = warning
 
 # CA1310: Specify StringComparison for correctness
-dotnet_diagnostic.CA1310.severity = suggestion
+dotnet_diagnostic.CA1310.severity = warning
 
 # CA1311: Specify a culture or use an invariant version
-dotnet_diagnostic.CA1311.severity = suggestion
+dotnet_diagnostic.CA1311.severity = warning
 
 # CA1507: Use nameof to express symbol names
 dotnet_diagnostic.CA1507.severity = suggestion
@@ -682,7 +682,7 @@ dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 
 # CA1062: Validate arguments of public methods
-[src/Azure/{Orleans.GrainDirectory.AzureStorage,Orleans.Reminders.AzureStorage,Orleans.Clustering.Cosmos,Orleans.Reminders.Cosmos,Shared}/**.cs]
+[src/Azure/{Orleans.GrainDirectory.AzureStorage,Orleans.Persistence.AzureStorage,Orleans.Reminders.AzureStorage,Orleans.Clustering.Cosmos,Orleans.Reminders.Cosmos,Shared}/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
 # Production source enforces the correctness baseline. Tests, samples, documentation,

--- a/.editorconfig
+++ b/.editorconfig
@@ -706,6 +706,17 @@ dotnet_diagnostic.IDE0043.severity = warning
 dotnet_diagnostic.CA1305.severity = warning
 dotnet_diagnostic.CA1307.severity = warning
 
+# Provider-specific globalization enforcement is centralized here.
+[src/{AWS/Orleans.Clustering.DynamoDB,Azure/Orleans.Clustering.AzureStorage}/**.cs]
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning
+
+# Azure Table sources are linked into multiple provider projects, so they share one enforcement policy.
+[src/Azure/Shared/{Storage/{AzureStorageOperationOptions.cs,AzureStoragePolicyOptions.cs,AzureTableDataManager.cs,AzureTableUtils.cs},Utilities/ErrorCode.cs}]
+dotnet_diagnostic.CA1062.severity = warning
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning
+
 # ActivationData's shared monitor migration is tracked by #10068.
 [src/Orleans.Runtime/Catalog/ActivationData.cs]
 dotnet_diagnostic.CA2002.severity = suggestion

--- a/docs/site/src/content/docs/grains/snippets/interceptors/Configuration.cs
+++ b/docs/site/src/content/docs/grains/snippets/interceptors/Configuration.cs
@@ -14,7 +14,8 @@ public static class IncomingFilterConfiguration
             // on the RequestContext which can then be read by other filters or the grain.
             if (string.Equals(
                 context.InterfaceMethod.Name,
-                nameof(IMyGrain.MyInterceptedMethod)))
+                nameof(IMyGrain.MyInterceptedMethod),
+                StringComparison.Ordinal))
             {
                 RequestContext.Set(
                     "intercepted value", "this value was added by the filter");

--- a/docs/site/src/content/docs/grains/snippets/interceptors/GrainFilters.cs
+++ b/docs/site/src/content/docs/grains/snippets/interceptors/GrainFilters.cs
@@ -15,7 +15,8 @@ public sealed class MyFilteredGrain
         // Change the result of the call from 7 to 38.
         if (string.Equals(
             context.InterfaceMethod.Name,
-            nameof(IMyFilteredGrain.GetFavoriteNumber)))
+            nameof(IMyFilteredGrain.GetFavoriteNumber),
+            StringComparison.Ordinal))
         {
             context.Result = 38;
         }

--- a/docs/site/src/content/docs/host/configuration-guide/snippets/serialization/MessagePackExamples.cs
+++ b/docs/site/src/content/docs/host/configuration-guide/snippets/serialization/MessagePackExamples.cs
@@ -44,7 +44,7 @@ public static class MessagePackConfiguration
         {
             siloBuilder.UseLocalhostClustering();
             siloBuilder.Services.AddSerializer(serializerBuilder => serializerBuilder.AddMessagePackSerializer(
-                isSerializable: type => type.Namespace?.StartsWith("MyApp.Messages") == true,
+                isSerializable: type => type.Namespace?.StartsWith("MyApp.Messages", StringComparison.Ordinal) == true,
                 isCopyable: type => false,
                 messagePackSerializerOptions: null
             ));

--- a/docs/site/src/content/docs/host/configuration-guide/snippets/serialization/TypeNameResolutionExamples.cs
+++ b/docs/site/src/content/docs/host/configuration-guide/snippets/serialization/TypeNameResolutionExamples.cs
@@ -13,7 +13,7 @@ public static class SerializationConfigurationExamples
         siloBuilder.Services.AddSerializer(serializerBuilder =>
         {
             serializerBuilder.AddNewtonsoftJsonSerializer(
-                isSupported: type => type.Namespace?.StartsWith("Example.Namespace") is true);
+                isSupported: type => type.Namespace?.StartsWith("Example.Namespace", StringComparison.Ordinal) is true);
         });
         // </configure_newtonsoft_json>
     }
@@ -24,7 +24,7 @@ public static class SerializationConfigurationExamples
         siloBuilder.Services.AddSerializer(serializerBuilder =>
         {
             serializerBuilder.AddJsonSerializer(
-                isSupported: type => type.Namespace?.StartsWith("Example.Namespace") is true);
+                isSupported: type => type.Namespace?.StartsWith("Example.Namespace", StringComparison.Ordinal) is true);
         });
         // </configure_system_text_json>
     }

--- a/docs/site/src/content/docs/snippets/compiled/Host/HostSnippets.cs
+++ b/docs/site/src/content/docs/snippets/compiled/Host/HostSnippets.cs
@@ -91,7 +91,7 @@ namespace Documentation.Hosting.SerializationConfiguration
 siloBuilder.Services.AddSerializer(serializerBuilder =>
 {
     serializerBuilder.AddJsonSerializer(
-        isSupported: type => type.Namespace?.StartsWith("MyApp") == true);
+        isSupported: type => type.Namespace?.StartsWith("MyApp", StringComparison.Ordinal) == true);
     serializerBuilder.Configure(options =>
         options.AddAllowedType(typeof(TriggerRule)));
 });

--- a/docs/site/src/content/docs/streaming/snippets/broadcastchannel/BroadcastChannel.Silo/Program.cs
+++ b/docs/site/src/content/docs/streaming/snippets/broadcastchannel/BroadcastChannel.Silo/Program.cs
@@ -21,7 +21,8 @@ await Host.CreateDefaultBuilder(args)
         silo.Services.AddSerializer(
             serializer => serializer.AddJsonSerializer(
                 isSupported: type => type?.Namespace?.StartsWith(
-                        nameof(BroadcastChannel)) ?? false,
+                        nameof(BroadcastChannel),
+                        StringComparison.Ordinal) ?? false,
                 jsonSerializerOptions: new(JsonSerializerDefaults.Web)));
         silo.Services.AddHostedService<StockWorker>();
         silo.UseLocalhostClustering();

--- a/docs/tools/PackageJsonGenerator/Helpers/PdbSourceReader.cs
+++ b/docs/tools/PackageJsonGenerator/Helpers/PdbSourceReader.cs
@@ -427,10 +427,10 @@ internal sealed class PdbSourceReader : IDisposable
             bool isMatch = mname == memberName
                 || (memberName == ".ctor" && mname == ".ctor")
                 || (mname == ".ctor" && memberName == tname)
-                || (mname.StartsWith("get_") && mname[4..] == memberName)
-                || (mname.StartsWith("set_") && mname[4..] == memberName)
-                || (mname.StartsWith("add_") && mname[4..] == memberName)
-                || (mname.StartsWith("remove_") && mname[7..] == memberName);
+                || (mname.StartsWith("get_", StringComparison.Ordinal) && mname[4..] == memberName)
+                || (mname.StartsWith("set_", StringComparison.Ordinal) && mname[4..] == memberName)
+                || (mname.StartsWith("add_", StringComparison.Ordinal) && mname[4..] == memberName)
+                || (mname.StartsWith("remove_", StringComparison.Ordinal) && mname[7..] == memberName);
 
             if (!isMatch) continue;
 

--- a/docs/tools/PackageJsonGenerator/PackageJsonGenerator.cs
+++ b/docs/tools/PackageJsonGenerator/PackageJsonGenerator.cs
@@ -279,7 +279,7 @@ public static class PackageJsonGenerator
 
     private static bool IsCompilerGenerated(INamedTypeSymbol type)
     {
-        return type.Name.StartsWith("<") ||
+        return type.Name.StartsWith("<", StringComparison.Ordinal) ||
                type.GetAttributes().Any(a =>
                    a.AttributeClass?.Name == "CompilerGeneratedAttribute");
     }
@@ -440,7 +440,9 @@ public static class PackageJsonGenerator
             var trimmed = lines[i].TrimStart();
 
             // Skip comment lines
-            if (trimmed.StartsWith("//") || trimmed.StartsWith("/*") || trimmed.StartsWith("*"))
+            if (trimmed.StartsWith("//", StringComparison.Ordinal)
+                || trimmed.StartsWith("/*", StringComparison.Ordinal)
+                || trimmed.StartsWith("*", StringComparison.Ordinal))
                 continue;
 
             if (pattern.IsMatch(lines[i]))

--- a/samples/Adventure/AdventureGrains/PlayerGrain.cs
+++ b/samples/Adventure/AdventureGrains/PlayerGrain.cs
@@ -201,7 +201,7 @@ public class PlayerGrain : Grain, IPlayerGrain
             builder.Append($"{words[i]} ");
         }
 
-        return builder.ToString().Trim().ToLower();
+        return builder.ToString().Trim().ToLowerInvariant();
     }
 
     async Task<string?> IPlayerGrain.Play(string command)
@@ -209,7 +209,7 @@ public class PlayerGrain : Grain, IPlayerGrain
         command = RemoveStopWords(command);
 
         string[] words = command.Split(' ');
-        string verb = words[0].ToLower();
+        string verb = words[0].ToLowerInvariant();
 
         if (_killed && verb is not "end")
         {

--- a/samples/Adventure/AdventureGrains/RoomGrain.cs
+++ b/samples/Adventure/AdventureGrains/RoomGrain.cs
@@ -70,18 +70,16 @@ public class RoomGrain : Grain, IRoomGrain
 
     Task<PlayerInfo?> IRoomGrain.FindPlayer(string name)
     {
-        name = name.ToLower();
         return Task.FromResult(
             _players.FirstOrDefault(
-                x => x?.Name?.ToLower()?.Contains(name) ?? false));
+                x => x?.Name?.Contains(name, StringComparison.OrdinalIgnoreCase) ?? false));
     }
 
     Task<MonsterInfo?> IRoomGrain.FindMonster(string name)
     {
-        name = name.ToLower();
         return Task.FromResult(
             _monsters.FirstOrDefault(
-                x => x?.Name?.ToLower()?.Contains(name) ?? false));
+                x => x?.Name?.Contains(name, StringComparison.OrdinalIgnoreCase) ?? false));
     }
 
     Task<string> IRoomGrain.Description(PlayerInfo whoisAsking)

--- a/samples/ChatRoom/ChatRoom.Client/Program.cs
+++ b/samples/ChatRoom/ChatRoom.Client/Program.cs
@@ -45,7 +45,7 @@ static async Task ProcessLoopAsync(ClientContext context)
             continue;
         }
 
-        if (input.StartsWith("/exit") &&
+        if (input.StartsWith("/exit", StringComparison.Ordinal) &&
             AnsiConsole.Confirm("Do you really want to exit?"))
         {
             break;

--- a/samples/Chirper/Chirper.Client/ShellHostedService.cs
+++ b/samples/Chirper/Chirper.Client/ShellHostedService.cs
@@ -37,7 +37,7 @@ public sealed partial class ShellHostedService : BackgroundService
                 _applicationLifetime.StopApplication();
                 return;
             }
-            else if (command.StartsWith("/user "))
+            else if (command.StartsWith("/user ", StringComparison.Ordinal))
             {
                 if (SetUsernameRegex().Match(command) is { Success: true } match)
                 {
@@ -52,7 +52,7 @@ public sealed partial class ShellHostedService : BackgroundService
                     AnsiConsole.MarkupLine("[bold red]Invalid username[/][red].[/] Try again or type [bold fuchsia]/help[/] for a list of commands.");
                 }
             }
-            else if (command.StartsWith("/follow "))
+            else if (command.StartsWith("/follow ", StringComparison.Ordinal))
             {
                 if (EnsureActiveAccount(_account))
                 {
@@ -136,7 +136,7 @@ public sealed partial class ShellHostedService : BackgroundService
                     AnsiConsole.MarkupLine("[bold grey][[[/][bold lime]✓[/][bold grey]]][/] [bold olive]No longer observing[/] [navy]{0}[/]", _account.GetPrimaryKeyString());
                 }
             }
-            else if (command.StartsWith("/unfollow "))
+            else if (command.StartsWith("/unfollow ", StringComparison.Ordinal))
             {
                 if (EnsureActiveAccount(_account))
                 {
@@ -151,7 +151,7 @@ public sealed partial class ShellHostedService : BackgroundService
                     }
                 }
             }
-            else if (command.StartsWith("/chirp "))
+            else if (command.StartsWith("/chirp ", StringComparison.Ordinal))
             {
                 if (EnsureActiveAccount(_account))
                 {

--- a/samples/Deployment/AzureContainerApps/Scaler/Services/ExternalScalerService.cs
+++ b/samples/Deployment/AzureContainerApps/Scaler/Services/ExternalScalerService.cs
@@ -129,12 +129,12 @@ namespace Scaler.Services
         {
             var statistics = await _managementGrain.GetDetailedGrainStatistics();
             var activeGrainsInCluster = statistics.Select(_ => new GrainInfo(_.GrainType, _.GrainId.Key.ToString(), _.SiloAddress.ToGatewayUri().AbsoluteUri));
-            var activeGrainsOfSpecifiedType = activeGrainsInCluster.Where(_ => _.Type.ToLower().Contains(grainType));
+            var activeGrainsOfSpecifiedType = activeGrainsInCluster.Where(_ => _.Type.Contains(grainType, StringComparison.OrdinalIgnoreCase));
             var detailedHosts = await _managementGrain.GetDetailedHosts();
             var silos = detailedHosts
                             .Where(x => x.Status == SiloStatus.Active)
                             .Select(_ => new SiloInfo(_.SiloName, _.SiloAddress.ToGatewayUri().AbsoluteUri));
-            var activeSiloCount = silos.Where(_ => _.SiloName.ToLower().Contains(siloNameFilter.ToLower())).Count();
+            var activeSiloCount = silos.Count(_ => _.SiloName.Contains(siloNameFilter, StringComparison.OrdinalIgnoreCase));
             _logger.LogInformation($"Found {activeGrainsOfSpecifiedType.Count()} instances of {grainType} in cluster, with {activeSiloCount} '{siloNameFilter}' silos in the cluster hosting {grainType} grains.");
             return new GrainSaturationSummary(activeGrainsOfSpecifiedType.Count(), activeSiloCount);
         }

--- a/samples/Deployment/AzureContainerApps/Scaler/Services/ExternalScalerService.cs
+++ b/samples/Deployment/AzureContainerApps/Scaler/Services/ExternalScalerService.cs
@@ -134,9 +134,10 @@ namespace Scaler.Services
             var silos = detailedHosts
                             .Where(x => x.Status == SiloStatus.Active)
                             .Select(_ => new SiloInfo(_.SiloName, _.SiloAddress.ToGatewayUri().AbsoluteUri));
+            var activeGrainCount = activeGrainsOfSpecifiedType.Count();
             var activeSiloCount = silos.Count(_ => _.SiloName.Contains(siloNameFilter, StringComparison.OrdinalIgnoreCase));
-            _logger.LogInformation($"Found {activeGrainsOfSpecifiedType.Count()} instances of {grainType} in cluster, with {activeSiloCount} '{siloNameFilter}' silos in the cluster hosting {grainType} grains.");
-            return new GrainSaturationSummary(activeGrainsOfSpecifiedType.Count(), activeSiloCount);
+            _logger.LogInformation($"Found {activeGrainCount} instances of {grainType} in cluster, with {activeSiloCount} '{siloNameFilter}' silos in the cluster hosting {grainType} grains.");
+            return new GrainSaturationSummary(activeGrainCount, activeSiloCount);
         }
     }
 

--- a/samples/Voting/Grains/VoteGrain.cs
+++ b/samples/Voting/Grains/VoteGrain.cs
@@ -27,7 +27,7 @@ public class VoteGrain : Grain, IVoteGrain
         var stopwatch = Stopwatch.StartNew();
         _logger.LogInformation("Saving vote");
 
-        var key = option.ToLower();
+        var key = option.ToLowerInvariant();
         if (!_state.State.ContainsKey(key))
         {
             _logger.LogInformation("Created a vote option and recorded a vote");
@@ -48,7 +48,7 @@ public class VoteGrain : Grain, IVoteGrain
         var stopwatch = Stopwatch.StartNew();
         _logger.LogInformation("Deleting vote option");
 
-        var key = option.ToLower();
+        var key = option.ToLowerInvariant();
         if (!_state.State.ContainsKey(key))
         {
             _logger.LogWarning("Didn't find the requested vote option");
@@ -57,7 +57,7 @@ public class VoteGrain : Grain, IVoteGrain
         else
         {
             _logger.LogInformation("Removed a vote option");
-            _state.State.Remove(key.ToLower());
+            _state.State.Remove(key);
         }
 
         await _state.WriteStateAsync();

--- a/src/AWS/Orleans.Clustering.DynamoDB/.editorconfig
+++ b/src/AWS/Orleans.Clustering.DynamoDB/.editorconfig
@@ -1,3 +1,0 @@
-[*.cs]
-dotnet_diagnostic.CA1305.severity = warning
-dotnet_diagnostic.CA1307.severity = warning

--- a/src/Azure/Orleans.Clustering.AzureStorage/Globalization.globalconfig
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Globalization.globalconfig
@@ -1,4 +1,0 @@
-is_global = true
-
-dotnet_diagnostic.CA1305.severity = warning
-dotnet_diagnostic.CA1307.severity = warning

--- a/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
@@ -21,10 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)Globalization.globalconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="$(SourceRoot)src\Orleans.Runtime\Orleans.Runtime.csproj" />
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Data.Tables" />

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -20,7 +20,6 @@
     <Compile Include="..\Shared\Storage\AzureTableDataManager.cs" Link="Storage\AzureTableDataManager.cs" />
     <Compile Include="..\Shared\Storage\AzureTableUtils.cs" Link="Storage\AzureTableUtils.cs" />
     <Compile Include="..\Shared\Utilities\ErrorCode.cs" Link="Utilities\ErrorCode.cs" />
-    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)Orleans.Persistence.AzureStorage.globalconfig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.globalconfig
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.globalconfig
@@ -1,3 +1,0 @@
-is_global = true
-
-dotnet_diagnostic.CA1062.severity = warning

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -331,7 +331,7 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
         {
             foreach (var idx in _options.StateFieldsToIndex)
             {
-                var path = idx.StartsWith("/") ? idx[1..] : idx;
+                var path = idx.StartsWith("/", StringComparison.Ordinal) ? idx[1..] : idx;
                 stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = $"/\"State\"/\"{path}\"/?" });
             }
         }

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -169,7 +169,7 @@ namespace Orleans.Runtime.ReminderService
             finally
             {
                 string serviceIdStr = this.clusterOptions.ServiceId;
-                if (!tableEntry.ServiceId!.Equals(serviceIdStr))
+                if (!tableEntry.ServiceId!.Equals(serviceIdStr, StringComparison.Ordinal))
                 {
                     LogWarningAzureTable_ReadWrongReminder(tableEntry, serviceIdStr);
                     throw new OrleansException($"Read a reminder entry for wrong Service id. Read {tableEntry}, but my service id is {serviceIdStr}. Going to discard it.");

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/RemindersTableManager.cs
@@ -173,8 +173,8 @@ namespace Orleans.Runtime.ReminderService
             // group by grain hashcode so each query goes to different partition
             var tasks = new List<Task>();
             var groupedByHash = entries
-                .Where(tuple => tuple.Entity.ServiceId!.Equals(_serviceId))
-                .Where(tuple => tuple.Entity.DeploymentId!.Equals(_clusterId))  // delete only entries that belong to our DeploymentId.
+                .Where(tuple => tuple.Entity.ServiceId!.Equals(_serviceId, StringComparison.Ordinal))
+                .Where(tuple => tuple.Entity.DeploymentId!.Equals(_clusterId, StringComparison.Ordinal))  // delete only entries that belong to our DeploymentId.
                 .GroupBy(x => x.Entity.GrainRefConsistentHash!).ToDictionary(g => g.Key, g => g.ToList());
 
             foreach (var entriesPerPartition in groupedByHash.Values)

--- a/src/Cassandra/Orleans.Clustering.Cassandra/CassandraClusteringTable.cs
+++ b/src/Cassandra/Orleans.Clustering.Cassandra/CassandraClusteringTable.cs
@@ -57,7 +57,7 @@ internal sealed class CassandraClusteringTable : IMembershipTable
 
     async Task IMembershipTable.DeleteMembershipTableEntries(string clusterId)
     {
-        if (string.Compare(clusterId, _clusterOptions.ClusterId, StringComparison.InvariantCultureIgnoreCase) != 0)
+        if (string.Compare(clusterId, _clusterOptions.ClusterId, StringComparison.OrdinalIgnoreCase) != 0)
         {
             throw new ArgumentException(
                 $"Cluster id {clusterId} does not match CassandraClusteringTable value of '{_clusterOptions.ClusterId}'.",

--- a/src/Orleans.BroadcastChannel/ChannelId.cs
+++ b/src/Orleans.BroadcastChannel/ChannelId.cs
@@ -231,7 +231,7 @@ namespace Orleans.BroadcastChannel
 
         public static implicit operator ChannelId(InternalChannelId internalStreamId) => internalStreamId.ChannelId;
 
-        public bool Equals(InternalChannelId other) => ChannelId.Equals(other) && ProviderName.Equals(other.ProviderName);
+        public bool Equals(InternalChannelId other) => ChannelId.Equals(other) && ProviderName.Equals(other.ProviderName, StringComparison.Ordinal);
 
         public override bool Equals(object? obj) => obj is InternalChannelId other ? this.Equals(other) : false;
 

--- a/src/Orleans.BroadcastChannel/SubscriberTable/Predicates/ExactMatchStreamNamespacePredicate.cs
+++ b/src/Orleans.BroadcastChannel/SubscriberTable/Predicates/ExactMatchStreamNamespacePredicate.cs
@@ -28,7 +28,7 @@ namespace Orleans.BroadcastChannel
         /// <inheritdoc/>
         public bool IsMatch(string streamNamespace)
         {
-            return string.Equals(targetStreamNamespace, streamNamespace?.Trim());
+            return string.Equals(targetStreamNamespace, streamNamespace?.Trim(), StringComparison.Ordinal);
         }
     }
 }

--- a/src/Orleans.CodeGenerator/Model/IMemberDescription.cs
+++ b/src/Orleans.CodeGenerator/Model/IMemberDescription.cs
@@ -35,7 +35,7 @@ internal sealed class MemberDescriptionTypeComparer : IEqualityComparer<IMemberD
             return false;
         }
 
-        return string.Equals(x.TypeName, y.TypeName) && string.Equals(x.AssemblyName, y.AssemblyName);
+        return string.Equals(x.TypeName, y.TypeName, StringComparison.Ordinal) && string.Equals(x.AssemblyName, y.AssemblyName, StringComparison.Ordinal);
     }
 
     public int GetHashCode(IMemberDescription obj)

--- a/src/Orleans.CodeGenerator/Model/MetadataModel.cs
+++ b/src/Orleans.CodeGenerator/Model/MetadataModel.cs
@@ -26,7 +26,7 @@ internal readonly struct CompoundTypeAliasComponent : IEquatable<CompoundTypeAli
     public bool Equals(CompoundTypeAliasComponent other) => (Value, other.Value) switch
     {
         (null, null) => true,
-        (string stringValue, string otherStringValue) => string.Equals(stringValue, otherStringValue),
+        (string stringValue, string otherStringValue) => string.Equals(stringValue, otherStringValue, StringComparison.Ordinal),
         (ITypeSymbol typeValue, ITypeSymbol otherTypeValue) => SymbolEqualityComparer.Default.Equals(typeValue, otherTypeValue),
         _ => false,
     };

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -226,7 +226,7 @@ namespace Orleans.Hosting
                 .ConfigureServices(services =>
                 {
                     // If the caller did not override service id or cluster id, configure default values as a fallback.
-                    if (string.Equals(serviceId, ClusterOptions.DevelopmentServiceId) && string.Equals(clusterId, ClusterOptions.DevelopmentClusterId))
+                    if (string.Equals(serviceId, ClusterOptions.DevelopmentServiceId, StringComparison.Ordinal) && string.Equals(clusterId, ClusterOptions.DevelopmentClusterId, StringComparison.Ordinal))
                     {
                         services.PostConfigure<ClusterOptions>(options =>
                         {

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -33,7 +33,7 @@ namespace Orleans.Runtime
                     return ActivitySources.ApplicationGrainSource;
 
                 default:
-                    return interfaceType.Namespace?.StartsWith(OrleansNamespacePrefix) == true
+                    return interfaceType.Namespace?.StartsWith(OrleansNamespacePrefix, StringComparison.Ordinal) == true
                         ? ActivitySources.RuntimeGrainSource
                         : ActivitySources.ApplicationGrainSource;
             }

--- a/src/Orleans.Core/Manifest/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Manifest/GrainTypeResolver.cs
@@ -71,7 +71,7 @@ namespace Orleans.Metadata
             }
 
             // Trim "Grain" suffix
-            index = name.LastIndexOf(GrainSuffix);
+            index = name.LastIndexOf(GrainSuffix, StringComparison.Ordinal);
             if (index > 0 && name.Length - index == GrainSuffix.Length)
             {
                 name = name[..index];

--- a/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
@@ -80,7 +80,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
 
         protected override void OnEventSourceCreated(EventSource source)
         {
-            if (source.Name.Equals("System.Runtime"))
+            if (source.Name.Equals("System.Runtime", StringComparison.Ordinal))
             {
                 Dictionary<string, string?>? refreshInterval = new() { ["EventCounterIntervalSec"] = "1" };
                 EnableEvents(source, EventLevel.Informational, (EventKeywords)(-1), refreshInterval);
@@ -89,7 +89,7 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            if ("EventCounters".Equals(eventData.EventName) && eventData.Payload is { } payload)
+            if ("EventCounters".Equals(eventData.EventName, StringComparison.Ordinal) && eventData.Payload is { } payload)
             {
                 for (var i = 0; i < payload.Count; i++)
                 {

--- a/src/Orleans.EventSourcing/Common/StringEncodedWriteVector.cs
+++ b/src/Orleans.EventSourcing/Common/StringEncodedWriteVector.cs
@@ -25,7 +25,7 @@ namespace Orleans.EventSourcing.Common
         public static bool GetBit(string writeVector, string Replica)
         {
             var pos = writeVector.IndexOf(Replica, StringComparison.Ordinal);
-            return pos != -1 && writeVector[pos - 1] == ',';
+            return pos > 0 && writeVector[pos - 1] == ',';
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Orleans.EventSourcing.Common
         public static bool FlipBit(ref string writeVector, string Replica)
         {
             var pos = writeVector.IndexOf(Replica, StringComparison.Ordinal);
-            if (pos != -1 && writeVector[pos - 1] == ',')
+            if (pos > 0 && writeVector[pos - 1] == ',')
             {
                 var pos2 = writeVector.IndexOf(',', pos + 1);
                 if (pos2 == -1)

--- a/src/Orleans.EventSourcing/Common/StringEncodedWriteVector.cs
+++ b/src/Orleans.EventSourcing/Common/StringEncodedWriteVector.cs
@@ -24,7 +24,7 @@ namespace Orleans.EventSourcing.Common
         /// <returns></returns>
         public static bool GetBit(string writeVector, string Replica)
         {
-            var pos = writeVector.IndexOf(Replica);
+            var pos = writeVector.IndexOf(Replica, StringComparison.Ordinal);
             return pos != -1 && writeVector[pos - 1] == ',';
         }
 
@@ -36,7 +36,7 @@ namespace Orleans.EventSourcing.Common
         /// <returns>the state of the bit after flipping it</returns>
         public static bool FlipBit(ref string writeVector, string Replica)
         {
-            var pos = writeVector.IndexOf(Replica);
+            var pos = writeVector.IndexOf(Replica, StringComparison.Ordinal);
             if (pos != -1 && writeVector[pos - 1] == ',')
             {
                 var pos2 = writeVector.IndexOf(',', pos + 1);

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -1543,7 +1543,7 @@ namespace Orleans.Runtime.ReminderService
             public readonly GrainId GrainId = grainId;
             public readonly string ReminderName = reminderName;
 
-            public readonly bool Equals(ReminderIdentity other) => GrainId.Equals(other.GrainId) && ReminderName.Equals(other.ReminderName);
+            public readonly bool Equals(ReminderIdentity other) => GrainId.Equals(other.GrainId) && ReminderName.Equals(other.ReminderName, StringComparison.Ordinal);
 
             public override readonly bool Equals(object? other) => other is ReminderIdentity id && Equals(id);
 

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -99,7 +99,7 @@ public sealed class GrainTypeSharedContext
         if (siloManifest.Grains.TryGetValue(grainType, out var properties)
             && properties.Properties.TryGetValue(WellKnownGrainTypeProperties.IdleDeactivationPeriod, out var idleTimeoutString))
         {
-            if (string.Equals(idleTimeoutString, WellKnownGrainTypeProperties.IndefiniteIdleDeactivationPeriodValue))
+            if (string.Equals(idleTimeoutString, WellKnownGrainTypeProperties.IndefiniteIdleDeactivationPeriodValue, StringComparison.Ordinal))
             {
                 return Timeout.InfiniteTimeSpan;
             }

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -69,7 +69,7 @@ namespace Orleans.Hosting
             builder.ConfigureServices(services =>
             {
                 // If the caller did not override service id or cluster id, configure default values as a fallback.
-                if (string.Equals(serviceId, ClusterOptions.DevelopmentServiceId) && string.Equals(clusterId, ClusterOptions.DevelopmentClusterId))
+                if (string.Equals(serviceId, ClusterOptions.DevelopmentServiceId, StringComparison.Ordinal) && string.Equals(clusterId, ClusterOptions.DevelopmentClusterId, StringComparison.Ordinal))
                 {
                     services.PostConfigure<ClusterOptions>(options =>
                     {

--- a/src/Orleans.Runtime/MembershipService/InMemoryMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/InMemoryMembershipTable.cs
@@ -47,7 +47,7 @@ namespace Orleans.Runtime.MembershipService
         {
             siloTable.TryGetValue(entry.SiloAddress, out var data);
             if (data != null) return false;
-            if (!tableVersion.VersionEtag.Equals(version.VersionEtag)) return false;
+            if (!tableVersion.VersionEtag.Equals(version.VersionEtag, StringComparison.Ordinal)) return false;
 
             siloTable[entry.SiloAddress] = new Tuple<MembershipEntry, string>(
                 entry, lastETagCounter++.ToString(CultureInfo.InvariantCulture));
@@ -59,7 +59,7 @@ namespace Orleans.Runtime.MembershipService
         {
             siloTable.TryGetValue(entry.SiloAddress, out var data);
             if (data == null) return false;
-            if (!data.Item2.Equals(etag) || !tableVersion.VersionEtag.Equals(version.VersionEtag)) return false;
+            if (!data.Item2.Equals(etag, StringComparison.Ordinal) || !tableVersion.VersionEtag.Equals(version.VersionEtag, StringComparison.Ordinal)) return false;
 
             siloTable[entry.SiloAddress] = new Tuple<MembershipEntry, string>(
                 entry, lastETagCounter++.ToString(CultureInfo.InvariantCulture));

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -224,7 +224,7 @@ namespace Orleans.Runtime.MembershipService
             string mySiloName = this.localSiloDetails.Name;
             MembershipEntry? mostRecentPreviousEntry = null;
             // look for silo instances that are same as me, find most recent with Generation before me.
-            foreach (var entry in snapshot.Entries.Select(entry => entry.Value).Where(data => mySiloName.Equals(data.SiloName)))
+            foreach (var entry in snapshot.Entries.Select(entry => entry.Value).Where(data => mySiloName.Equals(data.SiloName, StringComparison.Ordinal)))
             {
                 bool iAmLater = myAddress.Generation.CompareTo(entry.SiloAddress.Generation) > 0;
                 // more recent
@@ -234,7 +234,7 @@ namespace Orleans.Runtime.MembershipService
 
             if (mostRecentPreviousEntry is not null)
             {
-                bool physicalHostChanged = !myHostname.Equals(mostRecentPreviousEntry.HostName) || !myAddress.Endpoint.Equals(mostRecentPreviousEntry.SiloAddress.Endpoint);
+                bool physicalHostChanged = !myHostname.Equals(mostRecentPreviousEntry.HostName, StringComparison.Ordinal) || !myAddress.Endpoint.Equals(mostRecentPreviousEntry.SiloAddress.Endpoint);
                 if (physicalHostChanged)
                 {
                     LogWarningNodeMigrated(this.log, mySiloName, myHostname, myAddress, mostRecentPreviousEntry.HostName, mostRecentPreviousEntry.SiloAddress);

--- a/src/Orleans.Serialization/Codecs/CommonCodecTypeFilter.cs
+++ b/src/Orleans.Serialization/Codecs/CommonCodecTypeFilter.cs
@@ -20,7 +20,7 @@ public class CommonCodecTypeFilter
     public static bool IsAbstractOrFrameworkType(Type type)
     {
         if (type.IsAbstract
-            || type.GetCustomAttributes<GeneratedCodeAttribute>().Any(a => a.Tool!.Equals("OrleansCodeGen"))
+            || type.GetCustomAttributes<GeneratedCodeAttribute>().Any(a => a.Tool!.Equals("OrleansCodeGen", StringComparison.Ordinal))
             || type.Assembly.GetCustomAttribute<FrameworkPartAttribute>() is not null)
         {
             return true;

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -266,7 +266,7 @@ namespace Orleans.Serialization
 
                 foreach (var prefix in _options.SupportedNamespacePrefixes)
                 {
-                    if (ns.StartsWith(prefix))
+                    if (ns.StartsWith(prefix, StringComparison.Ordinal))
                     {
                         return true;
                     }

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameRewriter.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameRewriter.cs
@@ -174,7 +174,7 @@ internal static class RuntimeTypeNameRewriter
                 // Remove the assembly qualification
                 return (replacement.Type, assemblyName);
             }
-            else if (!string.Equals(replacement.Assembly, type.Assembly) || !ReferenceEquals(replacement.Type, type.Type))
+            else if (!string.Equals(replacement.Assembly, type.Assembly, StringComparison.Ordinal) || !ReferenceEquals(replacement.Type, type.Type))
             {
                 // Update the assembly or the type.
                 return (new AssemblyQualifiedTypeSpec(replacement.Type, replacement.Assembly), assemblyName);

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -401,7 +401,7 @@ public class TypeConverter
 
         foreach (var (displayName, runtimeName) in WellKnownTypeAliases)
         {
-            if (displayName.Equals(type.Type) || runtimeName.Equals(type.Type))
+            if (displayName.Equals(type.Type, StringComparison.Ordinal) || runtimeName.Equals(type.Type, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/src/Orleans.Streaming/Predicates/ExactMatchStreamNamespacePredicate.cs
+++ b/src/Orleans.Streaming/Predicates/ExactMatchStreamNamespacePredicate.cs
@@ -28,7 +28,7 @@ namespace Orleans.Streams
         /// <inheritdoc/>
         public bool IsMatch(string streamNamespace)
         {
-            return string.Equals(targetStreamNamespace, streamNamespace?.Trim());
+            return string.Equals(targetStreamNamespace, streamNamespace?.Trim(), StringComparison.Ordinal);
         }
     }
 }

--- a/src/Orleans.TestingHost/InProcess/InProcessMembershipTable.cs
+++ b/src/Orleans.TestingHost/InProcess/InProcessMembershipTable.cs
@@ -121,7 +121,7 @@ internal sealed class InProcessMembershipTable(string clusterId) : IMembershipTa
                     return false;
                 }
 
-                if (!_tableVersion.VersionEtag.Equals(version.VersionEtag))
+                if (!_tableVersion.VersionEtag.Equals(version.VersionEtag, StringComparison.Ordinal))
                 {
                     return false;
                 }
@@ -141,7 +141,7 @@ internal sealed class InProcessMembershipTable(string clusterId) : IMembershipTa
                     return false;
                 }
 
-                if (!data.ETag.Equals(etag) || !_tableVersion.VersionEtag.Equals(version.VersionEtag))
+                if (!data.ETag.Equals(etag, StringComparison.Ordinal) || !_tableVersion.VersionEtag.Equals(version.VersionEtag, StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/src/Orleans.TestingHost/StandaloneSiloHandle.cs
+++ b/src/Orleans.TestingHost/StandaloneSiloHandle.cs
@@ -200,7 +200,7 @@ namespace Orleans.TestingHost
             }
 
             FileInfo target;
-            if (string.Equals(".dll", originalFileInfo.Extension, StringComparison.Ordinal))
+            if (string.Equals(".dll", originalFileInfo.Extension, StringComparison.OrdinalIgnoreCase))
             {
                 if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {

--- a/src/Orleans.TestingHost/StandaloneSiloHandle.cs
+++ b/src/Orleans.TestingHost/StandaloneSiloHandle.cs
@@ -200,7 +200,7 @@ namespace Orleans.TestingHost
             }
 
             FileInfo target;
-            if (string.Equals(".dll", originalFileInfo.Extension))
+            if (string.Equals(".dll", originalFileInfo.Extension, StringComparison.Ordinal))
             {
                 if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -357,7 +357,7 @@ internal class Program
         }
 
         var slicedArgs = args.Skip(1).ToArray();
-        if (args.Length > 0 && args[0].Equals("all", StringComparison.InvariantCultureIgnoreCase))
+        if (args.Length > 0 && args[0].Equals("all", StringComparison.OrdinalIgnoreCase))
         {
             Console.WriteLine("Running full benchmarks suite");
             _benchmarks.Select(pair => pair.Value).ToList().ForEach(action => action(slicedArgs));

--- a/test/DistributedTests/DistributedTests.Client/Commands/CounterCaptureCommand.cs
+++ b/test/DistributedTests/DistributedTests.Client/Commands/CounterCaptureCommand.cs
@@ -72,7 +72,7 @@ namespace DistributedTests.Client.Commands
                 _logger.LogInformation("{Counter}: {Value}", counter, value);
                 BenchmarksEventSource.Register(counter, Operations.First, Operations.Sum, counter, counter, "n0");
                 BenchmarksEventSource.Measure(counter, value);
-                if (string.Equals(counter, "requests", StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(counter, "requests", StringComparison.OrdinalIgnoreCase))
                 {
                     var rps = (float)value / duration.TotalSeconds;
                     BenchmarksEventSource.Register("rps", Operations.First, Operations.Last, "rps", "Requests per second", "n0");

--- a/test/Extensions/Orleans.Azure.Tests/AzureQueueDataManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureQueueDataManagerTests.cs
@@ -19,7 +19,7 @@ namespace Tester.AzureUtils
     {
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
-        public static string DeploymentId = "aqdatamanagertests".ToLower();
+        public static string DeploymentId = "aqdatamanagertests";
         private string queueName = null!;
 
         public AzureQueueDataManagerTests()
@@ -49,7 +49,7 @@ namespace Tester.AzureUtils
         [Fact, TestCategory("Functional")]
         public async Task AQ_Standalone_1()
         {
-            queueName = "Test-1-".ToLower() + Guid.NewGuid();
+            queueName = "test-1-" + Guid.NewGuid();
             AzureQueueDataManager manager = await GetTableManager(queueName);
             Assert.Equal(0, await manager.GetApproximateMessageCount());
 
@@ -86,7 +86,7 @@ namespace Tester.AzureUtils
         [Fact, TestCategory("Functional")]
         public async Task AQ_Standalone_2()
         {
-            queueName = "Test-2-".ToLower() + Guid.NewGuid();
+            queueName = "test-2-" + Guid.NewGuid();
             AzureQueueDataManager manager = await GetTableManager(queueName);
 
             IEnumerable<QueueMessage> msgs = await manager.GetQueueMessages();
@@ -119,7 +119,7 @@ namespace Tester.AzureUtils
         [Fact, TestCategory("Functional")]
         public async Task AQ_Standalone_3_Init_MultipleThreads()
         {
-            queueName = "Test-4-".ToLower() + Guid.NewGuid();
+            queueName = "test-4-" + Guid.NewGuid();
 
             const int NumThreads = 100;
             Task<bool>[] promises = new Task<bool>[NumThreads];
@@ -142,7 +142,7 @@ namespace Tester.AzureUtils
         {
             var visibilityTimeout = TimeSpan.FromSeconds(2);
 
-            queueName = "Test-5-".ToLower() + Guid.NewGuid();
+            queueName = "test-5-" + Guid.NewGuid();
             var manager = await GetTableManager(queueName, visibilityTimeout);
 
             var inMessage = "Hello, World";

--- a/test/Grains/TestGrainInterfaces/RedStreamNamespacePredicate.cs
+++ b/test/Grains/TestGrainInterfaces/RedStreamNamespacePredicate.cs
@@ -8,7 +8,7 @@ namespace UnitTests.GrainInterfaces
 
         public bool IsMatch(string streamNamespace)
         {
-            return streamNamespace.StartsWith("red");
+            return streamNamespace.StartsWith("red", StringComparison.Ordinal);
         }
     }
 }

--- a/test/Grains/TestGrains/MessageSerializationGrain.cs
+++ b/test/Grains/TestGrains/MessageSerializationGrain.cs
@@ -66,7 +66,7 @@ namespace UnitTests.Grains
                 RequestContext.Set(IPlacementDirector.PlacementHintKey, silos.First());
                 otherGrain = this.GrainFactory.GetGrain<IMessageSerializationGrain>(++id);
                 var otherIdentity = await otherGrain.GetSiloIdentity();
-                if (!string.Equals(otherIdentity, currentSiloIdentity))
+                if (!string.Equals(otherIdentity, currentSiloIdentity, StringComparison.Ordinal))
                 {
                     break;
                 }

--- a/test/Grains/TestGrains/MethodInterceptionGrain.cs
+++ b/test/Grains/TestGrains/MethodInterceptionGrain.cs
@@ -305,12 +305,12 @@ namespace UnitTests.Grains
                 {
                     var interfaceMethod = ctx.InterfaceMethod ?? throw new ArgumentException("InterfaceMethod is null!");
                     var implementationMethod = ctx.ImplementationMethod ?? throw new ArgumentException("ImplementationMethod is null!");
-                    if (!string.Equals(implementationMethod.Name, interfaceMethod.Name))
+                    if (!string.Equals(implementationMethod.Name, interfaceMethod.Name, StringComparison.Ordinal))
                     {
                         throw new ArgumentException("InterfaceMethod.Name != ImplementationMethod.Name");
                     }
 
-                    if (string.Equals(implementationMethod.Name, nameof(GrainSpecificCallFilterMarker)))
+                    if (string.Equals(implementationMethod.Name, nameof(GrainSpecificCallFilterMarker), StringComparison.Ordinal))
                     {
                         // explicitly do not continue calling Invoke
                         return;
@@ -322,7 +322,7 @@ namespace UnitTests.Grains
                 }
                 catch (ArgumentOutOfRangeException) when (attemptsRemaining > 1)
                 {
-                    if (string.Equals(ctx.ImplementationMethod?.Name, nameof(ThrowIfGreaterThanZero)) && ctx.Request.GetArgument(0) is int value)
+                    if (string.Equals(ctx.ImplementationMethod?.Name, nameof(ThrowIfGreaterThanZero), StringComparison.Ordinal) && ctx.Request.GetArgument(0) is int value)
                     {
                         ctx.Request.SetArgument(0, value - 1);
                     }
@@ -365,12 +365,12 @@ namespace UnitTests.Grains
                 {
                     var interfaceMethod = ctx.InterfaceMethod ?? throw new ArgumentException("InterfaceMethod is null!");
                     var implementationMethod = ctx.ImplementationMethod ?? throw new ArgumentException("ImplementationMethod is null!");
-                    if (!string.Equals(implementationMethod.Name, interfaceMethod.Name))
+                    if (!string.Equals(implementationMethod.Name, interfaceMethod.Name, StringComparison.Ordinal))
                     {
                         throw new ArgumentException("InterfaceMethod.Name != ImplementationMethod.Name");
                     }
 
-                    if (string.Equals(implementationMethod.Name, nameof(GrainSpecificCallFilterMarker)))
+                    if (string.Equals(implementationMethod.Name, nameof(GrainSpecificCallFilterMarker), StringComparison.Ordinal))
                     {
                         // explicitly do not continue calling Invoke
                         return;
@@ -382,7 +382,7 @@ namespace UnitTests.Grains
                 }
                 catch (ArgumentOutOfRangeException) when (attemptsRemaining > 1)
                 {
-                    if (string.Equals(ctx.ImplementationMethod?.Name, nameof(ThrowIfGreaterThanZero)) && ctx.Request.GetArgument(0) is int value)
+                    if (string.Equals(ctx.ImplementationMethod?.Name, nameof(ThrowIfGreaterThanZero), StringComparison.Ordinal) && ctx.Request.GetArgument(0) is int value)
                     {
                         ctx.Request.SetArgument(0, value - 1);
                     }

--- a/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
+++ b/test/Grains/TestGrains/MultipleSubscriptionConsumerGrain.cs
@@ -181,7 +181,7 @@ namespace UnitTests.Grains
             {
                 logger.LogInformation("Got next event {Item} on handle {Handle}", item.Item, countCapture);
                 var contextValue = RequestContext.Get(SampleStreaming_ProducerGrain.RequestContextKey) as string;
-                if (!string.Equals(contextValue, SampleStreaming_ProducerGrain.RequestContextValue))
+                if (!string.Equals(contextValue, SampleStreaming_ProducerGrain.RequestContextValue, StringComparison.Ordinal))
                 {
                     throw new Exception($"Got the wrong RequestContext value {contextValue}.");
                 }

--- a/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
+++ b/test/Grains/TestInternalGrains/StreamLifecycleTestGrains.cs
@@ -56,7 +56,7 @@ namespace UnitTests.Grains
                 return false;
             }
 
-            return A.Equals(item.A) && B.Equals(item.B);
+            return A.Equals(item.A, StringComparison.Ordinal) && B.Equals(item.B);
         }
 
         public override int GetHashCode() => HashCode.Combine(A, B);

--- a/test/Orleans.Core.Tests/Membership/InMemoryMembershipTable.cs
+++ b/test/Orleans.Core.Tests/Membership/InMemoryMembershipTable.cs
@@ -163,7 +163,7 @@ namespace NonSilo.Tests.Membership
                 var existingEntry = this.entries.Find(e => e.Item1.SiloAddress.Equals(entry.SiloAddress));
                 if (existingEntry.Item1 is null) return Task.FromResult(false);
 
-                if (!etag.Equals(existingEntry.Item2))
+                if (!etag.Equals(existingEntry.Item2, StringComparison.Ordinal))
                 {
                     throw new InvalidOperationException($"Mismatching row etag. Required: {existingEntry.Item2}, Provided: {etag}");
                 }

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -77,7 +77,7 @@ namespace NonSilo.Tests.Membership
                 Entry(this.localSilo, SiloStatus.Active, now)), cancellationToken);
 
             Assert.False(cleanupCalled.Task.IsCompleted);
-            Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+            Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries), StringComparison.Ordinal));
 
             await lifecycle.OnStop(cancellationToken);
         }
@@ -217,7 +217,7 @@ namespace NonSilo.Tests.Membership
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
 
             await lifecycle.OnStart(cancellationToken);
-            Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+            Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries), StringComparison.Ordinal));
 
             if (enabled)
             {
@@ -236,12 +236,12 @@ namespace NonSilo.Tests.Membership
             {
                 var cleanupCall = Assert.Single(
                     table.Calls,
-                    call => call.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+                    call => call.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries), StringComparison.Ordinal));
                 Assert.Equal(now - options.DefunctSiloExpiration, cleanupCall.Arguments);
             }
             else
             {
-                Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+                Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries), StringComparison.Ordinal));
             }
         }
 

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -176,8 +176,8 @@ namespace NonSilo.Tests.Membership
 
             calls = membershipTable.Calls.Skip(2).ToList();
             Assert.NotEmpty(calls);
-            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.InsertRow)));
-            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.ReadAll)));
+            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.InsertRow), StringComparison.Ordinal));
+            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.ReadAll), StringComparison.Ordinal));
 
             {
                 // Check that a timer is being requested and that after it expires a call to
@@ -188,7 +188,7 @@ namespace NonSilo.Tests.Membership
                 membershipTable.ClearCalls();
                 completion.TrySetResult(true);
                 while (membershipTable.Calls.Count == 0) await Task.Delay(10, cancellationToken);
-                Assert.Contains(membershipTable.Calls, c => c.Method.Equals(nameof(IMembershipTable.ReadAll)));
+                Assert.Contains(membershipTable.Calls, c => c.Method.Equals(nameof(IMembershipTable.ReadAll), StringComparison.Ordinal));
             }
 
             using var shutdownCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -271,7 +271,7 @@ namespace NonSilo.Tests.Membership
             Assert.NotEmpty(calls);
             Assert.True(calls.Count >= 2);
             Assert.Equal(nameof(IMembershipTable.InitializeMembershipTable), calls[0].Method);
-            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.ReadAll)));
+            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.ReadAll), StringComparison.Ordinal));
 
             // During initialization, the table is read and predecessor entries are declared dead
             // before the table snapshot is published to other components.
@@ -300,8 +300,8 @@ namespace NonSilo.Tests.Membership
 
             calls = membershipTable.Calls.Skip(2).ToList();
             Assert.NotEmpty(calls);
-            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.InsertRow)));
-            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.ReadAll)));
+            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.InsertRow), StringComparison.Ordinal));
+            Assert.Contains(calls, call => call.Method.Equals(nameof(IMembershipTable.ReadAll), StringComparison.Ordinal));
 
             await this.lifecycle.OnStop(cancellationToken);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);

--- a/test/Orleans.DefaultCluster.Tests/ObserverTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/ObserverTests.cs
@@ -157,7 +157,7 @@ namespace DefaultCluster.Tests.General
                 Exception baseException = exc.GetBaseException();
                 this.Logger.LogInformation(baseException, "Received exception");
                 Assert.IsAssignableFrom<OrleansException>(baseException);
-                if (!baseException.Message.StartsWith("Cannot subscribe already subscribed observer"))
+                if (!baseException.Message.StartsWith("Cannot subscribe already subscribed observer", StringComparison.Ordinal))
                 {
                     Assert.Fail("Unexpected exception message: " + baseException);
                 }

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/StringEncodedWriteVectorTests.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/StringEncodedWriteVectorTests.cs
@@ -1,0 +1,24 @@
+using Orleans.EventSourcing.Common;
+using Xunit;
+
+namespace Tester.EventSourcingTests;
+
+public class StringEncodedWriteVectorTests
+{
+    [Fact]
+    public void GetBit_ReturnsFalse_WhenReplicaStartsMalformedVector()
+    {
+        Assert.False(StringEncodedWriteVector.GetBit("A", "A"));
+    }
+
+    [Fact]
+    public void FlipBit_AddsReplica_WhenReplicaStartsMalformedVector()
+    {
+        var writeVector = "A";
+
+        var result = StringEncodedWriteVector.FlipBit(ref writeVector, "A");
+
+        Assert.True(result);
+        Assert.Equal(",AA", writeVector);
+    }
+}

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -302,7 +302,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                     RequestContext.Remove(IPlacementDirector.PlacementHintKey);
                 }
 
-                if (this.testCluster.Primary!.SiloAddress.ToString().Equals(siloHostingActivation))
+                if (this.testCluster.Primary!.SiloAddress.ToString().Equals(siloHostingActivation, StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/test/Orleans.Runtime.Internal.Tests/MessageScheduling/CallChainReentrancyTestHelper.cs
+++ b/test/Orleans.Runtime.Internal.Tests/MessageScheduling/CallChainReentrancyTestHelper.cs
@@ -199,7 +199,7 @@ namespace UnitTests.General
             public async Task WaitForOperationAsync(CallChainOperation operationType, string grain, int callIndex, CancellationToken cancellationToken = default)
             {
                 // First check if we've already seen this operation
-                if (_allOperations.Any(op => op.Operation == operationType && op.Grain.Equals(grain) && op.CallIndex == callIndex))
+                if (_allOperations.Any(op => op.Operation == operationType && op.Grain.Equals(grain, StringComparison.Ordinal) && op.CallIndex == callIndex))
                 {
                     return;
                 }
@@ -210,7 +210,7 @@ namespace UnitTests.General
                     Assert.True(operations.TryRead(out var operation));
                     _allOperations.Add(operation);
 
-                    if (operation.Operation == operationType && operation.Grain.Equals(grain) && operation.CallIndex == callIndex)
+                    if (operation.Operation == operationType && operation.Grain.Equals(grain, StringComparison.Ordinal) && operation.CallIndex == callIndex)
                     {
                         return;
                     }

--- a/test/Orleans.Runtime.Internal.Tests/MessageScheduling/ReentrancyTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/MessageScheduling/ReentrancyTests.cs
@@ -111,7 +111,7 @@ namespace UnitTests
             Assert.Contains("exit:A", log);
             Assert.Contains("exit:B", log);
 
-            var firstExit = log.FindIndex(x => x.StartsWith("exit"));
+            var firstExit = log.FindIndex(x => x.StartsWith("exit", StringComparison.Ordinal));
             Assert.True(firstExit >= 2, $"Expected both methods to enter before exiting. Log: {string.Join(", ", log)}");
         }
 

--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -401,7 +401,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
             target = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
             targetInstanceId = await target.GetRuntimeInstanceId();
             RequestContext.Clear();
-        } while (placeOnDifferentSilos && instanceId.Equals(targetInstanceId) || !placeOnDifferentSilos && !instanceId.Equals(targetInstanceId));
+        } while (placeOnDifferentSilos && instanceId.Equals(targetInstanceId, StringComparison.Ordinal) || !placeOnDifferentSilos && !instanceId.Equals(targetInstanceId, StringComparison.Ordinal));
 
         return new Tuple<ILongRunningTaskGrain<T1>, ILongRunningTaskGrain<T1>>(grain, target);
     }

--- a/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
@@ -288,7 +288,7 @@ namespace UnitTests.CancellationTests
                 target = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<T1>>(Guid.NewGuid());
                 targetInstanceId = await target.GetRuntimeInstanceId();
                 RequestContext.Clear();
-            } while (placeOnDifferentSilos && instanceId.Equals(targetInstanceId) || !placeOnDifferentSilos && !instanceId.Equals(targetInstanceId));
+            } while (placeOnDifferentSilos && instanceId.Equals(targetInstanceId, StringComparison.Ordinal) || !placeOnDifferentSilos && !instanceId.Equals(targetInstanceId, StringComparison.Ordinal));
 
             return new Tuple<ILongRunningTaskGrain<T1>, ILongRunningTaskGrain<T1>>(grain, target);
         }

--- a/test/Orleans.Runtime.Tests/GrainCallFilterTests.cs
+++ b/test/Orleans.Runtime.Tests/GrainCallFilterTests.cs
@@ -102,7 +102,7 @@ namespace UnitTests.General
 
                             // Test 1: Verify RequestContext propagation through filters
                             // Each filter adds a digit to build up "1234"
-                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrain.GetRequestContext)))
+                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrain.GetRequestContext), StringComparison.Ordinal))
                             {
                                 if (RequestContext.Get(GrainCallFilterTestConstants.Key) != null) throw new InvalidOperationException();
                                 RequestContext.Set(GrainCallFilterTestConstants.Key, "1");
@@ -110,7 +110,7 @@ namespace UnitTests.General
 
                             // Test 2: Verify behavior when filter doesn't call context.Invoke()
                             // This should result in an InvalidOperationException for the caller
-                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrain.SystemWideCallFilterMarker)))
+                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrain.SystemWideCallFilterMarker), StringComparison.Ordinal))
                             {
                                 // explicitly do not continue calling Invoke
                                 return Task.CompletedTask;
@@ -118,7 +118,7 @@ namespace UnitTests.General
 
                             // Test 3: Demonstrate request manipulation - negate the value
                             // This shows filters can modify method arguments before execution
-                            if (string.Equals(context.InterfaceMethod.Name, nameof(IMyGrainExtension.SetExtensionValue)))
+                            if (string.Equals(context.InterfaceMethod.Name, nameof(IMyGrainExtension.SetExtensionValue), StringComparison.Ordinal))
                             {
                                 context.Request.SetArgument(0, (int)context.Request.GetArgument(0)! * -1);
                             }
@@ -137,7 +137,7 @@ namespace UnitTests.General
                                 ctx.Request.SetArgument(0, orig + orig);
                             }
 
-                            if (string.Equals(ctx.InterfaceMethod?.Name, nameof(IMethodInterceptionGrain.SystemWideCallFilterMarker)))
+                            if (string.Equals(ctx.InterfaceMethod?.Name, nameof(IMethodInterceptionGrain.SystemWideCallFilterMarker), StringComparison.Ordinal))
                             {
                                 // explicitly do not continue calling Invoke
                                 return;
@@ -168,13 +168,13 @@ namespace UnitTests.General
                             Assert.False(context.TargetId.IsDefault);
                             Assert.False(context.InterfaceType.IsDefault);
 
-                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrainObserver.GetRequestContext)))
+                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrainObserver.GetRequestContext), StringComparison.Ordinal))
                             {
                                 if (RequestContext.Get(GrainCallFilterTestConstants.Key) != null) throw new InvalidOperationException();
                                 RequestContext.Set(GrainCallFilterTestConstants.Key, "1");
                             }
 
-                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrainObserver.SystemWideCallFilterMarker)))
+                            if (string.Equals(context.InterfaceMethod.Name, nameof(IGrainCallFilterTestGrainObserver.SystemWideCallFilterMarker), StringComparison.Ordinal))
                             {
                                 // explicitly do not continue calling Invoke
                                 return Task.CompletedTask;
@@ -227,7 +227,7 @@ namespace UnitTests.General
                             catch (ArgumentOutOfRangeException) when (attemptsRemaining > 1 && ctx.Grain is IOutgoingMethodInterceptionGrain)
                             {
                                 // Retry by decrementing the problematic value
-                                if (string.Equals(ctx.InterfaceMethod?.Name, nameof(IOutgoingMethodInterceptionGrain.ThrowIfGreaterThanZero)) && ctx.Request.GetArgument(0) is int value)
+                                if (string.Equals(ctx.InterfaceMethod?.Name, nameof(IOutgoingMethodInterceptionGrain.ThrowIfGreaterThanZero), StringComparison.Ordinal) && ctx.Request.GetArgument(0) is int value)
                                 {
                                     ctx.Request.SetArgument(0, value - 1);
                                 }
@@ -252,7 +252,7 @@ namespace UnitTests.General
             {
                 Assert.NotNull(grainFactory);
                 // Continue building the RequestContext value: "1" -> "12"
-                if (string.Equals(context.ImplementationMethod?.Name, nameof(IGrainCallFilterTestGrain.GetRequestContext)))
+                if (string.Equals(context.ImplementationMethod?.Name, nameof(IGrainCallFilterTestGrain.GetRequestContext), StringComparison.Ordinal))
                 {
                     if (RequestContext.Get(GrainCallFilterTestConstants.Key) is string value)
                     {

--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/HeterogeneousTests.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/HeterogeneousTests.cs
@@ -51,7 +51,7 @@ namespace Tester.HeterogeneousSilosTests
                         var cfg = hostBuilder.GetConfiguration();
 
                         // The blocklist is only intended for the primary silo in these tests.
-                        if (string.Equals(siloOptions.Value.SiloName, Silo.PrimarySiloName))
+                        if (string.Equals(siloOptions.Value.SiloName, Silo.PrimarySiloName, StringComparison.Ordinal))
                         {
                             var typeNames = cfg["BlockedGrainTypes"]!.Split('|').ToList();
                             foreach (var typeName in typeNames)

--- a/test/Orleans.Runtime.Tests/ManagementGrainTests.cs
+++ b/test/Orleans.Runtime.Tests/ManagementGrainTests.cs
@@ -114,7 +114,7 @@ namespace UnitTests.Management
             Assert.True(stats.Length > 0, "Got some grain statistics: " + stats.Length);
             foreach (var s in stats)
             {
-                Assert.False(s.GrainType.EndsWith("Activation"), "Grain type name should not end with 'Activation' - " + s.GrainType);
+                Assert.False(s.GrainType.EndsWith("Activation", StringComparison.Ordinal), "Grain type name should not end with 'Activation' - " + s.GrainType);
             }
         }
 

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -2786,25 +2786,10 @@ namespace Orleans.Serialization.UnitTests
         {
             public bool Equals(string? left, string? right)
             {
-                if (left == null && right == null)
-                {
-                    return true;
-                }
-                else if (left == null || right == null)
-                {
-                    return false;
-                }
-                else if (left.ToUpper() == right.ToUpper())
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                return StringComparer.OrdinalIgnoreCase.Equals(left, right);
             }
 
-            public int GetHashCode(string s) => s.ToUpper().GetHashCode();
+            public int GetHashCode(string s) => StringComparer.OrdinalIgnoreCase.GetHashCode(s);
         }
     }
 

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -416,8 +416,8 @@ namespace Orleans.Serialization.UnitTests
 
         public override string ToString() => $"{nameof(SubTypeProperty)}: {SubTypeProperty}, {base.ToString()}";
         public bool Equals(MyNewtonsoftJsonClass? other) => other is not null && base.Equals(other) && string.Equals(SubTypeProperty, other.SubTypeProperty, StringComparison.Ordinal) && EqualityComparer<TestId>.Default.Equals(Id, other.Id)
-            && string.Equals(JsonConvert.SerializeObject(JsonArray), JsonConvert.SerializeObject(other.JsonArray))
-            && string.Equals(JsonConvert.SerializeObject(JsonObject), JsonConvert.SerializeObject(other.JsonObject));
+            && string.Equals(JsonConvert.SerializeObject(JsonArray), JsonConvert.SerializeObject(other.JsonArray), StringComparison.Ordinal)
+            && string.Equals(JsonConvert.SerializeObject(JsonObject), JsonConvert.SerializeObject(other.JsonObject), StringComparison.Ordinal);
         public override bool Equals(object? obj) => Equals(obj as MyJsonClass);
         public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), SubTypeProperty);
     }
@@ -439,8 +439,8 @@ namespace Orleans.Serialization.UnitTests
 
         public override string ToString() => $"{nameof(SubTypeProperty)}: {SubTypeProperty}, {base.ToString()}";
         public bool Equals(MyJsonClass? other) => other is not null && base.Equals(other) && string.Equals(SubTypeProperty, other.SubTypeProperty, StringComparison.Ordinal) && EqualityComparer<TestId>.Default.Equals(Id, other.Id)
-            && string.Equals(System.Text.Json.JsonSerializer.Serialize(JsonArray), System.Text.Json.JsonSerializer.Serialize(other.JsonArray))
-            && string.Equals(System.Text.Json.JsonSerializer.Serialize(JsonObject), System.Text.Json.JsonSerializer.Serialize(other.JsonObject));
+            && string.Equals(System.Text.Json.JsonSerializer.Serialize(JsonArray), System.Text.Json.JsonSerializer.Serialize(other.JsonArray), StringComparison.Ordinal)
+            && string.Equals(System.Text.Json.JsonSerializer.Serialize(JsonObject), System.Text.Json.JsonSerializer.Serialize(other.JsonObject), StringComparison.Ordinal);
         public override bool Equals(object? obj) => Equals(obj as MyJsonClass);
         public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), SubTypeProperty);
     }

--- a/test/Orleans.Streaming.Tests/StreamingTests/Filtering/StreamFilteringTestsBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/Filtering/StreamFilteringTestsBase.cs
@@ -38,25 +38,25 @@ public class CustomStreamFilter : IStreamFilter
 
     private static bool ShouldDeliverImpl(StreamId streamId, object item, string filterData)
     {
-        if (filterData.Equals("throw"))
+        if (filterData.Equals("throw", StringComparison.Ordinal))
             throw new Exception("throw");
 
         if (string.IsNullOrWhiteSpace(filterData))
             return true;
 
-        if (filterData.Equals("even"))
+        if (filterData.Equals("even", StringComparison.Ordinal))
         {
             var value = (int)item;
             return value % 2 == 0;
         }
 
-        if (filterData.Equals("only3"))
+        if (filterData.Equals("only3", StringComparison.Ordinal))
         {
             var value = (int)item;
             return value == 3;
         }
 
-        if (filterData.Equals("only7"))
+        if (filterData.Equals("only7", StringComparison.Ordinal))
         {
             var value = (int)item;
             return value == 7;

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/StandaloneSiloHandleTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/StandaloneSiloHandleTests.cs
@@ -28,4 +28,30 @@ public sealed class StandaloneSiloHandleTests
             File.Delete(processPath);
         }
     }
+
+    [Fact]
+    public void GetExecutablePath_UppercaseDllExtension_UsesExecutableSibling()
+    {
+        var fileName = $"StandaloneSiloHandle-{Guid.NewGuid():N}";
+        var assemblyPath = Path.Combine(Environment.CurrentDirectory, fileName + ".DLL");
+        var executablePath = Path.Combine(Environment.CurrentDirectory, fileName + (OperatingSystem.IsWindows() ? ".exe" : string.Empty));
+        File.WriteAllText(assemblyPath, string.Empty);
+        File.WriteAllText(executablePath, string.Empty);
+
+        try
+        {
+            var result = StandaloneSiloHandle.GetExecutablePath(
+                typeof(StandaloneSiloHandleTests).Assembly,
+                assemblyPath,
+                isEntryAssembly: false,
+                processPath: null);
+
+            Assert.Equal(executablePath, result);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+            File.Delete(executablePath);
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Culture-sensitive string comparisons can produce different runtime behavior across locales, and provider-specific analyzer configuration had become distributed across project directories.

## Solution

- Centralize provider analyzer configuration in the repository root `.editorconfig` and remove project-local analyzer config files and MSBuild wiring.
- Enable CA1309, CA1310, and CA1311 repository-wide.
- Resolve all detected string-comparison and culture-normalization findings across production code, tests, documentation tooling and snippets, and samples.
- Use ordinal semantics for identifiers, protocol values, type and method names, storage keys, command parsing, and assertions; use ordinal-ignore-case where matching is intentionally case-insensitive.
- Guard malformed string-encoded write vectors before reading the character preceding a match.

## Rationale

A single analyzer configuration is easier to maintain and review. Enforcing these diagnostics across repository build surfaces makes string semantics explicit and deterministic across operating-system cultures while keeping related changes in one coherent PR.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11150)