### PR TITLE
fix(serialization): validate support contracts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -699,6 +699,9 @@ dotnet_diagnostic.CA2000.severity = warning
 dotnet_diagnostic.CA2000.severity = warning
 
 # CA1062: Validate arguments of public methods
+[src/Orleans.Serialization/{GeneratedCodeHelpers,ISerializableSerializer,Utilities}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
 [src/{Orleans.BroadcastChannel,Orleans.Clustering.ZooKeeper,Orleans.Hosting.Kubernetes,Orleans.Persistence.Memory,Orleans.Persistence.TestKit,Orleans.Reminders.TestKit,Orleans.Serialization.FSharp,Orleans.Serialization.MessagePack,Orleans.Serialization.NewtonsoftJson,Orleans.Serialization.SystemTextJson,Orleans.Serialization.TestKit,Orleans.Transactions.TestKit.Base,Orleans.Transactions.TestKit.xUnit}/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 

--- a/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
+++ b/src/Orleans.Serialization/GeneratedCodeHelpers/OrleansGeneratedCodeHelper.cs
@@ -62,6 +62,8 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
             object caller,
             ICodecProvider codecProvider)
         {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(codecProvider);
+
             var state = ResolutionState.Value!;
 
             try
@@ -202,6 +204,8 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void SerializeUnexpectedType<TBufferWriter>(this ref Writer<TBufferWriter> writer, uint fieldIdDelta, [System.Diagnostics.CodeAnalysis.AllowNull] Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
         {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(value);
+
             var specificSerializer = writer.Session.CodecProvider.GetCodec(value.GetType());
             specificSerializer.WriteField(ref writer, fieldIdDelta, expectedType, value);
         }
@@ -335,6 +339,7 @@ namespace Orleans.Serialization.GeneratedCodeHelpers
 
             /// <inheritdoc/>
             [return: NotNullIfNotNull(nameof(original))]
+            [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "The Orleans deep-copy pipeline supplies the active non-null copy context.")]
             public T? DeepCopy(T? original, CopyContext context)
             {
                 if (original is null)

--- a/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/DotNetSerializableCodec.cs
@@ -68,6 +68,7 @@ namespace Orleans.Serialization
 
         /// <inheritdoc />
         [SecurityCritical]
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ReferenceCodec handles null serialized values and returns before the value is accessed.")]
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [System.Diagnostics.CodeAnalysis.AllowNull] Type expectedType, [System.Diagnostics.CodeAnalysis.AllowNull] object? value) where TBufferWriter : IBufferWriter<byte>
         {
             if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value!))

--- a/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/ExceptionCodec.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
@@ -51,6 +52,8 @@ namespace Orleans.Serialization
             IDeepCopier<Exception> exceptionCopier,
             IOptions<ExceptionSerializationOptions> exceptionSerializationOptions)
         {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(exceptionSerializationOptions);
+
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
             _streamingContext = new StreamingContext(StreamingContextStates.All);
             _formatterConverter = new FormatterConverter();
@@ -64,6 +67,7 @@ namespace Orleans.Serialization
         }
 
         /// <inheritdoc />
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "The serializer dispatches this base codec with an allocated non-null exception instance.")]
         public void Deserialize<TInput>(ref Reader<TInput> reader, Exception value)
         {
             uint fieldId = 0;
@@ -104,7 +108,7 @@ namespace Orleans.Serialization
                 }
             }
 
-            SetBaseProperties(value, message, stackTrace, innerException, hResult, data);
+            SetBasePropertiesCore(value, message, stackTrace, innerException, hResult, data);
         }
 
         /// <summary>
@@ -113,6 +117,12 @@ namespace Orleans.Serialization
         /// <param name="value">The value.</param>
         /// <returns>A populated <see cref="SerializationInfo"/> value.</returns>
         public SerializationInfo GetObjectData(Exception value)
