### PR TITLE
fix(runtime): use messaging clock for callback expiry

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/ApplicationRequestInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/ApplicationRequestInstruments.cs
@@ -30,6 +30,8 @@ internal class ApplicationRequestInstruments
             _appRequestsLatencyHistogramAggregator.Record(durationMilliseconds);
     }
 
+    internal bool AppRequestsLatencyEnabled => _appRequestsLatencyHistogramSum.Enabled;
+
     internal void OnAppRequestsTimedOut(string grainType)
     {
         _timedOutRequestsCounter.Add(1, new KeyValuePair<string, object?>("grain_type", grainType));

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Orleans.Serialization.Invocation;
@@ -16,6 +15,7 @@ namespace Orleans.Runtime
         private readonly SharedCallbackData shared;
         private readonly IResponseCompletionSource context;
         private readonly ApplicationRequestInstruments _applicationRequestInstruments;
+        private readonly long _startTimestamp;
         private int _state;
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
@@ -31,6 +31,7 @@ namespace Orleans.Runtime
             this.context = ctx;
             this.Message = msg;
             _applicationRequestInstruments = applicationRequestInstruments;
+            _startTimestamp = shared.TimeProvider.GetTimestamp();
             this.stopwatch = ValueStopwatch.StartNew();
         }
 
@@ -87,19 +88,19 @@ namespace Orleans.Runtime
 
         public bool IsExpired(long currentTimestamp)
         {
-            var duration = currentTimestamp - this.stopwatch.GetRawTimestamp();
-            return duration > GetResponseTimeoutStopwatchTicks();
+            var duration = currentTimestamp - _startTimestamp;
+            return duration > GetResponseTimeoutTimestampTicks();
         }
 
-        private long GetResponseTimeoutStopwatchTicks()
+        private long GetResponseTimeoutTimestampTicks()
         {
             var defaultResponseTimeout = (Message.BodyObject as IInvokable)?.GetDefaultResponseTimeout();
             if (defaultResponseTimeout.HasValue)
             {
-                return (long)(defaultResponseTimeout.Value.TotalSeconds * Stopwatch.Frequency);
+                return shared.GetTimestampTicks(defaultResponseTimeout.Value);
             }
 
-            return shared.ResponseTimeoutStopwatchTicks;
+            return shared.ResponseTimeoutTimestampTicks;
         }
 
         private TimeSpan GetResponseTimeout() => (Message.BodyObject as IInvokable)?.GetDefaultResponseTimeout() ?? shared.ResponseTimeout;

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -126,10 +126,9 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var elapsedMilliseconds = GetElapsedMilliseconds();
+            RecordElapsedTime();
             SignalCancellation();
             shared.Unregister(Message);
-            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
             _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
             OrleansCallBackDataEvent.Instance.OnCanceled(Message);
             context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
