### PR TITLE
docs: document formatting verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,13 @@ The `Orleans.slnx` solution includes the source projects under `src` and the tes
 
 ### Verify formatting
 
-Verify the repository-wide formatting baseline with:
+After building the solution, verify the repository-wide formatting baseline with:
 
 ```console
 dotnet format whitespace Orleans.slnx --verify-no-changes --no-restore
 ```
 
-The `whitespace` subcommand matches the formatting check enforced by CI. It verifies whitespace, final newlines, and encoding for the projects supported by `dotnet format`.
+This command checks the same whitespace formatting scope as CI and reuses the restore from the preceding build. Code-style and analyzer diagnostics are enforced by the repository build.
 
 ### Package compatibility
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,16 @@ dotnet build Orleans.slnx -bl
 
 The `Orleans.slnx` solution includes the source projects under `src` and the test projects under `test`. On Windows, `Build.cmd` additionally restores, builds, and packs the solution, placing packages in `Artifacts/<Configuration>`.
 
+### Verify formatting
+
+Verify the repository-wide formatting baseline with:
+
+```console
+dotnet format whitespace Orleans.slnx --verify-no-changes --no-restore
+```
+
+The `whitespace` subcommand matches the formatting check enforced by CI. It verifies whitespace, final newlines, and encoding for the projects supported by `dotnet format`.
+
 ### Package compatibility
 
 Packing validates API-bearing Orleans packages against the latest released package baseline. This catches binary breaking changes, dropped target frameworks, and inconsistent assets across target frameworks in the produced NuGet package. The generated API-diff workflow remains the reviewable source representation of the public API; package validation enforces compatibility on the actual package.


### PR DESCRIPTION
## Problem

Repository-wide `dotnet format` evaluates code-style diagnostics outside the formatting baseline enforced by Orleans CI, including existing import-order diagnostics.

## Solution

Document the supported `dotnet format whitespace Orleans.slnx --verify-no-changes --no-restore` command and the checks it covers.

## Rationale

This aligns contributor guidance with the existing CI formatting invariant without a broad unrelated import-order rewrite.

Fixes #11189
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11198)