### PR TITLE
fix(streaming): recover legacy sequence tokens

### DIFF
--- a/docs/site/src/content/docs/streaming/custom-queue-adapter.md
+++ b/docs/site/src/content/docs/streaming/custom-queue-adapter.md
@@ -71,6 +71,23 @@ Register the same provider name and compatible mapping on Orleans clients which 
 
 Keep the provider name and partition count stable. Changing either can map an existing stream to a different queue and strand previously enqueued messages. Configure durable `PubSubStore` grain storage for explicit subscriptions in production; `PubSubStore` preserves subscription records independently from queue durability.
 
+## Recover persisted token positions during an upgrade
+
+Earlier inherited `CreateSequenceTokenForEvent` implementations returned an exact <xref:Orleans.Providers.Streams.Common.EventSequenceToken> or <xref:Orleans.Providers.Streams.Common.EventSequenceTokenV2>, including when the batch token had a custom subtype. Current factories preserve the concrete subtype and its metadata while changing the event index.
+
+Orleans recovers these saved positions according to the provider's token contract:
+
+| Token contract | Persisted positions supported during recovery |
+| --- | --- |
+| Generic V1/V2 and custom subclasses inheriting the complete numeric contract | Exact V1 and V2 positions compare with current tokens by sequence number and event index, with matching equality and hashes across the family. |
+| Event Hubs V1/V2 and custom subclasses inheriting the complete Event Hubs contract | Exact V1 positions from the earlier inherited factory are normalized within Event Hubs recovery comparisons. The sequence number and event index identify the position; current delivered tokens retain their Event Hubs offset and custom metadata. |
+| Kinesis | Persisted Kinesis tokens retain the numeric shard offset as the authoritative position, followed by event index, across receiver restarts. |
+| Redis | Persisted Redis tokens retain the entry ID, per-millisecond sequence number, and event index. |
+
+The complete contract includes both equality overloads, ordering, hashing, and their interface implementations. An ordinary custom token which inherits these implementations shares its base family's numeric identity; additional metadata is preserved on delivery. A custom token which overrides any part of the contract owns the migration of its persisted positions and must implement consistent equality, ordering, and hashing together.
+
+Event Hubs, Kinesis, and Redis each retain their provider-specific public equality contract. Event Hubs recovery uses a sequence-only token with an empty offset for a legacy position whose factory omitted the offset; offset-bearing tokens come from the current provider data. Keep stream identity and partition mapping stable when replaying persisted positions.
+
 ## Validate failure behavior
 
 Test the adapter against the real queue service, including:
@@ -81,6 +98,7 @@ Test the adapter against the real queue service, including:
 1. queue ownership moving between silos during membership changes;
 1. duplicate delivery and consumer idempotency;
 1. stable stream-to-partition mapping across restarts and upgrades; and
-1. sustained load beyond cache capacity to verify backpressure and queue retention.
+1. sustained load beyond cache capacity to verify backpressure and queue retention; and
+1. sequence-token equality, ordering, and hashing in both comparison directions.
 
 Monitor queue depth and oldest-message age by partition, receive and acknowledgement latency, redelivery count, throttling, pulling-agent errors, and consumer delivery failures. Alert before retention or visibility limits can cause data loss or a redelivery storm.

--- a/docs/site/src/content/docs/streaming/custom-queue-adapter.md
+++ b/docs/site/src/content/docs/streaming/custom-queue-adapter.md
@@ -79,12 +79,12 @@ Orleans recovers these saved positions according to the provider's token contrac
 
 | Token contract | Persisted positions supported during recovery |
 | --- | --- |
-| Generic V1/V2 and custom subclasses retaining the generic compatibility domain | Exact V1 and V2 positions compare with current tokens by sequence number and event index, with matching equality and hashes across the family. |
-| Event Hubs V1/V2 and custom subclasses retaining the Event Hubs compatibility domain | Exact V1 positions from the earlier inherited factory are normalized within Event Hubs recovery comparisons. The sequence number and event index identify the position; current delivered tokens retain their Event Hubs offset and custom metadata. |
+| Generic V1/V2 and custom subclasses explicitly selecting the generic compatibility domain | Exact V1 and V2 positions compare with current tokens by sequence number and event index, with matching equality and hashes across the family. |
+| Event Hubs V1/V2 and custom subclasses explicitly selecting the Event Hubs compatibility domain | Exact V1 positions from the earlier inherited factory are normalized within Event Hubs recovery comparisons. The sequence number and event index identify the position; current delivered tokens retain their Event Hubs offset and custom metadata. |
 | Kinesis | Persisted Kinesis tokens retain the numeric shard offset as the authoritative position, followed by event index, across receiver restarts. |
 | Redis | Persisted Redis tokens retain the entry ID, per-millisecond sequence number, and event index. |
 
-An ordinary custom token inherits its base family's compatibility domain and numeric identity; additional metadata is preserved on delivery. A custom token which adds position identity overrides `SequenceTokenCompatibilityDomain` with a stable type representing its contract and implements equality, ordering, and hashing consistently for that domain.
+Derived tokens are isolated by default, which preserves the identity contract of adapters compiled before this compatibility hook existed. A custom token which uses the complete generic numeric contract overrides `SequenceTokenCompatibilityDomain` to return `typeof(EventSequenceToken)`. Related token versions select the same stable domain type. A custom token which adds position identity keeps a distinct domain and implements equality, ordering, and hashing consistently for that domain.
 
 Event Hubs, Kinesis, and Redis each retain their provider-specific public equality contract. Event Hubs recovery uses a sequence-only token with an empty offset for a legacy position whose factory omitted the offset; offset-bearing tokens come from the current provider data. Keep stream identity and partition mapping stable when replaying persisted positions.
 

--- a/docs/site/src/content/docs/streaming/custom-queue-adapter.md
+++ b/docs/site/src/content/docs/streaming/custom-queue-adapter.md
@@ -79,12 +79,12 @@ Orleans recovers these saved positions according to the provider's token contrac
 
 | Token contract | Persisted positions supported during recovery |
 | --- | --- |
-| Generic V1/V2 and custom subclasses inheriting the complete numeric contract | Exact V1 and V2 positions compare with current tokens by sequence number and event index, with matching equality and hashes across the family. |
-| Event Hubs V1/V2 and custom subclasses inheriting the complete Event Hubs contract | Exact V1 positions from the earlier inherited factory are normalized within Event Hubs recovery comparisons. The sequence number and event index identify the position; current delivered tokens retain their Event Hubs offset and custom metadata. |
+| Generic V1/V2 and custom subclasses retaining the generic compatibility domain | Exact V1 and V2 positions compare with current tokens by sequence number and event index, with matching equality and hashes across the family. |
+| Event Hubs V1/V2 and custom subclasses retaining the Event Hubs compatibility domain | Exact V1 positions from the earlier inherited factory are normalized within Event Hubs recovery comparisons. The sequence number and event index identify the position; current delivered tokens retain their Event Hubs offset and custom metadata. |
 | Kinesis | Persisted Kinesis tokens retain the numeric shard offset as the authoritative position, followed by event index, across receiver restarts. |
 | Redis | Persisted Redis tokens retain the entry ID, per-millisecond sequence number, and event index. |
 
-The complete contract includes both equality overloads, ordering, hashing, and their interface implementations. An ordinary custom token which inherits these implementations shares its base family's numeric identity; additional metadata is preserved on delivery. A custom token which overrides any part of the contract owns the migration of its persisted positions and must implement consistent equality, ordering, and hashing together.
+An ordinary custom token inherits its base family's compatibility domain and numeric identity; additional metadata is preserved on delivery. A custom token which adds position identity overrides `SequenceTokenCompatibilityDomain` with a stable type representing its contract and implements equality, ordering, and hashing consistently for that domain.
 
 Event Hubs, Kinesis, and Redis each retain their provider-specific public equality contract. Event Hubs recovery uses a sequence-only token with an empty offset for a legacy position whose factory omitted the offset; offset-bearing tokens come from the current provider data. Keep stream identity and partition mapping stable when replaying persisted positions.
 

--- a/docs/site/src/content/docs/streaming/custom-queue-adapter.md
+++ b/docs/site/src/content/docs/streaming/custom-queue-adapter.md
@@ -97,7 +97,7 @@ Test the adapter against the real queue service, including:
 1. producer, receiver, and silo failure before and after acknowledgement;
 1. queue ownership moving between silos during membership changes;
 1. duplicate delivery and consumer idempotency;
-1. stable stream-to-partition mapping across restarts and upgrades; and
+1. stable stream-to-partition mapping across restarts and upgrades;
 1. sustained load beyond cache capacity to verify backpressure and queue retention; and
 1. sequence-token equality, ordering, and hashing in both comparison directions.
 

--- a/src/AWS/Orleans.Streaming.Kinesis/Streams/KinesisSequenceToken.cs
+++ b/src/AWS/Orleans.Streaming.Kinesis/Streams/KinesisSequenceToken.cs
@@ -1,24 +1,30 @@
 using Newtonsoft.Json;
 using Orleans.Providers.Streams.Common;
+using Orleans.Streams;
 using System;
 using System.Globalization;
+using System.Numerics;
 
 namespace Orleans.Streaming.Kinesis
 {
     [Serializable]
     [GenerateSerializer]
-    internal class KinesisSequenceToken : EventSequenceTokenV2
+    internal sealed class KinesisSequenceToken : EventSequenceTokenV2
     {
+        [NonSerialized]
+        private BigInteger? _numericShardSequence;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="KinesisSequenceToken" /> class.
         /// </summary>
         /// <param name="shardSequence">Kinesis offset within the shard (partition) from which this message came.</param>
         /// <param name="sequenceNumber">Receiver-generated sequenceNumber for this message.</param>
         /// <param name="eventIndex">Index into a batch of events, if multiple events were delivered within a single Kinesis record.</param>
+        [JsonConstructor]
         public KinesisSequenceToken(string shardSequence, long sequenceNumber, int eventIndex)
             : base(sequenceNumber, eventIndex)
         {
-            ShardSequence = shardSequence;
+            ShardSequence = shardSequence ?? throw new ArgumentNullException(nameof(shardSequence));
         }
 
         /// <summary>
@@ -38,6 +44,37 @@ namespace Orleans.Streaming.Kinesis
         [JsonProperty]
         public string ShardSequence { get; } = null!;
 
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => obj is StreamSequenceToken token && Equals(token);
+
+        /// <inheritdoc />
+        public override bool Equals(StreamSequenceToken? other)
+        {
+            return other is KinesisSequenceToken token
+                && NumericShardSequence.Equals(token.NumericShardSequence)
+                && EventIndex == token.EventIndex;
+        }
+
+        /// <inheritdoc />
+        public override int CompareTo(StreamSequenceToken? other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            if (other is not KinesisSequenceToken token)
+            {
+                throw new ArgumentOutOfRangeException(nameof(other));
+            }
+
+            var difference = NumericShardSequence.CompareTo(token.NumericShardSequence);
+            return difference != 0 ? difference : EventIndex.CompareTo(token.EventIndex);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(NumericShardSequence, EventIndex);
+
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>
         /// <filterpriority>2</filterpriority>
@@ -45,5 +82,11 @@ namespace Orleans.Streaming.Kinesis
         {
             return string.Format(CultureInfo.InvariantCulture, "KinesisSequenceToken(ShardSequence: {0}, SequenceNumber: {1}, EventIndex: {2})", ShardSequence, SequenceNumber, EventIndex);
         }
+
+        private BigInteger NumericShardSequence
+            => _numericShardSequence ??= BigInteger.Parse(
+                ShardSequence,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture);
     }
 }

--- a/src/AWS/Orleans.Streaming.Kinesis/Streams/KinesisSequenceToken.cs
+++ b/src/AWS/Orleans.Streaming.Kinesis/Streams/KinesisSequenceToken.cs
@@ -45,6 +45,9 @@ namespace Orleans.Streaming.Kinesis
         public string ShardSequence { get; } = null!;
 
         /// <inheritdoc />
+        protected override Type SequenceTokenCompatibilityDomain => typeof(KinesisSequenceToken);
+
+        /// <inheritdoc />
         public override bool Equals(object? obj) => obj is StreamSequenceToken token && Equals(token);
 
         /// <inheritdoc />

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -3,6 +3,7 @@ using System;
 using System.Globalization;
 using Newtonsoft.Json;
 using Orleans.Providers.Streams.Common;
+using Orleans.Streams;
 
 namespace Orleans.Streaming.EventHubs
 {
@@ -31,6 +32,13 @@ namespace Orleans.Streaming.EventHubs
     ///   indicates which application layer event this token is for, within an EventHub message.  It is required for uniqueness
     ///   and ordering of application layer events within an EventHub message.
     /// </summary>
+    /// <remarks>
+    /// Event Hub token versions and subclasses which inherit their complete equality, ordering,
+    /// and hashing contract compare using the Event Hubs sequence number and event index.
+    /// During recovery, Orleans interprets exact <see cref="EventSequenceToken"/> positions from
+    /// the earlier inherited event-token factory in this provider's sequence-number space.
+    /// Delivered event tokens preserve their concrete type and Event Hubs offset.
+    /// </remarks>
     [Serializable]
     [GenerateSerializer]
     public class EventHubSequenceToken : EventSequenceToken, IEventHubPartitionLocation
@@ -64,6 +72,47 @@ namespace Orleans.Streaming.EventHubs
         {
         }
 
+        internal override StreamSequenceToken NormalizeLegacyToken(StreamSequenceToken token)
+        {
+            if (token.GetType() == typeof(EventSequenceToken) && HasInheritedEventHubContract(this))
+            {
+                // The former inherited factory persisted the position without the offset.
+                // Empty offsets also identify sequence-only tokens produced by EventHubDataAdapter.
+                return new EventHubSequenceToken(string.Empty, token.SequenceNumber, token.EventIndex);
+            }
+
+            return token;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(StreamSequenceToken? other)
+        {
+            return other is not null
+                && IsCompatibleEventHubToken(other)
+                && other.SequenceNumber == SequenceNumber
+                && other.EventIndex == EventIndex;
+        }
+
+        /// <inheritdoc />
+        public override int CompareTo(StreamSequenceToken? other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            if (!IsCompatibleEventHubToken(other))
+            {
+                throw new ArgumentOutOfRangeException(nameof(other));
+            }
+
+            var difference = SequenceNumber.CompareTo(other.SequenceNumber);
+            return difference != 0 ? difference : EventIndex.CompareTo(other.EventIndex);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(SequenceNumber, EventIndex);
+
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>
         /// <filterpriority>2</filterpriority>
@@ -71,5 +120,21 @@ namespace Orleans.Streaming.EventHubs
         {
             return string.Format(CultureInfo.InvariantCulture, "EventHubSequenceToken(EventHubOffset: {0}, SequenceNumber: {1}, EventIndex: {2})", EventHubOffset, SequenceNumber, EventIndex);
         }
+
+        private bool IsCompatibleEventHubToken(StreamSequenceToken? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return GetType() == other.GetType()
+                || other is EventHubSequenceToken
+                    && HasInheritedEventHubContract(this)
+                    && HasInheritedEventHubContract(other);
+        }
+
+        private static bool HasInheritedEventHubContract(StreamSequenceToken token)
+            => EventSequenceTokenCompatibility.HasInheritedContract(token, typeof(EventHubSequenceToken), typeof(EventSequenceToken));
     }
 }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -73,7 +73,11 @@ namespace Orleans.Streaming.EventHubs
         }
 
         /// <inheritdoc />
-        protected override Type SequenceTokenCompatibilityDomain => typeof(EventHubSequenceToken);
+        protected override Type SequenceTokenCompatibilityDomain
+            => GetType() is var type
+                && (type == typeof(EventHubSequenceToken) || type == typeof(EventHubSequenceTokenV2))
+                    ? typeof(EventHubSequenceToken)
+                    : type;
 
         internal override StreamSequenceToken NormalizeLegacyToken(StreamSequenceToken token)
         {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -33,8 +33,8 @@ namespace Orleans.Streaming.EventHubs
     ///   and ordering of application layer events within an EventHub message.
     /// </summary>
     /// <remarks>
-    /// Event Hub token versions and subclasses which retain the Event Hubs compatibility domain
-    /// compare using the Event Hubs sequence number and event index.
+    /// Event Hub token versions and subclasses which explicitly select the Event Hubs
+    /// compatibility domain compare using the Event Hubs sequence number and event index.
     /// During recovery, Orleans interprets exact <see cref="EventSequenceToken"/> positions from
     /// the earlier inherited event-token factory in this provider's sequence-number space.
     /// Delivered event tokens preserve their concrete type and Event Hubs offset.

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubSequenceToken.cs
@@ -33,8 +33,8 @@ namespace Orleans.Streaming.EventHubs
     ///   and ordering of application layer events within an EventHub message.
     /// </summary>
     /// <remarks>
-    /// Event Hub token versions and subclasses which inherit their complete equality, ordering,
-    /// and hashing contract compare using the Event Hubs sequence number and event index.
+    /// Event Hub token versions and subclasses which retain the Event Hubs compatibility domain
+    /// compare using the Event Hubs sequence number and event index.
     /// During recovery, Orleans interprets exact <see cref="EventSequenceToken"/> positions from
     /// the earlier inherited event-token factory in this provider's sequence-number space.
     /// Delivered event tokens preserve their concrete type and Event Hubs offset.
@@ -72,9 +72,13 @@ namespace Orleans.Streaming.EventHubs
         {
         }
 
+        /// <inheritdoc />
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventHubSequenceToken);
+
         internal override StreamSequenceToken NormalizeLegacyToken(StreamSequenceToken token)
         {
-            if (token.GetType() == typeof(EventSequenceToken) && HasInheritedEventHubContract(this))
+            if (token.GetType() == typeof(EventSequenceToken)
+                && SequenceTokenCompatibilityDomain == typeof(EventHubSequenceToken))
             {
                 // The former inherited factory persisted the position without the offset.
                 // Empty offsets also identify sequence-only tokens produced by EventHubDataAdapter.
@@ -128,13 +132,7 @@ namespace Orleans.Streaming.EventHubs
                 return false;
             }
 
-            return GetType() == other.GetType()
-                || other is EventHubSequenceToken
-                    && HasInheritedEventHubContract(this)
-                    && HasInheritedEventHubContract(other);
+            return EventSequenceTokenCompatibility.IsCompatibleNumericToken(this, other);
         }
-
-        private static bool HasInheritedEventHubContract(StreamSequenceToken token)
-            => EventSequenceTokenCompatibility.HasInheritedContract(token, typeof(EventHubSequenceToken), typeof(EventSequenceToken));
     }
 }

