### PR TITLE
fix(analyzers): expand CA1062 provider coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -682,7 +682,19 @@ dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 
 # CA1062: Validate arguments of public methods
-[src/Azure/{Orleans.GrainDirectory.AzureStorage,Orleans.Persistence.AzureStorage,Orleans.Reminders.AzureStorage,Orleans.Clustering.Cosmos,Orleans.Reminders.Cosmos,Shared}/**.cs]
+[src/{Orleans.Clustering.ZooKeeper,Orleans.Hosting.Kubernetes,Orleans.Persistence.Memory,Orleans.Persistence.TestKit,Orleans.Reminders.TestKit,Orleans.Serialization.TestKit}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
+[src/Azure/{Orleans.Clustering.AzureStorage,Orleans.DurableJobs.AzureStorage,Orleans.GrainDirectory.AzureStorage,Orleans.Journaling.AzureStorage,Orleans.Persistence.AzureStorage,Orleans.Reminders.AzureStorage,Orleans.Streaming.AzureStorage,Orleans.Transactions.AzureStorage,Shared}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
+[src/Azure/{Orleans.Clustering.Cosmos,Orleans.Reminders.Cosmos}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
+[src/Google/**/*.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
+[src/Redis/**/*.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
 # Production source enforces the correctness baseline. Tests, samples, documentation,
@@ -713,7 +725,6 @@ dotnet_diagnostic.CA1307.severity = warning
 
 # Azure Table sources are linked into multiple provider projects, so they share one enforcement policy.
 [src/Azure/Shared/{Storage/{AzureStorageOperationOptions.cs,AzureStoragePolicyOptions.cs,AzureTableDataManager.cs,AzureTableUtils.cs},Utilities/ErrorCode.cs}]
-dotnet_diagnostic.CA1062.severity = warning
 dotnet_diagnostic.CA1305.severity = warning
 dotnet_diagnostic.CA1307.severity = warning
 

--- a/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.csproj
+++ b/src/Azure/Orleans.Clustering.Cosmos/Orleans.Clustering.Cosmos.csproj
@@ -10,7 +10,6 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <DefineConstants>$(DefineConstants);ORLEANS_CLUSTERING</DefineConstants>
     <Nullable>enable</Nullable>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
@@ -14,6 +14,7 @@ public static class AzureBlobStorageHostingExtensions
     /// </summary>
     /// <param name="builder">The silo builder.</param>
     /// <returns>The silo builder.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     public static ISiloBuilder AddAzureBlobJournalStorage(this ISiloBuilder builder) => builder.AddAzureBlobJournalStorage(configure: null);
 
     /// <summary>
@@ -22,8 +23,11 @@ public static class AzureBlobStorageHostingExtensions
     /// <param name="builder">The silo builder.</param>
     /// <param name="configure">The delegate used to configure the journal storage provider.</param>
     /// <returns>The silo builder.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     public static ISiloBuilder AddAzureBlobJournalStorage(this ISiloBuilder builder, Action<AzureBlobJournalStorageOptions>? configure)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.AddJournalStorage();
 
         var services = builder.Services;

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureTableStorageHostingExtensions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureTableStorageHostingExtensions.cs
@@ -14,6 +14,7 @@ public static class AzureTableStorageHostingExtensions
     /// </summary>
     /// <param name="builder">The silo builder.</param>
     /// <returns>The silo builder.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     public static ISiloBuilder AddAzureTableJournalStorage(this ISiloBuilder builder) => builder.AddAzureTableJournalStorage(configure: null);
 
     /// <summary>
@@ -22,8 +23,11 @@ public static class AzureTableStorageHostingExtensions
     /// <param name="builder">The silo builder.</param>
     /// <param name="configure">The delegate used to configure the journal storage provider.</param>
     /// <returns>The silo builder.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     public static ISiloBuilder AddAzureTableJournalStorage(this ISiloBuilder builder, Action<AzureTableJournalStorageOptions>? configure)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.AddJournalStorage();
 
         var services = builder.Services;

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -10,7 +10,6 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <DefineConstants>$(DefineConstants);ORLEANS_PERSISTENCE</DefineConstants>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs
@@ -86,8 +86,12 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use azure blob lease provider
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="configurator"/> or <paramref name="configureOptions"/> is <see langword="null"/>.</exception>
         public static void UseAzureBlobLeaseProvider(this ISiloPersistentStreamConfigurator configurator, Action<OptionsBuilder<AzureBlobLeaseProviderOptions>> configureOptions)
         {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+
             configurator.ConfigureDelegate(services =>
             {
                 services.AddTransient(sp => AzureBlobLeaseProviderOptionsValidator.Create(sp, configurator.Name));

--- a/src/Azure/Orleans.Streaming.AzureStorage/Options/AzureBlobLeaseProviderOptions.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Options/AzureBlobLeaseProviderOptions.cs
@@ -121,6 +121,7 @@ namespace Orleans.Configuration
         /// Constructor
         /// </summary>
         /// <param name="options">The option to be validated.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Microsoft.Extensions.DependencyInjection supplies the registered options instance.")]
         public AzureBlobLeaseProviderOptionsValidator(IOptions<AzureBlobLeaseProviderOptions> options)
         {
             this.options = options.Value;

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Lease/AzureBlobLeaseProvider.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Lease/AzureBlobLeaseProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -25,6 +26,7 @@ namespace Orleans.LeaseProviders
         /// Initializes a new instance of the <see cref="AzureBlobLeaseProvider"/> class.
         /// </summary>
         /// <param name="options">The Azure Blob lease provider options.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Microsoft.Extensions.DependencyInjection supplies the registered options instance.")]
         public AzureBlobLeaseProvider(IOptions<AzureBlobLeaseProviderOptions> options)
             : this(options.Value)
         {
@@ -51,6 +53,8 @@ namespace Orleans.LeaseProviders
         /// <inheritdoc />
         public async Task<AcquireLeaseResult[]> Acquire(string category, LeaseRequest[] leaseRequests)
         {
+            ArgumentNullException.ThrowIfNull(leaseRequests);
+
             await InitContainerIfNotExistsAsync();
             var tasks = new List<Task<AcquireLeaseResult>>(leaseRequests.Length);
             foreach (var leaseRequest in leaseRequests)
@@ -91,6 +95,8 @@ namespace Orleans.LeaseProviders
         /// <inheritdoc />
         public async Task Release(string category, AcquiredLease[] acquiredLeases)
         {
+            ArgumentNullException.ThrowIfNull(acquiredLeases);
+
             await InitContainerIfNotExistsAsync();
             var tasks = new List<Task>(acquiredLeases.Length);
             foreach (var acquiredLease in acquiredLeases)
@@ -109,6 +115,8 @@ namespace Orleans.LeaseProviders
         /// <inheritdoc />
         public async Task<AcquireLeaseResult[]> Renew(string category, AcquiredLease[] acquiredLeases)
         {
+            ArgumentNullException.ThrowIfNull(acquiredLeases);
+
             await InitContainerIfNotExistsAsync();
             var tasks = new List<Task<AcquireLeaseResult>>(acquiredLeases.Length);
             foreach (var acquiredLease in acquiredLeases)

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamProviderUtils.cs
@@ -34,6 +34,8 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <param name="storageConnectionString">The azure storage connection string.</param>
         public static async Task DeleteAllUsedAzureQueues(ILoggerFactory loggerFactory, List<string> azureQueueNames, string storageConnectionString)
         {
+            ArgumentNullException.ThrowIfNull(azureQueueNames);
+
             var options = new AzureQueueOptions();
             options.QueueServiceClient = new(storageConnectionString);
             await DeleteAllUsedAzureQueues(loggerFactory, azureQueueNames, options);
@@ -47,6 +49,8 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <param name="queueOptions">The azure storage options.</param>
         public static async Task DeleteAllUsedAzureQueues(ILoggerFactory loggerFactory, List<string> azureQueueNames, AzureQueueOptions queueOptions)
         {
+            ArgumentNullException.ThrowIfNull(azureQueueNames);
+
             var deleteTasks = new List<Task>();
             foreach (var queueName in azureQueueNames)
             {
@@ -65,6 +69,8 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <param name="storageConnectionString">The azure storage connection string.</param>
         public static async Task ClearAllUsedAzureQueues(ILoggerFactory loggerFactory, List<string> azureQueueNames, string storageConnectionString)
         {
+            ArgumentNullException.ThrowIfNull(azureQueueNames);
+
             var options = new AzureQueueOptions();
             options.QueueServiceClient = new(storageConnectionString);
             await ClearAllUsedAzureQueues(loggerFactory, azureQueueNames, options);
@@ -78,6 +84,8 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// <param name="queueOptions">The azure storage options.</param>
         public static async Task ClearAllUsedAzureQueues(ILoggerFactory loggerFactory, List<string> azureQueueNames, AzureQueueOptions queueOptions)
         {
+            ArgumentNullException.ThrowIfNull(azureQueueNames);
+
             var deleteTasks = new List<Task>();
             foreach (var queueName in azureQueueNames)
             {

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs
@@ -31,8 +31,10 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// Initializes a new instance of the <see cref="AzureQueueDataAdapterV1"/> class.
         /// </summary>
         /// <param name="serializer"></param>
+        /// <exception cref="ArgumentNullException"><paramref name="serializer"/> is <see langword="null"/>.</exception>
         public AzureQueueDataAdapterV1(Serializer serializer)
         {
+            ArgumentNullException.ThrowIfNull(serializer);
             this.serializer = serializer.GetSerializer<AzureQueueBatchContainer>();
         }
 
@@ -75,8 +77,10 @@ namespace Orleans.Providers.Streams.AzureQueue
         /// Initializes a new instance of the <see cref="AzureQueueDataAdapterV2"/> class.
         /// </summary>
         /// <param name="serializer"></param>
+        /// <exception cref="ArgumentNullException"><paramref name="serializer"/> is <see langword="null"/>.</exception>
         public AzureQueueDataAdapterV2(Serializer serializer)
         {
+            ArgumentNullException.ThrowIfNull(serializer);
             this.serializer = serializer.GetSerializer<AzureQueueBatchContainerV2>();
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/AzureTableStorageStreamFailureHandler.cs
@@ -35,6 +35,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
             {
                 throw new ArgumentNullException(nameof(clusterId));
             }
+            ArgumentNullException.ThrowIfNull(azureStorageOptions);
             if (string.IsNullOrEmpty(azureStorageOptions.TableName))
             {
                 throw new ArgumentException("A table name must be configured.", nameof(azureStorageOptions));

--- a/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/PersistentStreams/StreamDeliveryFailureEntity.cs
@@ -87,6 +87,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
         /// <param name="token"></param>
         public virtual void SetSequenceToken(Serializer<StreamSequenceToken> serializer, StreamSequenceToken? token)
         {
+            ArgumentNullException.ThrowIfNull(serializer);
             SequenceToken = token != null ? serializer.SerializeToArray(token) : null;
         }
 
@@ -96,6 +97,7 @@ namespace Orleans.Providers.Streams.PersistentStreams
         /// <returns></returns>
         public virtual StreamSequenceToken? GetSequenceToken(Serializer<StreamSequenceToken> serializer)
         {
+            ArgumentNullException.ThrowIfNull(serializer);
             return SequenceToken != null ? serializer.Deserialize(SequenceToken) : null;
         }
 

--- a/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Storage/AzureQueueDataManager.cs
@@ -96,6 +96,9 @@ namespace Orleans.AzureUtils
         /// <param name="options">Queue connection options.</param>
         public AzureQueueDataManager(ILoggerFactory loggerFactory, string queueName, AzureQueueOptions options)
         {
+            ArgumentNullException.ThrowIfNull(queueName);
+            ArgumentNullException.ThrowIfNull(options);
+
             queueName = SanitizeQueueName(queueName);
             ValidateQueueName(queueName);
 
@@ -309,6 +312,8 @@ namespace Orleans.AzureUtils
         /// <param name="message">A message to be deleted from the queue.</param>
         public async Task DeleteQueueMessage(QueueMessage message)
         {
+            ArgumentNullException.ThrowIfNull(message);
+
             var startTime = DateTime.UtcNow;
             LogTraceDeletingAMessage(QueueName);
             try

--- a/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
+++ b/src/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>Orleans.Transactions.AzureStorage</RootNamespace>
     <DefineConstants>$(DefineConstants);ORLEANS_TRANSACTIONS</DefineConstants>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Google/Orleans.GrainDirectory.Firestore/Orleans.GrainDirectory.Firestore.csproj
+++ b/src/Google/Orleans.GrainDirectory.Firestore/Orleans.GrainDirectory.Firestore.csproj
@@ -10,7 +10,6 @@
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
     <DefineConstants>$(DefineConstants);ORLEANS_DIRECTORY</DefineConstants>
     <Nullable>enable</Nullable>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
+++ b/src/Orleans.Clustering.ZooKeeper/Orleans.Clustering.ZooKeeper.csproj
@@ -7,7 +7,6 @@
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <AssemblyName>Orleans.Clustering.ZooKeeper</AssemblyName>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
+++ b/src/Orleans.Hosting.Kubernetes/KubernetesClusterAgent.cs
@@ -68,6 +68,7 @@ namespace Orleans.Hosting.Kubernetes
         /// <param name="options">The Kubernetes hosting options.</param>
         /// <param name="clusterOptions">The cluster identity options.</param>
         /// <param name="localSiloDetails">The local silo identity.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Microsoft.Extensions.DependencyInjection supplies the registered cluster options instance.")]
         public KubernetesClusterAgent(
             IClusterMembershipService clusterMembershipService,
             ILogger<KubernetesClusterAgent> logger,

--- a/src/Orleans.Persistence.Memory/Orleans.Persistence.Memory.csproj
+++ b/src/Orleans.Persistence.Memory/Orleans.Persistence.Memory.csproj
@@ -7,7 +7,6 @@
     <AssemblyName>Orleans.Persistence.Memory</AssemblyName>
     <RootNamespace>Orleans.Persistence.Memory</RootNamespace>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Persistence.TestKit/GrainStorageTestRunner.cs
+++ b/src/Orleans.Persistence.TestKit/GrainStorageTestRunner.cs
@@ -67,6 +67,7 @@ public abstract class GrainStorageTestRunner
 
     /// <inheritdoc cref="Store_WriteRead{T}(string, GrainId, GrainState{T})"/>
     /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="grainState"/> is <see langword="null"/>.</exception>
     protected async Task Store_WriteRead<T>(
         string grainTypeName,
         GrainId grainId,
@@ -74,6 +75,9 @@ public abstract class GrainStorageTestRunner
         CancellationToken cancellationToken)
         where T : new()
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(grainState);
+
         await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken).ConfigureAwait(false);
         var storedGrainState = new GrainState<T> { State = new T() };
         await Storage.ReadStateAsync(grainTypeName, grainId, storedGrainState, cancellationToken).ConfigureAwait(false);
@@ -95,6 +99,7 @@ public abstract class GrainStorageTestRunner
 
     /// <inheritdoc cref="Store_WriteClearRead{T}(string, GrainId, GrainState{T})"/>
     /// <param name="cancellationToken">A token which cancels the storage operations.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="grainState"/> is <see langword="null"/>.</exception>
     protected async Task Store_WriteClearRead<T>(
         string grainTypeName,
         GrainId grainId,
@@ -102,6 +107,9 @@ public abstract class GrainStorageTestRunner
         CancellationToken cancellationToken)
         where T : new()
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(grainState);
+
         // A legal situation for clearing has to be arranged by writing a state to the storage before clearing it.
         // Writing and clearing both change the ETag, so they should differ.
         await Storage.WriteStateAsync(grainTypeName, grainId, grainState, cancellationToken);

--- a/src/Orleans.Reminders.TestKit/Orleans.Reminders.TestKit.csproj
+++ b/src/Orleans.Reminders.TestKit/Orleans.Reminders.TestKit.csproj
@@ -15,7 +15,6 @@
   <PropertyGroup>
     <AssemblyName>Orleans.Reminders.TestKit</AssemblyName>
     <RootNamespace>Orleans.Reminders.TestKit</RootNamespace>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.csproj
+++ b/src/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.csproj
@@ -7,7 +7,6 @@
     <PackageDescription>Test kit for projects using Orleans.Serialization</PackageDescription>
     <IsOrleansFrameworkPart>false</IsOrleansFrameworkPart>
     <IsTestProject>false</IsTestProject>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
+++ b/src/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.csproj
@@ -8,7 +8,6 @@
     <PackageTags>$(PackageTags) Redis Clustering</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.csproj
@@ -8,7 +8,6 @@
     <PackageTags>$(PackageTags) Redis Grain Directory</PackageTags>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
-    <WarningsAsErrors>$(WarningsAsErrors);CA1062</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Redis/Orleans.Journaling.Redis/RedisJournalStorageHostingExtensions.cs
+++ b/src/Redis/Orleans.Journaling.Redis/RedisJournalStorageHostingExtensions.cs
@@ -15,6 +15,7 @@ public static class RedisJournalStorageHostingExtensions
     /// </summary>
     /// <param name="builder">The silo builder.</param>
     /// <returns>The silo builder.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     public static ISiloBuilder AddRedisJournalStorage(this ISiloBuilder builder) => builder.AddRedisJournalStorage(configure: null);
 
     /// <summary>
@@ -23,8 +24,11 @@ public static class RedisJournalStorageHostingExtensions
     /// <param name="builder">The silo builder.</param>
     /// <param name="configure">The Redis journal storage configuration delegate.</param>
     /// <returns>The silo builder.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
     public static ISiloBuilder AddRedisJournalStorage(this ISiloBuilder builder, Action<RedisJournalStorageOptions>? configure)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.AddJournalStorage();
 
         var services = builder.Services;

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
@@ -55,8 +55,14 @@ namespace Orleans.Persistence
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
+        /// <param name="options">The storage options containing the Redis connection configuration.</param>
+        /// <returns>A task containing the created multiplexer and an indication that the provider owns it.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisStorageOptions options)
-            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
+        }
     }
 
     /// <summary>
@@ -71,8 +77,11 @@ namespace Orleans.Persistence
         /// This method is provided as a compatibility utility for users who are migrating from prerelease versions of the Redis storage provider.
         /// </remarks>
         /// <param name="optionsBuilder">The options builder.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="optionsBuilder"/> is <see langword="null"/>.</exception>
         public static void UseGetRedisKeyIgnoringGrainType(this OptionsBuilder<RedisStorageOptions> optionsBuilder)
         {
+            ArgumentNullException.ThrowIfNull(optionsBuilder);
+
             optionsBuilder.Configure((RedisStorageOptions options, IOptions<ClusterOptions> clusterOptions) =>
             {
                 RedisKey keyPrefix = Encoding.UTF8.GetBytes($"{clusterOptions.Value.ServiceId}/state/");

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -38,6 +39,7 @@ namespace Orleans.Persistence
         /// <summary>
         /// Creates a new instance of the <see cref="RedisGrainStorage"/> type.
         /// </summary>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "RedisGrainStorageFactory supplies named options and ActivatorUtilities resolves cluster options from dependency injection.")]
         public RedisGrainStorage(
             string name,
             RedisStorageOptions options,
@@ -89,6 +91,9 @@ namespace Orleans.Persistence
         /// <inheritdoc />
         public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             var key = _getKeyFunc(grainType, grainId);
 
             try
@@ -128,6 +133,9 @@ namespace Orleans.Persistence
         /// <inheritdoc />
         public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             const string WriteScript =
                 """
                 local etag = redis.call('HGET', KEYS[1], 'etag')
@@ -200,6 +208,9 @@ namespace Orleans.Persistence
         /// <inheritdoc />
         public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
+            ArgumentNullException.ThrowIfNull(grainType);
+            ArgumentNullException.ThrowIfNull(grainState);
+
             try
             {
                 RedisValue etag = grainState.ETag ?? "";

--- a/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Orleans.Reminders.Redis;
@@ -37,8 +38,12 @@ namespace Orleans.Configuration
         /// </summary>
         /// <param name="options">The reminder table options containing the Redis connection configuration.</param>
         /// <returns>A task containing the created multiplexer and an indication that the provider owns it.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
         public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisReminderTableOptions options)
-            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
+        }
     }
 
     internal class RedactRedisConfigurationOptions : RedactAttribute
@@ -57,6 +62,7 @@ namespace Orleans.Configuration
         /// Initializes a new instance of the <see cref="RedisReminderTableOptionsValidator"/> class.
         /// </summary>
         /// <param name="options">The reminder table options to validate.</param>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Microsoft.Extensions.DependencyInjection supplies the registered options instance.")]
         public RedisReminderTableOptionsValidator(IOptions<RedisReminderTableOptions> options)
         {
             _options = options.Value;

--- a/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamingOptions.cs
+++ b/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamingOptions.cs
@@ -45,8 +45,14 @@ public sealed class RedisStreamingOptions
     /// <summary>
     /// The default multiplexer creation delegate.
     /// </summary>
-    public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisStreamingOptions options) =>
-        (await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), false);
+    /// <param name="options">The streaming options containing the Redis connection configuration.</param>
+    /// <returns>A task containing the created multiplexer and an indication that the provider owns it.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisStreamingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return (await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), false);
+    }
 }
 
 internal sealed class RedactRedisConfigurationOptionsAttribute : RedactAttribute

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureStreamingArgumentValidationTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureStreamingArgumentValidationTests.cs
@@ -1,0 +1,177 @@
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.AzureUtils;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.LeaseProviders;
+using Orleans.Providers.Streams.AzureQueue;
+using Orleans.Providers.Streams.PersistentStreams;
+using Xunit;
+
+namespace Tester.AzureUtils.Streaming;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+[TestArea("Streaming")]
+public sealed class AzureStreamingArgumentValidationTests
+{
+    [Fact]
+    public void UseAzureBlobLeaseProvider_NullConfigurator_Throws()
+    {
+        ISiloPersistentStreamConfigurator configurator = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => configurator.UseAzureBlobLeaseProvider(_ => { }));
+
+        Assert.Equal("configurator", exception.ParamName);
+    }
+
+    [Fact]
+    public void AzureQueueDataAdapterV1_NullSerializer_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AzureQueueDataAdapterV1(null!));
+
+        Assert.Equal("serializer", exception.ParamName);
+    }
+
+    [Fact]
+    public void AzureQueueDataAdapterV2_NullSerializer_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AzureQueueDataAdapterV2(null!));
+
+        Assert.Equal("serializer", exception.ParamName);
+    }
+
+    [Fact]
+    public void AzureQueueDataManager_NullQueueName_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new AzureQueueDataManager(NullLoggerFactory.Instance, null!, new AzureQueueOptions()));
+
+        Assert.Equal("queueName", exception.ParamName);
+    }
+
+    [Fact]
+    public void AzureQueueDataManager_NullOptions_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new AzureQueueDataManager(NullLoggerFactory.Instance, "queue-name", (AzureQueueOptions)null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task DeleteQueueMessage_NullMessage_Throws()
+    {
+        var manager = new AzureQueueDataManager(NullLoggerFactory.Instance, "queue-name", new AzureQueueOptions());
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => manager.DeleteQueueMessage((QueueMessage)null!));
+
+        Assert.Equal("message", exception.ParamName);
+    }
+
+    [Fact]
+    public void SetSequenceToken_NullSerializer_ThrowsBeforeMutatingEntity()
+    {
+        var entity = new StreamDeliveryFailureEntity { SequenceToken = [1, 2, 3] };
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => entity.SetSequenceToken(null!, token: null));
+
+        Assert.Equal("serializer", exception.ParamName);
+        Assert.Equal([1, 2, 3], entity.SequenceToken);
+    }
+
+    [Fact]
+    public void GetSequenceToken_NullSerializer_Throws()
+    {
+        var entity = new StreamDeliveryFailureEntity { SequenceToken = [1, 2, 3] };
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => entity.GetSequenceToken(null!));
+
+        Assert.Equal("serializer", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(nameof(AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues))]
+    [InlineData(nameof(AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues))]
+    public async Task QueueUtility_NullQueueNamesWithOptions_Throws(string operation)
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeQueueUtility(operation));
+
+        Assert.Equal("azureQueueNames", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(nameof(AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues))]
+    [InlineData(nameof(AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues))]
+    public async Task QueueUtility_NullQueueNamesWithConnectionString_Throws(string operation)
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeQueueUtilityWithConnectionString(operation));
+
+        Assert.Equal("azureQueueNames", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(nameof(AzureBlobLeaseProvider.Acquire))]
+    [InlineData(nameof(AzureBlobLeaseProvider.Release))]
+    [InlineData(nameof(AzureBlobLeaseProvider.Renew))]
+    public async Task LeaseOperation_NullLeases_ThrowsBeforeAccessingStorage(string operation)
+    {
+        var provider = new AzureBlobLeaseProvider(Options.Create(new AzureBlobLeaseProviderOptions()));
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeLeaseOperation(provider, operation));
+
+        Assert.Equal(operation == nameof(AzureBlobLeaseProvider.Acquire) ? "leaseRequests" : "acquiredLeases", exception.ParamName);
+    }
+
+    [Fact]
+    public void AzureTableStorageStreamFailureHandler_NullStorageOptions_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new AzureTableStorageStreamFailureHandler<StreamDeliveryFailureEntity>(
+                null!,
+                NullLoggerFactory.Instance,
+                faultOnFailure: false,
+                clusterId: "cluster",
+                azureStorageOptions: null!));
+
+        Assert.Equal("azureStorageOptions", exception.ParamName);
+    }
+
+    private static Task InvokeQueueUtility(string operation) =>
+        operation switch
+        {
+            nameof(AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues) =>
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(null!, null!, (AzureQueueOptions)null!),
+            nameof(AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues) =>
+                AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(null!, null!, (AzureQueueOptions)null!),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+
+    private static Task InvokeQueueUtilityWithConnectionString(string operation) =>
+        operation switch
+        {
+            nameof(AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues) =>
+                AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(null!, null!, (string)null!),
+            nameof(AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues) =>
+                AzureQueueStreamProviderUtils.ClearAllUsedAzureQueues(null!, null!, (string)null!),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+
+    private static Task InvokeLeaseOperation(AzureBlobLeaseProvider provider, string operation) =>
+        operation switch
+        {
+            nameof(AzureBlobLeaseProvider.Acquire) => provider.Acquire("category", null!),
+            nameof(AzureBlobLeaseProvider.Release) => provider.Release("category", null!),
+            nameof(AzureBlobLeaseProvider.Renew) => provider.Renew("category", null!),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+}

--- a/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageOptionsTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Persistence/RedisStorageOptionsTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Persistence;
+using StackExchange.Redis;
+using TestExtensions;
+using Xunit;
+
+namespace Tester.Redis.Persistence;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+public sealed class RedisStorageOptionsTests
+{
+    [Fact]
+    public void UseGetRedisKeyIgnoringGrainType_ValidOptionsBuilder_ConfiguresKeyWithoutGrainType()
+    {
+        const string serviceId = "service";
+        const string grainType = "ignored-grain-type";
+        var grainId = GrainId.Create("stored-grain-id-type", "grain-key");
+        var services = new ServiceCollection();
+        services.Configure<ClusterOptions>(options => options.ServiceId = serviceId);
+        services.AddOptions<RedisStorageOptions>().UseGetRedisKeyIgnoringGrainType();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<RedisStorageOptions>>().Value;
+
+        Assert.NotNull(options.GetStorageKey);
+        var key = options.GetStorageKey(grainType, grainId);
+        Assert.Equal((RedisKey)$"{serviceId}/state/{grainId}", key);
+        Assert.DoesNotContain(grainType, key.ToString());
+    }
+}

--- a/test/Extensions/Orleans.Redis.Tests/ProviderArgumentValidationTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/ProviderArgumentValidationTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Journaling;
+using Orleans.Persistence;
+using Orleans.Storage;
+using Xunit;
+
+namespace Tester.Redis;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+public sealed class ProviderArgumentValidationTests
+{
+    [Fact]
+    public void AddRedisJournalStorage_NullBuilder_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => RedisJournalStorageHostingExtensions.AddRedisJournalStorage(null!));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task RedisStorageOptions_DefaultCreateMultiplexer_NullOptions_Throws()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RedisStorageOptions.DefaultCreateMultiplexer(null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task RedisReminderTableOptions_DefaultCreateMultiplexer_NullOptions_Throws()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RedisReminderTableOptions.DefaultCreateMultiplexer(null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task RedisStreamingOptions_DefaultCreateMultiplexer_NullOptions_Throws()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => RedisStreamingOptions.DefaultCreateMultiplexer(null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void UseGetRedisKeyIgnoringGrainType_NullOptionsBuilder_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => RedisStorageOptionsExtensions.UseGetRedisKeyIgnoringGrainType(null!));
+
+        Assert.Equal("optionsBuilder", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(nameof(RedisGrainStorage.ReadStateAsync))]
+    [InlineData(nameof(RedisGrainStorage.WriteStateAsync))]
+    [InlineData(nameof(RedisGrainStorage.ClearStateAsync))]
+    public async Task StorageOperation_NullGrainType_ThrowsBeforeMutatingState(string operation)
+    {
+        var storage = CreateStorage();
+        var state = new GrainState<string> { State = "value", ETag = "etag", RecordExists = true };
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => Invoke(storage, operation, null!, state));
+
+        Assert.Equal("grainType", exception.ParamName);
+        Assert.Equal("value", state.State);
+        Assert.Equal("etag", state.ETag);
+        Assert.True(state.RecordExists);
+    }
+
+    [Theory]
+    [InlineData(nameof(RedisGrainStorage.ReadStateAsync))]
+    [InlineData(nameof(RedisGrainStorage.WriteStateAsync))]
+    [InlineData(nameof(RedisGrainStorage.ClearStateAsync))]
+    public async Task StorageOperation_NullGrainState_Throws(string operation)
+    {
+        var storage = CreateStorage();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => Invoke(storage, operation, "grain-type", null!));
+
+        Assert.Equal("grainState", exception.ParamName);
+    }
+
+    private static RedisGrainStorage CreateStorage() =>
+        new(
+            "argument-tests",
+            new RedisStorageOptions(),
+            null!,
+            Options.Create(new ClusterOptions { ServiceId = "service" }),
+            null!,
+            NullLogger<RedisGrainStorage>.Instance);
+
+    private static Task Invoke(RedisGrainStorage storage, string operation, string grainType, IGrainState<string> grainState)
+    {
+        var grainId = GrainId.Create("grain-type", "grain-key");
+        return operation switch
+        {
+            nameof(RedisGrainStorage.ReadStateAsync) => storage.ReadStateAsync(grainType, grainId, grainState),
+            nameof(RedisGrainStorage.WriteStateAsync) => storage.WriteStateAsync(grainType, grainId, grainState),
+            nameof(RedisGrainStorage.ClearStateAsync) => storage.ClearStateAsync(grainType, grainId, grainState),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+    }
+}

--- a/test/Orleans.Journaling.Tests/JournalStorageHostingArgumentTests.cs
+++ b/test/Orleans.Journaling.Tests/JournalStorageHostingArgumentTests.cs
@@ -1,0 +1,30 @@
+using Orleans.Journaling;
+using Xunit;
+
+namespace Orleans.Journaling.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+[TestArea("Journaling")]
+public sealed class JournalStorageHostingArgumentTests
+{
+    [Fact]
+    public void AddAzureBlobJournalStorage_NullBuilder_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => AzureBlobStorageHostingExtensions.AddAzureBlobJournalStorage(null!));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddAzureTableJournalStorage_NullBuilder_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => AzureTableStorageHostingExtensions.AddAzureTableJournalStorage(null!));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+}

--- a/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageTests.cs
+++ b/test/Orleans.Persistence.TestKit.Tests/MemoryGrainStorageTests.cs
@@ -61,7 +61,70 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
         Assert.Contains("found '<null>'", exception.Message);
     }
 
-    private sealed class TestRunner(IGrainStorage storage) : GrainStorageTestRunner(storage);
+    [Fact]
+    public async Task StoreWriteRead_NullState_ThrowsBeforeCallingStorage()
+    {
+        var storage = new TrackingGrainStorage();
+        var runner = new TestRunner(storage);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => runner.StoreWriteReadWithNullState(TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        Assert.Equal(0, storage.CallCount);
+    }
+
+    [Fact]
+    public async Task StoreWriteClearRead_NullState_ThrowsBeforeCallingStorage()
+    {
+        var storage = new TrackingGrainStorage();
+        var runner = new TestRunner(storage);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => runner.StoreWriteClearReadWithNullState(TestContext.Current.CancellationToken));
+
+        Assert.Equal("grainState", exception.ParamName);
+        Assert.Equal(0, storage.CallCount);
+    }
+
+    [Fact]
+    public async Task StoreWriteRead_CanceledTokenTakesPrecedenceOverNullState()
+    {
+        var storage = new TrackingGrainStorage();
+        var runner = new TestRunner(storage);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => runner.StoreWriteReadWithNullState(cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Equal(0, storage.CallCount);
+    }
+
+    [Fact]
+    public async Task StoreWriteClearRead_CanceledTokenTakesPrecedenceOverNullState()
+    {
+        var storage = new TrackingGrainStorage();
+        var runner = new TestRunner(storage);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => runner.StoreWriteClearReadWithNullState(cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Equal(0, storage.CallCount);
+    }
+
+    private sealed class TestRunner(IGrainStorage storage) : GrainStorageTestRunner(storage)
+    {
+        public Task StoreWriteReadWithNullState(CancellationToken cancellationToken = default) =>
+            Store_WriteRead<object>("grain-type", default, null!, cancellationToken);
+
+        public Task StoreWriteClearReadWithNullState(CancellationToken cancellationToken = default) =>
+            Store_WriteClearRead<object>("grain-type", default, null!, cancellationToken);
+    }
 
     private sealed class NullStateGrainStorage : IGrainStorage
     {
@@ -78,6 +141,29 @@ public class MemoryGrainStorageTests : GrainStorageTestRunner, IClassFixture<Mem
         }
 
         public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState) => Task.CompletedTask;
+    }
+
+    private sealed class TrackingGrainStorage : IGrainStorage
+    {
+        public int CallCount { get; private set; }
+
+        public Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            CallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            CallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
+        {
+            CallCount++;
+            return Task.CompletedTask;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

CA1062 enforcement is split between root policy, project-local `WarningsAsErrors`, and a project-local global analyzer configuration. Several provider families also have a bounded set of unvalidated public inputs, leaving normal-build enforcement inconsistent.

## Solution

Centralize CA1062 warning severity in the root `.editorconfig` for the complete Azure Storage, Google, and Redis provider families plus the existing clean top-level projects. Remove the equivalent project-local CA1062 settings. Add boundary validation for the newly enrolled Azure Storage, Redis, Kubernetes, journaling, and persistence test-kit paths, retaining narrow suppressions where dependency injection or provider factories guarantee non-null values. Add service-independent contract tests for exception type, parameter name, validation ordering, state preservation, cancellation precedence, and Redis key configuration.

## Rationale

Family-level root sections keep policy readable and ensure normal builds enforce the same rule consistently. AWS and ADO.NET remain deferred as whole-family batches because shared source is compiled by projects with active or remaining findings. Azure Persistence.Cosmos and Event Hubs remain outside the broad Azure scope because their finding files overlap active pull requests, so this change uses a complete Azure Storage family section and preserves the previously clean Cosmos projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11157)