### PR TITLE
test(runtime): derive one-way topology from directory owner

### DIFF
--- a/test/Grains/TestGrainInterfaces/ITestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITestGrain.cs
@@ -71,7 +71,7 @@ namespace UnitTests.GrainInterfaces
 
         Task<bool> NotifyOtherGrainValueTask(IOneWayGrain otherGrain);
 
-        Task<IOneWayGrain> GetOtherGrain(SiloAddress targetSilo, SiloAddress directorySilo);
+        Task<IOneWayGrain> GetOtherGrain(IOneWayGrain candidate, SiloAddress targetSilo);
 
         Task NotifyOtherGrain();
 

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -209,7 +209,6 @@ namespace UnitTests.Grains
 
     internal class OneWayGrain : Grain, IOneWayGrain, ISimpleGrainObserver
     {
-        private const int MaxTopologyCandidateCount = 1_000;
         private readonly string _id = Guid.NewGuid().ToString();
         private int count;
         private TaskCompletionSource<int> countChanged = CreateCountChangedSource();
@@ -259,7 +258,7 @@ namespace UnitTests.Grains
             return completedSynchronously;
         }
 
-        public async Task<IOneWayGrain> GetOtherGrain(SiloAddress targetSilo, SiloAddress directorySilo)
+        public async Task<IOneWayGrain> GetOtherGrain(IOneWayGrain candidate, SiloAddress targetSilo)
         {
             if (this.other is not null)
             {
@@ -267,11 +266,14 @@ namespace UnitTests.Grains
             }
 
             var thisSilo = this.LocalSiloDetails.SiloAddress;
+            var grainId = ((GrainReference)candidate).GrainId;
+            var directorySilo = this.LocalGrainDirectory.GetPrimaryForGrain(grainId);
             var activeSilos = ServiceProvider.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members
                 .Where(member => member.Value.Status == SiloStatus.Active)
                 .Select(member => member.Key)
                 .ToHashSet();
-            if (targetSilo.Equals(thisSilo)
+            if (directorySilo is null
+                || targetSilo.Equals(thisSilo)
                 || directorySilo.Equals(thisSilo)
                 || targetSilo.Equals(directorySilo)
                 || !activeSilos.Contains(targetSilo)
@@ -283,42 +285,24 @@ namespace UnitTests.Grains
                     + $"active silos: {string.Join(", ", activeSilos.Order())}.");
             }
 
-            for (var candidateIndex = 0; candidateIndex < MaxTopologyCandidateCount; candidateIndex++)
+            RequestContext.Set(IPlacementDirector.PlacementHintKey, targetSilo);
+            try
             {
-                var candidate = this.GrainFactory.GetGrain<IOneWayGrain>(CreateTopologyCandidateKey(candidateIndex));
-                var grainId = ((GrainReference)candidate).GrainId;
-                if (!directorySilo.Equals(this.LocalGrainDirectory.GetPrimaryForGrain(grainId)))
+                var actualTargetSilo = await candidate.GetSiloAddress();
+                if (!targetSilo.Equals(actualTargetSilo))
                 {
-                    continue;
+                    throw new InvalidOperationException(
+                        $"The one-way target grain was placed on {actualTargetSilo} instead of {targetSilo}. "
+                        + $"Caller: {thisSilo}, directory: {directorySilo}, grain: {grainId}.");
                 }
 
-                RequestContext.Set(IPlacementDirector.PlacementHintKey, targetSilo);
-                try
-                {
-                    var actualTargetSilo = await candidate.GetSiloAddress();
-                    if (!targetSilo.Equals(actualTargetSilo))
-                    {
-                        throw new InvalidOperationException(
-                            $"The one-way target grain was placed on {actualTargetSilo} instead of {targetSilo}. "
-                            + $"Caller: {thisSilo}, directory: {directorySilo}, grain: {grainId}.");
-                    }
-
-                    return this.other = candidate;
-                }
-                finally
-                {
-                    RequestContext.Remove(IPlacementDirector.PlacementHintKey);
-                }
+                return this.other = candidate;
             }
-
-            throw new InvalidOperationException(
-                $"Could not select a one-way target grain owned by directory silo {directorySilo} "
-                + $"after checking {MaxTopologyCandidateCount} deterministic grain ids. "
-                + $"Caller: {thisSilo}, target: {targetSilo}.");
+            finally
+            {
+                RequestContext.Remove(IPlacementDirector.PlacementHintKey);
+            }
         }
