### PR TITLE
fix(streaming): validate boundary arguments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -702,6 +702,9 @@ dotnet_diagnostic.CA2000.severity = warning
 [src/{Orleans.BroadcastChannel,Orleans.Clustering.ZooKeeper,Orleans.Hosting.Kubernetes,Orleans.Persistence.Memory,Orleans.Persistence.TestKit,Orleans.Reminders.TestKit,Orleans.Serialization.FSharp,Orleans.Serialization.MessagePack,Orleans.Serialization.NewtonsoftJson,Orleans.Serialization.SystemTextJson,Orleans.Serialization.TestKit,Orleans.Transactions.TestKit.Base,Orleans.Transactions.TestKit.xUnit}/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
+[src/Orleans.Streaming/{PubSub,Extensions,Providers}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
 [src/Serializers/Orleans.Serialization.Protobuf/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 

--- a/src/Orleans.Streaming/Extensions/AsyncBatchObservableExtensions.cs
+++ b/src/Orleans.Streaming/Extensions/AsyncBatchObservableExtensions.cs
@@ -30,6 +30,8 @@ namespace Orleans.Streams
             StreamSubscriptionStartPosition startPosition)
         {
             startPosition.Validate();
+            ArgumentNullException.ThrowIfNull(obs);
+
             if (obs is StreamImpl<T> stream)
             {
                 return stream.SubscribeAsync(observer, startPosition);
@@ -63,6 +65,8 @@ namespace Orleans.Streams
                                                                            Func<Task> onCompletedAsync)
         {
             var genericObserver = new GenericAsyncBatchObserver<T>(onNextAsync, onErrorAsync, onCompletedAsync);
+            ArgumentNullException.ThrowIfNull(obs);
+
             return obs.SubscribeAsync(genericObserver);
         }
 

--- a/src/Orleans.Streaming/Extensions/AsyncObservableExtensions.cs
+++ b/src/Orleans.Streaming/Extensions/AsyncObservableExtensions.cs
@@ -31,6 +31,8 @@ namespace Orleans.Streams
             string? filterData = null)
         {
             startPosition.Validate();
+            ArgumentNullException.ThrowIfNull(obs);
+
             if (obs is StreamImpl<T> stream)
             {
                 return stream.SubscribeAsync(observer, startPosition, filterData);
@@ -64,6 +66,8 @@ namespace Orleans.Streams
                                                                            Func<Task> onCompletedAsync)
         {
             var genericObserver = new GenericAsyncObserver<T>(onNextAsync, onErrorAsync, onCompletedAsync);
+            ArgumentNullException.ThrowIfNull(obs);
+
             return obs.SubscribeAsync(genericObserver);
         }
 
@@ -147,6 +151,8 @@ namespace Orleans.Streams
                                                                            StreamSequenceToken token)
         {
             var genericObserver = new GenericAsyncObserver<T>(onNextAsync, onErrorAsync, onCompletedAsync);
+            ArgumentNullException.ThrowIfNull(obs);
+
             return obs.SubscribeAsync(genericObserver, token);
         }
 

--- a/src/Orleans.Streaming/Extensions/StreamSubscriptionHandleExtensions.cs
+++ b/src/Orleans.Streaming/Extensions/StreamSubscriptionHandleExtensions.cs
@@ -34,6 +34,8 @@ namespace Orleans.Streams
                                                                            StreamSequenceToken? token = null)
         {
             var genericObserver = new GenericAsyncObserver<T>(onNextAsync, onErrorAsync, onCompletedAsync);
+            ArgumentNullException.ThrowIfNull(handle);
+
             return handle.ResumeAsync(genericObserver, token);
         }
 
@@ -122,6 +124,8 @@ namespace Orleans.Streams
                                                                            StreamSequenceToken? token = null)
         {
             var genericObserver = new GenericAsyncBatchObserver<T>(onNextAsync, onErrorAsync, onCompletedAsync);
+            ArgumentNullException.ThrowIfNull(handle);
+
             return handle.ResumeAsync(genericObserver, token);
         }
 

