### PR TITLE
test(runtime): remove stateless worker directory race

### DIFF
--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
@@ -83,7 +83,6 @@ public class StatelessWorkerSingleActivationRaceTests(StatelessWorkerSingleActiv
         var workerCreated = await WaitForWorkerCreatedAsync(collector, forwarded.ReplacementContext);
 
         Assert.NotSame(c1, forwarded.ReplacementContext);
-        Assert.Same(forwarded.ReplacementContext, directory.FindTarget(grainId));
         Assert.Same(forwarded.ReplacementContext, workerCreated.Context);
         Assert.Empty(GetWorkerCreatedEvents(collector, c1));
     }


### PR DESCRIPTION
## Problem

`TerminatedContextForwardsLateDeliveryToFreshWrapper` waits for the forwarded message to create a worker and then samples `ActivationDirectory`. The fixture intentionally removes idle stateless workers after one 5 ms inspection cycle, so the replacement context can legitimately finish the one-way message and unregister before that sample.

This occurred in Azure DevOps build https://dev.azure.com/dnceng/internal/_build/results?buildId=3067537 at source commit `ced916f2c805ec2a335445564700b06e2a73e6b9`, producing a 96.88% pass rate in the 24-hour scan.

## Solution

Remove the transient directory-residency assertion. The test continues to verify the stable runtime outcomes: the terminated context forwards to a distinct replacement, that replacement creates the worker, and the terminated context creates no additional worker.

The focused test passes on both `net8.0` and `net10.0`.

Fixes #11162
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11163)