### PR TITLE
fix(codegen): honor RPC parameter field IDs

### DIFF
--- a/src/Orleans.CodeGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Orleans.CodeGenerator/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 ORLEANS0109 | Usage | Error | Method has multiple CancellationToken parameters
 ORLEANS0110 | Usage | Error | ReferenceAssemblyWithGenerateSerializerDiagnostic
 ORLEANS0111 | Usage | Error | Invalid invokable base type mapping
+ORLEANS0112 | Usage | Error | Invalid RPC parameter field identifier

--- a/src/Orleans.CodeGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Orleans.CodeGenerator/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ ORLEANS0109 | Usage | Error | Method has multiple CancellationToken parameters
 ORLEANS0110 | Usage | Error | ReferenceAssemblyWithGenerateSerializerDiagnostic
 ORLEANS0111 | Usage | Error | Invalid invokable base type mapping
 ORLEANS0112 | Usage | Error | Invalid RPC parameter field identifier
+ORLEANS0113 | Usage | Warning | CancellationToken parameter is not last

--- a/src/Orleans.CodeGenerator/Diagnostics/CancellationTokenNotLastDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/CancellationTokenNotLastDiagnostic.cs
@@ -1,0 +1,44 @@
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+/// <summary>
+/// Defines the diagnostic reported when an RPC method has a cancellation token parameter which is not last.
+/// </summary>
+public static class CancellationTokenNotLastDiagnostic
+{
+    /// <summary>
+    /// The diagnostic identifier.
+    /// </summary>
+    public const string DiagnosticId = DiagnosticRuleId.CancellationTokenNotLast;
+
+    /// <summary>
+    /// The diagnostic title.
+    /// </summary>
+    public const string Title = "CancellationToken should be the last RPC parameter";
+
+    /// <summary>
+    /// The diagnostic message format.
+    /// </summary>
+    public const string MessageFormat = "CancellationToken parameter '{0}' on RPC method '{1}' should be the last parameter";
+
+    /// <summary>
+    /// The diagnostic category.
+    /// </summary>
+    public const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal static Diagnostic CreateDiagnostic(IParameterSymbol parameter) =>
+        Diagnostic.Create(
+            Rule,
+            parameter.Locations.FirstOrDefault() ?? Location.None,
+            parameter.Name,
+            parameter.ContainingSymbol.ToDisplayString());
+}

--- a/src/Orleans.CodeGenerator/Diagnostics/DiagnosticRuleId.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/DiagnosticRuleId.cs
@@ -14,4 +14,5 @@ internal static class DiagnosticRuleId
     public const string MultipleCancellationTokenParameters = "ORLEANS0109";
     public const string ReferenceAssemblyWithGenerateSerializer = "ORLEANS0110";
     public const string InvalidInvokableBaseTypeMapping = "ORLEANS0111";
+    public const string InvalidRpcParameterId = "ORLEANS0112";
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/DiagnosticRuleId.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/DiagnosticRuleId.cs
@@ -15,4 +15,5 @@ internal static class DiagnosticRuleId
     public const string ReferenceAssemblyWithGenerateSerializer = "ORLEANS0110";
     public const string InvalidInvokableBaseTypeMapping = "ORLEANS0111";
     public const string InvalidRpcParameterId = "ORLEANS0112";
+    public const string CancellationTokenNotLast = "ORLEANS0113";
 }

--- a/src/Orleans.CodeGenerator/Diagnostics/InvalidRpcParameterIdDiagnostic.cs
+++ b/src/Orleans.CodeGenerator/Diagnostics/InvalidRpcParameterIdDiagnostic.cs
@@ -1,0 +1,44 @@
+using Microsoft.CodeAnalysis;
+
+namespace Orleans.CodeGenerator.Diagnostics;
+
+internal static class InvalidRpcParameterIdDiagnostic
+{
+    public const string DiagnosticId = DiagnosticRuleId.InvalidRpcParameterId;
+    public const string Category = "Usage";
+
+    private static readonly DiagnosticDescriptor CancellationTokenRule = new(
+        DiagnosticId,
+        "CancellationToken parameters cannot declare RPC field identifiers",
+        "The CancellationToken parameter '{0}' on RPC method '{1}' cannot declare [Id] because cancellation tokens are not serialized",
+        Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor DuplicateFieldIdRule = new(
+        DiagnosticId,
+        "RPC parameter field identifiers must be unique",
+        "RPC parameter '{0}' on method '{1}' uses field ID {2}, which is already used by parameter '{3}'",
+        Category,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static Diagnostic CreateCancellationTokenDiagnostic(IParameterSymbol parameter) =>
+        Diagnostic.Create(
+            CancellationTokenRule,
+            parameter.Locations.FirstOrDefault() ?? Location.None,
+            parameter.Name,
+            parameter.ContainingSymbol.ToDisplayString());
+
+    internal static Diagnostic CreateDuplicateFieldIdDiagnostic(
+        IParameterSymbol parameter,
+        uint fieldId,
+        IParameterSymbol conflictingParameter) =>
+        Diagnostic.Create(
+            DuplicateFieldIdRule,
+            parameter.Locations.FirstOrDefault() ?? Location.None,
+            parameter.Name,
+            parameter.ContainingSymbol.ToDisplayString(),
+            fieldId,
+            conflictingParameter.Name);
+}

--- a/src/Orleans.CodeGenerator/InvokableGenerator.cs
+++ b/src/Orleans.CodeGenerator/InvokableGenerator.cs
@@ -841,13 +841,50 @@ internal class InvokableGenerator(ProxyGenerationContext generationContext)
     private List<InvokerFieldDescription> GetFieldDescriptions(InvokableMethodDescription method)
     {
         var fields = new List<InvokerFieldDescription>();
-        uint fieldId = 0;
+        var assignedFieldIds = new Dictionary<uint, IParameterSymbol>();
+        uint serializedParameterOrdinal = 0;
 
         foreach (var parameter in method.Method.Parameters)
         {
             var isSerializable = !SymbolEqualityComparer.Default.Equals(LibraryTypes.CancellationToken, parameter.Type);
-            fields.Add(new MethodParameterFieldDescription(LibraryTypes, parameter, $"arg{fieldId}", fieldId, method.TypeParameterSubstitutions, isSerializable));
-            fieldId++;
+            var explicitFieldId = GeneratedCodeUtilities.GetId(LibraryTypes, parameter);
+            if (!isSerializable)
+            {
+                if (explicitFieldId.HasValue)
+                {
+                    throw new OrleansGeneratorDiagnosticAnalysisException(
+                        InvalidRpcParameterIdDiagnostic.CreateCancellationTokenDiagnostic(parameter));
+                }
+
+                fields.Add(new MethodParameterFieldDescription(
+                    LibraryTypes,
+                    parameter,
+                    $"arg{parameter.Ordinal}",
+                    serializedParameterOrdinal,
+                    method.TypeParameterSubstitutions,
+                    isSerializable: false));
+                continue;
+            }
+
+            var fieldId = explicitFieldId ?? serializedParameterOrdinal;
+            if (assignedFieldIds.TryGetValue(fieldId, out var conflictingParameter))
+            {
+                throw new OrleansGeneratorDiagnosticAnalysisException(
+                    InvalidRpcParameterIdDiagnostic.CreateDuplicateFieldIdDiagnostic(
+                        parameter,
+                        fieldId,
+                        conflictingParameter));
+            }
+
+            assignedFieldIds.Add(fieldId, parameter);
+            fields.Add(new MethodParameterFieldDescription(
+                LibraryTypes,
+                parameter,
+                $"arg{parameter.Ordinal}",
+                fieldId,
+                method.TypeParameterSubstitutions,
+                isSerializable: true));
+            serializedParameterOrdinal++;
         }
 
         fields.Add(new TargetFieldDescription(method.Method.ContainingType));

--- a/src/Orleans.CodeGenerator/Model/MethodModel.cs
+++ b/src/Orleans.CodeGenerator/Model/MethodModel.cs
@@ -3,7 +3,12 @@ namespace Orleans.CodeGenerator.Model;
 /// <summary>
 /// Describes a method parameter for invokable/proxy generation.
 /// </summary>
-internal readonly record struct MethodParameterModel(string Name, TypeRef Type, int Ordinal, bool IsCancellationToken);
+internal readonly record struct MethodParameterModel(
+    string Name,
+    TypeRef Type,
+    int Ordinal,
+    bool IsCancellationToken,
+    uint? ExplicitFieldId);
 
 /// <summary>
 /// Describes a method on a proxy interface for invokable generation.

--- a/src/Orleans.CodeGenerator/Model/ProxyInterfaceModelExtractor.cs
+++ b/src/Orleans.CodeGenerator/Model/ProxyInterfaceModelExtractor.cs
@@ -374,7 +374,8 @@ internal static class ProxyInterfaceModelExtractor
                 param.Name,
                 new TypeRef(param.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
                 param.Ordinal,
-                isCancellationToken));
+                isCancellationToken,
+                GeneratedCodeUtilities.GetId(libraryTypes, param)));
         }
 
         return builder.MoveToImmutable();

