### PR TITLE
fix(core): validate boundary arguments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -708,6 +708,12 @@ dotnet_diagnostic.CA1062.severity = warning
 [src/Orleans.Streaming/{PubSub,Extensions,Providers}/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 
+[src/Orleans.Core/{Configuration,Providers,Core,IDs}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
+[src/Orleans.Core.Abstractions/{Utils,Lifecycle}/**.cs]
+dotnet_diagnostic.CA1062.severity = warning
+
 [src/Serializers/Orleans.Serialization.Protobuf/**.cs]
 dotnet_diagnostic.CA1062.severity = warning
 

--- a/src/Orleans.Core.Abstractions/Lifecycle/LifecycleExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Lifecycle/LifecycleExtensions.cs
@@ -63,6 +63,8 @@ namespace Orleans
         /// <returns>A <see cref="IDisposable"/> instance which can be disposed to unsubscribe the observer from the lifecycle.</returns>
         public static IDisposable Subscribe<TObserver>(this ILifecycleObservable observable, int stage, ILifecycleObserver observer)
         {
+            ArgumentNullException.ThrowIfNull(observable);
+            ArgumentNullException.ThrowIfNull(observer);
             return observable.Subscribe(GetTypeName(typeof(TObserver)), stage, observer);
         }
 
@@ -106,6 +108,8 @@ namespace Orleans
         /// <returns>A <see cref="IDisposable"/> instance which can be disposed to unsubscribe the observer from the lifecycle.</returns>
         public static IDisposable Subscribe(this ILifecycleObservable observable, int stage, ILifecycleObserver observer)
         {
+            ArgumentNullException.ThrowIfNull(observable);
+            ArgumentNullException.ThrowIfNull(observer);
             return observable.Subscribe(GetTypeName(observer.GetType()), stage, observer);
         }
 

--- a/src/Orleans.Core.Abstractions/Utils/PublicOrleansTaskExtensions.cs
+++ b/src/Orleans.Core.Abstractions/Utils/PublicOrleansTaskExtensions.cs
@@ -20,6 +20,8 @@ namespace Orleans
         /// <param name="task">The task to be ignored.</param>
         public static void Ignore(this Task task)
         {
+            ArgumentNullException.ThrowIfNull(task);
+
             if (task.IsCompleted)
             {
                 _ = task.Exception;

--- a/src/Orleans.Core.Abstractions/Utils/Utils.cs
+++ b/src/Orleans.Core.Abstractions/Utils/Utils.cs
@@ -143,35 +143,51 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="uri">The input Uri</param>
         /// <returns></returns>
-        public static System.Net.IPEndPoint? ToIPEndPoint(this Uri uri) => uri.Scheme switch
+        public static System.Net.IPEndPoint? ToIPEndPoint(this Uri uri)
         {
-            "gwy.tcp" => new System.Net.IPEndPoint(System.Net.IPAddress.Parse(uri.Host), uri.Port),
-            _ => null,
-        };
+            ArgumentNullException.ThrowIfNull(uri);
+            return uri.Scheme switch
+            {
+                "gwy.tcp" => new System.Net.IPEndPoint(System.Net.IPAddress.Parse(uri.Host), uri.Port),
+                _ => null,
+            };
+        }
 
         /// <summary>
         /// Parse a Uri as a Silo address, excluding the generation identifier.
         /// </summary>
         /// <param name="uri">The input Uri</param>
-        public static SiloAddress? ToGatewayAddress(this Uri uri) => uri.Scheme switch
+        public static SiloAddress? ToGatewayAddress(this Uri uri)
         {
-            "gwy.tcp" => SiloAddress.New(System.Net.IPAddress.Parse(uri.Host), uri.Port, 0),
-            _ => null,
-        };
+            ArgumentNullException.ThrowIfNull(uri);
+            return uri.Scheme switch
+            {
+                "gwy.tcp" => SiloAddress.New(System.Net.IPAddress.Parse(uri.Host), uri.Port, 0),
+                _ => null,
+            };
+        }
 
         /// <summary>
         /// Represent an IP end point in the gateway URI format..
         /// </summary>
         /// <param name="ep">The input IP end point</param>
         /// <returns></returns>
-        public static Uri ToGatewayUri(this System.Net.IPEndPoint ep) => new($"gwy.tcp://{new SpanFormattableIPEndPoint(ep)}/0");
+        public static Uri ToGatewayUri(this System.Net.IPEndPoint ep)
+        {
+            ArgumentNullException.ThrowIfNull(ep);
+            return new($"gwy.tcp://{new SpanFormattableIPEndPoint(ep)}/0");
+        }
 
         /// <summary>
         /// Represent a silo address in the gateway URI format.
         /// </summary>
         /// <param name="address">The input silo address</param>
         /// <returns></returns>
-        public static Uri ToGatewayUri(this SiloAddress address) => new($"gwy.tcp://{new SpanFormattableIPEndPoint(address.Endpoint)}/{address.Generation}");
+        public static Uri ToGatewayUri(this SiloAddress address)
+        {
+            ArgumentNullException.ThrowIfNull(address);
+            return new($"gwy.tcp://{new SpanFormattableIPEndPoint(address.Endpoint)}/{address.Generation}");
+        }
 
         /// <summary>
         /// Executes an action and suppresses any exception it throws.
@@ -179,6 +195,8 @@ namespace Orleans.Runtime
         /// <param name="action">The action to execute.</param>
         public static void SafeExecute(Action action)
         {
+            ArgumentNullException.ThrowIfNull(action);
+
             try
             {
                 action();
@@ -194,6 +212,8 @@ namespace Orleans.Runtime
         /// <param name="caller">The name of the caller to include in the log entry.</param>
         public static void SafeExecute(Action action, ILogger? logger = null, string? caller = null)
         {
+            ArgumentNullException.ThrowIfNull(action);
+
             try
             {
                 action();
@@ -212,6 +232,8 @@ namespace Orleans.Runtime
         /// <returns>A task representing the operation.</returns>
         public static async Task SafeExecuteAsync(Task task)
         {
+            ArgumentNullException.ThrowIfNull(task);
+
             try
             {
                 await task;
@@ -246,20 +268,26 @@ namespace Orleans.Runtime
         /// <returns>A sequence of non-empty batches.</returns>
         public static IEnumerable<List<T>> BatchIEnumerable<T>(this IEnumerable<T> sequence, int batchSize)
         {
-            var batch = new List<T>(batchSize);
-            foreach (var item in sequence)
+            ArgumentNullException.ThrowIfNull(sequence);
+            return Enumerate(sequence, batchSize);
+
+            static IEnumerable<List<T>> Enumerate(IEnumerable<T> sequence, int batchSize)
             {
-                batch.Add(item);
-                // when we've accumulated enough in the batch, send it out  
-                if (batch.Count >= batchSize)
+                var batch = new List<T>(batchSize);
+                foreach (var item in sequence)
                 {
-                    yield return batch; // batch.ToArray();
-                    batch = new List<T>(batchSize);
+                    batch.Add(item);
+                    // when we've accumulated enough in the batch, send it out
+                    if (batch.Count >= batchSize)
+                    {
+                        yield return batch; // batch.ToArray();
+                        batch = new List<T>(batchSize);
+                    }
                 }
-            }
-            if (batch.Count > 0)
-            {
-                yield return batch; //batch.ToArray();
+                if (batch.Count > 0)
+                {
+                    yield return batch; //batch.ToArray();
+                }
             }
         }
 

--- a/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
+++ b/src/Orleans.Core/Configuration/CollectionAgeLimitAttribute.cs
@@ -60,6 +60,8 @@ namespace Orleans
         /// <inheritdoc />
         public void Populate(IServiceProvider services, Type grainClass, GrainType grainType, Dictionary<string, string> properties)
         {
+            ArgumentNullException.ThrowIfNull(properties);
+
             string idleDeactivationPeriod;
 
             if (AlwaysActive)
@@ -94,6 +96,7 @@ namespace Orleans
         /// <inheritdoc />
         public void Populate(IServiceProvider services, Type grainClass, GrainType grainType, Dictionary<string, string> properties)
         {
+            ArgumentNullException.ThrowIfNull(properties);
             properties[WellKnownGrainTypeProperties.IdleDeactivationPeriod] = WellKnownGrainTypeProperties.IndefiniteIdleDeactivationPeriodValue;
         }
     }

--- a/src/Orleans.Core/Configuration/NamedServiceConfigurator.cs
+++ b/src/Orleans.Core/Configuration/NamedServiceConfigurator.cs
@@ -70,6 +70,8 @@ namespace Orleans.Hosting
         public static void Configure<TOptions>(this INamedServiceConfigurator configurator, Action<OptionsBuilder<TOptions>>? configureOptions)
             where TOptions : class, new()
         {
+            ArgumentNullException.ThrowIfNull(configurator);
+
             configurator.ConfigureDelegate(services =>
             {
                 configureOptions?.Invoke(services.AddOptions<TOptions>(configurator.Name));
@@ -89,6 +91,9 @@ namespace Orleans.Hosting
             where TOptions : class, new()
             where TComponent : class
         {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(factory);
+
             configurator.Configure(configureOptions);
             configurator.ConfigureComponent(factory);
         }
@@ -102,6 +107,9 @@ namespace Orleans.Hosting
         public static void ConfigureComponent<TComponent>(this INamedServiceConfigurator configurator, Func<IServiceProvider, string, TComponent> factory)
            where TComponent : class
         {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(factory);
+
             configurator.ConfigureDelegate(services =>
             {
                 services.AddKeyedSingleton<TComponent>(configurator.Name, (sp, key) => factory(sp, (key as string)!));

--- a/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
+++ b/src/Orleans.Core/Configuration/OptionLogger/IOptionsLogger.cs
@@ -84,6 +84,8 @@ namespace Orleans
         /// <param name="formatters">The collection of options formatters.</param>
         public void LogOptions(IEnumerable<IOptionFormatter> formatters)
         {
+            ArgumentNullException.ThrowIfNull(formatters);
+
             foreach (var optionFormatter in formatters.OrderBy(f => f.Name))
             {
                 this.LogOption(optionFormatter);
@@ -96,6 +98,8 @@ namespace Orleans
         /// <param name="formatter">The options formatter.</param>
         public void LogOption(IOptionFormatter formatter)
         {
+            ArgumentNullException.ThrowIfNull(formatter);
+
             if (!logger.IsEnabled(LogLevel.Information))
             {
                 return;

--- a/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterOptions.cs
@@ -54,6 +54,7 @@ namespace Orleans.Configuration
         /// </param>
         public ClusterOptionsValidator(IOptions<ClusterOptions> options)
         {
+            ArgumentNullException.ThrowIfNull(options);
             this.options = options.Value;
         }
 

--- a/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Core/Configuration/ServiceCollectionExtensions.cs
@@ -28,6 +28,10 @@ namespace Orleans.Configuration.Internal
         /// <param name="implementation">The implementation of <paramref name="service"/>.</param>
         public static void AddFromExisting(this IServiceCollection services, Type service, Type implementation)
         {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(service);
+            ArgumentNullException.ThrowIfNull(implementation);
+
             ServiceDescriptor? registration = null;
             foreach (var descriptor in services)
             {

--- a/src/Orleans.Core/Configuration/Validators/SerializerConfigurationValidator.cs
+++ b/src/Orleans.Core/Configuration/Validators/SerializerConfigurationValidator.cs
@@ -34,6 +34,10 @@ namespace Orleans
         /// </param>
         public SerializerConfigurationValidator(ICodecProvider codecProvider, IOptions<TypeManifestOptions> options, IServiceProvider serviceProvider)
         {
+            ArgumentNullException.ThrowIfNull(codecProvider);
+            ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
             _codecProvider = codecProvider;
             _options = options.Value;
 

--- a/src/Orleans.Core/Core/ClientBuilderExtensions.cs
+++ b/src/Orleans.Core/Core/ClientBuilderExtensions.cs
@@ -70,6 +70,7 @@ namespace Orleans.Hosting
         /// <returns>The same instance of the <see cref="IClientBuilder"/> for chaining.</returns>
         public static IClientBuilder ConfigureServices(this IClientBuilder builder, Action<IServiceCollection> configureDelegate)
         {
+            ArgumentNullException.ThrowIfNull(builder);
             if (configureDelegate == null) throw new ArgumentNullException(nameof(configureDelegate));
             configureDelegate(builder.Services);
             return builder;
@@ -123,6 +124,8 @@ namespace Orleans.Hosting
         public static IClientBuilder AddClusterConnectionStatusObserver<TObserver>(this IClientBuilder builder, TObserver observer)
             where TObserver : IClusterConnectionStatusObserver
         {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(observer);
             builder.Services.AddSingleton<IClusterConnectionStatusObserver>(observer);
             return builder;
         }
@@ -135,6 +138,7 @@ namespace Orleans.Hosting
             this IClientBuilder builder)
             where TObserver : class, IClusterConnectionStatusObserver
         {
+            ArgumentNullException.ThrowIfNull(builder);
             builder.Services.AddSingleton<IClusterConnectionStatusObserver, TObserver>();
             return builder;
         }
@@ -171,6 +175,7 @@ namespace Orleans.Hosting
         /// <returns>The builder.</returns>
         public static IClientBuilder AddActivityPropagation(this IClientBuilder builder)
         {
+            ArgumentNullException.ThrowIfNull(builder);
             builder.Services.TryAddSingleton(DistributedContextPropagator.Current);
 
             return builder

--- a/src/Orleans.Core/IDs/GenericGrainInterfaceType.cs
+++ b/src/Orleans.Core/IDs/GenericGrainInterfaceType.cs
@@ -73,6 +73,9 @@ namespace Orleans.Runtime
         /// </summary>
         public GenericGrainInterfaceType Construct(TypeConverter formatter, params Type[] typeArguments)
         {
+            ArgumentNullException.ThrowIfNull(formatter);
+            ArgumentNullException.ThrowIfNull(typeArguments);
+
             if (Arity != typeArguments.Length)
             {
                 ThrowIncorrectArgumentLength(typeArguments);
@@ -85,7 +88,11 @@ namespace Orleans.Runtime
         /// <summary>
         /// Returns the type arguments which this instance was constructed with.
         /// </summary>
-        public Type[] GetArguments(TypeConverter formatter) => formatter.GetArguments(this.Value.Value);
+        public Type[] GetArguments(TypeConverter formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            return formatter.GetArguments(this.Value.Value);
+        }
 
         /// <summary>
         /// Returns a UTF8 interpretation of the current instance.

--- a/src/Orleans.Core/IDs/GenericGrainType.cs
+++ b/src/Orleans.Core/IDs/GenericGrainType.cs
@@ -68,6 +68,9 @@ namespace Orleans.Runtime
         /// </summary>
         public GenericGrainType Construct(TypeConverter formatter, params Type[] typeArguments)
         {
+            ArgumentNullException.ThrowIfNull(formatter);
+            ArgumentNullException.ThrowIfNull(typeArguments);
+
             if (Arity != typeArguments.Length)
             {
                 ThrowIncorrectArgumentLength(typeArguments);
@@ -82,7 +85,11 @@ namespace Orleans.Runtime
         /// </summary>
         /// <param name="converter">The type converter</param>
         /// <returns>The type arguments.</returns>
-        public Type[] GetArguments(TypeConverter converter) => converter.GetArguments(this.GrainType.Value);
+        public Type[] GetArguments(TypeConverter converter)
+        {
+            ArgumentNullException.ThrowIfNull(converter);
+            return converter.GetArguments(this.GrainType.Value);
+        }
 
         /// <inheritdoc/>
         public override string ToString() => this.GrainType.ToString();

--- a/src/Orleans.Core/Providers/IGrainStorage.cs
+++ b/src/Orleans.Core/Providers/IGrainStorage.cs
@@ -186,7 +186,7 @@ namespace Orleans.Storage
         /// <param name="currentEtag">The current ETag.</param>
         /// <param name="storageException">The storage exception.</param>
         public InconsistentStateException(string? storedEtag, string? currentEtag, Exception storageException)
-            : this(storageException.Message, storedEtag, currentEtag, storageException)
+            : this((storageException ?? throw new ArgumentNullException(nameof(storageException))).Message, storedEtag, currentEtag, storageException)
         {
         }
 

--- a/src/Orleans.Core/Providers/IGrainStorageSerializer.cs
+++ b/src/Orleans.Core/Providers/IGrainStorageSerializer.cs
@@ -67,7 +67,10 @@ namespace Orleans.Storage
         /// <typeparam name="T">The output type.</typeparam>
         /// <returns>The deserialized object.</returns>
         public static T? Deserialize<T>(this IGrainStorageSerializer serializer, ReadOnlyMemory<byte> input)
-            => serializer.Deserialize<T>(new BinaryData(input));
+        {
+            ArgumentNullException.ThrowIfNull(serializer);
+            return serializer.Deserialize<T>(new BinaryData(input));
+        }
     }
 
     /// <summary>
@@ -101,6 +104,8 @@ namespace Orleans.Storage
         /// <inheritdoc/>
         public void PostConfigure(string? name, TOptions options)
         {
+            ArgumentNullException.ThrowIfNull(options);
+
             if (options.GrainStorageSerializer == default)
             {
                 // First, try to get a IGrainStorageSerializer that was registered with

--- a/src/Orleans.Core/Providers/StorageSerializer/JsonGrainStorageSerializer.cs
+++ b/src/Orleans.Core/Providers/StorageSerializer/JsonGrainStorageSerializer.cs
@@ -27,6 +27,7 @@ namespace Orleans.Storage
         /// <inheritdoc/>
         public T? Deserialize<T>(BinaryData input)
         {
+            ArgumentNullException.ThrowIfNull(input);
             return (T?)_orleansJsonSerializer.Deserialize(typeof(T), input.ToString());
         }
 
@@ -34,6 +35,7 @@ namespace Orleans.Storage
         public ValueTask SerializeAsync<T>(T? value, Stream destination, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(destination);
             _orleansJsonSerializer.Serialize(value, typeof(T), destination);
             return ValueTask.CompletedTask;
         }
@@ -42,6 +44,7 @@ namespace Orleans.Storage
         public ValueTask<T?> DeserializeAsync<T>(Stream input, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(input);
             return ValueTask.FromResult((T?)_orleansJsonSerializer.Deserialize(typeof(T), input));
         }
     }

--- a/src/Orleans.Core/Providers/StorageSerializer/OrleansGrainStateSerializer.cs
+++ b/src/Orleans.Core/Providers/StorageSerializer/OrleansGrainStateSerializer.cs
@@ -35,12 +35,14 @@ namespace Orleans.Storage
         /// <inheritdoc/>
         public T? Deserialize<T>(BinaryData input)
         {
+            ArgumentNullException.ThrowIfNull(input);
             return this.serializer.Deserialize<T>(input.ToMemory());
         }
 
         /// <inheritdoc/>
         public ValueTask SerializeAsync<T>(T? value, Stream destination, CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(destination);
             this.serializer.Serialize(value, destination);
             return ValueTask.CompletedTask;
         }
@@ -48,6 +50,8 @@ namespace Orleans.Storage
         /// <inheritdoc/>
         public async ValueTask<T?> DeserializeAsync<T>(Stream input, CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             // Seekable streams (e.g., MemoryStream, FileStream) can be deserialized directly without buffering.
             // Non-seekable streams (e.g., NetworkStream) require buffering to enable efficient multi-pass reading.
             if (input.CanSeek)

--- a/src/Orleans.Core/Providers/StorageSerializer/SystemTextJsonGrainStorageSerializer.cs
+++ b/src/Orleans.Core/Providers/StorageSerializer/SystemTextJsonGrainStorageSerializer.cs
@@ -14,17 +14,27 @@ namespace Orleans.Storage
     public sealed class SystemTextJsonGrainStorageSerializer(IOptions<SystemTextJsonGrainStorageSerializerOptions> options) : IGrainStorageStreamingSerializer
     {
         /// <inheritdoc/>
-        public T? Deserialize<T>(BinaryData input) => input.ToObjectFromJson<T>(options.Value.JsonSerializerOptions);
+        public T? Deserialize<T>(BinaryData input)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            return input.ToObjectFromJson<T>(options.Value.JsonSerializerOptions);
+        }
 
         /// <inheritdoc/>
         public BinaryData Serialize<T>(T? input) => BinaryData.FromObjectAsJson(input, options.Value.JsonSerializerOptions);
 
         /// <inheritdoc/>
         public ValueTask SerializeAsync<T>(T? input, Stream destination, CancellationToken cancellationToken = default)
-            => new(JsonSerializer.SerializeAsync(destination, input, options.Value.JsonSerializerOptions, cancellationToken));
+        {
+            ArgumentNullException.ThrowIfNull(destination);
+            return new(JsonSerializer.SerializeAsync(destination, input, options.Value.JsonSerializerOptions, cancellationToken));
+        }
 
         /// <inheritdoc/>
         public async ValueTask<T?> DeserializeAsync<T>(Stream input, CancellationToken cancellationToken = default)
-            => await JsonSerializer.DeserializeAsync<T>(input, options.Value.JsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            return await JsonSerializer.DeserializeAsync<T>(input, options.Value.JsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/test/Orleans.Core.Tests/ConfigTests.cs
+++ b/test/Orleans.Core.Tests/ConfigTests.cs
@@ -1,5 +1,9 @@
 using System.Net;
 using System.Net.Sockets;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Metadata;
+using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Xunit;
 
@@ -75,6 +79,46 @@ namespace UnitTests
         public void Config_LocalIPAddressFallback_ThrowsForExplicitInterface()
         {
             Assert.Throws<Orleans.Runtime.OrleansException>(() => ConfigUtilities.ResolveLocalIPAddress(Array.Empty<IPAddress>(), AddressFamily.InterNetwork, "en0"));
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config")]
+        public void CollectionAttributes_NullProperties_ThrowWithExactParameterName()
+        {
+            var collectionAgeLimit = new CollectionAgeLimitAttribute();
+            var collectionException = Assert.Throws<ArgumentNullException>(
+                () => collectionAgeLimit.Populate(null!, null!, default, null!));
+            Assert.Equal("properties", collectionException.ParamName);
+
+            var keepAlive = new KeepAliveAttribute();
+            var keepAliveException = Assert.Throws<ArgumentNullException>(
+                () => keepAlive.Populate(null!, null!, default, null!));
+            Assert.Equal("properties", keepAliveException.ParamName);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config")]
+        public void CollectionAttributes_ValidProperties_PreserveIdleDeactivationValues()
+        {
+            var collectionProperties = new Dictionary<string, string>();
+            new CollectionAgeLimitAttribute { Minutes = 5 }.Populate(null!, null!, default, collectionProperties);
+
+            Assert.Equal(
+                TimeSpan.FromMinutes(5).ToString("c"),
+                collectionProperties[WellKnownGrainTypeProperties.IdleDeactivationPeriod]);
+
+            var keepAliveProperties = new Dictionary<string, string>();
+            new KeepAliveAttribute().Populate(null!, null!, default, keepAliveProperties);
+
+            Assert.Equal(
+                WellKnownGrainTypeProperties.IndefiniteIdleDeactivationPeriodValue,
+                keepAliveProperties[WellKnownGrainTypeProperties.IdleDeactivationPeriod]);
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Config")]
+        public void ClusterOptionsValidator_NullOptions_ThrowsWithExactParameterName()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new ClusterOptionsValidator(null!));
+
+            Assert.Equal("options", exception.ParamName);
         }
     }
 }

--- a/test/Orleans.Core.Tests/DependencyInjection/GenericRegistrationTests.cs
+++ b/test/Orleans.Core.Tests/DependencyInjection/GenericRegistrationTests.cs
@@ -79,6 +79,42 @@ public class CoreGenericRegistrationTests
     }
 
     [Fact]
+    public void ConfigureServices_NullBuilder_ThrowsBeforeDelegateInvocation()
+    {
+        var invoked = false;
+        IClientBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.ConfigureServices(_ => invoked = true));
+
+        Assert.Equal("builder", exception.ParamName);
+        Assert.False(invoked);
+    }
+
+    [Fact]
+    public void AddActivityPropagation_NullBuilder_ThrowsWithExactParameterName()
+    {
+        IClientBuilder builder = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => builder.AddActivityPropagation());
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddClusterConnectionStatusObserver_NullObserver_ThrowsWithoutMutation()
+    {
+        var builder = new TestClientBuilder();
+        var descriptorCount = builder.Services.Count;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => builder.AddClusterConnectionStatusObserver<IClusterConnectionStatusObserver>(null!));
+
+        Assert.Equal("observer", exception.ParamName);
+        Assert.Equal(descriptorCount, builder.Services.Count);
+    }
+
+    [Fact]
     public void GrainCallFilters_ActivateConstructorInjectedImplementations()
     {
         var dependency = new ActivationMarker();

--- a/test/Orleans.Core.Tests/DependencyInjection/NamedServiceConfiguratorTests.cs
+++ b/test/Orleans.Core.Tests/DependencyInjection/NamedServiceConfiguratorTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Hosting;
+using Xunit;
+
+namespace UnitTests.DependencyInjection;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+[TestCategory("BVT")]
+public class NamedServiceConfiguratorTests
+{
+    [Fact]
+    public void ConfigureComponent_NullFactory_ThrowsBeforeConfiguration()
+    {
+        var configurator = new TrackingNamedServiceConfigurator();
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => configurator.ConfigureComponent<TestOptions, TestComponent>(null!));
+
+        Assert.Equal("factory", exception.ParamName);
+        Assert.Equal(0, configurator.ConfigureInvocationCount);
+    }
+
+    [Fact]
+    public void ConfigureComponent_ValidName_RegistersNamedOptionsAndKeyedSingleton()
+    {
+        const string Name = "alpha";
+        var services = new ServiceCollection();
+        var factoryNames = new List<string>();
+        var configurator = new NamedServiceConfigurator(Name, configure => configure(services));
+
+        configurator.ConfigureComponent<TestOptions, TestComponent>(
+            (_, name) =>
+            {
+                factoryNames.Add(name);
+                return new TestComponent(name);
+            },
+            builder => builder.Configure(options => options.Value = 42));
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<TestOptions>>().Get(Name);
+        var first = provider.GetRequiredKeyedService<TestComponent>(Name);
+        var second = provider.GetRequiredKeyedService<TestComponent>(Name);
+
+        Assert.Equal(42, options.Value);
+        Assert.Equal(Name, first.Name);
+        Assert.Same(first, second);
+        Assert.Equal([Name], factoryNames);
+    }
+
+    private sealed class TrackingNamedServiceConfigurator : INamedServiceConfigurator
+    {
+        public string Name => "tracking";
+
+        public int ConfigureInvocationCount { get; private set; }
+
+        public Action<Action<IServiceCollection>> ConfigureDelegate => configure =>
+        {
+            ConfigureInvocationCount++;
+            configure(new ServiceCollection());
+        };
+    }
+
+    private sealed class TestOptions
+    {
+        public int Value { get; set; }
+    }
+
+    private sealed class TestComponent(string name)
+    {
+        public string Name { get; } = name;
+    }
+}

--- a/test/Orleans.Core.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.DependencyInjection;
+using CoreServiceCollectionExtensions = Orleans.Configuration.Internal.ServiceCollectionExtensions;
+using Xunit;
+
+namespace UnitTests.DependencyInjection;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+[TestCategory("BVT")]
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddFromExisting_NullImplementation_ThrowsWithoutMutation()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<Sentinel>();
+        var existingDescriptor = Assert.Single(services);
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => CoreServiceCollectionExtensions.AddFromExisting(services, typeof(ITestService), null!));
+
+        Assert.Equal("implementation", exception.ParamName);
+        Assert.Same(existingDescriptor, Assert.Single(services));
+    }
+
+    [Fact]
+    public void AddFromExisting_NullService_ThrowsWithoutMutation()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestService>();
+        var existingDescriptor = Assert.Single(services);
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => CoreServiceCollectionExtensions.AddFromExisting(services, null!, typeof(TestService)));
+
+        Assert.Equal("service", exception.ParamName);
+        Assert.Same(existingDescriptor, Assert.Single(services));
+    }
+
+    [Fact]
+    public void AddFromExisting_RegisteredImplementation_PreservesLifetimeAndInstance()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestService>();
+
+        CoreServiceCollectionExtensions.AddFromExisting(services, typeof(ITestService), typeof(TestService));
+
+        var alias = Assert.Single(services, descriptor => descriptor.ServiceType == typeof(ITestService));
+        Assert.Equal(ServiceLifetime.Singleton, alias.Lifetime);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Same(provider.GetRequiredService<TestService>(), provider.GetRequiredService<ITestService>());
+    }
+
+    private sealed class Sentinel;
+
+    private interface ITestService;
+
+    private sealed class TestService : ITestService;
+}

--- a/test/Orleans.Core.Tests/General/UtilsTests.cs
+++ b/test/Orleans.Core.Tests/General/UtilsTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Runtime;
 using Xunit;
 
@@ -39,6 +40,89 @@ namespace UnitTests.UtilsTests
             var ipv6silo = SiloAddress.New(ipv6, 100);
             uri = ipv6silo.ToGatewayUri();
             Assert.Equal("gwy.tcp://[::]:11111/100", uri.ToString());
+        }
+
+        [Fact]
+        public void GatewayConversions_NullReceiver_ThrowWithExactParameterName()
+        {
+            var endpointException = Assert.Throws<ArgumentNullException>(() => ((Uri)null!).ToIPEndPoint());
+            Assert.Equal("uri", endpointException.ParamName);
+
+            var addressException = Assert.Throws<ArgumentNullException>(() => ((Uri)null!).ToGatewayAddress());
+            Assert.Equal("uri", addressException.ParamName);
+
+            var uriException = Assert.Throws<ArgumentNullException>(() => ((SiloAddress)null!).ToGatewayUri());
+            Assert.Equal("address", uriException.ParamName);
+
+            var endpointUriException = Assert.Throws<ArgumentNullException>(() => ((IPEndPoint)null!).ToGatewayUri());
+            Assert.Equal("ep", endpointUriException.ParamName);
+        }
+
+        [Fact]
+        public void SafeExecute_NullAction_ThrowsWithExactParameterName()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => Utils.SafeExecute((Action)null!));
+            Assert.Equal("action", exception.ParamName);
+
+            exception = Assert.Throws<ArgumentNullException>(() => Utils.SafeExecute((Action)null!, NullLogger.Instance));
+            Assert.Equal("action", exception.ParamName);
+        }
+
+        [Fact]
+        public void SafeExecute_ThrowingActions_SuppressExceptions()
+        {
+            var invocationCount = 0;
+
+            Utils.SafeExecute(() =>
+            {
+                invocationCount++;
+                throw new InvalidOperationException("expected");
+            });
+            Utils.SafeExecute(() =>
+            {
+                invocationCount++;
+                throw new InvalidOperationException("expected");
+            }, NullLogger.Instance);
+
+            Assert.Equal(2, invocationCount);
+        }
+
+        [Fact]
+        public void BatchIEnumerable_NullSequence_ThrowsAtCallTime()
+        {
+            IEnumerable<int> sequence = null!;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sequence.BatchIEnumerable(2));
+
+            Assert.Equal("sequence", exception.ParamName);
+        }
+
+        [Fact]
+        public void BatchIEnumerable_ValidSequence_PreservesBatching()
+        {
+            var batches = Enumerable.Range(1, 5).BatchIEnumerable(2).Select(batch => batch.ToArray()).ToArray();
+
+            Assert.Equal(3, batches.Length);
+            Assert.Equal([1, 2], batches[0]);
+            Assert.Equal([3, 4], batches[1]);
+            Assert.Equal([5], batches[2]);
+        }
+
+        [Fact]
+        public void Ignore_NullTask_ThrowsWithExactParameterName()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => ((Task)null!).Ignore());
+
+            Assert.Equal("task", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task SafeExecuteAsync_NullTask_ThrowsWithExactParameterName()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Utils.SafeExecuteAsync(null!));
+
+            Assert.Equal("task", exception.ParamName);
         }
     }
 }

--- a/test/Orleans.Core.Tests/GenericGrainTypeTests.cs
+++ b/test/Orleans.Core.Tests/GenericGrainTypeTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Serialization.Configuration;
+using Orleans.Serialization.TypeSystem;
+using Xunit;
+
+namespace UnitTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+[TestCategory("BVT")]
+public class GenericGrainTypeTests
+{
+    [Fact]
+    public void GenericGrainTypes_Construct_NullFormatter_ThrowWithExactParameterName()
+    {
+        var grainType = ParseGrainType();
+        var interfaceType = ParseGrainInterfaceType();
+
+        var grainException = Assert.Throws<ArgumentNullException>(() => grainType.Construct(null!, typeof(int)));
+        Assert.Equal("formatter", grainException.ParamName);
+
+        var interfaceException = Assert.Throws<ArgumentNullException>(() => interfaceType.Construct(null!, typeof(int)));
+        Assert.Equal("formatter", interfaceException.ParamName);
+    }
+
+    [Fact]
+    public void GenericGrainTypes_Construct_NullTypeArguments_ThrowBeforeConverterUse()
+    {
+        var converter = CreateTypeConverter();
+
+        var grainException = Assert.Throws<ArgumentNullException>(() => ParseGrainType().Construct(converter, null!));
+        Assert.Equal("typeArguments", grainException.ParamName);
+
+        var interfaceException = Assert.Throws<ArgumentNullException>(() => ParseGrainInterfaceType().Construct(converter, null!));
+        Assert.Equal("typeArguments", interfaceException.ParamName);
+    }
+
+    [Fact]
+    public void GenericGrainTypes_GetArguments_NullConverter_ThrowWithExactParameterName()
+    {
+        var grainException = Assert.Throws<ArgumentNullException>(() => ParseGrainType().GetArguments(null!));
+        Assert.Equal("converter", grainException.ParamName);
+
+        var interfaceException = Assert.Throws<ArgumentNullException>(() => ParseGrainInterfaceType().GetArguments(null!));
+        Assert.Equal("formatter", interfaceException.ParamName);
+    }
+
+    [Fact]
+    public void GenericGrainTypes_ValidConstruction_RoundTripsArguments()
+    {
+        var converter = CreateTypeConverter();
+        var grainType = ParseGrainType();
+        var interfaceType = ParseGrainInterfaceType();
+
+        var constructedGrain = grainType.Construct(converter, typeof(int));
+        var constructedInterface = interfaceType.Construct(converter, typeof(int));
+
+        Assert.Equal(1, constructedGrain.Arity);
+        Assert.True(constructedGrain.IsConstructed);
+        Assert.Equal([typeof(int)], constructedGrain.GetArguments(converter));
+        Assert.Equal(grainType.GrainType, constructedGrain.GetUnconstructedGrainType().GrainType);
+
+        Assert.Equal(1, constructedInterface.Arity);
+        Assert.True(constructedInterface.IsConstructed);
+        Assert.Equal([typeof(int)], constructedInterface.GetArguments(converter));
+        Assert.Equal(interfaceType.Value, constructedInterface.GetGenericGrainType().Value);
+    }
+
+    private static GenericGrainType ParseGrainType()
+    {
+        Assert.True(GenericGrainType.TryParse(GrainType.Create("unit.test`1"), out var result));
+        return result;
+    }
+
+    private static GenericGrainInterfaceType ParseGrainInterfaceType()
+    {
+        Assert.True(GenericGrainInterfaceType.TryParse(GrainInterfaceType.Create("unit.test.interface`1"), out var result));
+        return result;
+    }
+
+    private static TypeConverter CreateTypeConverter() =>
+        new(
+            Array.Empty<ITypeConverter>(),
+            Array.Empty<ITypeNameFilter>(),
+            Array.Empty<ITypeFilter>(),
+            Options.Create(new TypeManifestOptions { AllowAllTypes = true }),
+            new CachedTypeResolver());
+}

--- a/test/Orleans.Core.Tests/LifecycleExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/LifecycleExtensionsTests.cs
@@ -1,0 +1,89 @@
+using Orleans;
+using Xunit;
+
+namespace UnitTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+[TestCategory("BVT")]
+public class LifecycleExtensionsTests
+{
+    [Fact]
+    public void Subscribe_NullObservable_ThrowsWithExactParameterName()
+    {
+        ILifecycleObservable observable = null!;
+        var observer = new TestObserver();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => observable.Subscribe(1, observer));
+        Assert.Equal("observable", exception.ParamName);
+
+        exception = Assert.Throws<ArgumentNullException>(() => observable.Subscribe<TestObserver>(1, observer));
+        Assert.Equal("observable", exception.ParamName);
+    }
+
+    [Fact]
+    public void Subscribe_NullObserver_ThrowsBeforeObservableCall()
+    {
+        var observable = new RecordingLifecycleObservable();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => observable.Subscribe(1, null!));
+
+        Assert.Equal("observer", exception.ParamName);
+        Assert.Equal(0, observable.SubscribeCallCount);
+
+        exception = Assert.Throws<ArgumentNullException>(
+            () => observable.Subscribe<TestObserver>(1, (ILifecycleObserver)null!));
+        Assert.Equal("observer", exception.ParamName);
+        Assert.Equal(0, observable.SubscribeCallCount);
+    }
+
+    [Fact]
+    public void Subscribe_ValidObserver_PreservesNameStageIdentityAndRegistration()
+    {
+        var registration = new TestRegistration();
+        var observable = new RecordingLifecycleObservable(registration);
+        var observer = new TestObserver();
+
+        var result = observable.Subscribe<TestObserver>(17, observer);
+
+        Assert.Same(registration, result);
+        Assert.Equal(typeof(TestObserver).FullName, observable.ObserverName);
+        Assert.Equal(17, observable.Stage);
+        Assert.Same(observer, observable.Observer);
+    }
+
+    private sealed class RecordingLifecycleObservable(IDisposable? registration = null) : ILifecycleObservable
+    {
+        public int SubscribeCallCount { get; private set; }
+
+        public string? ObserverName { get; private set; }
+
+        public int Stage { get; private set; }
+
+        public ILifecycleObserver? Observer { get; private set; }
+
+        public IDisposable Subscribe(string observerName, int stage, ILifecycleObserver observer)
+        {
+            SubscribeCallCount++;
+            ObserverName = observerName;
+            Stage = stage;
+            Observer = observer;
+            return registration ?? new TestRegistration();
+        }
+    }
+
+    private sealed class TestObserver : ILifecycleObserver
+    {
+        public Task OnStart(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task OnStop(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class TestRegistration : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Storage/GrainStorageSerializerTests.cs
+++ b/test/Orleans.Core.Tests/Storage/GrainStorageSerializerTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Serialization;
+using Orleans.Storage;
+using Xunit;
+
+namespace UnitTests.Storage;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+[TestCategory("BVT")]
+public class GrainStorageSerializerTests
+{
+    [Fact]
+    public async Task StorageSerializerEntryPoints_NullInput_ThrowBeforeCollaborators()
+    {
+        var json = new JsonGrainStorageSerializer(null!);
+        var jsonException = Assert.Throws<ArgumentNullException>(() => json.Deserialize<object>(null!));
+        Assert.Equal("input", jsonException.ParamName);
+
+        var jsonDestinationException = Assert.Throws<ArgumentNullException>(
+            () => json.SerializeAsync<object>(null, null!, TestContext.Current.CancellationToken));
+        Assert.Equal("destination", jsonDestinationException.ParamName);
+
+        var jsonStreamException = Assert.Throws<ArgumentNullException>(
+            () => json.DeserializeAsync<object>(null!, TestContext.Current.CancellationToken));
+        Assert.Equal("input", jsonStreamException.ParamName);
+
+        var orleans = new OrleansGrainStorageSerializer(null!);
+        var orleansException = Assert.Throws<ArgumentNullException>(() => orleans.Deserialize<object>(null!));
+        Assert.Equal("input", orleansException.ParamName);
+
+        var orleansDestinationException = Assert.Throws<ArgumentNullException>(
+            () => orleans.SerializeAsync<object>(null, null!, TestContext.Current.CancellationToken));
+        Assert.Equal("destination", orleansDestinationException.ParamName);
+
+        var streamException = await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await orleans.DeserializeAsync<object>(null!, TestContext.Current.CancellationToken));
+        Assert.Equal("input", streamException.ParamName);
+
+        var systemTextJson = new SystemTextJsonGrainStorageSerializer(
+            Options.Create(new SystemTextJsonGrainStorageSerializerOptions()));
+        var systemTextJsonException = Assert.Throws<ArgumentNullException>(
+            () => systemTextJson.Deserialize<object>(null!));
+        Assert.Equal("input", systemTextJsonException.ParamName);
+
+        var systemTextJsonDestinationException = Assert.Throws<ArgumentNullException>(
+            () => systemTextJson.SerializeAsync<object>(null, null!, TestContext.Current.CancellationToken));
+        Assert.Equal("destination", systemTextJsonDestinationException.ParamName);
+
+        var systemTextJsonStreamException = await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await systemTextJson.DeserializeAsync<object>(null!, TestContext.Current.CancellationToken));
+        Assert.Equal("input", systemTextJsonStreamException.ParamName);
+    }
+
+    [Fact]
+    public void GrainStorageSerializerExtensions_NullSerializer_ThrowsWithExactParameterName()
+    {
+        IGrainStorageSerializer serializer = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => serializer.Deserialize<object>(ReadOnlyMemory<byte>.Empty));
+
+        Assert.Equal("serializer", exception.ParamName);
+    }
+
+    [Fact]
+    public void JsonStorageSerializer_CanceledToken_PrecedesNullStream()
+    {
+        var serializer = new JsonGrainStorageSerializer(null!);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(
+            () => serializer.SerializeAsync<object>(null, null!, cancellation.Token));
+        Assert.Throws<OperationCanceledException>(
+            () => serializer.DeserializeAsync<object>(null!, cancellation.Token));
+    }
+
+    [Fact]
+    public void GrainStorageSerializerExtensions_ValidInput_ForwardsExactBytesOnce()
+    {
+        var serializer = new RecordingSerializer();
+        var input = new byte[] { 1, 2, 3, 4 };
+
+        var result = serializer.Deserialize<string>(input);
+
+        Assert.Equal("deserialized", result);
+        Assert.Equal(1, serializer.DeserializeCallCount);
+        Assert.Equal(input, serializer.Input.ToMemory().ToArray());
+    }
+
+    [Fact]
+    public void InconsistentStateException_NullStorageException_ThrowsWithExactParameterName()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new InconsistentStateException("stored", "current", (Exception)null!));
+
+        Assert.Equal("storageException", exception.ParamName);
+    }
+
+    [Fact]
+    public void InconsistentStateException_ValidStorageException_PreservesDetails()
+    {
+        var inner = new InvalidOperationException("storage failed");
+
+        var exception = new InconsistentStateException("stored", "current", inner);
+
+        Assert.Equal(inner.Message, exception.Message);
+        Assert.Equal("stored", exception.StoredEtag);
+        Assert.Equal("current", exception.CurrentEtag);
+        Assert.Same(inner, exception.InnerException);
+    }
+
+    [Fact]
+    public void SystemTextJsonGrainStorageSerializer_ValidValue_RoundTrips()
+    {
+        var serializer = new SystemTextJsonGrainStorageSerializer(
+            Options.Create(new SystemTextJsonGrainStorageSerializerOptions()));
+        var input = new TestState { Name = "alpha", Value = 42 };
+
+        var result = serializer.Deserialize<TestState>(serializer.Serialize(input));
+
+        Assert.NotNull(result);
+        Assert.Equal(input.Name, result.Name);
+        Assert.Equal(input.Value, result.Value);
+    }
+
+    [Fact]
+    public void DefaultStorageProviderSerializerOptionsConfigurator_NullOptions_ThrowsWithExactParameterName()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var configurator = new DefaultStorageProviderSerializerOptionsConfigurator<TestStorageOptions>(serviceProvider);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => configurator.PostConfigure(null, null!));
+
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    private sealed class RecordingSerializer : IGrainStorageSerializer
+    {
+        public int DeserializeCallCount { get; private set; }
+
+        public BinaryData Input { get; private set; } = new(Array.Empty<byte>());
+
+        public T? Deserialize<T>(BinaryData input)
+        {
+            DeserializeCallCount++;
+            Input = input;
+            return (T?)(object)"deserialized";
+        }
+
+        public BinaryData Serialize<T>(T? input) => throw new NotSupportedException();
+    }
+
+    private sealed class TestState
+    {
+        public string? Name { get; set; }
+
+        public int Value { get; set; }
+    }
+
+    private sealed class TestStorageOptions : IStorageProviderSerializerOptions
+    {
+        public IGrainStorageSerializer GrainStorageSerializer { get; set; } = null!;
+    }
+}

--- a/test/Orleans.Runtime.Tests/LogFomatterTests.cs
+++ b/test/Orleans.Runtime.Tests/LogFomatterTests.cs
@@ -44,6 +44,36 @@ namespace Tester
         }
 
         [Fact]
+        public void LogOption_NullFormatter_ThrowsBeforeLogging()
+        {
+            var loggerFactory = new TestLoggerFactory();
+            var logger = loggerFactory.CreateLogger(nameof(LogOption_NullFormatter_ThrowsBeforeLogging));
+            using var services = new ServiceCollection().BuildServiceProvider();
+            var target = new DirectOptionsLogger(logger, services);
+            var before = loggerFactory.ToString();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => target.LogOption(null!));
+
+            Assert.Equal("formatter", exception.ParamName);
+            Assert.Equal(before, loggerFactory.ToString());
+        }
+
+        [Fact]
+        public void LogOptions_NullFormatters_ThrowsBeforeLogging()
+        {
+            var loggerFactory = new TestLoggerFactory();
+            var logger = loggerFactory.CreateLogger(nameof(LogOptions_NullFormatters_ThrowsBeforeLogging));
+            using var services = new ServiceCollection().BuildServiceProvider();
+            var target = new DirectOptionsLogger(logger, services);
+            var before = loggerFactory.ToString();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => target.LogOptions(null!));
+
+            Assert.Equal("formatters", exception.ParamName);
+            Assert.Equal(before, loggerFactory.ToString());
+        }
+
+        [Fact]
         public void CanResolveGenericFormatter()
         {
             // expected output
@@ -606,6 +636,14 @@ namespace Tester
         private class TestOptionsLogger : OptionsLogger
         {
             public TestOptionsLogger(ILogger<TestOptionsLogger> logger, IServiceProvider services)
+                : base(logger, services)
+            {
+            }
+        }
+
+        private sealed class DirectOptionsLogger : OptionsLogger
+        {
+            public DirectOptionsLogger(ILogger logger, IServiceProvider services)
                 : base(logger, services)
             {
             }


### PR DESCRIPTION
## Problem

CA1062 remains advisory across several complete Orleans.Core and Orleans.Core.Abstractions physical families, leaving 36 reported public-boundary dereferences and several analyzer-blind paths which expose downstream exception contracts or suppress null failures.

## Solution

Enable CA1062 for the complete `Orleans.Core` Configuration, Providers, Core, and IDs families and the `Orleans.Core.Abstractions` Utils and Lifecycle families. Validate caller-controlled inputs before callbacks, dependency-injection mutation, serialization, parsing, and lifecycle registration. Preserve existing cancellation precedence for JSON streaming operations and keep nullable payload semantics unchanged.

Add focused regression coverage for exact parameter names, eager validation, no-effect failure paths, named registrations, storage serialization, lifecycle identity, utility behavior, and generic grain type round-trips.

## Rationale

Complete-family enforcement prevents new violations without per-file carveouts. Boundary checks provide stable Orleans-owned exception contracts, while inexpensive one-time guards preserve successful-path behavior and hot-path wire/type identity.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11178)