### PR TITLE
fix(analyzers): enforce CA1062 for Cosmos and S3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -699,7 +699,10 @@ dotnet_diagnostic.CA1062.severity = warning
 [src/Azure/{Orleans.Clustering.AzureStorage,Orleans.DurableJobs.AzureStorage,Orleans.GrainDirectory.AzureStorage,Orleans.Journaling.AzureStorage,Orleans.Persistence.AzureStorage,Orleans.Reminders.AzureStorage,Orleans.Streaming.AzureStorage,Orleans.Transactions.AzureStorage,Shared}/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
-[src/Azure/{Orleans.Clustering.Cosmos,Orleans.Reminders.Cosmos}/**.cs]
+[src/Azure/{Orleans.Clustering.Cosmos,Orleans.Persistence.Cosmos,Orleans.Reminders.Cosmos}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
+[src/AWS/Orleans.Journaling.S3/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
 [src/Google/**/*.cs]

--- a/src/AWS/Orleans.Journaling.S3/S3JournalStorageHostingExtensions.cs
+++ b/src/AWS/Orleans.Journaling.S3/S3JournalStorageHostingExtensions.cs
@@ -23,8 +23,13 @@ public static class S3JournalStorageHostingExtensions
     /// <param name="builder">The silo builder.</param>
     /// <param name="configure">The Amazon S3 journal storage configuration delegate.</param>
     /// <returns>The silo builder.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> is <see langword="null"/>.
+    /// </exception>
     public static ISiloBuilder AddS3JournalStorage(this ISiloBuilder builder, Action<S3JournalStorageOptions>? configure)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.AddJournalStorage();
 
         var services = builder.Services;

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -36,6 +36,9 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
     /// <param name="clusterOptions">The cluster options.</param>
     /// <param name="documentIdProvider">The provider used to create Cosmos DB document identifiers.</param>
     /// <param name="activatorProvider">The provider used to create grain state instances.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="options"/> or <paramref name="clusterOptions"/> is <see langword="null"/>.
+    /// </exception>
     public CosmosGrainStorage(
         string name,
         CosmosGrainStorageOptions options,
@@ -45,6 +48,9 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
         IDocumentIdProvider documentIdProvider,
         IActivatorProvider activatorProvider)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(clusterOptions);
+
         _logger = loggerFactory.CreateLogger<CosmosGrainStorage>();
         _options = options;
         _name = name;
@@ -59,6 +65,8 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
     /// <inheritdoc/>
     public async Task ReadStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
     {
+        ArgumentNullException.ThrowIfNull(grainState);
+
         var (id, partitionKey) = await _documentIdProvider.GetDocumentIdentifiers(grainType, grainId);
 
         LogTraceReadingState(grainType, id, grainId, _options.ContainerName, partitionKey);
@@ -110,6 +118,8 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
     /// <inheritdoc/>
     public async Task WriteStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
     {
+        ArgumentNullException.ThrowIfNull(grainState);
+
         var (id, partitionKey) = await _documentIdProvider.GetDocumentIdentifiers(grainType, grainId);
 
         LogTraceWritingState(grainType, id, grainId, grainState.ETag, _options.ContainerName, partitionKey);
@@ -179,6 +189,8 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
     /// <inheritdoc/>
     public async Task ClearStateAsync<T>(string grainType, GrainId grainId, IGrainState<T> grainState)
     {
+        ArgumentNullException.ThrowIfNull(grainState);
+
         var (id, partitionKey) = await _documentIdProvider.GetDocumentIdentifiers(grainType, grainId);
 
         LogTraceClearingState(grainType, id, grainId, grainState.ETag, _options.DeleteStateOnClear, _options.ContainerName, partitionKey);
@@ -252,7 +264,7 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
         }
         catch (CosmosException ex) when (ex.StatusCode is HttpStatusCode.PreconditionFailed or HttpStatusCode.Conflict or HttpStatusCode.NotFound)
         {
-            throw new CosmosConditionNotSatisfiedException(grainType, grainId, _options.ContainerName, "Unknown", grainState?.ETag ?? "Unknown");
+            throw new CosmosConditionNotSatisfiedException(grainType, grainId, _options.ContainerName, "Unknown", grainState.ETag ?? "Unknown");
         }
         catch (Exception exc)
         {

--- a/src/Azure/Orleans.Persistence.Cosmos/DefaultDocumentIdProvider.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/DefaultDocumentIdProvider.cs
@@ -18,8 +18,13 @@ public sealed class DefaultDocumentIdProvider : IDocumentIdProvider
     /// Initializes a new instance of the <see cref="DefaultDocumentIdProvider"/> class.
     /// </summary>
     /// <param name="options">The cluster options.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="options"/> is <see langword="null"/>.
+    /// </exception>
     public DefaultDocumentIdProvider(IOptions<ClusterOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(options);
+
         _options = options.Value;
     }
 
@@ -57,7 +62,15 @@ public sealed class DefaultDocumentIdProvider : IDocumentIdProvider
     /// <param name="grainType">The grain type.</param>
     /// <param name="grainId">The grain id.</param>
     /// <returns>The document partition key.</returns>
-    public string GetPartitionKey(string grainType, GrainId grainId) => Sanitize(grainType);
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="grainType"/> is <see langword="null"/>.
+    /// </exception>
+    public string GetPartitionKey(string grainType, GrainId grainId)
+    {
+        ArgumentNullException.ThrowIfNull(grainType);
+
+        return Sanitize(grainType);
+    }
 
     private async ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string documentId, string grainType, GrainId grainId)
     {

--- a/src/Azure/Orleans.Persistence.Cosmos/HostingExtensions.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/HostingExtensions.cs
@@ -39,6 +39,8 @@ public static class HostingExtensions
         string name,
         Action<CosmosGrainStorageOptions> configureOptions) where TProvider : class
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         AddIdentifierProvider(builder.Services, name, typeof(TProvider));
         builder.Services.AddCosmosGrainStorage(name, configureOptions);
         return builder;
@@ -73,6 +75,8 @@ public static class HostingExtensions
         Action<CosmosGrainStorageOptions> configureOptions,
         Type customPartitionKeyProviderType)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         if (customPartitionKeyProviderType != null)
         {
             AddIdentifierProvider(builder.Services, name, customPartitionKeyProviderType, registerUnkeyedPartitionProvider: true);
@@ -105,6 +109,8 @@ public static class HostingExtensions
         string name,
         Action<CosmosGrainStorageOptions> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.Services.AddCosmosGrainStorage(name, configureOptions);
         return builder;
     }
@@ -136,6 +142,8 @@ public static class HostingExtensions
         string name,
         Action<OptionsBuilder<CosmosGrainStorageOptions>>? configureOptions = null) where TProvider : class
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         AddIdentifierProvider(builder.Services, name, typeof(TProvider));
         builder.Services.AddCosmosGrainStorage(name, configureOptions);
         return builder;
@@ -170,6 +178,8 @@ public static class HostingExtensions
         Type customPartitionKeyProviderType,
         Action<OptionsBuilder<CosmosGrainStorageOptions>>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         if (customPartitionKeyProviderType != null)
         {
             AddIdentifierProvider(builder.Services, name, customPartitionKeyProviderType);
@@ -202,6 +212,8 @@ public static class HostingExtensions
         string name,
         Action<OptionsBuilder<CosmosGrainStorageOptions>>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.Services.AddCosmosGrainStorage(name, configureOptions);
         return builder;
     }

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageArgumentValidationTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosGrainStorageArgumentValidationTests.cs
@@ -1,0 +1,207 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Persistence.Cosmos;
+using Orleans.Runtime;
+using Orleans.Serialization.Activators;
+using Orleans.Serialization.Serializers;
+using Orleans.Storage;
+
+namespace Tester.Cosmos.Persistence;
+
+[TestCategory("Cosmos"), TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("Cosmos")]
+[TestArea("Persistence")]
+public sealed class CosmosGrainStorageArgumentValidationTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+    [Fact]
+    public void CosmosGrainStorage_Constructor_NullOptions_ThrowsArgumentNullException()
+    {
+        var loggerFactory = new TrackingLoggerFactory();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new CosmosGrainStorage(
+            "storage",
+            null!,
+            loggerFactory,
+            _serviceProvider,
+            CreateClusterOptions(),
+            new TrackingDocumentIdProvider(),
+            new ActivatorProvider()));
+
+        Assert.Equal("options", exception.ParamName);
+        Assert.Equal(0, loggerFactory.CreateLoggerCallCount);
+    }
+
+    [Fact]
+    public void CosmosGrainStorage_Constructor_NullClusterOptions_ThrowsArgumentNullException()
+    {
+        var loggerFactory = new TrackingLoggerFactory();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new CosmosGrainStorage(
+            "storage",
+            new CosmosGrainStorageOptions(),
+            loggerFactory,
+            _serviceProvider,
+            null!,
+            new TrackingDocumentIdProvider(),
+            new ActivatorProvider()));
+
+        Assert.Equal("clusterOptions", exception.ParamName);
+        Assert.Equal(0, loggerFactory.CreateLoggerCallCount);
+    }
+
+    [Fact]
+    public void CosmosGrainStorage_Constructor_NullOptionsAndClusterOptions_ValidatesOptionsFirst()
+    {
+        var loggerFactory = new TrackingLoggerFactory();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => new CosmosGrainStorage(
+            "storage",
+            null!,
+            loggerFactory,
+            _serviceProvider,
+            null!,
+            new TrackingDocumentIdProvider(),
+            new ActivatorProvider()));
+
+        Assert.Equal("options", exception.ParamName);
+        Assert.Equal(0, loggerFactory.CreateLoggerCallCount);
+    }
+
+    [Theory]
+    [InlineData(StorageOperation.Read)]
+    [InlineData(StorageOperation.Write)]
+    [InlineData(StorageOperation.Clear)]
+    public async Task CosmosGrainStorage_Operation_NullGrainState_ThrowsBeforeResolvingDocumentIdentifiers(
+        StorageOperation operation)
+    {
+        var documentIdProvider = new TrackingDocumentIdProvider();
+        var storage = CreateStorage(documentIdProvider);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+            () => InvokeStorageOperation(storage, operation));
+
+        Assert.Equal("grainState", exception.ParamName);
+        Assert.Equal(0, documentIdProvider.CallCount);
+    }
+
+    [Fact]
+    public void DefaultDocumentIdProvider_Constructor_NullOptions_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new DefaultDocumentIdProvider(null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void DefaultDocumentIdProvider_GetPartitionKey_NullGrainType_ThrowsArgumentNullException()
+    {
+        var provider = new DefaultDocumentIdProvider(CreateClusterOptions());
+        var grainId = GrainId.Create("grain/type", "grain/key");
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => provider.GetPartitionKey(null!, grainId));
+
+        Assert.Equal("grainType", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task DefaultDocumentIdProvider_ValidIdentifiers_PreserveFormatting()
+    {
+        var provider = new DefaultDocumentIdProvider(
+            Options.Create(new ClusterOptions { ServiceId = "service/id" }));
+        var grainId = GrainId.Create("grain/type", "grain/key");
+
+        var identifiers = await provider.GetDocumentIdentifiers("partition/type", grainId);
+        var documentId = provider.GetId("partition/type", grainId);
+        var partitionKey = provider.GetPartitionKey("partition/type", grainId);
+
+        Assert.Equal("service~0id__grain~0type_grain~0key", identifiers.DocumentId);
+        Assert.Equal("service~0id__grain~0type_grain~0key", documentId);
+        Assert.Equal("partition~0type", identifiers.PartitionKey);
+        Assert.Equal("partition~0type", partitionKey);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    private CosmosGrainStorage CreateStorage(IDocumentIdProvider documentIdProvider) => new(
+        "storage",
+        new CosmosGrainStorageOptions(),
+        NullLoggerFactory.Instance,
+        _serviceProvider,
+        CreateClusterOptions(),
+        documentIdProvider,
+        new ActivatorProvider());
+
+    private static IOptions<ClusterOptions> CreateClusterOptions() =>
+        Options.Create(new ClusterOptions { ServiceId = "service" });
+
+    private static Task InvokeStorageOperation(CosmosGrainStorage storage, StorageOperation operation)
+    {
+        var grainId = GrainId.Create("grain/type", "grain/key");
+        return operation switch
+        {
+            StorageOperation.Read => storage.ReadStateAsync<TestState>("grain-type", grainId, null!),
+            StorageOperation.Write => storage.WriteStateAsync<TestState>("grain-type", grainId, null!),
+            StorageOperation.Clear => storage.ClearStateAsync<TestState>("grain-type", grainId, null!),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
+    }
+
+    public enum StorageOperation
+    {
+        Read,
+        Write,
+        Clear,
+    }
+
+    private sealed class TrackingDocumentIdProvider : IDocumentIdProvider
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(
+            string grainType,
+            GrainId grainId)
+        {
+            CallCount++;
+            return new(("document", "partition"));
+        }
+    }
+
+    private sealed class TrackingLoggerFactory : ILoggerFactory
+    {
+        public int CreateLoggerCallCount { get; private set; }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            CreateLoggerCallCount++;
+            return NullLogger.Instance;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ActivatorProvider : IActivatorProvider
+    {
+        public IActivator<T> GetActivator<T>() => new DefaultActivator<T>();
+    }
+
+    private sealed class DefaultActivator<T> : IActivator<T>
+    {
+        public T Create() => Activator.CreateInstance<T>();
+    }
+
+    private sealed class TestState;
+}

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
@@ -128,6 +128,116 @@ public class CosmosHostingExtensionsTests
 
 #pragma warning restore CS0618 // Type or member is obsolete
 
+    [Fact]
+    public void AddCosmosGrainStorage_GenericConfigureOptions_NullBuilder_ThrowsArgumentNullException()
+    {
+        ISiloBuilder builder = null!;
+        var configureInvoked = false;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.AddCosmosGrainStorage<FirstDocumentIdProvider>(
+                "storage",
+                (Action<CosmosGrainStorageOptions>)(_ => configureInvoked = true)));
+
+        Assert.Equal("builder", exception.ParamName);
+        Assert.False(configureInvoked);
+    }
+
+    [Fact]
+    public void AddCosmosGrainStorage_TypeConfigureOptions_NullBuilder_ThrowsArgumentNullException()
+    {
+        ISiloBuilder builder = null!;
+        var configureInvoked = false;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.AddCosmosGrainStorage(
+                "storage",
+                (Action<CosmosGrainStorageOptions>)(_ => configureInvoked = true),
+                typeof(FirstDocumentIdProvider)));
+
+        Assert.Equal("builder", exception.ParamName);
+        Assert.False(configureInvoked);
+    }
+
+    [Fact]
+    public void AddCosmosGrainStorage_PlainConfigureOptions_NullBuilder_ThrowsArgumentNullException()
+    {
+        ISiloBuilder builder = null!;
+        var configureInvoked = false;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.AddCosmosGrainStorage(
+                "storage",
+                (Action<CosmosGrainStorageOptions>)(_ => configureInvoked = true)));
+
+        Assert.Equal("builder", exception.ParamName);
+        Assert.False(configureInvoked);
+    }
+
+    [Fact]
+    public void AddCosmosGrainStorage_GenericOptionsBuilder_NullBuilder_ThrowsArgumentNullException()
+    {
+        ISiloBuilder builder = null!;
+        var configureInvoked = false;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.AddCosmosGrainStorage<FirstDocumentIdProvider>(
+                "storage",
+                (Action<OptionsBuilder<CosmosGrainStorageOptions>>)(_ => configureInvoked = true)));
+
+        Assert.Equal("builder", exception.ParamName);
+        Assert.False(configureInvoked);
+    }
+
+    [Fact]
+    public void AddCosmosGrainStorage_TypeOptionsBuilder_NullBuilder_ThrowsArgumentNullException()
+    {
+        ISiloBuilder builder = null!;
+        var configureInvoked = false;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.AddCosmosGrainStorage(
+                "storage",
+                typeof(FirstDocumentIdProvider),
+                (Action<OptionsBuilder<CosmosGrainStorageOptions>>)(_ => configureInvoked = true)));
+
+        Assert.Equal("builder", exception.ParamName);
+        Assert.False(configureInvoked);
+    }
+
+    [Fact]
+    public void AddCosmosGrainStorage_PlainOptionsBuilder_NullBuilder_ThrowsArgumentNullException()
+    {
+        ISiloBuilder builder = null!;
+        var configureInvoked = false;
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            builder.AddCosmosGrainStorage(
+                "storage",
+                (Action<OptionsBuilder<CosmosGrainStorageOptions>>)(_ => configureInvoked = true)));
+
+        Assert.Equal("builder", exception.ParamName);
+        Assert.False(configureInvoked);
+    }
+
+    [Fact]
+    public void AddCosmosGrainStorage_PlainNamedRegistration_ConfiguresNamedOptions()
+    {
+        const string storageName = "plain-named-storage";
+        const string databaseName = "phase-two-database";
+        var builder = new TestSiloBuilder();
+
+        var result = builder.AddCosmosGrainStorage(
+            storageName,
+            (Action<CosmosGrainStorageOptions>)(options => options.DatabaseName = databaseName));
+        using var services = builder.Services.BuildServiceProvider();
+
+        var options = services.GetRequiredService<IOptionsMonitor<CosmosGrainStorageOptions>>().Get(storageName);
+
+        Assert.Same(builder, result);
+        Assert.Equal(databaseName, options.DatabaseName);
+    }
+
     private sealed class FirstDocumentIdProvider : IDocumentIdProvider
     {
         public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId) => default;