--- a/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
+++ b/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs
@@ -141,7 +141,7 @@ public sealed class OrleansSerializationSourceGenerator : IIncrementalGenerator
 
         context.RegisterSourceOutput(preparedProxyOutputs, static (productionContext, input) =>
         {
-            if (input.Diagnostic is { } diagnostic)
+            foreach (var diagnostic in input.Diagnostics)
             {
                 productionContext.ReportDiagnostic(diagnostic);
             }

--- a/src/Orleans.CodeGenerator/ProxySourceOutputGenerator.cs
+++ b/src/Orleans.CodeGenerator/ProxySourceOutputGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Orleans.CodeGenerator.Diagnostics;
 using Orleans.CodeGenerator.Model;
 
 namespace Orleans.CodeGenerator;
@@ -200,6 +201,7 @@ internal static class ProxySourceOutputGenerator
                 resolver,
                 models,
                 cancellationToken);
+            var diagnostics = GetCancellationTokenParameterDiagnostics(proxyContext);
 
             return ProxyOutputPreparationResult.FromModelsAndSources(
                 proxyOutputModels,
@@ -210,7 +212,8 @@ internal static class ProxySourceOutputGenerator
                     resolver,
                     proxyOutputModels,
                     options,
-                    cancellationToken));
+                    cancellationToken),
+                diagnostics);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -263,6 +266,35 @@ internal static class ProxySourceOutputGenerator
         }
 
         return GeneratedSourceOutput.DeduplicateSourceOutputs(sourceOutputs);
