### PR TITLE
fix(runtime): order ring range notifications

### DIFF
--- a/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/ConsistentRingProvider.cs
@@ -24,9 +24,8 @@ namespace Orleans.Runtime.ConsistentRing
         private readonly ILogger log;
         private bool isRunning;
         private readonly int myKey;
-        private readonly List<IRingRangeListener> statusListeners = new();
+        private readonly RingRangeListenerManager rangeChangeListeners;
         private readonly ISiloStatusOracle _siloStatusOracle;
-        private (IRingRange OldRange, IRingRange NewRange, bool Increased) lastNotification;
 
         public ConsistentRingProvider(SiloAddress siloAddr, ILoggerFactory loggerFactory, ISiloStatusOracle siloStatusOracle)
         {
@@ -36,7 +35,7 @@ namespace Orleans.Runtime.ConsistentRing
             myKey = MyAddress.GetConsistentHashCode();
 
             myRange = RangeFactory.CreateFullRange(); // i am responsible for the whole range
-            lastNotification = (myRange, myRange, true);
+            rangeChangeListeners = new(myRange);
 
             // add myself to the list of members
             AddServer(MyAddress);
@@ -71,6 +70,7 @@ namespace Orleans.Runtime.ConsistentRing
 
         internal void AddServer(SiloAddress silo)
         {
+            RingRangeListenerManager.NotificationWorkItem? notification = null;
             lock (membershipRingList)
             {
                 if (membershipRingList.Contains(silo)) return; // we already have this silo
@@ -95,10 +95,15 @@ namespace Orleans.Runtime.ConsistentRing
                 {
                     IRingRange oldRange = myRange;
                     myRange = RangeFactory.CreateRange(unchecked((uint)hash), unchecked((uint)myKey));
-                    NotifyLocalRangeSubscribers(oldRange, myRange, false);
+                    notification = PublishRangeChange(oldRange, myRange, false);
                 }
 
                 LogDebugAddedServer(log, new(silo), this);
+            }
+
+            if (notification is not null)
+            {
+                rangeChangeListeners.Dispatch(notification);
             }
         }
 
@@ -124,6 +129,7 @@ namespace Orleans.Runtime.ConsistentRing
 
         internal void RemoveServer(SiloAddress silo)
         {
+            RingRangeListenerManager.NotificationWorkItem? notification = null;
             lock (membershipRingList)
             {
                 int indexOfFailedSilo = membershipRingList.IndexOf(silo);
@@ -146,7 +152,6 @@ namespace Orleans.Runtime.ConsistentRing
                     if (membershipRingList.Count == 1) // i'm the only one left
                     {
                         myRange = RangeFactory.CreateFullRange();
-                        NotifyLocalRangeSubscribers(oldRange, myRange, true);
                     }
                     else
                     {
@@ -154,59 +159,38 @@ namespace Orleans.Runtime.ConsistentRing
                         int myPredecessorsHash = membershipRingList[myNewPredIndex].GetConsistentHashCode();
 
                         myRange = RangeFactory.CreateRange(unchecked((uint)myPredecessorsHash), unchecked((uint)myKey));
-                        NotifyLocalRangeSubscribers(oldRange, myRange, true);
                     }
+
+                    notification = PublishRangeChange(oldRange, myRange, true);
                 }
 
                 LogDebugRemovedServer(log, silo, new(silo), this);
             }
-        }
 
-        public bool SubscribeToRangeChangeEvents(IRingRangeListener observer)
-        {
-            (IRingRange OldRange, IRingRange NewRange, bool Increased) notification;
-            lock (statusListeners)
+            if (notification is not null)
             {
-                if (statusListeners.Contains(observer)) return false;
-
-                statusListeners.Add(observer);
-                notification = lastNotification;
-            }
-
-            observer.RangeChangeNotification(notification.OldRange, notification.NewRange, notification.Increased);
-            return true;
-        }
-
-        public bool UnSubscribeFromRangeChangeEvents(IRingRangeListener observer)
-        {
-            lock (statusListeners)
-            {
-                return statusListeners.Remove(observer);
+                rangeChangeListeners.Dispatch(notification);
             }
         }
 