--- a/src/Orleans.Streaming/Common/EventSequenceToken.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceToken.cs
@@ -8,6 +8,12 @@ namespace Orleans.Providers.Streams.Common
     /// <summary>
     /// Stream sequence token that tracks sequence number and event index
     /// </summary>
+    /// <remarks>
+    /// <see cref="EventSequenceToken"/> and <see cref="EventSequenceTokenV2"/> share a numeric
+    /// position contract with subclasses which inherit their complete equality, ordering, and
+    /// hashing implementations. This includes exact base tokens persisted by earlier event-token
+    /// factories. Subclasses which override that contract define their own compatibility.
+    /// </remarks>
     [Serializable]
     [GenerateSerializer]
     public class EventSequenceToken : StreamSequenceToken
@@ -61,24 +67,29 @@ namespace Orleans.Providers.Streams.Common
         /// Creates a sequence token for a specific event in the current batch.
         /// </summary>
         /// <param name="eventInd">The event index, for events which are part of a batch.</param>
-        /// <returns>The sequence token.</returns>
-        public EventSequenceToken CreateSequenceTokenForEvent(int eventInd)
+        /// <returns>A token with the same concrete runtime type and position metadata, targeting the specified event.</returns>
+        public virtual EventSequenceToken CreateSequenceTokenForEvent(int eventInd)
         {
-            return new EventSequenceToken(SequenceNumber, eventInd);
+            var result = (EventSequenceToken)MemberwiseClone();
+            result.EventIndex = eventInd;
+            return result;
         }
+
+        internal virtual StreamSequenceToken NormalizeLegacyToken(StreamSequenceToken token) => token;
 
         /// <inheritdoc />
         public override bool Equals(object? obj)
         {
-            return Equals(obj as EventSequenceToken);
+            return obj is StreamSequenceToken token && Equals(token);
         }
 
         /// <inheritdoc />
         public override bool Equals(StreamSequenceToken? other)
         {
-            var token = other as EventSequenceToken;
-            return token != null && (token.SequenceNumber == SequenceNumber &&
-                                     token.EventIndex == EventIndex);
+            return other is not null
+                && EventSequenceTokenCompatibility.IsCompatibleNumericToken(this, other)
+                && other.SequenceNumber == SequenceNumber
+                && other.EventIndex == EventIndex;
         }
 
         /// <inheritdoc />
@@ -87,12 +98,11 @@ namespace Orleans.Providers.Streams.Common
             if (other == null)
                 return 1;
 
-            var token = other as EventSequenceToken;
-            if (token == null)
+            if (!EventSequenceTokenCompatibility.IsCompatibleNumericToken(this, other))
                 throw new ArgumentOutOfRangeException(nameof(other));
 
-            int difference = SequenceNumber.CompareTo(token.SequenceNumber);
-            return difference != 0 ? difference : EventIndex.CompareTo(token.EventIndex);
+            int difference = SequenceNumber.CompareTo(other.SequenceNumber);
+            return difference != 0 ? difference : EventIndex.CompareTo(other.EventIndex);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Streaming/Common/EventSequenceToken.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceToken.cs
@@ -81,11 +81,11 @@ namespace Orleans.Providers.Streams.Common
         /// this token's numeric equality and ordering contract.
         /// </summary>
         /// <remarks>
-        /// Derived tokens which add position identity override this property and return a stable
-        /// type representing their contract. Tokens in the same domain compare by
-        /// <see cref="SequenceNumber"/> and <see cref="EventIndex"/>.
+        /// Derived tokens are isolated by default. A derived token which uses this complete numeric
+        /// contract overrides this property and returns <see cref="EventSequenceToken"/>. Tokens in
+        /// the same domain compare by <see cref="SequenceNumber"/> and <see cref="EventIndex"/>.
         /// </remarks>
-        protected virtual Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+        protected virtual Type SequenceTokenCompatibilityDomain => GetType();
 
         internal Type GetSequenceTokenCompatibilityDomain() => SequenceTokenCompatibilityDomain;
 

--- a/src/Orleans.Streaming/Common/EventSequenceToken.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceToken.cs
@@ -10,10 +10,9 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     /// <remarks>
     /// <see cref="EventSequenceToken"/> and <see cref="EventSequenceTokenV2"/> share a numeric
-    /// position contract with subclasses which retain the same
-    /// <see cref="SequenceTokenCompatibilityDomain"/>. This includes exact base tokens persisted
-    /// by earlier event-token factories. Subclasses which add position identity override that
-    /// domain together with equality, ordering, and hashing.
+    /// position contract. Derived tokens are isolated by default and can explicitly join that
+    /// contract through <see cref="SequenceTokenCompatibilityDomain"/>. This includes exact base
+    /// tokens persisted by earlier event-token factories.
     /// </remarks>
     [Serializable]
     [GenerateSerializer]

--- a/src/Orleans.Streaming/Common/EventSequenceToken.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceToken.cs
@@ -10,9 +10,10 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     /// <remarks>
     /// <see cref="EventSequenceToken"/> and <see cref="EventSequenceTokenV2"/> share a numeric
-    /// position contract with subclasses which inherit their complete equality, ordering, and
-    /// hashing implementations. This includes exact base tokens persisted by earlier event-token
-    /// factories. Subclasses which override that contract define their own compatibility.
+    /// position contract with subclasses which retain the same
+    /// <see cref="SequenceTokenCompatibilityDomain"/>. This includes exact base tokens persisted
+    /// by earlier event-token factories. Subclasses which add position identity override that
+    /// domain together with equality, ordering, and hashing.
     /// </remarks>
     [Serializable]
     [GenerateSerializer]
@@ -74,6 +75,19 @@ namespace Orleans.Providers.Streams.Common
             result.EventIndex = eventInd;
             return result;
         }
+
+        /// <summary>
+        /// Gets the compatibility domain used to determine which event sequence tokens share
+        /// this token's numeric equality and ordering contract.
+        /// </summary>
+        /// <remarks>
+        /// Derived tokens which add position identity override this property and return a stable
+        /// type representing their contract. Tokens in the same domain compare by
+        /// <see cref="SequenceNumber"/> and <see cref="EventIndex"/>.
+        /// </remarks>
+        protected virtual Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+
+        internal Type GetSequenceTokenCompatibilityDomain() => SequenceTokenCompatibilityDomain;
 
         internal virtual StreamSequenceToken NormalizeLegacyToken(StreamSequenceToken token) => token;
 

--- a/src/Orleans.Streaming/Common/EventSequenceTokenCompatibility.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceTokenCompatibility.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Concurrent;
+using Orleans.Streams;
+
+namespace Orleans.Providers.Streams.Common;
+
+internal static class EventSequenceTokenCompatibility
+{
+    private static readonly ConcurrentDictionary<Type, TokenContract> Contracts = new();
+
+    public static bool IsCompatibleNumericToken(StreamSequenceToken left, StreamSequenceToken right)
+        => left.GetType() == right.GetType() || HasNumericContract(left) && HasNumericContract(right);
+
+    public static bool HasInheritedContract(StreamSequenceToken token, Type contractType, Type objectEqualsType)
+    {
+        // Resolve virtual and interface dispatch once per type, including explicit interface reimplementations.
+        var contract = Contracts.GetOrAdd(token.GetType(), static (_, value) => new TokenContract(
+            new Func<object?, bool>(value.Equals).Method.DeclaringType,
+            new Func<StreamSequenceToken?, bool>(value.Equals).Method.DeclaringType,
+            new Func<StreamSequenceToken?, int>(value.CompareTo).Method.DeclaringType,
+            new Func<int>(value.GetHashCode).Method.DeclaringType,
+            new Func<StreamSequenceToken?, bool>(((IEquatable<StreamSequenceToken?>)value).Equals).Method.DeclaringType,
+            new Func<StreamSequenceToken?, int>(((IComparable<StreamSequenceToken?>)value).CompareTo).Method.DeclaringType), token);
+
+        return contract.ObjectEquals == objectEqualsType
+            && contract.TokenEquals == contractType
+            && contract.CompareTo == contractType
+            && contract.Hashing == contractType
+            && contract.EquatableEquals == contractType
+            && contract.ComparableCompareTo == contractType;
+    }
+
+    public static int Compare(StreamSequenceToken left, StreamSequenceToken right)
+    {
+        Normalize(ref left, ref right);
+        return left.CompareTo(right);
+    }
+
+    public static bool AreEqual(StreamSequenceToken left, StreamSequenceToken right)
+    {
+        Normalize(ref left, ref right);
+        return left.Equals(right);
+    }
+
+    private static bool HasNumericContract(StreamSequenceToken token)
+        => token switch
+        {
+            EventSequenceToken => HasInheritedContract(token, typeof(EventSequenceToken), typeof(EventSequenceToken)),
+            EventSequenceTokenV2 => HasInheritedContract(token, typeof(EventSequenceTokenV2), typeof(EventSequenceTokenV2)),
+            _ => false,
+        };
+
+    private static void Normalize(ref StreamSequenceToken left, ref StreamSequenceToken right)
+    {
+        // Provider-specific legacy positions are normalized only for recovery comparisons.
+        // Public token equality keeps the provider's contract, and delivered tokens keep their metadata.
+        if (left is EventSequenceToken leftProvider)
+        {
+            right = leftProvider.NormalizeLegacyToken(right);
+        }
+
+        if (right is EventSequenceToken rightProvider)
+        {
+            left = rightProvider.NormalizeLegacyToken(left);
+        }
+    }
+
+    private sealed record TokenContract(
+        Type? ObjectEquals,
+        Type? TokenEquals,
+        Type? CompareTo,
+        Type? Hashing,
+        Type? EquatableEquals,
+        Type? ComparableCompareTo);
+}

--- a/src/Orleans.Streaming/Common/EventSequenceTokenCompatibility.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceTokenCompatibility.cs
@@ -1,34 +1,15 @@
 using System;
