### PR TITLE
feat(streaming): add reusable checkpoint state machine

### DIFF
--- a/docs/site/src/content/docs/streaming/custom-queue-adapter.md
+++ b/docs/site/src/content/docs/streaming/custom-queue-adapter.md
@@ -53,6 +53,10 @@ The factory composes the adapter with queue mapping, caching, and failure handli
 
 `AddPersistentStreams` leaves checkpointing to the adapter. The non-rewindable example acknowledges completed messages through its receiver and therefore has no independent checkpoint. For a retained-log transport, implement an <xref:Orleans.Streams.IStreamQueueCheckpointerFactory>, have the receiver or cache load and update the per-partition position, and register it as a named component with `ConfigureComponent`. Persist a checkpoint only after all consumers have advanced beyond the corresponding cached messages. A no-op checkpointer is suitable only when replay position is deliberately disposable.
 
+For a durable custom checkpoint backend, implement <xref:Orleans.Streams.IStreamCheckpointStore> and pass it to <xref:Orleans.Streams.StreamQueueCheckpointer> with <xref:Orleans.Streams.StreamQueueCheckpointerOptions>. Load the checkpointer before processing the partition. Each store update receives the expected backend version and returns the resulting <xref:Orleans.Streams.StreamCheckpointStoreState>, so a version conflict supplies the authoritative checkpoint and version for retry or reconciliation.
+
+<xref:Orleans.Streams.StreamQueueCheckpointer> limits writes to the configured persistence interval, coalesces pending updates to the latest checkpoint, and flushes the latest position on demand. Set <xref:Orleans.Streams.StreamQueueCheckpointerOptions.CheckpointComparer> when checkpoint values have an ordering contract; the checkpointer then keeps progress monotonic across local updates and concurrent store writers.
+
 ## Register the provider
 
 Register the transport client in dependency injection, then pass the factory's `Create` method to `AddPersistentStreams`. Configure queue count and cache capacity through the provider configurator.

--- a/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointer.cs
@@ -13,14 +13,7 @@ namespace Orleans.Streams
     {
         private const char KeySeparator = '-';
         private const string StorageProviderKeyPrefix = "__orleans_storage_provider__-";
-        private readonly IStreamCheckpointerGrain _grain;
-        private readonly GrainStreamQueueCheckpointerOptions _options;
-        private readonly object _lock = new();
-
-        private string _latestCheckpoint = string.Empty;
-        private string _persistedCheckpoint = string.Empty;
-        private Task _inProgressSave = Task.CompletedTask;
-        private DateTime? _throttleSavesUntilUtc;
+        private readonly StreamQueueCheckpointer _inner;
 
         /// <summary>
         /// Initializes a new instance with default options.
@@ -55,21 +48,17 @@ namespace Orleans.Streams
                     nameof(options));
             }
 
-            _grain = grain;
-            _options = options;
+            _inner = new StreamQueueCheckpointer(
+                new StreamCheckpointStoreAdapter(grain),
+                new StreamQueueCheckpointerOptions
+                {
+                    CheckpointComparer = options.CheckpointComparer,
+                    PersistInterval = options.PersistInterval,
+                });
         }
 
         /// <inheritdoc />
-        public bool CheckpointExists
-        {
-            get
-            {
-                lock (_lock)
-                {
-                    return !string.IsNullOrEmpty(_latestCheckpoint);
-                }
-            }
-        }
+        public bool CheckpointExists => _inner.CheckpointExists;
 
         /// <summary>
         /// Creates and initializes a grain-based checkpointer with default options.
@@ -182,17 +171,7 @@ namespace Orleans.Streams
         public Task<string> Load() => Load(CancellationToken.None);
 
         /// <inheritdoc />
-        public async Task<string> Load(CancellationToken cancellationToken)
-        {
-            var checkpoint = await _grain.Load(cancellationToken);
-            lock (_lock)
-            {
-                _latestCheckpoint = checkpoint;
-                _persistedCheckpoint = checkpoint;
-            }
-
-            return checkpoint;
-        }
+        public Task<string> Load(CancellationToken cancellationToken) => _inner.Load(cancellationToken);
 
         /// <inheritdoc />
         [Obsolete("Use the overload which accepts a CancellationToken.")]