+        {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(value);
+            return GetObjectDataCore(value);
+        }
+
+        internal SerializationInfo GetObjectDataCore(Exception value)
         {
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
             var info = new SerializationInfo(value.GetType(), _formatterConverter);
@@ -133,6 +143,12 @@ namespace Orleans.Serialization
         /// <param name="hResult">The HResult.</param>
         /// <param name="data">The data.</param>
         public void SetBaseProperties(Exception value, string? message, string? stackTrace, Exception? innerException, int hResult, Dictionary<object, object?>? data)
+        {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(value);
+            SetBasePropertiesCore(value, message, stackTrace, innerException, hResult, data);
+        }
+
+        internal void SetBasePropertiesCore(Exception value, string? message, string? stackTrace, Exception? innerException, int hResult, Dictionary<object, object?>? data)
         {
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
             var info = new SerializationInfo(typeof(Exception), _formatterConverter);
@@ -178,6 +194,12 @@ namespace Orleans.Serialization
         /// <returns>The provided exception's <see cref="Exception.Data"/> property.</returns>
         public Dictionary<object, object?>? GetDataProperty(Exception exception)
         {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(exception);
+            return GetDataPropertyCore(exception);
+        }
+
+        internal static Dictionary<object, object?>? GetDataPropertyCore(Exception exception)
+        {
             if (exception.Data is null or { Count: 0 })
             {
                 return null;
@@ -195,19 +217,21 @@ namespace Orleans.Serialization
         }
 
         /// <inheritdoc />
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "The serializer dispatches this base codec only after handling null references.")]
         public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, Exception value) where TBufferWriter : IBufferWriter<byte>
         {
             StringCodec.WriteField(ref writer, 0, value.Message);
             StringCodec.WriteField(ref writer, 1, value.StackTrace);
             WriteField(ref writer, 1, typeof(Exception), value.InnerException!);
             Int32Codec.WriteField(ref writer, 1, value.HResult);
-            if (GetDataProperty(value) is { } dataDictionary)
+            if (GetDataPropertyCore(value) is { } dataDictionary)
             {
                 _dictionaryCodec.WriteField(ref writer, 1, typeof(Dictionary<object, object?>), dataDictionary);
             }
         }
 
         /// <inheritdoc />
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Exception fields invoke this method only after handling null references.")]
         public void SerializeException<TBufferWriter>(ref Writer<TBufferWriter> writer, Exception value) where TBufferWriter : IBufferWriter<byte>
         {
             StringCodec.WriteField(ref writer, 0, _typeConverter.Format(value.GetType()));
@@ -215,7 +239,7 @@ namespace Orleans.Serialization
             StringCodec.WriteField(ref writer, 1, value.StackTrace);
             WriteField(ref writer, 1, typeof(Exception), value.InnerException!);
             Int32Codec.WriteField(ref writer, 1, value.HResult);
-            if (GetDataProperty(value) is { } dataDictionary)
+            if (GetDataPropertyCore(value) is { } dataDictionary)
             {
                 _dictionaryCodec.WriteField(ref writer, 1, typeof(Dictionary<object, object?>), dataDictionary);
             }
@@ -245,6 +269,7 @@ namespace Orleans.Serialization
         }
 
         /// <inheritdoc />
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Codec selection supplies the non-null candidate type.")]
         public bool IsSupportedType(Type type)
         {
             if (type == typeof(ExceptionCodec))
@@ -419,22 +444,23 @@ namespace Orleans.Serialization
                 throw new NotSupportedException($"Type {type} is not supported");
             }
 
-            SetBaseProperties(result, message, stackTrace, innerException, hResult, data);
+            SetBasePropertiesCore(result, message, stackTrace, innerException, hResult, data);
             return result;
         }
 
         /// <inheritdoc />
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "The Orleans deep-copy pipeline supplies non-null source, destination, and context instances.")]
         public void DeepCopy(Exception input, Exception output, CopyContext context)
         {
-            var info = GetObjectData(input);
-            SetBaseProperties(
+            var info = GetObjectDataCore(input);
+            SetBasePropertiesCore(
                 output,
                 // Get the message from object data in case the property is overridden as it is with AggregateException
                 info.GetString("Message"),
                 input.StackTrace,
                 _exceptionCopier.DeepCopy(input.InnerException!, context),
                 input.HResult,
-                _dictionaryCopier.DeepCopy(GetDataProperty(input)!, context));
+                _dictionaryCopier.DeepCopy(GetDataPropertyCore(input)!, context));
         }
 
         /// <inheritdoc />
