### PR TITLE
feat(streaming): support provider-encoded cache offsets

### DIFF
--- a/docs/site/src/content/docs/streaming/custom-queue-adapter.md
+++ b/docs/site/src/content/docs/streaming/custom-queue-adapter.md
@@ -51,6 +51,8 @@ The factory composes the adapter with queue mapping, caching, and failure handli
 
 `SimpleQueueAdapterCache` is suitable for a non-rewindable adapter whose queue remains the durability boundary. A rewindable adapter usually needs a cache and sequence-token implementation which can position cursors at retained historical messages.
 
+Custom pooled caches use <xref:Orleans.Providers.Streams.Common.ICacheDataAdapter.Compare*> to position cursors against cached messages. The default implementation compares `SequenceNumber` and `EventIndex`, preserving the numeric ordering used by existing providers. Override it when the authoritative provider position is encoded in <xref:Orleans.Providers.Streams.Common.CachedMessage.Segment>; return an order consistent with the token produced by <xref:Orleans.Providers.Streams.Common.ICacheDataAdapter.GetSequenceToken*> so cache bounds, block selection, and cache-miss detection use the same position contract.
+
 `AddPersistentStreams` leaves checkpointing to the adapter. The non-rewindable example acknowledges completed messages through its receiver and therefore has no independent checkpoint. For a retained-log transport, implement an <xref:Orleans.Streams.IStreamQueueCheckpointerFactory>, have the receiver or cache load and update the per-partition position, and register it as a named component with `ConfigureComponent`. Persist a checkpoint only after all consumers have advanced beyond the corresponding cached messages. A no-op checkpointer is suitable only when replay position is deliberately disposable.
 
 ## Register the provider

--- a/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/CachedMessageBlock.cs
@@ -193,6 +193,28 @@ namespace Orleans.Providers.Streams.Common
         }
 
         /// <summary>
+        /// Gets the index of the newest message in this block whose sequence token is less than or equal to the provided token.
+        /// </summary>
+        /// <param name="token">The sequence token.</param>
+        /// <param name="dataAdapter">The data adapter used to compare provider-specific positions.</param>
+        /// <returns>The index of the newest message whose sequence token is less than or equal to the provided token.</returns>
+        public int GetIndexOfFirstMessageLessThanOrEqualTo(
+            StreamSequenceToken token,
+            ICacheDataAdapter dataAdapter)
+        {
+            ArgumentNullException.ThrowIfNull(dataAdapter);
+            for (int i = writeIndex - 1; i >= readIndex; i--)
+            {
+                if (dataAdapter.Compare(ref cachedMessages[i], token) <= 0)
+                {
+                    return i;
+                }
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(token));
+        }
+
+        /// <summary>
         /// Tries to find the first message in the block that is part of the provided stream.
         /// </summary>
         /// <param name="streamId">The stream identifier.</param>

--- a/src/Orleans.Streaming/Common/PooledCache/ICacheDataAdapter.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/ICacheDataAdapter.cs
@@ -23,5 +23,18 @@ namespace Orleans.Providers.Streams.Common
         /// <param name="cachedMessage">The cached message.</param>
         /// <returns>The sequence token.</returns>
         StreamSequenceToken GetSequenceToken(ref CachedMessage cachedMessage);
+
+        /// <summary>
+        /// Compares a cached message with a stream sequence token.
+        /// </summary>
+        /// <param name="cachedMessage">The cached message.</param>
+        /// <param name="token">The sequence token.</param>
+        /// <returns>A value indicating the relative order of the cached message and token.</returns>
+        /// <remarks>
+        /// The default implementation uses the allocation-free sequence number and event index fields.
+        /// Providers with external offsets can override this method and compare encoded offset data directly.
+        /// </remarks>
+        int Compare(ref CachedMessage cachedMessage, StreamSequenceToken token)
+            => cachedMessage.Compare(token);
     }
 }

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -251,7 +251,7 @@ namespace Orleans.Providers.Streams.Common
 
             // If sequenceToken is too new to be in cache, unset token, and wait for more data.
             CachedMessage newestMessage = newestBlock.Value.NewestMessage;