-        private void NotifyLocalRangeSubscribers(IRingRange old, IRingRange now, bool increased)
+        public bool SubscribeToRangeChangeEvents(IRingRangeListener observer) => rangeChangeListeners.Subscribe(observer);
+
+        public bool UnSubscribeFromRangeChangeEvents(IRingRangeListener observer) => rangeChangeListeners.Unsubscribe(observer);
+
+        private RingRangeListenerManager.NotificationWorkItem PublishRangeChange(IRingRange old, IRingRange now, bool increased)
         {
             LogDebugNotifyLocalRangeSubscribers(log, old, now, increased);
-
-            IRingRangeListener[] copy;
-            lock (statusListeners)
-            {
-                lastNotification = (old, now, increased);
-                copy = statusListeners.ToArray();
-            }
-
-            foreach (IRingRangeListener listener in copy)
-            {
-                try
-                {
-                    listener.RangeChangeNotification(old, now, increased);
-                }
-                catch (Exception exc)
-                {
-                    LogWarningErrorNotifyingListener(log, exc, listener.GetType().FullName, increased ? "expansion" : "contraction", old, now);
-                }
-            }
+            return rangeChangeListeners.Publish(
+                old,
+                now,
+                increased,
+                (listener, exception) => LogWarningErrorNotifyingListener(
+                    log,
+                    exception,
+                    listener.GetType().FullName,
+                    increased ? "expansion" : "contraction",
+                    old,
+                    now));
         }
 
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)

