### PR TITLE
test(runtime): allocate heterogeneous silo ports at startup

### DIFF
--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -224,7 +224,8 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
                     }
                 };
 
-                silo = await TestCluster.StartSiloAsync(cluster, siloIdx, testClusterOptions, sources);
+                // Allocate against the current listener set so the client cannot consume a future gateway port as an ephemeral endpoint.
+                silo = await TestCluster.StartSiloAsync(cluster, siloIdx, testClusterOptions, sources, startSiloOnNewPort: true);
             }
 
             this.deployedSilos.Add(silo);


### PR DESCRIPTION
Fixes #11186

The heterogeneous upgrade tests selected a consecutive gateway-port block before the cluster client connected. On Linux, the client could then receive one of the future gateway ports as its ephemeral source port; the reported failure shows the client using `49650` before the third silo attempted to bind that same gateway port.

Allocate each additional spawned silo's endpoints through the existing `startSiloOnNewPort` path immediately before launch. This checks the current listener set, preserves the cluster allocator's reservation tracking, and prevents delayed silo startup from consuming a port selected before client connections were established.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11201)