-            if (newestMessage.Compare(sequenceToken) < 0)
+            if (cacheDataAdapter.Compare(ref newestMessage, sequenceToken) < 0)
             {
                 cursor.State = CursorStates.Unset;
                 cursor.SequenceToken = sequenceToken;
@@ -261,7 +261,7 @@ namespace Orleans.Providers.Streams.Common
             // Check to see if sequenceToken is too old to be in cache
             var oldestBlock = messageBlocks.Last!; // messageBlocks.Count != 0 (checked above).
             var oldestMessage = oldestBlock.Value.OldestMessage;
-            if (oldestMessage.Compare(sequenceToken) > 0)
+            if (cacheDataAdapter.Compare(ref oldestMessage, sequenceToken) > 0)
             {
                 // Check if we missed an event since we last purged the cache
                 if (this.lastPurgedToken.TryGetValue(cursor.StreamId, out var entry) && sequenceToken.CompareTo(entry.Token) >= 0)
@@ -286,7 +286,7 @@ namespace Orleans.Providers.Streams.Common
             while (true)
             {
                 CachedMessage oldestMessageInBlock = node!.Value.OldestMessage; // Loop invariant: node is non-null while the search has not exhausted the cache (guaranteed by the bounds checks above).
-                if (oldestMessageInBlock.Compare(sequenceToken) <= 0)
+                if (cacheDataAdapter.Compare(ref oldestMessageInBlock, sequenceToken) <= 0)
                 {
                     break;
                 }
@@ -295,7 +295,7 @@ namespace Orleans.Providers.Streams.Common
 
             // return cursor from start.
             cursor.CurrentBlock = node;
-            cursor.Index = node!.Value.GetIndexOfFirstMessageLessThanOrEqualTo(sequenceToken); // See loop invariant above.
+            cursor.Index = node!.Value.GetIndexOfFirstMessageLessThanOrEqualTo(sequenceToken, cacheDataAdapter); // See loop invariant above.
             // if cursor has been idle, move to next message after message specified by sequenceToken  
             if (cursor.State == CursorStates.Idle)
             {
@@ -453,7 +453,7 @@ namespace Orleans.Providers.Streams.Common
             // has this message been purged
             CachedMessage oldestMessage = messageBlocks.Last!.Value.OldestMessage; // Cursor is Set, so the cache is non-empty.
             if (cursor.State == CursorStates.Set
-                && oldestMessage.Compare(cursor.SequenceToken!) > 0) // Cursor is Set, so SequenceToken is guaranteed non-null.
+                && cacheDataAdapter.Compare(ref oldestMessage, cursor.SequenceToken!) > 0) // Cursor is Set, so SequenceToken is guaranteed non-null.
             {
                 throw new QueueCacheMissException(cursor.SequenceToken!, // Cursor is Set, so SequenceToken is guaranteed non-null.
                     messageBlocks.Last!.Value.GetOldestSequenceToken(cacheDataAdapter), // Cursor is Set, so the cache is non-empty.

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -528,6 +528,8 @@ namespace Orleans.Providers.Streams.Common
 
         public void Add(CachedMessage message) { }
 
+        public int GetIndexOfFirstMessageLessThanOrEqualTo(Orleans.Streams.StreamSequenceToken token, ICacheDataAdapter dataAdapter) { throw null; }
+
         public int GetIndexOfFirstMessageLessThanOrEqualTo(Orleans.Streams.StreamSequenceToken token) { throw null; }
 
         public Orleans.Streams.StreamSequenceToken GetNewestSequenceToken(ICacheDataAdapter dataAdapter) { throw null; }
@@ -707,6 +709,7 @@ namespace Orleans.Providers.Streams.Common
 
     public partial interface ICacheDataAdapter
     {
+        int Compare(ref CachedMessage cachedMessage, Orleans.Streams.StreamSequenceToken token);
         Orleans.Streams.IBatchContainer GetBatchContainer(ref CachedMessage cachedMessage);
         Orleans.Streams.StreamSequenceToken GetSequenceToken(ref CachedMessage cachedMessage);
     }
@@ -1202,6 +1205,7 @@ namespace Orleans.Streaming.Diagnostics
             public readonly Runtime.StreamId StreamId;
             public readonly System.Guid SubscriptionId;
             public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
+
             public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, string clusterId, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
         }
 

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/CachedMessageBlockTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/CachedMessageBlockTests.cs
@@ -147,12 +147,12 @@ namespace UnitTests.OrleansRuntime.Streams
                 last++;
                 sequenceNumber += 2;
             }
-            Assert.Equal(block.OldestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(0)));
-            Assert.Equal(block.OldestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(1)));
-            Assert.Equal(block.NewestMessageIndex, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber - 2)));
-            Assert.Equal(block.NewestMessageIndex - 1, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber - 3)));
-            Assert.Equal(50, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber / 2)));
-            Assert.Equal(50, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EventSequenceTokenV2(sequenceNumber / 2 + 1)));
+            AssertIndex(block, dataAdapter, block.OldestMessageIndex, new EventSequenceTokenV2(0));
+            AssertIndex(block, dataAdapter, block.OldestMessageIndex, new EventSequenceTokenV2(1));
+            AssertIndex(block, dataAdapter, block.NewestMessageIndex, new EventSequenceTokenV2(sequenceNumber - 2));
+            AssertIndex(block, dataAdapter, block.NewestMessageIndex - 1, new EventSequenceTokenV2(sequenceNumber - 3));
+            AssertIndex(block, dataAdapter, 50, new EventSequenceTokenV2(sequenceNumber / 2));
+            AssertIndex(block, dataAdapter, 50, new EventSequenceTokenV2(sequenceNumber / 2 + 1));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -241,6 +241,16 @@ namespace UnitTests.OrleansRuntime.Streams
             Assert.Equal(last, block.NewestMessageIndex);
 
             Assert.True(block.GetSequenceToken(last, dataAdapter).Equals(message.SequenceToken));