@@ -147,6 +257,13 @@ public class CosmosHostingExtensionsTests
 
     private sealed class DocumentIdProviderDependency
     {
+    }
+
+    private sealed class TestSiloBuilder : ISiloBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = new ConfigurationBuilder().Build();
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/test/Orleans.Journaling.Tests/S3JournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/S3JournalStorageTests.cs
@@ -180,6 +180,19 @@ public sealed class S3JournalStorageTests : IAsyncLifetime
         }
 
         [Fact]
+        public void AddS3JournalStorage_NullBuilder_ThrowsBeforeConfiguring()
+        {
+            ISiloBuilder builder = null!;
+            var configureInvoked = false;
+
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => builder.AddS3JournalStorage(_ => configureInvoked = true));
+
+            Assert.Equal("builder", exception.ParamName);
+            Assert.False(configureInvoked);
+        }
+
+        [Fact]
         public async Task ListAsync_CustomObjectKeyMapping_FiltersParsedJournalIds()
         {
             var client = CreateTrackingClient();


### PR DESCRIPTION
## Problem

CA1062 remains advisory for the Cosmos grain persistence and S3 journaling projects, leaving public argument boundaries without consistent validation.

## Solution

- validate Cosmos storage options, cluster options, grain state, document partition keys, and silo builder inputs at their public boundaries
- validate the S3 journal storage silo builder before registration or configuration
- enable CA1062 warnings for both complete projects
- add focused regression coverage for exception parameter names, validation order, collaborator isolation, stable Cosmos identifiers, and representative provider registration

## Rationale

Boundary validation produces deterministic failures before dependency injection registration, identifier resolution, or storage operations while preserving existing persistence identifiers, ETags, and provider behavior.

## CI follow-up

The initial Windows net8 BVT job timed out in the unrelated `LocalReminderServiceCompatibilityTests.RangeChangeBarrier_PreservesRefreshThenRangeOrder` test ([failed job](https://github.com/dotnet/orleans/actions/runs/34051871422/job/101536819688)). This exact intermittent failure is tracked by #11159. The base remains current `main`, no newer pull request matching the failing test exists, and only the failed job is being rerun.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11171)