--- a/src/Orleans.Runtime/ConsistentRing/RingRangeListenerManager.cs
+++ b/src/Orleans.Runtime/ConsistentRing/RingRangeListenerManager.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.ConsistentRing;
+
+internal sealed class RingRangeListenerManager(IRingRange initialRange)
+{
+    private readonly object _lock = new();
+    private readonly List<IRingRangeListener> _listeners = [];
+    private readonly Queue<NotificationWorkItem> _pendingNotifications = [];
+    private Notification _lastNotification = new(initialRange, initialRange, true);
+    private bool _isDispatching;
+    private int _dispatchThreadId;
+
+    public bool Subscribe(IRingRangeListener listener)
+    {
+        NotificationWorkItem notification;
+        lock (_lock)
+        {
+            if (_listeners.Contains(listener))
+            {
+                return false;
+            }
+
+            _listeners.Add(listener);
+            notification = new([listener], _lastNotification, onException: null);
+            _pendingNotifications.Enqueue(notification);
+        }
+
+        Dispatch(notification);
+        return true;
+    }
+
+    public bool Unsubscribe(IRingRangeListener listener)
+    {
+        lock (_lock)
+        {
+            return _listeners.Remove(listener);
+        }
+    }
+
+    public NotificationWorkItem Publish(
+        IRingRange oldRange,
+        IRingRange newRange,
+        bool increased,
+        Action<IRingRangeListener, Exception> onException)
+    {
+        NotificationWorkItem notification;
+        lock (_lock)
+        {
+            _lastNotification = new(oldRange, newRange, increased);
+            notification = new([.. _listeners], _lastNotification, onException);
+            _pendingNotifications.Enqueue(notification);
+        }
+
+        return notification;
+    }
+
+    public void Dispatch(NotificationWorkItem notification)
+    {
+        bool shouldDispatch;
+        bool shouldWait;
+        lock (_lock)
+        {
+            shouldDispatch = !_isDispatching;
+            if (shouldDispatch)
+            {
+                _isDispatching = true;
+                _dispatchThreadId = Environment.CurrentManagedThreadId;
+            }
+
+            shouldWait = !shouldDispatch && _dispatchThreadId != Environment.CurrentManagedThreadId;
+        }
+
+        if (shouldDispatch)
+        {
+            Drain();
+        }
+        else if (shouldWait)
+        {
+            notification.Wait();
+        }
+
+        if (shouldDispatch || shouldWait)
+        {
+            notification.Wait();
+        }
+    }
+
+    private void Drain()
+    {
+        while (true)
+        {
+            NotificationWorkItem notification;
+            lock (_lock)
+            {
+                if (_pendingNotifications.Count == 0)
+                {
+                    _isDispatching = false;
+                    _dispatchThreadId = 0;
+                    return;
+                }
+
+                notification = _pendingNotifications.Dequeue();
+            }
+
+            notification.Execute();
+        }
+    }
+
+    internal readonly record struct Notification(IRingRange OldRange, IRingRange NewRange, bool Increased);
+
+    internal sealed class NotificationWorkItem(
+        IRingRangeListener[] listeners,
+        Notification notification,
+        Action<IRingRangeListener, Exception>? onException)
+    {
+        private readonly TaskCompletionSource _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool IsCompleted => _completion.Task.IsCompleted;
+
+        public void Wait() => _completion.Task.GetAwaiter().GetResult();
+
+        public void Execute()
+        {
+            try
+            {
+                foreach (var listener in listeners)
+                {
+                    try
+                    {
+                        listener.RangeChangeNotification(
+                            notification.OldRange,
+                            notification.NewRange,
+                            notification.Increased);
+                    }
+                    catch (Exception exception) when (onException is not null)
+                    {
+                        onException(listener, exception);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                _completion.TrySetException(exception);
+                return;
+            }
+
+            _completion.TrySetResult();
+        }
+    }
+}

--- a/src/Orleans.Runtime/ConsistentRing/RingRangeListenerManager.cs
+++ b/src/Orleans.Runtime/ConsistentRing/RingRangeListenerManager.cs
@@ -77,10 +77,6 @@ internal sealed class RingRangeListenerManager(IRingRange initialRange)
         {
             Drain();
         }
-        else if (shouldWait)
-        {
-            notification.Wait();
-        }
 
         if (shouldDispatch || shouldWait)
         {

--- a/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
@@ -15,16 +15,15 @@ namespace Orleans.Runtime.ConsistentRing
     internal sealed partial class VirtualBucketsRingProvider :
         IConsistentRingProvider, ISiloStatusListener, IDisposable
     {
-        private readonly List<IRingRangeListener> statusListeners = new();
         private readonly SortedDictionary<uint, SiloAddress> bucketsMap = new();
         private (uint Hash, SiloAddress SiloAddress)[] sortedBucketsList = null!; // flattened sorted bucket list for fast lock-free calculation of CalculateTargetSilo
         private readonly ILogger logger;
         private readonly SiloAddress myAddress;
         private readonly int numBucketsPerSilo;
         private readonly ISiloStatusOracle _siloStatusOracle;
+        private readonly RingRangeListenerManager rangeChangeListeners;
         private bool running;
         private IRingRange myRange;
-        private (IRingRange OldRange, IRingRange NewRange, bool Increased) lastNotification;
 
         internal VirtualBucketsRingProvider(SiloAddress siloAddress, ILoggerFactory loggerFactory, int numVirtualBuckets, ISiloStatusOracle siloStatusOracle, ConsistentRingInstruments consistentRingInstruments)
         {
@@ -38,7 +37,7 @@ namespace Orleans.Runtime.ConsistentRing
             myAddress = siloAddress;
             running = true;
             myRange = RangeFactory.CreateFullRange();
-            lastNotification = (myRange, myRange, true);
+            rangeChangeListeners = new(myRange);
 
             LogDebugStarting(logger, nameof(VirtualBucketsRingProvider), new(siloAddress));
 
@@ -73,55 +72,30 @@ namespace Orleans.Runtime.ConsistentRing
             }
         }
 
-        public bool SubscribeToRangeChangeEvents(IRingRangeListener observer)
-        {
-            (IRingRange OldRange, IRingRange NewRange, bool Increased) notification;
-            lock (statusListeners)
-            {
-                if (statusListeners.Contains(observer)) return false;
+        public bool SubscribeToRangeChangeEvents(IRingRangeListener observer) => rangeChangeListeners.Subscribe(observer);
 
-                notification = lastNotification;
-                statusListeners.Add(observer);
-            }
+        public bool UnSubscribeFromRangeChangeEvents(IRingRangeListener observer) => rangeChangeListeners.Unsubscribe(observer);
 
-            observer.RangeChangeNotification(notification.OldRange, notification.NewRange, notification.Increased);
-            return true;
-        }
-
-        public bool UnSubscribeFromRangeChangeEvents(IRingRangeListener observer)
-        {
-            lock (statusListeners)
-            {
-                return statusListeners.Remove(observer);
-            }
-        }
-
-        private void NotifyLocalRangeSubscribers(IRingRange old, IRingRange now, bool increased)
+        private RingRangeListenerManager.NotificationWorkItem PublishRangeChange(IRingRange old, IRingRange now, bool increased)
         {
             LogTraceNotifyLocalRangeSubscribers(logger, old, now, increased);
-
-            IRingRangeListener[] copy;
-            lock (statusListeners)
-            {
-                lastNotification = (old, now, increased);
-                copy = statusListeners.ToArray();
-            }
-            foreach (IRingRangeListener listener in copy)
-            {
-                try
-                {
-                    listener.RangeChangeNotification(old, now, increased);
-                }
-                catch (Exception exc)
-                {
-                    LogWarningErrorNotifyingListener(logger, exc, listener.GetType().FullName, increased ? "expansion" : "contraction", old, now);
-                }
-            }
+            return rangeChangeListeners.Publish(
+                old,
+                now,
+                increased,
+                (listener, exception) => LogWarningErrorNotifyingListener(
+                    logger,
+                    exception,
+                    listener.GetType().FullName,
+                    increased ? "expansion" : "contraction",
+                    old,
+                    now));
         }
 
         private void AddServer(SiloAddress silo)
         {
             var hashes = silo.GetUniformHashCodes(numBucketsPerSilo);
+            RingRangeListenerManager.NotificationWorkItem notification;
             lock (bucketsMap)
             {
                 foreach (var hash in hashes)
@@ -138,12 +112,15 @@ namespace Orleans.Runtime.ConsistentRing
                 var myNewRange = UpdateRange();
                 LogTraceAddedServer(logger, new(silo), this);
 
-                NotifyLocalRangeSubscribers(myOldRange, myNewRange, true);
+                notification = PublishRangeChange(myOldRange, myNewRange, true);
             }
+
+            rangeChangeListeners.Dispatch(notification);
         }
 
         private void RemoveServer(SiloAddress silo)
         {
+            RingRangeListenerManager.NotificationWorkItem notification;
             lock (bucketsMap)
             {
                 if (!bucketsMap.ContainsValue(silo)) return; // we have already removed this silo
@@ -165,8 +142,10 @@ namespace Orleans.Runtime.ConsistentRing
 
                 LogTraceRemovedServer(logger, new(silo), this);
 
-                NotifyLocalRangeSubscribers(myOldRange, myNewRange, true);
+                notification = PublishRangeChange(myOldRange, myNewRange, true);
             }
+
+            rangeChangeListeners.Dispatch(notification);
         }
 
         private IRingRange UpdateRange()

--- a/test/Orleans.Runtime.Internal.Tests/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LivenessTests/ConsistentRingProviderTests.cs
@@ -47,6 +47,44 @@ namespace UnitTests.LivenessTests
             }
         }
 
+        [Fact]
+        [TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Ring"), TestCategory("RingStandalone")]
+        public async Task RangeChangeSubscription_ReplayPrecedesConcurrentUpdates()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var initialRange = RangeFactory.CreateFullRange();
+            var updatedRange = RangeFactory.CreateRange(0, 1);
+            var listeners = new RingRangeListenerManager(initialRange);
+            using var replayEntered = new ManualResetEventSlim();
+            using var releaseReplay = new ManualResetEventSlim();
+            using var updateEntered = new ManualResetEventSlim();
+            var listener = new BlockingRangeListener(replayEntered, releaseReplay, updateEntered);
+
+            var subscription = Task.Run(() => listeners.Subscribe(listener), cancellationToken);
+            Assert.True(replayEntered.Wait(TimeSpan.FromSeconds(10), cancellationToken));
+
+            var update = listeners.Publish(
+                initialRange,
+                updatedRange,
+                increased: false,
+                static (_, _) => { });
+            try
+            {
+                Assert.False(update.IsCompleted);
+                Assert.False(updateEntered.IsSet);
+            }
+            finally
+            {
+                releaseReplay.Set();
+            }
+
+            listeners.Dispatch(update);
+            await subscription.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+            Assert.True(updateEntered.IsSet);
+            Assert.Same(updatedRange, listener.LastRange);
+        }
+
         [Fact, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Ring"), TestCategory("RingStandalone")]
         public void ConsistentRingProvider_Test3()
         {
@@ -126,6 +164,31 @@ namespace UnitTests.LivenessTests
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<ConsistentRingInstruments>();
             return services.BuildServiceProvider().GetRequiredService<ConsistentRingInstruments>();
+        }
+
+        private sealed class BlockingRangeListener(
+            ManualResetEventSlim replayEntered,
+            ManualResetEventSlim releaseReplay,
+            ManualResetEventSlim updateEntered) : IRingRangeListener
+        {
+            private int _notificationCount;
+
+            public IRingRange? LastRange { get; private set; }
+
+            public void RangeChangeNotification(IRingRange old, IRingRange now, bool increased)
+            {
+                if (Interlocked.Increment(ref _notificationCount) == 1)
+                {
+                    replayEntered.Set();
+                    releaseReplay.Wait();
+                }
+                else
+                {
+                    updateEntered.Set();
+                }
+
+                LastRange = now;
+            }
         }
 
         internal sealed class FakeSiloStatusOracle : ISiloStatusOracle

--- a/test/Orleans.Runtime.Internal.Tests/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LivenessTests/ConsistentRingProviderTests.cs
@@ -61,28 +61,30 @@ namespace UnitTests.LivenessTests
             var listener = new BlockingRangeListener(replayEntered, releaseReplay, updateEntered);
 
             var subscription = Task.Run(() => listeners.Subscribe(listener), cancellationToken);
-            Assert.True(replayEntered.Wait(TimeSpan.FromSeconds(10), cancellationToken));
-
-            var update = listeners.Publish(
-                initialRange,
-                updatedRange,
-                increased: false,
-                static (_, _) => { });
             try
             {
+                Assert.True(replayEntered.Wait(TimeSpan.FromSeconds(10), cancellationToken));
+
+                var update = listeners.Publish(
+                    initialRange,
+                    updatedRange,
+                    increased: false,
+                    static (_, _) => { });
                 Assert.False(update.IsCompleted);
                 Assert.False(updateEntered.IsSet);
+
+                releaseReplay.Set();
+                listeners.Dispatch(update);
+                await subscription.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+
+                Assert.True(updateEntered.IsSet);
+                Assert.Same(updatedRange, listener.LastRange);
             }
             finally
             {
                 releaseReplay.Set();
+                await subscription.WaitAsync(TimeSpan.FromSeconds(10), CancellationToken.None);
             }
-
-            listeners.Dispatch(update);
-            await subscription.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
-
-            Assert.True(updateEntered.IsSet);
-            Assert.Same(updatedRange, listener.LastRange);
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Liveness"), TestCategory("Ring"), TestCategory("RingStandalone")]
@@ -180,7 +182,10 @@ namespace UnitTests.LivenessTests
                 if (Interlocked.Increment(ref _notificationCount) == 1)
                 {
                     replayEntered.Set();
-                    releaseReplay.Wait();
+                    if (!releaseReplay.Wait(TimeSpan.FromSeconds(10)))
+                    {
+                        throw new TimeoutException("Timed out waiting to release the initial ring-range replay notification.");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Problem

A consistent-ring listener could subscribe concurrently with a membership update and receive the current range notification before the older initial replay captured during subscription. The reminder service then applied the stale replay last, restoring a full-ring view and allowing two silos to schedule the same PostgreSQL reminder.

## Solution

Queue initial range replays and subsequent range-change broadcasts through one FIFO listener dispatcher shared by both ring implementations. Ring mutations publish notifications while their state lock is held, then dispatch callbacks after releasing that lock. This preserves causal notification order without invoking listeners under provider locks.

Add a deterministic regression test which blocks the initial replay, publishes a newer range, and verifies the newer notification remains queued and becomes the listener's final state.

## Rationale

The reminder ownership invariant depends on every local service applying ring ranges monotonically. Ordered publication ensures a listener cannot regress to an older ownership view, while callback dispatch remains lock-safe and preserves existing exception handling.

Fixes #11169

Related: #10612, #11109
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11182)