### PR TITLE
perf(serialization): optimize buffered tail reads

### DIFF
--- a/src/Orleans.Serialization/Buffers/ArcBufferWriter.cs
+++ b/src/Orleans.Serialization/Buffers/ArcBufferWriter.cs
@@ -378,10 +378,22 @@ public sealed class ArcBufferWriter : IBufferWriter<byte>, IDisposable
             throw new ArgumentOutOfRangeException(nameof(offset));
         }
 
-        if (offset >= Length)
+        var length = Length;
+        if (offset >= length)
         {
             value = default;
             return false;
+        }
+
+        // Owned buffers end at the write page's written length; pinned slices can end partway through a page.
+        if (!_hasPinnedPages)
+        {
+            var writePageOffset = offset - (length - _writePage.Length);
+            if (writePageOffset >= 0)
+            {
+                value = _writePage.AsSpan((int)writePageOffset, 1)[0];
+                return true;
+            }
         }
 
         Debug.Assert(offset <= int.MaxValue);

--- a/test/Orleans.Journaling.Tests/JournalBufferWriterOwnershipTests.cs
+++ b/test/Orleans.Journaling.Tests/JournalBufferWriterOwnershipTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Text;
 using Orleans.Journaling.Json;
+using Orleans.Serialization.Buffers;
 using Xunit;
 
 namespace Orleans.Journaling.Tests;
@@ -252,6 +253,50 @@ public sealed class JournalBufferWriterOwnershipTests
         Assert.NotNull(exception);
         Assert.Equal("offset", exception.ParamName);
         Assert.Empty(ToArray(writer));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void JsonEmptyEntry_RetainsValidationAfterLargeOrConsumedPrefix(bool consumePrefix)
+    {
+        using var writer = CreateWriter(JsonFormat);
+        var payload = Encoding.UTF8.GetBytes($"[\"set\",\"{new string('x', ArcBufferWriter.MinimumPageSize * 3 + 17)}\"]");
+        AppendEntry(writer.CreateJournalStreamWriter(new JournalStreamId(1)), payload);
+        using var prefix = writer.GetCommittedBuffer();
+        var prefixBytes = Encoding.UTF8.GetBytes($"[1,{Encoding.UTF8.GetString(payload)}]\n");
+        Assert.Equal(prefixBytes, prefix.ToArray());
+        if (consumePrefix)
+        {
+            writer.Consume(prefix);
+        }
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            AppendEntry(writer.CreateJournalStreamWriter(new JournalStreamId(2)), []));
+        Assert.Equal("The JSON Lines journal entry has no entry payload.", exception.Message);
+        Assert.Equal(consumePrefix ? [] : prefixBytes, ToArray(writer));
+
+        AppendEntry(writer.CreateJournalStreamWriter(new JournalStreamId(3)), GetThirdPayload(JsonFormat));
+        var suffix = """[3,["set",3]]""" + "\n";
+        Assert.Equal(Encoding.UTF8.GetBytes((consumePrefix ? "" : Encoding.UTF8.GetString(prefixBytes)) + suffix), ToArray(writer));
+        Assert.Equal(prefixBytes, prefix.ToArray());
+    }
+
+    [Fact]
+    public void JsonEmptyEntry_RetainsValidationOnNewAndResetWriter()
+    {
+        using var writer = CreateWriter(JsonFormat);
+        for (var iteration = 0; iteration < 2; iteration++)
+        {
+            var stream = writer.CreateJournalStreamWriter(new JournalStreamId(1));
+            var exception = Assert.Throws<InvalidOperationException>(() => AppendEntry(stream, []));
+            Assert.Equal("The JSON Lines journal entry has no entry payload.", exception.Message);
+            Assert.Empty(ToArray(writer));
+
+            AppendEntry(stream, GetFirstPayload(JsonFormat));
+            Assert.Equal(Encoding.UTF8.GetBytes("""[1,["set",1]]""" + "\n"), ToArray(writer));
+            writer.Reset();
+        }
     }
 
     private static JournalBufferWriter CreateWriter(string format) => format switch

--- a/test/Orleans.Serialization.UnitTests/ArcBufferWriterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ArcBufferWriterTests.cs
@@ -142,6 +142,117 @@ public class ArcBufferWriterTests
         Assert.Equal(data.Length * 1_000L, length);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(17)]