@@ -143,7 +142,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var elapsedMilliseconds = GetElapsedMilliseconds();
+            RecordElapsedTime();
             if (shared.CancelRequestOnTimeout)
             {
                 SignalCancellation();
@@ -151,7 +150,6 @@ namespace Orleans.Runtime
 
             this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
             _applicationRequestInstruments.OnAppRequestsTimedOut(GetTargetGrainType());
 
             OrleansCallBackDataEvent.Instance.OnTimeout(this.Message);
@@ -173,10 +171,9 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var elapsedMilliseconds = GetElapsedMilliseconds();
+            RecordElapsedTime();
             this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
 
             OrleansCallBackDataEvent.Instance.OnTargetSiloFail(this.Message);
             var msg = this.Message;
@@ -193,10 +190,9 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var elapsedMilliseconds = GetElapsedMilliseconds();
+            RecordElapsedTime();
             this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
 
             var msg = this.Message;
             var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
@@ -212,9 +208,8 @@ namespace Orleans.Runtime
 
             OrleansCallBackDataEvent.Instance.DoCallback(this.Message);
 
-            var elapsedMilliseconds = GetElapsedMilliseconds();
+            RecordElapsedTime();
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
             ResponseCallback(response, this.context);
@@ -222,8 +217,14 @@ namespace Orleans.Runtime
 
         private bool TryComplete() => (Interlocked.Or(ref _state, StateCompleted) & StateCompleted) == 0;
 
-        private long GetElapsedMilliseconds()
-            => (long)shared.TimeProvider.GetElapsedTime(_startTimestamp).TotalMilliseconds;
+        private void RecordElapsedTime()
+        {
+            if (_applicationRequestInstruments.AppRequestsLatencyEnabled)
+            {
+                var elapsedMilliseconds = (long)shared.TimeProvider.GetElapsedTime(_startTimestamp).TotalMilliseconds;
+                _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
+            }
+        }
 
         private void DisposeCancellationRegistration()
         {

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -18,7 +18,6 @@ namespace Orleans.Runtime
         private readonly long _startTimestamp;
         private int _state;
         private StatusResponse? lastKnownStatus;
-        private ValueStopwatch stopwatch;
         private CancellationTokenRegistration _cancellationTokenRegistration;
 
         public CallbackData(
@@ -32,7 +31,6 @@ namespace Orleans.Runtime
             this.Message = msg;
             _applicationRequestInstruments = applicationRequestInstruments;
             _startTimestamp = shared.TimeProvider.GetTimestamp();
-            this.stopwatch = ValueStopwatch.StartNew();
         }
 
         public Message Message { get; } // might hold metadata used by response pipeline
@@ -128,10 +126,10 @@ namespace Orleans.Runtime
                 return;
             }
 
-            stopwatch.Stop();
+            var elapsedMilliseconds = GetElapsedMilliseconds();
             SignalCancellation();
             shared.Unregister(Message);
-            _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
             _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
             OrleansCallBackDataEvent.Instance.OnCanceled(Message);
             context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
@@ -145,7 +143,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            this.stopwatch.Stop();
+            var elapsedMilliseconds = GetElapsedMilliseconds();
             if (shared.CancelRequestOnTimeout)
             {
                 SignalCancellation();
@@ -153,7 +151,7 @@ namespace Orleans.Runtime
 
             this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
             _applicationRequestInstruments.OnAppRequestsTimedOut(GetTargetGrainType());
 
             OrleansCallBackDataEvent.Instance.OnTimeout(this.Message);
@@ -175,10 +173,10 @@ namespace Orleans.Runtime
                 return;
             }
 
-            this.stopwatch.Stop();
+            var elapsedMilliseconds = GetElapsedMilliseconds();
             this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
 
             OrleansCallBackDataEvent.Instance.OnTargetSiloFail(this.Message);
             var msg = this.Message;
@@ -195,10 +193,10 @@ namespace Orleans.Runtime
                 return;
             }
 
-            this.stopwatch.Stop();
+            var elapsedMilliseconds = GetElapsedMilliseconds();
             this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
 
             var msg = this.Message;
             var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
@@ -214,15 +212,18 @@ namespace Orleans.Runtime
 
             OrleansCallBackDataEvent.Instance.DoCallback(this.Message);
 
-            this.stopwatch.Stop();
+            var elapsedMilliseconds = GetElapsedMilliseconds();
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd(elapsedMilliseconds);
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
             ResponseCallback(response, this.context);
         }
 
         private bool TryComplete() => (Interlocked.Or(ref _state, StateCompleted) & StateCompleted) == 0;