@@ -467,21 +493,21 @@ namespace Orleans.Serialization
         {
             var result = new AggregateException(surrogate.InnerExceptions);
             var innerException = surrogate.InnerExceptions is { Count: > 0 } innerExceptions ? innerExceptions[0] : null;
-            _baseCodec.SetBaseProperties(result, surrogate.Message, surrogate.StackTrace, innerException, surrogate.HResult, surrogate.Data);
+            _baseCodec.SetBasePropertiesCore(result, surrogate.Message, surrogate.StackTrace, innerException, surrogate.HResult, surrogate.Data);
             return result;
         }
 
         /// <inheritdoc/>
         public override void ConvertToSurrogate(AggregateException value, ref AggregateExceptionSurrogate surrogate)
         {
-            var info = _baseCodec.GetObjectData(value);
+            var info = _baseCodec.GetObjectDataCore(value);
             surrogate.Message = info.GetString("Message")!;
             surrogate.StackTrace = value.StackTrace;
             surrogate.HResult = value.HResult;
             var data = info.GetValue("Data", typeof(IDictionary));
             if (data is { })
             {
-                surrogate.Data = _baseCodec.GetDataProperty(value);
+                surrogate.Data = ExceptionCodec.GetDataPropertyCore(value);
             }
 
             surrogate.InnerExceptions = value.InnerExceptions;

--- a/src/Orleans.Serialization/ISerializableSerializer/SerializationConstructorNotFoundException.cs
+++ b/src/Orleans.Serialization/ISerializableSerializer/SerializationConstructorNotFoundException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 using System.Security;
+using Orleans.Serialization.Codecs;
 
 namespace Orleans.Serialization
 {
@@ -15,8 +16,7 @@ namespace Orleans.Serialization
         /// </summary>
         /// <param name="type">The type.</param>
         [SecurityCritical]
-        public SerializationConstructorNotFoundException(Type type) : base(
-            (string)$"Could not find a suitable serialization constructor on type {type.FullName}")
+        public SerializationConstructorNotFoundException(Type type) : base(GetMessage(type))
         {
         }
 
@@ -31,6 +31,12 @@ namespace Orleans.Serialization
 #endif
         protected SerializationConstructorNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
+        }
+
+        private static string GetMessage(Type type)
+        {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(type);
+            return $"Could not find a suitable serialization constructor on type {type.FullName}";
         }
     }
 }

--- a/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
+++ b/src/Orleans.Serialization/Utilities/BitStreamFormatter.cs
@@ -107,6 +107,7 @@ namespace Orleans.Serialization.Utilities
         /// <param name="result">The destination string builder.</param>
         public static void Format<TInput>(ref Reader<TInput> reader, StringBuilder result)
         {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(result);
             var (field, type) = reader.ReadFieldHeaderForAnalysis();
             FormatField(ref reader, field, type, field.FieldIdDelta, result, indentation: 0);
         }
@@ -323,4 +324,3 @@ namespace Orleans.Serialization.Utilities
         }
     }
 }
-

--- a/src/Orleans.Serialization/Utilities/FieldAccessor.cs
+++ b/src/Orleans.Serialization/Utilities/FieldAccessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
+using Orleans.Serialization.Codecs;
 
 namespace Orleans.Serialization.Utilities
 {
@@ -43,7 +44,10 @@ namespace Orleans.Serialization.Utilities
 #endif
             Type declaringType,
             string fieldName)
-            => GetGetter(declaringType, fieldName, false);
+        {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(declaringType);
+            return GetGetter(declaringType, fieldName, false);
+        }
 
         /// <summary>
         /// Returns a delegate to get the value of a specified field.
@@ -55,7 +59,10 @@ namespace Orleans.Serialization.Utilities
 #endif
             Type declaringType,
             string fieldName)
-            => GetGetter(declaringType, fieldName, true);
+        {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(declaringType);
+            return GetGetter(declaringType, fieldName, true);
+        }
 
         private static Delegate GetGetter(
 #if NET5_0_OR_GREATER
@@ -89,7 +96,10 @@ namespace Orleans.Serialization.Utilities
 #endif
             Type declaringType,
             string fieldName)
-            => GetSetter(declaringType, fieldName, false);
+        {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(declaringType);
+            return GetSetter(declaringType, fieldName, false);
+        }
 
         /// <summary>
         /// Returns a delegate to set the value of this field for an instance.
@@ -101,7 +111,10 @@ namespace Orleans.Serialization.Utilities
 #endif
             Type declaringType,
             string fieldName)
