### PR TITLE
test(reminders): stabilize range-change barrier

### DIFF
--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -637,10 +637,21 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
         await schedulerBlocked.Task.WaitAsync(cancellation.Token);
 
         var refreshRead = reminderTable.BlockNextRangeRead(cancellation.Token);
+        var rangeChangePending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseRangeChange = new ManualResetEventSlim();
+        var rangeChangeBarrier = new Task(() =>
+        {
+            rangeChangePending.TrySetResult();
+            releaseRangeChange.Wait(cancellation.Token);
+        });
+        var rangeChangeBarrierQueued = false;
         RangeReadGate? rangeChangeRead = null;
         try
         {
             var refresh = reminderService.TestOnlyRefresh();
+            // Hold the scheduler between both operations so the second provider gate is armed before the range change can run.
+            reminderService.Scheduler.QueueTask(rangeChangeBarrier);
+            rangeChangeBarrierQueued = true;
             var rangeChange = reminderService.TestOnlyChangeRange(oldRange, newRange, increased: false);
             var reconciliation = reminderService.TestOnlyWaitForRangeChangeReconciliation(cancellation.Token);
             Assert.False(reconciliation.IsCompleted);
@@ -648,21 +659,32 @@ public class LocalReminderServiceCompatibilityTests : IClassFixture<LocalReminde
             releaseScheduler.Set();
             await blockingTask.WaitAsync(cancellation.Token);
             await refreshRead.WaitUntilBlockedAsync(cancellation.Token);
+            await rangeChangePending.Task.WaitAsync(cancellation.Token);
 
             rangeChangeRead = reminderTable.BlockNextRangeRead(cancellation.Token);
-            refreshRead.Release();
+            releaseRangeChange.Set();
+            await rangeChangeBarrier.WaitAsync(cancellation.Token);
             await rangeChangeRead.WaitUntilBlockedAsync(cancellation.Token);
             Assert.False(reconciliation.IsCompleted);
 
             rangeChangeRead.Release();
-            await Task.WhenAll(refresh, rangeChange, reconciliation).WaitAsync(cancellation.Token);
+            await Task.WhenAll(rangeChange, reconciliation).WaitAsync(cancellation.Token);
+            Assert.False(refresh.IsCompleted);
+
+            refreshRead.Release();
+            await refresh.WaitAsync(cancellation.Token);
         }
         finally
         {
             releaseScheduler.Set();
+            releaseRangeChange.Set();
             refreshRead.Release();
             rangeChangeRead?.Release();
             await blockingTask.WaitAsync(cancellation.Token);
+            if (rangeChangeBarrierQueued)
+            {
+                await rangeChangeBarrier.WaitAsync(cancellation.Token);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`LocalReminderServiceCompatibilityTests.RangeChangeBarrier_PreservesRefreshThenRangeOrder` armed its second provider-read gate after the first read reported that it was blocked. The reminder-service scheduler could execute the already-queued range change before the external test continuation installed that gate, causing the range-change read to complete immediately and leaving the test waiting for an unconsumed gate until its 60-second timeout.

The test was flaky from its introduction in #11118; the first known failing commit predates the later range-read ownership and ring-notification fixes.

## Solution

Insert a scheduler barrier between the queued refresh and range change. The test now waits until the refresh read and intermediate scheduler turn are both blocked, arms the range-change provider gate, and then releases the scheduler to execute the range change.

After releasing the range-change read, await the range change and reconciliation while the older refresh remains blocked. This preserves the original regression guarantee that the reconciliation barrier follows the newest operation rather than the obsolete refresh.

## Rationale

The explicit phase boundary controls only test observation timing. It preserves the runtime FIFO and reconciliation behavior under test while removing the race between the Orleans scheduler and the external test continuation.

Focused validation covered the complete compatibility class on net8.0 and net10.0 plus 20 consecutive net10.0 executions of the formerly flaky test.

Fixes #11192