### PR TITLE
test(analyzers): isolate nested restore from feeds

### DIFF
--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -2870,8 +2870,25 @@ interface Outer.IInnerGrain [Version(1)]
                 }
                 """,
                 TestContext.Current.CancellationToken);
+            var nuGetConfigPath = Path.Combine(tempDirectory, "NuGet.Config");
+            await File.WriteAllTextAsync(
+                nuGetConfigPath,
+                """
+                <configuration>
+                  <packageSources>
+                    <clear />
+                  </packageSources>
+                </configuration>
+                """,
+                TestContext.Current.CancellationToken);
 
-            var restore = await RunDotNetAsync(repositoryRoot, "restore", projectPath, "--nologo");
+            var restore = await RunDotNetAsync(
+                repositoryRoot,
+                "restore",
+                projectPath,
+                "--configfile",
+                nuGetConfigPath,
+                "--nologo");
             Assert.True(restore.ExitCode == 0, restore.Output);
             Assert.False(File.Exists(contractsPath));
 


### PR DESCRIPTION
## Problem

The analyzer contract tests create a temporary project with no package dependencies, then run a nested `dotnet restore`. That restore inherited the repository's configured package sources, allowing an unrelated feed or credential-provider delay to consume the two-minute process timeout. This caused the Windows `net10.0` BVT failure tracked by #11187; the same job passed on rerun.

## Solution

Create a temporary NuGet configuration with cleared package sources and pass it to the nested restore. The generated project resolves only SDK framework assets and direct assembly references, so restore remains fully representative while becoming independent of external feed availability.

Closes #11187
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11199)