-            => GetSetter(declaringType, fieldName, true);
+        {
+            ArgumentNullExceptionPolyfill.ThrowIfNull(declaringType);
+            return GetSetter(declaringType, fieldName, true);
+        }
 
         private static Delegate GetSetter(
 #if NET5_0_OR_GREATER

--- a/src/Orleans.Serialization/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Utilities/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Codecs;
 
 namespace Orleans.Serialization.Utilities.Internal;
 
@@ -27,6 +28,9 @@ public static class InternalServiceCollectionExtensions
     /// <param name="implementation">The implementation of <paramref name="service"/>.</param>
     public static void AddFromExisting(this IServiceCollection services, Type service, Type implementation)
     {
+        ArgumentNullExceptionPolyfill.ThrowIfNull(services);
+        ArgumentNullExceptionPolyfill.ThrowIfNull(implementation);
+
         ServiceDescriptor? registration = null;
         foreach (var descriptor in services)
         {

--- a/test/Orleans.Serialization.UnitTests/SerializationSupportContractTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializationSupportContractTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Buffers;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.GeneratedCodeHelpers;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.Session;
+using Orleans.Serialization.TypeSystem;
+using Orleans.Serialization.Utilities;
+using Orleans.Serialization.Utilities.Internal;
+using Orleans.Serialization.WireProtocol;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Serialization")]
+public sealed class SerializationSupportContractTests
+{
+    [Fact]
+    public void GeneratedCodeHelper_NullCodecProvider_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => OrleansGeneratedCodeHelper.GetService<object>(this, null!));
+
+        Assert.Equal("codecProvider", exception.ParamName);
+    }
+
+    [Fact]
+    public void GeneratedCodeHelper_NullUnexpectedValue_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(SerializeNullUnexpectedValue);
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void DotNetSerializableCodec_NullPayload_WritesAndReadsNullReference()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var sessionPool = serviceProvider.GetRequiredService<SerializerSessionPool>();
+        var codec = new DotNetSerializableCodec(serviceProvider.GetRequiredService<TypeConverter>());
+        var output = new ArrayBufferWriter<byte>();
+
+        using (var writerSession = sessionPool.GetSession())
+        {
+            var writer = Writer.Create(output, writerSession);
+            codec.WriteField(ref writer, 0, typeof(object), null);
+            writer.Commit();
+        }
+
+        using var readerSession = sessionPool.GetSession();
+        var reader = Reader.Create(output.WrittenMemory, readerSession);
+        var field = reader.ReadFieldHeader();
+        var result = codec.ReadValue(ref reader, field);
+
+        Assert.Equal(WireType.Reference, field.WireType);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ExceptionCodec_NullOptions_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new ExceptionCodec(null!, null!, null!, null!, null!));
+
+        Assert.Equal("exceptionSerializationOptions", exception.ParamName);
+    }
+
+    [Fact]
+    public void ExceptionCodec_NullObjectDataValue_ThrowsWithExactParamName()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var codec = serviceProvider.GetRequiredService<ExceptionCodec>();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => codec.GetObjectData(null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ExceptionCodec_NullBasePropertiesValue_ThrowsWithExactParamName()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var codec = serviceProvider.GetRequiredService<ExceptionCodec>();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => codec.SetBaseProperties(null!, null, null, null, 0, null));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ExceptionCodec_NullDataException_ThrowsWithExactParamName()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var codec = serviceProvider.GetRequiredService<ExceptionCodec>();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => codec.GetDataProperty(null!));
+
+        Assert.Equal("exception", exception.ParamName);
+    }
+
+    [Fact]
+    public void ExceptionCodec_RoundTrip_PreservesBaseExceptionState()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var original = new InvalidOperationException("outer", new ArgumentException("inner"));
+        original.Data["key"] = "value";
+
+        var result = serializer.Deserialize<Exception>(serializer.SerializeToArray(original));
+
+        var typedResult = Assert.IsType<InvalidOperationException>(result);
+        Assert.Equal("outer", typedResult.Message);
+        Assert.Equal("inner", Assert.IsType<ArgumentException>(typedResult.InnerException).Message);
+        Assert.Equal("value", typedResult.Data["key"]);
+    }
+
+    [Fact]
+    public void SerializationConstructorNotFoundException_NullType_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new SerializationConstructorNotFoundException(null!));
+
+        Assert.Equal("type", exception.ParamName);
+    }
+
+    [Fact]
+    public void BitStreamFormatter_NullResult_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(FormatIntoNullResult);
+
+        Assert.Equal("result", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(nameof(FieldAccessor.GetGetter))]
+    [InlineData(nameof(FieldAccessor.GetValueGetter))]
+    [InlineData(nameof(FieldAccessor.GetReferenceSetter))]
+    [InlineData(nameof(FieldAccessor.GetValueSetter))]
+    public void FieldAccessor_NullDeclaringType_ThrowsWithExactParamName(string methodName)
+    {
+        Action action = methodName switch
+        {
+            nameof(FieldAccessor.GetGetter) => () => FieldAccessor.GetGetter(null!, "_value"),
+            nameof(FieldAccessor.GetValueGetter) => () => FieldAccessor.GetValueGetter(null!, "_value"),
+            nameof(FieldAccessor.GetReferenceSetter) => () => FieldAccessor.GetReferenceSetter(null!, "_value"),
+            nameof(FieldAccessor.GetValueSetter) => () => FieldAccessor.GetValueSetter(null!, "_value"),
+            _ => throw new ArgumentOutOfRangeException(nameof(methodName)),
+        };
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+
+        Assert.Equal("declaringType", exception.ParamName);
+    }
+
+    [Fact]
+    public void FieldAccessor_ValidFields_PreserveReferenceAndValueTypeAccess()
+    {
+        var reference = new ReferenceHolder("original");
+        var referenceGetter = (Func<ReferenceHolder, string>)FieldAccessor.GetGetter(typeof(ReferenceHolder), "_value");
+        var referenceSetter = (Action<ReferenceHolder, string>)FieldAccessor.GetReferenceSetter(typeof(ReferenceHolder), "_value");
+        var value = new ValueHolder(17);
+        var valueGetter = (ValueTypeGetter<ValueHolder, int>)FieldAccessor.GetValueGetter(typeof(ValueHolder), "_value");
+        var valueSetter = (ValueTypeSetter<ValueHolder, int>)FieldAccessor.GetValueSetter(typeof(ValueHolder), "_value");
+
+        referenceSetter(reference, "updated");
+        valueSetter(ref value, 29);
+
+        Assert.Equal("updated", referenceGetter(reference));
+        Assert.Equal(29, valueGetter(ref value));
+    }
+
+    [Fact]
+    public void AddFromExisting_NullServices_ThrowsWithExactParamName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => InternalServiceCollectionExtensions.AddFromExisting(null!, typeof(IService), typeof(Service)));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddFromExisting_NullImplementation_ThrowsWithoutMutatingServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<Service>();
+        var originalCount = services.Count;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => InternalServiceCollectionExtensions.AddFromExisting(services, typeof(IService), null!));
+
+        Assert.Equal("implementation", exception.ParamName);
+        Assert.Equal(originalCount, services.Count);
+    }
+
+    [Fact]
+    public void AddFromExisting_ValidRegistration_PreservesSingletonIdentity()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<Service>();
+        services.AddFromExisting<IService, Service>();
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.Same(
+            serviceProvider.GetRequiredService<Service>(),
+            serviceProvider.GetRequiredService<IService>());
+    }
+
+    private static ServiceProvider CreateServiceProvider() =>
+        new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+
+    private static void SerializeNullUnexpectedValue()
+    {
+        Writer<ArrayBufferWriter<byte>> writer = default;
+        OrleansGeneratedCodeHelper.SerializeUnexpectedType(ref writer, 0, null, null!);
+    }
+
+    private static void FormatIntoNullResult()
+    {
+        Reader<byte[]> reader = default;
+        BitStreamFormatter.Format(ref reader, null!);
+    }
+
+    private interface IService;
+
+    private sealed class Service : IService;
+
+    private sealed class ReferenceHolder(string value)
+    {
+        private string _value = value;
+    }
+
+    private struct ValueHolder(int value)
+    {
+        private int _value = value;
+    }
+}


### PR DESCRIPTION
## Problem

CA1062 is not enforced across several Orleans.Serialization support families, leaving public caller-controlled boundaries without consistent argument validation and obscuring runtime contracts which already guarantee non-null inputs.

## Solution

- enable CA1062 for GeneratedCodeHelpers, ISerializableSerializer, and Utilities
- validate caller-controlled service, reflection, formatting, exception-helper, and registration inputs
- preserve null serialization, exception, reflection, graph, and service-registration behavior
- document narrow runtime guarantees for codec dispatch and deep-copy hot paths instead of adding redundant checks
- add focused contract tests for invalid boundaries and representative valid behavior

## Rationale

Validation is placed at the true external boundary. Runtime-only serialization paths continue relying on their established dispatch and copy-context guarantees, avoiding duplicate hot-path checks while keeping supported null payloads unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11174)