-using System.Collections.Concurrent;
 using Orleans.Streams;
 
 namespace Orleans.Providers.Streams.Common;
 
 internal static class EventSequenceTokenCompatibility
 {
-    private static readonly ConcurrentDictionary<Type, TokenContract> Contracts = new();
-
     public static bool IsCompatibleNumericToken(StreamSequenceToken left, StreamSequenceToken right)
-        => left.GetType() == right.GetType() || HasNumericContract(left) && HasNumericContract(right);
-
-    public static bool HasInheritedContract(StreamSequenceToken token, Type contractType, Type objectEqualsType)
-    {
-        // Resolve virtual and interface dispatch once per type, including explicit interface reimplementations.
-        var contract = Contracts.GetOrAdd(token.GetType(), static (_, value) => new TokenContract(
-            new Func<object?, bool>(value.Equals).Method.DeclaringType,
-            new Func<StreamSequenceToken?, bool>(value.Equals).Method.DeclaringType,
-            new Func<StreamSequenceToken?, int>(value.CompareTo).Method.DeclaringType,
-            new Func<int>(value.GetHashCode).Method.DeclaringType,
-            new Func<StreamSequenceToken?, bool>(((IEquatable<StreamSequenceToken?>)value).Equals).Method.DeclaringType,
-            new Func<StreamSequenceToken?, int>(((IComparable<StreamSequenceToken?>)value).CompareTo).Method.DeclaringType), token);
-
-        return contract.ObjectEquals == objectEqualsType
-            && contract.TokenEquals == contractType
-            && contract.CompareTo == contractType
-            && contract.Hashing == contractType
-            && contract.EquatableEquals == contractType
-            && contract.ComparableCompareTo == contractType;
-    }
+        => left.GetType() == right.GetType()
+            || TryGetCompatibilityDomain(left, out var leftDomain)
+                && TryGetCompatibilityDomain(right, out var rightDomain)
+                && leftDomain == rightDomain;
 
     public static int Compare(StreamSequenceToken left, StreamSequenceToken right)
     {
@@ -42,13 +23,17 @@ internal static class EventSequenceTokenCompatibility
         return left.Equals(right);
     }
 
-    private static bool HasNumericContract(StreamSequenceToken token)
-        => token switch
+    private static bool TryGetCompatibilityDomain(StreamSequenceToken token, out Type domain)
+    {
+        domain = token switch
         {
-            EventSequenceToken => HasInheritedContract(token, typeof(EventSequenceToken), typeof(EventSequenceToken)),
-            EventSequenceTokenV2 => HasInheritedContract(token, typeof(EventSequenceTokenV2), typeof(EventSequenceTokenV2)),
-            _ => false,
+            EventSequenceToken eventToken => eventToken.GetSequenceTokenCompatibilityDomain(),
+            EventSequenceTokenV2 eventToken => eventToken.GetSequenceTokenCompatibilityDomain(),
+            _ => null!,
         };
+
+        return domain is not null;
+    }
 
     private static void Normalize(ref StreamSequenceToken left, ref StreamSequenceToken right)
     {
@@ -64,12 +49,4 @@ internal static class EventSequenceTokenCompatibility
             left = rightProvider.NormalizeLegacyToken(left);
         }
     }
-
-    private sealed record TokenContract(
-        Type? ObjectEquals,
-        Type? TokenEquals,
-        Type? CompareTo,
-        Type? Hashing,
-        Type? EquatableEquals,
-        Type? ComparableCompareTo);
 }

--- a/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
@@ -8,6 +8,12 @@ namespace Orleans.Providers.Streams.Common
     /// <summary>
     /// Stream sequence token that tracks sequence number and event index
     /// </summary>
+    /// <remarks>
+    /// <see cref="EventSequenceTokenV2"/> and <see cref="EventSequenceToken"/> share a numeric
+    /// position contract with subclasses which inherit their complete equality, ordering, and
+    /// hashing implementations. This includes exact base tokens persisted by earlier event-token
+    /// factories. Subclasses which override that contract define their own compatibility.
+    /// </remarks>
     [Serializable]
     [GenerateSerializer]
     public class EventSequenceTokenV2 : StreamSequenceToken
@@ -61,24 +67,27 @@ namespace Orleans.Providers.Streams.Common
         /// Creates a sequence token for a specific event in the current batch
         /// </summary>
         /// <param name="eventInd">The event index.</param>
-        /// <returns>A new sequence token.</returns>
-        public EventSequenceTokenV2 CreateSequenceTokenForEvent(int eventInd)
+        /// <returns>A token with the same concrete runtime type and position metadata, targeting the specified event.</returns>
+        public virtual EventSequenceTokenV2 CreateSequenceTokenForEvent(int eventInd)
         {
-            return new EventSequenceTokenV2(SequenceNumber, eventInd);
+            var result = (EventSequenceTokenV2)MemberwiseClone();
+            result.EventIndex = eventInd;
+            return result;
         }
 
         /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
-            return Equals(obj as EventSequenceTokenV2);
+            return obj is StreamSequenceToken token && Equals(token);
         }
 
         /// <inheritdoc/>
         public override bool Equals(StreamSequenceToken? other)
         {
-            var token = other as EventSequenceTokenV2;
-            return token != null && (token.SequenceNumber == SequenceNumber &&
-                                     token.EventIndex == EventIndex);
+            return other is not null
+                && EventSequenceTokenCompatibility.IsCompatibleNumericToken(this, other)
+                && other.SequenceNumber == SequenceNumber
+                && other.EventIndex == EventIndex;
         }
 
         /// <inheritdoc/>
@@ -87,12 +96,11 @@ namespace Orleans.Providers.Streams.Common
             if (other == null)
                 return 1;
 
-            var token = other as EventSequenceTokenV2;
-            if (token == null)
+            if (!EventSequenceTokenCompatibility.IsCompatibleNumericToken(this, other))
                 throw new ArgumentOutOfRangeException(nameof(other));
 
-            int difference = SequenceNumber.CompareTo(token.SequenceNumber);
-            return difference != 0 ? difference : EventIndex.CompareTo(token.EventIndex);
+            int difference = SequenceNumber.CompareTo(other.SequenceNumber);
+            return difference != 0 ? difference : EventIndex.CompareTo(other.EventIndex);
         }
 
         /// <inheritdoc/>

--- a/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
@@ -81,11 +81,12 @@ namespace Orleans.Providers.Streams.Common
         /// this token's numeric equality and ordering contract.
         /// </summary>
         /// <remarks>
-        /// Derived tokens which add position identity override this property and return a stable
-        /// type representing their contract. Tokens in the same domain compare by
-        /// <see cref="SequenceNumber"/> and <see cref="EventIndex"/>.
+        /// Derived tokens are isolated by default. A derived token which uses this complete numeric
+        /// contract overrides this property and returns <see cref="EventSequenceToken"/>. Tokens in
+        /// the same domain compare by <see cref="SequenceNumber"/> and <see cref="EventIndex"/>.
         /// </remarks>
-        protected virtual Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+        protected virtual Type SequenceTokenCompatibilityDomain
+            => GetType() == typeof(EventSequenceTokenV2) ? typeof(EventSequenceToken) : GetType();
 
         internal Type GetSequenceTokenCompatibilityDomain() => SequenceTokenCompatibilityDomain;
 

--- a/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
@@ -10,9 +10,10 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     /// <remarks>
     /// <see cref="EventSequenceTokenV2"/> and <see cref="EventSequenceToken"/> share a numeric
-    /// position contract with subclasses which inherit their complete equality, ordering, and
-    /// hashing implementations. This includes exact base tokens persisted by earlier event-token
-    /// factories. Subclasses which override that contract define their own compatibility.
+    /// position contract with subclasses which retain the same
+    /// <see cref="SequenceTokenCompatibilityDomain"/>. This includes exact base tokens persisted
+    /// by earlier event-token factories. Subclasses which add position identity override that
+    /// domain together with equality, ordering, and hashing.
     /// </remarks>
     [Serializable]
     [GenerateSerializer]
@@ -74,6 +75,19 @@ namespace Orleans.Providers.Streams.Common
             result.EventIndex = eventInd;
             return result;
         }
+
+        /// <summary>
+        /// Gets the compatibility domain used to determine which event sequence tokens share
+        /// this token's numeric equality and ordering contract.
+        /// </summary>
+        /// <remarks>
+        /// Derived tokens which add position identity override this property and return a stable
+        /// type representing their contract. Tokens in the same domain compare by
+        /// <see cref="SequenceNumber"/> and <see cref="EventIndex"/>.
+        /// </remarks>
+        protected virtual Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+
+        internal Type GetSequenceTokenCompatibilityDomain() => SequenceTokenCompatibilityDomain;
 
         /// <inheritdoc/>
         public override bool Equals(object? obj)

--- a/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
+++ b/src/Orleans.Streaming/Common/EventSequenceTokenV2.cs
@@ -10,10 +10,9 @@ namespace Orleans.Providers.Streams.Common
     /// </summary>
     /// <remarks>
     /// <see cref="EventSequenceTokenV2"/> and <see cref="EventSequenceToken"/> share a numeric
-    /// position contract with subclasses which retain the same
-    /// <see cref="SequenceTokenCompatibilityDomain"/>. This includes exact base tokens persisted
-    /// by earlier event-token factories. Subclasses which add position identity override that
-    /// domain together with equality, ordering, and hashing.
+    /// position contract. Derived tokens are isolated by default and can explicitly join that
+    /// contract through <see cref="SequenceTokenCompatibilityDomain"/>. This includes exact base
+    /// tokens persisted by earlier event-token factories.
     /// </remarks>
     [Serializable]
     [GenerateSerializer]

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -380,7 +380,7 @@ namespace Orleans.Providers.Streams.Common
             var oldestMessage = messageBlocks.Last!.Value.OldestMessage;
             if (oldestMessage.Compare(sequenceToken) <= 0
                 || lastPurgedToken.TryGetValue(streamId, out var entry)
-                    && sequenceToken.CompareTo(entry.Token) >= 0)
+                    && EventSequenceTokenCompatibility.Compare(sequenceToken, entry.Token) >= 0)
             {
                 cacheMiss = default;
                 return false;

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -209,7 +209,7 @@ namespace Orleans.Providers.Streams.Common
             // Refresh only ever moves a cursor forward. If the cursor is already positioned at or ahead of the
             // requested token (for example an unset cursor waiting on a future token), leave it in place so we do
             // not rewind it and re-deliver events the consumer has already requested to start after.
-            if (cursor.SequenceToken is not null && cursor.SequenceToken.CompareTo(sequenceToken) >= 0)
+            if (cursor.SequenceToken is not null && EventSequenceTokenCompatibility.Compare(cursor.SequenceToken, sequenceToken) >= 0)
             {
                 return;
             }
@@ -303,7 +303,7 @@ namespace Orleans.Providers.Streams.Common
             if (cacheDataAdapter.Compare(ref oldestMessage, sequenceToken) > 0)
             {
                 // Check if we missed an event since we last purged the cache
-                if (this.lastPurgedToken.TryGetValue(cursor.StreamId, out var entry) && sequenceToken.CompareTo(entry.Token) >= 0)
+                if (this.lastPurgedToken.TryGetValue(cursor.StreamId, out var entry) && EventSequenceTokenCompatibility.Compare(sequenceToken, entry.Token) >= 0)
                 {
                     // If the token is more recent than the last purged token, then we didn't lose anything. Start from the oldest message in cache
                     cursor.State = CursorStates.Set;

--- a/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
+++ b/src/Orleans.Streaming/Common/SimpleCache/SimpleQueueCache.cs
@@ -275,7 +275,7 @@ namespace Orleans.Providers.Streams.Common
             sequenceToken = sequenceToken ?? cachedMessages.First?.Value?.SequenceToken!; // cachedMessages.Count > 0 here (checked above), so First/Value/SequenceToken are guaranteed non-null.
 
             // If sequenceToken is too new to be in cache, unset token, and wait for more data.
-            if (sequenceToken.Newer(cachedMessages.First!.Value.SequenceToken)) // cachedMessages.Count > 0 here (checked above), so First is guaranteed non-null.
+            if (EventSequenceTokenCompatibility.Compare(sequenceToken, cachedMessages.First!.Value.SequenceToken) > 0) // cachedMessages.Count > 0 here (checked above), so First is guaranteed non-null.
             {
                 UnsetCursor(cursor, sequenceToken);
                 return null;
@@ -283,7 +283,7 @@ namespace Orleans.Providers.Streams.Common
 
             LinkedListNode<SimpleQueueCacheItem> lastMessage = cachedMessages.Last!; // cachedMessages.Count > 0 here (checked above), so Last is guaranteed non-null.
             // Check to see if offset is too old to be in cache
-            if (sequenceToken.Older(lastMessage.Value.SequenceToken))
+            if (EventSequenceTokenCompatibility.Compare(sequenceToken, lastMessage.Value.SequenceToken) < 0)
             {
                 return CreateCacheMissInfo(sequenceToken);
             }
@@ -293,14 +293,14 @@ namespace Orleans.Providers.Streams.Common
             // Find first message at or below offset
             // Events are ordered from newest to oldest, so iterate from start of list until we hit a node at a previous offset, or the end.
             LinkedListNode<SimpleQueueCacheItem>? node = cachedMessages.First;
-            while (node != null && node.Value.SequenceToken.Newer(sequenceToken))
+            while (node != null && EventSequenceTokenCompatibility.Compare(node.Value.SequenceToken, sequenceToken) > 0)
             {
                 // did we get to the end?
                 if (node.Next == null) // node is the last message
                     break;
 
                 // if sequenceId is between the two, take the higher
-                if (node.Next.Value.SequenceToken.Older(sequenceToken))
+                if (EventSequenceTokenCompatibility.Compare(node.Next.Value.SequenceToken, sequenceToken) < 0)
                     break;
 
                 node = node.Next;
@@ -336,7 +336,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if (sequenceToken is null
                 || cachedMessages.Count == 0
-                || !sequenceToken.Older(cachedMessages.Last!.Value.SequenceToken))
+                || EventSequenceTokenCompatibility.Compare(sequenceToken, cachedMessages.Last!.Value.SequenceToken) >= 0)
             {
                 cacheMiss = default;
                 return false;

--- a/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
+++ b/src/Orleans.Streaming/Internal/StreamSubscriptionHandleImpl.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streaming.Diagnostics;
 
@@ -166,8 +167,9 @@ namespace Orleans.Streams
                 // Check if this even already has been delivered
                 if (IsRewindable)
                 {
-                    var currentToken = StreamHandshakeToken.CreateDeliveyToken(batch.SequenceToken);
-                    if (this.expectedToken.Equals(currentToken))
+                    if (this.expectedToken is DeliveryToken deliveryToken
+                        && deliveryToken.Token is { } deliveredToken
+                        && EventSequenceTokenCompatibility.AreEqual(deliveredToken, batch.SequenceToken))
                         return this.expectedToken;
                 }
             }
@@ -224,7 +226,7 @@ namespace Orleans.Streams
                 {
                     if (this.expectedToken is DeliveryToken deliveryToken
                         && deliveryToken.Token is { } deliveredToken
-                        && deliveredToken.Equals(currentToken))
+                        && EventSequenceTokenCompatibility.AreEqual(deliveredToken, currentToken))
                         return this.expectedToken;
                 }
             }

--- a/src/Orleans.Streaming/Orleans.Streaming.csproj
+++ b/src/Orleans.Streaming/Orleans.Streaming.csproj
@@ -20,9 +20,9 @@
     <InternalsVisibleTo Include="Orleans.Core.Tests" />
     <InternalsVisibleTo Include="Orleans.DefaultCluster.Tests" />
     <InternalsVisibleTo Include="Orleans.Runtime.Internal.Tests" />
+    <InternalsVisibleTo Include="Orleans.Streaming.EventHubs" />
     <InternalsVisibleTo Include="Orleans.Streaming.Tests" />
     <InternalsVisibleTo Include="TestExtensions" />
     <InternalsVisibleTo Include="TestInternalGrains" />
   </ItemGroup>
 </Project>
-

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -1000,9 +1000,25 @@ namespace Orleans.Streams
                         return false;
                     }
 
-                    if (earliest is null || IsBefore(current, earliest))
+                    if (earliest is null)
                     {
                         earliest = current;
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (IsBefore(current, earliest))
+                        {
+                            earliest = current;
+                        }
+                    }
+                    catch (ArgumentOutOfRangeException exception) when (exception.ParamName == "other")
+                    {
+                        LogWarningIncompatibleDeliveryProgress(
+                            new(QueueId), consumer.SubscriptionId, consumer.StreamId, current, earliest, exception);
+                        earliest = null;
+                        return false;
                     }
                 }
             }
