### PR TITLE
fix: avoid virtual calls during construction

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -746,6 +746,10 @@ dotnet_diagnostic.CA1062.severity = warning
 [src/{Orleans.Core.Abstractions,Orleans.EventSourcing,Orleans.Reminders,Orleans.Serialization.FSharp,Orleans.Serialization.TestKit,Orleans.Streaming,Orleans.Transactions,Orleans.Transactions.TestKit.Base}/**.cs]
 dotnet_diagnostic.CA1815.severity = warning
 
+# CA2214: Do not call overridable methods in constructors
+[src/{Orleans.EventSourcing,Orleans.Serialization.TestKit}/**.cs]
+dotnet_diagnostic.CA2214.severity = warning
+
 [src/{Azure/Orleans.Reminders.AzureStorage,Orleans.Reminders.TestKit}/**.cs]
 dotnet_diagnostic.CA2219.severity = warning
 

--- a/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -208,7 +208,7 @@ namespace Orleans.EventSourcing.Common
                 return;
             }
 
-            // Concrete adaptors call this after their instance state is ready; base operations provide lazy initialization for external subclasses.
+            // JournaledGrain calls this after adaptor construction; base operations initialize direct-construction paths on first use.
             InitializeConfirmedView(initialStateForConfirmedView);
             confirmedViewInitialized = true;
         }

--- a/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -1,13 +1,18 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace Orleans.EventSourcing.Common
 {
+    internal interface IInitializableLogViewAdaptor
+    {
+        void EnsureConfirmedViewInitialized();
+    }
+
     /// <summary>
     /// A general template for constructing log view adaptors that are based on
     /// a sequentially read and written primary. We use this to construct 
@@ -28,7 +33,8 @@ namespace Orleans.EventSourcing.Common
     /// <typeparam name="TSubmissionEntry">The type of submission entries stored in pending queue</typeparam>
     public abstract class PrimaryBasedLogViewAdaptor<TLogView, TLogEntry, TSubmissionEntry> :
         ILogViewAdaptor<TLogView, TLogEntry>,
-        ICancellationAwareLogViewAdaptor
+        ICancellationAwareLogViewAdaptor,
+        IInitializableLogViewAdaptor
     where TLogView : class, new()
         where TLogEntry : class
         where TSubmissionEntry : SubmissionEntry<TLogEntry>
@@ -151,7 +157,7 @@ namespace Orleans.EventSourcing.Common
         /// </summary>
         protected virtual void ProcessNotifications()
         {
-            if (lastVersionNotified > this.GetConfirmedVersion())
+            if (lastVersionNotified > GetInitializedConfirmedVersion())
             {
                 Services.Log(LogLevel.Debug, "force refresh because of version notification v{0}", lastVersionNotified);
                 needRefresh = true;
@@ -190,14 +196,42 @@ namespace Orleans.EventSourcing.Common
             Debug.Assert(host != null && services != null && initialstate != null);
             this.Host = host;
             this.Services = services;
+            initialStateForConfirmedView = initialstate;
             this.InitialState = Services.DeepCopy(initialstate);
-            InitializeConfirmedView(initialstate);
             worker = new BatchWorkerFromDelegate(Work);
+        }
+
+        private void EnsureConfirmedViewInitialized()
+        {
+            if (confirmedViewInitialized)
+            {
+                return;
+            }
+
+            // Concrete adaptors call this after their instance state is ready; base operations provide lazy initialization for external subclasses.
+            InitializeConfirmedView(initialStateForConfirmedView);
+            confirmedViewInitialized = true;
+        }
+
+        void IInitializableLogViewAdaptor.EnsureConfirmedViewInitialized() => EnsureConfirmedViewInitialized();
+
+        private TLogView GetInitializedConfirmedView()
+        {
+            EnsureConfirmedViewInitialized();
+            return LastConfirmedView();
+        }
+
+        private int GetInitializedConfirmedVersion()
+        {
+            EnsureConfirmedViewInitialized();
+            return GetConfirmedVersion();
         }
 
         /// <inheritdoc/>
         public virtual Task PreOnActivate()
         {
+            EnsureConfirmedViewInitialized();
+
             Services.Log(LogLevel.Trace, "PreActivation Started");
 
             // this flag indicates we have not done an initial load from storage yet
@@ -293,6 +327,9 @@ namespace Orleans.EventSourcing.Common
         /// </summary>
         private readonly BatchWorker worker;
 
+        private readonly TLogView initialStateForConfirmedView;
+        private bool confirmedViewInitialized;
+
         /// <summary>
         /// Cached version of initial state used during initialization. And for resetting.
         /// </summary>
@@ -323,6 +360,8 @@ namespace Orleans.EventSourcing.Common
         /// <inheritdoc />
         public void Submit(TLogEntry logEntry)
         {
+            EnsureConfirmedViewInitialized();
+
             if (!SupportSubmissions)
                 throw new InvalidOperationException("provider does not support submissions on cluster " + Services.MyClusterId);
 
@@ -338,6 +377,8 @@ namespace Orleans.EventSourcing.Common
         /// <inheritdoc />
         public void SubmitRange(IEnumerable<TLogEntry> logEntries)
         {
+            EnsureConfirmedViewInitialized();
+
             if (!SupportSubmissions)
                 throw new InvalidOperationException("Provider does not support submissions on cluster " + Services.MyClusterId);
 
@@ -356,6 +397,8 @@ namespace Orleans.EventSourcing.Common
         /// <inheritdoc />
         public Task<bool> TryAppend(TLogEntry logEntry)
         {
+            EnsureConfirmedViewInitialized();
+
             if (!SupportSubmissions)
                 throw new InvalidOperationException("Provider does not support submissions on cluster " + Services.MyClusterId);
 
@@ -365,7 +408,7 @@ namespace Orleans.EventSourcing.Common
 
             var promise = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            SubmitInternal(DateTime.UtcNow, logEntry, GetConfirmedVersion() + pending.Count, promise);
+            SubmitInternal(DateTime.UtcNow, logEntry, GetInitializedConfirmedVersion() + pending.Count, promise);
 
             worker.Notify();
 
@@ -375,6 +418,8 @@ namespace Orleans.EventSourcing.Common
         /// <inheritdoc />
         public Task<bool> TryAppendRange(IEnumerable<TLogEntry> logEntries)
         {
+            EnsureConfirmedViewInitialized();
+
             if (!SupportSubmissions)
                 throw new InvalidOperationException("Provider does not support submissions on cluster " + Services.MyClusterId);
 
@@ -384,7 +429,7 @@ namespace Orleans.EventSourcing.Common
 
             var promise = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var time = DateTime.UtcNow;
-            var pos = GetConfirmedVersion() + pending.Count;
+            var pos = GetInitializedConfirmedVersion() + pending.Count;
 
             bool first = true;
             foreach (var e in logEntries)
@@ -461,7 +506,7 @@ namespace Orleans.EventSourcing.Common
                 if (stats != null)
                     stats.EventCounters["ConfirmedViewCalled"]++;
 
-                return LastConfirmedView();
+                return GetInitializedConfirmedView();
             }
         }
 
@@ -473,7 +518,7 @@ namespace Orleans.EventSourcing.Common
                 if (stats != null)
                     stats.EventCounters["ConfirmedVersionCalled"]++;
 
-                return GetConfirmedVersion();
+                return GetInitializedConfirmedVersion();
             }
         }
 
@@ -484,6 +529,8 @@ namespace Orleans.EventSourcing.Common
         /// <returns></returns>
         public async Task<ILogConsistencyProtocolMessage?> OnProtocolMessageReceived(ILogConsistencyProtocolMessage payLoad)
         {
+            EnsureConfirmedViewInitialized();
+
             var notificationMessage = payLoad as INotificationMessage;
 
             if (notificationMessage != null)
@@ -552,7 +599,7 @@ namespace Orleans.EventSourcing.Common
         private void CalculateTentativeState()
         {
             // copy the confirmed view
-            this.tentativeStateInternal = Services.DeepCopy(LastConfirmedView());
+            this.tentativeStateInternal = Services.DeepCopy(GetInitializedConfirmedView());
 
             // Now apply all operations in pending 
             foreach (var u in this.pending)
@@ -626,11 +673,13 @@ namespace Orleans.EventSourcing.Common
         /// </summary>
         internal async Task Work()
         {
+            EnsureConfirmedViewInitialized();
+
             await ProcessClearLogRequest();
 
             Services.Log(LogLevel.Debug, "<1 ProcessNotifications");
 
-            var version = GetConfirmedVersion();
+            var version = GetInitializedConfirmedVersion();
 
             ProcessNotifications();
 
@@ -683,7 +732,7 @@ namespace Orleans.EventSourcing.Common
         /// </summary>
         internal async Task UpdatePrimary()
         {
-            int version = GetConfirmedVersion();
+            int version = GetInitializedConfirmedVersion();
 
             while (true)
             {
@@ -744,7 +793,7 @@ namespace Orleans.EventSourcing.Common
 
         private void NotifyViewChanges(ref int version, int numWritten = 0)
         {
-            var v = GetConfirmedVersion();
+            var v = GetInitializedConfirmedVersion();
             bool tentativeChanged = (v != version + numWritten);
             bool confirmedChanged = (v != version);
             if (tentativeChanged || confirmedChanged)
@@ -825,7 +874,7 @@ namespace Orleans.EventSourcing.Common
         /// </summary>
         protected void RemoveStaleConditionalUpdates()
         {
-            int version = GetConfirmedVersion();
+            int version = GetInitializedConfirmedVersion();
             bool foundFailedConditionalUpdates = false;
 
             for (int pos = 0; pos < pending.Count; pos++)

--- a/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
+++ b/src/Orleans.EventSourcing/Common/PrimaryBasedLogViewAdaptor.cs
@@ -196,7 +196,6 @@ namespace Orleans.EventSourcing.Common
             Debug.Assert(host != null && services != null && initialstate != null);
             this.Host = host;
             this.Services = services;
-            initialStateForConfirmedView = initialstate;
             this.InitialState = Services.DeepCopy(initialstate);
             worker = new BatchWorkerFromDelegate(Work);
         }
@@ -209,7 +208,7 @@ namespace Orleans.EventSourcing.Common
             }
 
             // JournaledGrain calls this after adaptor construction; base operations initialize direct-construction paths on first use.
-            InitializeConfirmedView(initialStateForConfirmedView);
+            InitializeConfirmedView(InitialState);
             confirmedViewInitialized = true;
         }
 
@@ -327,7 +326,6 @@ namespace Orleans.EventSourcing.Common
         /// </summary>
         private readonly BatchWorker worker;
 
-        private readonly TLogView initialStateForConfirmedView;
         private bool confirmedViewInitialized;
 
         /// <summary>

--- a/src/Orleans.EventSourcing/JournaledGrain.cs
+++ b/src/Orleans.EventSourcing/JournaledGrain.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.EventSourcing.Common;
 using Orleans.Storage;
 
 namespace Orleans.EventSourcing
@@ -265,6 +266,7 @@ namespace Orleans.EventSourcing
         {
             // call the log consistency provider to construct the adaptor, passing the type argument
             LogViewAdaptor = factory.MakeLogViewAdaptor<TGrainState, TEventBase>(this, (TGrainState)initialState, graintypename, grainStorage, services);
+            (LogViewAdaptor as IInitializableLogViewAdaptor)?.EnsureConfirmedViewInitialized();
         }
 
         /// <summary>

--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -19,7 +19,8 @@ namespace Orleans.Serialization.TestKit
     [ExcludeFromCodeCoverage]
     public abstract class CopierTester<TValue, TCopier> : SerializationTester where TCopier : class, IDeepCopier<TValue>
     {
-        private CodecProvider _codecProvider => ServiceProvider.GetRequiredService<CodecProvider>();
+        private CodecProvider? _codecProviderValue;
+        private CodecProvider _codecProvider => _codecProviderValue ??= ServiceProvider.GetRequiredService<CodecProvider>();
 
         /// <summary>
         /// Initializes a new <see cref="CopierTester{TValue, TCopier}"/> instance.

--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -1,11 +1,11 @@
-using Orleans.Serialization.Cloning;
-using Orleans.Serialization.Serializers;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Xunit;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Serializers;
+using Xunit;
 
 namespace Orleans.Serialization.TestKit
 {
@@ -19,7 +19,7 @@ namespace Orleans.Serialization.TestKit
     [ExcludeFromCodeCoverage]
     public abstract class CopierTester<TValue, TCopier> : SerializationTester where TCopier : class, IDeepCopier<TValue>
     {
-        private readonly CodecProvider _codecProvider;
+        private CodecProvider _codecProvider => ServiceProvider.GetRequiredService<CodecProvider>();
 
         /// <summary>
         /// Initializes a new <see cref="CopierTester{TValue, TCopier}"/> instance.
@@ -28,7 +28,6 @@ namespace Orleans.Serialization.TestKit
         protected CopierTester(ITestOutputHelper output) : base(output ?? throw new ArgumentNullException(nameof(output)))
         {
             output.WriteLine($"Random seed: {RandomSeed}");
-            _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();
         }
 
         /// <summary>
@@ -38,7 +37,6 @@ namespace Orleans.Serialization.TestKit
         protected CopierTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output ?? throw new ArgumentNullException(nameof(output)), fixture)
         {
             output.WriteLine($"Random seed: {RandomSeed}");
-            _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();
         }
 
         /// <inheritdoc/>

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -27,7 +27,8 @@ namespace Orleans.Serialization.TestKit
     [ExcludeFromCodeCoverage]
     public abstract class FieldCodecTester<TValue, TCodec> : SerializationTester where TCodec : class, IFieldCodec<TValue>
     {
-        private SerializerSessionPool _sessionPool => ServiceProvider.GetRequiredService<SerializerSessionPool>();
+        private SerializerSessionPool? _sessionPoolValue;
+        private SerializerSessionPool _sessionPool => _sessionPoolValue ??= ServiceProvider.GetRequiredService<SerializerSessionPool>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldCodecTester{TValue, TCodec}"/> class.

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -27,6 +27,10 @@ namespace Orleans.Serialization.TestKit
     [ExcludeFromCodeCoverage]
     public abstract class FieldCodecTester<TValue, TCodec> : SerializationTester where TCodec : class, IFieldCodec<TValue>
     {
+        [SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "SerializationTester or its shared fixture owns and disposes the service provider which owns this session pool.")]
         private SerializerSessionPool? _sessionPoolValue;
         private SerializerSessionPool _sessionPool => _sessionPoolValue ??= ServiceProvider.GetRequiredService<SerializerSessionPool>();
 

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -1,8 +1,3 @@
-using Orleans.Serialization.Buffers;
-using Orleans.Serialization.Codecs;
-using Orleans.Serialization.Session;
-using Orleans.Serialization.Utilities;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -11,9 +6,14 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Text;
-using Xunit;
-using Orleans.Serialization.Serializers;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Codecs;
 using Orleans.Serialization.GeneratedCodeHelpers;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.Session;
+using Orleans.Serialization.Utilities;
+using Xunit;
 
 namespace Orleans.Serialization.TestKit
 {
@@ -27,11 +27,7 @@ namespace Orleans.Serialization.TestKit
     [ExcludeFromCodeCoverage]
     public abstract class FieldCodecTester<TValue, TCodec> : SerializationTester where TCodec : class, IFieldCodec<TValue>
     {
-        [SuppressMessage(
-            "Usage",
-            "CA2213:Disposable fields should be disposed",
-            Justification = "SerializationTester or its shared fixture owns and disposes the service provider which owns this session pool.")]
-        private readonly SerializerSessionPool _sessionPool;
+        private SerializerSessionPool _sessionPool => ServiceProvider.GetRequiredService<SerializerSessionPool>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldCodecTester{TValue, TCodec}"/> class.
@@ -40,7 +36,6 @@ namespace Orleans.Serialization.TestKit
         protected FieldCodecTester(ITestOutputHelper output) : base(output ?? throw new ArgumentNullException(nameof(output)))
         {
             output.WriteLine($"Random seed: {RandomSeed}");
-            _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();
         }
 
         /// <summary>
@@ -50,7 +45,6 @@ namespace Orleans.Serialization.TestKit
         protected FieldCodecTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output ?? throw new ArgumentNullException(nameof(output)), fixture)
         {
             output.WriteLine($"Random seed: {RandomSeed}");
-            _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();
         }
 
         /// <inheritdoc/>

--- a/src/Orleans.Serialization.TestKit/SerializationTester.cs
+++ b/src/Orleans.Serialization.TestKit/SerializationTester.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Xunit;
 
 namespace Orleans.Serialization.TestKit
@@ -11,7 +12,9 @@ namespace Orleans.Serialization.TestKit
     public abstract class SerializationTester : IDisposable
     {
         private readonly bool _ownsServiceProvider;
-        private readonly Lazy<IServiceProvider> _serviceProvider;
+        private readonly Lazy<IServiceProvider>? _serviceProvider;
+        private readonly SerializationTesterFixture? _fixture;
+        private int _disposed;
 
         /// <summary>
         /// Initializes a new <see cref="SerializationTester"/> instance.
@@ -48,7 +51,8 @@ namespace Orleans.Serialization.TestKit
 
             RandomSeed = CreateRandomSeed();
             Random = new(RandomSeed);
-            _serviceProvider = fixture.GetOrCreateServiceProvider(CreateServiceProvider);
+            _fixture = fixture;
+            fixture.SetServiceProviderFactory(this);
         }
 
         private static int CreateRandomSeed()
@@ -70,19 +74,46 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Gets the service provider.
         /// </summary>
-        protected IServiceProvider ServiceProvider => _serviceProvider.Value;
+        protected IServiceProvider ServiceProvider
+        {
+            get
+            {
+                if (_fixture is null)
+                {
+                    return _serviceProvider!.Value;
+                }
+
+                var serviceProvider = _fixture.ServiceProvider;
+                GC.KeepAlive(this);
+                return serviceProvider;
+            }
+        }
 
         /// <summary>
         /// Creates the serializer service provider for this test class.
         /// </summary>
         protected abstract IServiceProvider CreateServiceProvider();
 
+        internal IServiceProvider CreateFixtureServiceProvider()
+        {
+            ThrowIfDisposed();
+            return CreateServiceProvider();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+
         /// <summary>
         /// Releases resources used by this instance.
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing && _ownsServiceProvider && _serviceProvider.IsValueCreated)
+            if (disposing && _ownsServiceProvider && _serviceProvider!.IsValueCreated)
             {
                 (_serviceProvider.Value as IDisposable)?.Dispose();
             }
@@ -92,6 +123,7 @@ namespace Orleans.Serialization.TestKit
         void IDisposable.Dispose()
         {
             Dispose(disposing: true);
+            Volatile.Write(ref _disposed, 1);
             GC.SuppressFinalize(this);
         }
     }
@@ -103,7 +135,9 @@ namespace Orleans.Serialization.TestKit
     public class SerializationTesterFixture : IDisposable
     {
         private readonly object _lock = new();
-        private Lazy<IServiceProvider>? _serviceProvider;
+        private IServiceProvider? _serviceProvider;
+        private WeakReference<SerializationTester>? _serviceProviderFactory;
+        private bool _isCreatingServiceProvider;
 
         /// <summary>
         /// Initializes a new <see cref="SerializationTesterFixture"/> instance.
@@ -113,20 +147,62 @@ namespace Orleans.Serialization.TestKit
         }
 
         /// <summary>
-        /// Gets the service provider.
+        /// Gets the service provider shared by tester instances using this fixture.
+        /// Before creation, the most recently constructed tester supplies the service provider configuration.
         /// </summary>
-        public IServiceProvider ServiceProvider => _serviceProvider?.Value ?? throw new InvalidOperationException("The service provider has not been initialized.");
-
-        internal Lazy<IServiceProvider> GetOrCreateServiceProvider(Func<IServiceProvider> factory)
+        /// <exception cref="InvalidOperationException">No tester is available to create the service provider, or the service provider factory accesses this property recursively.</exception>
+        /// <exception cref="ObjectDisposedException">The tester available to create the service provider has been disposed.</exception>
+        public IServiceProvider ServiceProvider
         {
-            if (_serviceProvider is { } serviceProvider)
+            get
             {
-                return serviceProvider;
-            }
+                lock (_lock)
+                {
+                    if (_serviceProvider is { } serviceProvider)
+                    {
+                        return serviceProvider;
+                    }
 
+                    if (_isCreatingServiceProvider)
+                    {
+                        throw new InvalidOperationException("The service provider factory cannot access the service provider while it is being created.");
+                    }
+
+                    if (_serviceProviderFactory is null || !_serviceProviderFactory.TryGetTarget(out var tester))
+                    {
+                        throw new InvalidOperationException("The serialization tester which configures the service provider is no longer available.");
+                    }
+
+                    _isCreatingServiceProvider = true;
+                    try
+                    {
+                        return _serviceProvider = tester.CreateFixtureServiceProvider();
+                    }
+                    finally
+                    {
+                        _isCreatingServiceProvider = false;
+                    }
+                }
+            }
+        }
+
+        internal void SetServiceProviderFactory(SerializationTester tester)
+        {
             lock (_lock)
             {
-                return _serviceProvider ??= new(factory);
+                if (_serviceProvider is not null)
+                {
+                    return;
+                }
+
+                if (_serviceProviderFactory is null)
+                {
+                    _serviceProviderFactory = new(tester);
+                }
+                else
+                {
+                    _serviceProviderFactory.SetTarget(tester);
+                }
             }
         }
 
@@ -135,10 +211,18 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing && _serviceProvider is { IsValueCreated: true } serviceProvider)
+            if (!disposing)
             {
-                (serviceProvider.Value as IDisposable)?.Dispose();
+                return;
             }
+
+            IServiceProvider? serviceProvider;
+            lock (_lock)
+            {
+                serviceProvider = _serviceProvider;
+            }
+
+            (serviceProvider as IDisposable)?.Dispose();
         }
 
         /// <inheritdoc/>
@@ -147,5 +231,6 @@ namespace Orleans.Serialization.TestKit
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
+
     }
 }

--- a/src/Orleans.Serialization.TestKit/SerializationTester.cs
+++ b/src/Orleans.Serialization.TestKit/SerializationTester.cs
@@ -122,8 +122,12 @@ namespace Orleans.Serialization.TestKit
         /// <inheritdoc/>
         void IDisposable.Dispose()
         {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
             Dispose(disposing: true);
-            Volatile.Write(ref _disposed, 1);
             GC.SuppressFinalize(this);
         }
     }

--- a/src/Orleans.Serialization.TestKit/SerializationTester.cs
+++ b/src/Orleans.Serialization.TestKit/SerializationTester.cs
@@ -11,6 +11,7 @@ namespace Orleans.Serialization.TestKit
     public abstract class SerializationTester : IDisposable
     {
         private readonly bool _ownsServiceProvider;
+        private readonly Lazy<IServiceProvider> _serviceProvider;
 
         /// <summary>
         /// Initializes a new <see cref="SerializationTester"/> instance.
@@ -25,7 +26,7 @@ namespace Orleans.Serialization.TestKit
 
             RandomSeed = CreateRandomSeed();
             Random = new(RandomSeed);
-            ServiceProvider = CreateServiceProvider();
+            _serviceProvider = new(CreateServiceProvider);
             _ownsServiceProvider = true;
         }
 
@@ -47,7 +48,7 @@ namespace Orleans.Serialization.TestKit
 
             RandomSeed = CreateRandomSeed();
             Random = new(RandomSeed);
-            ServiceProvider = fixture.GetOrCreateServiceProvider(CreateServiceProvider);
+            _serviceProvider = fixture.GetOrCreateServiceProvider(CreateServiceProvider);
         }
 
         private static int CreateRandomSeed()
@@ -69,7 +70,7 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Gets the service provider.
         /// </summary>
-        protected IServiceProvider ServiceProvider { get; }
+        protected IServiceProvider ServiceProvider => _serviceProvider.Value;
 
         /// <summary>
         /// Creates the serializer service provider for this test class.
@@ -81,9 +82,9 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing && _ownsServiceProvider)
+            if (disposing && _ownsServiceProvider && _serviceProvider.IsValueCreated)
             {
-                (ServiceProvider as IDisposable)?.Dispose();
+                (_serviceProvider.Value as IDisposable)?.Dispose();
             }
         }
 
@@ -102,7 +103,7 @@ namespace Orleans.Serialization.TestKit
     public class SerializationTesterFixture : IDisposable
     {
         private readonly object _lock = new();
-        private IServiceProvider? _serviceProvider;
+        private Lazy<IServiceProvider>? _serviceProvider;
 
         /// <summary>
         /// Initializes a new <see cref="SerializationTesterFixture"/> instance.
@@ -114,9 +115,9 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Gets the service provider.
         /// </summary>
-        public IServiceProvider ServiceProvider => _serviceProvider ?? throw new InvalidOperationException("The service provider has not been initialized.");
+        public IServiceProvider ServiceProvider => _serviceProvider?.Value ?? throw new InvalidOperationException("The service provider has not been initialized.");
 
-        internal IServiceProvider GetOrCreateServiceProvider(Func<IServiceProvider> factory)
+        internal Lazy<IServiceProvider> GetOrCreateServiceProvider(Func<IServiceProvider> factory)
         {
             if (_serviceProvider is { } serviceProvider)
             {
@@ -125,7 +126,7 @@ namespace Orleans.Serialization.TestKit
 
             lock (_lock)
             {
-                return _serviceProvider ??= factory();
+                return _serviceProvider ??= new(factory);
             }
         }
 
@@ -134,9 +135,9 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _serviceProvider is { IsValueCreated: true } serviceProvider)
             {
-                (_serviceProvider as IDisposable)?.Dispose();
+                (serviceProvider.Value as IDisposable)?.Dispose();
             }
         }
 

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/LogViewAdaptorTestInfrastructure.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/LogViewAdaptorTestInfrastructure.cs
@@ -242,6 +242,7 @@ internal sealed class TestPrimaryBasedLogViewAdaptor
     private int _confirmedVersion;
     private int _activePrimaryOperations;
     private int _maximumConcurrentPrimaryOperations;
+    private bool _constructorCompleted;
 
     public TestPrimaryBasedLogViewAdaptor(
         RecordingLogViewAdaptorHost host,
@@ -249,6 +250,7 @@ internal sealed class TestPrimaryBasedLogViewAdaptor
         RecordingProtocolServices services)
         : base(host, initialState, services)
     {
+        _constructorCompleted = true;
     }
 
     public List<string> OperationLog { get; } = [];
@@ -262,6 +264,8 @@ internal sealed class TestPrimaryBasedLogViewAdaptor
     public int ClearCount { get; private set; }
 
     public int MaximumConcurrentPrimaryOperations => Volatile.Read(ref _maximumConcurrentPrimaryOperations);
+
+    public int InitializationCount { get; private set; }
 
     public ControlledOperation<PrimaryReadResult> QueueRead(TestLogView view, int version)
     {
@@ -286,6 +290,13 @@ internal sealed class TestPrimaryBasedLogViewAdaptor
 
     protected override void InitializeConfirmedView(TestLogView initialstate)
     {
+        if (!_constructorCompleted)
+        {
+            throw new InvalidOperationException("Confirmed view initialization ran before the derived constructor completed.");
+        }
+
+        InitializationCount++;
+
         lock (_stateLock)
         {
             _confirmed = initialstate.Copy();

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/PrimaryBasedLogViewAdaptorTests.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/PrimaryBasedLogViewAdaptorTests.cs
@@ -16,6 +16,7 @@ public sealed class PrimaryBasedLogViewAdaptorTests
         var initialState = new TestLogView(["initial"]);
 
         var (adaptor, _, _) = CreateAdaptor(initialState);
+        initialState.Entries.Add("mutated");
 
         Assert.Equal(0, adaptor.InitializationCount);
 

--- a/test/Orleans.EventSourcing.Tests/EventSourcingTests/PrimaryBasedLogViewAdaptorTests.cs
+++ b/test/Orleans.EventSourcing.Tests/EventSourcingTests/PrimaryBasedLogViewAdaptorTests.cs
@@ -11,6 +11,20 @@ namespace Tester.EventSourcingTests;
 public sealed class PrimaryBasedLogViewAdaptorTests
 {
     [Fact]
+    public void Constructor_DefersConfirmedViewInitializationUntilDerivedStateIsReady()
+    {
+        var initialState = new TestLogView(["initial"]);
+
+        var (adaptor, _, _) = CreateAdaptor(initialState);
+
+        Assert.Equal(0, adaptor.InitializationCount);
+
+        Assert.Equal(0, adaptor.ConfirmedVersion);
+        Assert.Equal(1, adaptor.InitializationCount);
+        Assert.Equal(["initial"], adaptor.ConfirmedView.Entries);
+    }
+
+    [Fact]
     public async Task TryAppendRange_WithNonEmptyRange_AppendsAtomicallyInOrderAndCompletesTrue()
     {
         var (adaptor, host, _) = CreateAdaptor();
@@ -336,11 +350,11 @@ public sealed class PrimaryBasedLogViewAdaptorTests
     }
 
     private static (TestPrimaryBasedLogViewAdaptor Adaptor, RecordingLogViewAdaptorHost Host, RecordingProtocolServices Services)
-        CreateAdaptor()
+        CreateAdaptor(TestLogView? initialState = null)
     {
         var host = new RecordingLogViewAdaptorHost();
         var services = new RecordingProtocolServices();
-        return (new TestPrimaryBasedLogViewAdaptor(host, new TestLogView(), services), host, services);
+        return (new TestPrimaryBasedLogViewAdaptor(host, initialState ?? new TestLogView(), services), host, services);
     }
 
     private static TestLogEntry[] Entries(params string[] values) =>

--- a/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
@@ -42,6 +42,39 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void SerializationTester_Constructor_DefersServiceCreationUntilDerivedConstructionCompletes()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+
+        using var tester = new SerializationTesterHarness(output);
+
+        Assert.Equal(0, probe.ServiceProviderFactoryCount);
+
+        var first = tester.GetServiceProvider();
+        var second = tester.GetServiceProvider();
+
+        Assert.Same(first, second);
+        Assert.Equal(1, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
+    public void SerializationTester_FixtureServiceProvider_IsAvailableAfterDerivedConstructionCompletes()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+        using var tester = new SerializationTesterHarness(output, fixture);
+
+        Assert.Equal(0, probe.ServiceProviderFactoryCount);
+
+        var fixtureProvider = fixture.ServiceProvider;
+
+        Assert.Same(fixtureProvider, tester.GetServiceProvider());
+        Assert.Equal(1, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
     public void FieldCodecTester_FirstConstructor_NullOutput_ThrowsWithExactParamNameWithoutInvokingDependencies()
     {
         var probe = new ConstructionProbe();
@@ -190,20 +223,31 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
 
     private sealed class SerializationTesterHarness : SerializationTester
     {
+        private bool _constructionCompleted;
+
         public SerializationTesterHarness(ITestOutputHelper output)
             : base(output)
         {
+            _constructionCompleted = true;
         }
 
         public SerializationTesterHarness(ITestOutputHelper output, SerializationTesterFixture fixture)
             : base(output, fixture)
         {
+            _constructionCompleted = true;
         }
 
         public static ConstructionProbe Probe { get; set; } = null!;
 
+        public IServiceProvider GetServiceProvider() => ServiceProvider;
+
         protected override IServiceProvider CreateServiceProvider()
         {
+            if (!_constructionCompleted)
+            {
+                throw new InvalidOperationException("Service creation ran before the derived constructor completed.");
+            }
+
             Probe.ServiceProviderFactoryCount++;
             return new EmptyServiceProvider();
         }

--- a/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
@@ -59,6 +59,20 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void SerializationTester_Dispose_DisposesOwnedServiceProviderOnce()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+        var tester = new SerializationTesterHarness(output);
+        _ = tester.GetServiceProvider();
+
+        ((IDisposable)tester).Dispose();
+        ((IDisposable)tester).Dispose();
+
+        Assert.Equal(1, probe.ServiceProviderDisposeCount);
+    }
+
+    [Fact]
     public void SerializationTester_FixtureServiceProvider_IsAvailableAfterDerivedConstructionCompletes()
     {
         var probe = new ConstructionProbe();
@@ -287,6 +301,8 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
     {
         public int ServiceProviderFactoryCount { get; set; }
 
+        public int ServiceProviderDisposeCount { get; set; }
+
         public Exception? ServiceProviderFactoryException { get; set; }
 
         public bool ReenterServiceProviderFactory { get; set; }
@@ -344,7 +360,7 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
                 throw exception;
             }
 
-            return new EmptyServiceProvider();
+            return new EmptyServiceProvider(Probe);
         }
     }
 
@@ -443,8 +459,10 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
         }
     }
 
-    private sealed class EmptyServiceProvider : IServiceProvider
+    private sealed class EmptyServiceProvider(ConstructionProbe probe) : IServiceProvider, IDisposable
     {
         public object? GetService(Type serviceType) => null;
+
+        public void Dispose() => probe.ServiceProviderDisposeCount++;
     }
 }

--- a/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializationTestKitContractTests.cs
@@ -75,6 +75,85 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void SerializationTester_FixtureServiceProvider_UsesLatestLiveTester()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+        var firstTester = new SerializationTesterHarness(output, fixture);
+        ((IDisposable)firstTester).Dispose();
+
+        using var secondTester = new SerializationTesterHarness(output, fixture);
+        var fixtureProvider = fixture.ServiceProvider;
+
+        Assert.Same(fixtureProvider, secondTester.GetServiceProvider());
+        Assert.Equal(1, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
+    public void SerializationTester_FixtureServiceProvider_DoesNotUseDisposedTester()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+        var tester = new SerializationTesterHarness(output, fixture);
+        ((IDisposable)tester).Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => fixture.ServiceProvider);
+        GC.KeepAlive(tester);
+        Assert.Equal(0, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
+    public void SerializationTester_FixtureServiceProvider_RetriesAfterFactoryFailure()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+        using var tester = new SerializationTesterHarness(output, fixture);
+        var failure = new InvalidOperationException("service provider factory failed");
+        probe.ServiceProviderFactoryException = failure;
+
+        var actual = Assert.Throws<InvalidOperationException>(() => fixture.ServiceProvider);
+        var provider = fixture.ServiceProvider;
+
+        Assert.Same(failure, actual);
+        Assert.Same(provider, tester.GetServiceProvider());
+        Assert.Equal(2, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
+    public void SerializationTester_FixtureServiceProvider_RemainsSharedWithLaterTesters()
+    {
+        var probe = new ConstructionProbe();
+        SerializationTesterHarness.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+        using var firstTester = new SerializationTesterHarness(output, fixture);
+        var provider = firstTester.GetServiceProvider();
+        using var secondTester = new SerializationTesterHarness(output, fixture);
+
+        Assert.Same(provider, secondTester.GetServiceProvider());
+        Assert.Same(provider, fixture.ServiceProvider);
+        Assert.Equal(1, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
+    public void SerializationTester_FixtureServiceProvider_RejectsReentrantFactoryAccess()
+    {
+        var probe = new ConstructionProbe { ReenterServiceProviderFactory = true };
+        SerializationTesterHarness.Probe = probe;
+        using var fixture = new SerializationTesterFixture();
+        using var tester = new SerializationTesterHarness(output, fixture);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => fixture.ServiceProvider);
+        var provider = fixture.ServiceProvider;
+
+        Assert.Equal("The service provider factory cannot access the service provider while it is being created.", exception.Message);
+        Assert.Same(provider, tester.GetServiceProvider());
+        Assert.Equal(2, probe.ServiceProviderFactoryCount);
+    }
+
+    [Fact]
     public void FieldCodecTester_FirstConstructor_NullOutput_ThrowsWithExactParamNameWithoutInvokingDependencies()
     {
         var probe = new ConstructionProbe();
@@ -208,6 +287,10 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
     {
         public int ServiceProviderFactoryCount { get; set; }
 
+        public Exception? ServiceProviderFactoryException { get; set; }
+
+        public bool ReenterServiceProviderFactory { get; set; }
+
         public int ConfigureCount { get; set; }
 
         public int CodecCreationCount { get; set; }
@@ -249,6 +332,18 @@ public sealed class SerializationTestKitContractTests(ITestOutputHelper output)
             }
 
             Probe.ServiceProviderFactoryCount++;
+            if (Probe.ReenterServiceProviderFactory)
+            {
+                Probe.ReenterServiceProviderFactory = false;
+                return GetServiceProvider();
+            }
+
+            if (Probe.ServiceProviderFactoryException is { } exception)
+            {
+                Probe.ServiceProviderFactoryException = null;
+                throw exception;
+            }
+
             return new EmptyServiceProvider();
         }
     }


### PR DESCRIPTION
## Problem

`PrimaryBasedLogViewAdaptor` and `SerializationTester` invoked overridable members from their base constructors. Derived state could therefore be observed before construction completed, and CA2214 could not be enabled for the complete EventSourcing and Serialization TestKit projects.

## Solution

- Initialize primary-based log adaptors at the `JournaledGrain` installation boundary after the factory returns a fully constructed instance, with lifecycle and state-access guards for direct construction paths.
- Lazily materialize Serialization TestKit service providers after derived construction while preserving shared fixture identity and disposal ownership.
- Add focused derived-type contract tests which fail if virtual initialization or service creation occurs before derived construction completes.
- Enable CA2214 for all C# files in `Orleans.EventSourcing` and `Orleans.Serialization.TestKit`.

## Rationale

The initialization boundaries now rely on fully constructed objects while retaining existing log-state timing, fixture sharing, normal serializer behavior, and public API compatibility. This removes the two current CA2214 findings without suppressions or changes to unrelated CA1062 ownership.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11196)