--- a/src/Orleans.Streaming/Providers/IStreamProvider.cs
+++ b/src/Orleans.Streaming/Providers/IStreamProvider.cs
@@ -41,7 +41,11 @@ namespace Orleans.Streams
         /// <param name="streamProvider">The stream provider.</param>
         /// <param name="id">The identifier.</param>
         /// <returns>The stream.</returns>
-        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, Guid id) => streamProvider.GetStream<T>(StreamId.Create(null, id));
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, Guid id)
+        {
+            ArgumentNullException.ThrowIfNull(streamProvider);
+            return streamProvider.GetStream<T>(StreamId.Create(null, id));
+        }
 
         /// <summary>
         /// Gets the stream with the specified identity and namespace.
@@ -51,7 +55,11 @@ namespace Orleans.Streams
         /// <param name="ns">The namespace.</param>
         /// <param name="id">The identifier.</param>
         /// <returns>The stream.</returns>
-        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, Guid id) => streamProvider.GetStream<T>(StreamId.Create(ns, id));
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, Guid id)
+        {
+            ArgumentNullException.ThrowIfNull(streamProvider);
+            return streamProvider.GetStream<T>(StreamId.Create(ns, id));
+        }
 
         /// <summary>
         /// Gets the stream with the specified identity and namespace.
@@ -60,26 +68,11 @@ namespace Orleans.Streams
         /// <param name="streamProvider">The stream provider.</param>
         /// <param name="id">The identifier.</param>
         /// <returns>The stream.</returns>
-        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string id) => streamProvider.GetStream<T>(StreamId.Create(null, id));
-
-        /// <summary>
-        /// Gets the stream with the specified identity and namespace.
-        /// </summary>
-        /// <typeparam name="T">The stream element type.</typeparam>
-        /// <param name="streamProvider">The stream provider.</param>
-        /// <param name="ns">The namespace.</param>
-        /// <param name="id">The identifier.</param>
-        /// <returns>The stream.</returns>
-        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, string id) => streamProvider.GetStream<T>(StreamId.Create(ns, id));
-
-        /// <summary>
-        /// Gets the stream with the specified identity and namespace.
-        /// </summary>
-        /// <typeparam name="T">The stream element type.</typeparam>
-        /// <param name="streamProvider">The stream provider.</param>
-        /// <param name="id">The identifier.</param>
-        /// <returns>The stream.</returns>
-        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, long id) => streamProvider.GetStream<T>(StreamId.Create(null, id));
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string id)
+        {
+            ArgumentNullException.ThrowIfNull(streamProvider);
+            return streamProvider.GetStream<T>(StreamId.Create(null, id));
+        }
 
         /// <summary>
         /// Gets the stream with the specified identity and namespace.
@@ -89,7 +82,37 @@ namespace Orleans.Streams
         /// <param name="ns">The namespace.</param>
         /// <param name="id">The identifier.</param>
         /// <returns>The stream.</returns>
-        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, long id) => streamProvider.GetStream<T>(StreamId.Create(ns, id));
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, string id)
+        {
+            ArgumentNullException.ThrowIfNull(streamProvider);
+            return streamProvider.GetStream<T>(StreamId.Create(ns, id));
+        }
+
+        /// <summary>
+        /// Gets the stream with the specified identity and namespace.
+        /// </summary>
+        /// <typeparam name="T">The stream element type.</typeparam>
+        /// <param name="streamProvider">The stream provider.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>The stream.</returns>
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, long id)
+        {
+            ArgumentNullException.ThrowIfNull(streamProvider);
+            return streamProvider.GetStream<T>(StreamId.Create(null, id));
+        }
+
+        /// <summary>
+        /// Gets the stream with the specified identity and namespace.
+        /// </summary>
+        /// <typeparam name="T">The stream element type.</typeparam>
+        /// <param name="streamProvider">The stream provider.</param>
+        /// <param name="ns">The namespace.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>The stream.</returns>
+        public static IAsyncStream<T> GetStream<T>(this IStreamProvider streamProvider, string ns, long id)
+        {
+            ArgumentNullException.ThrowIfNull(streamProvider);
+            return streamProvider.GetStream<T>(StreamId.Create(ns, id));
+        }
     }
 }