@@ -1856,6 +1872,18 @@ namespace Orleans.Streams
             Message = "Failed to add subscription for stream {StreamId}."
         )]
         private partial void LogWarningFailedToAddSubscription(QualifiedStreamId streamId, Exception exception);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Retaining the previous delivery watermark for queue {Queue}: subscription {SubscriptionId} on stream {StreamId} has token {Token} incompatible with {OtherToken}."
+        )]
+        private partial void LogWarningIncompatibleDeliveryProgress(
+            QueueIdLogRecord queue,
+            GuidId subscriptionId,
+            QualifiedStreamId streamId,
+            StreamSequenceToken token,
+            StreamSequenceToken otherToken,
+            Exception exception);
 
         [LoggerMessage(
             Level = LogLevel.Warning,

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Internal;
+using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Runtime.Internal;
 using Orleans.Runtime.Scheduler;
@@ -538,7 +539,7 @@ namespace Orleans.Streams
                     throw new QueueCacheCursorContractException("A successful cursor move did not produce a current item.");
                 }
 
-                var comparison = batch.SequenceToken.CompareTo(token);
+                var comparison = EventSequenceTokenCompatibility.Compare(batch.SequenceToken, token);
                 if (comparison >= 0)
                 {
                     pendingBatch = comparison > 0 ? batch : null;
@@ -1010,10 +1011,7 @@ namespace Orleans.Streams
         }
 
         private static bool IsBefore(StreamSequenceToken current, StreamSequenceToken other)
-        {
-            var difference = current.SequenceNumber.CompareTo(other.SequenceNumber);
-            return difference < 0 || difference == 0 && current.EventIndex < other.EventIndex;
-        }
+            => EventSequenceTokenCompatibility.Compare(current, other) < 0;
 
         private void RegisterStream(
             QualifiedStreamId streamId,

--- a/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamSequenceToken.cs
+++ b/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamSequenceToken.cs
@@ -53,7 +53,8 @@ internal sealed class RedisStreamSequenceToken : EventSequenceTokenV2
     /// </summary>
     /// <param name="eventIndex">The event index within the Orleans batch.</param>
     /// <returns>A token for the specified event.</returns>
-    public new RedisStreamSequenceToken CreateSequenceTokenForEvent(int eventIndex) => new(EntryId, SequenceNumber, RedisSequenceNumber, eventIndex);
+    public override RedisStreamSequenceToken CreateSequenceTokenForEvent(int eventIndex)
+        => new(EntryId, SequenceNumber, RedisSequenceNumber, eventIndex);
 
     /// <inheritdoc />
     public override bool Equals(StreamSequenceToken? other)
@@ -73,22 +74,27 @@ internal sealed class RedisStreamSequenceToken : EventSequenceTokenV2
             return 1;
         }
 
+        if (other is not RedisStreamSequenceToken token)
+        {
+            throw new ArgumentOutOfRangeException(nameof(other));
+        }
+
         var difference = SequenceNumber.CompareTo(other.SequenceNumber);
         if (difference != 0)
         {
             return difference;
         }
 
-        if (other is RedisStreamSequenceToken token)
+        difference = RedisSequenceNumber.CompareTo(token.RedisSequenceNumber);
+        if (difference != 0)
         {
-            difference = RedisSequenceNumber.CompareTo(token.RedisSequenceNumber);
-            if (difference != 0)
-            {
-                return difference;
-            }
+            return difference;
         }
 
-        return EventIndex.CompareTo(other.EventIndex);
+        difference = EventIndex.CompareTo(other.EventIndex);
+        return difference != 0
+            ? difference
+            : string.CompareOrdinal(EntryId, token.EntryId);
     }
 
     /// <inheritdoc />

--- a/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamSequenceToken.cs
+++ b/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamSequenceToken.cs
@@ -48,6 +48,9 @@ internal sealed class RedisStreamSequenceToken : EventSequenceTokenV2
     [JsonProperty]
     public long RedisSequenceNumber { get; private set; }
 
+    /// <inheritdoc />
+    protected override Type SequenceTokenCompatibilityDomain => typeof(RedisStreamSequenceToken);
+
     /// <summary>
     /// Creates a token for an event within the same Redis entry.
     /// </summary>

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -538,6 +538,8 @@ namespace Orleans.Streaming.EventHubs
         [Newtonsoft.Json.JsonProperty]
         public string EventHubOffset { get { throw null; } }
 
+        protected override System.Type SequenceTokenCompatibilityDomain { get { throw null; } }
+
         public override int CompareTo(Streams.StreamSequenceToken? other) { throw null; }
 
         public override bool Equals(Streams.StreamSequenceToken? other) { throw null; }

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -538,6 +538,12 @@ namespace Orleans.Streaming.EventHubs
         [Newtonsoft.Json.JsonProperty]
         public string EventHubOffset { get { throw null; } }
 
+        public override int CompareTo(Streams.StreamSequenceToken? other) { throw null; }
+
+        public override bool Equals(Streams.StreamSequenceToken? other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
         public override string ToString() { throw null; }
     }
 

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -659,7 +659,7 @@ namespace Orleans.Providers.Streams.Common
 
         public override int CompareTo(Orleans.Streams.StreamSequenceToken? other) { throw null; }
 
-        public EventSequenceToken CreateSequenceTokenForEvent(int eventInd) { throw null; }
+        public virtual EventSequenceToken CreateSequenceTokenForEvent(int eventInd) { throw null; }
 
         public override bool Equals(Orleans.Streams.StreamSequenceToken? other) { throw null; }
 
@@ -689,7 +689,7 @@ namespace Orleans.Providers.Streams.Common
 
         public override int CompareTo(Orleans.Streams.StreamSequenceToken? other) { throw null; }
 
-        public EventSequenceTokenV2 CreateSequenceTokenForEvent(int eventInd) { throw null; }
+        public virtual EventSequenceTokenV2 CreateSequenceTokenForEvent(int eventInd) { throw null; }
 
         public override bool Equals(Orleans.Streams.StreamSequenceToken? other) { throw null; }
 

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -657,6 +657,8 @@ namespace Orleans.Providers.Streams.Common
         [Newtonsoft.Json.JsonProperty]
         public override long SequenceNumber { get { throw null; } protected set { } }
 
+        protected virtual System.Type SequenceTokenCompatibilityDomain { get { throw null; } }
+
         public override int CompareTo(Orleans.Streams.StreamSequenceToken? other) { throw null; }
 
         public virtual EventSequenceToken CreateSequenceTokenForEvent(int eventInd) { throw null; }
@@ -686,6 +688,8 @@ namespace Orleans.Providers.Streams.Common
         [Id(0)]
         [Newtonsoft.Json.JsonProperty]
         public override long SequenceNumber { get { throw null; } protected set { } }
+
+        protected virtual System.Type SequenceTokenCompatibilityDomain { get { throw null; } }
 
         public override int CompareTo(Orleans.Streams.StreamSequenceToken? other) { throw null; }
 

--- a/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamSequenceTokenTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamSequenceTokenTests.cs
@@ -1,0 +1,62 @@
+using Orleans.Providers.Streams.Common;
+using Orleans.Streaming.Redis;
+using Orleans.Streams;
+using UnitTests.StreamingTests;
+using Xunit;
+
+namespace Tester.Redis.Streaming;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+public sealed class RedisStreamSequenceTokenTests
+{
+    [Fact]
+    public void LegacyGenericRecovery_PreservesRedisEntryIdentity()
+    {
+        var first = new RedisStreamSequenceToken("10-1", 10, 1, 2);
+        var later = new RedisStreamSequenceToken("10-2", 10, 2, 0);
+        var eventToken = first.CreateSequenceTokenForEvent(3);
+
+        LegacyTokenRecoveryFixture.AssertProviderIsolation(first);
+        Assert.True(first.CompareTo(later) < 0);
+        Assert.True(later.CompareTo(first) > 0);
+        Assert.Equal("10-1", eventToken.EntryId);
+        Assert.Equal(1, eventToken.RedisSequenceNumber);
+        Assert.Equal(3, eventToken.EventIndex);
+        Assert.Equal(2, first.EventIndex);
+    }
+
+    [Fact]
+    public void RedisTokensUseOneSymmetricEqualityAndOrderingContract()
+    {
+        StreamSequenceToken first = new RedisStreamSequenceToken("10-1", 10, 1, 0);
+        StreamSequenceToken equal = new RedisStreamSequenceToken("10-1", 10, 1, 0);
+        StreamSequenceToken differentEntry = new RedisStreamSequenceToken("010-1", 10, 1, 0);
+        StreamSequenceToken baseToken = new EventSequenceTokenV2(10, 0);
+
+        Assert.True(first.Equals(equal));
+        Assert.True(equal.Equals(first));
+        Assert.Equal(0, first.CompareTo(equal));
+        Assert.Equal(first.GetHashCode(), equal.GetHashCode());
+        Assert.NotEqual(0, first.CompareTo(differentEntry));
+        Assert.Equal(-Math.Sign(first.CompareTo(differentEntry)), Math.Sign(differentEntry.CompareTo(first)));
+        Assert.False(first.Equals(differentEntry));
+        Assert.False(differentEntry.Equals(first));
+        Assert.False(first.Equals(baseToken));
+        Assert.False(baseToken.Equals(first));
+        Assert.Throws<ArgumentOutOfRangeException>(() => first.CompareTo(baseToken));
+        Assert.Throws<ArgumentOutOfRangeException>(() => baseToken.CompareTo(first));
+        Assert.Single(new Dictionary<StreamSequenceToken, string>
+        {
+            [first] = "first",
+            [equal] = "equal",
+        });
+        Assert.Equal(2, new Dictionary<StreamSequenceToken, string>
+        {
+            [first] = "first",
+            [differentEntry] = "different",
+        }.Count);
+        Assert.Equal(2, new SortedSet<StreamSequenceToken> { first, differentEntry }.Count);
+    }
+}

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
@@ -1,0 +1,187 @@
+using Orleans.Providers.Streams.Common;
+using Orleans.Streaming.EventHubs;
+using Orleans.Streams;
+using UnitTests.StreamingTests;
+using Xunit;
+
+namespace UnitTests.Streaming;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+public sealed class EventHubSequenceTokenTests
+{
+    [Fact]
+    public void EventHubVersionsRemainSymmetricAndRejectBaseTokens()
+    {
+        StreamSequenceToken v1 = new EventHubSequenceToken("100", 10, 2);
+        StreamSequenceToken v2 = new EventHubSequenceTokenV2("100", 10, 2);
+        StreamSequenceToken baseToken = new EventSequenceToken(10, 2);
+
+        Assert.True(v1.Equals(v2));
+        Assert.True(v2.Equals(v1));
+        Assert.Equal(0, v1.CompareTo(v2));
+        Assert.Equal(0, v2.CompareTo(v1));
+        Assert.Equal(v1.GetHashCode(), v2.GetHashCode());
+        Assert.False(v1.Equals(baseToken));
+        Assert.False(baseToken.Equals(v1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => v1.CompareTo(baseToken));
+        Assert.Throws<ArgumentOutOfRangeException>(() => baseToken.CompareTo(v1));
+    }
+
+    [Fact]
+    public void EventHubOrderingUsesSequenceBeforeEventIndexAcrossVersions()
+    {
+        StreamSequenceToken olderSequence = new EventHubSequenceToken("9", 9, 99);
+        StreamSequenceToken newerSequence = new EventHubSequenceTokenV2("10", 10, 0);
+        StreamSequenceToken earlierEvent = new EventHubSequenceTokenV2("10", 10, 1);
+        StreamSequenceToken laterEvent = new EventHubSequenceToken("10", 10, 2);
+
+        Assert.True(olderSequence.CompareTo(newerSequence) < 0);
+        Assert.True(newerSequence.CompareTo(olderSequence) > 0);
+        Assert.True(earlierEvent.CompareTo(laterEvent) < 0);
+        Assert.True(laterEvent.CompareTo(earlierEvent) > 0);
+    }
+
+    [Fact]
+    public void InheritedEventHubContractsRemainSymmetricAndTransitive()
+    {
+        StreamSequenceToken first = new CustomEventHubSequenceToken("10", 10, 2);
+        StreamSequenceToken second = new CustomEventHubSequenceToken("other-offset", 10, 2);
+        StreamSequenceToken builtIn = new EventHubSequenceToken("10", 10, 2);
+
+        Assert.True(first.Equals(second));
+        Assert.True(second.Equals(first));
+        Assert.Equal(0, first.CompareTo(second));
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+        StreamSequenceToken[] tokens =
+        [
+            first,
+            second,
+            builtIn,
+            new EventHubSequenceTokenV2("v2-offset", 10, 2),
+            new CustomEventHubSequenceTokenV2("custom-v2-offset", 10, 2),
+        ];
+        foreach (var left in tokens)
+        {
+            foreach (var right in tokens)
+            {
+                Assert.True(left.Equals(right));
+                Assert.True(left.Equals((object)right));
+                Assert.Equal(0, left.CompareTo(right));
+                Assert.Equal(left.GetHashCode(), right.GetHashCode());
+            }
+
+            var generic = new EventSequenceToken(10, 2);
+            Assert.False(left.Equals(generic));
+            Assert.False(generic.Equals(left));
+            Assert.Throws<ArgumentOutOfRangeException>(() => left.CompareTo(generic));
+            Assert.Throws<ArgumentOutOfRangeException>(() => generic.CompareTo(left));
+        }
+
+        Assert.Single(new HashSet<StreamSequenceToken>(tokens));
+        Assert.Single(new SortedSet<StreamSequenceToken>(Enumerable.Reverse(tokens)));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public Task LegacyFactoryBaseToken_InitialHandshakeRecoversCustomEventHubEvents(bool v2)
+        => LegacyTokenRecoveryFixture.VerifyRecovery(
+            LegacyTokenRecoveryFixture.LoadLegacyToken(v2: false),
+            (sequence, index) => CreateCustomToken(v2, sequence, index),
+            acknowledged: false,
+            renegotiate: false,
+            token => AssertCustomMetadata(token, v2));
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public Task LegacyFactoryBaseToken_DeliveryHandshakeRecoversCustomEventHubEvents(bool v2, bool acknowledged)
+        => LegacyTokenRecoveryFixture.VerifyRecovery(
+            LegacyTokenRecoveryFixture.LoadLegacyToken(v2: false),
+            (sequence, index) => CreateCustomToken(v2, sequence, index),
+            acknowledged,
+            renegotiate: true,
+            token => AssertCustomMetadata(token, v2));
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public Task LegacyAcknowledgedToken_RecognizesCustomEventHubDuplicate(bool v2, bool batch)
+        => LegacyTokenRecoveryFixture.VerifyDuplicate(
+            LegacyTokenRecoveryFixture.LoadLegacyToken(v2: false),
+            CreateCustomToken(v2, 500, 2),
+            batch);
+
+    [Fact]
+    public void OverriddenEventHubContract_KeepsLegacyGenericTokensIsolated()
+        => LegacyTokenRecoveryFixture.AssertProviderIsolation(new OverriddenEventHubSequenceToken("offset", 500, 2));
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EventHubLegacyRecovery_RequiresTheHistoricalV1FactoryShape(bool v2)
+        => LegacyTokenRecoveryFixture.AssertRecoveryIncompatible(
+            CreateCustomToken(v2, 500, 2),
+            LegacyTokenRecoveryFixture.LoadLegacyToken(v2: true));
+
+    [Fact]
+    public void CreateSequenceTokenForEventPreservesConcreteTypeAndOffset()
+    {
+        var batchToken = new EventHubSequenceTokenV2("offset-10", 10, 0);
+
+        var eventToken = Assert.IsType<EventHubSequenceTokenV2>(
+            batchToken.CreateSequenceTokenForEvent(2));
+
+        Assert.Equal("offset-10", eventToken.EventHubOffset);
+        Assert.Equal(10, eventToken.SequenceNumber);
+        Assert.Equal(2, eventToken.EventIndex);
+        Assert.True(batchToken.CompareTo(eventToken) < 0);
+    }
+
+    private static EventHubSequenceToken CreateCustomToken(bool v2, long sequence, int index)
+    {
+        EventHubSequenceToken batchToken = v2
+            ? new CustomEventHubSequenceTokenV2($"offset-{sequence}", sequence, 0)
+            : new CustomEventHubSequenceToken($"offset-{sequence}", sequence, 0);
+        return Assert.IsAssignableFrom<EventHubSequenceToken>(batchToken.CreateSequenceTokenForEvent(index));
+    }
+
+    private static void AssertCustomMetadata(StreamSequenceToken token, bool v2)
+    {
+        var metadata = v2
+            ? Assert.IsType<CustomEventHubSequenceTokenV2>(token).Metadata
+            : Assert.IsType<CustomEventHubSequenceToken>(token).Metadata;
+        Assert.Equal("custom-metadata", metadata);
+        Assert.Equal($"offset-{token.SequenceNumber}", Assert.IsAssignableFrom<EventHubSequenceToken>(token).EventHubOffset);
+    }
+
+    private sealed class CustomEventHubSequenceToken(
+        string eventHubOffset,
+        long sequenceNumber,
+        int eventIndex)
+        : EventHubSequenceToken(eventHubOffset, sequenceNumber, eventIndex)
+    {
+        public string Metadata { get; } = "custom-metadata";
+    }
+
+    private sealed class CustomEventHubSequenceTokenV2(
+        string eventHubOffset,
+        long sequenceNumber,
+        int eventIndex)
+        : EventHubSequenceTokenV2(eventHubOffset, sequenceNumber, eventIndex)
+    {
+        public string Metadata { get; } = "custom-metadata";
+    }
+
+    private sealed class OverriddenEventHubSequenceToken(string offset, long sequence, int index)
+        : EventHubSequenceToken(offset, sequence, index)
+    {
+        public override int CompareTo(StreamSequenceToken? other) => base.CompareTo(other);
+    }
+}

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
@@ -130,6 +130,14 @@ public sealed class EventHubSequenceTokenTests
             CreateCustomToken(v2, 500, 2),
             LegacyTokenRecoveryFixture.LoadLegacyToken(v2: true));
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PurgedLegacyPosition_UsesEventHubRecoveryComparison(bool v2)
+        => LegacyTokenRecoveryFixture.VerifyPurgedCursorRecovery(
+            LegacyTokenRecoveryFixture.LoadLegacyToken(v2: false),
+            (sequence, index) => CreateCustomToken(v2, sequence, index));
+
     [Fact]
     public void CreateSequenceTokenForEventPreservesConcreteTypeAndOffset()
     {
@@ -168,6 +176,7 @@ public sealed class EventHubSequenceTokenTests
         : EventHubSequenceToken(eventHubOffset, sequenceNumber, eventIndex)
     {
         public string Metadata { get; } = "custom-metadata";
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventHubSequenceToken);
     }
 
     private sealed class CustomEventHubSequenceTokenV2(
@@ -177,6 +186,7 @@ public sealed class EventHubSequenceTokenTests
         : EventHubSequenceTokenV2(eventHubOffset, sequenceNumber, eventIndex)
     {
         public string Metadata { get; } = "custom-metadata";
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventHubSequenceToken);
     }
 
     private sealed class IsolatedEventHubSequenceToken(string offset, long sequence, int index)

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
@@ -6,7 +6,7 @@ using Orleans.Streams;
 using UnitTests.StreamingTests;
 using Xunit;
 
-namespace UnitTests.Streaming;
+namespace ServiceBus.Tests;
 
 [TestSuite("BVT")]
 [TestProvider("None")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
@@ -119,8 +119,8 @@ public sealed class EventHubSequenceTokenTests
             batch);
 
     [Fact]
-    public void OverriddenEventHubContract_KeepsLegacyGenericTokensIsolated()
-        => LegacyTokenRecoveryFixture.AssertProviderIsolation(new OverriddenEventHubSequenceToken("offset", 500, 2));
+    public void ExplicitEventHubCompatibilityDomain_KeepsLegacyGenericTokensIsolated()
+        => LegacyTokenRecoveryFixture.AssertProviderIsolation(new IsolatedEventHubSequenceToken("offset", 500, 2));
 
     [Theory]
     [InlineData(false)]
@@ -179,9 +179,9 @@ public sealed class EventHubSequenceTokenTests
         public string Metadata { get; } = "custom-metadata";
     }
 
