### PR TITLE
fix: define CA1815 value semantics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -700,6 +700,10 @@ dotnet_diagnostic.CA1062.severity = warning
 [src/Redis/**/*.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
+# CA1815: Override equals and operator equals on value types
+[src/{Orleans.Core.Abstractions,Orleans.EventSourcing,Orleans.Reminders,Orleans.Serialization.FSharp,Orleans.Serialization.TestKit,Orleans.Streaming,Orleans.Transactions,Orleans.Transactions.TestKit.Base}/**.cs]
+dotnet_diagnostic.CA1815.severity = warning
+
 # Production source enforces the correctness baseline. Tests, samples, documentation,
 # playgrounds, templates, and tools retain advisory diagnostics during this rollout.
 [src/**/*.{cs,vb}]

--- a/src/Orleans.Core.Abstractions/Core/DeactivationReason.cs
+++ b/src/Orleans.Core.Abstractions/Core/DeactivationReason.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Collections.Generic;
 
 namespace Orleans
 {
     /// <summary>
     /// Represents a reason for initiating grain deactivation.
     /// </summary>
-    public readonly struct DeactivationReason
+    public readonly struct DeactivationReason : IEquatable<DeactivationReason>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeactivationReason"/> struct.
@@ -56,6 +57,28 @@ namespace Orleans
         /// Gets the exception which resulted in deactivation.
         /// </summary>
         public Exception? Exception { get; }
+
+        /// <inheritdoc/>
+        public bool Equals(DeactivationReason other) =>
+            ReasonCode == other.ReasonCode
+            && Description == other.Description
+            && EqualityComparer<Exception?>.Default.Equals(Exception, other.Exception);
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is DeactivationReason other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Combine(ReasonCode, Description, Exception);
+
+        /// <summary>
+        /// Determines whether two deactivation reasons are equal.
+        /// </summary>
+        public static bool operator ==(DeactivationReason left, DeactivationReason right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two deactivation reasons are unequal.
+        /// </summary>
+        public static bool operator !=(DeactivationReason left, DeactivationReason right) => !left.Equals(right);
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/Orleans.Core.Abstractions/Core/Immutable.cs
+++ b/src/Orleans.Core.Abstractions/Core/Immutable.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace Orleans.Concurrency
 {
     /// <summary>
@@ -13,7 +16,7 @@ namespace Orleans.Concurrency
     /// </remarks>
     /// <typeparam name="T">Type of data to be wrapped by this Immutable</typeparam>
     [GenerateSerializer, Immutable]
-    public readonly struct Immutable<T>
+    public readonly struct Immutable<T> : IEquatable<Immutable<T>>
     {
         /// <summary> Return reference to the original value stored in this Immutable wrapper. </summary>
         [Id(0)]
@@ -24,6 +27,25 @@ namespace Orleans.Concurrency
         /// </summary>
         /// <param name="value">Value to be wrapped and marked as immutable.</param>
         public Immutable(T value) => Value = value;
+
+        /// <inheritdoc/>
+        public bool Equals(Immutable<T> other) => EqualityComparer<T>.Default.Equals(Value, other.Value);
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is Immutable<T> other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode(Value!);
+
+        /// <summary>
+        /// Determines whether two immutable wrappers contain equal values.
+        /// </summary>
+        public static bool operator ==(Immutable<T> left, Immutable<T> right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two immutable wrappers contain unequal values.
+        /// </summary>
+        public static bool operator !=(Immutable<T> left, Immutable<T> right) => !left.Equals(right);
     }
 
     /// <summary>

--- a/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/RequestContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Orleans.Core.Internal;
@@ -183,6 +184,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Represents a scoped change to call-chain reentrancy.
         /// </summary>
+        [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This disposable scope token controls runtime reentrancy state and does not represent a comparable value.")]
         public readonly struct ReentrancySection : IDisposable
         {
             private readonly Guid _originalReentrancyId;

--- a/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core.Abstractions/Statistics/IEnvironmentStatisticsProvider.cs
@@ -27,7 +27,7 @@ public interface IEnvironmentStatisticsProvider
 [StructLayout(LayoutKind.Sequential, Pack = 1)]
 [Alias("Orleans.Statistics.EnvironmentStatistics")]
 [DebuggerDisplay("{ToString(),nq}")]
-public readonly struct EnvironmentStatistics
+public readonly struct EnvironmentStatistics : IEquatable<EnvironmentStatistics>
 {
     /// <summary>
     /// The system CPU usage.
@@ -180,6 +180,40 @@ public readonly struct EnvironmentStatistics
             return (float)Math.Clamp(fraction, 0.0, 1.0);
         }
     }
+
+    /// <inheritdoc/>
+    public bool Equals(EnvironmentStatistics other) =>
+        FilteredCpuUsagePercentage.Equals(other.FilteredCpuUsagePercentage)
+        && FilteredMemoryUsageBytes == other.FilteredMemoryUsageBytes
+        && FilteredAvailableMemoryBytes == other.FilteredAvailableMemoryBytes
+        && MaximumAvailableMemoryBytes == other.MaximumAvailableMemoryBytes
+        && RawCpuUsagePercentage.Equals(other.RawCpuUsagePercentage)
+        && RawMemoryUsageBytes == other.RawMemoryUsageBytes
+        && RawAvailableMemoryBytes == other.RawAvailableMemoryBytes;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is EnvironmentStatistics other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        HashCode.Combine(
+            FilteredCpuUsagePercentage,
+            FilteredMemoryUsageBytes,
+            FilteredAvailableMemoryBytes,
+            MaximumAvailableMemoryBytes,
+            RawCpuUsagePercentage,
+            RawMemoryUsageBytes,
+            RawAvailableMemoryBytes);
+
+    /// <summary>
+    /// Determines whether two environment statistics snapshots are equal.
+    /// </summary>
+    public static bool operator ==(EnvironmentStatistics left, EnvironmentStatistics right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two environment statistics snapshots are unequal.
+    /// </summary>
+    public static bool operator !=(EnvironmentStatistics left, EnvironmentStatistics right) => !left.Equals(right);
 
     private static string FormatBytes(long bytes)
     {

--- a/src/Orleans.Core.Abstractions/Timers/GrainTimerCreationOptions.cs
+++ b/src/Orleans.Core.Abstractions/Timers/GrainTimerCreationOptions.cs
@@ -8,7 +8,7 @@ namespace Orleans.Runtime;
 /// <summary>
 /// Options for creating grain timers.
 /// </summary>
-public readonly struct GrainTimerCreationOptions()
+public readonly struct GrainTimerCreationOptions() : IEquatable<GrainTimerCreationOptions>
 {
     /// <summary>
     /// Initializes a new <see cref="GrainTimerCreationOptions"/> instance.
@@ -65,4 +65,27 @@ public readonly struct GrainTimerCreationOptions()
     /// If the timer period is shorter than the grain's idle collection period, the grain will not be collected due to idleness.
     /// </remarks>
     public bool KeepAlive { get; init; }
+
+    /// <inheritdoc/>
+    public bool Equals(GrainTimerCreationOptions other) =>
+        DueTime == other.DueTime
+        && Period == other.Period
+        && Interleave == other.Interleave
+        && KeepAlive == other.KeepAlive;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is GrainTimerCreationOptions other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(DueTime, Period, Interleave, KeepAlive);
+
+    /// <summary>
+    /// Determines whether two timer creation options are equal.
+    /// </summary>
+    public static bool operator ==(GrainTimerCreationOptions left, GrainTimerCreationOptions right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two timer creation options are unequal.
+    /// </summary>
+    public static bool operator !=(GrainTimerCreationOptions left, GrainTimerCreationOptions right) => !left.Equals(right);
 }

--- a/src/Orleans.EventSourcing/Common/RecordedConnectionIssue.cs
+++ b/src/Orleans.EventSourcing/Common/RecordedConnectionIssue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Orleans.EventSourcing.Common
@@ -7,6 +8,7 @@ namespace Orleans.EventSourcing.Common
     /// Utility class for recording connection issues.
     /// It is public, not internal, because it is a useful building block for implementing other consistency providers.
     /// </summary>
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This mutable coordinator tracks connection state and notifications rather than representing a comparable value.")]
     public struct RecordedConnectionIssue
     {
         /// <summary>

--- a/src/Orleans.Reminders/Timers/IRemindable.cs
+++ b/src/Orleans.Reminders/Timers/IRemindable.cs
@@ -53,7 +53,7 @@ namespace Orleans
         /// Thereafter, the app can set count = curCount
         /// </summary>
         [Serializable, GenerateSerializer, Immutable]
-        public readonly struct TickStatus
+        public readonly struct TickStatus : IEquatable<TickStatus>
         {
             /// <summary>
             /// Gets the time at which the first tick of this reminder is due, or was triggered.
@@ -86,6 +86,28 @@ namespace Orleans
                 Period = period;
                 CurrentTickTime = timeStamp;
             }
+
+            /// <inheritdoc/>
+            public bool Equals(TickStatus other) =>
+                FirstTickTime == other.FirstTickTime
+                && Period == other.Period
+                && CurrentTickTime == other.CurrentTickTime;
+
+            /// <inheritdoc/>
+            public override bool Equals(object? obj) => obj is TickStatus other && Equals(other);
+
+            /// <inheritdoc/>
+            public override int GetHashCode() => HashCode.Combine(FirstTickTime, Period, CurrentTickTime);
+
+            /// <summary>
+            /// Determines whether two reminder tick statuses are equal.
+            /// </summary>
+            public static bool operator ==(TickStatus left, TickStatus right) => left.Equals(right);
+
+            /// <summary>
+            /// Determines whether two reminder tick statuses are unequal.
+            /// </summary>
+            public static bool operator !=(TickStatus left, TickStatus right) => !left.Equals(right);
 
             /// <inheritdoc/>
             public override string ToString() => $"<{FirstTickTime}, {Period}, {CurrentTickTime}>";

--- a/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
+++ b/src/Orleans.Serialization.FSharp/FSharpCodecs.cs
@@ -1058,6 +1058,7 @@ namespace Orleans.Serialization
     /// </summary>
     /// <typeparam name="T">The referenced value type.</typeparam>
     [GenerateSerializer]
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This mutable surrogate is a transient serialization carrier rather than a domain value.")]
     public struct FSharpRefSurrogate<T>
     {
         /// <summary>
@@ -1141,6 +1142,7 @@ namespace Orleans.Serialization
     /// </summary>
     /// <typeparam name="T">The list element type.</typeparam>
     [GenerateSerializer]
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This mutable surrogate carries a reference-backed collection during serialization and has no independent value contract.")]
     public struct FSharpListSurrogate<T>
     {
         /// <summary>
@@ -1230,6 +1232,7 @@ namespace Orleans.Serialization
     /// </summary>
     /// <typeparam name="T">The set element type.</typeparam>
     [GenerateSerializer]
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This mutable surrogate carries a reference-backed collection during serialization and has no independent value contract.")]
     public struct FSharpSetSurrogate<T>
     {
         /// <summary>
@@ -1324,6 +1327,7 @@ namespace Orleans.Serialization
     /// <typeparam name="TKey">The map key type.</typeparam>
     /// <typeparam name="TValue">The map value type.</typeparam>
     [GenerateSerializer]
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This mutable surrogate carries a reference-backed collection during serialization and has no independent value contract.")]
     public struct FSharpMapSurrogate<TKey, TValue>
     {
         /// <summary>

--- a/src/Orleans.Serialization.TestKit/TestBufferWriterStruct.cs
+++ b/src/Orleans.Serialization.TestKit/TestBufferWriterStruct.cs
@@ -10,6 +10,7 @@ namespace Orleans.Serialization.TestKit
     /// Provides a fixed-capacity buffer writer for serialization tests.
     /// </summary>
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This mutable writer owns an aliased buffer and cursor position rather than representing a comparable value.")]
     public struct TestBufferWriterStruct : IBufferWriter<byte>, IOutputBuffer
     {
         private readonly byte[] _buffer;

--- a/src/Orleans.Streaming/Common/PooledCache/CachedMessage.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/CachedMessage.cs
@@ -9,7 +9,7 @@ namespace Orleans.Providers.Streams.Common
     /// This is a tightly packed cached structure containing a queue message.
     /// It should only contain value types.
     /// </summary>
-    public struct CachedMessage
+    public struct CachedMessage : IEquatable<CachedMessage>
     {
         /// <summary>
         /// Identity of the stream this message is a part of.
@@ -40,6 +40,32 @@ namespace Orleans.Providers.Streams.Common
         /// Segment containing the serialized event data.
         /// </summary>
         public ArraySegment<byte> Segment;
+
+        /// <inheritdoc/>
+        public readonly bool Equals(CachedMessage other) =>
+            StreamId.Equals(other.StreamId)
+            && SequenceNumber == other.SequenceNumber
+            && EventIndex == other.EventIndex
+            && EnqueueTimeUtc == other.EnqueueTimeUtc
+            && DequeueTimeUtc == other.DequeueTimeUtc
+            && Segment.Equals(other.Segment);
+
+        /// <inheritdoc/>
+        public override readonly bool Equals(object? obj) => obj is CachedMessage other && Equals(other);
+
+        /// <inheritdoc/>
+        public override readonly int GetHashCode() =>
+            HashCode.Combine(StreamId, SequenceNumber, EventIndex, EnqueueTimeUtc, DequeueTimeUtc, Segment);
+
+        /// <summary>
+        /// Determines whether two cached messages are equal.
+        /// </summary>
+        public static bool operator ==(CachedMessage left, CachedMessage right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two cached messages are unequal.
+        /// </summary>
+        public static bool operator !=(CachedMessage left, CachedMessage right) => !left.Equals(right);
     }
 
     /// <summary>

--- a/src/Orleans.Streaming/MemoryStreams/MemoryMessageData.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryMessageData.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Orleans.Runtime;
 
 namespace Orleans.Providers
@@ -9,6 +10,7 @@ namespace Orleans.Providers
     /// </summary>
     [Serializable]
     [GenerateSerializer]
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "This mutable transport envelope carries aliased payload storage rather than representing a comparable value.")]
     public struct MemoryMessageData
     {
         /// <summary>

--- a/src/Orleans.Streaming/QueueAdapters/QueueCacheCursorResult.cs
+++ b/src/Orleans.Streaming/QueueAdapters/QueueCacheCursorResult.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Streams;
 
@@ -57,7 +58,7 @@ public enum QueueCacheCursorMoveResultKind
 /// <summary>
 /// Describes a queue cache miss.
 /// </summary>
-public readonly struct QueueCacheMissInfo
+public readonly struct QueueCacheMissInfo : IEquatable<QueueCacheMissInfo>
 {
     private readonly object? _requested;
     private readonly object? _low;
@@ -122,6 +123,28 @@ public readonly struct QueueCacheMissInfo
     /// </summary>
     public StreamSequenceToken? HighToken => _high as StreamSequenceToken;
 
+    /// <inheritdoc/>
+    public bool Equals(QueueCacheMissInfo other) =>
+        Equals(_requested, other._requested)
+        && Equals(_low, other._low)
+        && Equals(_high, other._high);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is QueueCacheMissInfo other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(_requested, _low, _high);
+
+    /// <summary>
+    /// Determines whether two cache-miss descriptions are equal.
+    /// </summary>
+    public static bool operator ==(QueueCacheMissInfo left, QueueCacheMissInfo right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two cache-miss descriptions are unequal.
+    /// </summary>
+    public static bool operator !=(QueueCacheMissInfo left, QueueCacheMissInfo right) => !left.Equals(right);
+
     /// <summary>
     /// Creates an exception representing this cache miss.
     /// </summary>
@@ -138,7 +161,7 @@ public readonly struct QueueCacheMissInfo
 /// All other results contain no cursor. A <see cref="QueueCacheCursorResultKind.CacheMiss"/> result
 /// contains <see cref="CacheMiss"/> details, while other results contain no cache-miss details.
 /// </remarks>
-public readonly struct QueueCacheCursorResult<TCursor> where TCursor : class
+public readonly struct QueueCacheCursorResult<TCursor> : IEquatable<QueueCacheCursorResult<TCursor>> where TCursor : class
 {
     private readonly TCursor? _cursor;
     private readonly QueueCacheMissInfo _cacheMiss;
@@ -167,6 +190,28 @@ public readonly struct QueueCacheCursorResult<TCursor> where TCursor : class
     /// Gets the cache miss details when <see cref="Kind"/> is <see cref="QueueCacheCursorResultKind.CacheMiss"/>.
     /// </summary>
     public QueueCacheMissInfo? CacheMiss => Kind == QueueCacheCursorResultKind.CacheMiss ? _cacheMiss : null;
+
+    /// <inheritdoc/>
+    public bool Equals(QueueCacheCursorResult<TCursor> other) =>
+        Kind == other.Kind
+        && EqualityComparer<TCursor?>.Default.Equals(_cursor, other._cursor)
+        && _cacheMiss.Equals(other._cacheMiss);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is QueueCacheCursorResult<TCursor> other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Kind, _cursor, _cacheMiss);
+
+    /// <summary>
+    /// Determines whether two cursor acquisition results are equal.
+    /// </summary>
+    public static bool operator ==(QueueCacheCursorResult<TCursor> left, QueueCacheCursorResult<TCursor> right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two cursor acquisition results are unequal.
+    /// </summary>
+    public static bool operator !=(QueueCacheCursorResult<TCursor> left, QueueCacheCursorResult<TCursor> right) => !left.Equals(right);
 
     /// <summary>
     /// Creates a successful result.
@@ -202,7 +247,7 @@ public readonly struct QueueCacheCursorResult<TCursor> where TCursor : class
 /// current item. All other results indicate that no current item was produced. A
 /// <see cref="QueueCacheCursorMoveResultKind.CacheMiss"/> result contains <see cref="CacheMiss"/> details.
 /// </remarks>
-public readonly struct QueueCacheCursorMoveResult
+public readonly struct QueueCacheCursorMoveResult : IEquatable<QueueCacheCursorMoveResult>
 {
     private readonly QueueCacheMissInfo _cacheMiss;
 
@@ -223,6 +268,26 @@ public readonly struct QueueCacheCursorMoveResult
     /// Gets the cache miss details when <see cref="Kind"/> is <see cref="QueueCacheCursorMoveResultKind.CacheMiss"/>.
     /// </summary>
     public QueueCacheMissInfo? CacheMiss => Kind == QueueCacheCursorMoveResultKind.CacheMiss ? _cacheMiss : null;
+
+    /// <inheritdoc/>
+    public bool Equals(QueueCacheCursorMoveResult other) =>
+        Kind == other.Kind && _cacheMiss.Equals(other._cacheMiss);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is QueueCacheCursorMoveResult other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Kind, _cacheMiss);
+
+    /// <summary>
+    /// Determines whether two cursor movement results are equal.
+    /// </summary>
+    public static bool operator ==(QueueCacheCursorMoveResult left, QueueCacheCursorMoveResult right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two cursor movement results are unequal.
+    /// </summary>
+    public static bool operator !=(QueueCacheCursorMoveResult left, QueueCacheCursorMoveResult right) => !left.Equals(right);
 
     /// <summary>
     /// Gets a successful cursor advancement result.

--- a/src/Orleans.Transactions.TestKit.Base/Consistency/Observation.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Consistency/Observation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Orleans.Transactions.TestKit.Consistency
 {
@@ -7,7 +8,7 @@ namespace Orleans.Transactions.TestKit.Consistency
     /// </summary>
     [Serializable]
     [GenerateSerializer]
-    public struct Observation
+    public struct Observation : IEquatable<Observation>
     {
         /// <summary>
         /// Gets or sets the logical number of the observed grain.
@@ -32,5 +33,28 @@ namespace Orleans.Transactions.TestKit.Consistency
         /// </summary>
         [Id(3)]
         public string ExecutingTx { get; set; }
+
+        /// <inheritdoc/>
+        public readonly bool Equals(Observation other) =>
+            Grain == other.Grain
+            && SeqNo == other.SeqNo
+            && EqualityComparer<string>.Default.Equals(WriterTx, other.WriterTx)
+            && EqualityComparer<string>.Default.Equals(ExecutingTx, other.ExecutingTx);
+
+        /// <inheritdoc/>
+        public override readonly bool Equals(object? obj) => obj is Observation other && Equals(other);
+
+        /// <inheritdoc/>
+        public override readonly int GetHashCode() => HashCode.Combine(Grain, SeqNo, WriterTx, ExecutingTx);
+
+        /// <summary>
+        /// Determines whether two observations are equal.
+        /// </summary>
+        public static bool operator ==(Observation left, Observation right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two observations are unequal.
+        /// </summary>
+        public static bool operator !=(Observation left, Observation right) => !left.Equals(right);
     }
 }

--- a/src/Orleans.Transactions/Abstractions/ITransactionManager.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionManager.cs
@@ -91,7 +91,7 @@ namespace Orleans.Transactions.Abstractions
     /// </summary>
     [GenerateSerializer]
     [Serializable]
-    public struct AccessCounter
+    public struct AccessCounter : IEquatable<AccessCounter>
     {
         /// <summary>
         /// The number of read accesses.
@@ -105,6 +105,25 @@ namespace Orleans.Transactions.Abstractions
         [Id(1)]
         public int Writes;
 
+        /// <inheritdoc/>
+        public readonly bool Equals(AccessCounter other) => Reads == other.Reads && Writes == other.Writes;
+
+        /// <inheritdoc/>
+        public override readonly bool Equals(object? obj) => obj is AccessCounter other && Equals(other);
+
+        /// <inheritdoc/>
+        public override readonly int GetHashCode() => HashCode.Combine(Reads, Writes);
+
+        /// <summary>
+        /// Determines whether two access counters are equal.
+        /// </summary>
+        public static bool operator ==(AccessCounter left, AccessCounter right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two access counters are unequal.
+        /// </summary>
+        public static bool operator !=(AccessCounter left, AccessCounter right) => !left.Equals(right);
+
         /// <summary>
         /// Adds the read and write counts from two values.
         /// </summary>
@@ -117,6 +136,5 @@ namespace Orleans.Transactions.Abstractions
         }
     }
 }
-
 
 

--- a/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
+++ b/src/Orleans.Transactions/DistributedTM/ParticipantId.cs
@@ -10,7 +10,7 @@ namespace Orleans.Transactions
     /// Identifies a transaction participant and the protocol roles which it supports.
     /// </summary>
     [Serializable, GenerateSerializer, Immutable]
-    public readonly struct ParticipantId
+    public readonly struct ParticipantId : IEquatable<ParticipantId>
     {
         /// <summary>
         /// Gets a comparer which identifies participants by <see cref="Name"/> and <see cref="Reference"/>,
@@ -71,6 +71,28 @@ namespace Orleans.Transactions
             this.Reference = reference;
             this.SupportedRoles = supportedRoles;
         }
+
+        /// <inheritdoc/>
+        public bool Equals(ParticipantId other) =>
+            Name == other.Name
+            && EqualityComparer<GrainReference>.Default.Equals(Reference, other.Reference)
+            && SupportedRoles == other.SupportedRoles;
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is ParticipantId other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Combine(Name, Reference, SupportedRoles);
+
+        /// <summary>
+        /// Determines whether two transaction participant identifiers and their supported roles are equal.
+        /// </summary>
+        public static bool operator ==(ParticipantId left, ParticipantId right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two transaction participant identifiers or their supported roles are unequal.
+        /// </summary>
+        public static bool operator !=(ParticipantId left, ParticipantId right) => !left.Equals(right);
 
         /// <summary>
         /// Returns a diagnostic representation of this participant.

--- a/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
+++ b/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 namespace Orleans
 {
-    public readonly partial struct DeactivationReason
+    public readonly partial struct DeactivationReason : System.IEquatable<DeactivationReason>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -21,6 +21,16 @@ namespace Orleans
         public System.Exception? Exception { get { throw null; } }
 
         public DeactivationReasonCode ReasonCode { get { throw null; } }
+
+        public readonly bool Equals(DeactivationReason other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(DeactivationReason left, DeactivationReason right) { throw null; }
+
+        public static bool operator !=(DeactivationReason left, DeactivationReason right) { throw null; }
 
         public override readonly string ToString() { throw null; }
     }
@@ -1431,11 +1441,21 @@ namespace Orleans.Concurrency
 
     [GenerateSerializer]
     [Immutable]
-    public readonly partial struct Immutable<T>
+    public readonly partial struct Immutable<T> : System.IEquatable<Immutable<T>>
     {
         [Id(0)]
         public readonly T Value;
         public Immutable(T value) { }
+
+        public readonly bool Equals(Immutable<T> other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(Immutable<T> left, Immutable<T> right) { throw null; }
+
+        public static bool operator !=(Immutable<T> left, Immutable<T> right) { throw null; }
     }
 
     [System.AttributeUsage(System.AttributeTargets.Class)]
@@ -2325,7 +2345,7 @@ namespace Orleans.Runtime
         public System.IServiceProvider ServiceProvider { get { throw null; } }
     }
 
-    public readonly partial struct GrainTimerCreationOptions
+    public readonly partial struct GrainTimerCreationOptions : System.IEquatable<GrainTimerCreationOptions>
     {
         private readonly int _dummyPrimitive;
         public GrainTimerCreationOptions() { }
@@ -2340,6 +2360,16 @@ namespace Orleans.Runtime
         public bool KeepAlive { get { throw null; } init { } }
 
         public required System.TimeSpan Period { get { throw null; } init { } }
+
+        public readonly bool Equals(GrainTimerCreationOptions other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(GrainTimerCreationOptions left, GrainTimerCreationOptions right) { throw null; }
+
+        public static bool operator !=(GrainTimerCreationOptions left, GrainTimerCreationOptions right) { throw null; }
     }
 
     [GenerateSerializer]
@@ -3325,7 +3355,7 @@ namespace Orleans.Statistics
     [GenerateSerializer]
     [Alias("Orleans.Statistics.EnvironmentStatistics")]
     [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
-    public readonly partial struct EnvironmentStatistics
+    public readonly partial struct EnvironmentStatistics : System.IEquatable<EnvironmentStatistics>
     {
         [Id(2)]
         public readonly long FilteredAvailableMemoryBytes;
@@ -3352,6 +3382,16 @@ namespace Orleans.Statistics
         public float NormalizedFilteredMemoryUsage { get { throw null; } }
 
         public float NormalizedMemoryUsage { get { throw null; } }
+
+        public readonly bool Equals(EnvironmentStatistics other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(EnvironmentStatistics left, EnvironmentStatistics right) { throw null; }
+
+        public static bool operator !=(EnvironmentStatistics left, EnvironmentStatistics right) { throw null; }
 
         public override readonly string ToString() { throw null; }
     }

--- a/src/api/Orleans.Reminders/Orleans.Reminders.cs
+++ b/src/api/Orleans.Reminders/Orleans.Reminders.cs
@@ -324,7 +324,7 @@ namespace Orleans.Runtime
 
     [GenerateSerializer]
     [Immutable]
-    public readonly partial struct TickStatus
+    public readonly partial struct TickStatus : System.IEquatable<TickStatus>
     {
         private readonly int _dummyPrimitive;
         public TickStatus(System.DateTime firstTickTime, System.TimeSpan period, System.DateTime timeStamp) { }
@@ -337,6 +337,16 @@ namespace Orleans.Runtime
 
         [Id(1)]
         public System.TimeSpan Period { get { throw null; } }
+
+        public readonly bool Equals(TickStatus other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(TickStatus left, TickStatus right) { throw null; }
+
+        public static bool operator !=(TickStatus left, TickStatus right) { throw null; }
 
         public override readonly string ToString() { throw null; }
     }

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -497,7 +497,7 @@ namespace Orleans.Providers.Streams.Common
         public string BlockPoolId { get { throw null; } set { } }
     }
 
-    public partial struct CachedMessage
+    public partial struct CachedMessage : System.IEquatable<CachedMessage>
     {
         public System.DateTime DequeueTimeUtc;
         public System.DateTime EnqueueTimeUtc;
@@ -505,6 +505,15 @@ namespace Orleans.Providers.Streams.Common
         public System.ArraySegment<byte> Segment;
         public long SequenceNumber;
         public Runtime.StreamId StreamId;
+        public readonly bool Equals(CachedMessage other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(CachedMessage left, CachedMessage right) { throw null; }
+
+        public static bool operator !=(CachedMessage left, CachedMessage right) { throw null; }
     }
 
     public partial class CachedMessageBlock : PooledResource<CachedMessageBlock>
@@ -1982,7 +1991,7 @@ namespace Orleans.Streams
         public bool UnSubscribeFromQueueDistributionChangeEvents(IStreamQueueBalanceListener observer) { throw null; }
     }
 
-    public readonly partial struct QueueCacheCursorMoveResult
+    public readonly partial struct QueueCacheCursorMoveResult : System.IEquatable<QueueCacheCursorMoveResult>
     {
         private readonly int _dummyPrimitive;
         public QueueCacheMissInfo? CacheMiss { get { throw null; } }
@@ -1993,7 +2002,17 @@ namespace Orleans.Streams
 
         public static QueueCacheCursorMoveResult Success { get { throw null; } }
 
+        public readonly bool Equals(QueueCacheCursorMoveResult other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
         public static QueueCacheCursorMoveResult FromCacheMiss(QueueCacheMissInfo cacheMiss) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(QueueCacheCursorMoveResult left, QueueCacheCursorMoveResult right) { throw null; }
+
+        public static bool operator !=(QueueCacheCursorMoveResult left, QueueCacheCursorMoveResult right) { throw null; }
     }
 
     public enum QueueCacheCursorMoveResultKind
@@ -2012,8 +2031,7 @@ namespace Orleans.Streams
         NotSupported = 3
     }
 
-    public readonly partial struct QueueCacheCursorResult<TCursor>
-        where TCursor : class
+    public readonly partial struct QueueCacheCursorResult<TCursor> : System.IEquatable<QueueCacheCursorResult<TCursor>> where TCursor : class
     {
         private readonly TCursor? _cursor;
         private readonly object _dummy;
@@ -2026,9 +2044,19 @@ namespace Orleans.Streams
 
         public static QueueCacheCursorResult<TCursor> NotSupported { get { throw null; } }
 
+        public readonly bool Equals(QueueCacheCursorResult<TCursor> other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
         public static QueueCacheCursorResult<TCursor> FromCacheMiss(QueueCacheMissInfo cacheMiss) { throw null; }
 
         public static QueueCacheCursorResult<TCursor> FromCursor(TCursor cursor) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(QueueCacheCursorResult<TCursor> left, QueueCacheCursorResult<TCursor> right) { throw null; }
+
+        public static bool operator !=(QueueCacheCursorResult<TCursor> left, QueueCacheCursorResult<TCursor> right) { throw null; }
     }
 
     [GenerateSerializer]
@@ -2057,7 +2085,7 @@ namespace Orleans.Streams
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 
-    public readonly partial struct QueueCacheMissInfo
+    public readonly partial struct QueueCacheMissInfo : System.IEquatable<QueueCacheMissInfo>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -2076,6 +2104,16 @@ namespace Orleans.Streams
         public string? Requested { get { throw null; } }
 
         public StreamSequenceToken? RequestedToken { get { throw null; } }
+
+        public readonly bool Equals(QueueCacheMissInfo other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(QueueCacheMissInfo left, QueueCacheMissInfo right) { throw null; }
+
+        public static bool operator !=(QueueCacheMissInfo left, QueueCacheMissInfo right) { throw null; }
 
         public readonly QueueCacheMissException ToException() { throw null; }
     }

--- a/src/api/Orleans.Transactions.TestKit.Base/Orleans.Transactions.TestKit.Base.cs
+++ b/src/api/Orleans.Transactions.TestKit.Base/Orleans.Transactions.TestKit.Base.cs
@@ -944,7 +944,7 @@ namespace Orleans.Transactions.TestKit.Consistency
     }
 
     [GenerateSerializer]
-    public partial struct Observation
+    public partial struct Observation : System.IEquatable<Observation>
     {
         private object _dummy;
         private int _dummyPrimitive;
@@ -959,6 +959,16 @@ namespace Orleans.Transactions.TestKit.Consistency
 
         [Id(2)]
         public string WriterTx { get { throw null; } set { } }
+
+        public readonly bool Equals(Observation other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(Observation left, Observation right) { throw null; }
+
+        public static bool operator !=(Observation left, Observation right) { throw null; }
     }
 
     public enum ReadWriteDetermination

--- a/src/api/Orleans.Transactions/Orleans.Transactions.cs
+++ b/src/api/Orleans.Transactions/Orleans.Transactions.cs
@@ -397,7 +397,7 @@ namespace Orleans.Transactions
 
     [GenerateSerializer]
     [Immutable]
-    public readonly partial struct ParticipantId
+    public readonly partial struct ParticipantId : System.IEquatable<ParticipantId>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -412,6 +412,16 @@ namespace Orleans.Transactions
 
         [Id(2)]
         public Role SupportedRoles { get { throw null; } }
+
+        public readonly bool Equals(ParticipantId other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ParticipantId left, ParticipantId right) { throw null; }
+
+        public static bool operator !=(ParticipantId left, ParticipantId right) { throw null; }
 
         public override readonly string ToString() { throw null; }
 
@@ -702,13 +712,23 @@ namespace Orleans.Transactions
 namespace Orleans.Transactions.Abstractions
 {
     [GenerateSerializer]
-    public partial struct AccessCounter
+    public partial struct AccessCounter : System.IEquatable<AccessCounter>
     {
         [Id(0)]
         public int Reads;
         [Id(1)]
         public int Writes;
+        public readonly bool Equals(AccessCounter other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
         public static AccessCounter operator +(AccessCounter c1, AccessCounter c2) { throw null; }
+
+        public static bool operator ==(AccessCounter left, AccessCounter right) { throw null; }
+
+        public static bool operator !=(AccessCounter left, AccessCounter right) { throw null; }
     }
 
     [GenerateSerializer]

--- a/test/Orleans.Core.Tests/General/CoreAbstractionsValueSemanticsTests.cs
+++ b/test/Orleans.Core.Tests/General/CoreAbstractionsValueSemanticsTests.cs
@@ -1,0 +1,436 @@
+using System.Reflection;
+using Orleans;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+using Orleans.Statistics;
+using TestExtensions;
+using UnitTests.Serialization;
+using Xunit;
+
+namespace UnitTests.General;
+
+[Collection(TestEnvironmentFixture.DefaultCollection)]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+[TestCategory("BVT")]
+public class CoreAbstractionsValueSemanticsTests
+{
+    private readonly TestEnvironmentFixture _fixture;
+
+    public CoreAbstractionsValueSemanticsTests(TestEnvironmentFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void DeactivationReason_EqualFieldsAndDefaultValues_SatisfyEqualityContract()
+    {
+        var defaultValue = default(DeactivationReason);
+        var equalDefaultValue = default(DeactivationReason);
+        var expected = new DeactivationReason(DeactivationReasonCode.ApplicationRequested, "requested");
+        var actual = new DeactivationReason(
+            DeactivationReasonCode.ApplicationRequested,
+            new string("requested".ToCharArray()));
+
+        Assert.Null(defaultValue.Description);
+        Assert.Equal(DeactivationReasonCode.None, defaultValue.ReasonCode);
+        Assert.Null(defaultValue.Exception);
+        AssertEqual(defaultValue, equalDefaultValue);
+
+        Assert.Equal("requested", actual.Description);
+        Assert.Equal(DeactivationReasonCode.ApplicationRequested, actual.ReasonCode);
+        Assert.Null(actual.Exception);
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public void DeactivationReason_NullSameAndDistinctExceptionReferences_UseReferenceIdentity()
+    {
+        var withoutException = new DeactivationReason(DeactivationReasonCode.ApplicationError, null, "failure");
+        var alsoWithoutException = new DeactivationReason(DeactivationReasonCode.ApplicationError, null, "failure");
+        AssertEqual(withoutException, alsoWithoutException);
+
+        var sharedException = new InvalidOperationException("failure");
+        var withSharedException = new DeactivationReason(DeactivationReasonCode.ApplicationError, sharedException, "failure");
+        var alsoWithSharedException = new DeactivationReason(DeactivationReasonCode.ApplicationError, sharedException, "failure");
+        Assert.Same(withSharedException.Exception, alsoWithSharedException.Exception);
+        AssertEqual(withSharedException, alsoWithSharedException);
+
+        var firstException = new InvalidOperationException("failure");
+        var secondException = new InvalidOperationException("failure");
+        var withFirstException = new DeactivationReason(DeactivationReasonCode.ApplicationError, firstException, "failure");
+        var withSecondException = new DeactivationReason(DeactivationReasonCode.ApplicationError, secondException, "failure");
+        Assert.NotSame(withFirstException.Exception, withSecondException.Exception);
+        AssertNotEqual(withFirstException, withSecondException);
+    }
+
+    [Fact]
+    public void DeactivationReason_EachDifferentField_IsUnequal()
+    {
+        var exception = new InvalidOperationException("failure");
+        var description = "failure";
+        var equalDescription = new string(description.ToCharArray());
+        var original = new DeactivationReason(DeactivationReasonCode.ApplicationError, exception, description);
+        var equal = new DeactivationReason(DeactivationReasonCode.ApplicationError, exception, equalDescription);
+
+        Assert.NotSame(description, equalDescription);
+        AssertEqual(original, equal);
+
+        AssertNotEqual(
+            original,
+            new DeactivationReason(DeactivationReasonCode.ActivationFailed, exception, description));
+        AssertNotEqual(
+            original,
+            new DeactivationReason(DeactivationReasonCode.ApplicationError, exception, "different"));
+        AssertNotEqual(
+            original,
+            new DeactivationReason(
+                DeactivationReasonCode.ApplicationError,
+                new InvalidOperationException("failure"),
+                description));
+    }
+
+    [Fact]
+    public void DeactivationReason_EqualAndUnequalValues_UseHashSetAndDictionary()
+    {
+        var exception = new InvalidOperationException("failure");
+        var original = new DeactivationReason(DeactivationReasonCode.ApplicationError, exception, "failure");
+        var equal = new DeactivationReason(DeactivationReasonCode.ApplicationError, exception, "failure");
+        var unequal = new DeactivationReason(DeactivationReasonCode.ApplicationError, exception, "different");
+
+        AssertHashCollections(original, equal, unequal);
+    }
+
+    [Fact]
+    public void Immutable_DefaultNullAndScalarValues_SatisfyEqualityContract()
+    {
+        var defaultValue = default(Immutable<string>);
+        var explicitNull = new Immutable<string>(null!);
+        var expectedScalar = new Immutable<int>(42);
+        var actualScalar = new Immutable<int>(42);
+
+        Assert.Null(defaultValue.Value);
+        Assert.Null(explicitNull.Value);
+        AssertEqual(defaultValue, explicitNull);
+
+        Assert.Equal(42, actualScalar.Value);
+        AssertEqual(expectedScalar, actualScalar);
+        Assert.False(actualScalar.Equals((object)42));
+    }
+
+    [Fact]
+    public void Immutable_ArrayValue_UsesReferenceIdentityNotSequenceEquality()
+    {
+        int[] sharedArray = [1, 2, 3];
+        int[] distinctArray = [1, 2, 3];
+        var first = new Immutable<int[]>(sharedArray);
+        var withSharedArray = new Immutable<int[]>(sharedArray);
+        var withDistinctArray = new Immutable<int[]>(distinctArray);
+        var nullArray = new Immutable<int[]>(null!);
+        var alsoNullArray = new Immutable<int[]>(null!);
+
+        Assert.Same(first.Value, withSharedArray.Value);
+        AssertEqual(first, withSharedArray);
+
+        Assert.NotSame(first.Value, withDistinctArray.Value);
+        AssertNotEqual(first, withDistinctArray);
+
+        Assert.Null(nullArray.Value);
+        Assert.Null(alsoNullArray.Value);
+        AssertEqual(nullArray, alsoNullArray);
+    }
+
+    [Fact]
+    public void Immutable_EqualAndUnequalValues_UseHashSetAndDictionary()
+    {
+        AssertHashCollections(new Immutable<int>(42), new Immutable<int>(42), new Immutable<int>(43));
+
+        int[] sharedArray = [1, 2, 3];
+        int[] distinctArray = [1, 2, 3];
+        Assert.Same(sharedArray, new Immutable<int[]>(sharedArray).Value);
+        Assert.NotSame(sharedArray, distinctArray);
+        AssertHashCollections(
+            new Immutable<int[]>(sharedArray),
+            new Immutable<int[]>(sharedArray),
+            new Immutable<int[]>(distinctArray));
+    }
+
+    [Fact]
+    public void Immutable_IntSerializerRoundTrip_PreservesEquality()
+    {
+        var original = new Immutable<int>(8675309);
+
+        var result = _fixture.Serializer.RoundTripSerializationForTesting(original);
+
+        Assert.Equal(8675309, result.Value);
+        AssertEqual(original, result);
+    }
+
+    [Fact]
+    public void Immutable_ValueSerializationId_IsZero()
+    {
+        var valueField = typeof(Immutable<int>).GetField(nameof(Immutable<int>.Value));
+
+        Assert.NotNull(valueField);
+        var id = valueField.GetCustomAttribute<IdAttribute>();
+        Assert.NotNull(id);
+        Assert.Equal(0U, id.Id);
+    }
+
+    [Fact]
+    public void EnvironmentStatistics_EqualAndDefaultValues_SatisfyEqualityContract()
+    {
+        var defaultValue = default(EnvironmentStatistics);
+        var equalDefaultValue = default(EnvironmentStatistics);
+        var expected = CreateEnvironmentStatistics();
+        var actual = CreateEnvironmentStatistics();
+
+        Assert.Equal(0f, defaultValue.FilteredCpuUsagePercentage);
+        Assert.Equal(0L, defaultValue.FilteredMemoryUsageBytes);
+        Assert.Equal(0L, defaultValue.FilteredAvailableMemoryBytes);
+        Assert.Equal(0L, defaultValue.MaximumAvailableMemoryBytes);
+        Assert.Equal(0f, defaultValue.RawCpuUsagePercentage);
+        Assert.Equal(0L, defaultValue.RawMemoryUsageBytes);
+        Assert.Equal(0L, defaultValue.RawAvailableMemoryBytes);
+        AssertEqual(defaultValue, equalDefaultValue);
+
+        Assert.Equal(12.5f, actual.FilteredCpuUsagePercentage);
+        Assert.Equal(200L, actual.FilteredMemoryUsageBytes);
+        Assert.Equal(700L, actual.FilteredAvailableMemoryBytes);
+        Assert.Equal(1_000L, actual.MaximumAvailableMemoryBytes);
+        Assert.Equal(34.5f, actual.RawCpuUsagePercentage);
+        Assert.Equal(300L, actual.RawMemoryUsageBytes);
+        Assert.Equal(600L, actual.RawAvailableMemoryBytes);
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public void EnvironmentStatistics_EachDifferentField_IsUnequal()
+    {
+        var original = CreateEnvironmentStatistics();
+
+        AssertNotEqual(original, CreateEnvironmentStatistics(filteredCpuUsagePercentage: 13.5f));
+        AssertNotEqual(original, CreateEnvironmentStatistics(filteredMemoryUsageBytes: 201L));
+        AssertNotEqual(original, CreateEnvironmentStatistics(filteredAvailableMemoryBytes: 701L));
+        AssertNotEqual(original, CreateEnvironmentStatistics(maximumAvailableMemoryBytes: 1_001L));
+        AssertNotEqual(original, CreateEnvironmentStatistics(rawCpuUsagePercentage: 35.5f));
+        AssertNotEqual(original, CreateEnvironmentStatistics(rawMemoryUsageBytes: 301L));
+        AssertNotEqual(original, CreateEnvironmentStatistics(rawAvailableMemoryBytes: 601L));
+    }
+
+    [Fact]
+    public void EnvironmentStatistics_EqualAndUnequalValues_UseHashSetAndDictionary()
+    {
+        var original = CreateEnvironmentStatistics();
+        var equal = CreateEnvironmentStatistics();
+        var unequal = CreateEnvironmentStatistics(rawMemoryUsageBytes: 301L);
+
+        AssertHashCollections(original, equal, unequal);
+    }
+
+    [Fact]
+    public void EnvironmentStatistics_SerializerRoundTrip_PreservesEquality()
+    {
+        var original = CreateEnvironmentStatistics();
+
+        var result = _fixture.Serializer.RoundTripSerializationForTesting(original);
+
+        Assert.Equal(12.5f, result.FilteredCpuUsagePercentage);
+        Assert.Equal(200L, result.FilteredMemoryUsageBytes);
+        Assert.Equal(700L, result.FilteredAvailableMemoryBytes);
+        Assert.Equal(1_000L, result.MaximumAvailableMemoryBytes);
+        Assert.Equal(34.5f, result.RawCpuUsagePercentage);
+        Assert.Equal(300L, result.RawMemoryUsageBytes);
+        Assert.Equal(600L, result.RawAvailableMemoryBytes);
+        AssertEqual(original, result);
+    }
+
+    [Fact]
+    public void EnvironmentStatistics_SerializationIdsAndAlias_ArePreserved()
+    {
+        var expectedIds = new Dictionary<string, uint>
+        {
+            [nameof(EnvironmentStatistics.FilteredCpuUsagePercentage)] = 0,
+            [nameof(EnvironmentStatistics.FilteredMemoryUsageBytes)] = 1,
+            [nameof(EnvironmentStatistics.FilteredAvailableMemoryBytes)] = 2,
+            [nameof(EnvironmentStatistics.MaximumAvailableMemoryBytes)] = 3,
+            [nameof(EnvironmentStatistics.RawCpuUsagePercentage)] = 4,
+            [nameof(EnvironmentStatistics.RawMemoryUsageBytes)] = 5,
+            [nameof(EnvironmentStatistics.RawAvailableMemoryBytes)] = 6,
+        };
+
+        foreach (var (memberName, expectedId) in expectedIds)
+        {
+            var field = typeof(EnvironmentStatistics).GetField(memberName);
+            Assert.NotNull(field);
+            var id = field.GetCustomAttribute<IdAttribute>();
+            Assert.NotNull(id);
+            Assert.Equal(expectedId, id.Id);
+        }
+
+        var alias = typeof(EnvironmentStatistics).GetCustomAttribute<AliasAttribute>();
+        Assert.NotNull(alias);
+        Assert.Equal("Orleans.Statistics.EnvironmentStatistics", alias.Alias);
+    }
+
+    [Fact]
+    public void GrainTimerCreationOptions_EqualAndDefaultValues_SatisfyEqualityContract()
+    {
+        var defaultValue = default(GrainTimerCreationOptions);
+        var equalDefaultValue = default(GrainTimerCreationOptions);
+        var expected = CreateGrainTimerCreationOptions();
+        var actual = CreateGrainTimerCreationOptions();
+
+        Assert.Equal(TimeSpan.Zero, defaultValue.DueTime);
+        Assert.Equal(TimeSpan.Zero, defaultValue.Period);
+        Assert.False(defaultValue.Interleave);
+        Assert.False(defaultValue.KeepAlive);
+        AssertEqual(defaultValue, equalDefaultValue);
+
+        Assert.Equal(TimeSpan.FromSeconds(2), actual.DueTime);
+        Assert.Equal(TimeSpan.FromMinutes(3), actual.Period);
+        Assert.True(actual.Interleave);
+        Assert.True(actual.KeepAlive);
+        AssertEqual(expected, actual);
+    }
+
+    [Fact]
+    public void GrainTimerCreationOptions_EachDifferentOption_IsUnequal()
+    {
+        var original = CreateGrainTimerCreationOptions();
+
+        AssertNotEqual(original, CreateGrainTimerCreationOptions(dueTime: TimeSpan.FromSeconds(3)));
+        AssertNotEqual(original, CreateGrainTimerCreationOptions(period: TimeSpan.FromMinutes(4)));
+        AssertNotEqual(original, CreateGrainTimerCreationOptions(interleave: false));
+        AssertNotEqual(original, CreateGrainTimerCreationOptions(keepAlive: false));
+    }
+
+    [Fact]
+    public void GrainTimerCreationOptions_EqualAndUnequalValues_UseHashSetAndDictionary()
+    {
+        var original = CreateGrainTimerCreationOptions();
+        var equal = CreateGrainTimerCreationOptions();
+        var unequal = CreateGrainTimerCreationOptions(keepAlive: false);
+
+        AssertHashCollections(original, equal, unequal);
+    }
+
+    private static EnvironmentStatistics CreateEnvironmentStatistics(
+        float filteredCpuUsagePercentage = 12.5f,
+        float rawCpuUsagePercentage = 34.5f,
+        long filteredMemoryUsageBytes = 200L,
+        long rawMemoryUsageBytes = 300L,
+        long filteredAvailableMemoryBytes = 700L,
+        long rawAvailableMemoryBytes = 600L,
+        long maximumAvailableMemoryBytes = 1_000L) =>
+        new(
+            filteredCpuUsagePercentage,
+            rawCpuUsagePercentage,
+            filteredMemoryUsageBytes,
+            rawMemoryUsageBytes,
+            filteredAvailableMemoryBytes,
+            rawAvailableMemoryBytes,
+            maximumAvailableMemoryBytes);
+
+    private static GrainTimerCreationOptions CreateGrainTimerCreationOptions(
+        TimeSpan? dueTime = null,
+        TimeSpan? period = null,
+        bool interleave = true,
+        bool keepAlive = true) =>
+        new(dueTime ?? TimeSpan.FromSeconds(2), period ?? TimeSpan.FromMinutes(3))
+        {
+            Interleave = interleave,
+            KeepAlive = keepAlive,
+        };
+
+    private static void AssertEqual(DeactivationReason left, DeactivationReason right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(DeactivationReason left, DeactivationReason right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual<T>(Immutable<T> left, Immutable<T> right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual<T>(Immutable<T> left, Immutable<T> right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual(EnvironmentStatistics left, EnvironmentStatistics right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(EnvironmentStatistics left, EnvironmentStatistics right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual(GrainTimerCreationOptions left, GrainTimerCreationOptions right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(GrainTimerCreationOptions left, GrainTimerCreationOptions right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqualContract<T>(T left, T right)
+        where T : struct, IEquatable<T>
+    {
+        Assert.Equal(left, right);
+        Assert.True(left.Equals(right));
+        Assert.True(right.Equals(left));
+        Assert.True(((object)left).Equals(right));
+        Assert.True(((object)right).Equals(left));
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    private static void AssertNotEqualContract<T>(T left, T right)
+        where T : struct, IEquatable<T>
+    {
+        Assert.NotEqual(left, right);
+        Assert.False(left.Equals(right));
+        Assert.False(right.Equals(left));
+        Assert.False(((object)left).Equals(right));
+        Assert.False(((object)right).Equals(left));
+    }
+
+    private static void AssertHashCollections<T>(T original, T equal, T unequal)
+        where T : notnull
+    {
+        var set = new HashSet<T> { original };
+        var dictionary = new Dictionary<T, string> { [original] = "stored" };
+
+        Assert.Contains(equal, set);
+        Assert.DoesNotContain(unequal, set);
+        Assert.True(dictionary.TryGetValue(equal, out var value));
+        Assert.Equal("stored", value);
+        Assert.False(dictionary.ContainsKey(unequal));
+    }
+}

--- a/test/Orleans.Reminders.Tests/TimerTests/TickStatusValueSemanticsTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/TickStatusValueSemanticsTests.cs
@@ -1,0 +1,120 @@
+using System.Reflection;
+using Orleans;
+using Orleans.Runtime;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.TimerTests;
+
+[CollectionDefinition(Name)]
+public sealed class TickStatusValueSemanticsCollection : ICollectionFixture<TestEnvironmentFixture>
+{
+    public const string Name = nameof(TickStatusValueSemanticsCollection);
+}
+
+[Collection(TickStatusValueSemanticsCollection.Name)]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Reminders")]
+[TestCategory("BVT"), TestCategory("Reminders")]
+public class TickStatusValueSemanticsTests
+{
+    private readonly TestEnvironmentFixture _fixture;
+
+    public TickStatusValueSemanticsTests(TestEnvironmentFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void EqualAndDefaultValuesSatisfyEqualityContract()
+    {
+        AssertEqual(default, default);
+
+        var first = CreateStatus();
+        var second = CreateStatus();
+
+        AssertEqual(first, second);
+        Assert.False(first.Equals(new object()));
+    }
+
+    [Fact]
+    public void EachFieldParticipatesInEquality()
+    {
+        var original = CreateStatus();
+
+        AssertNotEqual(original, CreateStatus(firstTickTime: original.FirstTickTime.AddTicks(1)));
+        AssertNotEqual(original, CreateStatus(period: original.Period.Add(TimeSpan.FromTicks(1))));
+        AssertNotEqual(original, CreateStatus(currentTickTime: original.CurrentTickTime.AddTicks(1)));
+    }
+
+    [Fact]
+    public void EqualValuesWorkAsHashKeys()
+    {
+        var original = CreateStatus();
+        var equal = CreateStatus();
+        var unequal = CreateStatus(period: TimeSpan.FromMinutes(2));
+        var set = new HashSet<TickStatus> { original };
+        var dictionary = new Dictionary<TickStatus, string> { [original] = "tick" };
+
+        Assert.Contains(equal, set);
+        Assert.DoesNotContain(unequal, set);
+        Assert.Equal("tick", dictionary[equal]);
+        Assert.False(dictionary.ContainsKey(unequal));
+    }
+
+    [Fact]
+    public void SerializerRoundTripPreservesEquality()
+    {
+        var original = CreateStatus();
+
+        var result = _fixture.Serializer.Deserialize<TickStatus>(_fixture.Serializer.SerializeToArray(original));
+
+        AssertEqual(original, result);
+    }
+
+    [Fact]
+    public void SerializationIdsArePreserved()
+    {
+        Assert.Equal(0U, GetId(nameof(TickStatus.FirstTickTime)));
+        Assert.Equal(1U, GetId(nameof(TickStatus.Period)));
+        Assert.Equal(2U, GetId(nameof(TickStatus.CurrentTickTime)));
+    }
+
+    private static TickStatus CreateStatus(
+        DateTime? firstTickTime = null,
+        TimeSpan? period = null,
+        DateTime? currentTickTime = null) =>
+        new(
+            firstTickTime ?? new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+            period ?? TimeSpan.FromMinutes(1),
+            currentTickTime ?? new DateTime(2026, 1, 2, 3, 5, 5, DateTimeKind.Utc));
+
+    private static uint GetId(string propertyName)
+    {
+        var property = typeof(TickStatus).GetProperty(propertyName);
+        Assert.NotNull(property);
+        var attribute = property.GetCustomAttribute<IdAttribute>();
+        Assert.NotNull(attribute);
+        return attribute.Id;
+    }
+
+    private static void AssertEqual(TickStatus left, TickStatus right)
+    {
+        Assert.Equal(left, right);
+        Assert.True(left.Equals(right));
+        Assert.True(((object)left).Equals(right));
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(TickStatus left, TickStatus right)
+    {
+        Assert.NotEqual(left, right);
+        Assert.False(left.Equals(right));
+        Assert.False(((object)left).Equals(right));
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+}

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/StreamingValueSemanticsTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/StreamingValueSemanticsTests.cs
@@ -1,0 +1,233 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Orleans;
+using Orleans.Providers;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace UnitTests.OrleansRuntime.Streams;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+[TestCategory("BVT"), TestCategory("Streaming")]
+public class StreamingValueSemanticsTests
+{
+    [Fact]
+    public void CachedMessageUsesAllFieldsAndSegmentIdentity()
+    {
+        AssertEqual(default(CachedMessage), default);
+
+        byte[] sharedPayload = [1, 2, 3, 4];
+        byte[] copiedPayload = [1, 2, 3, 4];
+        var original = CreateCachedMessage(new ArraySegment<byte>(sharedPayload, 1, 2));
+        var equal = CreateCachedMessage(new ArraySegment<byte>(sharedPayload, 1, 2));
+
+        Assert.Same(original.Segment.Array, equal.Segment.Array);
+        AssertEqual(original, equal);
+        AssertNotEqual(original, CreateCachedMessage(new ArraySegment<byte>(copiedPayload, 1, 2)));
+        AssertNotEqual(original, CreateCachedMessage(original.Segment, sequenceNumber: 11));
+        AssertNotEqual(original, CreateCachedMessage(original.Segment, eventIndex: 3));
+        AssertNotEqual(original, CreateCachedMessage(original.Segment, enqueueTimeUtc: original.EnqueueTimeUtc.AddTicks(1)));
+        AssertNotEqual(original, CreateCachedMessage(original.Segment, dequeueTimeUtc: original.DequeueTimeUtc.AddTicks(1)));
+        AssertNotEqual(original, CreateCachedMessage(original.Segment, streamId: StreamId.Create("other", "key")));
+        AssertHashCollections(original, equal, CreateCachedMessage(new ArraySegment<byte>(copiedPayload, 1, 2)));
+    }
+
+    [Fact]
+    public void QueueCacheMissInfoUsesStoredMemberEquality()
+    {
+        AssertEqual(default(QueueCacheMissInfo), new QueueCacheMissInfo((string?)null, null, null));
+
+        var requested = new string("requested".ToCharArray());
+        var equalRequested = new string("requested".ToCharArray());
+        Assert.NotSame(requested, equalRequested);
+        var original = new QueueCacheMissInfo(requested, "low", "high");
+        var equal = new QueueCacheMissInfo(equalRequested, "low", "high");
+        AssertEqual(original, equal);
+
+        var token = new IdentityToken(1, "token");
+        var sameToken = new QueueCacheMissInfo(token, token, token);
+        AssertEqual(sameToken, new QueueCacheMissInfo(token, token, token));
+        AssertNotEqual(sameToken, new QueueCacheMissInfo(new IdentityToken(1, "token"), token, token));
+        AssertNotEqual(original, new QueueCacheMissInfo("different", "low", "high"));
+        AssertNotEqual(original, new QueueCacheMissInfo("requested", "different", "high"));
+        AssertNotEqual(original, new QueueCacheMissInfo("requested", "low", "different"));
+        AssertHashCollections(original, equal, new QueueCacheMissInfo("different", "low", "high"));
+    }
+
+    [Fact]
+    public void QueueCacheCursorResultUsesKindCursorAndCacheMiss()
+    {
+        AssertEqual(default(QueueCacheCursorResult<TestCursor>), default);
+
+        var cursor = new TestCursor();
+        var cursorResult = QueueCacheCursorResult<TestCursor>.FromCursor(cursor);
+        var equalCursorResult = QueueCacheCursorResult<TestCursor>.FromCursor(cursor);
+        Assert.Same(cursorResult.Cursor, equalCursorResult.Cursor);
+        AssertEqual(cursorResult, equalCursorResult);
+        AssertNotEqual(cursorResult, QueueCacheCursorResult<TestCursor>.FromCursor(new TestCursor()));
+
+        var miss = new QueueCacheMissInfo("requested", "low", "high");
+        var missResult = QueueCacheCursorResult<TestCursor>.FromCacheMiss(miss);
+        var equalMissResult = QueueCacheCursorResult<TestCursor>.FromCacheMiss(miss);
+        AssertEqual(missResult, equalMissResult);
+        AssertNotEqual(missResult, QueueCacheCursorResult<TestCursor>.FromCacheMiss(new("different", "low", "high")));
+        AssertNotEqual(missResult, QueueCacheCursorResult<TestCursor>.NotSupported);
+        AssertEqual(QueueCacheCursorResult<TestCursor>.NotSupported, QueueCacheCursorResult<TestCursor>.NotSupported);
+        AssertHashCollections(cursorResult, equalCursorResult, QueueCacheCursorResult<TestCursor>.FromCursor(new TestCursor()));
+    }
+
+    [Fact]
+    public void QueueCacheCursorMoveResultUsesKindAndCacheMiss()
+    {
+        AssertEqual(default(QueueCacheCursorMoveResult), default);
+        AssertEqual(QueueCacheCursorMoveResult.Success, QueueCacheCursorMoveResult.Success);
+        AssertEqual(QueueCacheCursorMoveResult.NoData, QueueCacheCursorMoveResult.NoData);
+        AssertNotEqual(QueueCacheCursorMoveResult.Success, QueueCacheCursorMoveResult.NoData);
+
+        var miss = new QueueCacheMissInfo("requested", "low", "high");
+        var missResult = QueueCacheCursorMoveResult.FromCacheMiss(miss);
+        var equalMissResult = QueueCacheCursorMoveResult.FromCacheMiss(miss);
+        AssertEqual(missResult, equalMissResult);
+        AssertNotEqual(missResult, QueueCacheCursorMoveResult.FromCacheMiss(new("different", "low", "high")));
+        AssertHashCollections(missResult, equalMissResult, QueueCacheCursorMoveResult.NoData);
+    }
+
+    [Fact]
+    public void MemoryMessageDataSerializationIdsArePreserved()
+    {
+        Assert.Equal(0U, GetId(nameof(MemoryMessageData.StreamId)));
+        Assert.Equal(1U, GetId(nameof(MemoryMessageData.SequenceNumber)));
+        Assert.Equal(2U, GetId(nameof(MemoryMessageData.DequeueTimeUtc)));
+        Assert.Equal(3U, GetId(nameof(MemoryMessageData.EnqueueTimeUtc)));
+        Assert.Equal(4U, GetId(nameof(MemoryMessageData.Payload)));
+    }
+
+    private static CachedMessage CreateCachedMessage(
+        ArraySegment<byte> segment,
+        StreamId? streamId = null,
+        long sequenceNumber = 10,
+        int eventIndex = 2,
+        DateTime? enqueueTimeUtc = null,
+        DateTime? dequeueTimeUtc = null) =>
+        new()
+        {
+            StreamId = streamId ?? StreamId.Create("namespace", "key"),
+            SequenceNumber = sequenceNumber,
+            EventIndex = eventIndex,
+            EnqueueTimeUtc = enqueueTimeUtc ?? new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+            DequeueTimeUtc = dequeueTimeUtc ?? new DateTime(2026, 1, 2, 3, 4, 6, DateTimeKind.Utc),
+            Segment = segment,
+        };
+
+    private static uint GetId(string fieldName)
+    {
+        var field = typeof(MemoryMessageData).GetField(fieldName);
+        Assert.NotNull(field);
+        var attribute = field.GetCustomAttribute<IdAttribute>();
+        Assert.NotNull(attribute);
+        return attribute.Id;
+    }
+
+    private static void AssertEqual(CachedMessage left, CachedMessage right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(CachedMessage left, CachedMessage right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual(QueueCacheMissInfo left, QueueCacheMissInfo right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(QueueCacheMissInfo left, QueueCacheMissInfo right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual(QueueCacheCursorResult<TestCursor> left, QueueCacheCursorResult<TestCursor> right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(QueueCacheCursorResult<TestCursor> left, QueueCacheCursorResult<TestCursor> right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual(QueueCacheCursorMoveResult left, QueueCacheCursorMoveResult right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(QueueCacheCursorMoveResult left, QueueCacheCursorMoveResult right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqualContract<T>(T left, T right)
+        where T : struct, IEquatable<T>
+    {
+        Assert.Equal(left, right);
+        Assert.True(left.Equals(right));
+        Assert.True(((object)left).Equals(right));
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    private static void AssertNotEqualContract<T>(T left, T right)
+        where T : struct, IEquatable<T>
+    {
+        Assert.NotEqual(left, right);
+        Assert.False(left.Equals(right));
+        Assert.False(((object)left).Equals(right));
+    }
+
+    private static void AssertHashCollections<T>(T original, T equal, T unequal)
+        where T : notnull
+    {
+        var set = new HashSet<T> { original };
+        var dictionary = new Dictionary<T, string> { [original] = "stored" };
+
+        Assert.Contains(equal, set);
+        Assert.DoesNotContain(unequal, set);
+        Assert.Equal("stored", dictionary[equal]);
+        Assert.False(dictionary.ContainsKey(unequal));
+    }
+
+    private sealed class TestCursor;
+
+    private sealed class IdentityToken(long sequenceNumber, string text) : StreamSequenceToken
+    {
+        public override long SequenceNumber { get; protected set; } = sequenceNumber;
+        public override int EventIndex { get; protected set; }
+        public override bool Equals(StreamSequenceToken? other) => ReferenceEquals(this, other);
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj);
+        public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
+        public override int CompareTo(StreamSequenceToken? other) => ReferenceEquals(this, other) ? 0 : 1;
+        public override string ToString() => text;
+    }
+
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionValueSemanticsTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionValueSemanticsTests.cs
@@ -1,0 +1,287 @@
+using System.Reflection;
+using Orleans;
+using Orleans.GrainReferences;
+using Orleans.Runtime;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.TestKit.Consistency;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[CollectionDefinition(Name)]
+public sealed class TransactionValueSemanticsCollection : ICollectionFixture<TestEnvironmentFixture>
+{
+    public const string Name = nameof(TransactionValueSemanticsCollection);
+}
+
+[Collection(TransactionValueSemanticsCollection.Name)]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionValueSemanticsTests
+{
+    private readonly TestEnvironmentFixture _fixture;
+
+    public TransactionValueSemanticsTests(TestEnvironmentFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void AccessCounterSatisfiesEqualityAndAdditionContracts()
+    {
+        AssertEqual(default(AccessCounter), default);
+
+        var original = new AccessCounter { Reads = 2, Writes = 3 };
+        var equal = new AccessCounter { Reads = 2, Writes = 3 };
+        AssertEqual(original, equal);
+        AssertNotEqual(original, new AccessCounter { Reads = 1, Writes = 3 });
+        AssertNotEqual(original, new AccessCounter { Reads = 2, Writes = 4 });
+        AssertHashCollections(original, equal, new AccessCounter { Reads = 2, Writes = 4 });
+        AssertEqual(
+            new AccessCounter { Reads = 7, Writes = 11 },
+            original + new AccessCounter { Reads = 5, Writes = 8 });
+    }
+
+    [Fact]
+    public void AccessCounterSerializationContractIsPreserved()
+    {
+        var original = new AccessCounter { Reads = 2, Writes = 3 };
+
+        var result = RoundTrip(original);
+
+        AssertEqual(original, result);
+        Assert.Equal(0U, GetFieldId<AccessCounter>(nameof(AccessCounter.Reads)));
+        Assert.Equal(1U, GetFieldId<AccessCounter>(nameof(AccessCounter.Writes)));
+    }
+
+    [Fact]
+    public void ParticipantIdDefaultEqualityIncludesRoles()
+    {
+        AssertEqual(default(ParticipantId), default);
+
+        var reference = CreateGrainReference("resource");
+        var name = new string("state".ToCharArray());
+        var equalName = new string("state".ToCharArray());
+        var original = new ParticipantId(name, reference, ParticipantId.Role.Resource);
+        var equal = new ParticipantId(equalName, reference, ParticipantId.Role.Resource);
+        var differentRole = new ParticipantId(name, reference, ParticipantId.Role.Manager);
+
+        Assert.NotSame(name, equalName);
+        Assert.Same(original.Reference, equal.Reference);
+        AssertEqual(original, equal);
+        AssertNotEqual(original, differentRole);
+        AssertHashCollections(original, equal, differentRole);
+    }
+
+    [Fact]
+    public void ParticipantIdUsesGrainReferenceEquality()
+    {
+        var firstReference = CreateGrainReference("resource");
+        var equalReference = CreateGrainReference("resource");
+        var differentReference = CreateGrainReference("other");
+        var original = new ParticipantId("state", firstReference, ParticipantId.Role.Resource);
+        var equal = new ParticipantId("state", equalReference, ParticipantId.Role.Resource);
+
+        Assert.NotSame(firstReference, equalReference);
+        Assert.Equal(firstReference, equalReference);
+        AssertEqual(original, equal);
+        AssertNotEqual(original, new ParticipantId("state", differentReference, ParticipantId.Role.Resource));
+    }
+
+    [Fact]
+    public void ParticipantIdComparerIgnoresRoles()
+    {
+        var reference = CreateGrainReference("resource");
+        var resource = new ParticipantId("state", reference, ParticipantId.Role.Resource);
+        var manager = new ParticipantId("state", reference, ParticipantId.Role.Manager);
+        var differentName = new ParticipantId("other", reference, ParticipantId.Role.Manager);
+
+        AssertNotEqual(resource, manager);
+        Assert.True(ParticipantId.Comparer.Equals(resource, manager));
+        Assert.Equal(ParticipantId.Comparer.GetHashCode(resource), ParticipantId.Comparer.GetHashCode(manager));
+
+        var set = new HashSet<ParticipantId>(ParticipantId.Comparer) { resource };
+        var dictionary = new Dictionary<ParticipantId, string>(ParticipantId.Comparer) { [resource] = "stored" };
+        Assert.Contains(manager, set);
+        Assert.DoesNotContain(differentName, set);
+        Assert.Equal("stored", dictionary[manager]);
+        Assert.False(dictionary.ContainsKey(differentName));
+    }
+
+    [Fact]
+    public void ParticipantIdSerializationContractIsPreserved()
+    {
+        var original = new ParticipantId(
+            "state",
+            CreateGrainReference("serialized-resource"),
+            ParticipantId.Role.Resource | ParticipantId.Role.Manager);
+
+        var result = RoundTrip(original);
+
+        Assert.NotNull(result.Reference);
+        AssertEqual(original, result);
+        Assert.Equal(0U, GetPropertyId<ParticipantId>(nameof(ParticipantId.Name)));
+        Assert.Equal(1U, GetPropertyId<ParticipantId>(nameof(ParticipantId.Reference)));
+        Assert.Equal(2U, GetPropertyId<ParticipantId>(nameof(ParticipantId.SupportedRoles)));
+    }
+
+    [Fact]
+    public void ObservationUsesAllFieldsAndOrdinaryStringEquality()
+    {
+        AssertEqual(default(Observation), default);
+
+        var writer = new string("writer".ToCharArray());
+        var equalWriter = new string("writer".ToCharArray());
+        var executing = new string("executing".ToCharArray());
+        var equalExecuting = new string("executing".ToCharArray());
+        var original = CreateObservation(writer, executing);
+        var equal = CreateObservation(equalWriter, equalExecuting);
+
+        Assert.NotSame(writer, equalWriter);
+        Assert.NotSame(executing, equalExecuting);
+        AssertEqual(original, equal);
+        AssertNotEqual(original, CreateObservation(writer, executing, grain: 2));
+        AssertNotEqual(original, CreateObservation(writer, executing, seqNo: 4));
+        AssertNotEqual(original, CreateObservation("other", executing));
+        AssertNotEqual(original, CreateObservation(writer, "other"));
+        AssertHashCollections(original, equal, CreateObservation(writer, executing, seqNo: 4));
+    }
+
+    [Fact]
+    public void ObservationSerializationContractIsPreserved()
+    {
+        var original = CreateObservation("writer", "executing");
+
+        var result = RoundTrip(original);
+
+        AssertEqual(original, result);
+        Assert.Equal(0U, GetPropertyId<Observation>(nameof(Observation.Grain)));
+        Assert.Equal(1U, GetPropertyId<Observation>(nameof(Observation.SeqNo)));
+        Assert.Equal(2U, GetPropertyId<Observation>(nameof(Observation.WriterTx)));
+        Assert.Equal(3U, GetPropertyId<Observation>(nameof(Observation.ExecutingTx)));
+    }
+
+    private T RoundTrip<T>(T value) => _fixture.Serializer.Deserialize<T>(_fixture.Serializer.SerializeToArray(value))!;
+
+    private static Observation CreateObservation(
+        string writerTx,
+        string executingTx,
+        int grain = 1,
+        int seqNo = 3) =>
+        new()
+        {
+            Grain = grain,
+            SeqNo = seqNo,
+            WriterTx = writerTx,
+            ExecutingTx = executingTx,
+        };
+
+    private static GrainReference CreateGrainReference(string key)
+        => new TestGrainReference(GrainId.Create("transaction-value-semantics", key));
+
+    private static uint GetFieldId<T>(string fieldName)
+    {
+        var field = typeof(T).GetField(fieldName);
+        Assert.NotNull(field);
+        var attribute = field.GetCustomAttribute<IdAttribute>();
+        Assert.NotNull(attribute);
+        return attribute.Id;
+    }
+
+    private static uint GetPropertyId<T>(string propertyName)
+    {
+        var property = typeof(T).GetProperty(propertyName);
+        Assert.NotNull(property);
+        var attribute = property.GetCustomAttribute<IdAttribute>();
+        Assert.NotNull(attribute);
+        return attribute.Id;
+    }
+
+    private static void AssertEqual(AccessCounter left, AccessCounter right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(AccessCounter left, AccessCounter right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual(ParticipantId left, ParticipantId right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(ParticipantId left, ParticipantId right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqual(Observation left, Observation right)
+    {
+        AssertEqualContract(left, right);
+        Assert.True(left == right);
+        Assert.False(left != right);
+    }
+
+    private static void AssertNotEqual(Observation left, Observation right)
+    {
+        AssertNotEqualContract(left, right);
+        Assert.False(left == right);
+        Assert.True(left != right);
+    }
+
+    private static void AssertEqualContract<T>(T left, T right)
+        where T : struct, IEquatable<T>
+    {
+        Assert.Equal(left, right);
+        Assert.True(left.Equals(right));
+        Assert.True(((object)left).Equals(right));
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    private static void AssertNotEqualContract<T>(T left, T right)
+        where T : struct, IEquatable<T>
+    {
+        Assert.NotEqual(left, right);
+        Assert.False(left.Equals(right));
+        Assert.False(((object)left).Equals(right));
+    }
+
+    private static void AssertHashCollections<T>(T original, T equal, T unequal)
+        where T : notnull
+    {
+        var set = new HashSet<T> { original };
+        var dictionary = new Dictionary<T, string> { [original] = "stored" };
+
+        Assert.Contains(equal, set);
+        Assert.DoesNotContain(unequal, set);
+        Assert.Equal("stored", dictionary[equal]);
+        Assert.False(dictionary.ContainsKey(unequal));
+    }
+
+    private sealed class TestGrainReference(GrainId grainId)
+        : GrainReference(
+            new GrainReferenceShared(
+                grainId.Type,
+                default,
+                interfaceVersion: 0,
+                runtime: null!,
+                invokeMethodOptions: default,
+                codecProvider: null!,
+                copyContextPool: null!,
+                serviceProvider: null!),
+            grainId.Key);
+
+}


### PR DESCRIPTION
## Problem

CA1815 reports 40 diagnostics across 20 value types in eight projects. The affected types mix genuine values with mutable transport, serializer, buffer, and runtime-control carriers, so applying one mechanical equality strategy would introduce misleading contracts.

## Solution

- Implement field-complete value equality, hashing, and equality operators for 12 value-semantic structs across Core Abstractions, Reminders, Streaming, Transactions, and Transactions TestKit.
- Preserve ordinary member equality, including reference identity where that is the member's existing equality contract, rather than introducing collection-deep comparisons.
- Preserve `ParticipantId`'s two intentional contracts: default equality includes `SupportedRoles`, while `ParticipantId.Comparer` continues to identify resources by name and grain reference.
- Add narrow CA1815 suppressions for eight mutable or control-carrier structs where equality would misrepresent ownership, lifecycle, or transient serialization semantics.
- Enable CA1815 centrally for the eight complete projects and regenerate the affected public API surfaces.
- Add focused equality, hash collection, default/null/reference, serialization metadata, and representative round-trip coverage.

## Rationale

This removes the selected diagnostics while making equality an explicit domain contract only where values are stable and comparable. Mutable buffer writers, transport envelopes, serializer surrogates, connection trackers, and disposable scope tokens retain their existing behavioral guarantees without acquiring unsafe or misleading value semantics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11166)