### PR TITLE
fix(streaming): preserve pooled cache buffer ownership

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -35,7 +35,7 @@ namespace Orleans.Streaming.EventHubs
         private readonly ILogger logger;
         private readonly AggregatedCachePressureMonitor cachePressureMonitor;
         private readonly ICacheMonitor cacheMonitor;
-        private FixedSizeBuffer currentBuffer = null!;
+        private FixedSizeBuffer? currentBuffer;
 
         /// <summary>
         /// EventHub queue cache.
@@ -80,6 +80,10 @@ namespace Orleans.Streaming.EventHubs
         public void SignalPurge()
         {
             this.evictionStrategy.PerformPurge(DateTime.UtcNow);
+            if (this.cache.IsEmpty)
+            {
+                this.currentBuffer = null;
+            }
         }
 
         /// <summary>

--- a/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
@@ -94,6 +94,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (readIndex < writeIndex)
             {
+                cachedMessages[readIndex] = default;
                 readIndex++;
                 return true;
             }
@@ -235,6 +236,7 @@ namespace Orleans.Providers.Streams.Common
         /// <inheritdoc/>
         public override void OnResetState()
         {
+            Array.Clear(cachedMessages, 0, writeIndex);
             writeIndex = 0;
             readIndex = 0;
             generation++;

--- a/src/Orleans.Streaming/Common/PooledCache/ChronologicalEvictionStrategy.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/ChronologicalEvictionStrategy.cs
@@ -127,20 +127,33 @@ namespace Orleans.Providers.Streams.Common
             object? IdOfLastPurgedBufferId = lastMessagePurged?.Segment.Array;
             // IdOfLastBufferInCache will be null if cache is empty after purge
             object? IdOfLastBufferInCacheId = oldestMessageInCache?.Segment.Array;
-            //all buffers older than LastPurgedBuffer should be purged
-            while (this.inUseBuffers.Peek().Id != IdOfLastPurgedBufferId)
+            if (IdOfLastBufferInCacheId is null)
             {
-                var purgedBuffer = this.inUseBuffers.Dequeue();
-                memoryReleasedInByte += purgedBuffer.SizeInByte;
-                purgedBuffer.Dispose();
+                while (this.inUseBuffers.Count > 0)
+                {
+                    var purgedBuffer = this.inUseBuffers.Dequeue();
+                    memoryReleasedInByte += purgedBuffer.SizeInByte;
+                    purgedBuffer.Dispose();
+                }
             }
-            // if last purged message does not share buffer with remaining messages in cache and cache is not empty
-            //then last purged buffer should be purged too
-            if (IdOfLastBufferInCacheId != null && IdOfLastPurgedBufferId != IdOfLastBufferInCacheId)
+            else
             {
-                var purgedBuffer = this.inUseBuffers.Dequeue();
-                memoryReleasedInByte += purgedBuffer.SizeInByte;
-                purgedBuffer.Dispose();
+                // All buffers older than the last purged buffer can be returned.
+                while (this.inUseBuffers.Peek().Id != IdOfLastPurgedBufferId)
+                {
+                    var purgedBuffer = this.inUseBuffers.Dequeue();
+                    memoryReleasedInByte += purgedBuffer.SizeInByte;
+                    purgedBuffer.Dispose();
+                }
+
+                // If the last purged message does not share a buffer with the oldest remaining message,
+                // the last purged buffer can also be returned.
+                if (IdOfLastPurgedBufferId != IdOfLastBufferInCacheId)
+                {
+                    var purgedBuffer = this.inUseBuffers.Dequeue();
+                    memoryReleasedInByte += purgedBuffer.SizeInByte;
+                    purgedBuffer.Dispose();
+                }
             }
             //report metrics
             if (memoryReleasedInByte > 0)

--- a/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
@@ -30,11 +30,27 @@ namespace Orleans.Providers.Streams.Generator
         /// <param name="cacheMonitor">The cache monitor.</param>
         /// <param name="monitorWriteInterval">The monitor write interval. Only triggered for active caches</param>
         public GeneratorPooledCache(IObjectPool<FixedSizeBuffer> bufferPool, ILogger logger, Serialization.Serializer serializer, ICacheMonitor? cacheMonitor, TimeSpan? monitorWriteInterval)
+            : this(
+                bufferPool,
+                logger,
+                serializer,
+                cacheMonitor,
+                monitorWriteInterval,
+                new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)))
+        {
+        }
+
+        internal GeneratorPooledCache(
+            IObjectPool<FixedSizeBuffer> bufferPool,
+            ILogger logger,
+            Serialization.Serializer serializer,
+            ICacheMonitor? cacheMonitor,
+            TimeSpan? monitorWriteInterval,
+            TimePurgePredicate purgePredicate)
         {
             this.bufferPool = bufferPool;
             this.serializer = serializer;
             cache = new PooledQueueCache(this, logger, cacheMonitor, monitorWriteInterval);
-            TimePurgePredicate purgePredicate = new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10));
             this.evictionStrategy = new ChronologicalEvictionStrategy(logger, purgePredicate, cacheMonitor, monitorWriteInterval) { PurgeObservable = cache };
         }
 
