### PR TITLE
perf(dashboard): cache grain state JSON options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -758,6 +758,10 @@ dotnet_diagnostic.CA2246.severity = warning
 dotnet_diagnostic.IDE0035.severity = warning
 dotnet_diagnostic.IDE0043.severity = warning
 
+# Dashboard grain-state serialization reuses one serializer configuration.
+[src/Dashboard/Orleans.Dashboard/**.cs]
+dotnet_diagnostic.CA1869.severity = warning
+
 # Dashboard text handling explicitly distinguishes deterministic identifiers from localized display text.
 [src/Dashboard/Orleans.Dashboard/**/*.cs]
 dotnet_diagnostic.CA1305.severity = warning

--- a/src/Dashboard/Orleans.Dashboard/Implementation/Grains/DashboardGrain.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/Grains/DashboardGrain.cs
@@ -7,21 +7,26 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Orleans.Concurrency;
-using Orleans.Runtime;
-using Orleans.Serialization.Configuration;
+using Orleans.Dashboard.Core;
 using Orleans.Dashboard.Implementation.Helpers;
 using Orleans.Dashboard.Metrics.Details;
 using Orleans.Dashboard.Metrics.History;
 using Orleans.Dashboard.Metrics.TypeFormatting;
 using Orleans.Dashboard.Model;
 using Orleans.Dashboard.Model.History;
-using Orleans.Dashboard.Core;
+using Orleans.Runtime;
+using Orleans.Serialization.Configuration;
 
 namespace Orleans.Dashboard.Implementation.Grains;
 
 [Reentrant]
 internal sealed class DashboardGrain : Grain, IDashboardGrain
 {
+    private static readonly JsonSerializerOptions GrainStateSerializerOptions = new()
+    {
+        WriteIndented = true,
+    };
+
     private readonly TraceHistory _history;
     private readonly ISiloDetailsProvider _siloDetailsProvider;
     private readonly ISiloGrainClient _siloGrainClient;
@@ -391,10 +396,7 @@ internal sealed class DashboardGrain : Grain, IDashboardGrain
             result.TryAdd("error", error);
         }
 
-        return JsonSerializer.Serialize(result, options: new JsonSerializerOptions()
-        {
-            WriteIndented = true,
-        }).AsImmutable();
+        return JsonSerializer.Serialize(result, GrainStateSerializerOptions).AsImmutable();
     }
 
     public Task<Immutable<string[]>> GetGrainTypes(

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/DashboardGrainSerializationTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/DashboardGrainSerializationTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Orleans.Dashboard;
+using Orleans.Dashboard.Implementation.Grains;
+using Orleans.Serialization.Configuration;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Dashboard")]
+public class DashboardGrainSerializationTests
+{
+    private const string ExpectedUnknownGrainPayload = """
+        {
+          "error": "Unknown grain type \u0027UnitTests.UnknownGrain\u0027. (Parameter \u0027grainType\u0027)"
+        }
+        """;
+
+    [Fact]
+    public async Task GetGrainState_UnknownGrainType_PreservesIndentedJsonPayload()
+    {
+        var grain = CreateGrain();
+
+        var result = await grain.GetGrainState(
+            "42",
+            "UnitTests.UnknownGrain",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ExpectedUnknownGrainPayload.ReplaceLineEndings("\n"),
+            result.Value.ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public async Task GetGrainState_ConcurrentCalls_ReuseReadOnlySerializerOptions()
+    {
+        var serializerOptionsField = Assert.IsAssignableFrom<FieldInfo>(
+            typeof(DashboardGrain).GetField(
+                "GrainStateSerializerOptions",
+                BindingFlags.NonPublic | BindingFlags.Static));
+        var serializerOptions = Assert.IsType<JsonSerializerOptions>(serializerOptionsField.GetValue(null));
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = Enumerable.Range(0, 32).Select(async _ =>
+        {
+            await start.Task;
+            return await Task.Run(
+                () => CreateGrain().GetGrainState(
+                    "42",
+                    "UnitTests.UnknownGrain",
+                    TestContext.Current.CancellationToken),
+                TestContext.Current.CancellationToken);
+        }).ToArray();
+
+        start.SetResult();
+        var results = await Task.WhenAll(calls);
+
+        Assert.All(
+            results,
+            result => Assert.Equal(
+                ExpectedUnknownGrainPayload.ReplaceLineEndings("\n"),
+                result.Value.ReplaceLineEndings("\n")));
+        Assert.True(serializerOptions.IsReadOnly);
+    }
+
+    private static DashboardGrain CreateGrain() => new(
+        Options.Create(new DashboardOptions()),
+        Options.Create(new GrainProfilerOptions()),
+        Options.Create(new TypeManifestOptions()),
+        siloDetailsProvider: null!,
+        siloGrainClient: null!);
+}


### PR DESCRIPTION
## Problem

`DashboardGrain.GetGrainState` creates a new `JsonSerializerOptions` instance for every response, preventing reuse of the serializer metadata cache and leaving CA1869 advisory for the Dashboard project.

## Solution

Cache the existing `WriteIndented = true` configuration in a private static readonly options instance and enable CA1869 as a warning for every C# file in `Orleans.Dashboard`. Add focused coverage for the exact indented error payload, cached-options use, and concurrent serialization.

## Rationale

`JsonSerializerOptions` becomes read-only when first used and supports concurrent serialization afterward. Reusing the same exact configuration preserves the existing encoder, property naming, converter, reference handling, number, date, and dynamic `ExpandoObject` behavior while eliminating the per-operation options construction. `ServiceCollectionExtensions` remains unchanged because its options instance has a different startup-owned lifetime and is clean for this diagnostic.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11190)