### PR TITLE
fix(journaling): validate JSON codec contracts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -729,6 +729,9 @@ dotnet_diagnostic.CA1062.severity = warning
 [src/Orleans.Serialization/Codecs/{*.cs,**/*.cs}]
 dotnet_diagnostic.CA1062.severity = warning
 
+[src/Orleans.Journaling/Formats/Json/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
 # CA1815: Override equals and operator equals on value types
 [src/{Orleans.Core.Abstractions,Orleans.EventSourcing,Orleans.Reminders,Orleans.Serialization.FSharp,Orleans.Serialization.TestKit,Orleans.Streaming,Orleans.Transactions,Orleans.Transactions.TestKit.Base}/**.cs]
 dotnet_diagnostic.CA1815.severity = warning

--- a/src/Orleans.Journaling/Formats/Json/JsonDurableCollectionCommandCodecs.cs
+++ b/src/Orleans.Journaling/Formats/Json/JsonDurableCollectionCommandCodecs.cs
@@ -103,6 +103,7 @@ public sealed class JsonDurableListCommandCodec<T>(JsonSerializerOptions? option
     /// <inheritdoc/>
     public void Apply(JournalBufferReader input, IDurableListCommandHandler<T> consumer)
     {
+        ArgumentNullException.ThrowIfNull(consumer);
         var reader = new JsonCommandReader(input);
         try
         {
@@ -227,6 +228,7 @@ public sealed class JsonDurableQueueCommandCodec<T>(JsonSerializerOptions? optio
     /// <inheritdoc/>
     public void Apply(JournalBufferReader input, IDurableQueueCommandHandler<T> consumer)
     {
+        ArgumentNullException.ThrowIfNull(consumer);
         var reader = new JsonCommandReader(input);
         try
         {
@@ -344,6 +346,7 @@ public sealed class JsonDurableSetCommandCodec<T>(JsonSerializerOptions? options
     /// <inheritdoc/>
     public void Apply(JournalBufferReader input, IDurableSetCommandHandler<T> consumer)
     {
+        ArgumentNullException.ThrowIfNull(consumer);
         var reader = new JsonCommandReader(input);
         try
         {

--- a/src/Orleans.Journaling/Formats/Json/JsonDurableDictionaryCommandCodec.cs
+++ b/src/Orleans.Journaling/Formats/Json/JsonDurableDictionaryCommandCodec.cs
@@ -87,6 +87,7 @@ public sealed class JsonDurableDictionaryCommandCodec<TKey, TValue>(JsonSerializ
     /// <inheritdoc/>
     public void Apply(JournalBufferReader input, IDurableDictionaryCommandHandler<TKey, TValue> consumer)
     {
+        ArgumentNullException.ThrowIfNull(consumer);
         var reader = new JsonCommandReader(input);
         try
         {

--- a/src/Orleans.Journaling/Formats/Json/JsonDurableValueCommandCodecs.cs
+++ b/src/Orleans.Journaling/Formats/Json/JsonDurableValueCommandCodecs.cs
@@ -27,6 +27,7 @@ public sealed class JsonDurableValueCommandCodec<T>(JsonSerializerOptions? optio
     /// <inheritdoc/>
     public void Apply(JournalBufferReader input, IDurableValueCommandHandler<T> consumer)
     {
+        ArgumentNullException.ThrowIfNull(consumer);
         var reader = new JsonCommandReader(input);
         try
         {
@@ -87,6 +88,7 @@ public sealed class JsonPersistentStateCommandCodec<T>(JsonSerializerOptions? op
     /// <inheritdoc/>
     public void Apply(JournalBufferReader input, IPersistentStateCommandHandler<T> consumer)
     {
+        ArgumentNullException.ThrowIfNull(consumer);
         var reader = new JsonCommandReader(input);
         try
         {
@@ -154,6 +156,7 @@ public sealed class JsonDurableTaskCompletionSourceCommandCodec<T>(JsonSerialize
     /// <inheritdoc/>
     public void WriteFaulted(Exception exception, JournalStreamWriter writer)
     {
+        ArgumentNullException.ThrowIfNull(exception);
         JsonCommandWriter.Write(
             writer,
             exception.Message,
@@ -176,6 +179,7 @@ public sealed class JsonDurableTaskCompletionSourceCommandCodec<T>(JsonSerialize
     /// <inheritdoc/>
     public void Apply(JournalBufferReader input, IDurableTaskCompletionSourceCommandHandler<T> consumer)
     {
+        ArgumentNullException.ThrowIfNull(consumer);
         var reader = new JsonCommandReader(input);
         try
         {

--- a/test/Orleans.Journaling.Json.Tests/JsonCommandCodecArgumentValidationTests.cs
+++ b/test/Orleans.Journaling.Json.Tests/JsonCommandCodecArgumentValidationTests.cs
@@ -1,0 +1,101 @@
+using System.Text;
+using System.Text.Json;
+using Orleans.Journaling.Tests;
+using Xunit;
+
+namespace Orleans.Journaling.Json.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+public sealed class JsonCommandCodecArgumentValidationTests
+{
+    private static readonly JsonSerializerOptions Options = new() { TypeInfoResolver = JsonCodecTestJsonContext.Default };
+
+    [Fact]
+    public void DictionaryApply_NullConsumer_ThrowsBeforeReadingInput()
+    {
+        var codec = new JsonDurableDictionaryCommandCodec<string, int>(Options);
+
+        AssertNullConsumerRejected(input => codec.Apply(input, null!));
+    }
+
+    [Fact]
+    public void ListApply_NullConsumer_ThrowsBeforeReadingInput()
+    {
+        var codec = new JsonDurableListCommandCodec<int>(Options);
+
+        AssertNullConsumerRejected(input => codec.Apply(input, null!));
+    }
+
+    [Fact]
+    public void QueueApply_NullConsumer_ThrowsBeforeReadingInput()
+    {
+        var codec = new JsonDurableQueueCommandCodec<int>(Options);
+
+        AssertNullConsumerRejected(input => codec.Apply(input, null!));
+    }
+
+    [Fact]
+    public void SetApply_NullConsumer_ThrowsBeforeReadingInput()
+    {
+        var codec = new JsonDurableSetCommandCodec<int>(Options);
+
+        AssertNullConsumerRejected(input => codec.Apply(input, null!));
+    }
+
+    [Fact]
+    public void ValueApply_NullConsumer_ThrowsBeforeReadingInput()
+    {
+        var codec = new JsonDurableValueCommandCodec<int>(Options);
+
+        AssertNullConsumerRejected(input => codec.Apply(input, null!));
+    }
+
+    [Fact]
+    public void PersistentStateApply_NullConsumer_ThrowsBeforeReadingInput()
+    {
+        var codec = new JsonPersistentStateCommandCodec<int>(Options);
+
+        AssertNullConsumerRejected(input => codec.Apply(input, null!));
+    }
+
+    [Fact]
+    public void TaskCompletionSourceApply_NullConsumer_ThrowsBeforeReadingInput()
+    {
+        var codec = new JsonDurableTaskCompletionSourceCommandCodec<int>(Options);
+
+        AssertNullConsumerRejected(input => codec.Apply(input, null!));
+    }
+
+    [Fact]
+    public void TaskCompletionSourceWriteFaulted_NullException_ThrowsWithoutMutatingWriter()
+    {
+        var codec = new JsonDurableTaskCompletionSourceCommandCodec<int>(Options);
+        using var writer = new JsonLinesJournalFormat().CreateWriter();
+        var streamWriter = writer.CreateJournalStreamWriter(new JournalStreamId(1));
+
+        var exception = Assert.Throws<ArgumentNullException>(() => codec.WriteFaulted(null!, streamWriter));
+
+        Assert.Equal("exception", exception.ParamName);
+        using (var buffer = writer.GetBuffer())
+        {
+            Assert.Equal(0, buffer.Length);
+        }
+
+        codec.WritePending(streamWriter);
+        using var committed = writer.GetBuffer();
+        Assert.Equal("[1,[\"pending\"]]\n", Encoding.UTF8.GetString(committed.ToArray()));
+    }
+
+    private static void AssertNullConsumerRejected(Action<JournalBufferReader> apply)
+    {
+        var input = CodecTestHelpers.ReadBuffer("not-json"u8.ToArray());
+        var expected = input.ToArray();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => apply(input));
+
+        Assert.Equal("consumer", exception.ParamName);
+        Assert.Equal(expected, input.ToArray());
+    }
+}


### PR DESCRIPTION
## Problem

The JSON journaling codec family accepted caller-controlled command handlers without validating them before decoding persisted input. The task-completion-source codec also dereferenced a caller-provided exception before validating it. Enabling CA1062 for this family surfaced eight contract gaps.

## Solution

Validate every JSON command codec consumer before reading journal data, and validate fault exceptions before beginning an entry. Enable CA1062 for the complete physical `src/Orleans.Journaling/Formats/Json` source family and add focused regression coverage for all eight boundaries.

## Rationale

Eager validation gives callers consistent `ArgumentNullException` behavior with precise parameter names, prevents malformed persisted input from masking invalid API usage, and preserves writer state when fault input is invalid. Serialization, nullable payload, collection snapshot, and replay behavior remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11176)