@@ -201,121 +180,30 @@ namespace Orleans.Streams
 
         /// <inheritdoc />
         public void Update(string offset, DateTime utcNow, CancellationToken cancellationToken)
-        {
-            ArgumentNullException.ThrowIfNull(offset);
-            cancellationToken.ThrowIfCancellationRequested();
-
-            lock (_lock)
-            {
-                if (string.Equals(_latestCheckpoint, offset, StringComparison.Ordinal)
-                    || (_options.CheckpointComparer is { } comparer
-                        && !string.IsNullOrEmpty(_latestCheckpoint)
-                        && comparer.Compare(offset, _latestCheckpoint) <= 0))
-                {
-                    return;
-                }
-
-                _latestCheckpoint = offset;
-                if (_throttleSavesUntilUtc.HasValue && (_throttleSavesUntilUtc.Value > utcNow || !_inProgressSave.IsCompleted))
-                {
-                    return;
-                }
-
-                _throttleSavesUntilUtc = utcNow + _options.PersistInterval;
-                _inProgressSave = Save(offset, cancellationToken);
-                _inProgressSave.Ignore();
-            }
-        }
+            => _inner.Update(offset, utcNow, cancellationToken);
 
         /// <inheritdoc />
-        public async Task FlushAsync(CancellationToken cancellationToken)
+        public Task FlushAsync(CancellationToken cancellationToken)
+            => _inner.FlushAsync(cancellationToken);
+
+        private sealed class StreamCheckpointStoreAdapter(IStreamCheckpointerGrain grain) : IStreamCheckpointStore
         {
-            var retryingSave = false;
-            while (true)
+            public async ValueTask<StreamCheckpointStoreState> Load(CancellationToken cancellationToken)
             {
-                Task inProgressSave;
-                lock (_lock)
-                {
-                    inProgressSave = _inProgressSave;
-                }
-
-                if (retryingSave)
-                {
-                    await inProgressSave.WaitAsync(cancellationToken);
-                }
-                else
-                {
-                    try
-                    {
-                        await inProgressSave.WaitAsync(cancellationToken);
-                    }
-                    catch (Exception) when (!cancellationToken.IsCancellationRequested)
-                    {
-                    }
-
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
-
-                lock (_lock)
-                {
-                    if (!ReferenceEquals(inProgressSave, _inProgressSave))
-                    {
-                        retryingSave = false;
-                        continue;
-                    }
-
-                    if (string.Equals(_persistedCheckpoint, _latestCheckpoint, StringComparison.Ordinal))
-                    {
-                        return;
-                    }
-
-                    _inProgressSave = Save(_latestCheckpoint, cancellationToken);
-                    retryingSave = true;
-                }
-            }
-        }
-
-        private async Task Save(string checkpoint, CancellationToken cancellationToken)
-        {
-            string expectedCheckpoint;
-            lock (_lock)
-            {
-                expectedCheckpoint = _persistedCheckpoint;
+                var checkpoint = await grain.Load(cancellationToken).ConfigureAwait(false);
+                return new(checkpoint, checkpoint);
             }
 
-            while (true)
+            public async ValueTask<StreamCheckpointStoreState> Update(
+                string checkpoint,
+                string expectedVersion,
+                CancellationToken cancellationToken)
             {
-                var persistedCheckpoint = await _grain.Update(
+                var persistedCheckpoint = await grain.Update(
                     checkpoint,
-                    expectedCheckpoint,
-                    cancellationToken);
-
-                lock (_lock)
-                {
-                    _persistedCheckpoint = persistedCheckpoint;
-                    if (string.Equals(persistedCheckpoint, checkpoint, StringComparison.Ordinal))
-                    {
-                        return;
-                    }
-
-                    if (_options.CheckpointComparer is not { } comparer)
-                    {
-                        _latestCheckpoint = persistedCheckpoint;
-                        return;
-                    }
-
-                    if (comparer.Compare(_latestCheckpoint, persistedCheckpoint) <= 0)
-                    {
-                        _latestCheckpoint = persistedCheckpoint;
-                    }
-
-                    if (comparer.Compare(checkpoint, persistedCheckpoint) <= 0)
-                    {
-                        return;
-                    }
-
-                    expectedCheckpoint = persistedCheckpoint;
-                }
+                    expectedVersion,
+                    cancellationToken).ConfigureAwait(false);
+                return new(persistedCheckpoint, persistedCheckpoint);
             }
         }
     }

