### PR TITLE
fix(journaling): use ordinal identifier comparisons

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -759,6 +759,11 @@ dotnet_diagnostic.CA1307.severity = warning
 dotnet_diagnostic.CA1305.severity = warning
 dotnet_diagnostic.CA1307.severity = warning
 
+# Journal identifiers, metadata, and provider storage keys retain their exact persisted representation.
+[src/{Orleans.Journaling,Azure/Orleans.Journaling.AzureStorage,Redis/Orleans.Journaling.Redis,AWS/Orleans.Journaling.S3}/**.cs]
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning
+
 # Azure Table sources are linked into multiple provider projects, so they share one enforcement policy.
 [src/Azure/Shared/{Storage/{AzureStorageOperationOptions.cs,AzureStoragePolicyOptions.cs,AzureTableDataManager.cs,AzureTableUtils.cs},Utilities/ErrorCode.cs}]
 dotnet_diagnostic.CA1305.severity = warning

--- a/src/AWS/Orleans.Journaling.S3/S3JournalStorage.cs
+++ b/src/AWS/Orleans.Journaling.S3/S3JournalStorage.cs
@@ -1426,7 +1426,7 @@ internal sealed partial class S3JournalStorage : IJournalStorage
     private static void ValidateCallerMetadataPropertyName(string key)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        if (key.IndexOf('\0') >= 0)
+        if (key.IndexOf('\0', StringComparison.Ordinal) >= 0)
         {
             throw new ArgumentException("Journal metadata property names must not contain null characters.", nameof(key));
         }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -1014,7 +1014,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private static void ValidateCallerMetadataPropertyName(string key)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        if (key.IndexOf('\0') >= 0)
+        if (key.IndexOf('\0', StringComparison.Ordinal) >= 0)
         {
             throw new ArgumentException("Journal metadata property names must not contain null characters.", nameof(key));
         }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureTableJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureTableJournalStorage.cs
@@ -1167,7 +1167,7 @@ internal sealed partial class AzureTableJournalStorage : IJournalStorage
     private static void ValidateCallerMetadataPropertyName(string key)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        if (key.IndexOf('\0') >= 0)
+        if (key.IndexOf('\0', StringComparison.Ordinal) >= 0)
         {
             throw new ArgumentException("Journal metadata property names must not contain null characters.", nameof(key));
         }

--- a/src/Orleans.Journaling/IJournalStorageConsumer.cs
+++ b/src/Orleans.Journaling/IJournalStorageConsumer.cs
@@ -86,7 +86,7 @@ public sealed class JournalMetadata : IJournalMetadata
     internal static void ValidatePropertyName(string propertyName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(propertyName);
-        if (propertyName.IndexOf('\0') >= 0)
+        if (propertyName.IndexOf('\0', StringComparison.Ordinal) >= 0)
         {
             throw new ArgumentException("Journal metadata property names must not contain null characters.", nameof(propertyName));
         }

--- a/src/Orleans.Journaling/JournalId.cs
+++ b/src/Orleans.Journaling/JournalId.cs
@@ -150,7 +150,7 @@ public readonly struct JournalId : IEquatable<JournalId>
             throw new ArgumentException("Journal id segments must not be '.' or '..'.", parameterName);
         }
 
-        if (segment.IndexOf('\0') >= 0)
+        if (segment.IndexOf('\0', StringComparison.Ordinal) >= 0)
         {
             throw new ArgumentException("Journal id segments must not contain null characters.", parameterName);
         }

--- a/src/Redis/Orleans.Journaling.Redis/RedisJournalStorage.cs
+++ b/src/Redis/Orleans.Journaling.Redis/RedisJournalStorage.cs
@@ -887,7 +887,7 @@ internal sealed class RedisJournalStorage : IJournalStorage
     private static void ValidateCallerMetadataPropertyName(string key)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        if (key.IndexOf('\0') >= 0)
+        if (key.IndexOf('\0', StringComparison.Ordinal) >= 0)
         {
             throw new ArgumentException("Journal metadata property names must not contain null characters.", nameof(key));
         }

--- a/src/Redis/Orleans.Journaling.Redis/RedisJournalStorageOptionsValidator.cs
+++ b/src/Redis/Orleans.Journaling.Redis/RedisJournalStorageOptionsValidator.cs
@@ -38,7 +38,7 @@ internal sealed class RedisJournalStorageOptionsValidator(RedisJournalStorageOpt
                     $"Invalid configuration for {nameof(RedisJournalStorageProvider)}. {nameof(RedisJournalStorageOptions)}.{nameof(options.KeyPrefix)} must not be empty or whitespace.");
             }
 
-            if (keyPrefix.IndexOf('\0') >= 0)
+            if (keyPrefix.IndexOf('\0', StringComparison.Ordinal) >= 0)
             {
                 throw new OrleansConfigurationException(
                     $"Invalid configuration for {nameof(RedisJournalStorageProvider)}. {nameof(RedisJournalStorageOptions)}.{nameof(options.KeyPrefix)} must not contain null characters.");

--- a/test/Orleans.Journaling.Tests/JournalIdentifierCultureTests.cs
+++ b/test/Orleans.Journaling.Tests/JournalIdentifierCultureTests.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using Xunit;
+
+namespace Orleans.Journaling.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestCategory("BVT")]
+public sealed class JournalIdentifierCultureTests
+{
+    [Fact]
+    public void JournalId_CreateAndCompare_UsesOrdinalSemanticsUnderTurkishCulture()
+    {
+        using var culture = new CultureScope(CultureInfo.GetCultureInfo("tr-TR"));
+
+        var journalId = JournalId.Create("Iıİi", "café/日志");
+
+        Assert.Equal("I%C4%B1%C4%B0i/caf%C3%A9%2F%E6%97%A5%E5%BF%97", journalId.Value);
+        Assert.Equal(new JournalId(journalId.Value), journalId);
+        Assert.NotEqual(new JournalId("i%C4%B1%C4%B0i/caf%C3%A9%2F%E6%97%A5%E5%BF%97"), journalId);
+        Assert.True(JournalId.Create("Iıİi").IsPrefixOf(journalId));
+        Assert.False(JournalId.Create("I").IsPrefixOf(journalId));
+    }
+
+    [Fact]
+    public void JournalMetadata_CopyProperties_PreservesOrdinalNamesUnderTurkishCulture()
+    {
+        using var culture = new CultureScope(CultureInfo.GetCultureInfo("tr-TR"));
+        var properties = new Dictionary<string, string>
+        {
+            ["I"] = "latin-upper",
+            ["i"] = "latin-lower",
+            ["İ"] = "dotted-upper",
+            ["ı"] = "dotless-lower",
+            ["café"] = "non-ascii",
+        };
+
+        var copy = JournalMetadata.CopyProperties(properties);
+
+        Assert.Equal(properties.Count, copy.Count);
+        Assert.Equal("latin-upper", copy["I"]);
+        Assert.Equal("latin-lower", copy["i"]);
+        Assert.Equal("dotted-upper", copy["İ"]);
+        Assert.Equal("dotless-lower", copy["ı"]);
+        Assert.Equal("non-ascii", copy["café"]);
+    }
+
+    [Fact]
+    public void JournalIdentifierInputs_WithNullCharacter_AreRejectedUnderTurkishCulture()
+    {
+        using var culture = new CultureScope(CultureInfo.GetCultureInfo("tr-TR"));
+
+        var journalIdException = Assert.Throws<ArgumentException>(() => JournalId.Create("valid\0invalid"));
+        var metadataException = Assert.Throws<ArgumentException>(
+            () => JournalMetadata.CopyProperties(new Dictionary<string, string> { ["valid\0invalid"] = "value" }));
+
+        Assert.Equal("firstSegment", journalIdException.ParamName);
+        Assert.Equal("propertyName", metadataException.ParamName);
+    }
+
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+        private readonly CultureInfo _originalUICulture = CultureInfo.CurrentUICulture;
+
+        public CultureScope(CultureInfo culture)
+        {
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+
+        public void Dispose()
+        {
+            CultureInfo.CurrentCulture = _originalCulture;
+            CultureInfo.CurrentUICulture = _originalUICulture;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Journaling identifiers, metadata names, and provider storage prefixes represent persisted protocol data, but seven null-character checks relied on an implicit string comparison overload. CA1305 and CA1307 also remained advisory for the complete journaling provider set.

## Solution

- Use explicit ordinal comparisons for null-character validation in the core journal identifier and metadata paths and the Azure Blob, Azure Table, Redis, and S3 providers.
- Enforce CA1305 and CA1307 across the complete `Orleans.Journaling`, `Orleans.Journaling.AzureStorage`, `Orleans.Journaling.Redis`, and `Orleans.Journaling.S3` projects.
- Cover exact non-ASCII identifier encoding, ordinal equality and prefix boundaries, case-distinct Turkish metadata names, and null-character rejection under `tr-TR`.

## Rationale

Ordinal semantics preserve journal identity, storage-key bytes, metadata ownership boundaries, and provider formats independently of the process culture. Project-wide enforcement keeps future identifier and formatting changes explicit across the full provider closure.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11177)