+    [InlineData(PageSize)]
+    [InlineData(PageSize * 2 + 3)]
+    [InlineData(PageSize * 3 + 3)]
+    public void Peek_ReturnsEveryUnreadByteAcrossPages(int consumed)
+    {
+        using var writer = new ArcBufferWriter();
+        var data = Enumerable.Range(0, PageSize * 3 + 17).Select(static i => (byte)(i % 251)).ToArray();
+        writer.Write(data);
+        writer.AdvanceReader(consumed);
+
+        for (var offset = 0; offset < writer.Length; offset++)
+        {
+            Assert.Equal(data[consumed + offset], writer.Reader.Peek(offset));
+        }
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => writer.Reader.Peek(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => writer.Reader.Peek(writer.Length));
+        Assert.Throws<ArgumentOutOfRangeException>(() => writer.Reader.Peek(long.MaxValue));
+    }
+
+    [Fact]
+    public void Peek_UsesWrittenPageWhenLaterPagesAreReserved()
+    {
+        using var writer = new ArcBufferWriter();
+        var buffers = new List<ArraySegment<byte>>(4);
+        writer.ReplenishBuffers(buffers);
+        var data = Enumerable.Range(0, PageSize + 17).Select(static i => (byte)(i % 251)).ToArray();
+        writer.Write(data);
+
+        Assert.Equal(data[^1], writer.Reader.Peek(writer.Length - 1));
+        Assert.Equal(data[PageSize], writer.Reader.Peek(PageSize));
+        Assert.Equal(data[0], writer.Reader.Peek(0));
+    }
+
+    [Fact]
+    public void Peek_PreservesTailWhenNewWritePageIsEmpty()
+    {
+        using var writer = new ArcBufferWriter();
+        writer.Write([1, 2, 3]);
+        var memory = writer.GetMemory(PageSize * 2);
+
+        Assert.Equal(3, writer.Reader.Peek(2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => writer.Reader.Peek(3));
+
+        memory.Span[0] = 4;
+        writer.AdvanceWriter(1);
+        Assert.Equal(4, writer.Reader.Peek(3));
+        Assert.Equal(3, writer.Reader.Peek(2));
+    }
+
+    [Fact]
+    public void Peek_TracksTruncationPatchingAndAppends()
+    {
+        using var writer = new ArcBufferWriter();
+        var data = Enumerable.Range(0, PageSize * 3 + 17).Select(static i => (byte)(i % 251)).ToArray();
+        writer.Write(data);
+        writer.AdvanceReader(13);
+        writer.Truncate(PageSize + 7);
+
+        Assert.Equal(data[13 + PageSize + 6], writer.Reader.Peek(writer.Length - 1));
+        writer.WriteAt(writer.Length - 1, [255]);
+        Assert.Equal(255, writer.Reader.Peek(writer.Length - 1));
+        writer.Write([254, 253]);
+        Assert.Equal(254, writer.Reader.Peek(writer.Length - 2));
+        Assert.Equal(253, writer.Reader.Peek(writer.Length - 1));
+    }
+
+    [Fact]
+    public void Peek_RespectsPinnedSliceEndWhenSourceTailGrows()
+    {
+        using var source = new ArcBufferWriter();
+        var data = Enumerable.Range(0, PageSize + 64).Select(static i => (byte)(i % 251)).ToArray();
+        source.Write(data);
+        using var all = source.PeekSlice(source.Length);
+        using var slice = all.Slice(13, PageSize + 4);
+        using var destination = new ArcBufferWriter();
+        destination.AppendPinned(slice);
+        source.Write([253, 254, 255]);
+
+        for (var offset = 0; offset < destination.Length; offset++)
+        {
+            Assert.Equal(data[13 + offset], destination.Reader.Peek(offset));
+        }
+
+        destination.AdvanceReader(PageSize);
+        Assert.Equal(data[PageSize + 16], destination.Reader.Peek(3));
+        Assert.Throws<ArgumentOutOfRangeException>(() => destination.Reader.Peek(4));
+    }
+
+    [Fact]
+    public void Peek_ObservesResetReuseAndDisposal()
+    {
+        using var writer = new ArcBufferWriter();
+        var reader = writer.Reader;
+        writer.Write([1, 2, 3]);
+        writer.AdvanceReader(3);
+        Assert.Throws<ArgumentOutOfRangeException>(() => reader.Peek(0));
+        writer.Write([6]);
+        Assert.Equal(6, reader.Peek(0));
+
+        writer.Reset();
+        Assert.Throws<ArgumentOutOfRangeException>(() => reader.Peek(0));
+        writer.Write([4, 5]);
+        Assert.Equal(5, reader.Peek(1));
+        writer.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => reader.Peek(0));
+    }
+
     [Fact]
     public void AppendPinned_WholeBufferPinsPagesAndReadsData()
     {


### PR DESCRIPTION
JSON journal framing validates the final payload byte of every entry. `ArcBufferWriter.TryPeek` currently reaches that byte by walking from the first unread page, so a large unflushed batch repeatedly traverses a growing prefix.

This change reads bytes in an owned buffer's current write page directly using an unread-relative offset. Reads from earlier pages and pinned slices retain the existing traversal. The fast path relies on the existing write-page and length invariants, including consumed prefixes, reserved pages, truncation, and reuse.

Payload validation, public APIs, encoded bytes, and batching policy remain unchanged. Focused regressions cover page boundaries, consumption, empty/reserved write pages, truncation and patching, growing-source pinned slices, reset/disposal, and missing-payload rejection with rollback after large or consumed journal prefixes.

### Measured impact

In a task-scoped Windows experiment with a **fully queued burst of 4,096 jobs, 4 KiB metadata per job, and fast in-memory journal storage**, the normal validation-preserving writer's uncapped drain median decreased from **181.12 ms to 80.18 ms (~2.26× faster)** over five measured rounds per version. Observed ranges were 177.17–222.59 ms before and 54.81–114.75 ms after. Both versions used one append of up to 18,276,352 encoded bytes, with essentially unchanged allocations. Per-request p99 medians decreased from 168.27 ms to 48.61 ms.

The finite **128-outstanding-call** workload with injected storage latency was essentially unchanged: 997.37 ms versus 984.77 ms median drain time. The burst result is workload-specific; these measurements use simulated storage, a shared Windows machine, and sequential baseline/fixed processes. The requested 2 ms storage delay actually averaged about 15 ms in the latency-controlled case.

Both versions passed an encoding-equivalence check for 1,024 fixed records, and every measured round replayed all 4,097 jobs, including its seed, through the original reader. The improvement addresses the buffer traversal directly while preserving the existing mutation batch policy.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11209)