-    private sealed class OverriddenEventHubSequenceToken(string offset, long sequence, int index)
+    private sealed class IsolatedEventHubSequenceToken(string offset, long sequence, int index)
         : EventHubSequenceToken(offset, sequence, index)
     {
-        public override int CompareTo(StreamSequenceToken? other) => base.CompareTo(other);
+        protected override Type SequenceTokenCompatibilityDomain => typeof(IsolatedEventHubSequenceToken);
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EventHubSequenceTokenTests.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 using Orleans.Streaming.EventHubs;
 using Orleans.Streams;
 using UnitTests.StreamingTests;
@@ -150,6 +152,86 @@ public sealed class EventHubSequenceTokenTests
         Assert.Equal(10, eventToken.SequenceNumber);
         Assert.Equal(2, eventToken.EventIndex);
         Assert.True(batchToken.CompareTo(eventToken) < 0);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void SimpleCache_RecoversLegacyPositionAndPreservesCurrentTokens(bool v2, bool waitForData)
+    {
+        IQueueCache cache = new SimpleQueueCache(10, NullLogger.Instance);
+        var streamId = StreamId.Create("legacy-simple-cache", Guid.NewGuid());
+        var legacy = LegacyTokenRecoveryFixture.LoadLegacyToken(v2: false);
+        StreamSequenceToken[] currentTokens =
+        [
+            CreateCustomToken(v2, 500, 1),
+            CreateCustomToken(v2, 500, 2),
+            CreateCustomToken(v2, 500, 3),
+            CreateCustomToken(v2, 501, 0),
+        ];
+        var messages = currentTokens.Select(token => (IBatchContainer)new TokenBatch(streamId, token)).ToList();
+        cache.AddToCache([new TokenBatch(streamId, CreateCustomToken(v2, 499, 0))]);
+        if (!waitForData)
+        {
+            cache.AddToCache(messages);
+        }
+
+        var result = cache.TryGetCacheCursor(streamId, legacy);
+
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.Null(result.CacheMiss);
+        using var cursor = Assert.IsAssignableFrom<IQueueCacheCursor>(result.Cursor);
+        if (waitForData)
+        {
+            Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
+            cache.AddToCache(messages);
+            cursor.Refresh(currentTokens[0]);
+        }
+
+        foreach (var expected in currentTokens.Skip(1))
+        {
+            Assert.Equal(QueueCacheCursorMoveResultKind.Success, cursor.MoveNextWithResult().Kind);
+            var batch = cursor.GetCurrent(out var exception);
+            Assert.Null(exception);
+            Assert.NotNull(batch);
+            Assert.Same(expected, batch.SequenceToken);
+            AssertCustomMetadata(batch.SequenceToken, v2);
+        }
+
+        Assert.Equal(QueueCacheCursorMoveResultKind.NoData, cursor.MoveNextWithResult().Kind);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SimpleCache_ReportsCacheMissForEvictedLegacyPosition(bool v2)
+    {
+        IQueueCache cache = new SimpleQueueCache(10, NullLogger.Instance);
+        var streamId = StreamId.Create("legacy-simple-cache", Guid.NewGuid());
+        var legacy = LegacyTokenRecoveryFixture.LoadLegacyToken(v2: false);
+        var retained = CreateCustomToken(v2, 501, 0);
+        cache.AddToCache([new TokenBatch(streamId, retained)]);
+
+        var result = cache.TryGetCacheCursor(streamId, legacy);
+
+        Assert.Equal(QueueCacheCursorResultKind.CacheMiss, result.Kind);
+        Assert.Null(result.Cursor);
+        Assert.True(result.CacheMiss.HasValue);
+        Assert.Same(legacy, result.CacheMiss.Value.RequestedToken);
+        Assert.Same(retained, result.CacheMiss.Value.LowToken);
+        Assert.Same(retained, result.CacheMiss.Value.HighToken);
+        Assert.Throws<ArgumentOutOfRangeException>(() => cache.TryGetCacheCursor(
+            streamId, LegacyTokenRecoveryFixture.LoadLegacyToken(v2: true)));
+    }
+
+    private sealed class TokenBatch(StreamId streamId, StreamSequenceToken token) : IBatchContainer
+    {
+        public StreamId StreamId => streamId;
+        public StreamSequenceToken SequenceToken => token;
+        public bool ImportRequestContext() => false;
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() => throw new NotSupportedException();
     }
 
     private static EventHubSequenceToken CreateCustomToken(bool v2, long sequence, int index)

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisAdapterTests.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.Streaming.Kinesis;
@@ -105,6 +104,7 @@ namespace Orleans.Streaming.Kinesis.Tests
 
             int receivedBatches = 0;
             var streamsPerQueue = new ConcurrentDictionary<QueueId, HashSet<StreamId>>();
+            var firstTokens = new ConcurrentDictionary<(QueueId QueueId, StreamId StreamId), StreamSequenceToken>();
 
             // send events
             List<object> events = CreateEvents(NumMessagesPerBatch);
@@ -128,6 +128,7 @@ namespace Orleans.Streaming.Kinesis.Tests
                         output.WriteLine($"Queue {queueId} received message on stream {message.StreamId}");
                         Assert.Equal(NumMessagesPerBatch / 2, message.GetEvents<int>().Count());
                         Assert.Equal(NumMessagesPerBatch / 2, message.GetEvents<string>().Count());
+                        firstTokens.TryAdd((queueId, message.StreamId), message.SequenceToken);
 
                         streamsPerQueue.AddOrUpdate(
                             queueId,
@@ -150,7 +151,6 @@ namespace Orleans.Streaming.Kinesis.Tests
             Assert.Equal(NumBatches, receivedBatches);
 
             // check to see if all the events are in the cache and we can enumerate through them
-            StreamSequenceToken firstInCache = new EventSequenceTokenV2(0);
             foreach (KeyValuePair<QueueId, HashSet<StreamId>> kvp in streamsPerQueue)
             {
                 var receiver = receivers[kvp.Key];
@@ -158,6 +158,7 @@ namespace Orleans.Streaming.Kinesis.Tests
 
                 foreach (StreamId streamGuid in kvp.Value)
                 {
+                    var firstInCache = firstTokens[(kvp.Key, streamGuid)];
                     // read all messages in cache for stream
                     var cursorResult = qCache.TryGetCacheCursor(streamGuid, firstInCache);
                     Assert.Equal(QueueCacheCursorResultKind.Success, cursorResult.Kind);

--- a/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisSequenceTokenTests.cs
+++ b/test/Extensions/Orleans.Streaming.Kinesis.Tests/KinesisSequenceTokenTests.cs
@@ -1,0 +1,202 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Orleans.Serialization;
+using Orleans.Providers.Streams.Common;
+using Orleans.Streams;
+using Orleans.Streaming.Kinesis;
+using TestExtensions;
+using UnitTests.StreamingTests;
+using Xunit;
+
+namespace Orleans.Streaming.Kinesis.Tests;
+
+[TestSuite("BVT")]
+[TestArea("Streaming")]
+[TestProvider("Kinesis")]
+[TestCategory("AWS"), TestCategory("Kinesis")]
+[Collection(TestEnvironmentFixture.DefaultCollection)]
+public sealed class KinesisSequenceTokenTests
+{
+    // Representative of real Kinesis shard sequence numbers (up to 128 bits), which are far beyond
+    // long.MaxValue (~9.22e18, 19 digits).
+    private const string HugeShardSequence = "170141183460469231731687303715884105727";
+    private const string SlightlyLargerShardSequence = "170141183460469231731687303715884105728";
+
+    private readonly Serializer<KinesisSequenceToken> serializer;
+
+    public KinesisSequenceTokenTests(TestEnvironmentFixture fixture)
+    {
+        serializer = fixture.Services.GetRequiredService<Serializer<KinesisSequenceToken>>();
+    }
+
+    [Fact]
+    public void CompareToOrdersByShardSequenceMagnitudeBeyondInt64Range()
+    {
+        var older = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 0, eventIndex: 0);
+        var newer = new KinesisSequenceToken(SlightlyLargerShardSequence, sequenceNumber: 0, eventIndex: 0);
+
+        Assert.True(older.CompareTo(newer) < 0);
+        Assert.True(newer.CompareTo(older) > 0);
+        Assert.Equal(0, older.CompareTo(older));
+        Assert.False(older.Equals(newer));
+    }
+
+    [Theory]
+    [InlineData("9", "10")]
+    [InlineData("99", "100")]
+    [InlineData("999999999999999999", "1000000000000000000")]
+    public void CompareToUsesNumericNotLexicographicOrdering(string smaller, string larger)
+    {
+        var smallerToken = new KinesisSequenceToken(smaller, sequenceNumber: 0, eventIndex: 0);
+        var largerToken = new KinesisSequenceToken(larger, sequenceNumber: 0, eventIndex: 0);
+
+        Assert.True(smallerToken.CompareTo(largerToken) < 0);
+        Assert.True(string.CompareOrdinal(smaller, larger) > 0);
+    }
+
+    [Fact]
+    public void CompareToBreaksTiesOnEventIndexWhenShardSequenceMatches()
+    {
+        var first = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 5, eventIndex: 0);
+        var second = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 5, eventIndex: 1);
+
+        Assert.True(first.CompareTo(second) < 0);
+        Assert.True(second.CompareTo(first) > 0);
+        Assert.False(first.Equals(second));
+
+        var differentReceiverOrdinal = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 999, eventIndex: 0);
+        Assert.Equal(0, first.CompareTo(differentReceiverOrdinal));
+        Assert.True(first.Equals(differentReceiverOrdinal));
+    }
+
+    [Fact]
+    public void EqualsIgnoresShardSequenceStringFormattingButRespectsNumericValue()
+    {
+        var zeroPadded = new KinesisSequenceToken("007", sequenceNumber: 1, eventIndex: 2);
+        var unpadded = new KinesisSequenceToken("7", sequenceNumber: 999, eventIndex: 2);
+
+        Assert.True(zeroPadded.Equals(unpadded));
+        Assert.True(zeroPadded.Equals((object)unpadded));
+        Assert.Equal(zeroPadded.GetHashCode(), unpadded.GetHashCode());
+    }
+
+    [Fact]
+    public void EquivalentTokensCoalesceInHashAndSortedCollections()
+    {
+        StreamSequenceToken zeroPadded = new KinesisSequenceToken("007", sequenceNumber: 1, eventIndex: 2);
+        StreamSequenceToken unpadded = new KinesisSequenceToken("7", sequenceNumber: 999, eventIndex: 2);
+
+        Assert.Single(new HashSet<StreamSequenceToken> { zeroPadded, unpadded });
+        Assert.Single(new SortedSet<StreamSequenceToken> { unpadded, zeroPadded });
+    }
+
+    [Fact]
+    public void KinesisAndBaseTokensAreIncompatibleInBothDirections()
+    {
+        StreamSequenceToken kinesis = new KinesisSequenceToken("7", sequenceNumber: 1, eventIndex: 2);
+        StreamSequenceToken baseToken = new EventSequenceTokenV2(1, 2);
+
+        Assert.False(kinesis.Equals(baseToken));
+        Assert.False(baseToken.Equals(kinesis));
+        Assert.Throws<ArgumentOutOfRangeException>(() => kinesis.CompareTo(baseToken));
+        Assert.Throws<ArgumentOutOfRangeException>(() => baseToken.CompareTo(kinesis));
+        Assert.Equal(2, new Dictionary<StreamSequenceToken, string>
+        {
+            [kinesis] = "kinesis",
+            [baseToken] = "base",
+        }.Count);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new SortedSet<StreamSequenceToken> { kinesis, baseToken });
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new SortedSet<StreamSequenceToken> { baseToken, kinesis });
+    }
+
+    [Fact]
+    public void LegacyGenericRecovery_PreservesKinesisIdentityAndAuthoritativeOffset()
+    {
+        var older = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 999, eventIndex: 2);
+        var newer = new KinesisSequenceToken(SlightlyLargerShardSequence, sequenceNumber: 1, eventIndex: 0);
+        var samePosition = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 1, eventIndex: 2);
+
+        LegacyTokenRecoveryFixture.AssertProviderIsolation(older);
+        Assert.True(older.CompareTo(newer) < 0);
+        Assert.True(newer.CompareTo(older) > 0);
+        Assert.True(older.Equals(samePosition));
+        Assert.True(samePosition.Equals(older));
+        Assert.Equal(0, older.CompareTo(samePosition));
+        Assert.Equal(older.GetHashCode(), samePosition.GetHashCode());
+    }
+
+    [Fact]
+    public void CreateSequenceTokenForEventPreservesKinesisPosition()
+    {
+        var batchToken = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 42, eventIndex: 0);
+
+        var eventToken = Assert.IsType<KinesisSequenceToken>(batchToken.CreateSequenceTokenForEvent(3));
+
+        Assert.Equal(HugeShardSequence, eventToken.ShardSequence);
+        Assert.Equal(42, eventToken.SequenceNumber);
+        Assert.Equal(3, eventToken.EventIndex);
+        Assert.True(batchToken.CompareTo(eventToken) < 0);
+    }
+
+    [Fact]
+    public void RepeatedOrderingOperationsDoNotReparseShardSequence()
+    {
+        var older = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 0, eventIndex: 0);
+        var newer = new KinesisSequenceToken(SlightlyLargerShardSequence, sequenceNumber: 0, eventIndex: 0);
+
+        _ = older.CompareTo(newer);
+        _ = older.GetHashCode();
+        _ = newer.GetHashCode();
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        var comparisonTotal = 0;
+        var hash = 0;
+
+        for (var i = 0; i < 1_000; i++)
+        {
+            comparisonTotal += older.CompareTo(newer);
+            hash ^= older.GetHashCode();
+            hash ^= newer.GetHashCode();
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Assert.Equal(-1_000, comparisonTotal);
+        Assert.Equal(0, allocated);
+        GC.KeepAlive(hash);
+    }
+
+    [Fact]
+    public void BinarySerializationRoundTripPreservesFieldsAndOrderingAfterRestart()
+    {
+        var original = new KinesisSequenceToken(HugeShardSequence, sequenceNumber: 42, eventIndex: 3);
+
+        var bytes = serializer.SerializeToArray(original);
+        var restored = serializer.Deserialize(bytes);
+
+        Assert.NotNull(restored);
+        Assert.NotSame(original, restored);
+        Assert.Equal(HugeShardSequence, restored.ShardSequence);
+        Assert.Equal(42, restored.SequenceNumber);
+        Assert.Equal(3, restored.EventIndex);
+        Assert.True(original.Equals(restored));
+        Assert.Equal(0, original.CompareTo(restored));
+
+        var newer = new KinesisSequenceToken(SlightlyLargerShardSequence, sequenceNumber: 0, eventIndex: 0);
+        Assert.True(restored.CompareTo(newer) < 0);
+    }
+
+    [Fact]
+    public void LegacyJsonDeserializationPreservesTokenFieldsAndOrdering()
+    {
+        var json = $$"""{"ShardSequence":"{{HugeShardSequence}}","SequenceNumber":7,"EventIndex":2}""";
+        var restored = JsonConvert.DeserializeObject<KinesisSequenceToken>(json)!;
+
+        Assert.NotNull(restored);
+        Assert.Equal(HugeShardSequence, restored.ShardSequence);
+        Assert.Equal(7, restored.SequenceNumber);
+        Assert.Equal(2, restored.EventIndex);
+        Assert.True(restored.CompareTo(new KinesisSequenceToken(SlightlyLargerShardSequence, 0, 0)) < 0);
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
@@ -1,0 +1,426 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using NSubstitute;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+public sealed class LegacySequenceTokenRecoveryTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public Task LegacyFactoryBaseToken_InitialHandshakeRecoversDerivedProviderEvents(bool legacyV2, bool providerV2)
+        => LegacyTokenRecoveryFixture.VerifyRecovery(
+            LegacyTokenRecoveryFixture.LoadLegacyToken(legacyV2),
+            (sequence, index) => CreateProviderToken(providerV2, sequence, index),
+            acknowledged: false,
+            renegotiate: false,
+            token => AssertMetadata(token, providerV2));
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public Task LegacyFactoryBaseToken_DeliveryHandshakeRecoversDerivedProviderEvents(bool v2, bool acknowledged)
+        => LegacyTokenRecoveryFixture.VerifyRecovery(
+            LegacyTokenRecoveryFixture.LoadLegacyToken(v2),
+            (sequence, index) => CreateProviderToken(v2, sequence, index),
+            acknowledged,
+            renegotiate: true,
+            token => AssertMetadata(token, v2));
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public Task LegacyAcknowledgedToken_RecognizesDerivedDuplicate(bool v2, bool batch)
+        => LegacyTokenRecoveryFixture.VerifyDuplicate(
+            LegacyTokenRecoveryFixture.LoadLegacyToken(v2),
+            CreateProviderToken(v2, 500, 2),
+            batch);
+
+    [Fact]
+    public void InheritedContracts_AreSymmetricTransitiveAndHashCompatibleAcrossVersions()
+    {
+        StreamSequenceToken[] tokens =
+        [
+            new EventSequenceToken(500, 2),
+            new EventSequenceTokenV2(500, 2),
+            new CustomV1Token(500, 2, "first"),
+            new CustomV1Token(500, 2, "second"),
+            new CustomV2Token(500, 2, "third"),
+            new OtherV2Token(500, 2),
+        ];
+
+        foreach (var left in tokens)
+        {
+            foreach (var right in tokens)
+            {
+                Assert.True(left.Equals(right));
+                Assert.True(left.Equals((object)right));
+                Assert.True(((IEquatable<StreamSequenceToken?>)left).Equals(right));
+                Assert.Equal(0, left.CompareTo(right));
+                Assert.Equal(0, ((IComparable<StreamSequenceToken?>)left).CompareTo(right));
+                Assert.Equal(left.GetHashCode(), right.GetHashCode());
+            }
+
+            Assert.True(left.CompareTo(new EventSequenceTokenV2(500, 1)) > 0);
+            Assert.True(new EventSequenceTokenV2(500, 1).CompareTo(left) < 0);
+            Assert.True(left.CompareTo(new CustomV1Token(501, 0, "later")) < 0);
+            Assert.True(new CustomV1Token(501, 0, "later").CompareTo(left) > 0);
+        }
+
+        Assert.Single(new HashSet<StreamSequenceToken>(tokens));
+        Assert.Single(new SortedSet<StreamSequenceToken>(Enumerable.Reverse(tokens)));
+    }
+
+    [Fact]
+    public void OverridingAnyContractMember_PreservesSeparateCompatibility()
+    {
+        StreamSequenceToken[] overrides =
+        [
+            new ObjectEqualityToken(500, 2),
+            new TokenEqualityToken(500, 2),
+            new OrderingToken(500, 2),
+            new HashingToken(500, 2),
+            new InterfaceEqualityToken(500, 2),
+            new InterfaceOrderingToken(500, 2),
+        ];
+
+        foreach (var token in overrides)
+        {
+            LegacyTokenRecoveryFixture.AssertProviderIsolation(token);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CurrentFactory_PreservesSubtypeMetadataAndOriginalBatch(bool v2)
+    {
+        var original = CreateProviderToken(v2, 500, 0);
+        var perEvent = original switch
+        {
+            EventSequenceToken token => token.CreateSequenceTokenForEvent(2),
+            EventSequenceTokenV2 token => (StreamSequenceToken)token.CreateSequenceTokenForEvent(2),
+            _ => throw new InvalidOperationException(),
+        };
+
+        AssertMetadata(perEvent, v2);
+        Assert.Equal(500, perEvent.SequenceNumber);
+        Assert.Equal(2, perEvent.EventIndex);
+        Assert.Equal(0, original.EventIndex);
+        Assert.NotSame(original, perEvent);
+    }
+
+    private static StreamSequenceToken CreateProviderToken(bool v2, long sequence, int index)
+        => v2
+            ? new CustomV2Token(sequence, index, "provider-metadata")
+            : new CustomV1Token(sequence, index, "provider-metadata");
+
+    private static void AssertMetadata(StreamSequenceToken token, bool v2)
+    {
+        var metadata = v2
+            ? Assert.IsType<CustomV2Token>(token).Metadata
+            : Assert.IsType<CustomV1Token>(token).Metadata;
+        Assert.Equal("provider-metadata", metadata);
+    }
+
+    private sealed class CustomV1Token(long sequence, int index, string metadata) : EventSequenceToken(sequence, index)
+    {
+        public string Metadata { get; } = metadata;
+    }
+
+    private sealed class CustomV2Token(long sequence, int index, string metadata) : EventSequenceTokenV2(sequence, index)
+    {
+        public string Metadata { get; } = metadata;
+    }
+
+    private sealed class OtherV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index);
+
+    private sealed class ObjectEqualityToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
+    {
+        public override bool Equals(object? obj) => base.Equals(obj);
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
+    private sealed class TokenEqualityToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
+    {
+        public override bool Equals(StreamSequenceToken? other) => base.Equals(other);
+    }
+
+    private sealed class OrderingToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
+    {
+        public override int CompareTo(StreamSequenceToken? other) => base.CompareTo(other);
+    }
+
+    private sealed class HashingToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
+    {
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
+    private sealed class InterfaceEqualityToken(long sequence, int index)
+        : EventSequenceTokenV2(sequence, index), IEquatable<StreamSequenceToken?>
+    {
+        bool IEquatable<StreamSequenceToken?>.Equals(StreamSequenceToken? other) => base.Equals(other);
+    }
+
+    private sealed class InterfaceOrderingToken(long sequence, int index)
+        : EventSequenceTokenV2(sequence, index), IComparable<StreamSequenceToken?>
+    {
+        int IComparable<StreamSequenceToken?>.CompareTo(StreamSequenceToken? other) => base.CompareTo(other);
+    }
+}
+
+public static class LegacyTokenRecoveryFixture
+{
+    public static StreamSequenceToken LoadLegacyToken(bool v2)
+    {
+        // Earlier inherited factories persisted an exact base token, even for a custom provider.
+        const string json = """{"SequenceNumber":500,"EventIndex":2}""";
+        return v2
+            ? Assert.IsType<EventSequenceTokenV2>(JsonConvert.DeserializeObject<EventSequenceTokenV2>(json))
+            : Assert.IsType<EventSequenceToken>(JsonConvert.DeserializeObject<EventSequenceToken>(json));
+    }
+
+    public static async Task VerifyRecovery(
+        StreamSequenceToken legacy,
+        Func<long, int, StreamSequenceToken> createToken,
+        bool acknowledged,
+        bool renegotiate,
+        Action<StreamSequenceToken> assertMetadata)
+    {
+        var currentPosition = createToken(legacy.SequenceNumber, legacy.EventIndex);
+        Assert.Equal(0, EventSequenceTokenCompatibility.Compare(legacy, currentPosition));
+        Assert.Equal(0, EventSequenceTokenCompatibility.Compare(currentPosition, legacy));
+        Assert.True(EventSequenceTokenCompatibility.AreEqual(legacy, currentPosition));
+        Assert.True(EventSequenceTokenCompatibility.AreEqual(currentPosition, legacy));
+
+        var streamId = StreamId.Create("legacy-recovery", Guid.NewGuid());
+        var adapter = new RecoveryDataAdapter(createToken);
+        var cache = new PooledQueueCache(adapter, NullLogger.Instance, null, null);
+        var observer = new RecordingObserver();
+        var handshake = acknowledged
+            ? StreamHandshakeToken.CreateDeliveyToken(legacy)
+            : StreamHandshakeToken.CreateStartToken(legacy);
+        var handle = CreateHandle(streamId, observer, handshake);
+        Add(100, 0);
+        var cursor = cache.GetCursor(streamId, handle.GetSequenceToken()!.Token);
+
+        Assert.False(cache.TryGetNextMessage(cursor, out _));
+        foreach (var sequence in new[] { 101L, 102L })
+        {
+            Add(sequence, 0);
+            // This is the real Refresh path invoked by StartInactiveCursors after every nonempty read.
+            cache.Refresh(cursor, createToken(sequence, 0));
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+            Assert.Empty(observer.Tokens);
+        }
+
+        Add(499, 0);
+        for (var index = 0; index < 4; index++)
+        {
+            Add(500, index);
+        }
+
+        Add(501, 0);
+        cache.Refresh(cursor, createToken(499, 0));
+        SkipAcknowledgedPosition();
+        Assert.True(cache.TryGetNextMessage(cursor, out var first));
+        Assert.Equal(500, first.SequenceToken.SequenceNumber);
+        Assert.Equal(acknowledged ? 3 : 2, first.SequenceToken.EventIndex);
+
+        if (renegotiate)
+        {
+            var requested = await handle.DeliverBatch(first, handshakeToken: null);
+            Assert.Same(handshake, requested);
+            Assert.Same(legacy, requested!.Token);
+            Assert.Empty(observer.Tokens);
+            cursor = cache.GetCursor(streamId, requested.Token);
+            SkipAcknowledgedPosition();
+            Assert.True(cache.TryGetNextMessage(cursor, out first));
+            Assert.Equal(acknowledged ? 3 : 2, first.SequenceToken.EventIndex);
+        }
+
+        // An active refresh keeps its position.
+        cache.Refresh(cursor, createToken(700, 0));
+        cache.Refresh(cursor, createToken(100, 0));
+        Assert.Null(await handle.DeliverBatch(first, handshake));
+
+        while (cache.TryGetNextMessage(cursor, out var batch))
+        {
+            Assert.Null(await handle.DeliverBatch(batch, handle.GetSequenceToken()));
+        }
+
+        Assert.Equal(
+            acknowledged ? new[] { 5003, 5010 } : new[] { 5002, 5003, 5010 },
+            observer.Items);
+        Assert.All(observer.Tokens, assertMetadata);
+        var finalToken = Assert.IsType<DeliveryToken>(handle.GetSequenceToken()).Token;
+        Assert.Same(observer.Tokens[^1], finalToken);
+        Assert.Equal(501, finalToken!.SequenceNumber);
+        Assert.Equal(0, finalToken.EventIndex);
+        Assert.Equal(500, legacy.SequenceNumber);
+        Assert.Equal(2, legacy.EventIndex);
+
+        void SkipAcknowledgedPosition()
+        {
+            if (!acknowledged)
+            {
+                return;
+            }
+
+            Assert.True(cache.TryGetNextMessage(cursor, out var duplicate));
+            Assert.Equal(0, EventSequenceTokenCompatibility.Compare(legacy, duplicate.SequenceToken));
+            Assert.Equal(0, EventSequenceTokenCompatibility.Compare(duplicate.SequenceToken, legacy));
+        }
+
+        void Add(long sequence, int index)
+        {
+            var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            cache.Add(
+            [
+                new CachedMessage
+                {
+                    StreamId = streamId,
+                    SequenceNumber = sequence,
+                    EventIndex = index,
+                    EnqueueTimeUtc = now,
+                    DequeueTimeUtc = now,
+                },
+            ], now);
+        }
+    }
+
+    public static async Task VerifyDuplicate(StreamSequenceToken legacy, StreamSequenceToken current, bool batch)
+    {
+        var streamId = StreamId.Create("legacy-duplicate", Guid.NewGuid());
+        var observer = new RecordingObserver();
+        var acknowledged = StreamHandshakeToken.CreateDeliveyToken(legacy);
+        var handle = CreateHandle(streamId, observer, acknowledged);
+
+        var result = batch
+            ? await handle.DeliverBatch(new RecoveryBatch(streamId, current), acknowledged)
+            : await handle.DeliverItem(5002, current, acknowledged);
+
+        Assert.Same(acknowledged, result);
+        Assert.Same(acknowledged, handle.GetSequenceToken());
+        Assert.Empty(observer.Items);
+        Assert.Empty(observer.Tokens);
+    }
+
+    public static void AssertProviderIsolation(StreamSequenceToken provider)
+    {
+        StreamSequenceToken[] genericTokens =
+        [
+            new EventSequenceToken(provider.SequenceNumber, provider.EventIndex),
+            new EventSequenceTokenV2(provider.SequenceNumber, provider.EventIndex),
+            new InheritedV1Token(provider.SequenceNumber, provider.EventIndex),
+            new InheritedV2Token(provider.SequenceNumber, provider.EventIndex),
+        ];
+        foreach (var generic in genericTokens)
+        {
+            AssertRecoveryIncompatible(provider, generic);
+        }
+    }
+
+    public static void AssertRecoveryIncompatible(StreamSequenceToken provider, StreamSequenceToken generic)
+    {
+        Assert.False(generic.Equals(provider));
+        Assert.False(provider.Equals(generic));
+        Assert.False(generic.Equals((object)provider));
+        Assert.False(provider.Equals((object)generic));
+        Assert.False(EventSequenceTokenCompatibility.AreEqual(generic, provider));
+        Assert.False(EventSequenceTokenCompatibility.AreEqual(provider, generic));
+        Assert.Throws<ArgumentOutOfRangeException>(() => generic.CompareTo(provider));
+        Assert.Throws<ArgumentOutOfRangeException>(() => provider.CompareTo(generic));
+        Assert.Throws<ArgumentOutOfRangeException>(() => EventSequenceTokenCompatibility.Compare(generic, provider));
+        Assert.Throws<ArgumentOutOfRangeException>(() => EventSequenceTokenCompatibility.Compare(provider, generic));
+        Assert.Equal(2, new HashSet<StreamSequenceToken> { generic, provider }.Count);
+    }
+
+    private sealed class InheritedV1Token(long sequence, int index) : EventSequenceToken(sequence, index);
+    private sealed class InheritedV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index);
+
+    private static StreamSubscriptionHandleImpl<int> CreateHandle(
+        StreamId streamId,
+        RecordingObserver observer,
+        StreamHandshakeToken? handshake)
+    {
+        var stream = new StreamImpl<int>(
+            new QualifiedStreamId("legacy-provider", streamId),
+            new RecoveryStreamProvider(),
+            isRewindable: true,
+            Substitute.For<IRuntimeClient>());
+        return new StreamSubscriptionHandleImpl<int>(
+            GuidId.GetGuidId(SubscriptionMarker.MarkAsExplicitSubscriptionId(Guid.NewGuid())),
+            observer,
+            batchObserver: null,
+            stream,
+            token: null,
+            startPosition: null,
+            filterData: null,
+            handshakeState: new() { Token = handshake },
+            clusterId: "legacy-cluster");
+    }
+
+    private sealed class RecoveryStreamProvider : IInternalStreamProvider
+    {
+        public IInternalAsyncBatchObserver<T> GetProducerInterface<T>(IAsyncStream<T> streamId)
+            => throw new NotSupportedException();
+
+        public IInternalAsyncObservable<T> GetConsumerInterface<T>(IAsyncStream<T> streamId)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class RecoveryDataAdapter(Func<long, int, StreamSequenceToken> createToken) : ICacheDataAdapter
+    {
+        public StreamSequenceToken GetSequenceToken(ref CachedMessage message)
+            => createToken(message.SequenceNumber, message.EventIndex);
+
+        public IBatchContainer GetBatchContainer(ref CachedMessage message)
+            => new RecoveryBatch(message.StreamId, GetSequenceToken(ref message));
+    }
+
+    private sealed class RecoveryBatch(StreamId streamId, StreamSequenceToken token) : IBatchContainer
+    {
+        public StreamId StreamId => streamId;
+        public StreamSequenceToken SequenceToken => token;
+        public bool ImportRequestContext() => false;
+
+        public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>()
+        {
+            if ((int)(token.SequenceNumber * 10 + token.EventIndex) is T value)
+            {
+                yield return Tuple.Create(value, token);
+            }
+        }
+    }
+
+    private sealed class RecordingObserver : IAsyncObserver<int>
+    {
+        public List<int> Items { get; } = [];
+        public List<StreamSequenceToken> Tokens { get; } = [];
+
+        public Task OnNextAsync(int item, StreamSequenceToken? token = null)
+        {
+            Items.Add(item);
+            Tokens.Add(Assert.IsAssignableFrom<StreamSequenceToken>(token));
+            return Task.CompletedTask;
+        }
+
+        public Task OnCompletedAsync() => Task.CompletedTask;
+        public Task OnErrorAsync(Exception exception) => Task.FromException(exception);
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
@@ -175,15 +175,15 @@ public static class LegacyTokenRecoveryFixture
             : StreamHandshakeToken.CreateStartToken(legacy);
         var handle = CreateHandle(streamId, observer, handshake);
         Add(100, 0);
-        var cursor = cache.GetCursor(streamId, handle.GetSequenceToken()!.Token);
+        var cursor = GetCursor(cache, streamId, handle.GetSequenceToken()!.Token);
 
-        Assert.False(cache.TryGetNextMessage(cursor, out _));
+        Assert.False(TryGetNextMessage(cache, cursor, out _));
         foreach (var sequence in new[] { 101L, 102L })
         {
             Add(sequence, 0);
             // This is the real Refresh path invoked by StartInactiveCursors after every nonempty read.
             cache.Refresh(cursor, createToken(sequence, 0));
-            Assert.False(cache.TryGetNextMessage(cursor, out _));
+            Assert.False(TryGetNextMessage(cache, cursor, out _));
             Assert.Empty(observer.Tokens);
         }
 
@@ -196,7 +196,7 @@ public static class LegacyTokenRecoveryFixture
         Add(501, 0);
         cache.Refresh(cursor, createToken(499, 0));
         SkipAcknowledgedPosition();
-        Assert.True(cache.TryGetNextMessage(cursor, out var first));
+        Assert.True(TryGetNextMessage(cache, cursor, out var first));
         Assert.Equal(500, first.SequenceToken.SequenceNumber);
         Assert.Equal(acknowledged ? 3 : 2, first.SequenceToken.EventIndex);
 
@@ -206,9 +206,9 @@ public static class LegacyTokenRecoveryFixture
             Assert.Same(handshake, requested);
             Assert.Same(legacy, requested!.Token);
             Assert.Empty(observer.Tokens);
-            cursor = cache.GetCursor(streamId, requested.Token);
+            cursor = GetCursor(cache, streamId, requested.Token);
             SkipAcknowledgedPosition();
-            Assert.True(cache.TryGetNextMessage(cursor, out first));
+            Assert.True(TryGetNextMessage(cache, cursor, out first));
             Assert.Equal(acknowledged ? 3 : 2, first.SequenceToken.EventIndex);
         }
 
@@ -217,7 +217,7 @@ public static class LegacyTokenRecoveryFixture
         cache.Refresh(cursor, createToken(100, 0));
         Assert.Null(await handle.DeliverBatch(first, handshake));
 
-        while (cache.TryGetNextMessage(cursor, out var batch))
+        while (TryGetNextMessage(cache, cursor, out var batch))
         {
             Assert.Null(await handle.DeliverBatch(batch, handle.GetSequenceToken()));
         }
@@ -240,7 +240,7 @@ public static class LegacyTokenRecoveryFixture
                 return;
             }
 
-            Assert.True(cache.TryGetNextMessage(cursor, out var duplicate));
+            Assert.True(TryGetNextMessage(cache, cursor, out var duplicate));
             Assert.Equal(0, EventSequenceTokenCompatibility.Compare(legacy, duplicate.SequenceToken));
             Assert.Equal(0, EventSequenceTokenCompatibility.Compare(duplicate.SequenceToken, legacy));
         }
@@ -311,6 +311,24 @@ public static class LegacyTokenRecoveryFixture
 
     private sealed class InheritedV1Token(long sequence, int index) : EventSequenceToken(sequence, index);
     private sealed class InheritedV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index);
+
+    private static object GetCursor(PooledQueueCache cache, StreamId streamId, StreamSequenceToken? token)
+    {
+        var result = cache.TryGetCursor(streamId, token);
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.Null(result.CacheMiss);
+        Assert.NotNull(result.Cursor);
+        return result.Cursor;
+    }
+
+    private static bool TryGetNextMessage(PooledQueueCache cache, object cursor, out IBatchContainer message)
+    {
+        var result = cache.TryGetNextMessageWithResult(cursor, out var current);
+        Assert.NotEqual(QueueCacheCursorMoveResultKind.CacheMiss, result.Kind);
+        Assert.Null(result.CacheMiss);
+        message = current!;
+        return result.Kind == QueueCacheCursorMoveResultKind.Success;
+    }
 
     private static StreamSubscriptionHandleImpl<int> CreateHandle(
         StreamId streamId,

--- a/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
@@ -91,6 +91,12 @@ public sealed class LegacySequenceTokenRecoveryTests
         LegacyTokenRecoveryFixture.AssertProviderIsolation(new IsolatedV2Token(500, 2));
     }
 
+    [Fact]
+    public void ExistingCustomContractWithoutExplicitDomain_RemainsIsolated()
+    {
+        LegacyTokenRecoveryFixture.AssertProviderIsolation(new ExistingProviderToken(500, 2, "provider"));
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -127,18 +133,54 @@ public sealed class LegacySequenceTokenRecoveryTests
     private sealed class CustomV1Token(long sequence, int index, string metadata) : EventSequenceToken(sequence, index)
     {
         public string Metadata { get; } = metadata;
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
     }
 
     private sealed class CustomV2Token(long sequence, int index, string metadata) : EventSequenceTokenV2(sequence, index)
     {
         public string Metadata { get; } = metadata;
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
     }
 
-    private sealed class OtherV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index);
+    private sealed class OtherV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index)
+    {
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+    }
 
     private sealed class IsolatedV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index)
     {
         protected override Type SequenceTokenCompatibilityDomain => typeof(IsolatedV2Token);
+    }
+
+    private sealed class ExistingProviderToken(long sequence, int index, string provider) : EventSequenceTokenV2(sequence, index)
+    {
+        public override bool Equals(object? obj) => obj is StreamSequenceToken token && Equals(token);
+
+        public override bool Equals(StreamSequenceToken? other)
+            => other is ExistingProviderToken token
+                && token.SequenceNumber == SequenceNumber
+                && token.EventIndex == EventIndex
+                && token.Provider == Provider;
+
+        public override int CompareTo(StreamSequenceToken? other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            if (other is not ExistingProviderToken token)
+            {
+                throw new ArgumentOutOfRangeException(nameof(other));
+            }
+
+            var difference = string.CompareOrdinal(Provider, token.Provider);
+            return difference != 0 ? difference : base.CompareTo(token);
+        }
+
+        public override int GetHashCode() => HashCode.Combine(Provider, SequenceNumber, EventIndex);
+
+        private string Provider { get; } = provider;
     }
 }
 
