### PR TITLE
fix(test): retry SQL Server setup ownership race

### DIFF
--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -91,7 +91,7 @@ namespace UnitTests.General
                 using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 try
                 {
-                    await RestoreMultiUserAsync(quotedDatabaseName, cleanupCancellation.Token);
+                    await RestoreMultiUserAsync(connection, quotedDatabaseName, cleanupCancellation.Token);
                 }
                 catch when (!setupSucceeded)
                 {
@@ -142,17 +142,17 @@ namespace UnitTests.General
                 {
                     if (!acquired)
                     {
-                        await connection.DisposeAsync();
                         using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                         try
                         {
-                            await RestoreMultiUserAsync(quotedDatabaseName, cleanupCancellation.Token);
+                            await RestoreMultiUserAsync(connection, quotedDatabaseName, cleanupCancellation.Token);
                         }
                         catch
                         {
                             // Preserve the setup failure instead of replacing it with a cleanup failure.
                         }
 
+                        await connection.DisposeAsync();
                         using var pooledConnection = new SqlConnection(CurrentConnectionString);
                         SqlConnection.ClearPool(pooledConnection);
                     }
@@ -160,22 +160,14 @@ namespace UnitTests.General
             }
         }
 
-        private async Task RestoreMultiUserAsync(string quotedDatabaseName, CancellationToken cancellationToken)
-        {
-            var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
-            {
-                InitialCatalog = "master",
-                Pooling = false,
-                ConnectTimeout = 5
-            };
-
-            await using var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
-            await OpenConnectionAsync(connection, cancellationToken);
-            await ExecuteCommandAsync(
+        private static Task RestoreMultiUserAsync(
+            SqlConnection connection,
+            string quotedDatabaseName,
+            CancellationToken cancellationToken) =>
+            ExecuteCommandAsync(
                 connection,
                 $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER WITH ROLLBACK IMMEDIATE;",
                 cancellationToken);
-        }
 
         private static async Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
         {

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTesting.cs
@@ -8,6 +8,7 @@ namespace UnitTests.General
     public class SqlServerStorageForTesting : RelationalStorageForTesting
     {
         private const int DeadlockVictimError = 1205;
+        private const int DatabaseAlreadyOpenError = 924;
         private const int DatabaseInUseError = 3702;
 
         protected override string ProviderMoniker => "SQLServer";
@@ -62,34 +63,25 @@ namespace UnitTests.General
             string databaseName,
             CancellationToken cancellationToken)
         {
-            var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
-            {
-                Pooling = false,
-                ConnectTimeout = 5
-            };
-
-            await using var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
-            await OpenConnectionAsync(connection, cancellationToken);
-
-            using var commandBuilder = new SqlCommandBuilder();
-            var quotedDatabaseName = commandBuilder.QuoteIdentifier(databaseName);
-            using var scriptEnumerator = scripts.GetEnumerator();
-            if (!scriptEnumerator.MoveNext())
+            var scriptBatches = scripts.ToArray();
+            if (scriptBatches.Length == 0)
             {
                 return;
             }
 
+            using var commandBuilder = new SqlCommandBuilder();
+            var quotedDatabaseName = commandBuilder.QuoteIdentifier(databaseName);
             var setupSucceeded = false;
+            await using var connection = await AcquireSetupConnectionAsync(
+                scriptBatches[0],
+                quotedDatabaseName,
+                databaseName,
+                cancellationToken);
             try
             {
-                await ExecuteCommandAsync(
-                    connection,
-                    $"ALTER DATABASE {quotedDatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;\n{scriptEnumerator.Current}",
-                    cancellationToken);
-
-                while (scriptEnumerator.MoveNext())
+                for (var i = 1; i < scriptBatches.Length; i++)
                 {
-                    await ExecuteCommandAsync(connection, scriptEnumerator.Current, cancellationToken);
+                    await ExecuteCommandAsync(connection, scriptBatches[i], cancellationToken);
                 }
 
                 setupSucceeded = true;
@@ -99,10 +91,7 @@ namespace UnitTests.General
                 using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 try
                 {
-                    await ExecuteCommandAsync(
-                        connection,
-                        $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER;",
-                        cleanupCancellation.Token);
+                    await RestoreMultiUserAsync(quotedDatabaseName, cleanupCancellation.Token);
                 }
                 catch when (!setupSucceeded)
                 {
@@ -112,6 +101,80 @@ namespace UnitTests.General
                 using var pooledConnection = new SqlConnection(CurrentConnectionString);
                 SqlConnection.ClearPool(pooledConnection);
             }
+        }
+
+        private async Task<SqlConnection> AcquireSetupConnectionAsync(
+            string firstScript,
+            string quotedDatabaseName,
+            string databaseName,
+            CancellationToken cancellationToken)
+        {
+            const int maxAttempts = 3;
+            var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
+            {
+                Pooling = false,
+                ConnectTimeout = 5
+            };
+
+            for (var attempt = 1; ; attempt++)
+            {
+                var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
+                var acquired = false;
+                try
+                {
+                    await OpenConnectionAsync(connection, cancellationToken);
+                    await ExecuteCommandAsync(
+                        connection,
+                        $"ALTER DATABASE {quotedDatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;\n{firstScript}",
+                        cancellationToken);
+                    acquired = true;
+                    return connection;
+                }
+                catch (SqlException exception) when (IsRetryableDatabaseSetupError(exception.Number) && attempt < maxAttempts)
+                {
+                    Console.WriteLine(
+                        "SQL Server database '{0}' setup failed with transient error {1} on attempt {2}; retrying.",
+                        databaseName,
+                        exception.Number,
+                        attempt);
+                }
+                finally
+                {
+                    if (!acquired)
+                    {
+                        await connection.DisposeAsync();
+                        using var cleanupCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                        try
+                        {
+                            await RestoreMultiUserAsync(quotedDatabaseName, cleanupCancellation.Token);
+                        }
+                        catch
+                        {
+                            // Preserve the setup failure instead of replacing it with a cleanup failure.
+                        }
+
+                        using var pooledConnection = new SqlConnection(CurrentConnectionString);
+                        SqlConnection.ClearPool(pooledConnection);
+                    }
+                }
+            }
+        }
+
+        private async Task RestoreMultiUserAsync(string quotedDatabaseName, CancellationToken cancellationToken)
+        {
+            var connectionStringBuilder = new SqlConnectionStringBuilder(CurrentConnectionString)
+            {
+                InitialCatalog = "master",
+                Pooling = false,
+                ConnectTimeout = 5
+            };
+
+            await using var connection = new SqlConnection(connectionStringBuilder.ConnectionString);
+            await OpenConnectionAsync(connection, cancellationToken);
+            await ExecuteCommandAsync(
+                connection,
+                $"ALTER DATABASE {quotedDatabaseName} SET MULTI_USER WITH ROLLBACK IMMEDIATE;",
+                cancellationToken);
         }
 
         private static async Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
@@ -197,6 +260,9 @@ namespace UnitTests.General
 
         internal static bool IsRetryableDatabaseResetError(int errorNumber) =>
             errorNumber is DeadlockVictimError or DatabaseInUseError;
+
+        internal static bool IsRetryableDatabaseSetupError(int errorNumber) =>
+            errorNumber is DatabaseAlreadyOpenError;
 
         protected override string ExistsDatabaseTemplate
         {

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/SqlServerStorageForTestingTests.cs
@@ -20,6 +20,15 @@ public class SqlServerStorageForTestingTests
         Assert.Equal(expected, SqlServerStorageForTesting.IsRetryableDatabaseResetError(errorNumber));
     }
 
+    [Theory]
+    [InlineData(924, true)]
+    [InlineData(1205, false)]
+    [InlineData(18456, false)]
+    public void ClassifiesRetryableDatabaseSetupErrors(int errorNumber, bool expected)
+    {
+        Assert.Equal(expected, SqlServerStorageForTesting.IsRetryableDatabaseSetupError(errorNumber));
+    }
+
     [Fact]
     public async Task RecreatesDatabaseWithActivePooledConnection()
     {


### PR DESCRIPTION
## Problem

SQL Server schema setup can still lose the database's single-user slot to a reconnecting test client while entering the first schema batch. This surfaces as error 924 during unrelated provider fixture initialization even after #10823.

## Solution

Retry only the exclusive-access acquisition and first schema batch when SQL Server reports error 924. Between attempts, restore `MULTI_USER` on the target-database connection which owns the single-user slot, so the next attempt starts from a usable database state.

Later schema batches remain one-shot, preventing retries from replaying partially applied schema.

Fixes #10808