### PR TITLE
fix(reminders): preserve cleanup failures

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -742,6 +742,9 @@ dotnet_diagnostic.CA1062.severity = warning
 [src/{Orleans.Core.Abstractions,Orleans.EventSourcing,Orleans.Reminders,Orleans.Serialization.FSharp,Orleans.Serialization.TestKit,Orleans.Streaming,Orleans.Transactions,Orleans.Transactions.TestKit.Base}/**.cs]
 dotnet_diagnostic.CA1815.severity = warning
 
+[src/{Azure/Orleans.Reminders.AzureStorage,Orleans.Reminders.TestKit}/**.cs]
+dotnet_diagnostic.CA2219.severity = warning
+
 # Production source enforces the correctness baseline. Tests, samples, documentation,
 # playgrounds, templates, and tools retain advisory diagnostics during this rollout.
 [src/**/*.{cs,vb}]

--- a/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Storage/AzureBasedReminderTable.cs
@@ -16,6 +16,8 @@ namespace Orleans.Runtime.ReminderService
     /// </summary>
     public sealed partial class AzureBasedReminderTable : IReminderTable
     {
+        internal const string ServiceIdValidationExceptionDataKey = "AzureBasedReminderTable.ServiceIdValidationException";
+
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
         private readonly ClusterOptions clusterOptions;
@@ -148,11 +150,12 @@ namespace Orleans.Runtime.ReminderService
             return new ReminderTableData(remEntries);
         }
 
