### PR TITLE
fix(analyzers): enforce disposable field ownership

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -672,6 +672,14 @@ dotnet_diagnostic.CA1873.severity = warning
 dotnet_diagnostic.CA1001.severity = warning
 dotnet_diagnostic.CA2213.severity = warning
 
+[src/{Google,Redis}/**.cs]
+dotnet_diagnostic.CA1001.severity = warning
+dotnet_diagnostic.CA2213.severity = warning
+
+[src/{Dashboard/Orleans.Dashboard,Orleans.Persistence.Memory,Orleans.Serialization.TestKit,Orleans.Transactions,Orleans.Transactions.TestKit.Base}/**.cs]
+dotnet_diagnostic.CA1001.severity = warning
+dotnet_diagnostic.CA2213.severity = warning
+
 [src/Orleans.Runtime/Networking/**.cs]
 dotnet_diagnostic.CA1848.severity = warning
 dotnet_diagnostic.CA1849.severity = warning

--- a/src/Dashboard/Orleans.Dashboard/Implementation/DashboardLogger.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/DashboardLogger.cs
@@ -2,13 +2,11 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 
-#pragma warning disable IDE0069 // Disposable fields should be disposed
-
 namespace Orleans.Dashboard.Implementation;
 
 internal sealed class DashboardLogger : ILoggerProvider, ILogger
 {
-    private readonly NoopDisposable _scope = new();
+    private static readonly NoopDisposable Scope = new();
     private ImmutableArray<Action<EventId, LogLevel, string>> _actions = [];
 
     public void Add(Action<EventId, LogLevel, string> action) => _actions = _actions.Add(action);
@@ -40,7 +38,7 @@ internal sealed class DashboardLogger : ILoggerProvider, ILogger
 
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => _scope;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => Scope;
 
     private sealed class NoopDisposable : IDisposable
     {

--- a/src/Dashboard/Orleans.Dashboard/Metrics/GrainProfiler.cs
+++ b/src/Dashboard/Orleans.Dashboard/Metrics/GrainProfiler.cs
@@ -5,6 +5,7 @@ using Orleans.Dashboard.Model;
 using Orleans.Dashboard.Metrics.TypeFormatting;
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -19,9 +20,13 @@ internal sealed partial class GrainProfiler(
     IGrainFactory grainFactory,
     ILogger<GrainProfiler> logger,
     ILocalSiloDetails localSiloDetails,
-    IOptions<GrainProfilerOptions> options) : IGrainProfiler, ILifecycleParticipant<ISiloLifecycle>
+    IOptions<GrainProfilerOptions> options) : IGrainProfiler, ILifecycleParticipant<ISiloLifecycle>, IDisposable
 {
     private ConcurrentDictionary<string, SiloGrainTraceEntry> _grainTrace = new();
+    [SuppressMessage(
+        "Usage",
+        "CA2213:Disposable fields should be disposed",
+        Justification = "Lifecycle shutdown and dependency-injection disposal both atomically exchange and dispose the timer.")]
     private Timer? _timer;
     private string? _siloAddress;
     private bool _isEnabled;
@@ -47,9 +52,11 @@ internal sealed partial class GrainProfiler(
 
     private Task OnStop(CancellationToken _)
     {
-        _timer?.Dispose();
+        Interlocked.Exchange(ref _timer, null)?.Dispose();
         return Task.CompletedTask;
     }
+
+    public void Dispose() => Interlocked.Exchange(ref _timer, null)?.Dispose();
 
     public void Track(double elapsedMs, Type grainType, [CallerMemberName] string? methodName = null, bool failed = false)
     {

--- a/src/Google/Orleans.Reminders.Firestore/FirestoreReminderTable.cs
+++ b/src/Google/Orleans.Reminders.Firestore/FirestoreReminderTable.cs
@@ -12,6 +12,10 @@ using Orleans.Configuration;
 
 namespace Orleans.Reminders.Firestore;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Design",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "The lifecycle semaphore remains valid for all concurrent reminder-table operations and is reclaimed with the singleton reminder table.")]
 internal partial class FirestoreReminderTable : IReminderTable
 {
     private const string PERSISTENCE_GROUP = "Reminders";

--- a/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
+++ b/src/Orleans.Persistence.Memory/Storage/MemoryStorageWithLatency.cs
@@ -43,7 +43,7 @@ namespace Orleans.Storage
     ///  or long-term persistence capabilities.
     /// </remarks>
     [DebuggerDisplay("MemoryStore:{Name},WithLatency:{latency}")]
-    public class MemoryGrainStorageWithLatency : IGrainStorage
+    public class MemoryGrainStorageWithLatency : IGrainStorage, IDisposable
     {
         private readonly MemoryGrainStorage baseGranStorage;
         private readonly MemoryStorageWithLatencyOptions options;
@@ -85,6 +85,29 @@ namespace Orleans.Storage
         public Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
         {
             return MakeFixedLatencyCall(() => baseGranStorage.ClearStateAsync(grainType, grainId, grainState));
+        }
+
+        /// <summary>
+        /// Releases the resources owned by this storage provider.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the resources owned by this storage provider.
+        /// </summary>
+        /// <param name="disposing">
+        /// <see langword="true" /> to release managed resources; otherwise, <see langword="false" />.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                baseGranStorage.Dispose();
+            }
         }
 
         private async Task MakeFixedLatencyCall(Func<Task> action)

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -27,6 +27,10 @@ namespace Orleans.Serialization.TestKit
     [ExcludeFromCodeCoverage]
     public abstract class FieldCodecTester<TValue, TCodec> : SerializationTester where TCodec : class, IFieldCodec<TValue>
     {
+        [SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "SerializationTester or its shared fixture owns and disposes the service provider which owns this session pool.")]
         private readonly SerializerSessionPool _sessionPool;
 
         /// <summary>

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
@@ -18,6 +18,7 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
     private readonly long startedAt = Stopwatch.GetTimestamp();
     private readonly List<RecoveryTransition> timeline = [];
     private readonly List<Waiter> waiters = [];
+    private readonly HashSet<PhaseGate> reachedPhaseGates = [];
     private HashSet<GrainId>? relevantGrains;
     private PhaseGate? phaseGate;
     private long nextSequence;
@@ -228,6 +229,7 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
     {
         List<Waiter> waiters;
         PhaseGate? phaseGate;
+        PhaseGate[] reachedPhaseGates;
         lock (this.lockObj)
         {
             if (this.disposed)
@@ -240,10 +242,17 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
             this.waiters.Clear();
             phaseGate = this.phaseGate;
             this.phaseGate = null;
+            reachedPhaseGates = [.. this.reachedPhaseGates];
+            this.reachedPhaseGates.Clear();
         }
 
         this.subscription.Dispose();
-        phaseGate?.Release();
+        phaseGate?.Dispose();
+        foreach (var reachedPhaseGate in reachedPhaseGates)
+        {
+            reachedPhaseGate.Dispose();
+        }
+
         foreach (var waiter in waiters)
         {
             waiter.Completion.TrySetException(new ObjectDisposedException(nameof(TransactionRecoveryEventObserver)));
@@ -284,6 +293,7 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
                 && phaseGate.TryReach(transition))
             {
                 this.phaseGate = null;
+                this.reachedPhaseGates.Add(phaseGate);
                 reachedGate = phaseGate;
             }
 
@@ -309,7 +319,11 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
             }
         }
 
-        reachedGate?.Block();
+        if (reachedGate is not null)
+        {
+            reachedGate.Block();
+            this.ReleaseGate(reachedGate);
+        }
     }
 
     private static Func<ParticipantId, bool> CreateCandidateFilter(IEnumerable<GrainId> candidateGrains)
@@ -514,6 +528,8 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
             {
                 this.phaseGate = null;
             }
+
+            this.reachedPhaseGates.Remove(gate);
         }
     }
 

--- a/src/Orleans.Transactions/State/ActivationLifetime.cs
+++ b/src/Orleans.Transactions/State/ActivationLifetime.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 
 namespace Orleans.Transactions.State
 {
+    [SuppressMessage(
+        "Design",
+        "CA1001:Types that own disposable fields should be disposable",
+        Justification = "The cancellation source remains valid for all deactivation observers and is reclaimed with the grain activation.")]
     internal class ActivationLifetime : IActivationLifetime, ILifecycleObserver
     {
         private readonly CancellationTokenSource onDeactivating = new CancellationTokenSource();

--- a/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamAdapter.cs
+++ b/src/Redis/Orleans.Streaming.Redis/Streams/RedisStreamAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Configuration;
@@ -10,6 +11,10 @@ using Orleans.Streams;
 
 namespace Orleans.Streaming.Redis;
 
+[SuppressMessage(
+    "Design",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "The semaphore remains valid for every producer which shares this queue adapter and is reclaimed with the adapter.")]
 internal sealed class RedisStreamAdapter : IQueueAdapter
 {
     private readonly Serializer<RedisStreamBatchContainer> _serializer;

--- a/src/api/Orleans.Persistence.Memory/Orleans.Persistence.Memory.cs
+++ b/src/api/Orleans.Persistence.Memory/Orleans.Persistence.Memory.cs
@@ -69,11 +69,15 @@ namespace Orleans.Storage
     }
 
     [System.Diagnostics.DebuggerDisplay("MemoryStore:{Name},WithLatency:{latency}")]
-    public partial class MemoryGrainStorageWithLatency : IGrainStorage
+    public partial class MemoryGrainStorageWithLatency : IGrainStorage, System.IDisposable
     {
         public MemoryGrainStorageWithLatency(string name, MemoryStorageWithLatencyOptions options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, IGrainFactory grainFactory, Serialization.Serializers.IActivatorProvider activatorProvider, IGrainStorageSerializer defaultGrainStorageSerializer) { }
 
         public System.Threading.Tasks.Task ClearStateAsync<T>(string grainType, Runtime.GrainId grainId, IGrainState<T> grainState) { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
 
         public System.Threading.Tasks.Task ReadStateAsync<T>(string grainType, Runtime.GrainId grainId, IGrainState<T> grainState) { throw null; }
 

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/GrainProfilerDisposableOwnershipTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/GrainProfilerDisposableOwnershipTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Dashboard;
+using Orleans.Dashboard.Metrics;
+using Orleans.Runtime;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Dashboard")]
+public class GrainProfilerDisposableOwnershipTests
+{
+    [Fact]
+    public async Task StartAndStop_CompleteSuccessfully()
+    {
+        var profiler = CreateProfiler();
+        var observer = CaptureObserver(profiler);
+
+        var startTask = observer.OnStart(TestContext.Current.CancellationToken);
+        await startTask;
+        var stopTask = observer.OnStop(TestContext.Current.CancellationToken);
+        await stopTask;
+
+        Assert.True(startTask.IsCompletedSuccessfully);
+        Assert.True(stopTask.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task StopAndDispose_WhenRepeated_AreIdempotent()
+    {
+        var profiler = CreateProfiler();
+        var observer = CaptureObserver(profiler);
+
+        var startTask = observer.OnStart(TestContext.Current.CancellationToken);
+        await startTask;
+        var firstStopTask = observer.OnStop(TestContext.Current.CancellationToken);
+        await firstStopTask;
+        var secondStopTask = observer.OnStop(TestContext.Current.CancellationToken);
+        await secondStopTask;
+        profiler.Dispose();
+        profiler.Dispose();
+        var stopAfterDisposeTask = observer.OnStop(TestContext.Current.CancellationToken);
+        await stopAfterDisposeTask;
+
+        Assert.True(startTask.IsCompletedSuccessfully);
+        Assert.True(firstStopTask.IsCompletedSuccessfully);
+        Assert.True(secondStopTask.IsCompletedSuccessfully);
+        Assert.True(stopAfterDisposeTask.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task StartAfterStop_CompletesSuccessfully()
+    {
+        var profiler = CreateProfiler();
+        var observer = CaptureObserver(profiler);
+
+        var firstStartTask = observer.OnStart(TestContext.Current.CancellationToken);
+        await firstStartTask;
+        var firstStopTask = observer.OnStop(TestContext.Current.CancellationToken);
+        await firstStopTask;
+        var secondStartTask = observer.OnStart(TestContext.Current.CancellationToken);
+        await secondStartTask;
+        var secondStopTask = observer.OnStop(TestContext.Current.CancellationToken);
+        await secondStopTask;
+
+        Assert.True(firstStartTask.IsCompletedSuccessfully);
+        Assert.True(firstStopTask.IsCompletedSuccessfully);
+        Assert.True(secondStartTask.IsCompletedSuccessfully);
+        Assert.True(secondStopTask.IsCompletedSuccessfully);
+    }
+
+    private static GrainProfiler CreateProfiler() =>
+        new(
+            null!,
+            NullLogger<GrainProfiler>.Instance,
+            null!,
+            Options.Create(new GrainProfilerOptions()));
+
+    private static ILifecycleObserver CaptureObserver(GrainProfiler profiler)
+    {
+        var lifecycle = new CapturingLifecycle();
+        profiler.Participate(lifecycle);
+        return Assert.IsAssignableFrom<ILifecycleObserver>(lifecycle.Observer);
+    }
+
+    private sealed class CapturingLifecycle : ISiloLifecycle
+    {
+        public ILifecycleObserver? Observer { get; private set; }
+
+        public int HighestCompletedStage => int.MinValue;
+
+        public int LowestStoppedStage => int.MaxValue;
+
+        public IDisposable Subscribe(string observerName, int stage, ILifecycleObserver observer)
+        {
+            Observer = observer;
+            return Subscription.Instance;
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        public static Subscription Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/FieldCodecTesterBorrowedOwnershipTests.cs
+++ b/test/Orleans.Serialization.UnitTests/FieldCodecTesterBorrowedOwnershipTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Session;
+using Orleans.Serialization.TestKit;
+using Orleans.Serialization.WireProtocol;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Serialization")]
+public sealed class FieldCodecTesterBorrowedOwnershipTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void DisposingFixtureBackedTester_DoesNotDisposeSharedSerializerServices()
+    {
+        const int original = 0x1234_5678;
+        var fixture = new SerializationTesterFixture();
+        FixtureBackedInt32Tester? firstTester = null;
+        FixtureBackedInt32Tester? secondTester = null;
+
+        try
+        {
+            firstTester = new FixtureBackedInt32Tester(output, fixture);
+
+            try
+            {
+                secondTester = new FixtureBackedInt32Tester(output, fixture);
+                Assert.Same(firstTester.SharedSessionPool, secondTester.SharedSessionPool);
+            }
+            finally
+            {
+                ((IDisposable)firstTester).Dispose();
+                firstTester = null;
+            }
+
+            var result = secondTester.RoundTrip(original);
+
+            Assert.Equal(original, result);
+        }
+        finally
+        {
+            ((IDisposable?)firstTester)?.Dispose();
+            ((IDisposable?)secondTester)?.Dispose();
+            ((IDisposable)fixture).Dispose();
+        }
+    }
+
+    private sealed class FixtureBackedInt32Tester(
+        ITestOutputHelper output,
+        SerializationTesterFixture fixture)
+        : FieldCodecTester<int, UnusedInt32Codec>(output, fixture)
+    {
+        public SerializerSessionPool SharedSessionPool => SessionPool;
+
+        public int RoundTrip(int value)
+        {
+            var serializer = ServiceProvider.GetRequiredService<Serializer<int>>();
+            return serializer.Deserialize(serializer.SerializeToArray(value));
+        }
+
+        protected override IServiceProvider CreateServiceProvider()
+        {
+            var services = new ServiceCollection();
+            services.AddSerializer();
+            return services.BuildServiceProvider();
+        }
+
+        protected override int CreateValue() => 1;
+
+        protected override int[] TestValues => [1];
+    }
+
+    private abstract class UnusedInt32Codec : IFieldCodec<int>
+    {
+        public abstract void WriteField<TBufferWriter>(
+            ref Writer<TBufferWriter> writer,
+            uint fieldIdDelta,
+            [AllowNull] Type expectedType,
+            int value)
+            where TBufferWriter : IBufferWriter<byte>;
+
+        public abstract int ReadValue<TInput>(ref Reader<TInput> reader, Field field);
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryEventObserverDisposalTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryEventObserverDisposalTests.cs
@@ -1,0 +1,141 @@
+using System.Diagnostics;
+using Orleans.Transactions.Diagnostics;
+using Orleans.Transactions.TestKit;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Transactions")]
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionRecoveryEventObserverDisposalTests
+{
+    private static readonly TimeSpan SynchronizationTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task Dispose_ReleasesReachedPhaseGate()
+    {
+        var resource = CreateParticipant("manager", ParticipantId.Role.Manager);
+        var transactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        var observer = new TransactionRecoveryEventObserver(candidate => candidate.Name == resource.Name);
+        var gate = observer.GateNextTransition(transition =>
+            transition.Kind == TransactionRecoveryEventObserver.RecoveryTransitionKind.TransactionManagerWaitingForPrepared);
+        var deadline = GetDeadline();
+        var emission = RunLongRunning(() => TransactionDiagnosticEvents.EmitTransactionManagerWaitingForPrepared(
+            resource,
+            transactionId,
+            timestamp,
+            waitCount: 2,
+            deadline: timestamp.AddSeconds(10)));
+
+        try
+        {
+            var transition = await gate.WaitAsync(deadline, TestContext.Current.CancellationToken);
+
+            Assert.False(emission.IsCompleted);
+            Assert.Equal(transactionId, transition.TransactionId);
+            Assert.Equal(TransactionDiagnosticEvents.TransactionPhase.WaitingForRemotePrepares, transition.Phase);
+
+            observer.Dispose();
+
+            await WaitBeforeDeadlineAsync(emission, deadline, "observer disposal to release the reached phase gate");
+        }
+        finally
+        {
+            gate.Dispose();
+            observer.Dispose();
+            await WaitBeforeDeadlineAsync(
+                emission,
+                GetDeadline(),
+                "reached phase gate cleanup");
+        }
+    }
+
+    [Fact]
+    public async Task Dispose_ReleasesArmedPhaseGate()
+    {
+        var observer = new TransactionRecoveryEventObserver(_ => true);
+        var gate = observer.GateNextTransition(_ => true);
+        var blockStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blockingTask = RunLongRunning(() =>
+        {
+            blockStarted.TrySetResult();
+            gate.Block();
+        });
+
+        try
+        {
+            await WaitBeforeDeadlineAsync(blockStarted.Task, GetDeadline(), "the armed phase gate to begin blocking");
+            Assert.False(blockingTask.IsCompleted);
+
+            observer.Dispose();
+
+            await WaitBeforeDeadlineAsync(blockingTask, GetDeadline(), "observer disposal to release the armed phase gate");
+            Assert.False(gate.TryReach(null!));
+        }
+        finally
+        {
+            gate.Dispose();
+            observer.Dispose();
+            await WaitBeforeDeadlineAsync(blockingTask, GetDeadline(), "armed phase gate cleanup");
+        }
+    }
+
+    [Fact]
+    public async Task Dispose_WhenRepeated_IsIdempotent()
+    {
+        var observer = new TransactionRecoveryEventObserver(_ => true);
+        var gate = observer.GateNextTransition(_ => true);
+        var waiter = observer.WaitForNextTransitionAsync(
+            observer.LatestRelevantSequence,
+            GetDeadline(),
+            TestContext.Current.CancellationToken);
+
+        observer.Dispose();
+        observer.Dispose();
+        gate.Dispose();
+        gate.Dispose();
+
+        var exception = await Assert.ThrowsAsync<ObjectDisposedException>(() => waiter);
+        Assert.Equal(nameof(TransactionRecoveryEventObserver), exception.ObjectName);
+        Assert.False(gate.TryReach(null!));
+    }
+
+    private static ParticipantId CreateParticipant(string name, ParticipantId.Role role)
+        => new($"{name}-{Guid.NewGuid():N}", reference: null!, role);
+
+    private static long GetDeadline()
+        => Stopwatch.GetTimestamp() + (long)(SynchronizationTimeout.TotalSeconds * Stopwatch.Frequency);
+
+    private static Task RunLongRunning(Action action)
+        => Task.Factory.StartNew(
+            action,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
+    private static async Task WaitBeforeDeadlineAsync(Task task, long deadline, string phase)
+    {
+        var now = Stopwatch.GetTimestamp();
+        if (now >= deadline)
+        {
+            throw new TimeoutException($"Timed out waiting for {phase}; task status is {task.Status}.");
+        }
+
+        try
+        {
+            await task.WaitAsync(
+                Stopwatch.GetElapsedTime(now, deadline),
+                TestContext.Current.CancellationToken);
+        }
+        catch (TimeoutException exception)
+        {
+            throw new TimeoutException(
+                $"Timed out waiting for {phase}; task status is {task.Status}.",
+                exception);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

CA1001 and CA2213 remain advisory across several otherwise-clean provider and test-kit projects, leaving disposable ownership contracts unenforced.

## Solution

- Enable CA1001 and CA2213 for the complete Google and Redis provider families, including Google linked shared sources, plus Dashboard, Persistence.Memory, Serialization.TestKit, Transactions.TestKit.Base, and Transactions.
- Dispose resources owned by `GrainProfiler`, `MemoryGrainStorageWithLatency`, and `TransactionRecoveryEventObserver`.
- Keep dashboard no-op logger scopes process-wide instead of treating them as per-provider owned resources.
- Document the precise external/lifetime ownership of the Firestore lifecycle semaphore, Redis adapter semaphore, serializer session pool, and activation cancellation source with narrow suppressions.
- Add focused coverage for profiler lifecycle cleanup, fixture-borrowed serializer services, and armed/reached transaction phase-gate cleanup.
- Regenerate the Persistence.Memory public API surface for its `IDisposable` contract.

## Rationale

The changes make ownership explicit without disposing caller- or container-owned resources, preserve semaphores and cancellation tokens for all outstanding operations, and ensure reached transaction gates remain owned until blocked emitters are released. `Orleans.Hosting.Kubernetes` remains deferred because lifecycle cancellation can currently return before monitoring tasks finish; disposing its client, semaphore, or cancellation source in that state could race active monitoring work.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11167)