+        }
+
+        private static void AssertIndex(
+            CachedMessageBlock block,
+            ICacheDataAdapter dataAdapter,
+            int expected,
+            StreamSequenceToken token)
+        {
+            Assert.Equal(expected, block.GetIndexOfFirstMessageLessThanOrEqualTo(token));
+            Assert.Equal(expected, block.GetIndexOfFirstMessageLessThanOrEqualTo(token, dataAdapter));
         }
 
         private void RemoveAndCheck(CachedMessageBlock block, int first, int last)

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/EncodedOffsetPooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/EncodedOffsetPooledQueueCacheTests.cs
@@ -6,7 +6,7 @@ using Orleans.Streams;
 using TestExtensions;
 using Xunit;
 
-namespace UnitTests.StreamingTests;
+namespace UnitTests.OrleansRuntime.Streams;
 
 [TestSuite("BVT")]
 [TestProvider("None")]

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/EncodedOffsetPooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/EncodedOffsetPooledQueueCacheTests.cs
@@ -1,0 +1,198 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+[TestCategory("BVT")]
+public sealed class EncodedOffsetPooledQueueCacheTests
+{
+    [Fact]
+    public void CachedMessageBlock_AdapterAwareSearchUsesEncodedOffset()
+    {
+        var adapter = new EncodedOffsetDataAdapter();
+        var block = new CachedMessageBlock(3);
+        block.Add(CreateMessage(default, "001"));
+        block.Add(CreateMessage(default, "003"));
+        block.Add(CreateMessage(default, "005"));
+
+        Assert.Equal(1, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EncodedOffsetToken("003"), adapter));
+        Assert.Equal(1, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EncodedOffsetToken("004"), adapter));
+        Assert.Equal(2, block.GetIndexOfFirstMessageLessThanOrEqualTo(new EncodedOffsetToken("005"), adapter));
+        Assert.True(adapter.CompareCallCount >= 4);
+    }
+
+    [Fact]
+    public void Cursor_AfterNewestWaitsUntilExternalOffsetArrives()
+    {
+        var streamId = StreamId.Create("namespace", Guid.NewGuid());
+        var adapter = new EncodedOffsetDataAdapter();
+        var cache = CreateCache(adapter);
+        Add(cache, streamId, "010", "020");
+        var cursor = cache.GetCursor(streamId, new EncodedOffsetToken("030"));
+
+        Assert.False(cache.TryGetNextMessage(cursor, out _));
+        Assert.Equal(0, adapter.GetBatchContainerCallCount);
+
+        Add(cache, streamId, "030");
+
+        Assert.True(cache.TryGetNextMessage(cursor, out var batch));
+        Assert.Equal("030", Assert.IsType<EncodedOffsetToken>(batch.SequenceToken).Offset);
+        Assert.False(cache.TryGetNextMessage(cursor, out _));
+        Assert.True(adapter.CompareCallCount > 0);
+        Assert.Equal(1, adapter.GetBatchContainerCallCount);
+    }
+
+    [Fact]
+    public void Cursor_UsesExternalOffsetAcrossMessageBlocks()
+    {
+        const int defaultBlockSize = 16 * 1024;
+        var streamId = StreamId.Create("namespace", Guid.NewGuid());
+        var adapter = new EncodedOffsetDataAdapter();
+        var cache = CreateCache(adapter);
+        var messages = Enumerable.Range(0, defaultBlockSize + 2)
+            .Select(index => CreateMessage(
+                streamId,
+                index.ToString("D5", CultureInfo.InvariantCulture)))
+            .ToList();
+        cache.Add(messages, DateTime.UnixEpoch);
+        var requested = (defaultBlockSize - 1).ToString("D5", CultureInfo.InvariantCulture);
+
+        var cursor = cache.GetCursor(streamId, new EncodedOffsetToken(requested));
+
+        Assert.True(cache.TryGetNextMessage(cursor, out var first));
+        Assert.Equal(requested, Assert.IsType<EncodedOffsetToken>(first.SequenceToken).Offset);
+        Assert.True(cache.TryGetNextMessage(cursor, out var second));
+        Assert.Equal(
+            defaultBlockSize.ToString("D5", CultureInfo.InvariantCulture),
+            Assert.IsType<EncodedOffsetToken>(second.SequenceToken).Offset);
+        Assert.True(adapter.CompareCallCount >= 4);
+    }
+
+    [Fact]
+    public void Cursor_WhenExternalPositionWasPurgedThrowsCacheMiss()
+    {
+        var streamId = StreamId.Create("namespace", Guid.NewGuid());
+        var adapter = new EncodedOffsetDataAdapter();
+        var cache = CreateCache(adapter);
+        Add(cache, streamId, "010", "020");
+        var cursor = cache.GetCursor(streamId, new EncodedOffsetToken("010"));
+        cache.RemoveOldestMessage();
+
+        var exception = Assert.Throws<QueueCacheMissException>(
+            () => cache.TryGetNextMessage(cursor, out _));
+
+        Assert.Equal(new EncodedOffsetToken("010").ToString(), exception.Requested);
+        Assert.Equal(new EncodedOffsetToken("020").ToString(), exception.Low);
+        Assert.Equal(new EncodedOffsetToken("020").ToString(), exception.High);
+        Assert.Equal(0, adapter.GetBatchContainerCallCount);
+    }
+
+    private static PooledQueueCache CreateCache(EncodedOffsetDataAdapter adapter)
+        => new(adapter, NullLogger.Instance, cacheMonitor: null, cacheMonitorWriteInterval: null);
+
+    private static void Add(
+        PooledQueueCache cache,
+        StreamId streamId,
+        params string[] offsets)
+        => cache.Add(
+            offsets.Select(offset => CreateMessage(streamId, offset)).ToList(),
+            DateTime.UnixEpoch);
+
+    private static CachedMessage CreateMessage(StreamId streamId, string offset)
+    {
+        var bytes = new byte[SegmentBuilder.CalculateAppendSize(offset)];
+        var segment = new ArraySegment<byte>(bytes);
+        var writeOffset = 0;
+        SegmentBuilder.Append(segment, ref writeOffset, offset);
+        return new CachedMessage
+        {
+            StreamId = streamId,
+            SequenceNumber = EncodedOffsetToken.SharedSequenceNumber,
+            EventIndex = 0,
+            EnqueueTimeUtc = DateTime.UnixEpoch,
+            DequeueTimeUtc = DateTime.UnixEpoch,
+            Segment = segment,
+        };
+    }
+
+    private sealed class EncodedOffsetDataAdapter : ICacheDataAdapter
+    {
+        public int CompareCallCount { get; private set; }
+        public int GetBatchContainerCallCount { get; private set; }
+
+        public IBatchContainer GetBatchContainer(ref CachedMessage cachedMessage)
+        {
+            GetBatchContainerCallCount++;
+            return new TestBatchContainer(
+                cachedMessage.StreamId,
+                GetSequenceToken(ref cachedMessage));
+        }
+
+        public StreamSequenceToken GetSequenceToken(ref CachedMessage cachedMessage)
+            => new EncodedOffsetToken(ReadOffset(ref cachedMessage));
+
+        public int Compare(ref CachedMessage cachedMessage, StreamSequenceToken token)
+        {
+            CompareCallCount++;
+            var numericComparison = cachedMessage.Compare(token);
+            if (numericComparison != 0)
+            {
+                return numericComparison;
+            }
+
+            return string.CompareOrdinal(
+                ReadOffset(ref cachedMessage),
+                Assert.IsType<EncodedOffsetToken>(token).Offset);
+        }
+
+        private static string ReadOffset(ref CachedMessage cachedMessage)
+        {
+            var readOffset = 0;
+            return SegmentBuilder.ReadNextString(cachedMessage.Segment, ref readOffset)!;
+        }
+    }
+
+    private sealed class EncodedOffsetToken(string offset) : StreamSequenceToken
+    {
+        public const long SharedSequenceNumber = 42;
+
+        public string Offset { get; } = offset;
+
+        public override long SequenceNumber { get; protected set; } = SharedSequenceNumber;
+
+        public override int EventIndex { get; protected set; }
+
+        public override bool Equals(StreamSequenceToken? other)
+            => other is EncodedOffsetToken token && string.Equals(Offset, token.Offset, StringComparison.Ordinal);
+
+        public override int CompareTo(StreamSequenceToken? other)
+            => other is null
+                ? 1
+                : string.CompareOrdinal(Offset, Assert.IsType<EncodedOffsetToken>(other).Offset);
+
+        public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Offset);
+
+        public override string ToString() => $"EncodedOffset({Offset})";
+    }
+
+    private sealed class TestBatchContainer(
+        StreamId streamId,
+        StreamSequenceToken sequenceToken) : IBatchContainer
+    {
+        public StreamId StreamId { get; } = streamId;
+
+        public StreamSequenceToken SequenceToken { get; } = sequenceToken;
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() => [];
+
+        public bool ImportRequestContext() => false;
+    }
+}


### PR DESCRIPTION
## Problem

`PooledQueueCache` positions cursors by comparing the numeric fields stored in `CachedMessage`. Providers whose authoritative position is encoded in the cached payload cannot distinguish messages which intentionally share those numeric fields.

## Solution

Add a default `ICacheDataAdapter.Compare` implementation which preserves existing sequence-number and event-index ordering. Route pooled-cache cursor bounds, block selection, in-block lookup, and cache-miss detection through the adapter method. Add focused encoded-offset and legacy numeric tests, regenerate the Orleans.Streaming API surface, and document the custom pooled-cache position contract.

## Rationale

This independently mergeable change is extracted from #11076 and #10588. It establishes the provider-owned comparison boundary without carrying safe progress state, memory ownership changes, recoverable-stream infrastructure, or replay APIs.

Related: #756 and #10920.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11153)