--- a/src/Orleans.Streaming/Checkpointers/IStreamCheckpointStore.cs
+++ b/src/Orleans.Streaming/Checkpointers/IStreamCheckpointStore.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Streams;
+
+/// <summary>
+/// Stores a persistent stream checkpoint using conditional updates.
+/// </summary>
+public interface IStreamCheckpointStore
+{
+    /// <summary>
+    /// Loads the current checkpoint and its version.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The current checkpoint state.</returns>
+    ValueTask<StreamCheckpointStoreState> Load(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Updates the checkpoint if <paramref name="expectedVersion"/> matches the persisted version.
+    /// </summary>
+    /// <param name="checkpoint">The checkpoint to persist.</param>
+    /// <param name="expectedVersion">The expected persisted version.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// The persisted state after the update attempt. If the expected version did not match,
+    /// the returned state contains the conflicting persisted checkpoint and version.
+    /// </returns>
+    ValueTask<StreamCheckpointStoreState> Update(
+        string checkpoint,
+        string expectedVersion,
+        CancellationToken cancellationToken);
+}

--- a/src/Orleans.Streaming/Checkpointers/StreamCheckpointStoreState.cs
+++ b/src/Orleans.Streaming/Checkpointers/StreamCheckpointStoreState.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Orleans.Streams;
+
+/// <summary>
+/// Represents a persisted stream checkpoint and its backend version.
+/// </summary>
+public readonly struct StreamCheckpointStoreState
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamCheckpointStoreState"/> struct.
+    /// </summary>
+    /// <param name="checkpoint">The checkpoint value.</param>
+    /// <param name="version">The backend version or entity tag.</param>
+    public StreamCheckpointStoreState(string checkpoint, string version)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+        ArgumentNullException.ThrowIfNull(version);
+        Checkpoint = checkpoint;
+        Version = version;
+    }
+
+    /// <summary>
+    /// Gets the checkpoint value.
+    /// </summary>
+    public string Checkpoint { get; }
+
+    /// <summary>
+    /// Gets the backend version or entity tag.
+    /// </summary>
+    public string Version { get; }
+}

