### PR TITLE
fix(test): skip unavailable providers

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamingTests.cs
@@ -19,11 +19,18 @@ namespace Tester.AzureUtils.Streaming
     [TestSuite("Functional")]
     [TestProvider("AzureStorage")]
     [TestArea("Streaming")]
-    public class AQStreamingTests(AQStreamingTests.Fixture fixture) : IClassFixture<AQStreamingTests.Fixture>
+    public class AQStreamingTests : IClassFixture<AQStreamingTests.Fixture>
     {
         public const string AzureQueueStreamProviderName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
         public const string MemoryStreamProviderName = StreamTestsConstants.MEMORY_STREAM_PROVIDER_NAME;
         private const int queueCount = 8;
+        private readonly Fixture _fixture;
+
+        public AQStreamingTests(Fixture fixture)
+        {
+            fixture.EnsurePreconditionsMet();
+            _fixture = fixture;
+        }
 
         public sealed class Fixture : IAsyncLifetime
         {
@@ -106,6 +113,11 @@ namespace Tester.AzureUtils.Streaming
             public InProcessTestCluster? Cluster { get; }
             public SingleStreamTestRunner Runner { get; private set; } = null!;
 
+            public void EnsurePreconditionsMet()
+            {
+                _preconditionsException?.Throw();
+            }
+
             public async ValueTask DisposeAsync()
             {
                 if (Cluster is null)
@@ -130,7 +142,11 @@ namespace Tester.AzureUtils.Streaming
 
             public async ValueTask InitializeAsync()
             {
-                _preconditionsException?.Throw();
+                if (_preconditionsException is not null)
+                {
+                    return;
+                }
+
                 await Cluster!.DeployAsync();
                 Runner = new SingleStreamTestRunner(Cluster, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME); // DeployAsync initializes the client.
             }
@@ -141,25 +157,25 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_01_OneProducerGrainOneConsumerGrain()
         {
-            await fixture.Runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_01_OneProducerGrainOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_02_OneProducerGrainOneConsumerClient()
         {
-            await fixture.Runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_02_OneProducerGrainOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_03_OneProducerClientOneConsumerGrain()
         {
-            await fixture.Runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_03_OneProducerClientOneConsumerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_04_OneProducerClientOneConsumerClient()
         {
-            await fixture.Runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_04_OneProducerClientOneConsumerClient(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many different grains ----------------------//
@@ -167,50 +183,50 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_05_ManyDifferent_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_06_ManyDifferent_ManyProducerGrainManyConsumerClients()
         {
-            await fixture.Runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_06_ManyDifferent_ManyProducerGrainManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact(Skip = "https://github.com/dotnet/orleans/issues/5648"), TestCategory("Functional")]
         public async Task AQ_07_ManyDifferent_ManyProducerClientsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_07_ManyDifferent_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_08_ManyDifferent_ManyProducerClientsManyConsumerClients()
         {
-            await fixture.Runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_08_ManyDifferent_ManyProducerClientsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many Same grains ----------------------//
         [Fact, TestCategory("Functional")]
         public async Task AQ_09_ManySame_ManyProducerGrainsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_09_ManySame_ManyProducerGrainsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_10_ManySame_ManyConsumerGrainsManyProducerGrains()
         {
-            await fixture.Runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_10_ManySame_ManyConsumerGrainsManyProducerGrains(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_11_ManySame_ManyProducerGrainsManyConsumerClients()
         {
-            await fixture.Runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_11_ManySame_ManyProducerGrainsManyConsumerClients(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_12_ManySame_ManyProducerClientsManyConsumerGrains()
         {
-            await fixture.Runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_12_ManySame_ManyProducerClientsManyConsumerGrains(TestContext.Current.CancellationToken);
         }
 
         //------------------------ MANY to Many producer consumer same grain ----------------------//
@@ -218,13 +234,13 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_13_SameGrain_ConsumerFirstProducerLater()
         {
-            await fixture.Runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_13_SameGrain_ConsumerFirstProducerLater(false, TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_14_SameGrain_ProducerFirstConsumerLater()
         {
-            await fixture.Runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_14_SameGrain_ProducerFirstConsumerLater(false, TestContext.Current.CancellationToken);
         }
 
         //----------------------------------------------//
@@ -232,13 +248,13 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_15_ConsumeAtProducersRequest()
         {
-            await fixture.Runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_15_ConsumeAtProducersRequest(TestContext.Current.CancellationToken);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task AQ_16_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 16, false); // The fixture deploys the client.
+            var multiRunner = new MultipleStreamsTestRunner(_fixture.Cluster!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 16, false); // The fixture deploys the client.
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
                 cancellationToken: TestContext.Current.CancellationToken);
         }
@@ -246,9 +262,9 @@ namespace Tester.AzureUtils.Streaming
         [Fact, TestCategory("Functional")]
         public async Task AQ_17_MultipleStreams_1J_ManyProducerGrainsManyConsumerGrains()
         {
-            var multiRunner = new MultipleStreamsTestRunner(fixture.Cluster!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 17, false); // The fixture deploys the client.
+            var multiRunner = new MultipleStreamsTestRunner(_fixture.Cluster!, SingleStreamTestRunner.AQ_STREAM_PROVIDER_NAME, 17, false); // The fixture deploys the client.
             await multiRunner.StreamTest_MultipleStreams_ManyDifferent_ManyProducerGrainsManyConsumerGrains(
-                fixture.Cluster!.StartAdditionalSilo,
+                _fixture.Cluster!.StartAdditionalSilo,
                 cancellationToken: TestContext.Current.CancellationToken);
         }
 
@@ -265,21 +281,21 @@ namespace Tester.AzureUtils.Streaming
         public async Task AQ_19_ConsumerImplicitlySubscribedToProducerClient()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await fixture.Runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_19_ConsumerImplicitlySubscribedToProducerClient(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task AQ_20_ConsumerImplicitlySubscribedToProducerGrain()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await fixture.Runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_20_ConsumerImplicitlySubscribedToProducerGrain(TestContext.Current.CancellationToken);
         }
 
         [Fact(Skip = "Ignored"), TestCategory("Failures")]
         public async Task AQ_21_GenericConsumerImplicitlySubscribedToProducerGrain()
         {
             // todo: currently, the Azure queue queue adaptor doesn't support namespaces, so this test will fail.
-            await fixture.Runner.StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain(TestContext.Current.CancellationToken);
+            await _fixture.Runner.StreamTest_21_GenericConsumerImplicitlySubscribedToProducerGrain(TestContext.Current.CancellationToken);
         }
     }
 }

--- a/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraClusteringTableTests.cs
+++ b/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraClusteringTableTests.cs
@@ -27,6 +27,7 @@ public sealed class CassandraClusteringTableTests : IClassFixture<CassandraConta
 
     public CassandraClusteringTableTests(CassandraContainer cassandraContainer, ITestOutputHelper testOutputHelper)
     {
+        cassandraContainer.EnsurePreconditionsMet();
         _cassandraContainer = cassandraContainer;
         _cassandraContainer.Name = nameof(Cassandra);
         _testOutputHelper = testOutputHelper;

--- a/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraContainer.cs
+++ b/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraContainer.cs
@@ -21,6 +21,8 @@ public class CassandraContainer
     public async Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> RunImage(
         CancellationToken cancellationToken)
     {
+        EnsurePreconditionsMet();
+
         Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> task;
         lock (_lock)
         {

--- a/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraContainer.cs
+++ b/test/Extensions/Orleans.Clustering.Cassandra.Tests/Clustering/CassandraContainer.cs
@@ -2,14 +2,21 @@ using System.Net;
 using Cassandra;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
+using Xunit;
 
 namespace Tester.Cassandra.Clustering;
 
 public class CassandraContainer
 {
     private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(30);
+    private readonly string? _image = GetImage();
     private readonly object _lock = new();
     private Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)>? _runImage;
+
+    public void EnsurePreconditionsMet()
+    {
+        Assert.SkipWhen(string.IsNullOrWhiteSpace(_image), "CASSANDRAVERSION is not configured.");
+    }
 
     public async Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> RunImage(
         CancellationToken cancellationToken)
@@ -45,7 +52,7 @@ public class CassandraContainer
         }
     }
 
-    private static async Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> RunImageCore(
+    private async Task<(IContainer container, ushort exposedPort, Cluster cluster, ISession session)> RunImageCore(
         CancellationToken cancellationToken)
     {
         var containerPort = 9042;
@@ -53,7 +60,7 @@ public class CassandraContainer
 
         try
         {
-            container = new ContainerBuilder("cassandra:" + Environment.GetEnvironmentVariable("CASSANDRAVERSION"))
+            container = new ContainerBuilder(_image!)
                 .WithPortBinding(containerPort, true)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(containerPort))
                 .Build();
@@ -94,4 +101,10 @@ public class CassandraContainer
     }
 
     public string Name { get; set; } = string.Empty;
+
+    private static string? GetImage()
+    {
+        var version = Environment.GetEnvironmentVariable("CASSANDRAVERSION");
+        return string.IsNullOrWhiteSpace(version) ? null : $"cassandra:{version}";
+    }
 }

--- a/test/Extensions/Orleans.Persistence.Firestore.Tests/FirestorePersistenceGrainTests.cs
+++ b/test/Extensions/Orleans.Persistence.Firestore.Tests/FirestorePersistenceGrainTests.cs
@@ -13,6 +13,12 @@ public class FirestorePersistenceGrainTests : GrainPersistenceTestsRunner, IClas
 {
     public class Fixture : TestExtensions.BaseTestClusterFixture
     {
+        protected override void CheckPreconditionsOrThrow()
+        {
+            base.CheckPreconditionsOrThrow();
+            _ = GoogleEmulatorHost.FirestoreEndpoint;
+        }
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             builder.Options.InitialSilosCount = 4;

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHBatchedSubscriptionMultiplicityTests.cs
@@ -22,7 +22,7 @@ namespace ServiceBus.Tests.StreamingTests
         private readonly SubscriptionMultiplicityTestRunner runner;
         private readonly Fixture fixture;
 
-        public class Fixture : BaseTestClusterFixture
+        public class Fixture : BaseEventHubTestClusterFixture
         {
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
@@ -60,6 +60,7 @@ namespace ServiceBus.Tests.StreamingTests
 
         public EHBatchedSubscriptionMultiplicityTests(Fixture fixture)
         {
+            fixture.EnsurePreconditionsMet();
             this.fixture = fixture;
             this.runner = new SubscriptionMultiplicityTestRunner(StreamProviderName, fixture.HostedCluster);
         }


### PR DESCRIPTION
## Problem

Provider test projects fail when external services are unavailable because prerequisite checks run during fixture initialization, which xUnit reports as failures instead of dynamic skips. Cassandra also constructs the invalid image reference `cassandra:` when `CASSANDRAVERSION` is unset.

## Solution

Move unavailable-service checks to test construction and let fixtures remain uninitialized when prerequisites are absent. This covers Cassandra, Event Hubs batching, Firestore persistence, and Azure Queue streaming while preserving genuine initialization failures.

## Rationale

Test construction is the supported dynamic-skip boundary, matching #11015.

Fixes #11191
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11200)