-        private ReminderEntry ConvertFromTableEntry(ReminderTableEntry tableEntry, string eTag)
+        internal ReminderEntry ConvertFromTableEntry(ReminderTableEntry tableEntry, string eTag)
         {
+            ReminderEntry converted;
             try
             {
-                return new ReminderEntry
+                converted = new ReminderEntry
                 {
                     GrainId = GrainId.Parse(tableEntry.GrainReference!),
                     ReminderName = tableEntry.ReminderName!,
@@ -164,16 +167,33 @@ namespace Orleans.Runtime.ReminderService
             catch (Exception exc)
             {
                 LogErrorParsingReminderEntry(exc, tableEntry);
+                try
+                {
+                    ValidateServiceId(tableEntry);
+                }
+                catch (OrleansException serviceIdException)
+                {
+                    exc.Data[ServiceIdValidationExceptionDataKey] = serviceIdException;
+                }
+                catch (NullReferenceException serviceIdException)
+                {
+                    exc.Data[ServiceIdValidationExceptionDataKey] = serviceIdException;
+                }
+
                 throw;
             }
-            finally
+
+            ValidateServiceId(tableEntry);
+            return converted;
+        }
+
+        private void ValidateServiceId(ReminderTableEntry tableEntry)
+        {
+            string serviceIdStr = this.clusterOptions.ServiceId;
+            if (!tableEntry.ServiceId!.Equals(serviceIdStr, StringComparison.Ordinal))
             {
-                string serviceIdStr = this.clusterOptions.ServiceId;
-                if (!tableEntry.ServiceId!.Equals(serviceIdStr, StringComparison.Ordinal))
-                {
-                    LogWarningAzureTable_ReadWrongReminder(tableEntry, serviceIdStr);
-                    throw new OrleansException($"Read a reminder entry for wrong Service id. Read {tableEntry}, but my service id is {serviceIdStr}. Going to discard it.");
-                }
+                LogWarningAzureTable_ReadWrongReminder(tableEntry, serviceIdStr);
+                throw new OrleansException($"Read a reminder entry for wrong Service id. Read {tableEntry}, but my service id is {serviceIdStr}. Going to discard it.");
             }
         }
 

--- a/src/Orleans.Reminders.TestKit/ReminderTableModelBasedTestRunner.cs
+++ b/src/Orleans.Reminders.TestKit/ReminderTableModelBasedTestRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,25 +104,21 @@ public sealed class ReminderTableModelBasedTestRunner
     /// <exception cref="ReminderConformanceException">One or more generated test cases failed.</exception>
     public async Task RunGeneratedConformanceTests(CancellationToken cancellationToken)
     {
-        var results = await ReminderTableModelBasedConformance.RunGeneratedTests(
-            _reminderTable,
-            _options,
-            cancellationToken,
-            _output);
-        var failures = results
-            .Where(result => !result.Success)
-            .Select(result => ReminderTableModelBasedConformance.BuildFailureMessage(_options.ProviderName, _options.Seed, result))
-            .ToList();
-
-        if (failures.Count > 0)
-        {
-            throw new ReminderConformanceException(string.Join(Environment.NewLine, failures));
-        }
+        await ReminderTableModelBasedConformance.ExecuteWithCleanup(
+            () => ReminderTableModelBasedConformance.RunGeneratedTests(
+                _reminderTable,
+                _options,
+                cancellationToken,
+                _output),
+            results => ReminderTableModelBasedConformance.CreateFailureException(_options, results),
+            () => ReminderTableModelBasedConformance.Cleanup(_reminderTable, _options),
+            cancellationToken);
     }
 }
 
 internal static class ReminderTableModelBasedConformance
 {
+    internal const string FinalCleanupExceptionDataKey = "ReminderTableModelBasedTestRunner.FinalCleanupException";
 
     public static async Task<IList<TestCaseExecutionResult>> RunGeneratedTests(
         IReminderTable reminderTable,
@@ -151,84 +148,129 @@ internal static class ReminderTableModelBasedConformance
         context.ResponsePrinter = response => response?.ToString() ?? "<null>";
 
         var testIndex = 0;
-        IList<TestCaseExecutionResult>? results = null;
+        return await spec.RunTests(
+            context,
+            initialState,
+            testCases,
+            new TestExecutionOptions
+            {
+                StopOnFirstFailure = true,
+                BeforeEach = info =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    reminderTable.TestOnlyClearTable().WaitAsync(cancellationToken).GetAwaiter().GetResult();
+                    var prefix = $"{runId}-{testIndex++:D4}";
+                    info.Context.Register(new ReminderExecutionContext(
+                        reminderTable,
+                        options.ProviderName,
+                        options.GrainType,
+                        prefix,
+                        options.Seed,
+                        cancellationToken));
+                },
+                AfterEach = info =>
+                {
+                    try
+                    {
+                        using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+                        reminderTable.TestOnlyClearTable()
+                            .WaitAsync(cleanupCancellation.Token)
+                            .GetAwaiter()
+                            .GetResult();
+                    }
+                    catch when (!info.Success || cancellationToken.IsCancellationRequested)
+                    {
+                        // Preserve the generated failure or test cancellation.
+                    }
+
+                    if (!info.Success)
+                    {
+                        output?.Invoke(info.FailureMessage);
+                    }
+                }
+            }).WaitAsync(cancellationToken);
+    }
+
+    internal static async Task<T> ExecuteWithCleanup<T>(
+        Func<Task<T>> execute,
+        Func<T, Exception?> getFailure,
+        Func<Task> cleanup,
+        CancellationToken cancellationToken = default)
+    {
+        T result = default!;
+        Exception? primaryException = null;
         try
         {
-            var executionResults = await spec.RunTests(
-                context,
-                initialState,
-                testCases,
-                new TestExecutionOptions
-                {
-                    StopOnFirstFailure = true,
-                    BeforeEach = info =>
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        reminderTable.TestOnlyClearTable().WaitAsync(cancellationToken).GetAwaiter().GetResult();
-                        var prefix = $"{runId}-{testIndex++:D4}";
-                        info.Context.Register(new ReminderExecutionContext(
-                            reminderTable,
-                            options.ProviderName,
-                            options.GrainType,
-                            prefix,
-                            options.Seed,
-                            cancellationToken));
-                    },
-                    AfterEach = info =>
-                    {
-                        try
-                        {
-                            using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                            reminderTable.TestOnlyClearTable()
-                                .WaitAsync(cleanupCancellation.Token)
-                                .GetAwaiter()
-                                .GetResult();
-                        }
-                        catch when (!info.Success || cancellationToken.IsCancellationRequested)
-                        {
-                            // Preserve the generated failure or test cancellation.
-                        }
-
-                        if (!info.Success)
-                        {
-                            output?.Invoke(info.FailureMessage);
-                        }
-                    }
-                }).WaitAsync(cancellationToken);
-            results = executionResults;
-
-            return executionResults;
+            result = await execute();
+            primaryException = getFailure(result);
         }
-        finally
+        catch (Exception exception)
         {
-            try
+            primaryException = exception;
+        }
+
+        try
+        {
+            await cleanup();
+        }
+        catch (Exception cleanupException)
+        {
+            if (primaryException is null && cancellationToken.IsCancellationRequested)
             {
-                using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-                await reminderTable.TestOnlyClearTable().WaitAsync(cleanupCancellation.Token);
-                var finalRows = await ReminderTableRetryPolicy.ReadUntilAsync(
-                    () => reminderTable.ReadRows(0, 0),
-                    rows => rows is not null && rows.Reminders.Count == 0,
-                    options.ProviderName,
-                    nameof(ReminderTableModelBasedTestRunner),
-                    "FinalCleanup/ReadRows(0, 0)",
-                    "an empty reminder table after final cleanup",
-                    rows => rows is null
-                        ? "null"
-                        : $"{rows.Reminders.Count.ToString(CultureInfo.InvariantCulture)} rows",
-                    cleanupCancellation.Token);
-                if (finalRows is null || finalRows.Reminders.Count != 0)
-                {
-                    throw new ReminderConformanceException(
-                        $"Final reminder table cleanup left {finalRows?.Reminders.Count.ToString(CultureInfo.InvariantCulture) ?? "null"} rows; expected an empty table.");
-                }
+                primaryException = new OperationCanceledException(cancellationToken);
             }
-            catch when (
-                results is null
-                || cancellationToken.IsCancellationRequested
-                || results.Any(result => !result.Success))
+
+            if (primaryException is null)
             {
-                // Preserve the generated failure, test cancellation, or execution exception.
+                throw;
             }
+
+            primaryException.Data[FinalCleanupExceptionDataKey] = cleanupException;
+        }
+
+        if (primaryException is not null)
+        {
+            ExceptionDispatchInfo.Capture(primaryException).Throw();
+        }
+
+        return result;
+    }
+
+    internal static Exception? CreateFailureException(
+        ReminderTableModelBasedConformanceOptions options,
+        IList<TestCaseExecutionResult> results)
+    {
+        var failures = results
+            .Where(result => !result.Success)
+            .Select(result => BuildFailureMessage(options.ProviderName, options.Seed, result))
+            .ToList();
+
+        return failures.Count > 0
+            ? new ReminderConformanceException(string.Join(Environment.NewLine, failures))
+            : null;
+    }
+
+    internal static async Task Cleanup(
+        IReminderTable reminderTable,
+        ReminderTableModelBasedConformanceOptions options)
+    {
+        using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        await reminderTable.TestOnlyClearTable().WaitAsync(cleanupCancellation.Token);
+        var finalRows = await ReminderTableRetryPolicy.ReadUntilAsync(
+            () => reminderTable.ReadRows(0, 0),
+            rows => rows is not null && rows.Reminders.Count == 0,
+            options.ProviderName,
+            nameof(ReminderTableModelBasedTestRunner),
+            "FinalCleanup/ReadRows(0, 0)",
+            "an empty reminder table after final cleanup",
+            rows => rows is null
+                ? "null"
+                : $"{rows.Reminders.Count.ToString(CultureInfo.InvariantCulture)} rows",
+            cleanupCancellation.Token);
+        if (finalRows is null || finalRows.Reminders.Count != 0)
+        {
+            throw new ReminderConformanceException(
+                $"Final reminder table cleanup left {finalRows?.Reminders.Count.ToString(CultureInfo.InvariantCulture) ?? "null"} rows; expected an empty table.");
         }
     }
 