+    }
+
+    private static ImmutableArray<Diagnostic> GetCancellationTokenParameterDiagnostics(ProxyGenerationContext proxyContext)
+    {
+        var inspectedMethods = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        var parameters = new HashSet<IParameterSymbol>(SymbolEqualityComparer.Default);
+        foreach (var invokable in proxyContext.MetadataModel.GeneratedInvokables.Values)
+        {
+            var method = invokable.MethodDescription.Method.OriginalDefinition;
+            if (!inspectedMethods.Add(method) || method.Parameters.Length < 2)
+            {
+                continue;
+            }
+
+            for (var index = 0; index < method.Parameters.Length - 1; index++)
+            {
+                var parameter = method.Parameters[index];
+                if (parameter.Locations.Any(static location => location.IsInSource)
+                    && SymbolEqualityComparer.Default.Equals(proxyContext.LibraryTypes.CancellationToken, parameter.Type))
+                {
+                    parameters.Add(parameter);
+                }
+            }
+        }
+
+        return [.. parameters
+            .OrderBy(static parameter => parameter.Locations.First().SourceTree?.FilePath, StringComparer.Ordinal)
+            .ThenBy(static parameter => parameter.Locations.First().SourceSpan.Start)
+            .Select(CancellationTokenNotLastDiagnostic.CreateDiagnostic)];
     }
 
     internal static ImmutableArray<ProxyOutputModel> CreateProxyOutputModels(

--- a/src/Orleans.CodeGenerator/SourceGeneratorResults.cs
+++ b/src/Orleans.CodeGenerator/SourceGeneratorResults.cs
@@ -133,24 +133,25 @@ internal readonly struct SerializableTypeResult(
 internal readonly struct ProxyOutputPreparationResult(
     ImmutableArray<ProxyOutputModel> proxyOutputModels,
     ImmutableArray<SourceOutputResult> sourceOutputs,
-    Diagnostic? diagnostic) : IEquatable<ProxyOutputPreparationResult>
+    ImmutableArray<Diagnostic> diagnostics) : IEquatable<ProxyOutputPreparationResult>
 {
     public ImmutableArray<ProxyOutputModel> ProxyOutputModels { get; } = proxyOutputModels;
     public ImmutableArray<SourceOutputResult> SourceOutputs { get; } = sourceOutputs;
-    public Diagnostic? Diagnostic { get; } = diagnostic;
+    public ImmutableArray<Diagnostic> Diagnostics { get; } = diagnostics;
 
     public static ProxyOutputPreparationResult FromModelsAndSources(
         ImmutableArray<ProxyOutputModel> proxyOutputModels,
-        ImmutableArray<SourceOutputResult> sourceOutputs)
-        => new(proxyOutputModels, sourceOutputs, diagnostic: null);
+        ImmutableArray<SourceOutputResult> sourceOutputs,
+        ImmutableArray<Diagnostic> diagnostics = default)
+        => new(proxyOutputModels, sourceOutputs, diagnostics.IsDefault ? [] : diagnostics);
 
     public static ProxyOutputPreparationResult FromDiagnostic(Diagnostic diagnostic)
-        => new([], [], diagnostic);
+        => new([], [], [diagnostic]);
 
     public bool Equals(ProxyOutputPreparationResult other)
         => StructuralEquality.SequenceEqual(ProxyOutputModels, other.ProxyOutputModels)
             && StructuralEquality.SequenceEqual(SourceOutputs, other.SourceOutputs)
-            && SourceGeneratorDiagnosticComparer.AreEqual(Diagnostic, other.Diagnostic);
+            && SourceGeneratorDiagnosticComparer.AreSequencesEqual(Diagnostics, other.Diagnostics);
 
     public override bool Equals(object? obj) => obj is ProxyOutputPreparationResult other && Equals(other);
 
@@ -160,7 +161,7 @@ internal readonly struct ProxyOutputPreparationResult(
         {
             var hash = StructuralEquality.GetSequenceHashCode(ProxyOutputModels);
             hash = hash * 31 + StructuralEquality.GetSequenceHashCode(SourceOutputs);
-            hash = hash * 31 + SourceGeneratorDiagnosticComparer.GetHashCode(Diagnostic);
+            hash = hash * 31 + SourceGeneratorDiagnosticComparer.GetSequenceHashCode(Diagnostics);
             return hash;
         }
     }

--- a/src/Orleans.Serialization.Abstractions/Annotations.cs
+++ b/src/Orleans.Serialization.Abstractions/Annotations.cs
@@ -256,6 +256,8 @@ namespace Orleans
     /// <remarks>
     /// Every serializable member in a type which has <see cref="GenerateSerializerAttribute"/> applied to it must have one <see cref="IdAttribute"/> attribute applied with a unique <see cref="IdAttribute.Id"/> value.
     /// For positional records, this attribute can be applied directly to a primary constructor parameter instead of its generated property.
+    /// On RPC method parameters, an explicit identifier overrides the parameter's zero-based ordinal among serialized parameters.
+    /// Cancellation token parameters are excluded from serialized parameter ordinals, and all resulting identifiers must be unique.
     /// </remarks>
     /// <seealso cref="System.Attribute" />
     [AttributeUsage(

--- a/test/Grains/TestGrainInterfaces/ICancellationTestSystemTarget.cs
+++ b/test/Grains/TestGrainInterfaces/ICancellationTestSystemTarget.cs
@@ -17,7 +17,7 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="delay">The delay to wait.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
-    Task LongWait(CancellationToken cancellationToken, TimeSpan delay, Guid callId);
+    Task LongWait(CancellationToken cancellationToken, [Id(1)] TimeSpan delay, [Id(2)] Guid callId);
 
     /// <summary>
     /// Calls another system target's LongWait method, passing through the cancellation token.
@@ -26,7 +26,11 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="delay">The delay to wait.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
-    Task CallOtherLongRunningTask(ICancellationTestSystemTarget target, CancellationToken cancellationToken, TimeSpan delay, Guid callId);
+    Task CallOtherLongRunningTask(
+        ICancellationTestSystemTarget target,
+        CancellationToken cancellationToken,
+        [Id(2)] TimeSpan delay,
+        [Id(3)] Guid callId);
 
     /// <summary>
     /// Calls another system target's LongWait method with a locally created cancellation token
@@ -44,7 +48,7 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
-    Task<bool> CancellationTokenCallbackResolve(CancellationToken cancellationToken, Guid callId);
+    Task<bool> CancellationTokenCallbackResolve(CancellationToken cancellationToken, [Id(1)] Guid callId);
 
     /// <summary>
     /// Calls another system target's CancellationTokenCallbackResolve method with a locally created
@@ -59,7 +63,7 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
-    Task CancellationTokenCallbackThrow(CancellationToken cancellationToken, Guid callId);
+    Task CancellationTokenCallbackThrow(CancellationToken cancellationToken, [Id(1)] Guid callId);
 
     /// <summary>
     /// Checks if a specific call was cancelled.

--- a/test/Grains/TestGrainInterfaces/ICancellationTestSystemTarget.cs
+++ b/test/Grains/TestGrainInterfaces/ICancellationTestSystemTarget.cs
@@ -14,18 +14,18 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// <summary>
     /// Performs a long wait that can be cancelled via the provided cancellation token.
     /// </summary>
-    /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="delay">The delay to wait.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     Task LongWait(TimeSpan delay, Guid callId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Calls another system target's LongWait method, passing through the cancellation token.
     /// </summary>
     /// <param name="target">The target system target to call.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="delay">The delay to wait.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     Task CallOtherLongRunningTask(
         ICancellationTestSystemTarget target,
         TimeSpan delay,
@@ -46,8 +46,8 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// Tests that cancellation token callbacks execute in the correct execution context.
     /// Returns true if the callback ran on the correct TaskScheduler.
     /// </summary>
-    /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     Task<bool> CancellationTokenCallbackResolve(Guid callId, CancellationToken cancellationToken);
 
     /// <summary>
@@ -61,8 +61,8 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// <summary>
     /// Tests that exceptions thrown in cancellation callbacks do not propagate.
     /// </summary>
-    /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     Task CancellationTokenCallbackThrow(Guid callId, CancellationToken cancellationToken);
 
     /// <summary>

--- a/test/Grains/TestGrainInterfaces/ICancellationTestSystemTarget.cs
+++ b/test/Grains/TestGrainInterfaces/ICancellationTestSystemTarget.cs
@@ -17,7 +17,7 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="delay">The delay to wait.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
-    Task LongWait(CancellationToken cancellationToken, [Id(1)] TimeSpan delay, [Id(2)] Guid callId);
+    Task LongWait(TimeSpan delay, Guid callId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Calls another system target's LongWait method, passing through the cancellation token.
@@ -28,9 +28,9 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
     Task CallOtherLongRunningTask(
         ICancellationTestSystemTarget target,
-        CancellationToken cancellationToken,
-        [Id(2)] TimeSpan delay,
-        [Id(3)] Guid callId);
+        TimeSpan delay,
+        Guid callId,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Calls another system target's LongWait method with a locally created cancellation token
@@ -48,7 +48,7 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
-    Task<bool> CancellationTokenCallbackResolve(CancellationToken cancellationToken, [Id(1)] Guid callId);
+    Task<bool> CancellationTokenCallbackResolve(Guid callId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Calls another system target's CancellationTokenCallbackResolve method with a locally created
@@ -63,7 +63,7 @@ public interface ICancellationTestSystemTarget : ISystemTarget
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="callId">A unique identifier for this call, used to track cancellations.</param>
-    Task CancellationTokenCallbackThrow(CancellationToken cancellationToken, [Id(1)] Guid callId);
+    Task CancellationTokenCallbackThrow(Guid callId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks if a specific call was cancelled.

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -205,23 +205,23 @@ namespace UnitTests.GrainInterfaces
         Task LongWaitGrainCancellation(GrainCancellationToken tc, TimeSpan delay, Guid callId);
         [AlwaysInterleave]
         Task LongWaitGrainCancellationInterleaving(GrainCancellationToken tc, TimeSpan delay, Guid callId);
-        Task LongWait(CancellationToken tc, [Id(1)] TimeSpan delay, [Id(2)] Guid callId);
+        Task LongWait(TimeSpan delay, Guid callId, CancellationToken tc);
         Task LongWaitWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken);
         [AlwaysInterleave]
-        Task LongWaitInterleaving(CancellationToken tc, [Id(1)] TimeSpan delay, [Id(2)] Guid callId);
+        Task LongWaitInterleaving(TimeSpan delay, Guid callId, CancellationToken tc);
         [AlwaysInterleave]
         Task LongWaitInterleavingWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken);
-        Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, [Id(2)] TimeSpan delay, [Id(3)] Guid callId);
-        Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, CancellationToken tc, [Id(3)] TimeSpan delay, [Id(4)] Guid callId);
+        Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, TimeSpan delay, Guid callId, CancellationToken tc);
+        Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, TimeSpan delay, Guid callId, CancellationToken tc);
         Task CallOtherLongRunningTaskGrainCancellation(ILongRunningTaskGrain<T> target, GrainCancellationToken tc, TimeSpan delay, Guid callId);
         Task CallOtherLongRunningTaskWithLocalGrainCancellationToken(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId);
         Task CallOtherLongRunningTaskWithLocalCancellation(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId);
         Task<bool> GrainCancellationTokenCallbackResolve(GrainCancellationToken tc, Guid callId);
-        Task<bool> CancellationTokenCallbackResolve(CancellationToken tc, [Id(1)] Guid callId);
+        Task<bool> CancellationTokenCallbackResolve(Guid callId, CancellationToken tc);
         Task<bool> CallOtherGrainCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
         Task<bool> CallOtherCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
         Task GrainCancellationTokenCallbackThrow(GrainCancellationToken tc, Guid callId, ILongRunningTaskObserver observer);
-        Task CancellationTokenCallbackThrow(CancellationToken tc, [Id(1)] Guid callId);
+        Task CancellationTokenCallbackThrow(Guid callId, CancellationToken tc);
         Task<T> GetLastValue();
 
         IAsyncEnumerable<(Guid CallId, Exception Error)> WatchCancellations(CancellationToken cancellationToken = default);

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -205,23 +205,23 @@ namespace UnitTests.GrainInterfaces
         Task LongWaitGrainCancellation(GrainCancellationToken tc, TimeSpan delay, Guid callId);
         [AlwaysInterleave]
         Task LongWaitGrainCancellationInterleaving(GrainCancellationToken tc, TimeSpan delay, Guid callId);
-        Task LongWait(CancellationToken tc, TimeSpan delay, Guid callId);
+        Task LongWait(CancellationToken tc, [Id(1)] TimeSpan delay, [Id(2)] Guid callId);
         Task LongWaitWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken);
         [AlwaysInterleave]