+
+        private long GetElapsedMilliseconds()
+            => (long)shared.TimeProvider.GetElapsedTime(_startTimestamp).TotalMilliseconds;
 
         private void DisposeCancellationRegistration()
         {

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -99,6 +99,7 @@ namespace Orleans
             this.sharedCallbackData = new SharedCallbackData(
                 msg => this.UnregisterCallback(msg.Id),
                 this.loggerFactory.CreateLogger<CallbackData>(),
+                timeProvider,
                 this.clientMessagingOptions.ResponseTimeout,
                 this.clientMessagingOptions.CancelRequestOnTimeout,
                 this.clientMessagingOptions.WaitForCancellationAcknowledgement,
@@ -519,7 +520,7 @@ namespace Orleans
             {
                 try
                 {
-                    var currentStopwatchTicks = ValueStopwatch.GetTimestamp();
+                    var currentTimestamp = TimeProvider.GetTimestamp();
                     foreach (var (_, callback) in callbacks)
                     {
                         if (callback.IsCompleted)
@@ -527,7 +528,7 @@ namespace Orleans
                             continue;
                         }
 
-                        if (callback.IsExpired(currentStopwatchTicks))
+                        if (callback.IsExpired(currentTimestamp))
                         {
                             callback.OnTimeout();
                         }

--- a/src/Orleans.Core/Runtime/SharedCallbackData.cs
+++ b/src/Orleans.Core/Runtime/SharedCallbackData.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Orleans.Runtime;
@@ -8,12 +7,14 @@ internal sealed class SharedCallbackData
 {
     public readonly Action<Message> Unregister;
     public readonly ILogger Logger;
+    public readonly TimeProvider TimeProvider;
     private TimeSpan _responseTimeout;
-    public long ResponseTimeoutStopwatchTicks;
+    public long ResponseTimeoutTimestampTicks;
 
     public SharedCallbackData(
         Action<Message> unregister,
         ILogger logger,
+        TimeProvider timeProvider,
         TimeSpan responseTimeout,
         bool cancelOnTimeout,
         bool waitForCancellationAcknowledgement,
@@ -21,6 +22,7 @@ internal sealed class SharedCallbackData
     {
         Unregister = unregister;
         Logger = logger;
+        TimeProvider = timeProvider;
         ResponseTimeout = responseTimeout;
         CancelRequestOnTimeout = cancelOnTimeout;
         WaitForCancellationAcknowledgement = waitForCancellationAcknowledgement;
@@ -33,9 +35,11 @@ internal sealed class SharedCallbackData
         set
         {
             _responseTimeout = value;
-            ResponseTimeoutStopwatchTicks = (long)(value.TotalSeconds * Stopwatch.Frequency);
+            ResponseTimeoutTimestampTicks = GetTimestampTicks(value);
         }
     }
+
+    public long GetTimestampTicks(TimeSpan duration) => (long)(duration.TotalSeconds * TimeProvider.TimestampFrequency);
 
     public IGrainCallCancellationManager? CancellationManager { get; internal set; }
 

--- a/src/Orleans.Core/Runtime/SharedCallbackData.cs
+++ b/src/Orleans.Core/Runtime/SharedCallbackData.cs
@@ -39,7 +39,8 @@ internal sealed class SharedCallbackData
         }
     }
 
-    public long GetTimestampTicks(TimeSpan duration) => (long)(duration.TotalSeconds * TimeProvider.TimestampFrequency);
+    public long GetTimestampTicks(TimeSpan duration)
+        => (long)((Int128)duration.Ticks * TimeProvider.TimestampFrequency / TimeSpan.TicksPerSecond);
 
     public IGrainCallCancellationManager? CancellationManager { get; internal set; }
 

--- a/src/Orleans.Core/Runtime/SharedCallbackData.cs
+++ b/src/Orleans.Core/Runtime/SharedCallbackData.cs
@@ -40,7 +40,20 @@ internal sealed class SharedCallbackData
     }
 
     public long GetTimestampTicks(TimeSpan duration)
-        => (long)((Int128)duration.Ticks * TimeProvider.TimestampFrequency / TimeSpan.TicksPerSecond);
+    {
+        var timestampTicks = (Int128)duration.Ticks * TimeProvider.TimestampFrequency / TimeSpan.TicksPerSecond;
+        if (timestampTicks > long.MaxValue)
+        {
+            return long.MaxValue;
+        }
+
+        if (timestampTicks < long.MinValue)
+        {
+            return long.MinValue;
+        }
+
+        return (long)timestampTicks;
+    }
 
     public IGrainCallCancellationManager? CancellationManager { get; internal set; }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -90,6 +90,7 @@ namespace Orleans.Runtime
             this.sharedCallbackData = new SharedCallbackData(
                 msg => this.UnregisterCallback(msg.SendingGrain, msg.Id),
                 callbackDataLogger,
+                timeProvider,
                 this.messagingOptions.ResponseTimeout,
                 this.messagingOptions.CancelRequestOnTimeout,
                 this.messagingOptions.WaitForCancellationAcknowledgement,
@@ -98,6 +99,7 @@ namespace Orleans.Runtime
             this.systemSharedCallbackData = new SharedCallbackData(
                 msg => this.UnregisterCallback(msg.SendingGrain, msg.Id),
                 callbackDataLogger,
+                timeProvider,
                 this.messagingOptions.SystemResponseTimeout,
                 cancelOnTimeout: false,
                 waitForCancellationAcknowledgement: this.messagingOptions.WaitForCancellationAcknowledgement,
@@ -624,7 +626,7 @@ namespace Orleans.Runtime
             {
                 try
                 {
-                    var currentStopwatchTicks = ValueStopwatch.GetTimestamp();
+                    var currentTimestamp = TimeProvider.GetTimestamp();
                     foreach (var (_, callback) in callbacks)
                     {
                         if (callback.IsCompleted)
@@ -632,7 +634,7 @@ namespace Orleans.Runtime
                             continue;
                         }
 
-                        if (callback.IsExpired(currentStopwatchTicks))
+                        if (callback.IsExpired(currentTimestamp))
                         {
                             callback.OnTimeout();
                         }

--- a/test/Orleans.DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/HostedClientTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Orleans.Concurrency;
 using Orleans.Configuration;
 using Orleans.Internal;
@@ -31,11 +32,13 @@ namespace DefaultCluster.Tests.General
     {
         private readonly TimeSpan _timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(10);
         private readonly IHost _host;
+        private readonly FakeTimeProvider _messagingTimeProvider;
 
         public class Fixture : IAsyncLifetime
         {
             private readonly TestClusterPortAllocator portAllocator;
             public IHost Host { get; private set; } = null!;
+            public FakeTimeProvider MessagingTimeProvider { get; } = new();
 
             public Fixture()
             {
@@ -46,21 +49,22 @@ namespace DefaultCluster.Tests.General
             {
                 var cancellationToken = TestContext.Current.CancellationToken;
                 var (siloPort, gatewayPort) = portAllocator.AllocateConsecutivePortPairs(1);
-                Host = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder()
-                    .UseOrleans(siloBuilder =>
-                    {
-                        siloBuilder
-                            .UseLocalhostClustering(siloPort, gatewayPort)
-                            .Configure<ClusterOptions>(options =>
-                            {
-                                options.ClusterId = Guid.NewGuid().ToString();
-                                options.ServiceId = Guid.NewGuid().ToString();
-                            })
-                            .ConfigureLogging(logging => logging.AddDebug())
-                            .AddMemoryGrainStorage("PubSubStore")
-                            .AddMemoryStreams<DefaultMemoryMessageBodySerializer>("MemStream");
-                    })
-                    .Build();
+                var builder = Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder();
+                builder.UseOrleans(siloBuilder =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering(siloPort, gatewayPort)
+                        .Configure<ClusterOptions>(options =>
+                        {
+                            options.ClusterId = Guid.NewGuid().ToString();
+                            options.ServiceId = Guid.NewGuid().ToString();
+                        })
+                        .ConfigureLogging(logging => logging.AddDebug())
+                        .AddMemoryGrainStorage("PubSubStore")
+                        .AddMemoryStreams<DefaultMemoryMessageBodySerializer>("MemStream");
+                });
+                builder.Services.AddKeyedSingleton(TimeProviderNames.Messaging, MessagingTimeProvider);
+                Host = builder.Build();
                 await Host.StartAsync(cancellationToken);
             }
 
@@ -82,6 +86,7 @@ namespace DefaultCluster.Tests.General
         public HostedClientTests(Fixture fixture)
         {
             _host = fixture.Host;
+            _messagingTimeProvider = fixture.MessagingTimeProvider;
         }
 
         /// <summary>
@@ -118,31 +123,25 @@ namespace DefaultCluster.Tests.General
             var initialTimeout = runtimeClient.GetResponseTimeout();
 
             var timeout = TimeSpan.FromSeconds(1);
-            var maxTimeout = timeout.Multiply(3.5);
 
             try
             {
                 runtimeClient.SetResponseTimeout(timeout);
-                var stopwatch = Stopwatch.StartNew();
-
                 var assertionTask = Assert.ThrowsAsync<TimeoutException>(
-                        async () =>
-                        {
-                            var grain = client.GetGrain<IStuckGrain>(Guid.NewGuid());
-                            await grain.RunForever();
-                        })
-                    .WaitAsync(maxTimeout, cancellationToken);
+                    async () =>
+                    {
+                        var grain = client.GetGrain<IStuckGrain>(Guid.NewGuid());
+                        await grain.RunForever();
+                    });
 
+                Assert.False(assertionTask.IsCompleted);
                 Assert.Equal(expected: 1, actual: runtimeClient.GetRunningRequestsCount(stuckGrainType));
 
-                await assertionTask;
-                stopwatch.Stop();
+                // Callback expiry is checked at least once per second.
+                _messagingTimeProvider.Advance(timeout + TimeSpan.FromSeconds(1));
+                await assertionTask.WaitAsync(cancellationToken);
 
                 Assert.Equal(expected: 0, actual: runtimeClient.GetRunningRequestsCount(stuckGrainType));
-
-                Assert.True(stopwatch.Elapsed >= timeout, $"Waited less than {timeout}. Waited {stopwatch.Elapsed}");
-                Assert.True(stopwatch.Elapsed <= maxTimeout, $"Waited longer than {maxTimeout}. Waited {stopwatch.Elapsed}");
-                stopwatch.Stop();
             }
             finally
             {

--- a/test/Orleans.DefaultCluster.Tests/HostedClientTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/HostedClientTests.cs
@@ -63,7 +63,7 @@ namespace DefaultCluster.Tests.General
                         .AddMemoryGrainStorage("PubSubStore")
                         .AddMemoryStreams<DefaultMemoryMessageBodySerializer>("MemStream");
                 });
-                builder.Services.AddKeyedSingleton(TimeProviderNames.Messaging, MessagingTimeProvider);
+                builder.Services.AddKeyedSingleton<TimeProvider>(TimeProviderNames.Messaging, MessagingTimeProvider);
                 Host = builder.Build();
                 await Host.StartAsync(cancellationToken);
             }

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -104,6 +104,21 @@ public class CallbackDataTests
         Assert.True(callback.IsExpired(timeProvider.GetTimestamp()));
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void TimestampConversionClampsToLongRange()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var shared = CreateSharedCallbackData(
+            _ => { },
+            new HighFrequencyTimeProvider(),
+            TimeSpan.Zero);
+
+        Assert.Equal(long.MaxValue, shared.GetTimestampTicks(TimeSpan.MaxValue));
+        Assert.Equal(long.MinValue, shared.GetTimestampTicks(TimeSpan.MinValue));
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
@@ -122,16 +137,25 @@ public class CallbackDataTests
         TimeProvider? timeProvider = null,
         TimeSpan? responseTimeout = null)
     {
-        var shared = new SharedCallbackData(
+        var shared = CreateSharedCallbackData(
+            unregister,
+            timeProvider ?? TimeProvider.System,
+            responseTimeout ?? TimeSpan.FromMinutes(1));
+        return new CallbackData(shared, completion, new Message(), instruments);
+    }
+
+    private static SharedCallbackData CreateSharedCallbackData(
+        Action<Message> unregister,
+        TimeProvider timeProvider,
+        TimeSpan responseTimeout)
+        => new(
             unregister,
             logger: NullLogger<CallbackData>.Instance,
-            timeProvider: timeProvider ?? TimeProvider.System,
-            responseTimeout: responseTimeout ?? TimeSpan.FromMinutes(1),
+            timeProvider,
+            responseTimeout,
             cancelOnTimeout: false,
             waitForCancellationAcknowledgement: false,
             cancellationManager: null);
-        return new CallbackData(shared, completion, new Message(), instruments);
-    }
 
     private static ServiceProvider CreateServiceProvider()
     {
@@ -150,5 +174,10 @@ public class CallbackDataTests
         public void Complete(Response value) => Response = value;
 
         public void Complete() => Response = Orleans.Serialization.Invocation.Response.Completed;
+    }
+
+    private sealed class HighFrequencyTimeProvider : TimeProvider
+    {
+        public override long TimestampFrequency => long.MaxValue;
     }
 }

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -80,6 +80,30 @@ public class CallbackDataTests
         Assert.True(callback.IsExpired(timeProvider.GetTimestamp()));
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void TimestampConversionPreservesTimeSpanPrecision()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var timeProvider = new FakeTimeProvider();
+        var timeout = TimeSpan.FromTicks((1L << 53) + 1);
+        var callback = CreateCallback(
+            new TestResponseCompletionSource(),
+            _ => { },
+            CreateInstruments(serviceProvider),
+            timeProvider,
+            timeout);
+
+        Assert.False(callback.IsExpired(timeProvider.GetTimestamp()));
+
+        timeProvider.Advance(timeout);
+        Assert.False(callback.IsExpired(timeProvider.GetTimestamp()));
+
+        timeProvider.Advance(TimeSpan.FromTicks(1));
+        Assert.True(callback.IsExpired(timeProvider.GetTimestamp()));
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -119,6 +119,26 @@ public class CallbackDataTests
         Assert.Equal(long.MinValue, shared.GetTimestampTicks(TimeSpan.MinValue));
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void DisabledLatencyDiagnosticsDoNotReadCompletionTimestamp()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var timeProvider = new CountingTimeProvider();
+        var callback = CreateCallback(
+            new TestResponseCompletionSource(),
+            _ => { },
+            CreateInstruments(serviceProvider),
+            timeProvider);
+
+        Assert.Equal(1, timeProvider.GetTimestampCallCount);
+
+        callback.OnHostShutdown();
+
+        Assert.Equal(1, timeProvider.GetTimestampCallCount);
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
@@ -179,5 +199,12 @@ public class CallbackDataTests
     private sealed class HighFrequencyTimeProvider : TimeProvider
     {
         public override long TimestampFrequency => long.MaxValue;
+    }
+
+    private sealed class CountingTimeProvider : TimeProvider
+    {
+        public int GetTimestampCallCount { get; private set; }
+
+        public override long GetTimestamp() => ++GetTimestampCallCount;
     }
 }

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Orleans.Runtime;
 using Orleans.Serialization.Invocation;
 using Xunit;
@@ -55,6 +56,30 @@ public class CallbackDataTests
         GC.KeepAlive(cancellation);
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void ExpirationUsesConfiguredTimeProvider()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var timeProvider = new FakeTimeProvider();
+        var timeout = TimeSpan.FromSeconds(1);
+        var callback = CreateCallback(
+            new TestResponseCompletionSource(),
+            _ => { },
+            CreateInstruments(serviceProvider),
+            timeProvider,
+            timeout);
+
+        Assert.False(callback.IsExpired(timeProvider.GetTimestamp()));
+
+        timeProvider.Advance(timeout);
+        Assert.False(callback.IsExpired(timeProvider.GetTimestamp()));
+
+        timeProvider.Advance(TimeSpan.FromTicks(1));
+        Assert.True(callback.IsExpired(timeProvider.GetTimestamp()));
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
@@ -69,12 +94,15 @@ public class CallbackDataTests
     private static CallbackData CreateCallback(
         IResponseCompletionSource completion,
         Action<Message> unregister,
-        ApplicationRequestInstruments instruments)
+        ApplicationRequestInstruments instruments,
+        TimeProvider? timeProvider = null,
+        TimeSpan? responseTimeout = null)
     {
         var shared = new SharedCallbackData(
             unregister,
             logger: NullLogger<CallbackData>.Instance,
-            responseTimeout: TimeSpan.FromMinutes(1),
+            timeProvider: timeProvider ?? TimeProvider.System,
+            responseTimeout: responseTimeout ?? TimeSpan.FromMinutes(1),
             cancelOnTimeout: false,
             waitForCancellationAcknowledgement: false,
             cancellationManager: null);


### PR DESCRIPTION
Fixes #11151.

`HostedClient_TimeoutTest` assumed the callback expiry monitor would process a one-second timeout within a 3.5-second wall-clock guard. Loaded Windows runners can delay the monitor beyond that guard even though the runtime remains healthy.

Callback expiry timers already resolve the keyed messaging `TimeProvider`, but callback age was measured independently with `Stopwatch`. This change makes callback registration, timeout conversion, and expiry scans use the same messaging clock for hosted and external clients. Production retains the system clock, while tests can drive the full timeout lifecycle deterministically.

The hosted-client regression test now installs a messaging `FakeTimeProvider`, advances through the timeout and scan interval, and verifies both timeout delivery and callback removal. A focused callback test covers the configured clock and timeout boundary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11180)