@@ -177,6 +193,11 @@ namespace Orleans.Providers.Streams.Generator
         {
             purgedItems = null!; // Return value is always false, per [MaybeNullWhen(false)] on the interface.
             this.evictionStrategy.PerformPurge(DateTime.UtcNow);
+            if (cache.IsEmpty)
+            {
+                currentBuffer = null;
+            }
+
             return false;
         }
 

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -172,6 +172,11 @@ namespace Orleans.Providers
         {
             purgedItems = null!; // Return value is always false, per [MaybeNullWhen(false)] on the interface.
             this.evictionStrategy.PerformPurge(DateTime.UtcNow);
+            if (cache.IsEmpty)
+            {
+                currentBuffer = null;
+            }
+
             return false;
         }
 

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -161,13 +161,12 @@ namespace ServiceBus.Tests.EvictionStrategyTests
 
             //perform purge
 
-            //after purge, inUseBuffers should be purged and return to the pool, except for the current buffer
+            //after purge, inUseBuffers should be purged and return to the pool
             var expectedPurgedBuffers = new List<FixedSizeBuffer>();
             this.evictionStrategyList.ForEach(strategy =>
             {
                 var purgedBufferList = strategy.InUseBuffers.ToArray<FixedSizeBuffer>();
-                //last one in purgedBufferList should be current buffer, which shouldn't be purged
-                for (int i = 0; i < purgedBufferList.Count() - 1; i++)
+                for (int i = 0; i < purgedBufferList.Count(); i++)
                     expectedPurgedBuffers.Add(purgedBufferList[i]);
             });
 
@@ -175,8 +174,8 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             this.receiver1.TryPurgeFromCache(out ignore);
             this.receiver2.TryPurgeFromCache(out ignore);
 
