### PR TITLE
perf(durable-jobs): coalesce flush signals

### DIFF
--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Diagnostics;
 using Orleans.Journaling;
+using Orleans.Runtime;
 
 namespace Orleans.DurableJobs;
 
@@ -21,7 +22,7 @@ internal sealed class JournaledJobShard : IJobShard
     private readonly TimeSpan _batchLingerDelay;
     private readonly object _pendingOperationsLock = new();
     private readonly Queue<PendingOperation> _pendingOperations = new();
-    private readonly SemaphoreSlim _pendingOperationSignal = new(0);
+    private readonly SingleWaiterAutoResetEvent _pendingOperationSignal = new() { RunContinuationsAsynchronously = true };
     private readonly CancellationTokenSource _shutdownCancellation = new();
     private readonly Task _operationProcessor;
     private int _disposed;
@@ -260,14 +261,13 @@ internal sealed class JournaledJobShard : IJobShard
         try
         {
             _shutdownCancellation.Cancel();
-            _pendingOperationSignal.Release();
+            _pendingOperationSignal.Signal();
             await _operationProcessor.ConfigureAwait(false);
             await _stateManager.DisposeAsync();
         }
         finally
         {
             _shutdownCancellation.Dispose();
-            _pendingOperationSignal.Dispose();
             GC.SuppressFinalize(this);
         }
     }
@@ -282,7 +282,7 @@ internal sealed class JournaledJobShard : IJobShard
         {
             ThrowIfDisposed();
             _pendingOperations.Enqueue(operation);
-            _pendingOperationSignal.Release();
+            _pendingOperationSignal.Signal();
         }
     }
 