--- a/src/Orleans.Streaming/Checkpointers/StreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/Checkpointers/StreamQueueCheckpointer.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Streams;
+
+/// <summary>
+/// Coalesces and persists stream queue checkpoints using an <see cref="IStreamCheckpointStore"/>.
+/// </summary>
+public sealed class StreamQueueCheckpointer : IStreamQueueCheckpointer<string>
+{
+    private readonly IStreamCheckpointStore _store;
+    private readonly StreamQueueCheckpointerOptions _options;
+    private readonly object _lock = new();
+
+    private string _latestCheckpoint = string.Empty;
+    private StreamCheckpointStoreState _persistedState = new(string.Empty, string.Empty);
+    private Task _inProgressSave = Task.CompletedTask;
+    private DateTime? _throttleSavesUntilUtc;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamQueueCheckpointer"/> class.
+    /// </summary>
+    /// <param name="store">The checkpoint store.</param>
+    /// <param name="options">The checkpointer options.</param>
+    public StreamQueueCheckpointer(IStreamCheckpointStore store, StreamQueueCheckpointerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.PersistInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.PersistInterval,
+                $"{nameof(StreamQueueCheckpointerOptions.PersistInterval)} must be greater than zero.");
+        }
+
+        _store = store;
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public bool CheckpointExists
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return !string.IsNullOrEmpty(_latestCheckpoint);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    [Obsolete("Use the overload which accepts a CancellationToken.")]
+    public Task<string> Load() => Load(CancellationToken.None);
+
+    /// <inheritdoc />
+    public async Task<string> Load(CancellationToken cancellationToken)
+    {
+        var state = await _store.Load(cancellationToken);
+        lock (_lock)
+        {
+            _latestCheckpoint = state.Checkpoint;
+            _persistedState = state;
+        }
+
+        return state.Checkpoint;
+    }
+
+    /// <inheritdoc />
+    [Obsolete("Use the overload which accepts a CancellationToken.")]
+    public void Update(string offset, DateTime utcNow)
+        => Update(offset, utcNow, CancellationToken.None);
+
+    /// <inheritdoc />
+    public void Update(string offset, DateTime utcNow, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(offset);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            if (string.Equals(_latestCheckpoint, offset, StringComparison.Ordinal))
+            {
+                if (string.Equals(_persistedState.Checkpoint, offset, StringComparison.Ordinal)
+                    || !_inProgressSave.IsCompleted
+                    || (_throttleSavesUntilUtc.HasValue && _throttleSavesUntilUtc.Value > utcNow))
+                {
+                    return;
+                }
+
+                _throttleSavesUntilUtc = utcNow + _options.PersistInterval;
+                _inProgressSave = Save(offset, cancellationToken);
+                _inProgressSave.Ignore();
+                return;
+            }
+
+            if (_options.CheckpointComparer is { } comparer
+                    && !string.IsNullOrEmpty(_latestCheckpoint)
+                    && comparer.Compare(offset, _latestCheckpoint) <= 0)
+            {
+                return;
+            }
+
+            _latestCheckpoint = offset;
+            if (_throttleSavesUntilUtc.HasValue
+                && (_throttleSavesUntilUtc.Value > utcNow || !_inProgressSave.IsCompleted))
+            {
+                return;
+            }
+
+            _throttleSavesUntilUtc = utcNow + _options.PersistInterval;
+            _inProgressSave = Save(offset, cancellationToken);
+            _inProgressSave.Ignore();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        var retryingSave = false;
+        while (true)
+        {
+            Task inProgressSave;
+            lock (_lock)
+            {
+                inProgressSave = _inProgressSave;
+            }
+
+            if (retryingSave)
+            {
+                await inProgressSave.WaitAsync(cancellationToken);
+            }
+            else
+            {
+                try
+                {
+                    await inProgressSave.WaitAsync(cancellationToken);
+                }
+                catch (Exception) when (!cancellationToken.IsCancellationRequested)
+                {
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            lock (_lock)
+            {
+                if (!ReferenceEquals(inProgressSave, _inProgressSave))
+                {
+                    retryingSave = false;
+                    continue;
+                }
+
+                if (string.Equals(_persistedState.Checkpoint, _latestCheckpoint, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _inProgressSave = Save(_latestCheckpoint, cancellationToken);
+                retryingSave = true;
+            }
+        }
+    }
+
+    private async Task Save(string checkpoint, CancellationToken cancellationToken)
+    {
+        string expectedVersion;
+        lock (_lock)
+        {
+            expectedVersion = _persistedState.Version;
+        }
+
+        while (true)
+        {
+            var persistedState = await _store.Update(checkpoint, expectedVersion, cancellationToken);
+
+            lock (_lock)
+            {
+                _persistedState = persistedState;
+                if (string.Equals(persistedState.Checkpoint, checkpoint, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                if (_options.CheckpointComparer is not { } comparer)
+                {
+                    _latestCheckpoint = persistedState.Checkpoint;
+                    return;
+                }
+
+                if (Compare(comparer, _latestCheckpoint, persistedState.Checkpoint) <= 0)
+                {
+                    _latestCheckpoint = persistedState.Checkpoint;
+                }
+
+                if (Compare(comparer, checkpoint, persistedState.Checkpoint) <= 0)
+                {
+                    return;
+                }
+
+                expectedVersion = persistedState.Version;
+            }
+        }
+    }
+
+    private static int Compare(IComparer<string> comparer, string left, string right)
+    {
+        if (string.IsNullOrEmpty(left))
+        {
+            return string.IsNullOrEmpty(right) ? 0 : -1;
+        }
+
+        return string.IsNullOrEmpty(right) ? 1 : comparer.Compare(left, right);
+    }
+}

--- a/src/Orleans.Streaming/Checkpointers/StreamQueueCheckpointerOptions.cs
+++ b/src/Orleans.Streaming/Checkpointers/StreamQueueCheckpointerOptions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace Orleans.Streams;
+
+/// <summary>
+/// Configures a <see cref="StreamQueueCheckpointer"/>.
+/// </summary>
+public sealed class StreamQueueCheckpointerOptions
+{
+    /// <summary>
+    /// Gets or sets the minimum interval between checkpoint writes.
+    /// </summary>
+    public TimeSpan PersistInterval { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Gets or sets the comparer used to prevent a checkpoint from moving backwards.
+    /// </summary>
+    /// <remarks>
+    /// When this property is <see langword="null"/>, checkpoints are assumed to arrive in increasing order.
+    /// </remarks>
+    public IComparer<string>? CheckpointComparer { get; set; }
+}

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1202,6 +1202,7 @@ namespace Orleans.Streaming.Diagnostics
             public readonly Runtime.StreamId StreamId;
             public readonly System.Guid SubscriptionId;
             public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
+
             public ItemDelivered(string streamProvider, Runtime.StreamId streamId, System.Guid subscriptionId, Runtime.SiloAddress? siloAddress, string clusterId, Streams.StreamSequenceToken? sequenceToken) : base(default!, default) { }
         }
 
@@ -1708,6 +1709,12 @@ namespace Orleans.Streams
         System.Threading.Tasks.ValueTask<string> Update(string offset, string expectedCheckpoint, System.Threading.CancellationToken cancellationToken);
     }
 
+    public partial interface IStreamCheckpointStore
+    {
+        System.Threading.Tasks.ValueTask<StreamCheckpointStoreState> Load(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.ValueTask<StreamCheckpointStoreState> Update(string checkpoint, string expectedVersion, System.Threading.CancellationToken cancellationToken);
+    }
+
     public partial interface IStreamFailureHandler
     {
         bool ShouldFaultSubsriptionOnError { get; }
@@ -2066,6 +2073,17 @@ namespace Orleans.Streams
         public System.Threading.Tasks.ValueTask<string> Update(string offset, string expectedCheckpoint, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 
+    public readonly partial struct StreamCheckpointStoreState
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public StreamCheckpointStoreState(string checkpoint, string version) { }
+
+        public string Checkpoint { get { throw null; } }
+
+        public string Version { get { throw null; } }
+    }
+
     [GenerateSerializer]
     public sealed partial class StreamEventDeliveryFailureException : Runtime.OrleansException
     {
@@ -2138,6 +2156,32 @@ namespace Orleans.Streams
         ExplicitGrainBasedAndImplicit = 0,
         ExplicitGrainBasedOnly = 1,
         ImplicitOnly = 2
+    }
+
+    public sealed partial class StreamQueueCheckpointer : IStreamQueueCheckpointer<string>
+    {
+        public StreamQueueCheckpointer(IStreamCheckpointStore store, StreamQueueCheckpointerOptions options) { }
+
+        public bool CheckpointExists { get { throw null; } }
+
+        public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
+        public System.Threading.Tasks.Task<string> Load() { throw null; }
+
+        public System.Threading.Tasks.Task<string> Load(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Update(string offset, System.DateTime utcNow, System.Threading.CancellationToken cancellationToken) { }
+
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
+        public void Update(string offset, System.DateTime utcNow) { }
+    }
+
+    public sealed partial class StreamQueueCheckpointerOptions
+    {
+        public System.Collections.Generic.IComparer<string>? CheckpointComparer { get { throw null; } set { } }
+
+        public System.TimeSpan PersistInterval { get { throw null; } set { } }
     }
 
     [GenerateSerializer]

--- a/test/Orleans.Streaming.Tests/Checkpointers/ReusableStreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/ReusableStreamQueueCheckpointerTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Streams;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+public sealed class ReusableStreamQueueCheckpointerTests : StreamQueueCheckpointerTests
+{
+    protected override OffsetRegressionPolicy RegressionPolicy => OffsetRegressionPolicy.Ignore;
+
+    protected override Task<IStreamQueueCheckpointer<string>> CreateCheckpointer(
+        ControllableCheckpointStore store)
+        => Task.FromResult<IStreamQueueCheckpointer<string>>(
+            new StreamQueueCheckpointer(
+                new TestCheckpointStore(store),
+                new StreamQueueCheckpointerOptions
+                {
+                    CheckpointComparer = StreamCheckpointComparers.Numeric,
+                    PersistInterval = PersistInterval,
+                }));
+
+    [Fact]
+    public async Task ConditionalConflict_RetriesWithReturnedVersion()
+    {
+        var store = new ConflictingCheckpointStore();
+        var checkpointer = new StreamQueueCheckpointer(
+            store,
+            new StreamQueueCheckpointerOptions
+            {
+                CheckpointComparer = StreamCheckpointComparers.Numeric,
+            });
+        Assert.Equal("10", await checkpointer.Load(CancellationToken.None));
+
+        checkpointer.Update("30", DateTime.UtcNow, CancellationToken.None);
+        await checkpointer.FlushAsync(CancellationToken.None);
+
+        Assert.Equal(["version-1", "version-2"], store.ExpectedVersions);
+        Assert.Equal("30", (await store.Load(CancellationToken.None)).Checkpoint);
+    }
+
+    [Fact]
+    public async Task ConditionalConflict_WithEmptyPersistedCheckpoint_RetriesFirstCheckpoint()
+    {
+        var store = new EmptyCheckpointConflictStore();
+        var checkpointer = new StreamQueueCheckpointer(
+            store,
+            new StreamQueueCheckpointerOptions
+            {
+                CheckpointComparer = StreamCheckpointComparers.Numeric,
+            });
+        Assert.Equal(string.Empty, await checkpointer.Load(CancellationToken.None));
+
+        checkpointer.Update("10", DateTime.UtcNow, CancellationToken.None);
+        await checkpointer.FlushAsync(CancellationToken.None);
+
+        Assert.Equal(["version-1", "version-2"], store.ExpectedVersions);
+        Assert.Equal("10", (await store.Load(CancellationToken.None)).Checkpoint);
+    }
+
+    [Fact]
+    public async Task SamePendingCheckpoint_RetriesAfterFailedWriteAtPersistInterval()
+    {
+        var store = new ControllableCheckpointStore("10");
+        var checkpointer = await CreateCheckpointer(store);
+        Assert.Equal("10", await checkpointer.Load(CancellationToken.None));
+        store.FailNextWrite(new InvalidOperationException("checkpoint write failed"));
+
+        checkpointer.Update("20", DateTime.UtcNow, CancellationToken.None);
+        await store.WaitForWriteAttempts(1);
+        checkpointer.Update("20", DateTime.UtcNow + PersistInterval, CancellationToken.None);
+        await store.WaitForCompletedWrites(1);
+
+        Assert.Equal(["20", "20"], store.WriteAttempts);
+        Assert.Equal(["20"], store.CompletedWrites);
+        Assert.Equal("20", store.PersistedCheckpoint);
+    }
+
+    [Fact]
+    public async Task ConditionalConflict_WithoutComparerAdoptsAuthoritativeCheckpoint()
+    {
+        var store = new BlockingAuthoritativeConflictStore();
+        var checkpointer = new StreamQueueCheckpointer(
+            store,
+            new StreamQueueCheckpointerOptions { CheckpointComparer = null });
+        Assert.Equal("10", await checkpointer.Load(CancellationToken.None));
+
+        checkpointer.Update("20", DateTime.UtcNow, CancellationToken.None);
+        await store.FirstUpdateStarted.Task;
+        checkpointer.Update("30", DateTime.UtcNow, CancellationToken.None);
+        store.ReleaseFirstUpdate.SetResult();
+        await checkpointer.FlushAsync(CancellationToken.None);
+
+        Assert.Equal(["20"], store.Attempts);
+        Assert.Equal("40", (await store.Load(CancellationToken.None)).Checkpoint);
+    }
+
+    private sealed class TestCheckpointStore(ControllableCheckpointStore store) : IStreamCheckpointStore
+    {
+        public async ValueTask<StreamCheckpointStoreState> Load(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var checkpoint = await store.Load().ConfigureAwait(false);
+            return new(checkpoint, checkpoint);
+        }
+
+        public async ValueTask<StreamCheckpointStoreState> Update(
+            string checkpoint,
+            string expectedVersion,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var persistedCheckpoint = await store.Write(checkpoint).ConfigureAwait(false);
+            return new(persistedCheckpoint, persistedCheckpoint);
+        }
+    }
+
+    private sealed class ConflictingCheckpointStore : IStreamCheckpointStore
+    {
+        private StreamCheckpointStoreState state = new("10", "version-1");
+        private bool conflict = true;
+
+        public List<string> ExpectedVersions { get; } = [];
+
+        public ValueTask<StreamCheckpointStoreState> Load(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(state);
+        }
+
+        public ValueTask<StreamCheckpointStoreState> Update(
+            string checkpoint,
+            string expectedVersion,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ExpectedVersions.Add(expectedVersion);
+            if (conflict)
+            {
+                conflict = false;
+                state = new("20", "version-2");
+            }
+            else
+            {
+                Assert.Equal(state.Version, expectedVersion);
+                state = new(checkpoint, "version-3");
+            }
+
+            return ValueTask.FromResult(state);
+        }
+    }
+
+    private sealed class EmptyCheckpointConflictStore : IStreamCheckpointStore
+    {
+        private StreamCheckpointStoreState state = new(string.Empty, "version-1");
+        private bool conflict = true;
+
+        public List<string> ExpectedVersions { get; } = [];
+
+        public ValueTask<StreamCheckpointStoreState> Load(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(state);
+        }
+
+        public ValueTask<StreamCheckpointStoreState> Update(
+            string checkpoint,
+            string expectedVersion,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ExpectedVersions.Add(expectedVersion);
+            if (conflict)
+            {
+                conflict = false;
+                state = new(string.Empty, "version-2");
+            }
+            else
+            {
+                Assert.Equal(state.Version, expectedVersion);
+                state = new(checkpoint, "version-3");
+            }
+
+            return ValueTask.FromResult(state);
+        }
+    }
+
+    private sealed class BlockingAuthoritativeConflictStore : IStreamCheckpointStore
+    {
+        private StreamCheckpointStoreState state = new("10", "version-1");
+
+        public TaskCompletionSource FirstUpdateStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseFirstUpdate { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<string> Attempts { get; } = [];
+
+        public ValueTask<StreamCheckpointStoreState> Load(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(state);
+        }
+
+        public async ValueTask<StreamCheckpointStoreState> Update(
+            string checkpoint,
+            string expectedVersion,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Attempts.Add(checkpoint);
+            FirstUpdateStarted.TrySetResult();
+            await ReleaseFirstUpdate.Task.WaitAsync(cancellationToken);
+            state = new("40", "version-2");
+            return state;
+        }
+    }
+}

--- a/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
@@ -74,6 +74,20 @@ public abstract class StreamQueueCheckpointerTests
         Assert.Equal(["20"], store.CompletedWrites);
     }
 
+    [Theory]
+    [InlineData("9", "10")]
+    [InlineData("99", "100")]
+    public async Task Update_AcrossNumericBoundary_PersistsCheckpoint(string persisted, string candidate)
+    {
+        var (checkpointer, store) = await CreateLoadedSubject(persisted);
+
+        checkpointer.Update(candidate, TestTimeUtc, CancellationToken.None);
+        await checkpointer.FlushAsync(CancellationToken.None);
+
+        Assert.Equal(candidate, store.PersistedCheckpoint);
+        Assert.Equal([candidate], store.CompletedWrites);
+    }
+
     [Fact]
     public async Task Update_WithinPersistInterval_ThrottlesWriteUntilFlush()
     {


### PR DESCRIPTION
## Problem

Checkpoint throttling, coalescing, retry, monotonicity, and optimistic-conflict handling are embedded in the Grain-backed implementation, so custom queue adapters cannot reuse those guarantees with their own durable checkpoint store.

This extracts the checkpoint-focused first wave from #11076 and reconciles overlapping code with the newer #10588 foundation.

## Solution

- Add `IStreamCheckpointStore`, `StreamCheckpointStoreState`, `StreamQueueCheckpointer`, and `StreamQueueCheckpointerOptions` as the reusable checkpoint core.
- Delegate `GrainStreamQueueCheckpointer` to the reusable state machine while preserving its public facade and storage-provider behavior.
- Cover cancellation, flush retry, update coalescing, monotonic checkpoints, numeric boundaries, and optimistic version conflicts with focused contract tests.
- Regenerate the Orleans.Streaming public API and document how custom queue adapters compose a durable checkpoint store with the reusable checkpointer.

## Rationale

Separating persistence from checkpoint coordination gives custom adapters one implementation of the state-machine guarantees while keeping the existing Grain adapter as an immediate production consumer. Provider migrations, replay, pooled cache, pulling-agent, and receiver changes remain independent follow-ups.

Related #756
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11154)