--- a/test/Extensions/Orleans.Azure.Tests/AzureBasedReminderTableTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureBasedReminderTableTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Reminders.AzureStorage;
+using Orleans.Runtime;
 using Orleans.Runtime.ReminderService;
 using TestExtensions;
 using Xunit;
@@ -39,17 +40,89 @@ public class AzureBasedReminderTableTests
     [Fact]
     public async Task UpsertRow_NullEntry_ThrowsArgumentNullException()
     {
-        var table = new AzureBasedReminderTable(
-            NullLoggerFactory.Instance,
-            Options.Create(new ClusterOptions
-            {
-                ServiceId = "service-id",
-                ClusterId = "cluster-id",
-            }),
-            Options.Create(new AzureTableReminderStorageOptions()));
+        var table = CreateTable();
 
         var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => table.UpsertRow(null!));
 
         Assert.Equal("entry", exception.ParamName);
     }
+
+    [Fact]
+    public void ConvertFromTableEntry_ConversionAndServiceValidationFail_PreservesConversionFailure()
+    {
+        var table = CreateTable();
+        var entry = CreateEntry(serviceId: "other-service", period: "not-a-period");
+        var expectedMessage = Assert.Throws<FormatException>(() => TimeSpan.Parse(entry.Period!)).Message;
+
+        var exception = Assert.Throws<FormatException>(() => table.ConvertFromTableEntry(entry, "etag"));
+
+        Assert.Equal(expectedMessage, exception.Message);
+        var validationException = Assert.IsType<OrleansException>(
+            exception.Data[AzureBasedReminderTable.ServiceIdValidationExceptionDataKey]);
+        Assert.Contains("other-service", validationException.Message, StringComparison.Ordinal);
+        Assert.Contains("service-id", validationException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConvertFromTableEntry_ServiceValidationFails_SurfacesValidationFailure()
+    {
+        var table = CreateTable();
+        var entry = CreateEntry(serviceId: "other-service");
+
+        var exception = Assert.Throws<OrleansException>(() => table.ConvertFromTableEntry(entry, "etag"));
+
+        Assert.Contains("other-service", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("service-id", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConvertFromTableEntry_ConversionFailsWithMissingServiceId_PreservesConversionFailure()
+    {
+        var table = CreateTable();
+        var entry = CreateEntry(serviceId: null, period: "not-a-period");
+        var expectedMessage = Assert.Throws<FormatException>(() => TimeSpan.Parse(entry.Period!)).Message;
+
+        var exception = Assert.Throws<FormatException>(() => table.ConvertFromTableEntry(entry, "etag"));
+
+        Assert.Equal(expectedMessage, exception.Message);
+        Assert.IsType<NullReferenceException>(
+            exception.Data[AzureBasedReminderTable.ServiceIdValidationExceptionDataKey]);
+    }
+
+    [Fact]
+    public void ConvertFromTableEntry_ValidEntry_PreservesReminderData()
+    {
+        var table = CreateTable();
+        var entry = CreateEntry(serviceId: "service-id");
+
+        var result = table.ConvertFromTableEntry(entry, "etag");
+
+        Assert.Equal(GrainId.Parse(entry.GrainReference!), result.GrainId);
+        Assert.Equal(entry.ReminderName, result.ReminderName);
+        Assert.Equal(LogFormatter.ParseDate(entry.StartAt!), result.StartAt);
+        Assert.Equal(TimeSpan.Parse(entry.Period!), result.Period);
+        Assert.Equal("etag", result.ETag);
+    }
+
+    private static AzureBasedReminderTable CreateTable() => new(
+        NullLoggerFactory.Instance,
+        Options.Create(new ClusterOptions
+        {
+            ServiceId = "service-id",
+            ClusterId = "cluster-id",
+        }),
+        Options.Create(new AzureTableReminderStorageOptions()));
+
+    private static ReminderTableEntry CreateEntry(string? serviceId, string period = "00:05:00") => new()
+    {
+        PartitionKey = "partition",
+        RowKey = "row",
+        ServiceId = serviceId,
+        DeploymentId = "cluster-id",
+        GrainReference = GrainId.Create("test-grain", "test-key").ToString(),
+        ReminderName = "test-reminder",
+        StartAt = LogFormatter.PrintDate(new DateTime(2026, 9, 7, 12, 0, 0, DateTimeKind.Utc)),
+        Period = period,
+        GrainRefConsistentHash = "00000000",
+    };
 }

--- a/test/Orleans.Reminders.TestKit.Tests/ReminderTableModelBasedCleanupTests.cs
+++ b/test/Orleans.Reminders.TestKit.Tests/ReminderTableModelBasedCleanupTests.cs
@@ -1,0 +1,175 @@
+using Orleans.Reminders.TestKit;
+using Xunit;
+
+namespace Orleans.Reminders.TestKit.Tests;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Reminders")]
+[TestCategory("BVT"), TestCategory("Reminders")]
+public sealed class ReminderTableModelBasedCleanupTests
+{
+    [Fact]
+    public async Task ExecuteWithCleanup_OperationAndCleanupFail_PreservesOperationFailureAndRecordsCleanup()
+    {
+        var operationException = new InvalidOperationException("operation failed");
+        var cleanupException = new InvalidOperationException("cleanup failed");
+        var cleanupAttempted = false;
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ReminderTableModelBasedConformance.ExecuteWithCleanup(
+                () => Task.FromException<int>(operationException),
+                _ => null,
+                () =>
+                {
+                    cleanupAttempted = true;
+                    return Task.FromException(cleanupException);
+                },
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(operationException, exception);
+        Assert.True(cleanupAttempted);
+        Assert.Same(
+            cleanupException,
+            exception.Data[ReminderTableModelBasedConformance.FinalCleanupExceptionDataKey]);
+    }
+
+    [Fact]
+    public async Task ExecuteWithCleanup_GeneratedFailureAndCleanupFail_PreservesGeneratedDiagnosticAndRecordsCleanup()
+    {
+        var generatedException = new ReminderConformanceException("oracle failure diagnostic");
+        var cleanupException = new InvalidOperationException("cleanup failed");
+
+        var exception = await Assert.ThrowsAsync<ReminderConformanceException>(() =>
+            ReminderTableModelBasedConformance.ExecuteWithCleanup(
+                () => Task.FromResult(42),
+                _ => generatedException,
+                () => Task.FromException(cleanupException),
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(generatedException, exception);
+        Assert.Equal("oracle failure diagnostic", exception.Message);
+        Assert.Same(
+            cleanupException,
+            exception.Data[ReminderTableModelBasedConformance.FinalCleanupExceptionDataKey]);
+    }
+
+    [Fact]
+    public async Task ExecuteWithCleanup_OnlyCleanupFails_SurfacesCleanupFailure()
+    {
+        var cleanupException = new InvalidOperationException("cleanup failed");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ReminderTableModelBasedConformance.ExecuteWithCleanup(
+                () => Task.FromResult(42),
+                _ => null,
+                () => Task.FromException(cleanupException),
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(cleanupException, exception);
+    }
+
+    [Fact]
+    public async Task ExecuteWithCleanup_CancellationAndCleanupFail_PreservesCancellationAndRecordsCleanup()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var cleanupException = new InvalidOperationException("cleanup failed");
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ReminderTableModelBasedConformance.ExecuteWithCleanup(
+                () => Task.FromResult(42),
+                _ => null,
+                () => Task.FromException(cleanupException),
+                cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Same(
+            cleanupException,
+            exception.Data[ReminderTableModelBasedConformance.FinalCleanupExceptionDataKey]);
+    }
+
+    [Fact]
+    public async Task ExecuteWithCleanup_Succeeds_ReturnsOperationResultAndAttemptsCleanup()
+    {
+        var cleanupAttempted = false;
+
+        var result = await ReminderTableModelBasedConformance.ExecuteWithCleanup(
+            () => Task.FromResult(42),
+            _ => null,
+            () =>
+            {
+                cleanupAttempted = true;
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(42, result);
+        Assert.True(cleanupAttempted);
+    }
+
+    [Fact]
+    public async Task Cleanup_ClearFails_SurfacesCleanupFailure()
+    {
+        var cleanupException = new InvalidOperationException("cleanup failed");
+        var table = new CleanupReminderTable(cleanupException);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ReminderTableModelBasedConformance.Cleanup(table, new ReminderTableModelBasedConformanceOptions()));
+
+        Assert.Same(cleanupException, exception);
+        Assert.Equal(1, table.ClearAttempts);
+    }
+
+    [Fact]
+    public async Task Cleanup_ClearSucceeds_ConfirmsTableIsEmpty()
+    {
+        var table = new CleanupReminderTable();
+
+        await ReminderTableModelBasedConformance.Cleanup(
+            table,
+            new ReminderTableModelBasedConformanceOptions());
+
+        Assert.Equal(1, table.ClearAttempts);
+        Assert.Equal(1, table.RangeReadAttempts);
+    }
+
+    private sealed class CleanupReminderTable(Exception? cleanupException = null) : IReminderTable
+    {
+        private bool _hasRows = true;
+
+        public int ClearAttempts { get; private set; }
+
+        public int RangeReadAttempts { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<ReminderEntry?> ReadRow(GrainId grainId, string reminderName) => throw new NotSupportedException();
+
+        public Task<ReminderTableData> ReadRows(GrainId grainId) => throw new NotSupportedException();
+
+        public Task<ReminderTableData> ReadRows(uint begin, uint end)
+        {
+            RangeReadAttempts++;
+            return Task.FromResult(new ReminderTableData(_hasRows ? [new ReminderEntry()] : []));
+        }
+
+        public Task<string?> UpsertRow(ReminderEntry entry) => throw new NotSupportedException();
+
+        public Task<bool> RemoveRow(GrainId grainId, string reminderName, string eTag) => throw new NotSupportedException();
+
+        public Task TestOnlyClearTable()
+        {
+            ClearAttempts++;
+            if (cleanupException is not null)
+            {
+                return Task.FromException(cleanupException);
+            }
+
+            _hasRows = false;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Two reminder paths raised from `finally`, allowing service validation or final test cleanup to replace the original conversion, conformance, or cancellation failure.

## Solution

- Preserve the original Azure reminder conversion exception and record a secondary service-id validation failure in `Exception.Data`.
- Run model-based final cleanup through an exception-precedence helper which records secondary cleanup failures, surfaces cleanup-only failures, and preserves generated diagnostics and cancellation.
- Add deterministic coverage for dual failures, cleanup-only failures, cancellation, and successful cleanup.
- Enable CA2219 as a warning for the complete Azure Storage reminders and Reminders TestKit project directories.

## Rationale

The primary operation remains the authoritative outcome while cleanup is still attempted and its failure remains available for diagnostics. Successful reminder conversion, ETags, schedules, generated model results, and cleanup behavior remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11195)