-        Task LongWaitInterleaving(CancellationToken tc, TimeSpan delay, Guid callId);
+        Task LongWaitInterleaving(CancellationToken tc, [Id(1)] TimeSpan delay, [Id(2)] Guid callId);
         [AlwaysInterleave]
         Task LongWaitInterleavingWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken);
-        Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, TimeSpan delay, Guid callId);
-        Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, CancellationToken tc, TimeSpan delay, Guid callId);
+        Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, [Id(2)] TimeSpan delay, [Id(3)] Guid callId);
+        Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, CancellationToken tc, [Id(3)] TimeSpan delay, [Id(4)] Guid callId);
         Task CallOtherLongRunningTaskGrainCancellation(ILongRunningTaskGrain<T> target, GrainCancellationToken tc, TimeSpan delay, Guid callId);
         Task CallOtherLongRunningTaskWithLocalGrainCancellationToken(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId);
         Task CallOtherLongRunningTaskWithLocalCancellation(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId);
         Task<bool> GrainCancellationTokenCallbackResolve(GrainCancellationToken tc, Guid callId);
-        Task<bool> CancellationTokenCallbackResolve(CancellationToken tc, Guid callId);
+        Task<bool> CancellationTokenCallbackResolve(CancellationToken tc, [Id(1)] Guid callId);
         Task<bool> CallOtherGrainCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
         Task<bool> CallOtherCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId);
         Task GrainCancellationTokenCallbackThrow(GrainCancellationToken tc, Guid callId, ILongRunningTaskObserver observer);
-        Task CancellationTokenCallbackThrow(CancellationToken tc, Guid callId);
+        Task CancellationTokenCallbackThrow(CancellationToken tc, [Id(1)] Guid callId);
         Task<T> GetLastValue();
 
         IAsyncEnumerable<(Guid CallId, Exception Error)> WatchCancellations(CancellationToken cancellationToken = default);

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -651,7 +651,7 @@ namespace UnitTests.Grains
             await Task.Delay(TimeSpan.FromSeconds(10), ct.CancellationToken);
         }
 
-        public async Task CancellationTokenCallbackThrow(CancellationToken ct, Guid callId)
+        public async Task CancellationTokenCallbackThrow(Guid callId, CancellationToken ct)
         {
             ct.Register(() =>
             {
@@ -670,7 +670,7 @@ namespace UnitTests.Grains
         public async Task<bool> CallOtherCancellationTokenCallbackResolve(ILongRunningTaskGrain<T> target, Guid callId)
         {
             using var cts = new CancellationTokenSource();
-            var grainTask = target.CancellationTokenCallbackResolve(cts.Token, callId);
+            var grainTask = target.CancellationTokenCallbackResolve(callId, cts.Token);
             cts.CancelAfter(300);
             return await grainTask;
         }
@@ -706,7 +706,7 @@ namespace UnitTests.Grains
             return tcs.Task;
         }
 
-        public Task<bool> CancellationTokenCallbackResolve(CancellationToken tc, Guid callId)
+        public Task<bool> CancellationTokenCallbackResolve(Guid callId, CancellationToken tc)
         {
             var tcs = new TaskCompletionSource<bool>();
             var orleansTs = TaskScheduler.Current;
@@ -749,12 +749,12 @@ namespace UnitTests.Grains
             await target.LongWaitGrainCancellation(tc, delay, callId);
         }
 
-        public async Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, TimeSpan delay, Guid callId)
+        public async Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, TimeSpan delay, Guid callId, CancellationToken tc)
         {
-            await target.LongWait(tc, delay, callId);
+            await target.LongWait(delay, callId, tc);
         }
 
-        public async Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, CancellationToken tc, TimeSpan delay, Guid callId)
+        public async Task CallOtherLongRunningTaskWithStartNotification(ILongRunningTaskGrain<T> target, ILongRunningTaskObserver observer, TimeSpan delay, Guid callId, CancellationToken tc)
         {
             await target.LongWaitWithStartNotification(delay, callId, observer, tc);
         }
@@ -762,7 +762,7 @@ namespace UnitTests.Grains
         public async Task CallOtherLongRunningTaskWithLocalCancellation(ILongRunningTaskGrain<T> target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId)
         {
             using var cts = new CancellationTokenSource();
-            var task = target.LongWait(cts.Token, delay, callId);
+            var task = target.LongWait(delay, callId, cts.Token);
             cts.CancelAfter(delayBeforeCancel);
             await task;
         }
@@ -791,21 +791,21 @@ namespace UnitTests.Grains
             }
         }
 
-        public Task LongWaitInterleaving(CancellationToken ct, TimeSpan delay, Guid callId) => LongWait(ct, delay, callId);
+        public Task LongWaitInterleaving(TimeSpan delay, Guid callId, CancellationToken ct) => LongWait(delay, callId, ct);
 
         public Task LongWaitWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken)
         {
             observer.OnCallStarted(callId);
-            return LongWait(cancellationToken, delay, callId);
+            return LongWait(delay, callId, cancellationToken);
         }
 
         public Task LongWaitInterleavingWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken)
         {
             observer.OnCallStarted(callId);
-            return LongWait(cancellationToken, delay, callId);
+            return LongWait(delay, callId, cancellationToken);
         }
 
