### PR TITLE
fix(runtime): specify continuation schedulers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -666,6 +666,10 @@ dotnet_diagnostic.CA1873.severity = warning
 [src/Orleans.Core/**.cs]
 dotnet_diagnostic.CA1873.severity = warning
 
+# CA2008: Do not create tasks without passing a TaskScheduler
+[src/{Orleans.Core,Orleans.Streaming}/**.cs]
+dotnet_diagnostic.CA2008.severity = warning
+
 # CA1001: Types that own disposable fields should be disposable
 # CA2213: Disposable fields should be disposed
 [src/Orleans.Core/**.cs]

--- a/src/Orleans.Core/Async/BatchWorker.cs
+++ b/src/Orleans.Core/Async/BatchWorker.cs
@@ -112,7 +112,12 @@ namespace Orleans
             currentWorkCycle = task;
 
             // chain a continuation that checks for more work, on the same scheduler
-            task.ContinueWith((_, s) => ((BatchWorker)s!).CheckForMoreWork(), this);
+            task.ContinueWith(
+                (_, s) => ((BatchWorker)s!).CheckForMoreWork(),
+                this,
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Current);
             return task;
         }
 

--- a/src/Orleans.Streaming/Core/StreamSubscriptionManager.cs
+++ b/src/Orleans.Streaming/Core/StreamSubscriptionManager.cs
@@ -1,8 +1,9 @@
-using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Runtime;
 
 namespace Orleans.Streams.Core
 {
@@ -36,9 +37,12 @@ namespace Orleans.Streams.Core
         public Task<IEnumerable<StreamSubscription>> GetSubscriptions(string streamProviderName, StreamId streamId)
         {
             var internalStreamId = new QualifiedStreamId(streamProviderName, streamId);
-            return streamPubSub.GetAllSubscriptions(internalStreamId).ContinueWith(subs => subs.Result.AsEnumerable());
+            return streamPubSub.GetAllSubscriptions(internalStreamId).ContinueWith(
+                subs => subs.Result.AsEnumerable(),
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Current);
         }
     }
 
 }
-

--- a/test/Orleans.Streaming.Tests/StreamingTests/TaskSchedulerSelectionTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/TaskSchedulerSelectionTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+[TestCategory("BVT"), TestCategory("Streaming")]
+public class TaskSchedulerSelectionTests
+{
+    [Fact]
+    public void BatchWorker_FollowUpCycleUsesCallingSchedulerAndPreservesOrder()
+    {
+        var scheduler = new ManualTaskScheduler();
+        var observedCycles = new ConcurrentQueue<(int Cycle, TaskScheduler Scheduler)>();
+        var activeCycles = 0;
+        var nextCycle = 0;
+        var worker = new BatchWorkerFromDelegate(() =>
+        {
+            Assert.Equal(0, Interlocked.Exchange(ref activeCycles, 1));
+            try
+            {
+                observedCycles.Enqueue((Interlocked.Increment(ref nextCycle), TaskScheduler.Current));
+                return Task.CompletedTask;
+            }
+            finally
+            {
+                Volatile.Write(ref activeCycles, 0);
+            }
+        });
+
+        Task? serviced = null;
+        var notification = Task.Factory.StartNew(
+            () =>
+            {
+                worker.Notify();
+                worker.Notify();
+                serviced = worker.WaitForCurrentWorkToBeServiced();
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        scheduler.ExecuteAll();
+
+        Assert.True(notification.IsCompletedSuccessfully);
+        Assert.NotNull(serviced);
+        Assert.True(serviced.IsCompletedSuccessfully);
+        var cycles = observedCycles.ToArray();
+        Assert.Equal([1, 2], cycles.Select(entry => entry.Cycle));
+        Assert.All(cycles, entry => Assert.Same(scheduler, entry.Scheduler));
+        Assert.True(worker.IsIdle());
+    }
+
+    [Fact]
+    public async Task BatchWorker_FailureRemainsObservableOnCallingScheduler()
+    {
+        var scheduler = new ManualTaskScheduler();
+        var expectedException = new InvalidOperationException("Expected failure");
+        Task? work = null;
+        TaskScheduler? observedScheduler = null;
+        var worker = new BatchWorkerFromDelegate(() =>
+        {
+            observedScheduler = TaskScheduler.Current;
+            return Task.FromException(expectedException);
+        });
+
+        var notification = Task.Factory.StartNew(
+            () => work = worker.NotifyAndWaitForWorkToBeServiced(),
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        scheduler.ExecuteAll();
+
+        Assert.True(notification.IsCompletedSuccessfully);
+        Assert.Same(scheduler, observedScheduler);
+        Assert.NotNull(work);
+        Assert.True(work.IsFaulted);
+        Assert.Same(expectedException, await Assert.ThrowsAsync<InvalidOperationException>(() => work));
+        Assert.True(worker.IsIdle());
+    }
+
+    [Fact]
+    public async Task BatchWorker_CancellationRemainsObservableOnCallingScheduler()
+    {
+        var scheduler = new ManualTaskScheduler();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Task? work = null;
+        TaskScheduler? observedScheduler = null;
+        var worker = new BatchWorkerFromDelegate(() =>
+        {
+            observedScheduler = TaskScheduler.Current;
+            return Task.FromCanceled(cancellation.Token);
+        });
+
+        var notification = Task.Factory.StartNew(
+            () => work = worker.NotifyAndWaitForWorkToBeServiced(),
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        scheduler.ExecuteAll();
+
+        Assert.True(notification.IsCompletedSuccessfully);
+        Assert.Same(scheduler, observedScheduler);
+        Assert.NotNull(work);
+        Assert.True(work.IsCanceled);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => work);
+        Assert.True(worker.IsIdle());
+    }
+
+    [Fact]
+    public async Task StreamSubscriptionManager_QueryProjectionUsesCallingScheduler()
+    {
+        var scheduler = new ManualTaskScheduler();
+        var pubSub = Substitute.For<IStreamPubSub>();
+        var subscriptions = new List<StreamSubscription>();
+        var query = new TaskCompletionSource<List<StreamSubscription>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Func<QualifiedStreamId, GrainId, Task<List<StreamSubscription>>> getAllSubscriptions = pubSub.GetAllSubscriptions;
+        getAllSubscriptions(Arg.Any<QualifiedStreamId>(), Arg.Any<GrainId>()).Returns(query.Task);
+        var manager = new StreamSubscriptionManager(pubSub, StreamSubscriptionManagerType.ExplicitSubscribeOnly);
+
+        Task<IEnumerable<StreamSubscription>>? result = null;
+        var invocation = Task.Factory.StartNew(
+            () => result = manager.GetSubscriptions("provider", StreamId.Create("namespace", "key")),
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            scheduler);
+
+        scheduler.ExecuteAll();
+        query.SetResult(subscriptions);
+
+        Assert.True(invocation.IsCompletedSuccessfully);
+        Assert.NotNull(result);
+        Assert.False(result.IsCompleted);
+        Assert.Equal(1, scheduler.PendingTaskCount);
+
+        scheduler.ExecuteAll();
+
+        Assert.True(result.IsCompletedSuccessfully);
+        Assert.Same(subscriptions, await result);
+    }
+
+    private sealed class ManualTaskScheduler : TaskScheduler
+    {
+        private readonly Queue<Task> pendingTasks = new();
+
+        public int PendingTaskCount
+        {
+            get
+            {
+                lock (pendingTasks)
+                {
+                    return pendingTasks.Count;
+                }
+            }
+        }
+
+        public void ExecuteAll()
+        {
+            while (TryDequeue(out var task))
+            {
+                Assert.True(TryExecuteTask(task));
+            }
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            lock (pendingTasks)
+            {
+                return pendingTasks.ToArray();
+            }
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            lock (pendingTasks)
+            {
+                pendingTasks.Enqueue(task);
+            }
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        private bool TryDequeue(out Task task)
+        {
+            lock (pendingTasks)
+            {
+                return pendingTasks.TryDequeue(out task!);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Orleans.Core` and `Orleans.Streaming` still relied on `ContinueWith` overloads which select `TaskScheduler.Current` implicitly, leaving CA2008 unenforced across both projects and obscuring scheduler-affinity guarantees in scheduler-sensitive paths.

## Solution

- Enable CA2008 as a warning for all C# files in `Orleans.Core` and `Orleans.Streaming`.
- Pass `CancellationToken.None`, `TaskContinuationOptions.None`, and `TaskScheduler.Current` explicitly for the `BatchWorker` cycle continuation and `StreamSubscriptionManager` query projection.
- Add deterministic custom-scheduler coverage for scheduler selection, serialized follow-up cycles, cancellation, and exception propagation.

## Rationale

The explicit arguments preserve the exact behavior of the previous overloads. `BatchWorker` continues to run work and follow-up cycle coordination on the caller's scheduler, including Orleans activation schedulers, while retaining its ordering and backpressure handshake. Subscription query projection likewise remains on the caller's scheduler. The analyzer audit moves from three global CA2008 findings to the single separately deferred Reminders finding, with zero findings in the two enabled projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11194)