@@ -279,6 +321,48 @@ public static class LegacyTokenRecoveryFixture
         Assert.Empty(observer.Tokens);
     }
 
+    public static void VerifyPurgedCursorRecovery(
+        StreamSequenceToken legacy,
+        Func<long, int, StreamSequenceToken> createToken)
+    {
+        var streamId = StreamId.Create("legacy-purged-recovery", Guid.NewGuid());
+        var cache = new PooledQueueCache(
+            new RecoveryDataAdapter(createToken),
+            NullLogger.Instance,
+            cacheMonitor: null,
+            cacheMonitorWriteInterval: null,
+            purgeMetadataInterval: TimeSpan.FromMinutes(1));
+        var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        Add(legacy.SequenceNumber, legacy.EventIndex);
+        cache.RemoveOldestMessage();
+        Add(legacy.SequenceNumber + 1, 0);
+
+        var result = cache.TryGetCursor(streamId, legacy);
+
+        Assert.Equal(QueueCacheCursorResultKind.Success, result.Kind);
+        Assert.Null(result.CacheMiss);
+        Assert.NotNull(result.Cursor);
+        Assert.Equal(
+            QueueCacheCursorMoveResultKind.Success,
+            cache.TryGetNextMessageWithResult(result.Cursor, out var message).Kind);
+        Assert.Equal(legacy.SequenceNumber + 1, message!.SequenceToken.SequenceNumber);
+
+        void Add(long sequence, int index)
+        {
+            cache.Add(
+            [
+                new CachedMessage
+                {
+                    StreamId = streamId,
+                    SequenceNumber = sequence,
+                    EventIndex = index,
+                    EnqueueTimeUtc = now,
+                    DequeueTimeUtc = now,
+                },
+            ], now);
+        }
+    }
+
     public static void AssertProviderIsolation(StreamSequenceToken provider)
     {
         StreamSequenceToken[] genericTokens =
@@ -309,8 +393,14 @@ public static class LegacyTokenRecoveryFixture
         Assert.Equal(2, new HashSet<StreamSequenceToken> { generic, provider }.Count);
     }
 