-        public async Task LongWait(CancellationToken ct, TimeSpan delay, Guid callId)
+        public async Task LongWait(TimeSpan delay, Guid callId, CancellationToken ct)
         {
             try
             {

--- a/test/Orleans.CodeGenerator.Tests/IncrementalCachingTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/IncrementalCachingTests.cs
@@ -314,6 +314,45 @@ public class IncrementalCachingTests
     }
 
     [Fact]
+    public async Task ChangedRpcParameterId_TriggersProxyRegeneration()
+    {
+        const string originalCode = """
+            using Orleans;
+            using System.Threading.Tasks;
+
+            namespace TestProject;
+
+            public interface IMyGrain : IGrainWithIntegerKey
+            {
+                Task<string> SayHello([Id(7)] string name);
+            }
+            """;
+
+        const string modifiedCode = """
+            using Orleans;
+            using System.Threading.Tasks;
+
+            namespace TestProject;
+
+            public interface IMyGrain : IGrainWithIntegerKey
+            {
+                Task<string> SayHello([Id(8)] string name);
+            }
+            """;
+
+        var compilation = await CreateCompilation(originalCode);
+        var newCompilation = ReplaceSource(compilation, modifiedCode);
+        var (result1, result2) = await RunTwice(compilation, newCompilation);
+
+        AssertTrackedStepModifiedOrNew(result2, OrleansSerializationSourceGenerator.PreparedProxyOutputsTrackingName);
+        AssertTrackedStepModifiedOrNew(result2, OrleansSerializationSourceGenerator.ProxyOutputsTrackingName);
+        AssertSourcesChanged(
+            result1,
+            result2,
+            static hint => hint.Contains(".orleans.proxy.", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task UnchangedProxyInterface_ProducesCachedOutput()
     {
         const string code = """

--- a/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/ModelExtractorTests.cs
@@ -709,6 +709,32 @@ public record DemoRecord([Id(42)] string Value);
         Assert.Equal(expectedMethodId, method.GeneratedMethodId);
     }
 
+    [Fact]
+    public async Task ExtractProxyInterfaceModel_CapturesExplicitParameterFieldIds()
+    {
+        const string code = """
+            using Orleans;
+            using Orleans.Runtime;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestProject;
+
+            [GenerateMethodSerializers(typeof(GrainReference))]
+            public interface ITestGrain : IGrainWithIntegerKey
+            {
+                ValueTask Call(int first, CancellationToken cancellationToken, [Id(7)] string second);
+            }
+            """;
+
+        var model = ExtractProxyInterfaceModel(await CreateCompilation(code), "TestProject.ITestGrain");
+        var method = Assert.Single(model.Methods);
+
+        Assert.Null(method.Parameters[0].ExplicitFieldId);
+        Assert.Null(method.Parameters[1].ExplicitFieldId);
+        Assert.Equal((uint)7, method.Parameters[2].ExplicitFieldId);
+    }
+
     #region Helpers
 
     private static async Task<CSharpCompilation> CreateReferenceExtractionCompilation(bool reverseReferenceOrder = false)

--- a/test/Orleans.CodeGenerator.Tests/RpcParameterFieldIdTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/RpcParameterFieldIdTests.cs
@@ -1,0 +1,242 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Orleans.CodeGenerator.Diagnostics;
+
+namespace Orleans.CodeGenerator.Tests;
+
+public class RpcParameterFieldIdTests
+{
+    [Fact]
+    public async Task AutomaticIds_ExcludeCancellationTokens_AndPreserveClrArgumentOrdinals()
+    {
+        const string code = """
+            using Orleans;
+            using Orleans.Runtime;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [GenerateMethodSerializers(typeof(GrainReference))]
+            public interface ITestGrain : IGrainWithIntegerKey
+            {
+                ValueTask TokenFirst(CancellationToken cancellationToken, int first, string second);
+                ValueTask TokenMiddle(int first, CancellationToken cancellationToken, string second);
+                ValueTask TokenLast(int first, string second, CancellationToken cancellationToken);
+            }
+            """;
+
+        var result = await RunGenerator(code);
+
+        Assert.Empty(result.Diagnostics);
+        AssertInvokable(
+            result,
+            "TokenFirst",
+            ["arg0", "arg1", "arg2"],
+            [(0, "arg1"), (1, "arg2")]);
+        AssertInvokable(
+            result,
+            "TokenMiddle",
+            ["arg0", "arg1", "arg2"],
+            [(0, "arg0"), (1, "arg2")]);
+        AssertInvokable(
+            result,
+            "TokenLast",
+            ["arg0", "arg1", "arg2"],
+            [(0, "arg0"), (1, "arg1")]);
+    }
+
+    [Fact]
+    public async Task ExplicitIds_OverrideAutomaticSerializedOrdinals_AndOrderWireFields()
+    {
+        const string code = """
+            using Orleans;
+            using Orleans.Runtime;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [GenerateMethodSerializers(typeof(GrainReference))]
+            public interface ITestGrain : IGrainWithIntegerKey
+            {
+                ValueTask Call([Id(7)] int first, CancellationToken cancellationToken, string second, [Id(12)] long third);
+            }
+            """;
+
+        var result = await RunGenerator(code);
+
+        Assert.Empty(result.Diagnostics);
+        AssertInvokable(
+            result,
+            "Call",
+            ["arg0", "arg1", "arg2", "arg3"],
+            [(1, "arg2"), (7, "arg0"), (12, "arg3")]);
+    }
+
+    [Fact]
+    public async Task DuplicateExplicitIds_ReportOffendingParameter()
+    {
+        const string code = """
+            using Orleans;
+            using Orleans.Runtime;
+            using System.Threading.Tasks;
+
+            [GenerateMethodSerializers(typeof(GrainReference))]
+            public interface ITestGrain : IGrainWithIntegerKey
+            {
+                ValueTask Call([Id(4)] int first, [Id(4)] string second);
+            }
+            """;
+
+        var diagnostic = Assert.Single((await RunGenerator(code)).Diagnostics);
+
+        Assert.Equal(DiagnosticRuleId.InvalidRpcParameterId, diagnostic.Id);
+        Assert.Contains("second", GetDiagnosticSource(diagnostic), StringComparison.Ordinal);
+        Assert.Contains("already used by parameter 'first'", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExplicitIdConflictingWithAutomaticId_ReportsOffendingParameter()
+    {
+        const string code = """
+            using Orleans;
+            using Orleans.Runtime;
+            using System.Threading.Tasks;
+
+            [GenerateMethodSerializers(typeof(GrainReference))]
+            public interface ITestGrain : IGrainWithIntegerKey
+            {
+                ValueTask Call(int first, [Id(0)] string second);
+            }
+            """;
+
+        var diagnostic = Assert.Single((await RunGenerator(code)).Diagnostics);
+
+        Assert.Equal(DiagnosticRuleId.InvalidRpcParameterId, diagnostic.Id);
+        Assert.Contains("second", GetDiagnosticSource(diagnostic), StringComparison.Ordinal);
+        Assert.Contains("already used by parameter 'first'", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CancellationTokenWithExplicitId_ReportsOffendingParameter()
+    {
+        const string code = """
+            using Orleans;
+            using Orleans.Runtime;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [GenerateMethodSerializers(typeof(GrainReference))]
+            public interface ITestGrain : IGrainWithIntegerKey
+            {
+                ValueTask Call([Id(0)] CancellationToken cancellationToken);
+            }
+            """;
+
+        var diagnostic = Assert.Single((await RunGenerator(code)).Diagnostics);
+
+        Assert.Equal(DiagnosticRuleId.InvalidRpcParameterId, diagnostic.Id);
+        Assert.Contains("cancellationToken", GetDiagnosticSource(diagnostic), StringComparison.Ordinal);
+        Assert.Contains("cancellation tokens are not serialized", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    private static void AssertInvokable(
+        GeneratorRunResult result,
+        string methodName,
+        string[] expectedArgumentFields,
+        (uint FieldId, string FieldName)[] expectedSerializedFields)
+    {
+        var invokable = GetGeneratedClasses(result)
+            .Single(declaration => declaration.Identifier.ValueText.StartsWith("Invokable_", StringComparison.Ordinal)
+                && declaration.Members.OfType<MethodDeclarationSyntax>().Any(method =>
+                    method.Identifier.ValueText == "GetMethodName"
+                    && method.ExpressionBody?.Expression is LiteralExpressionSyntax literal
+                    && string.Equals(literal.Token.ValueText, methodName, StringComparison.Ordinal)));
+        var argumentFields = invokable.Members
+            .OfType<FieldDeclarationSyntax>()
+            .Where(field => field.Modifiers.Any(SyntaxKind.PublicKeyword))
+            .SelectMany(field => field.Declaration.Variables)
+            .Select(variable => variable.Identifier.ValueText)
+            .ToArray();
+        Assert.Equal(expectedArgumentFields, argumentFields);
+
+        var getArgument = Assert.Single(
+            invokable.Members.OfType<MethodDeclarationSyntax>(),
+            method => method.Identifier.ValueText == "GetArgument");
+        var setArgument = Assert.Single(
+            invokable.Members.OfType<MethodDeclarationSyntax>(),
+            method => method.Identifier.ValueText == "SetArgument");
+        for (var index = 0; index < expectedArgumentFields.Length; index++)
+        {
+            Assert.Contains($"case {index}:", getArgument.ToString(), StringComparison.Ordinal);
+            Assert.Contains($"return {expectedArgumentFields[index]};", getArgument.ToString(), StringComparison.Ordinal);
+            Assert.Contains($"case {index}:", setArgument.ToString(), StringComparison.Ordinal);
+            Assert.Contains($"{expectedArgumentFields[index]} =", setArgument.ToString(), StringComparison.Ordinal);
+        }
+
+        var invokeInner = Assert.Single(
+            invokable.Members.OfType<MethodDeclarationSyntax>(),
+            method => method.Identifier.ValueText == "InvokeInner");
+        Assert.Contains(
+            $"_target.{methodName}({string.Join(", ", expectedArgumentFields)})",
+            invokeInner.ToString(),
+            StringComparison.Ordinal);
+
+        var codec = GetGeneratedClasses(result)
+            .Single(declaration => declaration.Identifier.ValueText == $"Codec_{invokable.Identifier.ValueText}");
+        var deserialize = Assert.Single(
+            codec.Members.OfType<MethodDeclarationSyntax>(),
+            method => method.Identifier.ValueText == "Deserialize");
+        var serializedFields = deserialize.DescendantNodes()
+            .OfType<IfStatementSyntax>()
+            .Select(static statement => TryGetSerializedField(statement))
+            .OfType<(uint FieldId, string FieldName)>()
+            .ToArray();
+        Assert.Equal(expectedSerializedFields, serializedFields);
+    }
+
+    private static (uint FieldId, string FieldName)? TryGetSerializedField(IfStatementSyntax statement)
+    {
+        if (statement.Condition is not BinaryExpressionSyntax
+            {
+                RawKind: (int)SyntaxKind.EqualsExpression,
+                Left: IdentifierNameSyntax { Identifier.ValueText: "id" },
+                Right: LiteralExpressionSyntax fieldIdLiteral
+            })
+        {
+            return null;
+        }
+
+        var assignment = statement.Statement.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .FirstOrDefault(static assignment =>
+                assignment.Left is MemberAccessExpressionSyntax
+                {
+                    Expression: IdentifierNameSyntax { Identifier.ValueText: "instance" }
+                });
+        if (assignment?.Left is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return null;
+        }
+
+        return (Convert.ToUInt32(fieldIdLiteral.Token.Value), memberAccess.Name.Identifier.ValueText);
+    }
+
+    private static IEnumerable<ClassDeclarationSyntax> GetGeneratedClasses(GeneratorRunResult result) =>
+        result.GeneratedSources.SelectMany(static source =>
+            CSharpSyntaxTree.ParseText(source.SourceText.ToString().TrimStart('\uFEFF'))
+                .GetCompilationUnitRoot()
+                .DescendantNodes()
+                .OfType<ClassDeclarationSyntax>());
+
+    private static string GetDiagnosticSource(Diagnostic diagnostic) =>
+        diagnostic.Location.SourceTree!.GetText().ToString(diagnostic.Location.SourceSpan);
+
+    private static async Task<GeneratorRunResult> RunGenerator(string code)
+    {
+        var compilation = await TestCompilationHelper.CreateCompilation(code);
+        Assert.Empty(compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new OrleansSerializationSourceGenerator().AsSourceGenerator());
+        driver = driver.RunGenerators(compilation);
+        return driver.GetRunResult().Results.Single();
+    }
+}

--- a/test/Orleans.CodeGenerator.Tests/RpcParameterFieldIdTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/RpcParameterFieldIdTests.cs
@@ -32,16 +32,19 @@ public class RpcParameterFieldIdTests
             result,
             "TokenFirst",
             ["arg0", "arg1", "arg2"],
+            ["global::System.Threading.CancellationToken", "int", "string"],
             [(0, "arg1"), (1, "arg2")]);
         AssertInvokable(
             result,
             "TokenMiddle",
             ["arg0", "arg1", "arg2"],
+            ["int", "global::System.Threading.CancellationToken", "string"],
             [(0, "arg0"), (1, "arg2")]);
         AssertInvokable(
             result,
             "TokenLast",
             ["arg0", "arg1", "arg2"],
+            ["int", "string", "global::System.Threading.CancellationToken"],
             [(0, "arg0"), (1, "arg1")]);
     }
 
@@ -68,6 +71,7 @@ public class RpcParameterFieldIdTests
             result,
             "Call",
             ["arg0", "arg1", "arg2", "arg3"],
+            ["int", "global::System.Threading.CancellationToken", "string", "long"],
             [(1, "arg2"), (7, "arg0"), (12, "arg3")]);
     }
 
@@ -142,6 +146,7 @@ public class RpcParameterFieldIdTests
         GeneratorRunResult result,
         string methodName,
         string[] expectedArgumentFields,
+        string[] expectedReflectionParameterTypes,
         (uint FieldId, string FieldName)[] expectedSerializedFields)
     {
         var invokable = GetGeneratedClasses(result)
@@ -157,6 +162,17 @@ public class RpcParameterFieldIdTests
             .Select(variable => variable.Identifier.ValueText)
             .ToArray();
         Assert.Equal(expectedArgumentFields, argumentFields);
+
+        var methodBackingField = Assert.Single(
+            invokable.Members.OfType<FieldDeclarationSyntax>(),
+            field => field.Declaration.Variables.Any(variable => variable.Identifier.ValueText == "MethodBackingField"));
+        var parameterTypes = Assert.Single(
+                methodBackingField.DescendantNodes().OfType<ImplicitArrayCreationExpressionSyntax>())
+            .Initializer.Expressions
+            .OfType<TypeOfExpressionSyntax>()
+            .Select(static expression => expression.Type.ToString())
+            .ToArray();
+        Assert.Equal(expectedReflectionParameterTypes, parameterTypes);
 
         var getArgument = Assert.Single(
             invokable.Members.OfType<MethodDeclarationSyntax>(),

--- a/test/Orleans.CodeGenerator.Tests/RpcParameterFieldIdTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/RpcParameterFieldIdTests.cs
@@ -27,7 +27,16 @@ public class RpcParameterFieldIdTests
 
         var result = await RunGenerator(code);
 
-        Assert.Empty(result.Diagnostics);
+        var diagnostics = result.Diagnostics
+            .Where(static diagnostic => diagnostic.Id == DiagnosticRuleId.CancellationTokenNotLast)
+            .ToArray();
+        Assert.Equal(2, diagnostics.Length);
+        Assert.All(diagnostics, static diagnostic => Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity));
+        Assert.Equal(["cancellationToken", "cancellationToken"], diagnostics.Select(GetDiagnosticSource));
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            static diagnostic => diagnostic.Id == DiagnosticRuleId.CancellationTokenNotLast
+                && diagnostic.GetMessage().Contains("TokenLast", StringComparison.Ordinal));
         AssertInvokable(
             result,
             "TokenFirst",
@@ -66,7 +75,10 @@ public class RpcParameterFieldIdTests
 
         var result = await RunGenerator(code);
 
-        Assert.Empty(result.Diagnostics);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(DiagnosticRuleId.CancellationTokenNotLast, diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("Call", diagnostic.GetMessage(), StringComparison.Ordinal);
         AssertInvokable(
             result,
             "Call",

--- a/test/Orleans.Runtime.Internal.Tests/CancellationTests/SystemTargetCancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/CancellationTests/SystemTargetCancellationTokenTests.cs
@@ -104,7 +104,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
 
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
-        var task = systemTarget.LongWait(cts.Token, TimeSpan.FromSeconds(10), callId);
+        var task = systemTarget.LongWait(TimeSpan.FromSeconds(10), callId, cts.Token);
         cts.CancelAfter(delay);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         if (delay > 0)
@@ -128,7 +128,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
 
         var tasks = systemTargets.Select(st =>
             Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                st.LongWait(cts.Token, TimeSpan.FromSeconds(10), callId)))
+                st.LongWait(TimeSpan.FromSeconds(10), callId, cts.Token)))
             .ToList();
 
         cts.CancelAfter(delay);
@@ -162,7 +162,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
             {
                 using var cts = new CancellationTokenSource();
                 // All these calls run concurrently since SystemTarget calls are interleaving
-                var task = systemTarget.LongWait(cts.Token, TimeSpan.FromSeconds(10), callId);
+                var task = systemTarget.LongWait(TimeSpan.FromSeconds(10), callId, cts.Token);
                 cts.CancelAfter(delay);
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
             })
@@ -187,7 +187,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         using var cts = new CancellationTokenSource();
         try
         {
-            await systemTarget.LongWait(cts.Token, TimeSpan.FromMilliseconds(1), Guid.Empty);
+            await systemTarget.LongWait(TimeSpan.FromMilliseconds(1), Guid.Empty, cts.Token);
         }
         catch (Exception ex)
         {
@@ -206,7 +206,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
 
         // Expect an OperationCanceledException to be thrown as the token is already cancelled
         Assert.Throws<OperationCanceledException>(() =>
-            systemTarget.LongWait(cts.Token, TimeSpan.FromSeconds(10), Guid.Empty).Ignore());
+            systemTarget.LongWait(TimeSpan.FromSeconds(10), Guid.Empty, cts.Token).Ignore());
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -218,7 +218,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
 
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
-        var task = systemTarget.CancellationTokenCallbackResolve(cts.Token, callId);
+        var task = systemTarget.CancellationTokenCallbackResolve(callId, cts.Token);
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
         if (WaitForCancellationAcknowledgement)
@@ -267,7 +267,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
 
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
-        systemTarget.CancellationTokenCallbackThrow(cts.Token, callId).Ignore();
+        systemTarget.CancellationTokenCallbackThrow(callId, cts.Token).Ignore();
         // Cancellation is a cooperative mechanism, so we don't expect the exception to propagate
         cts.CancelAfter(100);
         await WaitForCallCancellation(systemTarget, callId, cancellationToken);
@@ -340,7 +340,7 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
 
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
-        var task = sourceTarget.CallOtherLongRunningTask(target, cts.Token, TimeSpan.FromSeconds(10), callId);
+        var task = sourceTarget.CallOtherLongRunningTask(target, TimeSpan.FromSeconds(10), callId, cts.Token);
         cts.CancelAfter(delay);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
         if (delay > 0)
@@ -406,9 +406,9 @@ public abstract class SystemTargetCancellationTokenTests(SystemTargetCancellatio
         var callId2 = Guid.NewGuid();
         var callId3 = Guid.NewGuid();
 
-        var task1 = systemTarget.LongWait(cts1.Token, TimeSpan.FromSeconds(10), callId1);
-        var task2 = systemTarget.LongWait(cts2.Token, TimeSpan.FromSeconds(10), callId2);
-        var task3 = systemTarget.LongWait(cts3.Token, TimeSpan.FromSeconds(10), callId3);
+        var task1 = systemTarget.LongWait(TimeSpan.FromSeconds(10), callId1, cts1.Token);
+        var task2 = systemTarget.LongWait(TimeSpan.FromSeconds(10), callId2, cts2.Token);
+        var task3 = systemTarget.LongWait(TimeSpan.FromSeconds(10), callId3, cts3.Token);
 
         // Wait for all to be running
         await Task.Delay(100, cancellationToken);
@@ -461,7 +461,7 @@ internal sealed class CancellationTestSystemTarget : SystemTarget, ICancellation
     }
 
     /// <inheritdoc />
-    public async Task LongWait(CancellationToken cancellationToken, TimeSpan delay, Guid callId)
+    public async Task LongWait(TimeSpan delay, Guid callId, CancellationToken cancellationToken)
     {
         try
         {
@@ -475,22 +475,22 @@ internal sealed class CancellationTestSystemTarget : SystemTarget, ICancellation
     }
 
     /// <inheritdoc />
-    public async Task CallOtherLongRunningTask(ICancellationTestSystemTarget target, CancellationToken cancellationToken, TimeSpan delay, Guid callId)
+    public async Task CallOtherLongRunningTask(ICancellationTestSystemTarget target, TimeSpan delay, Guid callId, CancellationToken cancellationToken)
     {
-        await target.LongWait(cancellationToken, delay, callId);
+        await target.LongWait(delay, callId, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task CallOtherLongRunningTaskWithLocalCancellation(ICancellationTestSystemTarget target, TimeSpan delay, TimeSpan delayBeforeCancel, Guid callId)
     {
         using var cts = new CancellationTokenSource();
-        var task = target.LongWait(cts.Token, delay, callId);
+        var task = target.LongWait(delay, callId, cts.Token);
         cts.CancelAfter(delayBeforeCancel);
         await task;
     }
 
     /// <inheritdoc />
-    public Task<bool> CancellationTokenCallbackResolve(CancellationToken cancellationToken, Guid callId)
+    public Task<bool> CancellationTokenCallbackResolve(Guid callId, CancellationToken cancellationToken)
     {
         var tcs = new TaskCompletionSource<bool>();
         var orleansTs = TaskScheduler.Current;
@@ -516,13 +516,13 @@ internal sealed class CancellationTestSystemTarget : SystemTarget, ICancellation
     public async Task<bool> CallOtherCancellationTokenCallbackResolve(ICancellationTestSystemTarget target, Guid callId)
     {
         using var cts = new CancellationTokenSource();
-        var task = target.CancellationTokenCallbackResolve(cts.Token, callId);
+        var task = target.CancellationTokenCallbackResolve(callId, cts.Token);
         cts.CancelAfter(300);
         return await task;
     }
 
     /// <inheritdoc />
-    public async Task CancellationTokenCallbackThrow(CancellationToken cancellationToken, Guid callId)
+    public async Task CancellationTokenCallbackThrow(Guid callId, CancellationToken cancellationToken)
     {
         cancellationToken.Register(() =>
         {

--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -122,9 +122,9 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
                         observerReference,
                         cts.Token)
                     : grain.LongWaitInterleaving(
-                        cts.Token,
                         TimeSpan.FromSeconds(10),
-                        callIds[index]))
+                        callIds[index],
+                        cts.Token))
                 .ToArray();
             if (delay > 0)
             {
@@ -168,9 +168,9 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
                         observerReference,
                         cancellationSources[index].Token)
                     : grain.LongWaitInterleaving(
-                        cancellationSources[index].Token,
                         TimeSpan.FromSeconds(10),
-                        callId))
+                        callId,
+                        cancellationSources[index].Token))
                 .ToArray();
             if (delay > 0)
             {
@@ -208,7 +208,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         using var cts = new CancellationTokenSource();
         try
         {
-            await grain.LongWait(cts.Token, TimeSpan.FromMilliseconds(1), Guid.Empty);
+            await grain.LongWait(TimeSpan.FromMilliseconds(1), Guid.Empty, cts.Token);
         }
         catch (Exception ex)
         {
@@ -224,7 +224,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         await cts.CancelAsync();
 
         // Except a OperationCanceledException to be thrown as the token is already cancelled
-        Assert.Throws<OperationCanceledException>(() => grain.LongWait(cts.Token, TimeSpan.FromSeconds(10), Guid.Empty).Ignore());
+        Assert.Throws<OperationCanceledException>(() => grain.LongWait(TimeSpan.FromSeconds(10), Guid.Empty, cts.Token).Ignore());
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -233,7 +233,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         var grain = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
-        var grainTask = grain.CancellationTokenCallbackResolve(cts.Token, callId);
+        var grainTask = grain.CancellationTokenCallbackResolve(callId, cts.Token);
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
         if (fixture.WaitForCancellationAcknowledgement)
         {
@@ -274,7 +274,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         var grain = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
         using var cts = new CancellationTokenSource();
         var callId = Guid.NewGuid();
-        grain.CancellationTokenCallbackThrow(cts.Token, callId).Ignore();
+        grain.CancellationTokenCallbackThrow(callId, cts.Token).Ignore();
         // Cancellation is a cooperative mechanism, so we don't expect the exception to propagate
         cts.CancelAfter(100);
         await WaitForCallCancellation(grain, callId);
@@ -325,7 +325,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         var callId = Guid.NewGuid();
         if (delay == 0)
         {
-            var grainTask = grain.CallOtherLongRunningTask(target, cts.Token, TimeSpan.FromSeconds(10), callId);
+            var grainTask = grain.CallOtherLongRunningTask(target, TimeSpan.FromSeconds(10), callId, cts.Token);
             cts.CancelAfter(delay);
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
             return;
@@ -338,9 +338,9 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
             var grainTask = grain.CallOtherLongRunningTaskWithStartNotification(
                 target,
                 observerReference,
-                cts.Token,
                 TimeSpan.FromSeconds(10),
-                callId);
+                callId,
+                cts.Token);
             await observer.WaitForCallToStart(callId);
 
             cts.CancelAfter(delay);
@@ -477,7 +477,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         var callId = Guid.NewGuid();
         if (delay == 0)
         {
-            var grainTask = grain.LongWaitInterleaving(cts.Token, TimeSpan.FromSeconds(10), callId);
+            var grainTask = grain.LongWaitInterleaving(TimeSpan.FromSeconds(10), callId, cts.Token);
             cts.CancelAfter(delay);
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
             return;
@@ -516,7 +516,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         // Start a regular (non-interleaving) long-running request
         using var regularCts = new CancellationTokenSource();
         var regularCallId = Guid.NewGuid();
-        var regularTask = grain.LongWait(regularCts.Token, TimeSpan.FromSeconds(30), regularCallId);
+        var regularTask = grain.LongWait(TimeSpan.FromSeconds(30), regularCallId, regularCts.Token);
 
         // Wait for the regular request to start
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -524,7 +524,7 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         // Start an interleaving request (this should run concurrently)
         using var interleavingCts = new CancellationTokenSource();
         var interleavingCallId = Guid.NewGuid();
-        var interleavingTask = grain.LongWaitInterleaving(interleavingCts.Token, TimeSpan.FromSeconds(10), interleavingCallId);
+        var interleavingTask = grain.LongWaitInterleaving(TimeSpan.FromSeconds(10), interleavingCallId, interleavingCts.Token);
 
         // Wait a bit for the interleaving request to start
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -556,9 +556,9 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         var callId2 = Guid.NewGuid();
         var callId3 = Guid.NewGuid();
 
-        var task1 = grain.LongWaitInterleaving(cts1.Token, TimeSpan.FromSeconds(10), callId1);
-        var task2 = grain.LongWaitInterleaving(cts2.Token, TimeSpan.FromSeconds(10), callId2);
-        var task3 = grain.LongWaitInterleaving(cts3.Token, TimeSpan.FromSeconds(10), callId3);
+        var task1 = grain.LongWaitInterleaving(TimeSpan.FromSeconds(10), callId1, cts1.Token);
+        var task2 = grain.LongWaitInterleaving(TimeSpan.FromSeconds(10), callId2, cts2.Token);
+        var task3 = grain.LongWaitInterleaving(TimeSpan.FromSeconds(10), callId3, cts3.Token);
 
         // Wait for all to be running
         await Task.Delay(100, TestContext.Current.CancellationToken);


### PR DESCRIPTION
RPC invokable serialization derived field IDs from CLR parameter ordinals, so `CancellationToken` parameters consumed wire IDs and explicit parameter `[Id]` attributes were ignored.

This change assigns automatic IDs from serialized-parameter ordinals, applies explicit IDs as overrides, and keeps CLR argument ordering independent from wire-field numbering. Invalid cancellation-token IDs and field-ID collisions produce source-generator diagnostics at the offending parameter. A non-final `CancellationToken` parameter now produces warning `ORLEANS0113` while generation continues, guiding RPC declarations toward the established token-last convention.

The incremental proxy model includes explicit parameter IDs so attribute-only changes invalidate cached generator output. Existing test RPC declarations and call sites now place `CancellationToken` last.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11179)