@@ -293,10 +293,12 @@ internal sealed class JournaledJobShard : IJobShard
         {
             while (true)
             {
-                await _pendingOperationSignal.WaitAsync(_shutdownCancellation.Token).ConfigureAwait(false);
+                _shutdownCancellation.Token.ThrowIfCancellationRequested();
 
                 if (!TryDequeueOperation(out var operation) || operation is null)
                 {
+                    // The queue is authoritative: drain it before waiting for another coalesced signal.
+                    await _pendingOperationSignal.WaitAsync().ConfigureAwait(false);
                     continue;
                 }
 

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
@@ -21,7 +21,7 @@ namespace Tester.DurableJobs;
 [TestProvider("None")]
 [TestArea("DurableJobs")]
 [TestCategory("BVT"), TestCategory("DurableJobs")]
-public class JournaledJobShardManagerTests
+public partial class JournaledJobShardManagerTests
 {
     [Fact]
     public async Task ReleasedShard_IsClaimedClosedAndReplayedFromJournal()
@@ -567,13 +567,13 @@ public class JournaledJobShardManagerTests
         }
     }
 
-    private static ServiceProvider CreateServices(IJournalStorageProvider storageProvider)
+    private static ServiceProvider CreateServices(IJournalStorageProvider storageProvider, TimeProvider? timeProvider = null)
     {
         var builder = new TestSiloBuilder();
         builder.AddJournalStorage();
         builder.UseJsonJournalFormat(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
         builder.Services.AddLogging();
-        builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddSingleton(timeProvider ?? TimeProvider.System);
         builder.Services.AddKeyedSingleton<TimeProvider>(KeyedService.AnyKey, static (sp, _) => sp.GetRequiredService<TimeProvider>());
         builder.Services.AddSingleton<IJournalStorageProvider>(storageProvider);
         builder.Services.AddSingleton((IJournalStorageCatalog)storageProvider);
@@ -598,15 +598,17 @@ public class JournaledJobShardManagerTests
     private sealed class CountingJournalStorageProvider : IJournalStorageProvider, IJournalStorageCatalog
     {
         private readonly VolatileJournalStorageProvider _inner = new();
+        private readonly Func<CancellationToken, ValueTask>? _onAppend;
         private readonly object _appendGate = new();
         private bool _delayAppends;
         private TaskCompletionSource _appendStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private TaskCompletionSource _allowAppends = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _appendCount;
 
-        public CountingJournalStorageProvider(bool delayAppends)
+        public CountingJournalStorageProvider(bool delayAppends, Func<CancellationToken, ValueTask>? onAppend = null)
         {
             _delayAppends = delayAppends;
+            _onAppend = onAppend;
         }
 
         public Task AppendStarted
@@ -659,6 +661,11 @@ public class JournaledJobShardManagerTests
             if (waitTask is not null)
             {
                 await waitTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (_onAppend is { } onAppend)
+            {
+                await onAppend(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardSignalTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardSignalTests.cs
@@ -1,0 +1,290 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Orleans.DurableJobs;
+using Orleans.Journaling;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.DurableJobs;
+
+public partial class JournaledJobShardManagerTests
+{
+    [Fact]
+    public async Task FlushSignal_DrainsQueuedMutationsAndBarriersWithoutAnotherEnqueue()
+    {
+        await using var test = await SignalTest.CreateAsync();
+        var firstWrite = test.GateNextAppend();
+        var first = test.Schedule(0);
+        await firstWrite.Started.Task.WaitAsync(test.Token);
+        var nextWrite = test.GateNextAppend();
+        var queued = Enumerable.Range(1, 3).Select(index => test.Schedule(index)).ToArray();
+        var close = test.Shard.MarkAsCompleteAsync(test.Token);
+        var rejected = test.Schedule(4);
+        var followingBarrier = test.Shard.MarkAsCompleteAsync(test.Token);
+
+        Assert.Empty(await test.ReadPersistedJobNamesAsync());
+        Assert.False(first.IsCompleted);
+        firstWrite.Release.SetResult();
+        await nextWrite.Started.Task.WaitAsync(test.Token);
+        Assert.NotNull(await first.WaitAsync(test.Token));
+        Assert.Equal(["job-0"], await test.ReadPersistedJobNamesAsync());
+        Assert.All(queued, task => Assert.False(task.IsCompleted));
+        Assert.False(close.IsCompleted);
+        Assert.False(rejected.IsCompleted);
+        Assert.False(followingBarrier.IsCompleted);
+
+        nextWrite.Release.SetResult();
+        Assert.All(await Task.WhenAll(queued).WaitAsync(test.Token), job => Assert.NotNull(job));
+        await Task.WhenAll(close, followingBarrier).WaitAsync(test.Token);
+        Assert.Null(await rejected.WaitAsync(test.Token));
+        Assert.True(test.Shard.IsAddingCompleted);
+        Assert.Equal(2, test.Storage.AppendCount);
+        Assert.Equal(Enumerable.Range(0, 4).Select(index => $"job-{index}"), await test.ReadPersistedJobNamesAsync());
+    }
+
+    [Fact]
+    public async Task FlushSignal_DeleteBarrierFollowsPersistedMutations()
+    {
+        await using var test = await SignalTest.CreateAsync();
+        var write = test.GateNextAppend();
+        var first = test.Schedule(0);
+        await write.Started.Task.WaitAsync(test.Token);
+        var nextWrite = test.GateNextAppend();
+        var queued = test.Schedule(1);
+        var delete = test.Shard.DeleteStateAsync(test.Token).AsTask();
+
+        write.Release.SetResult();
+        await nextWrite.Started.Task.WaitAsync(test.Token);
+        Assert.NotNull(await first.WaitAsync(test.Token));
+        Assert.False(queued.IsCompleted);
+        Assert.False(delete.IsCompleted);
+        Assert.Equal(["job-0"], await test.ReadPersistedJobNamesAsync());
+
+        nextWrite.Release.SetResult();
+        Assert.NotNull(await queued.WaitAsync(test.Token));
+        await delete.WaitAsync(test.Token);
+        Assert.Equal(2, test.Storage.AppendCount);
+        Assert.Equal(0, await test.Shard.GetJobCountAsync());
+        Assert.Null(await test.Storage.CreateStorage(test.Shard.StorageId).GetMetadataAsync(test.Token));
+    }
+
+    [Fact]
+    public async Task FlushSignal_ConcurrentProducersDrainAfterActiveWrite()
+    {
+        await using var test = await SignalTest.CreateAsync();
+        var write = test.GateNextAppend();
+        var first = test.Schedule(0);
+        await write.Started.Task.WaitAsync(test.Token);
+
+        var producers = Enumerable.Range(0, 4).Select(producer => Task.Run(() =>
+            Enumerable.Range(1 + producer * 8, 8).Select(index => test.Schedule(index)).ToArray())).ToArray();
+        var queued = (await Task.WhenAll(producers).WaitAsync(test.Token)).SelectMany(tasks => tasks).ToArray();
+        Assert.All(queued, task => Assert.False(task.IsCompleted));
+        write.Release.SetResult();
+
+        var jobs = await Task.WhenAll(queued.Prepend(first)).WaitAsync(test.Token);
+        Assert.All(jobs, job => Assert.NotNull(job));
+        Assert.Equal(33, jobs.Select(job => job!.Id).Distinct().Count());
+        Assert.Equal(2, test.Storage.AppendCount);
+        Assert.Equal(Enumerable.Range(0, 33).Select(index => $"job-{index}"), await test.ReadPersistedJobNamesAsync());
+    }
+
+    [Fact]
+    public async Task FlushSignal_CancellationBeforeExecutionPreservesFollowingWork()
+    {
+        await using var test = await SignalTest.CreateAsync();
+        var write = test.GateNextAppend();
+        var first = test.Schedule(0);
+        await write.Started.Task.WaitAsync(test.Token);
+        using var cancellation = new CancellationTokenSource();
+        var canceled = test.Schedule(1, cancellation.Token);
+        var canceledBarrier = test.Shard.MarkAsCompleteAsync(cancellation.Token);
+        var following = test.Schedule(2);
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceled.WaitAsync(test.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledBarrier.WaitAsync(test.Token));
+
+        write.Release.SetResult();
+        Assert.NotNull(await first.WaitAsync(test.Token));
+        Assert.NotNull(await following.WaitAsync(test.Token));
+        Assert.False(test.Shard.IsAddingCompleted);
+        Assert.Equal(2, test.Storage.AppendCount);
+        Assert.Equal(["job-0", "job-2"], await test.ReadPersistedJobNamesAsync());
+    }
+
+    [Fact]
+    public async Task FlushSignal_DisposeIdleShardCompletes()
+    {
+        await using var test = await SignalTest.CreateAsync();
+        await test.Shard.DisposeAsync().AsTask().WaitAsync(test.Token);
+        Assert.Equal(0, test.Storage.AppendCount);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => test.Schedule(0));
+    }
+
+    [Fact]
+    public async Task FlushSignal_DisposeDuringWriteCancelsActiveAndQueuedWork()
+    {
+        await using var test = await SignalTest.CreateAsync();
+        var write = test.GateNextAppend();
+        var active = test.Schedule(0);
+        await write.Started.Task.WaitAsync(test.Token);
+        var queued = test.Schedule(1);
+        var barrier = test.Shard.MarkAsCompleteAsync(test.Token);
+
+        await test.Shard.DisposeAsync().AsTask().WaitAsync(test.Token);
+        foreach (var task in new Task[] { active, queued, barrier })
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task.WaitAsync(test.Token));
+        }
+
+        Assert.Equal(1, test.Storage.AppendCount);
+        Assert.Empty(await test.ReadPersistedJobNamesAsync());
+    }
+
+    [Fact]
+    public async Task FlushSignal_EnqueueDuringLingerJoinsPersistedBatch()
+    {
+        var clock = new SignalTimeProvider();
+        await using var test = await SignalTest.CreateAsync(clock);
+        var write = test.GateNextAppend();
+        var first = test.Schedule(0);
+        await clock.TimerCreated.Task.WaitAsync(test.Token);
+        var queued = test.Schedule(1);
+        clock.Advance(TimeSpan.FromSeconds(1));
+        await write.Started.Task.WaitAsync(test.Token);
+        Assert.Equal(2, await test.Shard.GetJobCountAsync());
+        Assert.False(first.IsCompleted);
+        Assert.False(queued.IsCompleted);
+
+        write.Release.SetResult();
+        Assert.All(await Task.WhenAll(first, queued).WaitAsync(test.Token), job => Assert.NotNull(job));
+        Assert.Equal(1, test.Storage.AppendCount);
+        Assert.Equal(["job-0", "job-1"], await test.ReadPersistedJobNamesAsync());
+    }
+
+    [Fact]
+    public async Task FlushSignal_DisposeDuringLingerCancelsBatchAndBarrier()
+    {
+        var clock = new SignalTimeProvider();
+        await using var test = await SignalTest.CreateAsync(clock);
+        var first = test.Schedule(0);
+        await clock.TimerCreated.Task.WaitAsync(test.Token);
+        var queued = test.Schedule(1);
+        var barrier = test.Shard.MarkAsCompleteAsync(test.Token);
+
+        await test.Shard.DisposeAsync().AsTask().WaitAsync(test.Token);
+        foreach (var task in new Task[] { first, queued, barrier })
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task.WaitAsync(test.Token));
+        }
+
+        Assert.Equal(0, test.Storage.AppendCount);
+        Assert.Empty(await test.ReadPersistedJobNamesAsync());
+    }
+
+    private sealed class SignalTimeProvider : FakeTimeProvider
+    {
+        public TaskCompletionSource TimerCreated { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = base.CreateTimer(callback, state, dueTime, period);
+            TimerCreated.TrySetResult();
+            return timer;
+        }
+    }
+
+    private sealed class AppendGate
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class SignalTest : IAsyncDisposable
+    {
+        private readonly Queue<AppendGate> _writes = new();
+        private readonly CancellationTokenSource _timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        private SignalTest(TimeProvider? clock)
+        {
+            _timeout.CancelAfter(TimeSpan.FromSeconds(30));
+            Storage = new CountingJournalStorageProvider(delayAppends: false, onAppend: OnAppendAsync);
+            Services = CreateServices(Storage, clock);
+        }
+
+        public CancellationToken Token => _timeout.Token;
+        public CountingJournalStorageProvider Storage { get; }
+        public ServiceProvider Services { get; }
+        public JournaledJobShard Shard { get; private set; } = null!;
+
+        public static async Task<SignalTest> CreateAsync(SignalTimeProvider? clock = null)
+        {
+            var test = new SignalTest(clock);
+            var membership = new TestClusterMembershipService();
+            var silo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5090), 0);
+            membership.SetSiloStatus(silo, SiloStatus.Active);
+            var manager = CreateManager(test.Services, membership, silo, new DurableJobsOptions
+            {
+                ShardBatchLingerDelay = clock is null ? TimeSpan.Zero : TimeSpan.FromSeconds(1)
+            });
+            var start = (clock?.GetUtcNow() ?? DateTimeOffset.UtcNow).AddMinutes(-1);
+            test.Shard = Assert.IsType<JournaledJobShard>(await manager.CreateShardAsync(
+                start, start.AddHours(1), new Dictionary<string, string>(), test.Token));
+            return test;
+        }
+
+        public Task<DurableJob?> Schedule(int index, CancellationToken? cancellationToken = null)
+            => Shard.TryScheduleJobAsync(new()
+            {
+                Target = GrainId.Create("type", "target"),
+                JobName = $"job-{index}",
+                DueTime = Shard.StartTime.AddSeconds(index + 1)
+            }, cancellationToken ?? Token);
+
+        public AppendGate GateNextAppend()
+        {
+            var gate = new AppendGate();
+            lock (_writes)
+            {
+                _writes.Enqueue(gate);
+            }
+
+            return gate;
+        }
+
+        public async Task<string[]> ReadPersistedJobNamesAsync()
+        {
+            var formatKey = Services.GetRequiredService<IOptions<JournaledStateManagerOptions>>().Value.JournalFormatKey;
+            var codec = Services.GetRequiredKeyedService<IDurableValueCommandCodec<DurableJobShardJournalRecord>>(formatKey);
+            var state = new JournaledJobShardState(JobShardId.Parse(Shard.Id), Shard.StartTime, Shard.EndTime, codec);
+            await using var manager = Services.GetRequiredService<IJournaledStateManagerFactory>().Create(Shard.StorageId);
+            manager.RegisterState(JournaledJobShardState.StateName, state);
+            await manager.InitializeAsync(Token);
+            return state.CaptureSnapshot().Jobs.OrderBy(entry => entry.Job.DueTime).Select(entry => entry.Job.Name).ToArray();
+        }
+
+        private async ValueTask OnAppendAsync(CancellationToken cancellationToken)
+        {
+            AppendGate? gate;
+            lock (_writes)
+            {
+                _writes.TryDequeue(out gate);
+            }
+
+            if (gate is not null)
+            {
+                gate.Started.SetResult();
+                await gate.Release.Task.WaitAsync(cancellationToken);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Shard.DisposeAsync();
+            await Services.DisposeAsync();
+            _timeout.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
`JournaledJobShard` releases one semaphore credit per queued operation, while its single consumer processes consecutive mutations in batches. A finite burst can therefore leave surplus credits which the consumer drains through successful synchronous waits and empty queue checks.

Use the existing `SingleWaiterAutoResetEvent` with asynchronous continuations, retaining the queue and its lock. The consumer checks the authoritative queue before waiting, and shutdown explicitly signals it. FIFO barriers, mutation batching, linger, cancellation, and completion after persistence retain their existing semantics.

An instrumented copy of the actual enqueue/drain flow processed 257 jobs in exactly two writes with either implementation: empty dequeues fell from 255 to 2. Uninstrumented comparisons showed approximately 374–388 fewer allocated bytes for a single outstanding request (about 12%). Throughput differences were modest and noisy, with essentially equal results for concurrent producers and delayed storage; the evidence supports a small bookkeeping cleanup.

Deterministic regression coverage exercises queued-work draining, enqueue during persistence and linger, close/delete barriers, cancellation before execution, and idle/active/lingering shutdown.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11206)