-    private sealed class InheritedV1Token(long sequence, int index) : EventSequenceToken(sequence, index);
-    private sealed class InheritedV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index);
+    private sealed class InheritedV1Token(long sequence, int index) : EventSequenceToken(sequence, index)
+    {
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+    }
+    private sealed class InheritedV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index)
+    {
+        protected override Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+    }
 
     private static object GetCursor(PooledQueueCache cache, StreamId streamId, StreamSequenceToken? token)
     {

--- a/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/LegacySequenceTokenRecoveryTests.cs
@@ -86,22 +86,9 @@ public sealed class LegacySequenceTokenRecoveryTests
     }
 
     [Fact]
-    public void OverridingAnyContractMember_PreservesSeparateCompatibility()
+    public void ExplicitCompatibilityDomain_PreservesSeparateCompatibility()
     {
-        StreamSequenceToken[] overrides =
-        [
-            new ObjectEqualityToken(500, 2),
-            new TokenEqualityToken(500, 2),
-            new OrderingToken(500, 2),
-            new HashingToken(500, 2),
-            new InterfaceEqualityToken(500, 2),
-            new InterfaceOrderingToken(500, 2),
-        ];
-
-        foreach (var token in overrides)
-        {
-            LegacyTokenRecoveryFixture.AssertProviderIsolation(token);
-        }
+        LegacyTokenRecoveryFixture.AssertProviderIsolation(new IsolatedV2Token(500, 2));
     }
 
     [Theory]
