### PR TITLE
fix(analyzers): validate transaction test kit inputs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -682,7 +682,7 @@ dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 
 # CA1062: Validate arguments of public methods
-[src/{Orleans.BroadcastChannel,Orleans.Clustering.ZooKeeper,Orleans.Hosting.Kubernetes,Orleans.Persistence.Memory,Orleans.Persistence.TestKit,Orleans.Reminders.TestKit,Orleans.Serialization.FSharp,Orleans.Serialization.MessagePack,Orleans.Serialization.NewtonsoftJson,Orleans.Serialization.SystemTextJson,Orleans.Serialization.TestKit,Orleans.Transactions.TestKit.xUnit}/**.cs]
+[src/{Orleans.BroadcastChannel,Orleans.Clustering.ZooKeeper,Orleans.Hosting.Kubernetes,Orleans.Persistence.Memory,Orleans.Persistence.TestKit,Orleans.Reminders.TestKit,Orleans.Serialization.FSharp,Orleans.Serialization.MessagePack,Orleans.Serialization.NewtonsoftJson,Orleans.Serialization.SystemTextJson,Orleans.Serialization.TestKit,Orleans.Transactions.TestKit.Base,Orleans.Transactions.TestKit.xUnit}/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
 [src/Serializers/Orleans.Serialization.Protobuf/**.cs]

--- a/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestGrain.cs
@@ -53,6 +53,7 @@ namespace Orleans.Transactions.TestKit.Consistency
             ILoggerFactory loggerFactory
             )
         {
+            ArgumentNullException.ThrowIfNull(loggerFactory);
             this.data = data;
             this.logger = loggerFactory.CreateLogger(nameof(ConsistencyTestGrain) + ".graincall");
         }
@@ -64,6 +65,9 @@ namespace Orleans.Transactions.TestKit.Consistency
         /// <inheritdoc />
         public async Task<Observation[]> Run(ConsistencyTestOptions options, int depth, string stack, int maxgrain, DateTime stopAfter)
         {
+            ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(stack);
+
             if (random == null)
                 random = new Random(options.RandomSeed * options.NumGrains + MyNumber);
 

--- a/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Consistency/ConsistencyTestHarness.cs
@@ -161,6 +161,9 @@ namespace Orleans.Transactions.TestKit.Consistency
         /// <returns>A task which represents the transaction sequence.</returns>
         public async Task RunRandomTransactionSequence(int partition, int count, IGrainFactory grainFactory, Action<string> output)
         {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+            ArgumentNullException.ThrowIfNull(output);
+
             this.output = output;
             var localRandom = new Random(options.RandomSeed + partition);
 

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionAzureTableTransactionStateStorage.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionAzureTableTransactionStateStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
@@ -53,6 +54,8 @@ namespace Orleans.Transactions.TestKit
             long? abortAfter
         )
         {
+            ArgumentNullException.ThrowIfNull(metadata);
+
             var transactionIds = ControlledTransactionFaultInjectorExtensions.GetTransactionIds(
                 metadata,
                 statesToPrepare);
@@ -95,6 +98,7 @@ namespace Orleans.Transactions.TestKit
         }
 
         /// <inheritdoc />
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Orleans invokes transactional state storage factories with the current non-null grain context.")]
         public ITransactionalStateStorage<TState> Create<TState>(string stateName, IGrainContext context) where TState : class, new()
         {
             var azureStateStorage = this.factory.Create<TState>(stateName, context);

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionDynamoDBTransactionStateStorage.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionDynamoDBTransactionStateStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -55,6 +56,8 @@ public class FaultInjectionDynamoDBTransactionStateStorage<TState> : ITransactio
         long? abortAfter
     )
     {
+        ArgumentNullException.ThrowIfNull(metadata);
+
         var transactionIds = ControlledTransactionFaultInjectorExtensions.GetTransactionIds(
             metadata,
             statesToPrepare);
@@ -97,6 +100,7 @@ public class FaultInjectionDynamoDBTransactionStateStorageFactory : ITransaction
     }
 
     /// <inheritdoc />
+    [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Orleans invokes transactional state storage factories with the current non-null grain context.")]
     public ITransactionalStateStorage<TState> Create<TState>(string stateName, IGrainContext context) where TState : class, new()
     {
         var dynamodbStateStorage = this.factory.Create<TState>(stateName, context);

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionStateAttribute.cs
@@ -92,6 +92,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc />
         public Factory<IGrainContext, object> GetFactory(ParameterInfo parameter, FaultInjectionTransactionalStateAttribute attribute)
         {
+            ArgumentNullException.ThrowIfNull(parameter);
             IFaultInjectionTransactionalStateConfiguration config = attribute;
             // use generic type args to define collection type.
             MethodInfo genericCreate = create.MakeGenericMethod(parameter.ParameterType.GetGenericArguments());

--- a/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockCoordinatorGrain.cs
@@ -12,6 +12,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public async Task ReadThenWrite(ITransactionTestGrain grain, int value)
         {
+            ArgumentNullException.ThrowIfNull(grain);
             await grain.Get();
             await Task.Delay(TimeSpan.FromMilliseconds(100)); // add some delay to make concurrent txs interleave each other
             await grain.Add(value);
@@ -20,6 +21,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public async Task ReadThenWriteWithExclusiveLock(IExclusiveLockTransactionTestGrain grain, int value)
         {
+            ArgumentNullException.ThrowIfNull(grain);
             await grain.Get();
             await Task.Delay(TimeSpan.FromMilliseconds(100)); // add some delay to make concurrent txs interleave each other
             await grain.Add(value);

--- a/src/Orleans.Transactions.TestKit.Base/Grains/ITransactionAttributionGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ITransactionAttributionGrain.cs
@@ -109,6 +109,8 @@ namespace Orleans.Transactions.TestKit
         /// <exception cref="NotSupportedException"><paramref name="option"/> is not a supported transaction option.</exception>
         public static ITransactionAttributionGrain GetTransactionAttributionGrain(this IGrainFactory grainFactory, Guid id, TransactionOption? option = null)
         {
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
             if (!option.HasValue)
             {
                 return new NoAttributionGrain(grainFactory.GetGrain<INoAttributionGrain>(id));

--- a/src/Orleans.Transactions.TestKit.Base/Grains/MultiStateTransactionalBitArrayGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/MultiStateTransactionalBitArrayGrain.cs
@@ -25,6 +25,7 @@ namespace Orleans.Transactions.TestKit.Correctnesss
         /// <returns><see langword="true"/> when the packed values are equal; otherwise, <see langword="false"/>.</returns>
         protected bool Equals(BitArrayState other)
         {
+            ArgumentNullException.ThrowIfNull(other);
             if (ReferenceEquals(null, this.value)) return false;
             if (ReferenceEquals(null, other.value)) return false;
             if (this.value.Length != other.value.Length) return false;
@@ -82,6 +83,7 @@ namespace Orleans.Transactions.TestKit.Correctnesss
         /// <param name="other">The state to copy.</param>
         public BitArrayState(BitArrayState other)
         {
+            ArgumentNullException.ThrowIfNull(other);
             this.value = new int[other.value.Length];
             for (var i = 0; i < other.value.Length; i++)
             {
@@ -219,6 +221,10 @@ namespace Orleans.Transactions.TestKit.Correctnesss
         /// <returns>A new state containing the operation results.</returns>
         public static BitArrayState Apply(BitArrayState left, BitArrayState right, Func<int, int, int> op)
         {
+            ArgumentNullException.ThrowIfNull(left);
+            ArgumentNullException.ThrowIfNull(right);
+            ArgumentNullException.ThrowIfNull(op);
+
             var result = new BitArrayState(left.value.Length > right.value.Length ? left : right);
             var overlappingLength = Math.Min(left.value.Length, right.value.Length);
             var i = 0;

--- a/src/Orleans.Transactions.TestKit.Base/Grains/RemoteCommitService.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/RemoteCommitService.cs
@@ -127,6 +127,7 @@ namespace Orleans.Transactions.TestKit
         /// <returns><see langword="true"/> when the remote commit succeeds.</returns>
         public async Task<bool> Commit(Guid transactionId, IRemoteCommitService service)
         {
+            ArgumentNullException.ThrowIfNull(service);
             return await service.Pass(transactionId, this.Data);
         }
     }
@@ -161,6 +162,7 @@ namespace Orleans.Transactions.TestKit
         /// <returns><see langword="false"/> to reject the remote commit.</returns>
         public async Task<bool> Commit(Guid transactionId, IRemoteCommitService service)
         {
+            ArgumentNullException.ThrowIfNull(service);
             return await service.Fail(transactionId, this.Data);
         }
     }
@@ -195,6 +197,7 @@ namespace Orleans.Transactions.TestKit
         /// <returns>A task which always faults.</returns>
         public async Task<bool> Commit(Guid transactionId, IRemoteCommitService service)
         {
+            ArgumentNullException.ThrowIfNull(service);
             return await service.Throw(transactionId, this.Data);
         }
     }

--- a/src/Orleans.Transactions.TestKit.Base/Grains/TransactionAttributionGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/TransactionAttributionGrain.cs
@@ -13,6 +13,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task<List<string?>?[]> GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers)
         {
+            ArgumentNullException.ThrowIfNull(tiers);
             return AttributionGrain.GetNestedTransactionIds(tier, tiers);
         }
     }
@@ -25,6 +26,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task<List<string?>?[]> GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers)
         {
+            ArgumentNullException.ThrowIfNull(tiers);
             return AttributionGrain.GetNestedTransactionIds(tier, tiers);
         }
     }
@@ -37,6 +39,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task<List<string?>?[]> GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers)
         {
+            ArgumentNullException.ThrowIfNull(tiers);
             return AttributionGrain.GetNestedTransactionIds(tier, tiers);
         }
     }
@@ -49,6 +52,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task<List<string?>?[]> GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers)
         {
+            ArgumentNullException.ThrowIfNull(tiers);
             return AttributionGrain.GetNestedTransactionIds(tier, tiers);
         }
     }
@@ -61,6 +65,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task<List<string?>?[]> GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers)
         {
+            ArgumentNullException.ThrowIfNull(tiers);
             return AttributionGrain.GetNestedTransactionIds(tier, tiers);
         }
     }
@@ -73,6 +78,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task<List<string?>?[]> GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers)
         {
+            ArgumentNullException.ThrowIfNull(tiers);
             return AttributionGrain.GetNestedTransactionIds(tier, tiers);
         }
     }
@@ -85,6 +91,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task<List<string?>?[]> GetNestedTransactionIds(int tier, List<ITransactionAttributionGrain>[] tiers)
         {
+            ArgumentNullException.ThrowIfNull(tiers);
             return AttributionGrain.GetNestedTransactionIds(tier, tiers);
         }
     }

--- a/src/Orleans.Transactions.TestKit.Base/Grains/TransactionCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/TransactionCoordinatorGrain.cs
@@ -43,6 +43,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public async Task AddAndThrow(ITransactionTestGrain grain, int numberToAdd)
         {
+            ArgumentNullException.ThrowIfNull(grain);
             await grain.Add(numberToAdd);
             throw new Exception("This should abort the transaction");
         }
@@ -63,6 +64,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task MultiGrainAdd(ITransactionCommitterTestGrain committer, ITransactionCommitOperation<IRemoteCommitService> operation, List<ITransactionTestGrain> grains, int numberToAdd)
         {
+            ArgumentNullException.ThrowIfNull(committer);
             List<Task> tasks = new List<Task>();
             tasks.AddRange(grains.Select(g => g.Add(numberToAdd)));
             tasks.Add(committer.Commit(operation));
@@ -72,6 +74,7 @@ namespace Orleans.Transactions.TestKit
         /// <inheritdoc/>
         public Task UpdateViolated(ITransactionTestGrain grain, int numberToAdd)
         {
+            ArgumentNullException.ThrowIfNull(grain);
             return grain.Add(numberToAdd);
         }
 

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
@@ -108,7 +108,7 @@ namespace Orleans.Transactions.TestKit
         /// <param name="testCluster">The test cluster whose silos and grains are used by recovery scenarios.</param>
         /// <param name="testOutput">The callback used to write test output.</param>
         public TransactionRecoveryTestsRunner(TestCluster testCluster, Action<string> testOutput)
-            : base(testCluster.GrainFactory!, testOutput) // Transaction test clusters initialize a client.
+            : base(GetGrainFactory(testCluster), testOutput)
         {
             this.testCluster = testCluster;
             this.logger = this.testCluster.ServiceProvider.GetService<ILogger<TransactionRecoveryTestsRunner>>()!;
@@ -122,6 +122,12 @@ namespace Orleans.Transactions.TestKit
                 FailureDetectionSchedulingMargin).MaximumDuration;
             this.recoveryTimeout =
                 this.failureDetectionTimeout + TransactionalStateOptions.DefaultRemoteTransactionPingFrequency;
+        }
+
+        private static IGrainFactory GetGrainFactory(TestCluster testCluster)
+        {
+            ArgumentNullException.ThrowIfNull(testCluster);
+            return testCluster.GrainFactory!; // Transaction test clusters initialize a client.
         }
 
         /// <summary>

--- a/test/Transactions/Orleans.Transactions.Tests/BitArrayStateInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/BitArrayStateInputValidationTests.cs
@@ -144,6 +144,17 @@ public class BitArrayStateInputValidationTests
         Assert.True(source.Equals((object)copy));
         Assert.NotSame(source.Value, copy.Value);
 
+        copy.Set(2, false);
+
+        Assert.False(source.TypedEquals(copy));
+        Assert.False(source.Equals((object)copy));
+        Assert.Equal(originalSource, source.Value);
+
+        copy.Set(2, true);
+
+        Assert.True(source.TypedEquals(copy));
+        Assert.True(source.Equals((object)copy));
+
         copy.Set(64, true);
 
         Assert.Equal(originalSource, source.Value);
@@ -153,20 +164,26 @@ public class BitArrayStateInputValidationTests
     }
 
     [Theory]
-    [InlineData("^", 0b0110, 0b0101)]
-    [InlineData("|", 0b1110, 0b0101)]
-    [InlineData("&", 0b1000, 0)]
-    public void Apply_UnequalLengths_UsesMissingWordsAsZero(
+    [InlineData("^", false, 0b0110, 0b0101)]
+    [InlineData("|", false, 0b1110, 0b0101)]
+    [InlineData("&", false, 0b1000, 0)]
+    [InlineData("^", true, 0b0110, 0b0101)]
+    [InlineData("|", true, 0b1110, 0b0101)]
+    [InlineData("&", true, 0b1000, 0)]
+    public void Apply_UnequalLengthsInEitherOperand_UsesMissingWordsAsZero(
         string operation,
+        bool longerOnLeft,
         int expectedOverlappingWord,
         int expectedTrailingWord)
     {
-        var left = new BitArrayState();
-        left[0] = 0b1010;
-        var right = new BitArrayState();
-        right[0] = 0b1100;
-        right.Set(32, true);
-        right.Set(34, true);
+        var shorter = new BitArrayState();
+        shorter[0] = longerOnLeft ? 0b1100 : 0b1010;
+        var longer = new BitArrayState();
+        longer[0] = longerOnLeft ? 0b1010 : 0b1100;
+        longer.Set(32, true);
+        longer.Set(34, true);
+        var left = longerOnLeft ? longer : shorter;
+        var right = longerOnLeft ? shorter : longer;
         var originalLeft = left.Value.ToArray();
         var originalRight = right.Value.ToArray();
 

--- a/test/Transactions/Orleans.Transactions.Tests/BitArrayStateInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/BitArrayStateInputValidationTests.cs
@@ -1,0 +1,202 @@
+using Orleans.Transactions.TestKit.Correctnesss;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class BitArrayStateInputValidationTests
+{
+    [Fact]
+    public void Equals_TypedNull_ThrowsArgumentNullExceptionWithOtherParamName()
+    {
+        var state = new TestableBitArrayState();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => state.TypedEquals(null!));
+
+        Assert.Equal("other", exception.ParamName);
+        Assert.False(state.Equals((object?)null));
+    }
+
+    [Fact]
+    public void CopyConstructor_NullOther_ThrowsArgumentNullExceptionWithOtherParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new BitArrayState(null!));
+
+        Assert.Equal("other", exception.ParamName);
+    }
+
+    [Fact]
+    public void Apply_NullLeft_ThrowsWithLeftParamNameBeforeOtherValidationOrOperation()
+    {
+        var operationCallCount = 0;
+        var right = new BitArrayState();
+        right.Set(3, true);
+        right.Set(36, true);
+        var originalRight = right.Value.ToArray();
+
+        int Operation(int left, int rightValue)
+        {
+            operationCallCount++;
+            return left | rightValue;
+        }
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => BitArrayState.Apply(null!, right, Operation));
+        var allNullException = Assert.Throws<ArgumentNullException>(
+            () => BitArrayState.Apply(null!, null!, null!));
+
+        Assert.Equal("left", exception.ParamName);
+        Assert.Equal("left", allNullException.ParamName);
+        Assert.Equal(0, operationCallCount);
+        Assert.Equal(originalRight, right.Value);
+    }
+
+    [Fact]
+    public void Apply_NullRight_ThrowsWithRightParamNameBeforeOperation()
+    {
+        var operationCallCount = 0;
+        var left = new BitArrayState();
+        left.Set(7, true);
+        left.Set(39, true);
+        var originalLeft = left.Value.ToArray();
+
+        int Operation(int leftValue, int right)
+        {
+            operationCallCount++;
+            return leftValue | right;
+        }
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => BitArrayState.Apply(left, null!, Operation));
+        var nullOperationException = Assert.Throws<ArgumentNullException>(
+            () => BitArrayState.Apply(left, null!, null!));
+
+        Assert.Equal("right", exception.ParamName);
+        Assert.Equal("right", nullOperationException.ParamName);
+        Assert.Equal(0, operationCallCount);
+        Assert.Equal(originalLeft, left.Value);
+    }
+
+    [Fact]
+    public void Apply_NullOperation_ThrowsWithOpParamNameWithoutMutatingOperands()
+    {
+        var left = new BitArrayState();
+        left.Set(1, true);
+        left.Set(34, true);
+        var right = new BitArrayState();
+        right.Set(2, true);
+        right.Set(35, true);
+        var originalLeft = left.Value.ToArray();
+        var originalRight = right.Value.ToArray();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => BitArrayState.Apply(left, right, null!));
+
+        Assert.Equal("op", exception.ParamName);
+        Assert.Equal(originalLeft, left.Value);
+        Assert.Equal(originalRight, right.Value);
+    }
+
+    [Fact]
+    public void SetAndClear_UpdatesOnlyTheRequestedBit()
+    {
+        var state = new BitArrayState();
+
+        Assert.Equal(new[] { 0 }, state.Value);
+
+        state.Set(4, true);
+        Assert.Equal(new[] { 1 << 4 }, state.Value);
+
+        state.Set(5, true);
+        Assert.Equal(new[] { (1 << 4) | (1 << 5) }, state.Value);
+
+        state.Set(5, false);
+        Assert.Equal(new[] { 1 << 4 }, state.Value);
+    }
+
+    [Fact]
+    public void Set_BitBeyondThirtyTwo_GrowsAndPreservesExistingBits()
+    {
+        var state = new BitArrayState();
+
+        state.Set(31, true);
+        state.Set(32, true);
+
+        Assert.Equal(2, state.Length);
+        Assert.Equal(new[] { int.MinValue, 1 }, state.Value);
+    }
+
+    [Fact]
+    public void CopyConstructor_CreatesIndependentEquivalentCopy()
+    {
+        var source = new TestableBitArrayState();
+        source.Set(2, true);
+        source.Set(35, true);
+        var originalSource = source.Value.ToArray();
+
+        var copy = new TestableBitArrayState(source);
+
+        Assert.True(source.TypedEquals(copy));
+        Assert.True(source.Equals((object)copy));
+        Assert.NotSame(source.Value, copy.Value);
+
+        copy.Set(64, true);
+
+        Assert.Equal(originalSource, source.Value);
+        Assert.Equal(new[] { 1 << 2, 1 << 3, 1 }, copy.Value);
+        Assert.False(source.TypedEquals(copy));
+        Assert.False(source.Equals((object)copy));
+    }
+
+    [Theory]
+    [InlineData("^", 0b0110, 0b0101)]
+    [InlineData("|", 0b1110, 0b0101)]
+    [InlineData("&", 0b1000, 0)]
+    public void Apply_UnequalLengths_UsesMissingWordsAsZero(
+        string operation,
+        int expectedOverlappingWord,
+        int expectedTrailingWord)
+    {
+        var left = new BitArrayState();
+        left[0] = 0b1010;
+        var right = new BitArrayState();
+        right[0] = 0b1100;
+        right.Set(32, true);
+        right.Set(34, true);
+        var originalLeft = left.Value.ToArray();
+        var originalRight = right.Value.ToArray();
+
+        var result = operation switch
+        {
+            "^" => left ^ right,
+            "|" => left | right,
+            "&" => left & right,
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(new[] { expectedOverlappingWord, expectedTrailingWord }, result.Value);
+        Assert.Equal(originalLeft, left.Value);
+        Assert.Equal(originalRight, right.Value);
+        Assert.NotSame(left.Value, result.Value);
+        Assert.NotSame(right.Value, result.Value);
+    }
+
+    private sealed class TestableBitArrayState : BitArrayState
+    {
+        public TestableBitArrayState()
+        {
+        }
+
+        public TestableBitArrayState(BitArrayState other)
+            : base(other)
+        {
+        }
+
+        public bool TypedEquals(BitArrayState other) => base.Equals(other);
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestGrainInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestGrainInputValidationTests.cs
@@ -1,0 +1,149 @@
+using Microsoft.Extensions.Logging;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.TestKit.Consistency;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class ConsistencyTestGrainInputValidationTests
+{
+    [Fact]
+    public void Constructor_NullLoggerFactory_ThrowsWithLoggerFactoryParamNameBeforeCreateLogger()
+    {
+        var state = new RecordingTransactionalState();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new ConsistencyTestGrain(state, loggerFactory: null!));
+
+        Assert.Equal("loggerFactory", exception.ParamName);
+        Assert.Equal(0, state.InteractionCount);
+    }
+
+    [Fact]
+    public async Task Run_NullOptions_ThrowsWithOptionsParamNameBeforeRuntimeOrStateAccess()
+    {
+        var state = new RecordingTransactionalState();
+        var loggerFactory = new RecordingLoggerFactory();
+        var grain = new ConsistencyTestGrain(state, loggerFactory);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => grain.Run(
+                options: null!,
+                depth: 2,
+                stack: "(4,7)",
+                maxgrain: 13,
+                stopAfter: DateTime.MaxValue));
+
+        Assert.Equal("options", exception.ParamName);
+        Assert.Equal(0, state.InteractionCount);
+        Assert.Equal(0, loggerFactory.Logger.InteractionCount);
+        Assert.Equal(1, loggerFactory.CreateLoggerCallCount);
+        Assert.Equal("ConsistencyTestGrain.graincall", loggerFactory.LastCategoryName);
+    }
+
+    [Fact]
+    public async Task Run_NullStack_ThrowsWithStackParamNameBeforeRuntimeOrStateAccess()
+    {
+        var state = new RecordingTransactionalState();
+        var loggerFactory = new RecordingLoggerFactory();
+        var grain = new ConsistencyTestGrain(state, loggerFactory);
+        var options = new ConsistencyTestOptions
+        {
+            RandomSeed = 17,
+            NumGrains = 23,
+            MaxDepth = 4,
+            AvoidDeadlocks = true,
+            AvoidTimeouts = true,
+            ReadWrite = ReadWriteDetermination.PerGrain,
+            GrainOffset = 101,
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => grain.Run(
+                options,
+                depth: 1,
+                stack: null!,
+                maxgrain: 19,
+                stopAfter: DateTime.MaxValue));
+
+        Assert.Equal("stack", exception.ParamName);
+        Assert.Equal(0, state.InteractionCount);
+        Assert.Equal(0, loggerFactory.Logger.InteractionCount);
+        Assert.Equal(1, loggerFactory.CreateLoggerCallCount);
+        Assert.Equal("ConsistencyTestGrain.graincall", loggerFactory.LastCategoryName);
+    }
+
+    private sealed class RecordingTransactionalState : ITransactionalState<ConsistencyTestGrain.State>
+    {
+        public int InteractionCount { get; private set; }
+
+        public Task<TResult> PerformRead<TResult>(Func<ConsistencyTestGrain.State, TResult> readFunction)
+        {
+            InteractionCount++;
+            throw new InvalidOperationException("Transactional state must not be read.");
+        }
+
+        public Task<TResult> PerformUpdate<TResult>(Func<ConsistencyTestGrain.State, TResult> updateFunction)
+        {
+            InteractionCount++;
+            throw new InvalidOperationException("Transactional state must not be updated.");
+        }
+    }
+
+    private sealed class RecordingLoggerFactory : ILoggerFactory
+    {
+        public RecordingLogger Logger { get; } = new();
+
+        public int CreateLoggerCallCount { get; private set; }
+
+        public string? LastCategoryName { get; private set; }
+
+        public void AddProvider(ILoggerProvider provider) =>
+            throw new InvalidOperationException("A logger provider must not be added.");
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            CreateLoggerCallCount++;
+            LastCategoryName = categoryName;
+            return Logger;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public int InteractionCount { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            InteractionCount++;
+            throw new InvalidOperationException("A logging scope must not be created.");
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            InteractionCount++;
+            throw new InvalidOperationException("Logging must not be queried.");
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            InteractionCount++;
+            throw new InvalidOperationException("Logging must not occur.");
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestHarnessInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConsistencyTestHarnessInputValidationTests.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using Orleans.Transactions.TestKit.Consistency;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class ConsistencyTestHarnessInputValidationTests
+{
+    [Fact]
+    public async Task RunRandomTransactionSequence_NullGrainFactory_ThrowsBeforeOutputOrHistoryMutation()
+    {
+        var constructorFactory = CreateRecordingGrainFactory(out var constructorFactoryProxy);
+        var harness = CreateHarness(constructorFactory);
+        SeedValidHistory(harness);
+        var initialAbortedCount = harness.NumAborted;
+        var outputCallCount = 0;
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => harness.RunRandomTransactionSequence(
+                partition: 7,
+                count: 3,
+                grainFactory: null!,
+                output: _ => outputCallCount++));
+
+        Assert.Equal("grainFactory", exception.ParamName);
+        Assert.Equal(0, outputCallCount);
+        Assert.Equal(0, constructorFactoryProxy.CallCount);
+        AssertHistoryPreserved(harness, initialAbortedCount);
+
+        var secondConstructorFactory = CreateRecordingGrainFactory(out var secondConstructorFactoryProxy);
+        var secondHarness = CreateHarness(secondConstructorFactory);
+        SeedValidHistory(secondHarness);
+        initialAbortedCount = secondHarness.NumAborted;
+        exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => secondHarness.RunRandomTransactionSequence(
+                partition: 7,
+                count: 3,
+                grainFactory: null!,
+                output: null!));
+
+        Assert.Equal("grainFactory", exception.ParamName);
+        Assert.Equal(0, secondConstructorFactoryProxy.CallCount);
+        AssertHistoryPreserved(secondHarness, initialAbortedCount);
+    }
+
+    [Fact]
+    public async Task RunRandomTransactionSequence_NullOutput_ThrowsBeforeGetGrainOrHistoryMutation()
+    {
+        var grainFactory = CreateRecordingGrainFactory(out var grainFactoryProxy);
+        var harness = CreateHarness(grainFactory);
+        SeedValidHistory(harness);
+        var initialAbortedCount = harness.NumAborted;
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => harness.RunRandomTransactionSequence(
+                partition: 11,
+                count: 4,
+                grainFactory,
+                output: null!));
+
+        Assert.Equal("output", exception.ParamName);
+        Assert.Equal(0, grainFactoryProxy.CallCount);
+        AssertHistoryPreserved(harness, initialAbortedCount);
+    }
+
+    private static ConsistencyTestHarness CreateHarness(IGrainFactory grainFactory) =>
+        new(
+            grainFactory,
+            numGrains: 5,
+            seed: 29,
+            avoidDeadlocks: true,
+            avoidTimeouts: true,
+            readWrite: ReadWriteDetermination.PerGrain,
+            tolerateUnknownExceptions: false);
+
+    private static void SeedValidHistory(ConsistencyTestHarness harness)
+    {
+        harness.RecordSucceeded(
+            new Observation
+            {
+                Grain = 2,
+                SeqNo = 0,
+                WriterTx = ConsistencyTestHarness.InitialTx,
+                ExecutingTx = "existing-transaction",
+            });
+        harness.CheckConsistency();
+    }
+
+    private static void AssertHistoryPreserved(
+        ConsistencyTestHarness harness,
+        int expectedAbortedCount)
+    {
+        Assert.Equal(expectedAbortedCount, harness.NumAborted);
+        harness.RecordSucceeded(
+            new Observation
+            {
+                Grain = 2,
+                SeqNo = 1,
+                WriterTx = "continuing-transaction",
+                ExecutingTx = "continuing-transaction",
+            });
+        harness.CheckConsistency();
+    }
+
+    private static IGrainFactory CreateRecordingGrainFactory(out RecordingGrainFactory proxy)
+    {
+        var grainFactory = DispatchProxy.Create<IGrainFactory, RecordingGrainFactory>();
+        proxy = (RecordingGrainFactory)(object)grainFactory;
+        return grainFactory;
+    }
+
+    private class RecordingGrainFactory : DispatchProxy
+    {
+        public int CallCount { get; private set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            CallCount++;
+            throw new InvalidOperationException(
+                $"Grain factory method {targetMethod?.Name} must not be called.");
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/ExclusiveLockCoordinatorInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ExclusiveLockCoordinatorInputValidationTests.cs
@@ -1,0 +1,106 @@
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class ExclusiveLockCoordinatorInputValidationTests
+{
+    [Fact]
+    public async Task ReadThenWrite_NullGrain_ThrowsWithGrainParamNameBeforeGetOrAdd()
+    {
+        var coordinator = new ExclusiveLockCoordinatorGrain();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => coordinator.ReadThenWrite(null!, 43));
+
+        Assert.Equal("grain", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task ReadThenWriteWithExclusiveLock_NullGrain_ThrowsBeforeGetDelayOrAdd()
+    {
+        var coordinator = new ExclusiveLockCoordinatorGrain();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => coordinator.ReadThenWriteWithExclusiveLock(null!, 47));
+
+        Assert.Equal("grain", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(nameof(ExclusiveLockCoordinatorGrain.ReadThenWrite))]
+    [InlineData(nameof(ExclusiveLockCoordinatorGrain.ReadThenWriteWithExclusiveLock))]
+    public async Task ReadThenWriteMethods_ValidGrain_CallGetBeforeAddWithExactValue(
+        string method)
+    {
+        var events = new List<string>();
+        var grain = new RecordingTransactionTestGrain(events);
+        var coordinator = new ExclusiveLockCoordinatorGrain();
+
+        switch (method)
+        {
+            case nameof(ExclusiveLockCoordinatorGrain.ReadThenWrite):
+                await coordinator.ReadThenWrite(grain, 53);
+                break;
+            case nameof(ExclusiveLockCoordinatorGrain.ReadThenWriteWithExclusiveLock):
+                await coordinator.ReadThenWriteWithExclusiveLock(grain, 53);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(method), method, null);
+        }
+
+        Assert.Equal(new[] { "Get", "Add(53)" }, events);
+        Assert.Equal(1, grain.GetCallCount);
+        Assert.Equal(1, grain.AddCallCount);
+        Assert.Equal(53, grain.LastAddedValue);
+    }
+
+    private sealed class RecordingTransactionTestGrain :
+        ITransactionTestGrain,
+        IExclusiveLockTransactionTestGrain
+    {
+        private readonly List<string> events;
+
+        public RecordingTransactionTestGrain(List<string> events)
+        {
+            this.events = events;
+        }
+
+        public int GetCallCount { get; private set; }
+
+        public int AddCallCount { get; private set; }
+
+        public int LastAddedValue { get; private set; }
+
+        public Task<int[]> Get()
+        {
+            GetCallCount++;
+            events.Add("Get");
+            return Task.FromResult(new[] { 59 });
+        }
+
+        public Task<int[]> Add(int numberToAdd)
+        {
+            AddCallCount++;
+            LastAddedValue = numberToAdd;
+            events.Add($"Add({numberToAdd})");
+            return Task.FromResult(new[] { 59 + numberToAdd });
+        }
+
+        public Task Set(int newValue) => UnexpectedCall(nameof(Set));
+
+        public Task AddAndThrow(int numberToAdd) => UnexpectedCall(nameof(AddAndThrow));
+
+        public Task SetAndThrow(int numberToSet) => UnexpectedCall(nameof(SetAndThrow));
+
+        public Task Deactivate() => UnexpectedCall(nameof(Deactivate));
+
+        private static Task UnexpectedCall(string method) =>
+            Task.FromException(new InvalidOperationException($"Unexpected {method} call."));
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/FaultInjectionAzureTableTransactionStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/FaultInjectionAzureTableTransactionStateStorageTests.cs
@@ -1,0 +1,416 @@
+using Azure;
+using Azure.Core;
+using Azure.Data.Tables;
+using Azure.Data.Tables.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Orleans.Configuration;
+using Orleans.GrainReferences;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.AzureStorage;
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class FaultInjectionAzureTableTransactionStateStorageTests
+{
+    private const string ProviderName = "azure-faults";
+    private const string Partition = "test-partition";
+
+    [Fact]
+    public async Task Store_NullMetadata_ThrowsWithMetadataParamNameBeforeInjectorOrStorage()
+    {
+        var events = new List<string>();
+        var table = new RecordingTableClient(events);
+        var injector = new RecordingFaultInjector(events);
+        var storage = CreateStorage(table, injector);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => storage.Store(
+                expectedETag: "unobserved-etag",
+                metadata: null!,
+                statesToPrepare: null,
+                commitUpTo: null,
+                abortAfter: null));
+
+        Assert.Equal("metadata", exception.ParamName);
+        Assert.Empty(events);
+        Assert.Equal(0, table.QueryCallCount);
+        Assert.Empty(table.SubmittedTransactions);
+    }
+
+    [Fact]
+    public async Task Load_ForwardsFreshSnapshotWithoutInvokingInjector()
+    {
+        var events = new List<string>();
+        var table = new RecordingTableClient(events);
+        var injector = new RecordingFaultInjector(events);
+        var storage = CreateStorage(table, injector);
+
+        var result = await storage.Load();
+
+        Assert.Null(result.ETag);
+        Assert.Equal(0, result.CommittedSequenceId);
+        Assert.NotNull(result.CommittedState);
+        Assert.Empty(result.Metadata.CommitRecords);
+        Assert.Empty(result.PendingStates);
+        Assert.Equal(1, table.QueryCallCount);
+        Assert.Empty(events);
+        Assert.Empty(injector.BeforeTransactionIds);
+        Assert.Empty(injector.AfterTransactionIds);
+    }
+
+    [Fact]
+    public async Task Store_ValidMetadataAndETag_ForwardsStorageCallBetweenInjectorCallbacks()
+    {
+        var events = new List<string>();
+        var table = new RecordingTableClient(events);
+        var injector = new RecordingFaultInjector(events);
+        var storage = CreateStorage(table, injector);
+        var firstTransactionId = new Guid("26891220-BECA-48A2-89A6-950751110A20");
+        var secondTransactionId = new Guid("AB6A8FF5-5D3F-4A8E-B11E-2E302057CE5C");
+
+        var loaded = await storage.Load();
+        var firstMetadata = CreateMetadata(firstTransactionId, 101);
+        var firstETag = await storage.Store(
+            loaded.ETag,
+            firstMetadata,
+            statesToPrepare: null,
+            commitUpTo: null,
+            abortAfter: null);
+        var secondMetadata = CreateMetadata(secondTransactionId, 202);
+        var secondETag = await storage.Store(
+            firstETag,
+            secondMetadata,
+            statesToPrepare: null,
+            commitUpTo: null,
+            abortAfter: null);
+
+        Assert.Equal("etag-1", firstETag);
+        Assert.Equal("etag-2", secondETag);
+        Assert.Equal(
+            ["before", "storage", "after", "before", "storage", "after"],
+            events);
+        Assert.Collection(
+            injector.BeforeTransactionIds,
+            ids => Assert.Equal([firstTransactionId], ids),
+            ids => Assert.Equal([secondTransactionId], ids));
+        Assert.Collection(
+            injector.AfterTransactionIds,
+            ids => Assert.Equal([firstTransactionId], ids),
+            ids => Assert.Equal([secondTransactionId], ids));
+
+        Assert.Equal(2, table.SubmittedTransactions.Count);
+        var firstKey = Assert.Single(
+            table.SubmittedTransactions[0],
+            action => action.RowKey == "k");
+        Assert.Equal(TableTransactionActionType.Add, firstKey.ActionType);
+        Assert.Contains(firstTransactionId.ToString(), firstKey.Metadata);
+        Assert.Contains("101", firstKey.Metadata);
+
+        var secondKey = Assert.Single(
+            table.SubmittedTransactions[1],
+            action => action.RowKey == "k");
+        Assert.Equal(TableTransactionActionType.UpdateReplace, secondKey.ActionType);
+        Assert.Equal(firstETag, secondKey.ETag.ToString());
+        Assert.Contains(secondTransactionId.ToString(), secondKey.Metadata);
+        Assert.Contains("202", secondKey.Metadata);
+    }
+
+    [Fact]
+    public void FactoryCreate_RegisteredNamedOptions_ReturnsWrapperFactoryWithoutStorageAccess()
+    {
+        var table = new RecordingTableClient([]);
+        var tableService = new RecordingTableServiceClient(table);
+        using var services = CreateServices(options => options.TableServiceClient = tableService);
+
+        var result = FaultInjectionAzureTableTransactionStateStorageFactory.Create(
+            services,
+            ProviderName);
+
+        Assert.IsType<FaultInjectionAzureTableTransactionStateStorageFactory>(result);
+        Assert.Equal(0, tableService.GetTableClientCallCount);
+        Assert.Equal(0, table.CreateIfNotExistsCallCount);
+        Assert.Equal(0, table.QueryCallCount);
+        Assert.Empty(table.SubmittedTransactions);
+    }
+
+    [Fact]
+    public async Task Participate_CanceledStart_ForwardsCancellationTokenWithoutContactingStorage()
+    {
+        var table = new RecordingTableClient([]);
+        var tableService = new RecordingTableServiceClient(table);
+        using var services = CreateServices(options => options.TableServiceClient = tableService);
+        var inner = new AzureTableTransactionalStateStorageFactory(
+            ProviderName,
+            services.GetRequiredService<IOptionsMonitor<AzureTableTransactionalStateOptions>>().Get(ProviderName),
+            services.GetRequiredService<IOptions<ClusterOptions>>(),
+            services,
+            NullLoggerFactory.Instance);
+        var factory = new FaultInjectionAzureTableTransactionStateStorageFactory(inner);
+        var lifecycle = new RecordingSiloLifecycle();
+        factory.Participate(lifecycle);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => lifecycle.StartAsync(cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Equal(AzureTableTransactionalStateOptions.DEFAULT_INIT_STAGE, lifecycle.Stage);
+        Assert.Equal(1, tableService.GetTableClientCallCount);
+        Assert.Equal(1, table.CreateIfNotExistsCallCount);
+        Assert.Equal(cancellation.Token, table.CreateCancellationToken);
+        Assert.Equal(0, table.QueryCallCount);
+        Assert.Empty(table.SubmittedTransactions);
+    }
+
+    private static FaultInjectionAzureTableTransactionStateStorage<TestState> CreateStorage(
+        RecordingTableClient table,
+        ITransactionFaultInjector injector)
+    {
+        var inner = new AzureTableTransactionalStateStorage<TestState>(
+            table,
+            Partition,
+            new JsonSerializerSettings(),
+            NullLogger<AzureTableTransactionalStateStorage<TestState>>.Instance);
+        return new FaultInjectionAzureTableTransactionStateStorage<TestState>(injector, inner);
+    }
+
+    private static TransactionalStateMetaData CreateMetadata(Guid transactionId, long ticks) => new()
+    {
+        TimeStamp = new DateTime(ticks),
+        CommitRecords =
+        {
+            [transactionId] = new CommitRecord
+            {
+                Timestamp = new DateTime(ticks + 1),
+                WriteParticipants = [],
+            },
+        },
+    };
+
+    private static ServiceProvider CreateServices(
+        Action<AzureTableTransactionalStateOptions> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSerializer();
+        services.AddSingleton(
+            serviceProvider => new GrainReferenceActivator(
+                serviceProvider,
+                []));
+        services.Configure<ClusterOptions>(options => options.ServiceId = "service");
+        services.Configure<AzureTableTransactionalStateOptions>(ProviderName, configure);
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class RecordingFaultInjector(List<string> events)
+        : ITransactionFaultInjector, ITransactionScopedFaultInjector
+    {
+        public List<IReadOnlyList<Guid>> BeforeTransactionIds { get; } = [];
+
+        public List<IReadOnlyList<Guid>> AfterTransactionIds { get; } = [];
+
+        public void BeforeStore() => throw new InvalidOperationException(
+            "The transaction-scoped injector path was expected.");
+
+        public void AfterStore() => throw new InvalidOperationException(
+            "The transaction-scoped injector path was expected.");
+
+        public void Arm(
+            Guid transactionId,
+            FaultInjectionType injectionType,
+            bool requireTransactionMatch) =>
+            throw new NotSupportedException();
+
+        public void BeforeStore(System.Collections.Immutable.ImmutableArray<Guid> transactionIds)
+        {
+            BeforeTransactionIds.Add(transactionIds);
+            events.Add("before");
+        }
+
+        public void AfterStore(System.Collections.Immutable.ImmutableArray<Guid> transactionIds)
+        {
+            AfterTransactionIds.Add(transactionIds);
+            events.Add("after");
+        }
+    }
+
+    private sealed class RecordingTableServiceClient(RecordingTableClient table) : TableServiceClient
+    {
+        public int GetTableClientCallCount { get; private set; }
+
+        public override TableClient GetTableClient(string tableName)
+        {
+            GetTableClientCallCount++;
+            Assert.Equal("TransactionalState", tableName);
+            return table;
+        }
+    }
+
+    private sealed class RecordingTableClient(List<string> events) : TableClient
+    {
+        public override string Name => "transactional-state";
+
+        public int QueryCallCount { get; private set; }
+
+        public int CreateIfNotExistsCallCount { get; private set; }
+
+        public CancellationToken CreateCancellationToken { get; private set; }
+
+        public List<IReadOnlyList<SubmittedAction>> SubmittedTransactions { get; } = [];
+
+        public override AsyncPageable<T> QueryAsync<T>(
+            string? filter = null,
+            int? maxPerPage = null,
+            IEnumerable<string>? select = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            QueryCallCount++;
+            var page = Page<T>.FromValues([], null, new StubResponse(default));
+            return AsyncPageable<T>.FromPages([page]);
+        }
+
+        public override Task<Response<IReadOnlyList<Response>>> SubmitTransactionAsync(
+            IEnumerable<TableTransactionAction> transactionActions,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            events.Add("storage");
+            var etag = new ETag($"etag-{SubmittedTransactions.Count + 1}");
+            var actions = transactionActions
+                .Select(action => new SubmittedAction(
+                    action.ActionType,
+                    action.Entity.RowKey,
+                    action.ETag,
+                    action.Entity is TableEntity entity
+                        ? entity.GetString("Metadata") ?? string.Empty
+                        : action.Entity.GetType().GetProperty("Metadata")?.GetValue(action.Entity) as string
+                            ?? string.Empty))
+                .ToList();
+            SubmittedTransactions.Add(actions);
+            IReadOnlyList<Response> responses = actions
+                .Select(_ => (Response)new StubResponse(etag))
+                .ToList();
+            return Task.FromResult(
+                Response.FromValue(responses, new StubResponse(default)));
+        }
+
+        public override Task<Response<TableItem>> CreateIfNotExistsAsync(
+            CancellationToken cancellationToken = default)
+        {
+            CreateIfNotExistsCallCount++;
+            CreateCancellationToken = cancellationToken;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(
+                Response.FromValue(
+                    new TableItem(Name),
+                    new StubResponse(default)));
+        }
+    }
+
+    private sealed record SubmittedAction(
+        TableTransactionActionType ActionType,
+        string RowKey,
+        ETag ETag,
+        string Metadata);
+
+    private sealed class RecordingSiloLifecycle : ISiloLifecycle
+    {
+        private ILifecycleObserver? _observer;
+
+        public int HighestCompletedStage => 0;
+
+        public int LowestStoppedStage => 0;
+
+        public int? Stage { get; private set; }
+
+        public IDisposable Subscribe(
+            string observerName,
+            int stage,
+            ILifecycleObserver observer)
+        {
+            Assert.Null(_observer);
+            Assert.Contains(nameof(AzureTableTransactionalStateStorageFactory), observerName);
+            Stage = stage;
+            _observer = observer;
+            return NoopDisposable.Instance;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken) =>
+            Assert.IsAssignableFrom<ILifecycleObserver>(_observer).OnStart(cancellationToken);
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static NoopDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class StubResponse(ETag etag) : Response
+    {
+        public override int Status => 204;
+
+        public override string ReasonPhrase => "No Content";
+
+        public override Stream? ContentStream { get; set; }
+
+        public override string ClientRequestId { get; set; } = string.Empty;
+
+        public override void Dispose()
+        {
+        }
+
+        protected override bool ContainsHeader(string name) => TryGetHeader(name, out _);
+
+        protected override IEnumerable<HttpHeader> EnumerateHeaders() =>
+            etag == default ? [] : [new HttpHeader("ETag", etag.ToString("H"))];
+
+        protected override bool TryGetHeader(string name, out string value)
+        {
+            if (etag != default && string.Equals(name, "ETag", StringComparison.OrdinalIgnoreCase))
+            {
+                value = etag.ToString("H");
+                return true;
+            }
+
+            value = string.Empty;
+            return false;
+        }
+
+        protected override bool TryGetHeaderValues(
+            string name,
+            out IEnumerable<string> values)
+        {
+            if (TryGetHeader(name, out var value))
+            {
+                values = [value];
+                return true;
+            }
+
+            values = [];
+            return false;
+        }
+    }
+
+    private sealed class TestState
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/FaultInjectionDynamoDBTransactionStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/FaultInjectionDynamoDBTransactionStateStorageTests.cs
@@ -1,0 +1,380 @@
+using System.Reflection;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Storage;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.DynamoDB;
+using Orleans.Transactions.DynamoDB.TransactionalState;
+using Orleans.Transactions.TestKit;
+using Orleans.Transactions.TestKit.Base.FaultInjection.ControlledInjection;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class FaultInjectionDynamoDBTransactionStateStorageTests
+{
+    private const string ProviderName = "dynamodb-faults";
+    private const string TableName = "Transactions";
+
+    [Fact]
+    public async Task Store_NullMetadata_ThrowsWithMetadataParamNameBeforeInjectorOrStorage()
+    {
+        var events = new List<string>();
+        using var client = new RecordingAmazonDynamoDBClient(events);
+        var injector = new RecordingFaultInjector(events);
+        var storage = CreateStorage(client, injector);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => storage.Store(
+                expectedETag: "unobserved-etag",
+                metadata: null!,
+                statesToPrepare: null,
+                commitUpTo: null,
+                abortAfter: null));
+
+        Assert.Equal("metadata", exception.ParamName);
+        Assert.Empty(events);
+        Assert.Empty(client.GetItemCalls);
+        Assert.Empty(client.QueryCalls);
+        Assert.Empty(client.TransactWriteItemsCalls);
+    }
+
+    [Fact]
+    public async Task Load_ForwardsFreshSnapshotWithoutInvokingInjector()
+    {
+        var events = new List<string>();
+        using var client = new RecordingAmazonDynamoDBClient(events);
+        var injector = new RecordingFaultInjector(events);
+        var storage = CreateStorage(client, injector);
+
+        var result = await storage.Load();
+
+        Assert.Null(result.ETag);
+        Assert.Equal(0, result.CommittedSequenceId);
+        Assert.NotNull(result.CommittedState);
+        Assert.Empty(result.Metadata.CommitRecords);
+        Assert.Empty(result.PendingStates);
+        Assert.Equal(2, client.GetItemCalls.Count);
+        Assert.Single(client.QueryCalls);
+        Assert.Empty(events);
+        Assert.Empty(injector.BeforeTransactionIds);
+        Assert.Empty(injector.AfterTransactionIds);
+    }
+
+    [Fact]
+    public async Task Store_ValidMetadataAndETag_ForwardsStorageCallBetweenInjectorCallbacks()
+    {
+        var events = new List<string>();
+        using var client = new RecordingAmazonDynamoDBClient(events);
+        var injector = new RecordingFaultInjector(events);
+        var storage = CreateStorage(client, injector);
+        var firstTransactionId = new Guid("89DD96F6-9BDD-4637-96AA-12AB6B5EF701");
+        var secondTransactionId = new Guid("067485E1-35D1-453F-9B64-DBCC87BCBD8E");
+
+        var loaded = await storage.Load();
+        var firstMetadata = CreateMetadata(firstTransactionId, 303);
+        var firstETag = await storage.Store(
+            loaded.ETag,
+            firstMetadata,
+            statesToPrepare: null,
+            commitUpTo: null,
+            abortAfter: null);
+        var secondMetadata = CreateMetadata(secondTransactionId, 404);
+        var secondETag = await storage.Store(
+            firstETag,
+            secondMetadata,
+            statesToPrepare: null,
+            commitUpTo: null,
+            abortAfter: null);
+
+        Assert.Equal("0", firstETag);
+        Assert.Equal("1", secondETag);
+        Assert.Equal(
+            ["before", "storage", "after", "before", "storage", "after"],
+            events);
+        Assert.Collection(
+            injector.BeforeTransactionIds,
+            ids => Assert.Equal([firstTransactionId], ids),
+            ids => Assert.Equal([secondTransactionId], ids));
+        Assert.Collection(
+            injector.AfterTransactionIds,
+            ids => Assert.Equal([firstTransactionId], ids),
+            ids => Assert.Equal([secondTransactionId], ids));
+
+        Assert.Equal(2, client.TransactWriteItemsCalls.Count);
+        var firstKeyPut = Assert.Single(client.TransactWriteItemsCalls[0].TransactItems).Put;
+        Assert.Equal(TableName, firstKeyPut.TableName);
+        Assert.Equal("key", firstKeyPut.Item[DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME].S);
+        Assert.Equal("0", firstKeyPut.Item[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N);
+        Assert.NotEmpty(firstKeyPut.Item["Metadata"].B.ToArray());
+        Assert.Contains("attribute_not_exists", firstKeyPut.ConditionExpression);
+        AssertMetadataEqual(
+            firstMetadata,
+            DeserializeMetadata(firstKeyPut.Item["Metadata"].B.ToArray()));
+
+        var secondKeyPut = Assert.Single(client.TransactWriteItemsCalls[1].TransactItems).Put;
+        Assert.Equal("1", secondKeyPut.Item[DynamoDBTransactionalStateConstants.ETAG_PROPERTY_NAME].N);
+        Assert.Equal(
+            "0",
+            secondKeyPut.ExpressionAttributeValues[
+                DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS].N);
+        Assert.NotEmpty(secondKeyPut.Item["Metadata"].B.ToArray());
+        AssertMetadataEqual(
+            secondMetadata,
+            DeserializeMetadata(secondKeyPut.Item["Metadata"].B.ToArray()));
+    }
+
+    [Fact]
+    public void FactoryCreate_RegisteredNamedOptions_ReturnsWrapperFactoryWithoutStorageAccess()
+    {
+        using var services = CreateServices();
+
+        var result = FaultInjectionDynamoDBTransactionStateStorageFactory.Create(
+            services,
+            ProviderName);
+
+        Assert.IsType<FaultInjectionDynamoDBTransactionStateStorageFactory>(result);
+    }
+
+    [Fact]
+    public async Task Participate_CanceledStart_ForwardsCancellationTokenWithoutContactingStorage()
+    {
+        var options = CreateOptions();
+        var inner = new DynamoDBTransactionalStateStorageFactory(
+            ProviderName,
+            options,
+            Options.Create(new ClusterOptions { ServiceId = "service" }),
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance);
+        var factory = new FaultInjectionDynamoDBTransactionStateStorageFactory(inner);
+        var lifecycle = new RecordingSiloLifecycle();
+        factory.Participate(lifecycle);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => lifecycle.StartAsync(cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Equal(DynamoDBTransactionalStorageOptions.DEFAULT_INIT_STAGE, lifecycle.Stage);
+    }
+
+    private static FaultInjectionDynamoDBTransactionStateStorage<TestState> CreateStorage(
+        RecordingAmazonDynamoDBClient client,
+        ITransactionFaultInjector injector)
+    {
+        var storage = new DynamoDBStorage(
+            NullLogger.Instance,
+            "http://127.0.0.1:65535",
+            accessKey: "dummy",
+            secretKey: "dummy");
+        typeof(DynamoDBStorage)
+            .GetField("_ddbClient", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(storage, client);
+        var inner = new DynamoDBTransactionalStateStorage<TestState>(
+            storage,
+            CreateOptions(),
+            "test-partition",
+            NullLogger<DynamoDBTransactionalStateStorage<TestState>>.Instance);
+        return new FaultInjectionDynamoDBTransactionStateStorage<TestState>(
+            injector,
+            inner);
+    }
+
+    private static DynamoDBTransactionalStorageOptions CreateOptions() => new()
+    {
+        Service = "http://127.0.0.1:65535",
+        AccessKey = "dummy",
+        SecretKey = "dummy",
+        TableName = TableName,
+        CreateIfNotExists = false,
+        UpdateIfExists = false,
+        GrainStorageSerializer = new JsonGrainStorageSerializer(
+            new OrleansJsonSerializer(
+                new OptionsWrapper<OrleansJsonSerializerOptions>(
+                    new OrleansJsonSerializerOptions()))),
+    };
+
+    private static TransactionalStateMetaData CreateMetadata(Guid transactionId, long ticks) => new()
+    {
+        TimeStamp = new DateTime(ticks),
+        CommitRecords =
+        {
+            [transactionId] = new CommitRecord
+            {
+                Timestamp = new DateTime(ticks + 1),
+                WriteParticipants = [],
+            },
+        },
+    };
+
+    private static TransactionalStateMetaData DeserializeMetadata(byte[] value) =>
+        CreateOptions().GrainStorageSerializer.Deserialize<TransactionalStateMetaData>(
+            new BinaryData(value))!;
+
+    private static void AssertMetadataEqual(
+        TransactionalStateMetaData expected,
+        TransactionalStateMetaData actual)
+    {
+        Assert.Equal(expected.TimeStamp, actual.TimeStamp);
+        var expectedRecord = Assert.Single(expected.CommitRecords);
+        var actualRecord = Assert.Single(actual.CommitRecords);
+        Assert.Equal(expectedRecord.Key, actualRecord.Key);
+        Assert.Equal(expectedRecord.Value.Timestamp, actualRecord.Value.Timestamp);
+        Assert.Equal(expectedRecord.Value.WriteParticipants, actualRecord.Value.WriteParticipants);
+    }
+
+    private static ServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSerializer();
+        services.Configure<ClusterOptions>(options => options.ServiceId = "service");
+        services.Configure<DynamoDBTransactionalStorageOptions>(
+            ProviderName,
+            options =>
+            {
+                var configured = CreateOptions();
+                options.Service = configured.Service;
+                options.AccessKey = configured.AccessKey;
+                options.SecretKey = configured.SecretKey;
+                options.TableName = configured.TableName;
+                options.CreateIfNotExists = configured.CreateIfNotExists;
+                options.UpdateIfExists = configured.UpdateIfExists;
+                options.GrainStorageSerializer = configured.GrainStorageSerializer;
+            });
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class RecordingFaultInjector(List<string> events)
+        : ITransactionFaultInjector, ITransactionScopedFaultInjector
+    {
+        public List<IReadOnlyList<Guid>> BeforeTransactionIds { get; } = [];
+
+        public List<IReadOnlyList<Guid>> AfterTransactionIds { get; } = [];
+
+        public void BeforeStore() => throw new InvalidOperationException(
+            "The transaction-scoped injector path was expected.");
+
+        public void AfterStore() => throw new InvalidOperationException(
+            "The transaction-scoped injector path was expected.");
+
+        public void Arm(
+            Guid transactionId,
+            FaultInjectionType injectionType,
+            bool requireTransactionMatch) =>
+            throw new NotSupportedException();
+
+        public void BeforeStore(System.Collections.Immutable.ImmutableArray<Guid> transactionIds)
+        {
+            BeforeTransactionIds.Add(transactionIds);
+            events.Add("before");
+        }
+
+        public void AfterStore(System.Collections.Immutable.ImmutableArray<Guid> transactionIds)
+        {
+            AfterTransactionIds.Add(transactionIds);
+            events.Add("after");
+        }
+    }
+
+    private sealed class RecordingAmazonDynamoDBClient(List<string> events)
+        : AmazonDynamoDBClient(
+            new BasicAWSCredentials("dummy", "dummy"),
+            new AmazonDynamoDBConfig
+            {
+                ServiceURL = "http://127.0.0.1:65535",
+            })
+    {
+        public List<GetItemRequest> GetItemCalls { get; } = [];
+
+        public List<QueryRequest> QueryCalls { get; } = [];
+
+        public List<TransactWriteItemsRequest> TransactWriteItemsCalls { get; } = [];
+
+        public override Task<GetItemResponse> GetItemAsync(
+            GetItemRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            GetItemCalls.Add(request);
+            return Task.FromResult(new GetItemResponse());
+        }
+
+        public override Task<QueryResponse> QueryAsync(
+            QueryRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            QueryCalls.Add(request);
+            return Task.FromResult(new QueryResponse
+            {
+                Items = [],
+                LastEvaluatedKey = [],
+            });
+        }
+
+        public override Task<TransactWriteItemsResponse> TransactWriteItemsAsync(
+            TransactWriteItemsRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TransactWriteItemsCalls.Add(request);
+            events.Add("storage");
+            return Task.FromResult(new TransactWriteItemsResponse());
+        }
+    }
+
+    private sealed class RecordingSiloLifecycle : ISiloLifecycle
+    {
+        private ILifecycleObserver? _observer;
+
+        public int HighestCompletedStage => 0;
+
+        public int LowestStoppedStage => 0;
+
+        public int? Stage { get; private set; }
+
+        public IDisposable Subscribe(
+            string observerName,
+            int stage,
+            ILifecycleObserver observer)
+        {
+            Assert.Null(_observer);
+            Assert.Contains(nameof(DynamoDBTransactionalStateStorageFactory), observerName);
+            Stage = stage;
+            _observer = observer;
+            return NoopDisposable.Instance;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken) =>
+            Assert.IsAssignableFrom<ILifecycleObserver>(_observer).OnStart(cancellationToken);
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static NoopDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestState
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/FaultInjectionTransactionalStateAttributeMapperTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/FaultInjectionTransactionalStateAttributeMapperTests.cs
@@ -1,0 +1,156 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class FaultInjectionTransactionalStateAttributeMapperTests
+{
+    [Fact]
+    public void GetFactory_NullParameter_ThrowsWithParameterParamNameBeforeActivation()
+    {
+        var mapper = new FaultInjectionTransactionalStateAttributeMapper();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => mapper.GetFactory(
+                parameter: null!,
+                attribute: null!));
+
+        Assert.Equal("parameter", exception.ParamName);
+    }
+
+    [Fact]
+    public void GetFactory_ValidAttribute_UsesParameterStateTypeAndOriginalConfiguration()
+    {
+        var expectedState = new RecordingTransactionalState();
+        var stateFactory = new RecordingTransactionalStateFactory(expectedState);
+        using var services = new ServiceCollection()
+            .AddSingleton<IFaultInjectionTransactionalStateFactory>(stateFactory)
+            .BuildServiceProvider();
+        var context = new TestGrainContext(services);
+        var parameter = typeof(FaultInjectionTransactionalStateAttributeMapperTests)
+            .GetMethod(
+                nameof(AttributeTarget),
+                BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetParameters()
+            .Single();
+        var attribute = Assert.IsType<FaultInjectionTransactionalStateAttribute>(
+            parameter.GetCustomAttribute<FaultInjectionTransactionalStateAttribute>());
+        var mapper = new FaultInjectionTransactionalStateAttributeMapper();
+
+        var factory = mapper.GetFactory(parameter, attribute);
+        var result = factory(context);
+
+        Assert.Same(expectedState, result);
+        Assert.Equal(1, stateFactory.CreateCallCount);
+        Assert.Equal(typeof(TestState), stateFactory.CreatedStateType);
+        Assert.Same(attribute, stateFactory.Configuration);
+        Assert.Equal("account", stateFactory.Configuration!.StateName);
+        Assert.Equal("fault-store", stateFactory.Configuration.StorageName);
+    }
+
+    private static void AttributeTarget(
+        [FaultInjectionTransactionalState("account", "fault-store")]
+        IFaultInjectionTransactionalState<TestState> state)
+    {
+    }
+
+    private sealed class RecordingTransactionalStateFactory(
+        RecordingTransactionalState state)
+        : IFaultInjectionTransactionalStateFactory
+    {
+        public int CreateCallCount { get; private set; }
+
+        public Type? CreatedStateType { get; private set; }
+
+        public IFaultInjectionTransactionalStateConfiguration? Configuration { get; private set; }
+
+        public IFaultInjectionTransactionalState<TState> Create<TState>(
+            IFaultInjectionTransactionalStateConfiguration config)
+            where TState : class, new()
+        {
+            CreateCallCount++;
+            CreatedStateType = typeof(TState);
+            Configuration = config;
+            return (IFaultInjectionTransactionalState<TState>)(object)state;
+        }
+    }
+
+    private sealed class RecordingTransactionalState
+        : IFaultInjectionTransactionalState<TestState>
+    {
+        public FaultInjectionControl FaultInjectionControl { get; set; } = new();
+
+        public Task<TResult> PerformRead<TResult>(Func<TestState, TResult> readFunction) =>
+            Task.FromResult(readFunction(new TestState()));
+
+        public Task<TResult> PerformUpdate<TResult>(Func<TestState, TResult> updateFunction) =>
+            Task.FromResult(updateFunction(new TestState()));
+    }
+
+    private sealed class TestGrainContext(IServiceProvider activationServices) : IGrainContext
+    {
+        public GrainReference GrainReference => throw new NotSupportedException();
+
+        public GrainId GrainId => throw new NotSupportedException();
+
+        public object? GrainInstance => null;
+
+        public ActivationId ActivationId => throw new NotSupportedException();
+
+        public GrainAddress Address => throw new NotSupportedException();
+
+        public IServiceProvider ActivationServices => activationServices;
+
+        public IGrainLifecycle ObservableLifecycle => throw new NotSupportedException();
+
+        public IWorkItemScheduler Scheduler => throw new NotSupportedException();
+
+        public Task Deactivated => Task.CompletedTask;
+
+        public void Activate(
+            Dictionary<string, object>? requestContext,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void Deactivate(
+            DeactivationReason deactivationReason,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public bool Equals(IGrainContext? other) => ReferenceEquals(this, other);
+
+        public TComponent? GetComponent<TComponent>() where TComponent : class => null;
+
+        public object? GetComponent(Type componentType) => null;
+
+        public TTarget? GetTarget<TTarget>() where TTarget : class => null;
+
+        public object? GetTarget() => null;
+
+        public void Migrate(
+            Dictionary<string, object>? requestContext,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void ReceiveMessage(object message) => throw new NotSupportedException();
+
+        public void Rehydrate(IRehydrationContext context) => throw new NotSupportedException();
+
+        public void SetComponent<TComponent>(TComponent? value)
+            where TComponent : class =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class TestState
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/RemoteCommitOperationInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/RemoteCommitOperationInputValidationTests.cs
@@ -1,0 +1,175 @@
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class RemoteCommitOperationInputValidationTests
+{
+    [Fact]
+    public async Task PassOperation_Commit_NullService_ThrowsWithServiceParamName()
+    {
+        var operation = new PassOperation("pass-null-service");
+
+        var commitTask = operation.Commit(
+            new Guid("72D8A038-64D8-431D-8592-23D38522F914"),
+            null!);
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => commitTask);
+
+        Assert.Equal("service", exception.ParamName);
+        Assert.Equal("pass-null-service", operation.Data);
+    }
+
+    [Fact]
+    public async Task FailOperation_Commit_NullService_ThrowsWithServiceParamName()
+    {
+        var operation = new FailOperation("fail-null-service");
+
+        var commitTask = operation.Commit(
+            new Guid("E0DD10C9-213F-4D2D-97D9-B0FC030A5D87"),
+            null!);
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => commitTask);
+
+        Assert.Equal("service", exception.ParamName);
+        Assert.Equal("fail-null-service", operation.Data);
+    }
+
+    [Fact]
+    public async Task ThrowOperation_Commit_NullService_ThrowsWithServiceParamName()
+    {
+        var operation = new ThrowOperation("throw-null-service");
+
+        var commitTask = operation.Commit(
+            new Guid("8E4CF4DD-082F-4DD6-8342-46F2BA30C8D7"),
+            null!);
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => commitTask);
+
+        Assert.Equal("service", exception.ParamName);
+        Assert.Equal("throw-null-service", operation.Data);
+    }
+
+    [Fact]
+    public async Task PassOperation_Commit_ForwardsExactTransactionIdAndDataAndReturnsOutcome()
+    {
+        var transactionId = new Guid("25816EE5-5DFC-47F2-AC99-9C14372F906B");
+        var data = new string("pass-operation-data".ToCharArray());
+        var operation = new PassOperation(data);
+        var service = new RecordingRemoteCommitService();
+
+        var result = await operation.Commit(transactionId, service);
+
+        Assert.True(result);
+        Assert.Equal(1, service.PassCallCount);
+        Assert.Equal(0, service.FailCallCount);
+        Assert.Equal(0, service.ThrowCallCount);
+        Assert.Equal(transactionId, service.LastTransactionId);
+        Assert.Equal(data, service.LastData);
+        Assert.Same(data, service.LastData);
+        Assert.Equal(RemoteCommitMethod.Pass, service.LastMethod);
+    }
+
+    [Fact]
+    public async Task FailOperation_Commit_ForwardsExactTransactionIdAndDataAndReturnsOutcome()
+    {
+        var transactionId = new Guid("340AD8DE-6F8D-4BB9-9E5B-2D6FD6DCE80C");
+        var data = new string("fail-operation-data".ToCharArray());
+        var operation = new FailOperation(data);
+        var service = new RecordingRemoteCommitService();
+
+        var result = await operation.Commit(transactionId, service);
+
+        Assert.False(result);
+        Assert.Equal(0, service.PassCallCount);
+        Assert.Equal(1, service.FailCallCount);
+        Assert.Equal(0, service.ThrowCallCount);
+        Assert.Equal(transactionId, service.LastTransactionId);
+        Assert.Equal(data, service.LastData);
+        Assert.Same(data, service.LastData);
+        Assert.Equal(RemoteCommitMethod.Fail, service.LastMethod);
+    }
+
+    [Fact]
+    public async Task ThrowOperation_Commit_ForwardsExactTransactionIdAndDataAndPropagatesFailure()
+    {
+        var transactionId = new Guid("9B7345CB-0186-40BA-BE23-13A44684A24D");
+        var data = new string("throw-operation-data".ToCharArray());
+        var operation = new ThrowOperation(data);
+        var expectedException = new InvalidOperationException("remote commit failed");
+        var service = new RecordingRemoteCommitService(expectedException);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => operation.Commit(transactionId, service));
+
+        Assert.Same(expectedException, exception);
+        Assert.Equal(0, service.PassCallCount);
+        Assert.Equal(0, service.FailCallCount);
+        Assert.Equal(1, service.ThrowCallCount);
+        Assert.Equal(transactionId, service.LastTransactionId);
+        Assert.Equal(data, service.LastData);
+        Assert.Same(data, service.LastData);
+        Assert.Equal(RemoteCommitMethod.Throw, service.LastMethod);
+    }
+
+    private enum RemoteCommitMethod
+    {
+        None,
+        Pass,
+        Fail,
+        Throw,
+    }
+
+    private sealed class RecordingRemoteCommitService : IRemoteCommitService
+    {
+        private readonly Exception? exception;
+
+        public RecordingRemoteCommitService(Exception? exception = null)
+        {
+            this.exception = exception;
+        }
+
+        public int PassCallCount { get; private set; }
+
+        public int FailCallCount { get; private set; }
+
+        public int ThrowCallCount { get; private set; }
+
+        public Guid LastTransactionId { get; private set; }
+
+        public string? LastData { get; private set; }
+
+        public RemoteCommitMethod LastMethod { get; private set; }
+
+        public Task<bool> Pass(Guid transactionId, string data)
+        {
+            PassCallCount++;
+            Record(RemoteCommitMethod.Pass, transactionId, data);
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> Fail(Guid transactionId, string data)
+        {
+            FailCallCount++;
+            Record(RemoteCommitMethod.Fail, transactionId, data);
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> Throw(Guid transactionId, string data)
+        {
+            ThrowCallCount++;
+            Record(RemoteCommitMethod.Throw, transactionId, data);
+            return Task.FromException<bool>(
+                exception ?? new InvalidOperationException("Unexpected throw invocation."));
+        }
+
+        private void Record(RemoteCommitMethod method, Guid transactionId, string data)
+        {
+            LastMethod = method;
+            LastTransactionId = transactionId;
+            LastData = data;
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionAttributionFactoryInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionAttributionFactoryInputValidationTests.cs
@@ -1,0 +1,27 @@
+using Orleans.Transactions;
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionAttributionFactoryInputValidationTests
+{
+    [Fact]
+    public void GetTransactionAttributionGrain_NullGrainFactory_ThrowsBeforeOptionDispatch()
+    {
+        var unsupportedOption = (TransactionOption)int.MaxValue;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            TransactionAttributionGrainExtensions.GetTransactionAttributionGrain(
+                grainFactory: null!,
+                new Guid("B6589B9B-C606-481F-BF1A-7084332033B5"),
+                unsupportedOption));
+
+        Assert.Equal("grainFactory", exception.ParamName);
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionAttributionInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionAttributionInputValidationTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionAttributionInputValidationTests
+{
+    public static TheoryData<string> AttributionGrainCases => new()
+    {
+        nameof(NoAttributionGrain),
+        nameof(SuppressAttributionGrain),
+        nameof(CreateOrJoinAttributionGrain),
+        nameof(CreateAttributionGrain),
+        nameof(JoinAttributionGrain),
+        nameof(SupportedAttributionGrain),
+        nameof(NotAllowedAttributionGrain),
+    };
+
+    [Theory]
+    [MemberData(nameof(AttributionGrainCases))]
+    public void GetNestedTransactionIds_NullTiers_ThrowsWithTiersParamNameBeforeRuntimeAccess(
+        string grainCase)
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+        {
+            _ = InvokeGetNestedTransactionIds(grainCase, tiers: null!);
+        });
+
+        Assert.Equal("tiers", exception.ParamName);
+    }
+
+    private static Task<List<string?>?[]> InvokeGetNestedTransactionIds(
+        string grainCase,
+        List<ITransactionAttributionGrain>[] tiers) =>
+        grainCase switch
+        {
+            nameof(NoAttributionGrain) =>
+                new NoAttributionGrain().GetNestedTransactionIds(0, tiers),
+            nameof(SuppressAttributionGrain) =>
+                new SuppressAttributionGrain().GetNestedTransactionIds(0, tiers),
+            nameof(CreateOrJoinAttributionGrain) =>
+                new CreateOrJoinAttributionGrain().GetNestedTransactionIds(0, tiers),
+            nameof(CreateAttributionGrain) =>
+                new CreateAttributionGrain().GetNestedTransactionIds(0, tiers),
+            nameof(JoinAttributionGrain) =>
+                new JoinAttributionGrain().GetNestedTransactionIds(0, tiers),
+            nameof(SupportedAttributionGrain) =>
+                new SupportedAttributionGrain().GetNestedTransactionIds(0, tiers),
+            nameof(NotAllowedAttributionGrain) =>
+                new NotAllowedAttributionGrain().GetNestedTransactionIds(0, tiers),
+            _ => throw new ArgumentOutOfRangeException(nameof(grainCase), grainCase, null),
+        };
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionCoordinatorInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionCoordinatorInputValidationTests.cs
@@ -1,0 +1,190 @@
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionCoordinatorInputValidationTests
+{
+    [Fact]
+    public async Task AddAndThrow_NullGrain_ThrowsWithGrainParamNameBeforeGrainCall()
+    {
+        var coordinator = new TransactionCoordinatorGrain();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => coordinator.AddAndThrow(null!, 17));
+
+        Assert.Equal("grain", exception.ParamName);
+    }
+
+    [Fact]
+    public void MultiGrainAddWithCommitter_NullCommitter_ThrowsBeforeEnumeratingOrUpdatingGrains()
+    {
+        var events = new List<string>();
+        var firstGrain = new RecordingTransactionTestGrain("first", events);
+        var secondGrain = new RecordingTransactionTestGrain("second", events);
+        var grains = new List<ITransactionTestGrain> { firstGrain, secondGrain };
+        var operation = new RecordingCommitOperation();
+        var coordinator = new TransactionCoordinatorGrain();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+        {
+            _ = coordinator.MultiGrainAdd(null!, operation, grains, 23);
+        });
+        var allNullException = Assert.Throws<ArgumentNullException>(() =>
+        {
+            _ = coordinator.MultiGrainAdd(null!, null!, null!, 23);
+        });
+
+        Assert.Equal("committer", exception.ParamName);
+        Assert.Equal("committer", allNullException.ParamName);
+        Assert.Empty(events);
+        Assert.Equal(0, firstGrain.AddCallCount);
+        Assert.Equal(0, secondGrain.AddCallCount);
+        Assert.Equal(0, operation.CommitCallCount);
+    }
+
+    [Fact]
+    public async Task UpdateViolated_NullGrain_ThrowsWithGrainParamNameBeforeGrainCall()
+    {
+        var coordinator = new TransactionCoordinatorGrain();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => coordinator.UpdateViolated(null!, 29));
+
+        Assert.Equal("grain", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task MultiGrainAddWithCommitter_ValidInputs_EnlistsCommitAndFansOutExactValue()
+    {
+        var events = new List<string>();
+        var firstGrain = new RecordingTransactionTestGrain("first", events);
+        var secondGrain = new RecordingTransactionTestGrain("second", events);
+        var grains = new List<ITransactionTestGrain> { firstGrain, secondGrain };
+        var committer = new RecordingCommitterTestGrain(events);
+        var operation = new RecordingCommitOperation();
+        var coordinator = new TransactionCoordinatorGrain();
+
+        await coordinator.MultiGrainAdd(committer, operation, grains, 31);
+
+        Assert.Equal(
+            new[] { "first:Add(31)", "second:Add(31)", "Commit" },
+            events);
+        Assert.Equal(1, firstGrain.AddCallCount);
+        Assert.Equal(1, secondGrain.AddCallCount);
+        Assert.Equal(31, firstGrain.LastAddedValue);
+        Assert.Equal(31, secondGrain.LastAddedValue);
+        Assert.Equal(1, committer.CommitCallCount);
+        Assert.Same(operation, committer.LastOperation);
+        Assert.Equal(0, operation.CommitCallCount);
+    }
+
+    [Fact]
+    public async Task AddAndThrow_ValidGrain_PerformsExpectedUpdateBeforePropagatingAbortFailure()
+    {
+        var events = new List<string>();
+        var grain = new RecordingTransactionTestGrain("target", events);
+        var coordinator = new TransactionCoordinatorGrain();
+
+        var exception = await Assert.ThrowsAsync<Exception>(
+            () => coordinator.AddAndThrow(grain, 37));
+
+        Assert.Equal("This should abort the transaction", exception.Message);
+        Assert.Equal(new[] { "target:Add(37)" }, events);
+        Assert.Equal(1, grain.AddCallCount);
+        Assert.Equal(37, grain.LastAddedValue);
+    }
+
+    [Fact]
+    public async Task UpdateViolated_ValidGrain_ForwardsTheExactValue()
+    {
+        var events = new List<string>();
+        var grain = new RecordingTransactionTestGrain("target", events);
+        var coordinator = new TransactionCoordinatorGrain();
+
+        await coordinator.UpdateViolated(grain, 41);
+
+        Assert.Equal(new[] { "target:Add(41)" }, events);
+        Assert.Equal(1, grain.AddCallCount);
+        Assert.Equal(41, grain.LastAddedValue);
+    }
+
+    private sealed class RecordingTransactionTestGrain : ITransactionTestGrain
+    {
+        private readonly string name;
+        private readonly List<string> events;
+
+        public RecordingTransactionTestGrain(string name, List<string> events)
+        {
+            this.name = name;
+            this.events = events;
+        }
+
+        public int AddCallCount { get; private set; }
+
+        public int LastAddedValue { get; private set; }
+
+        public Task<int[]> Add(int numberToAdd)
+        {
+            AddCallCount++;
+            LastAddedValue = numberToAdd;
+            events.Add($"{name}:Add({numberToAdd})");
+            return Task.FromResult(new[] { numberToAdd });
+        }
+
+        public Task Set(int newValue) => UnexpectedCall(nameof(Set));
+
+        public Task<int[]> Get() => UnexpectedCall<int[]>(nameof(Get));
+
+        public Task AddAndThrow(int numberToAdd) => UnexpectedCall(nameof(AddAndThrow));
+
+        public Task SetAndThrow(int numberToSet) => UnexpectedCall(nameof(SetAndThrow));
+
+        public Task Deactivate() => UnexpectedCall(nameof(Deactivate));
+
+        private static Task UnexpectedCall(string method) =>
+            Task.FromException(new InvalidOperationException($"Unexpected {method} call."));
+
+        private static Task<T> UnexpectedCall<T>(string method) =>
+            Task.FromException<T>(new InvalidOperationException($"Unexpected {method} call."));
+    }
+
+    private sealed class RecordingCommitterTestGrain : ITransactionCommitterTestGrain
+    {
+        private readonly List<string> events;
+
+        public RecordingCommitterTestGrain(List<string> events)
+        {
+            this.events = events;
+        }
+
+        public int CommitCallCount { get; private set; }
+
+        public ITransactionCommitOperation<IRemoteCommitService>? LastOperation { get; private set; }
+
+        public Task Commit(ITransactionCommitOperation<IRemoteCommitService> operation)
+        {
+            CommitCallCount++;
+            LastOperation = operation;
+            events.Add("Commit");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingCommitOperation : ITransactionCommitOperation<IRemoteCommitService>
+    {
+        public int CommitCallCount { get; private set; }
+
+        public Task<bool> Commit(Guid transactionId, IRemoteCommitService service)
+        {
+            CommitCallCount++;
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryTestsRunnerInputValidationTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryTestsRunnerInputValidationTests.cs
@@ -1,0 +1,26 @@
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionRecoveryTestsRunnerInputValidationTests
+{
+    [Fact]
+    public void Constructor_NullTestCluster_ThrowsWithTestClusterParamNameBeforeBaseDereference()
+    {
+        var outputCallCount = 0;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new TransactionRecoveryTestsRunner(
+                testCluster: null!,
+                testOutput: _ => outputCallCount++));
+
+        Assert.Equal("testCluster", exception.ParamName);
+        Assert.Equal(0, outputCallCount);
+    }
+}


### PR DESCRIPTION
## Problem
The centralized CA1062 rollout still left 32 unsuppressed findings in Orleans.Transactions.TestKit.Base. These public grain, harness, fault-injection, and runner boundaries accepted invalid dependencies or payloads and relied on incidental null dereferences.

## Solution
Validate caller-controlled inputs before state mutation or collaborator invocation across transaction attribution, consistency, bit-array operations, remote commit coordination, exclusive locking, fault-injection storage, attribute mapping, and recovery runners. Two storage-factory context diagnostics use narrow suppressions for Orleans' current non-null grain-context contract.

CA1062 is enabled centrally in the root `.editorconfig` for the complete project. Focused tests cover exact parameter names, validation ordering, no mutation/collaborator calls on failure, and representative valid transaction behavior.

## Rationale
The complete-project rollout establishes one clear analyzer boundary while preserving transaction protocol, commit/abort, fault-injection, cancellation, and grain invocation semantics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11161)