-
-        private static Guid CreateTopologyCandidateKey(int candidateIndex) =>
-            new(candidateIndex, 0x1133, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
         public Task<string> GetActivationId()
         {

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -266,7 +266,7 @@ namespace UnitTests.Grains
             }
 
             var thisSilo = this.LocalSiloDetails.SiloAddress;
-            var grainId = ((GrainReference)candidate).GrainId;
+            var grainId = candidate.GetGrainId();
             var directorySilo = this.LocalGrainDirectory.GetPrimaryForGrain(grainId);
             var activeSilos = ServiceProvider.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members
                 .Where(member => member.Value.Status == SiloStatus.Active)

--- a/test/Orleans.Runtime.Tests/OneWayDeactivationTests.cs
+++ b/test/Orleans.Runtime.Tests/OneWayDeactivationTests.cs
@@ -54,10 +54,20 @@ namespace UnitTests.General
         [Fact]
         public async Task OneWay_Deactivation_CacheInvalidated()
         {
-            var directoryCache = ((InProcessSiloHandle)_fixture.HostedCluster.Primary!).SiloHost.Services.GetRequiredService<TestDirectoryCache>();
-            var callerSilo = _fixture.HostedCluster.Primary.SiloAddress;
-            var targetSilo = _fixture.HostedCluster.SecondarySilos[0].SiloAddress;
-            var directorySilo = _fixture.HostedCluster.SecondarySilos[1].SiloAddress;
+            var grainToDeactivate = _fixture.Client.GetGrain<IOneWayGrain>(new Guid("00000000-1133-0000-0000-000000000000"));
+            var grainId = grainToDeactivate.GetGrainId();
+            var topologyView = ((InProcessSiloHandle)_fixture.HostedCluster.Primary!).SiloHost.Services.GetRequiredService<ILocalGrainDirectory>();
+            var directorySilo = Assert.IsType<SiloAddress>(topologyView.GetPrimaryForGrain(grainId));
+            var nonDirectorySilos = _fixture.HostedCluster.Silos
+                .Where(silo => !directorySilo.Equals(silo.SiloAddress))
+                .OrderBy(silo => silo.SiloAddress)
+                .ToArray();
+            Assert.Equal(2, nonDirectorySilos.Length);
+
+            var caller = (InProcessSiloHandle)nonDirectorySilos[0];
+            var callerSilo = caller.SiloAddress;
+            var targetSilo = nonDirectorySilos[1].SiloAddress;
+            var directoryCache = caller.SiloHost.Services.GetRequiredService<TestDirectoryCache>();
             var grainToCallFrom = _fixture.Client.GetGrain<IOneWayGrain>(new Guid("9e773e45-24e0-4e99-b630-6523f5f53b68"));
 
             RequestContext.Set(IPlacementDirector.PlacementHintKey, callerSilo);
@@ -72,11 +82,10 @@ namespace UnitTests.General
             }
 
             // Activate the grain & record its address.
-            var grainToDeactivate = await grainToCallFrom.GetOtherGrain(targetSilo, directorySilo);
+            grainToDeactivate = await grainToCallFrom.GetOtherGrain(grainToDeactivate, targetSilo);
             Assert.Equal(targetSilo, await grainToDeactivate.GetSiloAddress());
             Assert.Equal(directorySilo, await grainToDeactivate.GetPrimaryForGrain());
             var initialActivationId = await grainToDeactivate.GetActivationId();
-            var grainId = grainToDeactivate.GetGrainId();
             var activationAddress = directoryCache.Operations
                 .OfType<TestDirectoryCache.CacheOperation.AddOrUpdate>()
                 .Last(op => op.Value.GrainId.Equals(grainId))


### PR DESCRIPTION
## Problem

`OneWay_Deactivation_CacheInvalidated` preassigned a specific silo as the directory owner, then searched 1,000 deterministic grain IDs for one owned by that silo. A silo can own an arbitrarily small consistent-hash interval, so the bounded search could miss it and fail before exercising one-way cache invalidation.

## Solution

- select one fixed target grain and derive its directory owner from the active directory ring
- assign the caller and activation target to the other two silos
- pass the selected reference into the caller grain and retain strict assertions for directory ownership, placement, reactivation, and caller-cache updates

## Rationale

The topology now follows the directory ring's ownership invariant directly. Every role is distinct without probabilistic search, retries, or longer timeouts.

Fixes #11158
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11181)