### PR TITLE
fix(analyzers): expand CA1062 library coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -682,7 +682,10 @@ dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 
 # CA1062: Validate arguments of public methods
-[src/{Orleans.Clustering.ZooKeeper,Orleans.Hosting.Kubernetes,Orleans.Persistence.Memory,Orleans.Persistence.TestKit,Orleans.Reminders.TestKit,Orleans.Serialization.TestKit}/**.cs]
+[src/{Orleans.BroadcastChannel,Orleans.Clustering.ZooKeeper,Orleans.Hosting.Kubernetes,Orleans.Persistence.Memory,Orleans.Persistence.TestKit,Orleans.Reminders.TestKit,Orleans.Serialization.FSharp,Orleans.Serialization.MessagePack,Orleans.Serialization.NewtonsoftJson,Orleans.Serialization.SystemTextJson,Orleans.Serialization.TestKit,Orleans.Transactions.TestKit.xUnit}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
+[src/Serializers/Orleans.Serialization.Protobuf/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
 [src/Azure/{Orleans.Clustering.AzureStorage,Orleans.DurableJobs.AzureStorage,Orleans.GrainDirectory.AzureStorage,Orleans.Journaling.AzureStorage,Orleans.Persistence.AzureStorage,Orleans.Reminders.AzureStorage,Orleans.Streaming.AzureStorage,Orleans.Transactions.AzureStorage,Shared}/**.cs]

--- a/src/Orleans.BroadcastChannel/ChannelId.cs
+++ b/src/Orleans.BroadcastChannel/ChannelId.cs
@@ -114,6 +114,8 @@ namespace Orleans.BroadcastChannel
         /// <param name="key">The key.</param>
         public static ChannelId Create(string ns, string key)
         {
+            ArgumentNullException.ThrowIfNull(key);
+
             if (ns is null)
                 return new ChannelId(Encoding.UTF8.GetBytes(key), 0);
 
@@ -153,6 +155,8 @@ namespace Orleans.BroadcastChannel
         /// <inheritdoc/>
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
+            ArgumentNullException.ThrowIfNull(info);
+
             info.AddValue("fk", fullKey);
             info.AddValue("ki", this.keyIndex);
             info.AddValue("fh", this.hash);

--- a/src/Orleans.BroadcastChannel/Hosting/ChannelHostingExtensions.cs
+++ b/src/Orleans.BroadcastChannel/Hosting/ChannelHostingExtensions.cs
@@ -21,6 +21,10 @@ namespace Orleans.Hosting
         /// <returns>The silo builder.</returns>
         public static ISiloBuilder AddBroadcastChannel(this ISiloBuilder @this, string name, Action<BroadcastChannelOptions> configureOptions)
         {
+            ArgumentNullException.ThrowIfNull(@this, nameof(@this));
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+
             @this.Services.AddBroadcastChannel(name, ob => ob.Configure(configureOptions));
             @this.AddGrainExtension<IBroadcastChannelConsumerExtension, BroadcastChannelConsumerExtension>();
             return @this;
@@ -35,6 +39,9 @@ namespace Orleans.Hosting
         /// <returns>The silo builder.</returns>
         public static ISiloBuilder AddBroadcastChannel(this ISiloBuilder @this, string name, Action<OptionsBuilder<BroadcastChannelOptions>>? configureOptions = null)
         {
+            ArgumentNullException.ThrowIfNull(@this, nameof(@this));
+            ArgumentNullException.ThrowIfNull(name);
+
             @this.Services.AddBroadcastChannel(name, configureOptions);
             @this.AddGrainExtension<IBroadcastChannelConsumerExtension, BroadcastChannelConsumerExtension>();
             return @this;
@@ -49,6 +56,10 @@ namespace Orleans.Hosting
         /// <returns>The client builder.</returns>
         public static IClientBuilder AddBroadcastChannel(this IClientBuilder @this, string name, Action<BroadcastChannelOptions> configureOptions)
         {
+            ArgumentNullException.ThrowIfNull(@this, nameof(@this));
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+
             @this.Services.AddBroadcastChannel(name, ob => ob.Configure(configureOptions));
             return @this;
         }
@@ -62,6 +73,9 @@ namespace Orleans.Hosting
         /// <returns>The client builder.</returns>
         public static IClientBuilder AddBroadcastChannel(this IClientBuilder @this, string name, Action<OptionsBuilder<BroadcastChannelOptions>>? configureOptions = null)
         {
+            ArgumentNullException.ThrowIfNull(@this, nameof(@this));
+            ArgumentNullException.ThrowIfNull(name);
+
             @this.Services.AddBroadcastChannel(name, configureOptions);
             return @this;
         }
@@ -73,7 +87,12 @@ namespace Orleans.Hosting
         /// <param name="name">The name of the provider</param>
         /// <returns>The named broadcast channel provider.</returns>
         public static IBroadcastChannelProvider GetBroadcastChannelProvider(this IClusterClient @this, string name)
-            => @this.ServiceProvider.GetRequiredKeyedService<IBroadcastChannelProvider>(name);
+        {
+            ArgumentNullException.ThrowIfNull(@this, nameof(@this));
+            ArgumentNullException.ThrowIfNull(name);
+
+            return @this.ServiceProvider.GetRequiredKeyedService<IBroadcastChannelProvider>(name);
+        }
 
         private static void AddBroadcastChannel(this IServiceCollection services, string name, Action<OptionsBuilder<BroadcastChannelOptions>>? configureOptions)
         {

--- a/src/Orleans.BroadcastChannel/IdMapping/DefaultChannelIdMapper.cs
+++ b/src/Orleans.BroadcastChannel/IdMapping/DefaultChannelIdMapper.cs
@@ -18,6 +18,8 @@ namespace Orleans.BroadcastChannel
         /// <inheritdoc />
         public IdSpan GetGrainKeyId(GrainBindings grainBindings, ChannelId streamId)
         {
+            ArgumentNullException.ThrowIfNull(grainBindings);
+
             string? keyType = null;
             bool includeNamespaceInGrainId = false;
 

--- a/src/Orleans.BroadcastChannel/SubscriberTable/Predicates/DefaultStreamNamespacePredicateProvider.cs
+++ b/src/Orleans.BroadcastChannel/SubscriberTable/Predicates/DefaultStreamNamespacePredicateProvider.cs
@@ -12,6 +12,8 @@ namespace Orleans.BroadcastChannel
         /// <inheritdoc/>
         public bool TryGetPredicate(string predicatePattern, [NotNullWhen(true)] out IChannelNamespacePredicate? predicate)
         {
+            ArgumentNullException.ThrowIfNull(predicatePattern);
+
             switch (predicatePattern)
             {
                 case "*":
@@ -56,6 +58,8 @@ namespace Orleans.BroadcastChannel
         /// <inheritdoc/>
         public bool TryGetPredicate(string predicatePattern, [NotNullWhen(true)] out IChannelNamespacePredicate? predicate)
         {
+            ArgumentNullException.ThrowIfNull(predicatePattern);
+
             if (!predicatePattern.StartsWith(Prefix, StringComparison.Ordinal))
             {
                 predicate = null;

--- a/src/Orleans.BroadcastChannel/SubscriberTable/Predicates/ImplicitChannelSubscriptionAttribute.cs
+++ b/src/Orleans.BroadcastChannel/SubscriberTable/Predicates/ImplicitChannelSubscriptionAttribute.cs
@@ -39,6 +39,8 @@ namespace Orleans
         /// <param name="channelIdMapper">The name of the stream identity mapper.</param>
         public ImplicitChannelSubscriptionAttribute(string streamNamespace, string? channelIdMapper = null)
         {
+            ArgumentNullException.ThrowIfNull(streamNamespace);
+
             Predicate = new ExactMatchChannelNamespacePredicate(streamNamespace.Trim());
             ChannelIdMapper = channelIdMapper;
         }

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -62,6 +62,7 @@ namespace Orleans.Serialization
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ReferenceCodec handles null serialized options before the value is accessed.")]
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [AllowNull] Type expectedType, [AllowNull] FSharpOption<T> value) where TBufferWriter : IBufferWriter<byte>
         {
             if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
@@ -134,6 +135,8 @@ namespace Orleans.Serialization
         [return: NotNullIfNotNull(nameof(input))]
         public FSharpOption<T>? DeepCopy([AllowNull] FSharpOption<T> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (input is null || FSharpOption<T>.get_IsNone(input))
             {
                 return input;
@@ -351,6 +354,8 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2> DeepCopy(FSharpChoice<T1, T2> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2>? result))
             {
                 return result!;
@@ -490,6 +495,8 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3> DeepCopy(FSharpChoice<T1, T2, T3> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3>? result))
             {
                 return result!;
@@ -643,6 +650,8 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3, T4> DeepCopy(FSharpChoice<T1, T2, T3, T4> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3, T4>? result))
             {
                 return result!;
@@ -810,6 +819,8 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3, T4, T5> DeepCopy(FSharpChoice<T1, T2, T3, T4, T5> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3, T4, T5>? result))
             {
                 return result!;
@@ -991,6 +1002,8 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3, T4, T5, T6> DeepCopy(FSharpChoice<T1, T2, T3, T4, T5, T6> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3, T4, T5, T6>? result))
             {
                 return result!;
@@ -1033,6 +1046,7 @@ namespace Orleans.Serialization
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "GeneralizedReferenceTypeSurrogateCodec handles null references before converting a value to its surrogate.")]
         public override void ConvertToSurrogate(FSharpRef<T> value, ref FSharpRefSurrogate<T> surrogate)
         {
             surrogate.Value = value.Value;
@@ -1071,6 +1085,8 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpRef<T> DeepCopy(FSharpRef<T> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (context.TryGetCopy<FSharpRef<T>>(input, out var result))
             {
                 return result!;
@@ -1152,6 +1168,13 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpList<T> DeepCopy(FSharpList<T> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
+            if (input is null)
+            {
+                return null!;
+            }
+
             if (context.TryGetCopy<FSharpList<T>>(input, out var result))
             {
                 return result!;
@@ -1234,6 +1257,13 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpSet<T> DeepCopy(FSharpSet<T> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
+            if (input is null)
+            {
+                return null!;
+            }
+
             if (context.TryGetCopy<FSharpSet<T>>(input, out var result))
             {
                 return result!;
@@ -1328,6 +1358,13 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpMap<TKey, TValue> DeepCopy(FSharpMap<TKey, TValue> input, CopyContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
+            if (input is null)
+            {
+                return null!;
+            }
+
             if (context.TryGetCopy<FSharpMap<TKey, TValue>>(input, out var result))
             {
                 return result!;

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -135,7 +135,7 @@ namespace Orleans.Serialization
         [return: NotNullIfNotNull(nameof(input))]
         public FSharpOption<T>? DeepCopy([AllowNull] FSharpOption<T> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (input is null || FSharpOption<T>.get_IsNone(input))
             {
@@ -354,7 +354,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2> DeepCopy(FSharpChoice<T1, T2> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2>? result))
             {
@@ -495,7 +495,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3> DeepCopy(FSharpChoice<T1, T2, T3> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3>? result))
             {
@@ -650,7 +650,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3, T4> DeepCopy(FSharpChoice<T1, T2, T3, T4> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3, T4>? result))
             {
@@ -819,7 +819,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3, T4, T5> DeepCopy(FSharpChoice<T1, T2, T3, T4, T5> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3, T4, T5>? result))
             {
@@ -1002,7 +1002,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpChoice<T1, T2, T3, T4, T5, T6> DeepCopy(FSharpChoice<T1, T2, T3, T4, T5, T6> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (context.TryGetCopy(input, out FSharpChoice<T1, T2, T3, T4, T5, T6>? result))
             {
@@ -1085,7 +1085,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpRef<T> DeepCopy(FSharpRef<T> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (context.TryGetCopy<FSharpRef<T>>(input, out var result))
             {
@@ -1168,7 +1168,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpList<T> DeepCopy(FSharpList<T> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (input is null)
             {
@@ -1257,7 +1257,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpSet<T> DeepCopy(FSharpSet<T> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (input is null)
             {
@@ -1358,7 +1358,7 @@ namespace Orleans.Serialization
         /// <inheritdoc/>
         public FSharpMap<TKey, TValue> DeepCopy(FSharpMap<TKey, TValue> input, CopyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (input is null)
             {

--- a/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
+++ b/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
@@ -50,9 +50,9 @@ public class MessagePackCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilt
         IEnumerable<ICopierSelector> copyableTypeSelectors,
         IOptions<MessagePackCodecOptions> options)
     {
-        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
-        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
-        ArgumentNullException.ThrowIfNull(options);
+        if (serializableTypeSelectors is null) throw new ArgumentNullException(nameof(serializableTypeSelectors));
+        if (copyableTypeSelectors is null) throw new ArgumentNullException(nameof(copyableTypeSelectors));
+        if (options is null) throw new ArgumentNullException(nameof(options));
 
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();

--- a/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
+++ b/src/Orleans.Serialization.MessagePack/MessagePackCodec.cs
@@ -50,6 +50,10 @@ public class MessagePackCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilt
         IEnumerable<ICopierSelector> copyableTypeSelectors,
         IOptions<MessagePackCodecOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
+        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
+        ArgumentNullException.ThrowIfNull(options);
+
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _options = options.Value;

--- a/src/Orleans.Serialization.MessagePack/SerializationHostingExtensions.cs
+++ b/src/Orleans.Serialization.MessagePack/SerializationHostingExtensions.cs
@@ -54,6 +54,8 @@ public static class SerializationHostingExtensions
         Func<Type, bool>? isCopyable,
         Action<OptionsBuilder<MessagePackCodecOptions>>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(serializerBuilder);
+
         var services = serializerBuilder.Services;
         if (configureOptions != null)
         {

--- a/src/Orleans.Serialization.MessagePack/SerializationHostingExtensions.cs
+++ b/src/Orleans.Serialization.MessagePack/SerializationHostingExtensions.cs
@@ -54,7 +54,7 @@ public static class SerializationHostingExtensions
         Func<Type, bool>? isCopyable,
         Action<OptionsBuilder<MessagePackCodecOptions>>? configureOptions = null)
     {
-        ArgumentNullException.ThrowIfNull(serializerBuilder);
+        if (serializerBuilder is null) throw new ArgumentNullException(nameof(serializerBuilder));
 
         var services = serializerBuilder.Services;
         if (configureOptions != null)

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -46,6 +46,10 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
         IEnumerable<ICopierSelector> copyableTypeSelectors,
         IOptions<NewtonsoftJsonCodecOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
+        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
+        ArgumentNullException.ThrowIfNull(options);
+
         _options = options.Value;
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();

--- a/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -46,9 +46,9 @@ public class NewtonsoftJsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeF
         IEnumerable<ICopierSelector> copyableTypeSelectors,
         IOptions<NewtonsoftJsonCodecOptions> options)
     {
-        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
-        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
-        ArgumentNullException.ThrowIfNull(options);
+        if (serializableTypeSelectors is null) throw new ArgumentNullException(nameof(serializableTypeSelectors));
+        if (copyableTypeSelectors is null) throw new ArgumentNullException(nameof(copyableTypeSelectors));
+        if (options is null) throw new ArgumentNullException(nameof(options));
 
         _options = options.Value;
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();

--- a/src/Orleans.Serialization.NewtonsoftJson/SerializationHostingExtensions.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/SerializationHostingExtensions.cs
@@ -63,7 +63,7 @@ public static class SerializationHostingExtensions
         Func<Type, bool>? isCopyable,
         Action<OptionsBuilder<NewtonsoftJsonCodecOptions>>? configureOptions)
     {
-        ArgumentNullException.ThrowIfNull(serializerBuilder);
+        if (serializerBuilder is null) throw new ArgumentNullException(nameof(serializerBuilder));
 
         var services = serializerBuilder.Services;
         if (configureOptions != null)

--- a/src/Orleans.Serialization.NewtonsoftJson/SerializationHostingExtensions.cs
+++ b/src/Orleans.Serialization.NewtonsoftJson/SerializationHostingExtensions.cs
@@ -63,6 +63,8 @@ public static class SerializationHostingExtensions
         Func<Type, bool>? isCopyable,
         Action<OptionsBuilder<NewtonsoftJsonCodecOptions>>? configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(serializerBuilder);
+
         var services = serializerBuilder.Services;
         if (configureOptions != null)
         {

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -44,9 +44,9 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         IEnumerable<ICopierSelector> copyableTypeSelectors,
         IOptions<JsonCodecOptions> options)
     {
-        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
-        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
-        ArgumentNullException.ThrowIfNull(options);
+        if (serializableTypeSelectors is null) throw new ArgumentNullException(nameof(serializableTypeSelectors));
+        if (copyableTypeSelectors is null) throw new ArgumentNullException(nameof(copyableTypeSelectors));
+        if (options is null) throw new ArgumentNullException(nameof(options));
 
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();

--- a/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
+++ b/src/Orleans.Serialization.SystemTextJson/JsonCodec.cs
@@ -44,6 +44,10 @@ public class JsonCodec : IGeneralizedCodec, IGeneralizedCopier, ITypeFilter
         IEnumerable<ICopierSelector> copyableTypeSelectors,
         IOptions<JsonCodecOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
+        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
+        ArgumentNullException.ThrowIfNull(options);
+
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _options = options.Value;

--- a/src/Orleans.Serialization.SystemTextJson/SerializationHostingExtensions.cs
+++ b/src/Orleans.Serialization.SystemTextJson/SerializationHostingExtensions.cs
@@ -49,6 +49,8 @@ public static class SerializationHostingExtensions
         Func<Type, bool>? isCopyable,
         Action<OptionsBuilder<JsonCodecOptions>>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(serializerBuilder);
+
         var services = serializerBuilder.Services;
         if (configureOptions != null)
         {

--- a/src/Orleans.Serialization.SystemTextJson/SerializationHostingExtensions.cs
+++ b/src/Orleans.Serialization.SystemTextJson/SerializationHostingExtensions.cs
@@ -49,7 +49,7 @@ public static class SerializationHostingExtensions
         Func<Type, bool>? isCopyable,
         Action<OptionsBuilder<JsonCodecOptions>>? configureOptions = null)
     {
-        ArgumentNullException.ThrowIfNull(serializerBuilder);
+        if (serializerBuilder is null) throw new ArgumentNullException(nameof(serializerBuilder));
 
         var services = serializerBuilder.Services;
         if (configureOptions != null)

--- a/src/Orleans.Transactions.TestKit.xUnit/ConsistencyTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/ConsistencyTransactionTestRunner.cs
@@ -13,7 +13,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         public ConsistencyTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-            : base(grainFactory, output.WriteLine)
+            : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output)))
         {
         }
 

--- a/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         public ControlledFaultInjectionTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-         : base(grainFactory, output.WriteLine)
+         : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output)))
         { }
 
         /// <inheritdoc cref="ControlledFaultInjectionTransactionTestRunner.SingleGrainReadTransaction"/>

--- a/src/Orleans.Transactions.TestKit.xUnit/DisabledTransactionsTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/DisabledTransactionsTestRunner.cs
@@ -11,7 +11,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         protected DisabledTransactionsTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-            : base(grainFactory, output.WriteLine) { }
+            : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output))) { }
 
         /// <inheritdoc cref="DisabledTransactionsTestRunner.TransactionGrainsThrowWhenTransactions(string)"/>
         [Theory]

--- a/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs
@@ -11,7 +11,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         protected ExclusiveLockTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-            : base(grainFactory, output.WriteLine)
+            : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output)))
         {
         }
 

--- a/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         protected GoldenPathTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-        : base(grainFactory, output.WriteLine) { }
+        : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output))) { }
 
         /// <inheritdoc cref="GoldenPathTransactionTestRunner.SingleGrainReadTransaction(string)"/>
         [Theory]

--- a/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/GrainFaultTransactionTestRunner.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         public GrainFaultTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-        : base(grainFactory, output.WriteLine)
+        : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output)))
         { }
 
         /// <inheritdoc cref="GrainFaultTransactionTestRunner.AbortTransactionOnExceptions(string)"/>

--- a/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/ScopedTransactionsTestRunnerxUnit.cs
@@ -14,7 +14,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="transactionFrame">The client used to create transaction scopes.</param>
         /// <param name="output">The xUnit test output helper.</param>
         protected ScopedTransactionsTestRunnerxUnit(IGrainFactory grainFactory, ITransactionClient transactionFrame, ITestOutputHelper output)
-        : base(grainFactory, transactionFrame, output.WriteLine) { }
+        : base(grainFactory, transactionFrame, TestOutputHelperExtensions.GetWriteLine(output, nameof(output))) { }
 
         /// <inheritdoc cref="ScopedTransactionsTestRunner.CreateTransactionScopeAndSetValue(string)"/>
         [Theory]

--- a/src/Orleans.Transactions.TestKit.xUnit/TOCGoldenPathTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TOCGoldenPathTestRunner.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         protected TocGoldenPathTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-        : base(grainFactory, output.WriteLine) { }
+        : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output))) { }
 
         /// <inheritdoc cref="TocGoldenPathTestRunner.MultiGrainWriteTransaction(string, int)"/>
         [Theory]

--- a/src/Orleans.Transactions.TestKit.xUnit/TestOutputHelperExtensions.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TestOutputHelperExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+using Xunit;
+
+namespace Orleans.Transactions.TestKit.xUnit;
+
+internal static class TestOutputHelperExtensions
+{
+    public static Action<string> GetWriteLine(ITestOutputHelper output, string paramName)
+    {
+        ArgumentNullException.ThrowIfNull(output, paramName);
+        return output.WriteLine;
+    }
+}

--- a/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         protected TocFaultTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-        : base(grainFactory, output.WriteLine) { }
+        : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output))) { }
 
         /// <inheritdoc cref="TocFaultTransactionTestRunner.MultiGrainWriteTransactionWithCommitFailure(string, int)"/>
         [Theory]

--- a/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs
@@ -12,7 +12,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="grainFactory">The grain factory used to access test grains.</param>
         /// <param name="output">The xUnit test output helper.</param>
         protected TransactionConcurrencyTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-        : base(grainFactory, output.WriteLine) { }
+        : base(grainFactory, TestOutputHelperExtensions.GetWriteLine(output, nameof(output))) { }
 
         /// <inheritdoc cref="TransactionConcurrencyTestRunner.SingleSharedGrainTest(string)"/>
         [Theory]

--- a/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TransactionRecoveryTestsRunner.cs
@@ -13,7 +13,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// <param name="cluster">The test cluster used to run recovery scenarios.</param>
         /// <param name="testOutput">The xUnit test output helper.</param>
         public TransactionRecoveryTestsRunnerxUnit(TestCluster cluster, ITestOutputHelper testOutput)
-            : base(cluster, testOutput.WriteLine)
+            : base(cluster, TestOutputHelperExtensions.GetWriteLine(testOutput, nameof(testOutput)))
         {
         }
 

--- a/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs
@@ -24,7 +24,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         public TransactionalStateStorageTestRunnerxUnit(Func<Task<ITransactionalStateStorage<TState>>> stateStorageFactory,
             Func<int, TState> stateFactory, IGrainFactory grainFactory, ITestOutputHelper testOutput,
             Func<EquivalencyOptions<TState>, EquivalencyOptions<TState>>? assertConfig = null)
-            : base(stateStorageFactory, stateFactory, grainFactory, testOutput.WriteLine, assertConfig)
+            : base(stateStorageFactory, stateFactory, grainFactory, TestOutputHelperExtensions.GetWriteLine(testOutput, nameof(testOutput)), assertConfig)
         {
         }
 

--- a/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
@@ -1,3 +1,4 @@
+using System;
 using Google.Protobuf;
 using Orleans.Serialization.Cloning;
 
@@ -12,6 +13,13 @@ public sealed class ByteStringCopier : IDeepCopier<ByteString>
     /// <inheritdoc/>
     public ByteString DeepCopy(ByteString input, CopyContext context)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (input is null)
+        {
+            return null!;
+        }
+
         if (context.TryGetCopy<ByteString>(input, out var result))
         {
             return result!;

--- a/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ByteStringCopier.cs
@@ -13,7 +13,7 @@ public sealed class ByteStringCopier : IDeepCopier<ByteString>
     /// <inheritdoc/>
     public ByteString DeepCopy(ByteString input, CopyContext context)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        if (context is null) throw new ArgumentNullException(nameof(context));
 
         if (input is null)
         {

--- a/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCodec.cs
@@ -38,6 +38,7 @@ public sealed class MapFieldCodec<TKey, TValue> : IFieldCodec<MapField<TKey, TVa
     }
 
     /// <inheritdoc/>
+    [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ReferenceCodec handles null serialized values before the MapField is accessed.")]
     public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [AllowNull] Type expectedType, [AllowNull] MapField<TKey, TValue> value) where TBufferWriter : IBufferWriter<byte>
     {
         if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))

--- a/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
@@ -1,3 +1,4 @@
+using System;
 using Google.Protobuf.Collections;
 using Orleans.Serialization.Cloning;
 
@@ -28,6 +29,13 @@ public sealed class MapFieldCopier<TKey, TValue> : IDeepCopier<MapField<TKey, TV
     /// <inheritdoc/>
     public MapField<TKey, TValue> DeepCopy(MapField<TKey, TValue> input, CopyContext context)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (input is null)
+        {
+            return null!;
+        }
+
         if (context.TryGetCopy<MapField<TKey, TValue>>(input, out var result))
         {
             return result!;
@@ -51,6 +59,10 @@ public sealed class MapFieldCopier<TKey, TValue> : IDeepCopier<MapField<TKey, TV
     /// <inheritdoc/>
     public void DeepCopy(MapField<TKey, TValue> input, MapField<TKey, TValue> output, CopyContext context)
     {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(context);
+
         foreach (var pair in input)
         {
             output[_keyCopier.DeepCopy(pair.Key, context)] = _valueCopier.DeepCopy(pair.Value, context);

--- a/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCopier.cs
@@ -29,7 +29,7 @@ public sealed class MapFieldCopier<TKey, TValue> : IDeepCopier<MapField<TKey, TV
     /// <inheritdoc/>
     public MapField<TKey, TValue> DeepCopy(MapField<TKey, TValue> input, CopyContext context)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        if (context is null) throw new ArgumentNullException(nameof(context));
 
         if (input is null)
         {
@@ -59,9 +59,9 @@ public sealed class MapFieldCopier<TKey, TValue> : IDeepCopier<MapField<TKey, TV
     /// <inheritdoc/>
     public void DeepCopy(MapField<TKey, TValue> input, MapField<TKey, TValue> output, CopyContext context)
     {
-        ArgumentNullException.ThrowIfNull(input);
-        ArgumentNullException.ThrowIfNull(output);
-        ArgumentNullException.ThrowIfNull(context);
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (context is null) throw new ArgumentNullException(nameof(context));
 
         foreach (var pair in input)
         {

--- a/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
@@ -43,6 +43,9 @@ public sealed class ProtobufCodec : IGeneralizedCodec, IGeneralizedCopier, IType
         IEnumerable<ICodecSelector> serializableTypeSelectors,
         IEnumerable<ICopierSelector> copyableTypeSelectors)
     {
+        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
+        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
+
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
     }
@@ -51,6 +54,8 @@ public sealed class ProtobufCodec : IGeneralizedCodec, IGeneralizedCopier, IType
     [return: NotNullIfNotNull(nameof(input))]
     public object? DeepCopy(object? input, CopyContext context)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         if (!context.TryGetCopy(input!, out object? result))
         {
             if (input is not IMessage protobufMessage)

--- a/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
@@ -43,8 +43,8 @@ public sealed class ProtobufCodec : IGeneralizedCodec, IGeneralizedCopier, IType
         IEnumerable<ICodecSelector> serializableTypeSelectors,
         IEnumerable<ICopierSelector> copyableTypeSelectors)
     {
-        ArgumentNullException.ThrowIfNull(serializableTypeSelectors);
-        ArgumentNullException.ThrowIfNull(copyableTypeSelectors);
+        if (serializableTypeSelectors is null) throw new ArgumentNullException(nameof(serializableTypeSelectors));
+        if (copyableTypeSelectors is null) throw new ArgumentNullException(nameof(copyableTypeSelectors));
 
         _serializableTypeSelectors = serializableTypeSelectors.Where(t => string.Equals(t.CodecName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
         _copyableTypeSelectors = copyableTypeSelectors.Where(t => string.Equals(t.CopierName, WellKnownAlias, StringComparison.Ordinal)).ToArray();
@@ -54,7 +54,7 @@ public sealed class ProtobufCodec : IGeneralizedCodec, IGeneralizedCopier, IType
     [return: NotNullIfNotNull(nameof(input))]
     public object? DeepCopy(object? input, CopyContext context)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        if (context is null) throw new ArgumentNullException(nameof(context));
 
         if (!context.TryGetCopy(input!, out object? result))
         {

--- a/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCodec.cs
@@ -32,6 +32,7 @@ public sealed class RepeatedFieldCodec<T> : IFieldCodec<RepeatedField<T>>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ReferenceCodec handles null serialized values before the RepeatedField is accessed.")]
     public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [AllowNull] Type expectedType, [AllowNull] RepeatedField<T> value) where TBufferWriter : IBufferWriter<byte>
     {
         if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))

--- a/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCopier.cs
@@ -25,7 +25,7 @@ public sealed class RepeatedFieldCopier<T> : IDeepCopier<RepeatedField<T>>, IBas
     /// <inheritdoc/>
     public RepeatedField<T> DeepCopy(RepeatedField<T> input, CopyContext context)
     {
-        ArgumentNullException.ThrowIfNull(context);
+        if (context is null) throw new ArgumentNullException(nameof(context));
 
         if (input is null)
         {
@@ -55,9 +55,9 @@ public sealed class RepeatedFieldCopier<T> : IDeepCopier<RepeatedField<T>>, IBas
     /// <inheritdoc/>
     public void DeepCopy(RepeatedField<T> input, RepeatedField<T> output, CopyContext context)
     {
-        ArgumentNullException.ThrowIfNull(input);
-        ArgumentNullException.ThrowIfNull(output);
-        ArgumentNullException.ThrowIfNull(context);
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+        if (context is null) throw new ArgumentNullException(nameof(context));
 
         foreach (var item in input)
         {

--- a/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCopier.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCopier.cs
@@ -1,3 +1,4 @@
+using System;
 using Google.Protobuf.Collections;
 using Orleans.Serialization.Cloning;
 
@@ -24,6 +25,13 @@ public sealed class RepeatedFieldCopier<T> : IDeepCopier<RepeatedField<T>>, IBas
     /// <inheritdoc/>
     public RepeatedField<T> DeepCopy(RepeatedField<T> input, CopyContext context)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (input is null)
+        {
+            return null!;
+        }
+
         if (context.TryGetCopy<RepeatedField<T>>(input, out var result))
         {
             return result!;
@@ -47,6 +55,10 @@ public sealed class RepeatedFieldCopier<T> : IDeepCopier<RepeatedField<T>>, IBas
     /// <inheritdoc/>
     public void DeepCopy(RepeatedField<T> input, RepeatedField<T> output, CopyContext context)
     {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(context);
+
         foreach (var item in input)
         {
             output.Add(_copier.DeepCopy(item, context));

--- a/src/Serializers/Orleans.Serialization.Protobuf/SerializationHostingExtensions.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/SerializationHostingExtensions.cs
@@ -35,9 +35,9 @@ public static class SerializationHostingExtensions
         Func<Type, bool> isSerializable,
         Func<Type, bool> isCopyable)
     {
-        ArgumentNullException.ThrowIfNull(serializerBuilder);
-        ArgumentNullException.ThrowIfNull(isSerializable);
-        ArgumentNullException.ThrowIfNull(isCopyable);
+        if (serializerBuilder is null) throw new ArgumentNullException(nameof(serializerBuilder));
+        if (isSerializable is null) throw new ArgumentNullException(nameof(isSerializable));
+        if (isCopyable is null) throw new ArgumentNullException(nameof(isCopyable));
 
         var services = serializerBuilder.Services;
 

--- a/src/Serializers/Orleans.Serialization.Protobuf/SerializationHostingExtensions.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/SerializationHostingExtensions.cs
@@ -35,6 +35,10 @@ public static class SerializationHostingExtensions
         Func<Type, bool> isSerializable,
         Func<Type, bool> isCopyable)
     {
+        ArgumentNullException.ThrowIfNull(serializerBuilder);
+        ArgumentNullException.ThrowIfNull(isSerializable);
+        ArgumentNullException.ThrowIfNull(isCopyable);
+
         var services = serializerBuilder.Services;
 
         if (isSerializable != null)

--- a/test/Orleans.BroadcastChannel.Tests/BroadcastChannelArgumentValidationTests.cs
+++ b/test/Orleans.BroadcastChannel.Tests/BroadcastChannelArgumentValidationTests.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.BroadcastChannel;
+using Orleans.Hosting;
+using Orleans.Metadata;
+using Orleans.Runtime;
+using Xunit;
+
+namespace UnitTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+[TestCategory("BVT"), TestCategory("BroadcastChannel")]
+public class BroadcastChannelArgumentValidationTests
+{
+    private const string ProviderName = "phase-one-provider";
+    private const string OtherProviderName = "other-provider";
+
+    [Fact]
+    public void Create_NullKey_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => ChannelId.Create("namespace", key: null!));
+
+        Assert.Equal("key", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("namespace", "namespace/key")]
+    [InlineData(null, "null/key")]
+    public void Create_ValidStringKey_PreservesIdentityEqualityHashAndFormatting(string? channelNamespace, string expectedFormatting)
+    {
+        var channelId = ChannelId.Create(channelNamespace!, "key");
+        var equivalent = ChannelId.Create(channelNamespace!, "key");
+
+        Assert.Equal("key", channelId.GetKeyAsString());
+        Assert.Equal(channelNamespace, channelId.GetNamespace());
+        Assert.Equal(equivalent, channelId);
+        Assert.True(channelId == equivalent);
+        Assert.False(channelId != equivalent);
+        Assert.Equal(equivalent.GetHashCode(), channelId.GetHashCode());
+        Assert.Equal(expectedFormatting, channelId.ToString());
+    }
+
+    [Fact]
+    public void GetObjectData_NullInfo_ThrowsWithExactParamName()
+    {
+        var channelId = ChannelId.Create("namespace", "key");
+
+        var exception = Assert.Throws<ArgumentNullException>(() => channelId.GetObjectData(null!, default));
+
+        Assert.Equal("info", exception.ParamName);
+    }
+
+    [Fact]
+    public void DefaultPredicateProvider_NullPattern_ThrowsWithoutAssigningOutPredicate()
+    {
+        var provider = new DefaultChannelNamespacePredicateProvider();
+        var sentinel = new SentinelPredicate();
+        IChannelNamespacePredicate? predicate = sentinel;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => provider.TryGetPredicate(null!, out predicate));
+
+        Assert.Equal("predicatePattern", exception.ParamName);
+        Assert.Same(sentinel, predicate);
+    }
+
+    [Fact]
+    public void ConstructorPredicateProvider_NullPattern_ThrowsWithoutAssigningOutPredicate()
+    {
+        var provider = new ConstructorChannelNamespacePredicateProvider();
+        var sentinel = new SentinelPredicate();
+        IChannelNamespacePredicate? predicate = sentinel;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => provider.TryGetPredicate(null!, out predicate));
+
+        Assert.Equal("predicatePattern", exception.ParamName);
+        Assert.Same(sentinel, predicate);
+    }
+
+    [Fact]
+    public void GetGrainKeyId_NullGrainBindings_ThrowsBeforeReadingChannelId()
+    {
+        var mapper = new DefaultChannelIdMapper();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => mapper.GetGrainKeyId(null!, default));
+
+        Assert.Equal("grainBindings", exception.ParamName);
+    }
+
+    [Fact]
+    public void GetGrainKeyId_EmptyBindings_ReturnsChannelKey()
+    {
+        var mapper = new DefaultChannelIdMapper();
+        var bindings = new GrainBindings(default, ImmutableArray<ImmutableDictionary<string, string>>.Empty);
+        var channelId = ChannelId.Create("orders", "customer-42");
+
+        var result = mapper.GetGrainKeyId(bindings, channelId);
+
+        Assert.Equal(IdSpan.Create("customer-42"), result);
+        Assert.Equal("customer-42", result.ToString());
+    }
+
+    [Fact]
+    public void ImplicitSubscriptionAttribute_NullNamespace_ThrowsBeforeTrimOrAssignment()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new ImplicitChannelSubscriptionAttribute((string)null!));
+
+        Assert.Equal("streamNamespace", exception.ParamName);
+    }
+
+    [Fact]
+    public void ImplicitSubscriptionAttribute_ValidNamespace_TrimsAndCreatesExactMatchPredicate()
+    {
+        var attribute = new ImplicitChannelSubscriptionAttribute("  orders  ");
+
+        Assert.Equal("namespace:orders", attribute.Predicate.PredicatePattern);
+        Assert.True(attribute.Predicate.IsMatch("orders"));
+        Assert.True(attribute.Predicate.IsMatch("  orders  "));
+        Assert.False(attribute.Predicate.IsMatch("orders-priority"));
+        Assert.Null(attribute.ChannelIdMapper);
+    }
+
+    [Theory]
+    [InlineData(BuilderKind.Client, OptionsOverload.OptionsAction)]
+    [InlineData(BuilderKind.Client, OptionsOverload.OptionsBuilderAction)]
+    [InlineData(BuilderKind.Silo, OptionsOverload.OptionsAction)]
+    [InlineData(BuilderKind.Silo, OptionsOverload.OptionsBuilderAction)]
+    public void AddBroadcastChannel_NullBuilder_ThrowsWithExactParamName(
+        BuilderKind builderKind,
+        OptionsOverload optionsOverload)
+    {
+        var callbackCount = 0;
+        Action<BroadcastChannelOptions> optionsAction = _ => callbackCount++;
+        Action<OptionsBuilder<BroadcastChannelOptions>> optionsBuilderAction = _ => callbackCount++;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => AddBroadcastChannel(
+                builder: null,
+                builderKind,
+                optionsOverload,
+                ProviderName,
+                optionsAction,
+                optionsBuilderAction));
+
+        Assert.Equal("this", exception.ParamName);
+        Assert.Equal(0, callbackCount);
+    }
+
+    [Theory]
+    [InlineData(BuilderKind.Client, OptionsOverload.OptionsAction)]
+    [InlineData(BuilderKind.Client, OptionsOverload.OptionsBuilderAction)]
+    [InlineData(BuilderKind.Silo, OptionsOverload.OptionsAction)]
+    [InlineData(BuilderKind.Silo, OptionsOverload.OptionsBuilderAction)]
+    public void AddBroadcastChannel_NullName_ThrowsBeforeCallbackOrServiceMutation(
+        BuilderKind builderKind,
+        OptionsOverload optionsOverload)
+    {
+        var builder = CreateBuilder(builderKind);
+        var services = GetServices(builder, builderKind);
+        var initialServiceCount = services.Count;
+        var callbackCount = 0;
+        Action<BroadcastChannelOptions> optionsAction = _ => callbackCount++;
+        Action<OptionsBuilder<BroadcastChannelOptions>> optionsBuilderAction = _ => callbackCount++;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => AddBroadcastChannel(
+                builder,
+                builderKind,
+                optionsOverload,
+                name: null!,
+                optionsAction,
+                optionsBuilderAction));
+
+        Assert.Equal("name", exception.ParamName);
+        Assert.Equal(0, callbackCount);
+        Assert.Equal(initialServiceCount, services.Count);
+    }
+
+    [Theory]
+    [InlineData(BuilderKind.Client)]
+    [InlineData(BuilderKind.Silo)]
+    public void AddBroadcastChannel_NullOptionsCallback_ThrowsBeforeServiceMutation(BuilderKind builderKind)
+    {
+        var builder = CreateBuilder(builderKind);
+        var services = GetServices(builder, builderKind);
+        var initialServiceCount = services.Count;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => AddBroadcastChannel(
+                builder,
+                builderKind,
+                OptionsOverload.OptionsAction,
+                ProviderName,
+                optionsAction: null,
+                optionsBuilderAction: null));
+
+        Assert.Equal("configureOptions", exception.ParamName);
+        Assert.Equal(initialServiceCount, services.Count);
+    }
+
+    [Theory]
+    [InlineData(BuilderKind.Client)]
+    [InlineData(BuilderKind.Silo)]
+    public void AddBroadcastChannel_NullOptionsBuilderCallback_RemainsOptional(BuilderKind builderKind)
+    {
+        var builder = CreateBuilder(builderKind);
+        var services = GetServices(builder, builderKind);
+
+        var result = AddBroadcastChannel(
+            builder,
+            builderKind,
+            OptionsOverload.OptionsBuilderAction,
+            ProviderName,
+            optionsAction: null,
+            optionsBuilderAction: null);
+
+        Assert.Same(builder, result);
+        AssertNamedProviderRegistration(services, ProviderName);
+        AssertNoNamedProviderRegistration(services, OtherProviderName);
+    }
+
+    [Theory]
+    [InlineData(BuilderKind.Client)]
+    [InlineData(BuilderKind.Silo)]
+    public void AddBroadcastChannel_OptionsAction_ConfiguresOnlyWhenNamedOptionsResolve(BuilderKind builderKind)
+    {
+        var builder = CreateBuilder(builderKind);
+        var services = GetServices(builder, builderKind);
+        var callbackCount = 0;
+
+        var result = AddBroadcastChannel(
+            builder,
+            builderKind,
+            OptionsOverload.OptionsAction,
+            ProviderName,
+            options =>
+            {
+                callbackCount++;
+                options.FireAndForgetDelivery = false;
+            },
+            optionsBuilderAction: null);
+
+        Assert.Same(builder, result);
+        Assert.Equal(0, callbackCount);
+        AssertNamedProviderRegistration(services, ProviderName);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<BroadcastChannelOptions>>();
+        var otherOptions = optionsMonitor.Get(OtherProviderName);
+        Assert.True(otherOptions.FireAndForgetDelivery);
+        Assert.Equal(0, callbackCount);
+
+        var namedOptions = optionsMonitor.Get(ProviderName);
+        Assert.False(namedOptions.FireAndForgetDelivery);
+        Assert.Equal(1, callbackCount);
+        Assert.Same(namedOptions, optionsMonitor.Get(ProviderName));
+        Assert.Equal(1, callbackCount);
+    }
+
+    [Theory]
+    [InlineData(BuilderKind.Client)]
+    [InlineData(BuilderKind.Silo)]
+    public void AddBroadcastChannel_OptionsBuilderAction_ConfiguresExpectedNamedRegistration(BuilderKind builderKind)
+    {
+        var builder = CreateBuilder(builderKind);
+        var services = GetServices(builder, builderKind);
+        var callbackCount = 0;
+        string? callbackName = null;
+
+        var result = AddBroadcastChannel(
+            builder,
+            builderKind,
+            OptionsOverload.OptionsBuilderAction,
+            ProviderName,
+            optionsAction: null,
+            optionsBuilder =>
+            {
+                callbackCount++;
+                callbackName = optionsBuilder.Name;
+                optionsBuilder.Configure(options => options.FireAndForgetDelivery = false);
+            });
+
+        Assert.Same(builder, result);
+        Assert.Equal(1, callbackCount);
+        Assert.Equal(ProviderName, callbackName);
+        AssertNamedProviderRegistration(services, ProviderName);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<BroadcastChannelOptions>>();
+        Assert.True(optionsMonitor.Get(OtherProviderName).FireAndForgetDelivery);
+        Assert.False(optionsMonitor.Get(ProviderName).FireAndForgetDelivery);
+        Assert.Equal(1, callbackCount);
+    }
+
+    [Fact]
+    public void GetBroadcastChannelProvider_NullClient_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => ChannelHostingExtensions.GetBroadcastChannelProvider(null!, ProviderName));
+
+        Assert.Equal("this", exception.ParamName);
+    }
+
+    [Fact]
+    public void GetBroadcastChannelProvider_NullName_ThrowsWithExactParamName()
+    {
+        var client = DispatchProxy.Create<IClusterClient, ThrowingClusterClientProxy>();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => ChannelHostingExtensions.GetBroadcastChannelProvider(client, name: null!));
+
+        Assert.Equal("name", exception.ParamName);
+    }
+
+    private static object CreateBuilder(BuilderKind builderKind)
+        => builderKind switch
+        {
+            BuilderKind.Client => new TestClientBuilder(),
+            BuilderKind.Silo => new TestSiloBuilder(),
+            _ => throw new ArgumentOutOfRangeException(nameof(builderKind)),
+        };
+
+    private static IServiceCollection GetServices(object builder, BuilderKind builderKind)
+        => builderKind switch
+        {
+            BuilderKind.Client => ((IClientBuilder)builder).Services,
+            BuilderKind.Silo => ((ISiloBuilder)builder).Services,
+            _ => throw new ArgumentOutOfRangeException(nameof(builderKind)),
+        };
+
+    private static object AddBroadcastChannel(
+        object? builder,
+        BuilderKind builderKind,
+        OptionsOverload optionsOverload,
+        string name,
+        Action<BroadcastChannelOptions>? optionsAction,
+        Action<OptionsBuilder<BroadcastChannelOptions>>? optionsBuilderAction)
+        => (builderKind, optionsOverload) switch
+        {
+            (BuilderKind.Client, OptionsOverload.OptionsAction) => ChannelHostingExtensions.AddBroadcastChannel(
+                (IClientBuilder)builder!,
+                name,
+                optionsAction!),
+            (BuilderKind.Client, OptionsOverload.OptionsBuilderAction) => ChannelHostingExtensions.AddBroadcastChannel(
+                (IClientBuilder)builder!,
+                name,
+                optionsBuilderAction),
+            (BuilderKind.Silo, OptionsOverload.OptionsAction) => ChannelHostingExtensions.AddBroadcastChannel(
+                (ISiloBuilder)builder!,
+                name,
+                optionsAction!),
+            (BuilderKind.Silo, OptionsOverload.OptionsBuilderAction) => ChannelHostingExtensions.AddBroadcastChannel(
+                (ISiloBuilder)builder!,
+                name,
+                optionsBuilderAction),
+            _ => throw new ArgumentOutOfRangeException(nameof(optionsOverload)),
+        };
+
+    private static void AssertNamedProviderRegistration(IServiceCollection services, string name)
+    {
+        var registration = Assert.Single(
+            services,
+            descriptor => descriptor.IsKeyedService
+                && descriptor.ServiceType == typeof(IBroadcastChannelProvider)
+                && Equals(descriptor.ServiceKey, name));
+
+        Assert.Equal(name, registration.ServiceKey);
+        Assert.NotNull(registration.KeyedImplementationFactory);
+    }
+
+    private static void AssertNoNamedProviderRegistration(IServiceCollection services, string name)
+        => Assert.DoesNotContain(
+            services,
+            descriptor => descriptor.IsKeyedService
+                && descriptor.ServiceType == typeof(IBroadcastChannelProvider)
+                && Equals(descriptor.ServiceKey, name));
+
+    private sealed class SentinelPredicate : IChannelNamespacePredicate
+    {
+        public string PredicatePattern => "sentinel";
+
+        public bool IsMatch(string streamNamespace) => false;
+    }
+
+    private sealed class TestSiloBuilder : ISiloBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = new ConfigurationBuilder().Build();
+    }
+
+    private sealed class TestClientBuilder : IClientBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = new ConfigurationBuilder().Build();
+    }
+
+    private class ThrowingClusterClientProxy : DispatchProxy
+    {
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            => throw new InvalidOperationException($"Unexpected client invocation: {targetMethod?.Name}");
+    }
+
+    public enum BuilderKind
+    {
+        Client,
+        Silo,
+    }
+
+    public enum OptionsOverload
+    {
+        OptionsAction,
+        OptionsBuilderAction,
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/ProtobufNullAndCopierContractTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ProtobufNullAndCopierContractTests.cs
@@ -1,0 +1,424 @@
+using System;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Serializers;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Serialization")]
+public sealed class ProtobufNullAndCopierContractTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider = new ServiceCollection()
+        .AddSerializer(builder => builder.AddProtobufSerializer())
+        .BuildServiceProvider();
+
+    [Fact]
+    public void MapFieldCodec_NullPayload_RoundTripsAsNull()
+    {
+        var serializer = _serviceProvider.GetRequiredService<Serializer<MapField<string, int>>>();
+
+        var payload = serializer.SerializeToArray(null!);
+        var result = serializer.Deserialize(payload);
+
+        Assert.NotEmpty(payload);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void MapFieldCodec_ValidPayload_RoundTripsEntriesIntoIndependentCollection()
+    {
+        var serializer = _serviceProvider.GetRequiredService<Serializer<MapField<string, int>>>();
+        var input = new MapField<string, int>
+        {
+            ["first"] = 17,
+            ["second"] = -23,
+        };
+
+        var payload = serializer.SerializeToArray(input);
+        var result = serializer.Deserialize(payload);
+
+        Assert.NotEmpty(payload);
+        Assert.NotNull(result);
+        Assert.NotSame(input, result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(17, result["first"]);
+        Assert.Equal(-23, result["second"]);
+    }
+
+    [Fact]
+    public void RepeatedFieldCodec_NullPayload_RoundTripsAsNull()
+    {
+        var serializer = _serviceProvider.GetRequiredService<Serializer<RepeatedField<int>>>();
+
+        var payload = serializer.SerializeToArray(null!);
+        var result = serializer.Deserialize(payload);
+
+        Assert.NotEmpty(payload);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void RepeatedFieldCodec_ValidPayload_RoundTripsItemsInOrderIntoIndependentCollection()
+    {
+        var serializer = _serviceProvider.GetRequiredService<Serializer<RepeatedField<int>>>();
+        var input = new RepeatedField<int> { 17, -23, 41 };
+
+        var payload = serializer.SerializeToArray(input);
+        var result = serializer.Deserialize(payload);
+
+        Assert.NotEmpty(payload);
+        Assert.NotNull(result);
+        Assert.NotSame(input, result);
+        Assert.Equal([17, -23, 41], result);
+    }
+
+    [Fact]
+    public void ByteStringCopier_NullInputWithValidContext_ReturnsNull()
+    {
+        var sut = new ByteStringCopier();
+        using var context = GetCopyContext();
+
+        var result = sut.DeepCopy(null!, context);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ByteStringCopier_NullContext_ThrowsWithExactParamNameBeforeCopyingInput()
+    {
+        var input = ByteString.CopyFrom(1, 2, 3, 4);
+        var sut = new ByteStringCopier();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, null!));
+
+        Assert.Equal("context", exception.ParamName);
+        Assert.Equal(ByteString.CopyFrom(1, 2, 3, 4), input);
+    }
+
+    [Fact]
+    public void ByteStringCopier_ValidInput_CopiesContentAndReusesContextCopy()
+    {
+        var input = ByteString.CopyFrom(1, 2, 3, 4);
+        var sut = new ByteStringCopier();
+        using var context = GetCopyContext();
+
+        var result = sut.DeepCopy(input, context);
+        var repeatedResult = sut.DeepCopy(input, context);
+
+        Assert.Equal(input, result);
+        Assert.NotSame(input, result);
+        Assert.Same(result, repeatedResult);
+    }
+
+    [Fact]
+    public void MapFieldCopier_NullInputWithValidContext_ReturnsNullWithoutInvokingElementCopiers()
+    {
+        var keyCopier = new TrackingStringCopier("key:");
+        var valueCopier = new TrackingStringCopier("value:");
+        var sut = new MapFieldCopier<string, string>(keyCopier, valueCopier);
+        using var context = GetCopyContext();
+
+        var result = sut.DeepCopy(null!, context);
+
+        Assert.Null(result);
+        Assert.Equal(0, keyCopier.InvocationCount);
+        Assert.Equal(0, valueCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void MapFieldCopier_NullContext_ThrowsWithExactParamNameBeforeInvokingElementCopiers()
+    {
+        var keyCopier = new TrackingStringCopier("key:");
+        var valueCopier = new TrackingStringCopier("value:");
+        var sut = new MapFieldCopier<string, string>(keyCopier, valueCopier);
+        var input = new MapField<string, string> { ["alpha"] = "one" };
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, null!));
+
+        Assert.Equal("context", exception.ParamName);
+        Assert.Equal("one", input["alpha"]);
+        Assert.Equal(0, keyCopier.InvocationCount);
+        Assert.Equal(0, valueCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void MapFieldCopier_CopyIntoNullInput_ThrowsWithExactParamNameBeforeMutatingOutput()
+    {
+        var keyCopier = new TrackingStringCopier("key:");
+        var valueCopier = new TrackingStringCopier("value:");
+        var sut = new MapFieldCopier<string, string>(keyCopier, valueCopier);
+        var output = new MapField<string, string> { ["existing"] = "unchanged" };
+        using var context = GetCopyContext();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(null!, output, context));
+
+        Assert.Equal("input", exception.ParamName);
+        Assert.Single(output);
+        Assert.Equal("unchanged", output["existing"]);
+        Assert.Equal(0, keyCopier.InvocationCount);
+        Assert.Equal(0, valueCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void MapFieldCopier_CopyIntoNullOutput_ThrowsWithExactParamNameBeforeInvokingElementCopiers()
+    {
+        var keyCopier = new TrackingStringCopier("key:");
+        var valueCopier = new TrackingStringCopier("value:");
+        var sut = new MapFieldCopier<string, string>(keyCopier, valueCopier);
+        var input = new MapField<string, string> { ["alpha"] = "one" };
+        using var context = GetCopyContext();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, null!, context));
+
+        Assert.Equal("output", exception.ParamName);
+        Assert.Equal("one", input["alpha"]);
+        Assert.Equal(0, keyCopier.InvocationCount);
+        Assert.Equal(0, valueCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void MapFieldCopier_CopyIntoNullContext_ThrowsWithExactParamNameBeforeMutatingOutput()
+    {
+        var keyCopier = new TrackingStringCopier("key:");
+        var valueCopier = new TrackingStringCopier("value:");
+        var sut = new MapFieldCopier<string, string>(keyCopier, valueCopier);
+        var input = new MapField<string, string> { ["alpha"] = "one" };
+        var output = new MapField<string, string> { ["existing"] = "unchanged" };
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, output, null!));
+
+        Assert.Equal("context", exception.ParamName);
+        Assert.Single(output);
+        Assert.Equal("unchanged", output["existing"]);
+        Assert.Equal(0, keyCopier.InvocationCount);
+        Assert.Equal(0, valueCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void MapFieldCopier_ValidInput_DeepCopiesEntriesAndReusesContextCopy()
+    {
+        var keyCopier = new TrackingStringCopier("key:");
+        var valueCopier = new TrackingStringCopier("value:");
+        var sut = new MapFieldCopier<string, string>(keyCopier, valueCopier);
+        var input = new MapField<string, string>
+        {
+            ["alpha"] = "one",
+            ["beta"] = "two",
+        };
+        using var context = GetCopyContext();
+
+        var result = sut.DeepCopy(input, context);
+        var repeatedResult = sut.DeepCopy(input, context);
+
+        Assert.NotSame(input, result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("value:one", result["key:alpha"]);
+        Assert.Equal("value:two", result["key:beta"]);
+        Assert.Equal("one", input["alpha"]);
+        Assert.Equal(2, keyCopier.InvocationCount);
+        Assert.Equal(2, valueCopier.InvocationCount);
+        Assert.Same(result, repeatedResult);
+    }
+
+    [Fact]
+    public void MapFieldCopier_CopyIntoValidCollections_PreservesExistingEntriesAndCopiesNewEntries()
+    {
+        var keyCopier = new TrackingStringCopier("key:");
+        var valueCopier = new TrackingStringCopier("value:");
+        var sut = new MapFieldCopier<string, string>(keyCopier, valueCopier);
+        var input = new MapField<string, string>
+        {
+            ["alpha"] = "one",
+            ["beta"] = "two",
+        };
+        var output = new MapField<string, string> { ["existing"] = "unchanged" };
+        using var context = GetCopyContext();
+
+        sut.DeepCopy(input, output, context);
+
+        Assert.Equal(3, output.Count);
+        Assert.Equal("unchanged", output["existing"]);
+        Assert.Equal("value:one", output["key:alpha"]);
+        Assert.Equal("value:two", output["key:beta"]);
+        Assert.Equal(2, keyCopier.InvocationCount);
+        Assert.Equal(2, valueCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void RepeatedFieldCopier_NullInputWithValidContext_ReturnsNullWithoutInvokingElementCopier()
+    {
+        var elementCopier = new TrackingStringCopier("copy:");
+        var sut = new RepeatedFieldCopier<string>(elementCopier);
+        using var context = GetCopyContext();
+
+        var result = sut.DeepCopy(null!, context);
+
+        Assert.Null(result);
+        Assert.Equal(0, elementCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void RepeatedFieldCopier_NullContext_ThrowsWithExactParamNameBeforeInvokingElementCopier()
+    {
+        var elementCopier = new TrackingStringCopier("copy:");
+        var sut = new RepeatedFieldCopier<string>(elementCopier);
+        var input = new RepeatedField<string> { "alpha", "beta" };
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, null!));
+
+        Assert.Equal("context", exception.ParamName);
+        Assert.Equal(["alpha", "beta"], input);
+        Assert.Equal(0, elementCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void RepeatedFieldCopier_CopyIntoNullInput_ThrowsWithExactParamNameBeforeMutatingOutput()
+    {
+        var elementCopier = new TrackingStringCopier("copy:");
+        var sut = new RepeatedFieldCopier<string>(elementCopier);
+        var output = new RepeatedField<string> { "unchanged" };
+        using var context = GetCopyContext();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(null!, output, context));
+
+        Assert.Equal("input", exception.ParamName);
+        Assert.Equal(["unchanged"], output);
+        Assert.Equal(0, elementCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void RepeatedFieldCopier_CopyIntoNullOutput_ThrowsWithExactParamNameBeforeInvokingElementCopier()
+    {
+        var elementCopier = new TrackingStringCopier("copy:");
+        var sut = new RepeatedFieldCopier<string>(elementCopier);
+        var input = new RepeatedField<string> { "alpha", "beta" };
+        using var context = GetCopyContext();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, null!, context));
+
+        Assert.Equal("output", exception.ParamName);
+        Assert.Equal(["alpha", "beta"], input);
+        Assert.Equal(0, elementCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void RepeatedFieldCopier_CopyIntoNullContext_ThrowsWithExactParamNameBeforeMutatingOutput()
+    {
+        var elementCopier = new TrackingStringCopier("copy:");
+        var sut = new RepeatedFieldCopier<string>(elementCopier);
+        var input = new RepeatedField<string> { "alpha", "beta" };
+        var output = new RepeatedField<string> { "unchanged" };
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, output, null!));
+
+        Assert.Equal("context", exception.ParamName);
+        Assert.Equal(["unchanged"], output);
+        Assert.Equal(0, elementCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void RepeatedFieldCopier_ValidInput_DeepCopiesItemsAndReusesContextCopy()
+    {
+        var elementCopier = new TrackingStringCopier("copy:");
+        var sut = new RepeatedFieldCopier<string>(elementCopier);
+        var input = new RepeatedField<string> { "alpha", "beta" };
+        using var context = GetCopyContext();
+
+        var result = sut.DeepCopy(input, context);
+        var repeatedResult = sut.DeepCopy(input, context);
+
+        Assert.NotSame(input, result);
+        Assert.Equal(["copy:alpha", "copy:beta"], result);
+        Assert.Equal(["alpha", "beta"], input);
+        Assert.Equal(2, elementCopier.InvocationCount);
+        Assert.Same(result, repeatedResult);
+    }
+
+    [Fact]
+    public void RepeatedFieldCopier_CopyIntoValidCollections_PreservesExistingItemsAndAppendsCopies()
+    {
+        var elementCopier = new TrackingStringCopier("copy:");
+        var sut = new RepeatedFieldCopier<string>(elementCopier);
+        var input = new RepeatedField<string> { "alpha", "beta" };
+        var output = new RepeatedField<string> { "existing" };
+        using var context = GetCopyContext();
+
+        sut.DeepCopy(input, output, context);
+
+        Assert.Equal(["existing", "copy:alpha", "copy:beta"], output);
+        Assert.Equal(2, elementCopier.InvocationCount);
+    }
+
+    [Fact]
+    public void ProtobufCodec_NullInputWithValidContext_ReturnsNull()
+    {
+        var sut = _serviceProvider.GetRequiredService<ProtobufCodec>();
+        using var context = GetCopyContext();
+
+        var result = sut.DeepCopy(null, context);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ProtobufCodec_NullContext_ThrowsWithExactParamNameBeforeInspectingInput()
+    {
+        var sut = _serviceProvider.GetRequiredService<ProtobufCodec>();
+        var input = new MyProtobufClass
+        {
+            IntProperty = 17,
+            StringProperty = "unchanged",
+        };
+
+        var exception = Assert.Throws<ArgumentNullException>(() => sut.DeepCopy(input, null!));
+
+        Assert.Equal("context", exception.ParamName);
+        Assert.Equal(17, input.IntProperty);
+        Assert.Equal("unchanged", input.StringProperty);
+    }
+
+    [Fact]
+    public void ProtobufCodec_ValidInput_DeepCopiesMessageAndReusesContextCopy()
+    {
+        var sut = _serviceProvider.GetRequiredService<ProtobufCodec>();
+        var id = Guid.NewGuid().ToByteString();
+        var input = new MyProtobufClass
+        {
+            IntProperty = 17,
+            StringProperty = "payload",
+            SubClass = new MyProtobufClass.Types.SubClass { Id = id },
+        };
+        using var context = GetCopyContext();
+
+        var result = Assert.IsType<MyProtobufClass>(sut.DeepCopy(input, context));
+        var repeatedResult = sut.DeepCopy(input, context);
+
+        Assert.NotSame(input, result);
+        Assert.Equal(17, result.IntProperty);
+        Assert.Equal("payload", result.StringProperty);
+        Assert.NotSame(input.SubClass, result.SubClass);
+        Assert.Equal(id, result.SubClass.Id);
+        Assert.Same(result, repeatedResult);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    private CopyContext GetCopyContext()
+        => _serviceProvider.GetRequiredService<CopyContextPool>().GetContext();
+
+    private sealed class TrackingStringCopier(string prefix) : IDeepCopier<string>
+    {
+        public int InvocationCount { get; private set; }
+
+        public string DeepCopy(string input, CopyContext context)
+        {
+            InvocationCount++;
+            return prefix + input;
+        }
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/SerializerConstructorAndRegistrationTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializerConstructorAndRegistrationTests.cs
@@ -1,0 +1,614 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Configuration;
+using Orleans.Serialization.Serializers;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Serialization")]
+public sealed class SerializerConstructorAndRegistrationTests
+{
+    [Fact]
+    public void MessagePackCodec_NullSerializableSelectors_ThrowsWithExactParamNameBeforeUsingOtherDependencies()
+        => AssertOptionsCodecRejectsNullSerializableSelectors(
+            (serializable, copyable, options) => new MessagePackCodec(serializable, copyable, options),
+            new MessagePackCodecOptions());
+
+    [Fact]
+    public void MessagePackCodec_NullCopyableSelectors_ThrowsWithExactParamNameBeforeUsingOtherDependencies()
+        => AssertOptionsCodecRejectsNullCopyableSelectors(
+            (serializable, copyable, options) => new MessagePackCodec(serializable, copyable, options),
+            new MessagePackCodecOptions());
+
+    [Fact]
+    public void MessagePackCodec_NullOptions_ThrowsWithExactParamNameBeforeEnumeratingSelectors()
+        => AssertOptionsCodecRejectsNullOptions<MessagePackCodecOptions>(
+            (serializable, copyable, options) => new MessagePackCodec(serializable, copyable, options));
+
+    [Fact]
+    public void MessagePackCodec_ValidDependencies_RetainsSelectorAndOptionsSemantics()
+    {
+        var observations = new CodecConstructionObservations();
+        var options = new MessagePackCodecOptions
+        {
+            IsSerializableType = observations.IsSerializableByOptions,
+            IsCopyableType = observations.IsCopyableByOptions,
+        };
+
+        var codec = new MessagePackCodec(
+            observations.CreateCodecSelectors(MessagePackCodec.WellKnownAlias),
+            observations.CreateCopierSelectors(MessagePackCodec.WellKnownAlias),
+            Options.Create(options));
+
+        AssertValidOptionsCodecSemantics(codec, observations);
+    }
+
+    [Fact]
+    public void NewtonsoftJsonCodec_NullSerializableSelectors_ThrowsWithExactParamNameBeforeUsingOtherDependencies()
+        => AssertOptionsCodecRejectsNullSerializableSelectors(
+            (serializable, copyable, options) => new NewtonsoftJsonCodec(serializable, copyable, options),
+            new NewtonsoftJsonCodecOptions());
+
+    [Fact]
+    public void NewtonsoftJsonCodec_NullCopyableSelectors_ThrowsWithExactParamNameBeforeUsingOtherDependencies()
+        => AssertOptionsCodecRejectsNullCopyableSelectors(
+            (serializable, copyable, options) => new NewtonsoftJsonCodec(serializable, copyable, options),
+            new NewtonsoftJsonCodecOptions());
+
+    [Fact]
+    public void NewtonsoftJsonCodec_NullOptions_ThrowsWithExactParamNameBeforeEnumeratingSelectors()
+        => AssertOptionsCodecRejectsNullOptions<NewtonsoftJsonCodecOptions>(
+            (serializable, copyable, options) => new NewtonsoftJsonCodec(serializable, copyable, options));
+
+    [Fact]
+    public void NewtonsoftJsonCodec_ValidDependencies_RetainsSelectorAndOptionsSemantics()
+    {
+        var observations = new CodecConstructionObservations();
+        var options = new NewtonsoftJsonCodecOptions
+        {
+            IsSerializableType = observations.IsSerializableByOptions,
+            IsCopyableType = observations.IsCopyableByOptions,
+        };
+
+        var codec = new NewtonsoftJsonCodec(
+            observations.CreateCodecSelectors(NewtonsoftJsonCodec.WellKnownAlias),
+            observations.CreateCopierSelectors(NewtonsoftJsonCodec.WellKnownAlias),
+            Options.Create(options));
+
+        AssertValidOptionsCodecSemantics(codec, observations);
+    }
+
+    [Fact]
+    public void JsonCodec_NullSerializableSelectors_ThrowsWithExactParamNameBeforeUsingOtherDependencies()
+        => AssertOptionsCodecRejectsNullSerializableSelectors(
+            (serializable, copyable, options) => new JsonCodec(serializable, copyable, options),
+            new JsonCodecOptions());
+
+    [Fact]
+    public void JsonCodec_NullCopyableSelectors_ThrowsWithExactParamNameBeforeUsingOtherDependencies()
+        => AssertOptionsCodecRejectsNullCopyableSelectors(
+            (serializable, copyable, options) => new JsonCodec(serializable, copyable, options),
+            new JsonCodecOptions());
+
+    [Fact]
+    public void JsonCodec_NullOptions_ThrowsWithExactParamNameBeforeEnumeratingSelectors()
+        => AssertOptionsCodecRejectsNullOptions<JsonCodecOptions>(
+            (serializable, copyable, options) => new JsonCodec(serializable, copyable, options));
+
+    [Fact]
+    public void JsonCodec_ValidDependencies_RetainsSelectorAndOptionsSemantics()
+    {
+        var observations = new CodecConstructionObservations();
+        var options = new JsonCodecOptions
+        {
+            IsSerializableType = observations.IsSerializableByOptions,
+            IsCopyableType = observations.IsCopyableByOptions,
+        };
+
+        var codec = new JsonCodec(
+            observations.CreateCodecSelectors(JsonCodec.WellKnownAlias),
+            observations.CreateCopierSelectors(JsonCodec.WellKnownAlias),
+            Options.Create(options));
+
+        AssertValidOptionsCodecSemantics(codec, observations);
+    }
+
+    [Fact]
+    public void ProtobufCodec_NullSerializableSelectors_ThrowsWithExactParamNameBeforeEnumeratingCopyableSelectors()
+    {
+        var copyable = new TrackingEnumerable<ICopierSelector>([]);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new ProtobufCodec(null!, copyable));
+
+        Assert.Equal("serializableTypeSelectors", exception.ParamName);
+        Assert.Equal(0, copyable.EnumerationCount);
+    }
+
+    [Fact]
+    public void ProtobufCodec_NullCopyableSelectors_ThrowsWithExactParamNameBeforeEnumeratingSerializableSelectors()
+    {
+        var serializable = new TrackingEnumerable<ICodecSelector>([]);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new ProtobufCodec(serializable, null!));
+
+        Assert.Equal("copyableTypeSelectors", exception.ParamName);
+        Assert.Equal(0, serializable.EnumerationCount);
+    }
+
+    [Fact]
+    public void ProtobufCodec_ValidDependencies_RetainsSelectorSemantics()
+    {
+        var serializableCallbackCount = 0;
+        var copyableCallbackCount = 0;
+        var unrelatedCallbackCount = 0;
+        var codec = new ProtobufCodec(
+            [
+                new DelegateCodecSelector
+                {
+                    CodecName = "unrelated",
+                    IsSupportedTypeDelegate = _ =>
+                    {
+                        unrelatedCallbackCount++;
+                        return true;
+                    },
+                },
+                new DelegateCodecSelector
+                {
+                    CodecName = ProtobufCodec.WellKnownAlias,
+                    IsSupportedTypeDelegate = type =>
+                    {
+                        serializableCallbackCount++;
+                        return type == typeof(MyProtobufClass);
+                    },
+                },
+            ],
+            [
+                new DelegateCopierSelector
+                {
+                    CopierName = "unrelated",
+                    IsSupportedTypeDelegate = _ =>
+                    {
+                        unrelatedCallbackCount++;
+                        return true;
+                    },
+                },
+                new DelegateCopierSelector
+                {
+                    CopierName = ProtobufCodec.WellKnownAlias,
+                    IsSupportedTypeDelegate = type =>
+                    {
+                        copyableCallbackCount++;
+                        return type == typeof(MyProtobufClass);
+                    },
+                },
+            ]);
+
+        Assert.True(((IGeneralizedCodec)codec).IsSupportedType(typeof(MyProtobufClass)));
+        Assert.True(((IGeneralizedCopier)codec).IsSupportedType(typeof(MyProtobufClass)));
+        Assert.Equal(1, serializableCallbackCount);
+        Assert.Equal(1, copyableCallbackCount);
+        Assert.Equal(0, unrelatedCallbackCount);
+    }
+
+    [Fact]
+    public void AddMessagePackSerializer_NullBuilder_ThrowsBeforeInvokingCallbacks()
+    {
+        ISerializerBuilder builder = null!;
+        var callbacks = new RegistrationCallbackObservations();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.AddMessagePackSerializer(
+                callbacks.IsSerializable,
+                callbacks.IsCopyable,
+                _ => callbacks.ConfigureCount++));
+
+        Assert.Equal("serializerBuilder", exception.ParamName);
+        callbacks.AssertNotInvoked();
+    }
+
+    [Fact]
+    public void AddNewtonsoftJsonSerializer_NullBuilder_ThrowsBeforeInvokingCallbacks()
+    {
+        ISerializerBuilder builder = null!;
+        var callbacks = new RegistrationCallbackObservations();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.AddNewtonsoftJsonSerializer(
+                callbacks.IsSerializable,
+                callbacks.IsCopyable,
+                _ => callbacks.ConfigureCount++));
+
+        Assert.Equal("serializerBuilder", exception.ParamName);
+        callbacks.AssertNotInvoked();
+    }
+
+    [Fact]
+    public void AddJsonSerializer_NullBuilder_ThrowsBeforeInvokingCallbacks()
+    {
+        ISerializerBuilder builder = null!;
+        var callbacks = new RegistrationCallbackObservations();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.AddJsonSerializer(
+                callbacks.IsSerializable,
+                callbacks.IsCopyable,
+                _ => callbacks.ConfigureCount++));
+
+        Assert.Equal("serializerBuilder", exception.ParamName);
+        callbacks.AssertNotInvoked();
+    }
+
+    [Fact]
+    public void AddProtobufSerializer_NullBuilder_ThrowsBeforeInvokingSelectorCallbacks()
+    {
+        ISerializerBuilder builder = null!;
+        var callbacks = new RegistrationCallbackObservations();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.AddProtobufSerializer(callbacks.IsSerializable, callbacks.IsCopyable));
+
+        Assert.Equal("serializerBuilder", exception.ParamName);
+        callbacks.AssertSelectorsNotInvoked();
+    }
+
+    [Fact]
+    public void AddProtobufSerializer_NullSerializableSelector_ThrowsBeforeCallbacksOrServiceMutation()
+    {
+        var builder = CreateBuilder(out var services);
+        var callbacks = new RegistrationCallbackObservations();
+        var initialServiceCount = services.Count;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.AddProtobufSerializer(null!, callbacks.IsCopyable));
+
+        Assert.Equal("isSerializable", exception.ParamName);
+        callbacks.AssertSelectorsNotInvoked();
+        Assert.Equal(initialServiceCount, services.Count);
+    }
+
+    [Fact]
+    public void AddProtobufSerializer_NullCopyableSelector_ThrowsBeforeCallbacksOrServiceMutation()
+    {
+        var builder = CreateBuilder(out var services);
+        var callbacks = new RegistrationCallbackObservations();
+        var initialServiceCount = services.Count;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.AddProtobufSerializer(callbacks.IsSerializable, null!));
+
+        Assert.Equal("isCopyable", exception.ParamName);
+        callbacks.AssertSelectorsNotInvoked();
+        Assert.Equal(initialServiceCount, services.Count);
+    }
+
+    [Fact]
+    public void AddMessagePackSerializer_ValidInputs_RegistersCodecSelectorsOptionsAndAlias()
+    {
+        var builder = CreateBuilder(out var services);
+        var callbacks = new RegistrationCallbackObservations();
+
+        var result = builder.AddMessagePackSerializer(
+            callbacks.IsSerializable,
+            callbacks.IsCopyable,
+            optionsBuilder =>
+            {
+                callbacks.ConfigureCount++;
+                optionsBuilder.Configure(options => options.AllowDataContractAttributes = true);
+            });
+
+        Assert.Same(builder, result);
+        Assert.Equal(1, callbacks.ConfigureCount);
+        callbacks.AssertSelectorsNotInvoked();
+        AssertValidRegistration<MessagePackCodec>(services, MessagePackCodec.WellKnownAlias, callbacks);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        Assert.True(serviceProvider.GetRequiredService<IOptions<MessagePackCodecOptions>>().Value.AllowDataContractAttributes);
+    }
+
+    [Fact]
+    public void AddNewtonsoftJsonSerializer_ValidInputs_RegistersCodecSelectorsOptionsAndAlias()
+    {
+        var builder = CreateBuilder(out var services);
+        var callbacks = new RegistrationCallbackObservations();
+
+        var result = builder.AddNewtonsoftJsonSerializer(
+            callbacks.IsSerializable,
+            callbacks.IsCopyable,
+            optionsBuilder =>
+            {
+                callbacks.ConfigureCount++;
+                optionsBuilder.Configure(options => options.IsSerializableType = _ => true);
+            });
+
+        Assert.Same(builder, result);
+        Assert.Equal(1, callbacks.ConfigureCount);
+        callbacks.AssertSelectorsNotInvoked();
+        AssertValidRegistration<NewtonsoftJsonCodec>(services, NewtonsoftJsonCodec.WellKnownAlias, callbacks);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        Assert.True(serviceProvider.GetRequiredService<IOptions<NewtonsoftJsonCodecOptions>>().Value.IsSerializableType!(typeof(OptionsSelectedType)));
+    }
+
+    [Fact]
+    public void AddJsonSerializer_ValidInputs_RegistersCodecSelectorsOptionsAndAlias()
+    {
+        var builder = CreateBuilder(out var services);
+        var callbacks = new RegistrationCallbackObservations();
+
+        var result = builder.AddJsonSerializer(
+            callbacks.IsSerializable,
+            callbacks.IsCopyable,
+            optionsBuilder =>
+            {
+                callbacks.ConfigureCount++;
+                optionsBuilder.Configure(options => options.IsCopyableType = _ => true);
+            });
+
+        Assert.Same(builder, result);
+        Assert.Equal(1, callbacks.ConfigureCount);
+        callbacks.AssertSelectorsNotInvoked();
+        AssertValidRegistration<JsonCodec>(services, JsonCodec.WellKnownAlias, callbacks);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        Assert.True(serviceProvider.GetRequiredService<IOptions<JsonCodecOptions>>().Value.IsCopyableType!(typeof(OptionsSelectedType)));
+    }
+
+    [Fact]
+    public void AddProtobufSerializer_ValidInputs_RegistersCodecSelectorsAndAlias()
+    {
+        var builder = CreateBuilder(out var services);
+        var callbacks = new RegistrationCallbackObservations();
+
+        var result = builder.AddProtobufSerializer(callbacks.IsSerializable, callbacks.IsCopyable);
+
+        Assert.Same(builder, result);
+        callbacks.AssertSelectorsNotInvoked();
+        AssertValidRegistration<ProtobufCodec>(services, ProtobufCodec.WellKnownAlias, callbacks);
+    }
+
+    private static void AssertOptionsCodecRejectsNullSerializableSelectors<TOptions>(
+        Func<IEnumerable<ICodecSelector>, IEnumerable<ICopierSelector>, IOptions<TOptions>, object> factory,
+        TOptions validOptions)
+        where TOptions : class
+    {
+        var copyable = new TrackingEnumerable<ICopierSelector>([]);
+        var options = new TrackingOptions<TOptions>(validOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => factory(null!, copyable, options));
+
+        Assert.Equal("serializableTypeSelectors", exception.ParamName);
+        Assert.Equal(0, copyable.EnumerationCount);
+        Assert.Equal(0, options.ValueAccessCount);
+    }
+
+    private static void AssertOptionsCodecRejectsNullCopyableSelectors<TOptions>(
+        Func<IEnumerable<ICodecSelector>, IEnumerable<ICopierSelector>, IOptions<TOptions>, object> factory,
+        TOptions validOptions)
+        where TOptions : class
+    {
+        var serializable = new TrackingEnumerable<ICodecSelector>([]);
+        var options = new TrackingOptions<TOptions>(validOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => factory(serializable, null!, options));
+
+        Assert.Equal("copyableTypeSelectors", exception.ParamName);
+        Assert.Equal(0, serializable.EnumerationCount);
+        Assert.Equal(0, options.ValueAccessCount);
+    }
+
+    private static void AssertOptionsCodecRejectsNullOptions<TOptions>(
+        Func<IEnumerable<ICodecSelector>, IEnumerable<ICopierSelector>, IOptions<TOptions>, object> factory)
+        where TOptions : class
+    {
+        var serializable = new TrackingEnumerable<ICodecSelector>([]);
+        var copyable = new TrackingEnumerable<ICopierSelector>([]);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => factory(serializable, copyable, null!));
+
+        Assert.Equal("options", exception.ParamName);
+        Assert.Equal(0, serializable.EnumerationCount);
+        Assert.Equal(0, copyable.EnumerationCount);
+    }
+
+    private static void AssertValidOptionsCodecSemantics(
+        object codec,
+        CodecConstructionObservations observations)
+    {
+        Assert.True(((IGeneralizedCodec)codec).IsSupportedType(typeof(SelectorSelectedType)));
+        Assert.True(((IGeneralizedCopier)codec).IsSupportedType(typeof(SelectorSelectedType)));
+        Assert.True(((IGeneralizedCodec)codec).IsSupportedType(typeof(OptionsSelectedType)));
+        Assert.True(((IGeneralizedCopier)codec).IsSupportedType(typeof(OptionsSelectedType)));
+
+        Assert.Equal(2, observations.SerializableSelectorCount);
+        Assert.Equal(2, observations.CopyableSelectorCount);
+        Assert.Equal(1, observations.SerializableOptionsCount);
+        Assert.Equal(1, observations.CopyableOptionsCount);
+        Assert.Equal(0, observations.UnrelatedSelectorCount);
+    }
+
+    private static ISerializerBuilder CreateBuilder(out ServiceCollection services)
+    {
+        services = new ServiceCollection();
+        services.AddOptions();
+        return new TestSerializerBuilder(services);
+    }
+
+    private static void AssertValidRegistration<TCodec>(
+        ServiceCollection services,
+        string alias,
+        RegistrationCallbackObservations callbacks)
+    {
+        var codecRegistration = Assert.Single(services, service => service.ServiceType == typeof(TCodec));
+        Assert.Equal(ServiceLifetime.Singleton, codecRegistration.Lifetime);
+        Assert.Equal(typeof(TCodec), codecRegistration.ImplementationType);
+        Assert.Single(services, service => service.ServiceType == typeof(IGeneralizedCodec));
+        Assert.Single(services, service => service.ServiceType == typeof(IGeneralizedCopier));
+        Assert.Single(services, service => service.ServiceType == typeof(ITypeFilter));
+
+        var codecSelector = Assert.IsType<DelegateCodecSelector>(
+            Assert.Single(services, service => service.ServiceType == typeof(ICodecSelector)).ImplementationInstance);
+        var copierSelector = Assert.IsType<DelegateCopierSelector>(
+            Assert.Single(services, service => service.ServiceType == typeof(ICopierSelector)).ImplementationInstance);
+
+        Assert.Equal(alias, codecSelector.CodecName);
+        Assert.Equal(alias, copierSelector.CopierName);
+        Assert.True(codecSelector.IsSupportedType(typeof(RegistrationSelectedType)));
+        Assert.True(copierSelector.IsSupportedType(typeof(RegistrationSelectedType)));
+        Assert.Equal(1, callbacks.SerializableSelectorCount);
+        Assert.Equal(1, callbacks.CopyableSelectorCount);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var manifest = serviceProvider.GetRequiredService<IOptions<TypeManifestOptions>>().Value;
+        Assert.Equal(typeof(TCodec), manifest.WellKnownTypeAliases[alias]);
+    }
+
+    private sealed class TestSerializerBuilder(IServiceCollection services) : ISerializerBuilder
+    {
+        public IServiceCollection Services { get; } = services;
+    }
+
+    private sealed class TrackingEnumerable<T>(T[] values) : IEnumerable<T>
+    {
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            EnumerationCount++;
+            return ((IEnumerable<T>)values).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class TrackingOptions<T>(T value) : IOptions<T>
+        where T : class
+    {
+        public int ValueAccessCount { get; private set; }
+
+        public T Value
+        {
+            get
+            {
+                ValueAccessCount++;
+                return value;
+            }
+        }
+    }
+
+    private sealed class CodecConstructionObservations
+    {
+        public int SerializableSelectorCount { get; private set; }
+
+        public int CopyableSelectorCount { get; private set; }
+
+        public int SerializableOptionsCount { get; private set; }
+
+        public int CopyableOptionsCount { get; private set; }
+
+        public int UnrelatedSelectorCount { get; private set; }
+
+        public ICodecSelector[] CreateCodecSelectors(string alias) =>
+        [
+            new DelegateCodecSelector
+            {
+                CodecName = "unrelated",
+                IsSupportedTypeDelegate = _ =>
+                {
+                    UnrelatedSelectorCount++;
+                    return true;
+                },
+            },
+            new DelegateCodecSelector
+            {
+                CodecName = alias,
+                IsSupportedTypeDelegate = type =>
+                {
+                    SerializableSelectorCount++;
+                    return type == typeof(SelectorSelectedType);
+                },
+            },
+        ];
+
+        public ICopierSelector[] CreateCopierSelectors(string alias) =>
+        [
+            new DelegateCopierSelector
+            {
+                CopierName = "unrelated",
+                IsSupportedTypeDelegate = _ =>
+                {
+                    UnrelatedSelectorCount++;
+                    return true;
+                },
+            },
+            new DelegateCopierSelector
+            {
+                CopierName = alias,
+                IsSupportedTypeDelegate = type =>
+                {
+                    CopyableSelectorCount++;
+                    return type == typeof(SelectorSelectedType);
+                },
+            },
+        ];
+
+        public bool? IsSerializableByOptions(Type type)
+        {
+            SerializableOptionsCount++;
+            return type == typeof(OptionsSelectedType);
+        }
+
+        public bool? IsCopyableByOptions(Type type)
+        {
+            CopyableOptionsCount++;
+            return type == typeof(OptionsSelectedType);
+        }
+    }
+
+    private sealed class RegistrationCallbackObservations
+    {
+        public int SerializableSelectorCount { get; private set; }
+
+        public int CopyableSelectorCount { get; private set; }
+
+        public int ConfigureCount { get; set; }
+
+        public bool IsSerializable(Type type)
+        {
+            SerializableSelectorCount++;
+            return type == typeof(RegistrationSelectedType);
+        }
+
+        public bool IsCopyable(Type type)
+        {
+            CopyableSelectorCount++;
+            return type == typeof(RegistrationSelectedType);
+        }
+
+        public void AssertNotInvoked()
+        {
+            AssertSelectorsNotInvoked();
+            Assert.Equal(0, ConfigureCount);
+        }
+
+        public void AssertSelectorsNotInvoked()
+        {
+            Assert.Equal(0, SerializableSelectorCount);
+            Assert.Equal(0, CopyableSelectorCount);
+        }
+    }
+
+    private sealed class SelectorSelectedType;
+
+    private sealed class OptionsSelectedType;
+
+    private sealed class RegistrationSelectedType;
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TestOutputHelperExtensionsTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TestOutputHelperExtensionsTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+using Orleans.Transactions.TestKit.xUnit;
+using Xunit;
+
+namespace UnitTests.Transactions;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+public sealed class TestOutputHelperExtensionsTests
+{
+    [Fact]
+    public void GetWriteLine_NullOutput_ThrowsWithRequestedParameterName()
+    {
+        var helperType = typeof(ConsistencyTransactionTestRunnerxUnit).Assembly.GetType(
+            "Orleans.Transactions.TestKit.xUnit.TestOutputHelperExtensions",
+            throwOnError: true)!;
+        var method = helperType.GetMethod("GetWriteLine", BindingFlags.Public | BindingFlags.Static)!;
+
+        var exception = Assert.Throws<TargetInvocationException>(
+            () => method.Invoke(null, [null, "testOutput"]));
+
+        var argumentException = Assert.IsType<ArgumentNullException>(exception.InnerException);
+        Assert.Equal("testOutput", argumentException.ParamName);
+    }
+}


### PR DESCRIPTION
## Problem
The CA1062 rollout still left 58 unsuppressed findings across independent libraries and test-runner packages. Enabling them project-by-project would recreate scattered policy and make the repository configuration harder to reason about.

## Solution
Validate public caller-controlled inputs across BroadcastChannel, the MessagePack/Newtonsoft.Json/System.Text.Json/Protobuf/F# serialization adapters, and Transactions.TestKit.xUnit. Nullable serialized payload behavior remains supported; guards apply to required contexts, services, builders, options, collections, and test output dependencies. Four narrow codec suppressions document framework paths which handle null payloads before invoking the audited method.

CA1062 is enabled centrally in the root `.editorconfig` for the complete included project paths, including the physical Protobuf source path under `src/Serializers`. Consul is deferred as a whole project because both finding files are owned by active PRs, avoiding partial enablement.

## Rationale
The grouped rollout keeps static-analysis policy centralized and simple while preserving each library's existing null and serialization contracts. Complete-project boundaries ensure normal builds enforce the rule consistently without nested configuration or project-specific warning settings.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11160)