-

--- a/src/Orleans.Streaming/PubSub/DefaultStreamNamespacePredicateProvider.cs
+++ b/src/Orleans.Streaming/PubSub/DefaultStreamNamespacePredicateProvider.cs
@@ -12,6 +12,8 @@ namespace Orleans.Streams
         /// <inheritdoc/>
         public bool TryGetPredicate(string predicatePattern, [MaybeNullWhen(false)] out IStreamNamespacePredicate predicate)
         {
+            ArgumentNullException.ThrowIfNull(predicatePattern);
+
             switch (predicatePattern)
             {
                 case "*":
@@ -56,6 +58,8 @@ namespace Orleans.Streams
         /// <inheritdoc/>
         public bool TryGetPredicate(string predicatePattern, [MaybeNullWhen(false)] out IStreamNamespacePredicate predicate)
         {
+            ArgumentNullException.ThrowIfNull(predicatePattern);
+
             if (!predicatePattern.StartsWith(Prefix, StringComparison.Ordinal))
             {
                 predicate = null;

--- a/src/Orleans.Streaming/PubSub/StreamSubscriptionManagerExtensions.cs
+++ b/src/Orleans.Streaming/PubSub/StreamSubscriptionManagerExtensions.cs
@@ -29,6 +29,9 @@ namespace Orleans.Streams.PubSub
             GrainId grainId)
             where TGrainInterface : IGrainWithGuidKey
         {
+            ArgumentNullException.ThrowIfNull(manager);
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
             var grainRef = grainFactory.GetGrain(grainId) as GrainReference;
             return manager.AddSubscription(streamProviderName, streamId, grainRef!); // GetGrain always returns a GrainReference-derived reference.
         }
@@ -53,6 +56,9 @@ namespace Orleans.Streams.PubSub
             string? grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithGuidKey
         {
+            ArgumentNullException.ThrowIfNull(manager);
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
             var grainRef = grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix) as GrainReference;
             return manager.AddSubscription(streamProviderName, streamId, grainRef!); // GetGrain always returns a GrainReference-derived reference.
         }
@@ -77,6 +83,9 @@ namespace Orleans.Streams.PubSub
             string? grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithIntegerKey
         {
+            ArgumentNullException.ThrowIfNull(manager);
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
             var grainRef = grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix) as GrainReference;
             return manager.AddSubscription(streamProviderName, streamId, grainRef!); // GetGrain always returns a GrainReference-derived reference.
         }
@@ -101,6 +110,9 @@ namespace Orleans.Streams.PubSub
             string? grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithStringKey
         {
+            ArgumentNullException.ThrowIfNull(manager);
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
             var grainRef = grainFactory.GetGrain<TGrainInterface>(primaryKey, grainClassNamePrefix) as GrainReference;
             return manager.AddSubscription(streamProviderName, streamId, grainRef!); // GetGrain always returns a GrainReference-derived reference.
         }
@@ -127,6 +139,9 @@ namespace Orleans.Streams.PubSub
             string? grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithGuidCompoundKey
         {
+            ArgumentNullException.ThrowIfNull(manager);
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
             var grainRef = grainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix) as GrainReference;
             return manager.AddSubscription(streamProviderName, streamId, grainRef!); // GetGrain always returns a GrainReference-derived reference.
         }