-            //Each cache should have all buffers purged, except for current buffer
-            this.evictionStrategyList.ForEach(strategy => Assert.Single(strategy.InUseBuffers));
+            //Each cache should have all buffers purged
+            this.evictionStrategyList.ForEach(strategy => Assert.Empty(strategy.InUseBuffers));
             var oldBuffersInCaches = new List<FixedSizeBuffer>();
             this.evictionStrategyList.ForEach(strategy =>
             {

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledCacheBufferOwnershipTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledCacheBufferOwnershipTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Providers;
+using Orleans.Providers.Streams.Common;
+using Orleans.Providers.Streams.Generator;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Streams;
+using Xunit;
+
+namespace UnitTests.OrleansRuntime.Streams;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+public sealed class PooledCacheBufferOwnershipTests
+{
+    [Fact]
+    public void MemoryCache_EmptyPurgeAllocatesFreshBufferForNextMessage()
+    {
+        var pool = new TrackingBufferPool();
+        var serializer = new TestMemorySerializer();
+        var cache = new MemoryPooledCache<TestMemorySerializer>(
+            pool,
+            new AlwaysPurgePredicate(),
+            NullLogger.Instance,
+            serializer,
+            cacheMonitor: null,
+            monitorWriteInterval: null,
+            purgeMetadataInterval: null);
+        var streamId = StreamId.Create("namespace", Guid.NewGuid());
+
+        cache.AddToCache([CreateMemoryBatch(streamId, 1, serializer)]);
+        Assert.False(cache.TryPurgeFromCache(out _));
+        Assert.Equal(1, pool.FreeCount);
+
+        cache.AddToCache([CreateMemoryBatch(streamId, 2, serializer)]);
+
+        Assert.Equal(2, pool.AllocateCount);
+    }
+
+    [Fact]
+    public void GeneratorCache_EmptyPurgeAllocatesFreshBufferForNextMessage()
+    {
+        var pool = new TrackingBufferPool();
+        using var services = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var cache = new GeneratorPooledCache(
+            pool,
+            NullLogger.Instance,
+            services.GetRequiredService<Serializer>(),
+            cacheMonitor: null,
+            monitorWriteInterval: null,
+            new AlwaysPurgePredicate());
+        var streamId = StreamId.Create("namespace", Guid.NewGuid());
+
+        cache.AddToCache([new GeneratedBatchContainer(streamId, 1, new EventSequenceTokenV2(1))]);
+        Assert.False(cache.TryPurgeFromCache(out _));
+        Assert.Equal(1, pool.FreeCount);
+
+        cache.AddToCache([new GeneratedBatchContainer(streamId, 2, new EventSequenceTokenV2(2))]);
+
+        Assert.Equal(2, pool.AllocateCount);
+    }
+
+    private static MemoryBatchContainer<TestMemorySerializer> CreateMemoryBatch(
+        StreamId streamId,
+        long sequenceNumber,
+        TestMemorySerializer serializer)
+        => new(
+            new MemoryMessageData
+            {
+                StreamId = streamId,
+                SequenceNumber = sequenceNumber,
+                EnqueueTimeUtc = DateTime.UtcNow,
+                Payload = new byte[] { 1 },
+            },
+            serializer);
+
+    private sealed class AlwaysPurgePredicate : TimePurgePredicate
+    {
+        public AlwaysPurgePredicate()
+            : base(TimeSpan.Zero, TimeSpan.Zero)
+        {
+        }
+
+        public override bool ShouldPurgeFromTime(TimeSpan timeInCache, TimeSpan relativeAge) => true;
+    }
+
+    private sealed class TrackingBufferPool : IObjectPool<FixedSizeBuffer>
+    {
+        public int AllocateCount { get; private set; }
+
+        public int FreeCount { get; private set; }
+
+        public FixedSizeBuffer Allocate()
+        {
+            AllocateCount++;
+            return new FixedSizeBuffer(4 * 1024) { Pool = this };
+        }
+
+        public void Free(FixedSizeBuffer resource)
+        {
+            FreeCount++;
+        }
+    }
+
+    private sealed class TestMemorySerializer : IMemoryMessageBodySerializer
+    {
+        public ArraySegment<byte> Serialize(MemoryMessageBody body) => new byte[] { 1 };
+
+        public MemoryMessageBody Deserialize(ArraySegment<byte> bodyBytes) => new([], requestContext: null);
+    }
+}


### PR DESCRIPTION
## Problem

Pooled cache eviction retains the final buffer when a purge empties the cache because cache adapters keep that buffer as their current append target. Cached-message blocks also retain removed entries and their backing-buffer references until those slots are overwritten.

## Solution

- Release every tracked buffer when chronological eviction empties the cache.
- Clear the Generator, Memory, and Event Hubs caches' `currentBuffer` after an emptying purge so the next append reacquires a buffer from the pool and registers its ownership.
- Clear removed and reset cached-message slots so backing-buffer references follow the cached message lifetime.
- Cover Generator and Memory cache ownership directly and align the existing Event Hubs purge expectations with full buffer release.

## Rationale

This is an independently mergeable extraction of the pooled-buffer lifetime fixes from #11076 and #10588. The coordinated eviction and adapter updates allow an empty cache to release all buffers while preserving correct ownership for the next append, and contribute toward #756 without bringing in retained-history replay, checkpointing, or public extensibility changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11152)