@@ -149,37 +136,9 @@ public sealed class LegacySequenceTokenRecoveryTests
 
     private sealed class OtherV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index);
 
-    private sealed class ObjectEqualityToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
+    private sealed class IsolatedV2Token(long sequence, int index) : EventSequenceTokenV2(sequence, index)
     {
-        public override bool Equals(object? obj) => base.Equals(obj);
-        public override int GetHashCode() => base.GetHashCode();
-    }
-
-    private sealed class TokenEqualityToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
-    {
-        public override bool Equals(StreamSequenceToken? other) => base.Equals(other);
-    }
-
-    private sealed class OrderingToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
-    {
-        public override int CompareTo(StreamSequenceToken? other) => base.CompareTo(other);
-    }
-
-    private sealed class HashingToken(long sequence, int index) : EventSequenceTokenV2(sequence, index)
-    {
-        public override int GetHashCode() => base.GetHashCode();
-    }
-
-    private sealed class InterfaceEqualityToken(long sequence, int index)
-        : EventSequenceTokenV2(sequence, index), IEquatable<StreamSequenceToken?>
-    {
-        bool IEquatable<StreamSequenceToken?>.Equals(StreamSequenceToken? other) => base.Equals(other);
-    }
-
-    private sealed class InterfaceOrderingToken(long sequence, int index)
-        : EventSequenceTokenV2(sequence, index), IComparable<StreamSequenceToken?>
-    {
-        int IComparable<StreamSequenceToken?>.CompareTo(StreamSequenceToken? other) => base.CompareTo(other);
+        protected override Type SequenceTokenCompatibilityDomain => typeof(IsolatedV2Token);
     }
 }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -988,6 +988,52 @@ namespace UnitTests.StreamingTests
             }
         }
 
+        private sealed class FixedQueueCache(IReadOnlyList<IBatchContainer> messages) : IQueueCache
+        {
+            public int GetMaxAddCount() => 1000;
+
+            public void AddToCache(IList<IBatchContainer> messages) => throw new NotSupportedException();
+
+            public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+            {
+                purgedItems = [];
+                return false;
+            }
+
+            public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken? token)
+                => new Cursor(messages);
+
+            public IQueueCacheCursor GetCacheCursorAtPosition(StreamId streamId, StreamSubscriptionStartPosition startPosition)
+                => throw new NotSupportedException();
+
+            public bool IsUnderPressure() => false;
+
+            private sealed class Cursor(IReadOnlyList<IBatchContainer> messages) : IQueueCacheCursor
+            {
+                private int index = -1;
+
+                public void Dispose()
+                {
+                }
+
+                public IBatchContainer GetCurrent(out Exception exception)
+                {
+                    exception = null!;
+                    return messages[index];
+                }
+
+                public bool MoveNext() => ++index < messages.Count;
+
+                public void Refresh(StreamSequenceToken token)
+                {
+                }
+
+                public void RecordDeliveryFailure()
+                {
+                }
+            }
+        }
+
         private sealed class TestBatchContainer(StreamId streamId, StreamSequenceToken token) : IBatchContainer
         {
             public StreamId StreamId { get; } = streamId;
@@ -995,6 +1041,9 @@ namespace UnitTests.StreamingTests
             public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() => [];
             public bool ImportRequestContext() => false;
         }
+
+        private sealed class DerivedEventSequenceTokenV2(long sequenceNumber, int eventIndex)
+            : EventSequenceTokenV2(sequenceNumber, eventIndex);
 
         private sealed class RecordingConsumer(StreamHandshakeToken? requestedToken = null) : IStreamConsumerExtension
         {
@@ -1303,6 +1352,51 @@ namespace UnitTests.StreamingTests
 
             Assert.True(cursor.MoveNext());
             Assert.Equal(futureToken, Assert.IsType<TestBatchContainer>(cursor.GetCurrent(out _)).SequenceToken);
+            await accessor.Shutdown();
+        }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task LegacyAcknowledgedTokenSkipsDerivedDuplicateAndDeliversPrefetchedNewerBatch()
+        {
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var acknowledgedToken = new EventSequenceTokenV2(1);
+            var duplicateToken = new DerivedEventSequenceTokenV2(1, 0);
+            var nextToken = new DerivedEventSequenceTokenV2(2, 0);
+            var queueCache = new FixedQueueCache(
+            [
+                new TestBatchContainer(streamId, duplicateToken),
+                new TestBatchContainer(streamId, nextToken),
+            ]);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var agent = CreateAgent(
+                pubSub: Substitute.For<IStreamPubSub>(),
+                QueueId.GetQueueId("queue", 0u, 0u),
+                queueAdapterCache: queueAdapterCache);
+            var accessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            var consumer = new RecordingConsumer(StreamHandshakeToken.CreateDeliveyToken(acknowledgedToken));
+            var consumerData = new StreamConsumerData(
+                GuidId.GetGuidId(SubscriptionMarker.MarkAsExplicitSubscriptionId(Guid.NewGuid())),
+                qualifiedStreamId,
+                consumer,
+                filterData: null);
+
+            Assert.True(await accessor.DoHandshakeWithConsumer(consumerData, cacheToken: null));
+            Assert.IsType<DeliveryToken>(consumerData.LastToken);
+            Assert.NotNull(consumerData.Cursor);
+
+            var deliveryTask = accessor.RunConsumerCursor(consumerData);
+            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.Equal(nextToken, Assert.Single(consumer.DeliveredTokens));
+            Assert.Empty(consumer.Errors);
+
+            consumer.ReleaseDelivery();
+            await deliveryTask;
             await accessor.Shutdown();
         }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -1043,7 +1043,10 @@ namespace UnitTests.StreamingTests
         }
 
         private sealed class DerivedEventSequenceTokenV2(long sequenceNumber, int eventIndex)
-            : EventSequenceTokenV2(sequenceNumber, eventIndex);
+            : EventSequenceTokenV2(sequenceNumber, eventIndex)
+        {
+            protected override Type SequenceTokenCompatibilityDomain => typeof(EventSequenceToken);
+        }
 
         private sealed class RecordingConsumer(StreamHandshakeToken? requestedToken = null) : IStreamConsumerExtension
         {

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -1016,9 +1016,9 @@ namespace UnitTests.StreamingTests
                 {
                 }
 
-                public IBatchContainer GetCurrent(out Exception exception)
+                public IBatchContainer? GetCurrent(out Exception? exception)
                 {
-                    exception = null!;
+                    exception = null;
                     return messages[index];
                 }
 
@@ -2819,6 +2819,62 @@ namespace UnitTests.StreamingTests
 
             Assert.Equal(earliestConsumer.LastProcessedToken, Assert.Single(queueCache.DeliveryProgressTokens));
         }
+
+        [TestSuite("BVT")]
+        [TestProvider("None")]
+        [TestArea("Streaming")]
+        [Theory, TestCategory("BVT"), TestCategory("Streaming")]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Shutdown_PreservesCheckpointForIncompatibleTokens(bool providerTokenFirst)
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default, TestContext.Current.CancellationToken)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.Shutdown(Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            var queueCache = new RecordingQueueCache();
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(queueId).Returns(queueCache);
+            var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var accessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await accessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
+            var streamData = (await accessor.GetPubSubCache()).Single().Value;
+            Assert.Null(streamData.RegistrationTask);
+            queueCache.ClearDeliveryProgress();
+
+            StreamSequenceToken[] tokens = [new EventSequenceTokenV2(10), new IsolatedProviderToken(20)];
+            if (providerTokenFirst)
+            {
+                Array.Reverse(tokens);
+            }
+
+            foreach (var token in tokens)
+            {
+                var consumer = streamData.AddConsumer(
+                    GuidId.GetGuidId(Guid.NewGuid()),
+                    streamId,
+                    streamConsumer: null!,
+                    filterData: null,
+                    now: DateTime.UtcNow);
+                consumer.IsRegistered = true;
+                consumer.LastProcessedToken = token;
+            }
+
+            await accessor.Shutdown();
+
+            Assert.Empty(queueCache.DeliveryProgressTokens);
+            Assert.Equal(0, queueCache.DeliveryProgressCallCount);
+            await receiver.Received(1).Shutdown(Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+            await pubSub.Received(1).UnregisterProducer(streamId, Arg.Any<GrainId>(), Arg.Any<CancellationToken>());
+            Assert.Empty(await accessor.GetPubSubCache());
+        }
+
+        private sealed class IsolatedProviderToken(long sequenceNumber) : EventSequenceTokenV2(sequenceNumber);
 
         [TestSuite("BVT")]
         [TestProvider("None")]


### PR DESCRIPTION
## Problem

Persisted stream positions created by earlier inherited event-token factories can deserialize as exact `EventSequenceToken` or `EventSequenceTokenV2` instances. Current provider tokens can be derived types carrying provider metadata, which makes upgrade-time comparison asymmetric and can cause duplicate delivery or incorrect resume positioning.

This correctness foundation is extracted from the final compatibility implementation in #10588 and separated from the broader replay work in #11076. Related: #756.

## Solution

- Define explicit compatibility domains for event token equality and ordering, without runtime reflection.
- Keep unknown and previously compiled derived token types isolated by default; current custom tokens explicitly opt into a shared numeric domain.
- Preserve concrete token subtypes and metadata when creating per-event tokens.
- Normalize the historical Event Hubs V1 factory shape only at recovery comparison boundaries.
- Keep Kinesis ordering authoritative on arbitrary-precision shard sequence values and Redis ordering authoritative on full entry identity.
- Apply compatibility comparison at retained-cache positioning, duplicate acknowledgement, delivery progress, and the existing `PendingBatch`/`AdvanceCursorPastToken` resume path.
- Document the custom adapter token contract and regenerate affected API surfaces.

## Rationale

Recovery comparisons need to recognize positions persisted by earlier Orleans versions without weakening provider-specific token identity or changing normal delivery metadata. Explicit domains make that contract deterministic and extensible without method metadata inspection. Default isolation preserves custom providers compiled before the new hook, while recovery-only normalization preserves established provider behavior.