@@ -153,6 +168,9 @@ namespace Orleans.Streams.PubSub
             string? grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithIntegerCompoundKey
         {
+            ArgumentNullException.ThrowIfNull(manager);
+            ArgumentNullException.ThrowIfNull(grainFactory);
+
             var grainRef = grainFactory.GetGrain<TGrainInterface>(primaryKey, keyExtension, grainClassNamePrefix) as GrainReference;
             return manager.AddSubscription(streamProviderName, streamId, grainRef!); // GetGrain always returns a GrainReference-derived reference.
         }

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingBoundaryArgumentValidationTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingBoundaryArgumentValidationTests.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+using Orleans.Streams.PubSub;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+[TestCategory("BVT"), TestCategory("Streaming")]
+public class StreamingBoundaryArgumentValidationTests
+{
+    [Fact]
+    public void DefaultPredicateProviderRejectsNullPattern()
+    {
+        var provider = new DefaultStreamNamespacePredicateProvider();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => provider.TryGetPredicate(null!, out _));
+
+        Assert.Equal("predicatePattern", exception.ParamName);
+    }
+
+    [Fact]
+    public void ConstructorPredicateProviderRejectsNullPattern()
+    {
+        var provider = new ConstructorStreamNamespacePredicateProvider();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => provider.TryGetPredicate(null!, out _));
+
+        Assert.Equal("predicatePattern", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("guid")]
+    [InlineData("namespaced-guid")]
+    [InlineData("string")]
+    [InlineData("namespaced-string")]
+    [InlineData("long")]
+    [InlineData("namespaced-long")]
+    public void GetStreamOverloadsRejectNullProvider(string overload)
+    {
+        Action invocation = overload switch
+        {
+            "guid" => () => StreamProviderExtensions.GetStream<int>(null!, Guid.Empty),
+            "namespaced-guid" => () => StreamProviderExtensions.GetStream<int>(null!, "orders", Guid.Empty),
+            "string" => () => StreamProviderExtensions.GetStream<int>(null!, "order-1"),
+            "namespaced-string" => () => StreamProviderExtensions.GetStream<int>(null!, "orders", "order-1"),
+            "long" => () => StreamProviderExtensions.GetStream<int>(null!, 1L),
+            "namespaced-long" => () => StreamProviderExtensions.GetStream<int>(null!, "orders", 1L),
+            _ => throw new ArgumentOutOfRangeException(nameof(overload)),
+        };
+
+        var exception = Assert.Throws<ArgumentNullException>(invocation);
+
+        Assert.Equal("streamProvider", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task GetStreamForwardsIdentityAndReturnedStreamPublishes()
+    {
+        var provider = Substitute.For<IStreamProvider>();
+        var stream = Substitute.For<IAsyncStream<int>>();
+        var streamId = StreamId.Create("orders", "order-1");
+        provider.GetStream<int>(streamId).Returns(stream);
+
+        var result = provider.GetStream<int>("orders", "order-1");
+        await result.OnNextAsync(42);
+
+        Assert.Same(stream, result);
+        _ = provider.Received(1).GetStream<int>(streamId);
+        await stream.Received(1).OnNextAsync(42, null);
+    }
+
+    [Fact]
+    public void AddSubscriptionRejectsNullManagerBeforeGrainLookup()
+    {
+        var grainFactory = Substitute.For<IGrainFactory>();
+
+        AssertArgumentNull(
+            () => StreamSubscriptionManagerExtensions.AddSubscription<ITestGuidGrain>(
+                null!,
+                grainFactory,
+                StreamId.Create("orders", "order-1"),
+                "provider",
+                Guid.Empty),
+            "manager");
+
+        Assert.Empty(grainFactory.ReceivedCalls());
+    }
+
+    [Fact]
+    public void AddSubscriptionRejectsNullGrainFactoryBeforeRegistration()
+    {
+        var manager = Substitute.For<IStreamSubscriptionManager>();
+
+        AssertArgumentNull(
+            () => manager.AddSubscription<ITestGuidGrain>(
+                null!,
+                StreamId.Create("orders", "order-1"),
+                "provider",
+                Guid.Empty),
+            "grainFactory");
+
+        Assert.Empty(manager.ReceivedCalls());
+    }
+
+    [Fact]
+    public void ObservableSubscribeEntryPointsRejectNullObservableWithoutInvokingCallbacks()
+    {
+        var observer = Substitute.For<IAsyncObserver<int>>();
+        var token = Substitute.For<StreamSequenceToken>();
+        var callbackCount = 0;
+        Func<int, StreamSequenceToken?, Task> onNext = (_, _) =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+        Func<Exception, Task> onError = _ =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+        Func<Task> onCompleted = () =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+
+        AssertArgumentNull(
+            () => AsyncObservableExtensions.SubscribeAsync(
+                null!,
+                observer,
+                StreamSubscriptionStartPosition.Latest),
+            "obs");
+        AssertArgumentNull(
+            () => AsyncObservableExtensions.SubscribeAsync(null!, onNext, onError, onCompleted),
+            "obs");
+        AssertArgumentNull(
+            () => AsyncObservableExtensions.SubscribeAsync(null!, onNext, onError, onCompleted, token),
+            "obs");
+
+        Assert.Equal(0, callbackCount);
+    }
+
+    [Fact]
+    public void BatchObservableSubscribeEntryPointsRejectNullObservableWithoutInvokingCallbacks()
+    {
+        var observer = Substitute.For<IAsyncBatchObserver<int>>();
+        var callbackCount = 0;
+        Func<IList<SequentialItem<int>>, Task> onNext = _ =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+        Func<Exception, Task> onError = _ =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+        Func<Task> onCompleted = () =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+
+        AssertArgumentNull(
+            () => AsyncBatchObservableExtensions.SubscribeAsync(
+                null!,
+                observer,
+                StreamSubscriptionStartPosition.Latest),
+            "obs");
+        AssertArgumentNull(
+            () => AsyncBatchObservableExtensions.SubscribeAsync(null!, onNext, onError, onCompleted),
+            "obs");
+
+        Assert.Equal(0, callbackCount);
+    }
+
+    [Fact]
+    public void ResumeEntryPointsRejectNullHandleWithoutInvokingCallbacks()
+    {
+        var callbackCount = 0;
+        Func<int, StreamSequenceToken?, Task> onNext = (_, _) =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+        Func<IList<SequentialItem<int>>, Task> onNextBatch = _ =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+        Func<Exception, Task> onError = _ =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+        Func<Task> onCompleted = () =>
+        {
+            callbackCount++;
+            return Task.CompletedTask;
+        };
+
+        AssertArgumentNull(
+            () => StreamSubscriptionHandleExtensions.ResumeAsync(
+                null!,
+                onNext,
+                onError,
+                onCompleted),
+            "handle");
+        AssertArgumentNull(
+            () => StreamSubscriptionHandleExtensions.ResumeAsync(
+                null!,
+                onNextBatch,
+                onError,
+                onCompleted),
+            "handle");
+
+        Assert.Equal(0, callbackCount);
+    }
+
+    [Fact]
+    public async Task DelegateSubscribeForwardsCallbacks()
+    {
+        var observable = Substitute.For<IAsyncObservable<int>>();
+        var handle = Substitute.For<StreamSubscriptionHandle<int>>();
+        IAsyncObserver<int>? registeredObserver = null;
+        observable.SubscribeAsync(Arg.Do<IAsyncObserver<int>>(value => registeredObserver = value))
+            .Returns(Task.FromResult(handle));
+        var receivedItem = 0;
+        StreamSequenceToken? receivedToken = null;
+        Exception? receivedError = null;
+        var completed = false;
+
+        var result = await observable.SubscribeAsync(
+            (item, token) =>
+            {
+                receivedItem = item;
+                receivedToken = token;
+                return Task.CompletedTask;
+            },
+            exception =>
+            {
+                receivedError = exception;
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                completed = true;
+                return Task.CompletedTask;
+            });
+
+        var token = Substitute.For<StreamSequenceToken>();
+        var error = new InvalidOperationException("test");
+        Assert.NotNull(registeredObserver);
+        await registeredObserver.OnNextAsync(42, token);
+        await registeredObserver.OnErrorAsync(error);
+        await registeredObserver.OnCompletedAsync();
+
+        Assert.Same(handle, result);
+        Assert.Equal(42, receivedItem);
+        Assert.Same(token, receivedToken);
+        Assert.Same(error, receivedError);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public async Task BatchDelegateSubscribeForwardsCallbacks()
+    {
+        var observable = Substitute.For<IAsyncBatchObservable<int>>();
+        var handle = Substitute.For<StreamSubscriptionHandle<int>>();
+        IAsyncBatchObserver<int>? registeredObserver = null;
+        observable.SubscribeAsync(Arg.Do<IAsyncBatchObserver<int>>(value => registeredObserver = value))
+            .Returns(Task.FromResult(handle));
+        IList<SequentialItem<int>>? receivedItems = null;
+        Exception? receivedError = null;
+        var completed = false;
+
+        var result = await observable.SubscribeAsync(
+            items =>
+            {
+                receivedItems = items;
+                return Task.CompletedTask;
+            },
+            exception =>
+            {
+                receivedError = exception;
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                completed = true;
+                return Task.CompletedTask;
+            });
+
+        var items = new List<SequentialItem<int>>
+        {
+            new(42, Substitute.For<StreamSequenceToken>()),
+        };
+        var error = new InvalidOperationException("test");
+        Assert.NotNull(registeredObserver);
+        await registeredObserver.OnNextAsync(items);
+        await registeredObserver.OnErrorAsync(error);
+        await registeredObserver.OnCompletedAsync();
+
+        Assert.Same(handle, result);
+        Assert.Same(items, receivedItems);
+        Assert.Same(error, receivedError);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public async Task DelegateResumeForwardsCallbacksAndToken()
+    {
+        var handle = Substitute.For<StreamSubscriptionHandle<int>>();
+        var resumedHandle = Substitute.For<StreamSubscriptionHandle<int>>();
+        var token = Substitute.For<StreamSequenceToken>();
+        IAsyncObserver<int>? registeredObserver = null;
+        handle.ResumeAsync(
+                Arg.Do<IAsyncObserver<int>>(value => registeredObserver = value),
+                token)
+            .Returns(Task.FromResult(resumedHandle));
+        var receivedItem = 0;
+
+        var result = await handle.ResumeAsync(
+            (item, _) =>
+            {
+                receivedItem = item;
+                return Task.CompletedTask;
+            },
+            _ => Task.CompletedTask,
+            () => Task.CompletedTask,
+            token);
+
+        Assert.NotNull(registeredObserver);
+        await registeredObserver.OnNextAsync(42, token);
+
+        Assert.Same(resumedHandle, result);
+        Assert.Equal(42, receivedItem);
+        await handle.Received(1).ResumeAsync(registeredObserver, token);
+    }
+
+    private static void AssertArgumentNull(Action action, string paramName)
+    {
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(paramName, exception.ParamName);
+    }
+
+    public interface ITestGuidGrain : IGrainWithGuidKey;
+}


### PR DESCRIPTION
Public streaming extension methods dereferenced caller-provided boundary objects without consistently validating them, leaving CA1062 findings across the PubSub, Extensions, and Providers families.

This change validates stream providers, observables, subscription handles, predicate patterns, subscription managers, and grain factories at their public boundaries. Validation occurs before grain lookup, subscription registration, or callback dispatch while preserving existing delegate validation order, subscription identity, and valid publish/subscribe behavior.

CA1062 is enabled for the complete physical PubSub, Extensions, and Providers source families without file-specific carveouts. Focused regression coverage verifies argument names, rejection before collaborator activity, and representative valid stream lookup, publish, subscribe, resume, and callback forwarding.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11172)