### PR TITLE
fix(ci): retry stalled coverage uploads

### DIFF
--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -59,15 +59,15 @@ runs:
         TestResults/${{ inputs.name }}.cobertura.xml
         TestResults/${{ inputs.name }}.coverage.json
   - name: Wait before retrying coverage upload
-    if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
+    if: steps.archive-coverage.outcome == 'failure'
     shell: pwsh
     run: Start-Sleep -Seconds 30
   - name: Report coverage upload retry
-    if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
+    if: steps.archive-coverage.outcome == 'failure'
     shell: pwsh
     run: Write-Output '::warning title=Coverage artifact upload failed::Retrying the coverage upload under a distinct immutable artifact name.'
   - name: Retry coverage upload
-    if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
+    if: steps.archive-coverage.outcome == 'failure'
     uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     with:
       name: coverage_${{ inputs.name }}-attempt-${{ github.run_attempt }}-retry

--- a/.github/actions/archive-test-results/action.yml
+++ b/.github/actions/archive-test-results/action.yml
@@ -47,10 +47,30 @@ runs:
          ConvertTo-Json |
          Set-Content -LiteralPath 'TestResults/${{ inputs.name }}.coverage.json' -Encoding utf8NoBOM
   - name: Archive coverage
+    id: archive-coverage
     if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)))
+    continue-on-error: true
     uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
     with:
-      name: coverage_${{ inputs.name }}
+      name: coverage_${{ inputs.name }}-attempt-${{ github.run_attempt }}
+      if-no-files-found: error
+      retention-days: ${{ github.event_name == 'push' && 7 || 1 }}
+      path: |
+        TestResults/${{ inputs.name }}.cobertura.xml
+        TestResults/${{ inputs.name }}.coverage.json
+  - name: Wait before retrying coverage upload
+    if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
+    shell: pwsh
+    run: Start-Sleep -Seconds 30
+  - name: Report coverage upload retry
+    if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
+    shell: pwsh
+    run: Write-Output '::warning title=Coverage artifact upload failed::Retrying the coverage upload under a distinct immutable artifact name.'
+  - name: Retry coverage upload
+    if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))) && steps.archive-coverage.outcome == 'failure'
+    uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+    with:
+      name: coverage_${{ inputs.name }}-attempt-${{ github.run_attempt }}-retry
       if-no-files-found: error
       retention-days: ${{ github.event_name == 'push' && 7 || 1 }}
       path: |

--- a/.github/coverage-artifacts.txt
+++ b/.github/coverage-artifacts.txt
@@ -13,6 +13,7 @@ test_output_test-mariadb_net10.0
 test_output_test-nats_net10.0
 test_output_test-postgres_net10.0
 test_output_test-redis_net10.0
+test_output_test-s3_net10.0
 test_output_test-sqlite_net10.0
 test_output_test-sqlserver_net10.0
 test_output_test-sqs_net10.0

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -852,8 +852,8 @@ exit 0
             '(?s)Verify tested commit.*?parents -notcontains \$env:HEAD_SHA.*?Download covered source' `
             'The trusted reporter must bind the recorded merge commit to the triggering pull request head.'
         Assert-Equal 0 ([regex]::Matches($workflow, 'name: Checkout covered source')).Count 'The privileged reporter must not check out untrusted pull request code.'
-        Assert-Equal 22 $expectedArtifacts.Count 'Expected coverage artifact count differs.'
-        Assert-Equal 22 (@($expectedArtifacts | Sort-Object -Unique)).Count 'Expected coverage artifact identities must be unique.'
+        Assert-Equal 23 $expectedArtifacts.Count 'Expected coverage artifact count differs.'
+        Assert-Equal 23 (@($expectedArtifacts | Sort-Object -Unique)).Count 'Expected coverage artifact identities must be unique.'
         Assert-Equal 0 (@($expectedArtifacts | Where-Object { $_ -notmatch 'net10\.0$' })).Count 'Coverage artifacts must target .NET 10.'
         Assert-Equal 0 (@($expectedArtifacts | Where-Object { $_ -match 'macos|windows' })).Count 'Coverage artifacts must target Linux.'
     }
@@ -910,7 +910,9 @@ exit 0
             [Text.UTF8Encoding]::new($false)
         )
         Write-ArtifactMetadata $firstArtifact 'test_output_a'
-        Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts | Out-Null
+        $validatorOutput = @(Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts)
+        Assert-Equal 1 $validatorOutput.Count 'Artifact validation must not emit collection indices.'
+        Assert-Equal 'Validated 2 coverage artifacts.' $validatorOutput[0] 'Artifact validation output differs.'
         Assert-Equal $false (Test-Path -LiteralPath $firstArtifact) 'A legacy canonical artifact must yield to an attempt-qualified artifact.'
         Assert-Equal $true (Test-Path -LiteralPath $firstRetryArtifact) 'The attempt-qualified artifact must remain available for aggregation.'
 

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -899,6 +899,33 @@ exit 0
         $secondManifestSha = (Get-Content -Raw $validationPath | ConvertFrom-Json).manifest_sha256
         Assert-Equal $firstManifestSha $secondManifestSha 'Artifact manifest fingerprints must use ordinal ordering.'
 
+        $firstRetryArtifact = "$firstArtifact-attempt-1-retry"
+        Move-Item -LiteralPath $firstArtifact -Destination $firstRetryArtifact
+        Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts | Out-Null
+
+        [void] (New-Item -ItemType Directory -Path $firstArtifact)
+        [IO.File]::WriteAllText(
+            (Join-Path $firstArtifact 'test_output_a.cobertura.xml'),
+            '<coverage />',
+            [Text.UTF8Encoding]::new($false)
+        )
+        Write-ArtifactMetadata $firstArtifact 'test_output_a'
+        Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts | Out-Null
+        Assert-Equal $false (Test-Path -LiteralPath $firstArtifact) 'A legacy canonical artifact must yield to an attempt-qualified artifact.'
+        Assert-Equal $true (Test-Path -LiteralPath $firstRetryArtifact) 'The attempt-qualified artifact must remain available for aggregation.'
+
+        $secondAttemptArtifact = "$firstArtifact-attempt-2"
+        [void] (New-Item -ItemType Directory -Path $secondAttemptArtifact)
+        [IO.File]::WriteAllText(
+            (Join-Path $secondAttemptArtifact 'test_output_a.cobertura.xml'),
+            '<coverage />',
+            [Text.UTF8Encoding]::new($false)
+        )
+        Write-ArtifactMetadata $secondAttemptArtifact 'test_output_a'
+        Invoke-ArtifactValidator $testCase.ReportDirectory $expectedArtifacts | Out-Null
+        Assert-Equal $false (Test-Path -LiteralPath $firstRetryArtifact) 'An artifact from an older run attempt must not be aggregated.'
+        Assert-Equal $true (Test-Path -LiteralPath $secondAttemptArtifact) 'The newest run attempt must remain available for aggregation.'
+
         $unexpectedArtifact = Join-Path $testCase.ReportDirectory 'coverage_test_output_unexpected'
         [void] (New-Item -ItemType Directory -Path $unexpectedArtifact)
         [IO.File]::WriteAllText(
@@ -1209,15 +1236,16 @@ exit 0
             $archiveTestResultsAction `
             "github\.event_name == 'push'.*?github\.event\.repository\.default_branch" `
             'Current-main test jobs must publish the same raw coverage artifacts.'
-        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, "github\.event_name == 'push' && 7 \|\| 1")).Count 'Current-main coverage retention count differs.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, "github\.event_name == 'push' && 7 \|\| 1")).Count 'Current-main coverage retention count differs.'
         Assert-Matches `
             $archiveTestResultsAction `
             '(?s)path:\s*\|.*?TestResults/\$\{\{ inputs\.name \}\}\.cobertura\.xml.*?TestResults/\$\{\{ inputs\.name \}\}\.coverage\.json' `
             'Each selected test job must publish its exact coverage report.'
-        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'uses: actions/upload-artifact@')).Count 'Each artifact must have one immutable upload attempt.'
+        Assert-Equal 3 ([regex]::Matches($archiveTestResultsAction, 'uses: actions/upload-artifact@')).Count 'Coverage must have one distinct-name retry.'
+        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'run: Start-Sleep -Seconds 30')).Count 'Coverage upload retry delay count differs.'
         Assert-Equal 0 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact uploads must not replace an ambiguous partial upload.'
-        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Coverage upload must require the report.'
-        Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload may remain advisory.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Both coverage upload attempts must require the report.'
+        Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload and the initial coverage attempt may remain advisory.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'retention-days: \$\{\{ inputs\[''retention-days''\] \}\}')).Count 'Diagnostic upload must use the requested retention period.'
         Assert-Equal 1 ([regex]::Matches($runTestsAction, '(?m)^    id: retry\r?$')).Count 'The retry outcome must be available to diagnostic retention policy.'
         Assert-Equal 1 ([regex]::Matches($runTestsAction, 'retention-days: \$\{\{ steps\.test\.outcome == ''failure'' && steps\.retry\.outcome != ''success'' && 14 \|\| 1 \}\}')).Count 'Only unrecovered test failures may retain diagnostics for 14 days.'
@@ -1227,8 +1255,8 @@ exit 0
             'Test result upload failures must remain advisory and explicit.'
         Assert-Matches `
             $archiveTestResultsAction `
-            "(?ms)^  - name: Archive coverage\r?\n    if: .*?github\.event_name == 'pull_request'.*?github\.event_name == 'push'.*?\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      if-no-files-found: error\r?$" `
-            'Coverage upload must remain directly gating.'
+            "(?ms)^  - name: Archive coverage\r?\n    id: archive-coverage\r?\n    if: .*?github\.event_name == 'pull_request'.*?github\.event_name == 'push'.*?\r?\n    continue-on-error: true\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      name: coverage_\$\{\{ inputs\.name \}\}-attempt-\$\{\{ github\.run_attempt \}\}\r?\n.*?^  - name: Report coverage upload retry\r?\n    if: .*?steps\.archive-coverage\.outcome == 'failure'\r?\n    shell: pwsh\r?\n    run: Write-Output '::warning title=Coverage artifact upload failed::.*?^  - name: Retry coverage upload\r?\n    if: .*?steps\.archive-coverage\.outcome == 'failure'\r?\n    uses: actions/upload-artifact@.*?\r?\n    with:\r?\n(?:(?!^  - ).)*?      name: coverage_\$\{\{ inputs\.name \}\}-attempt-\$\{\{ github\.run_attempt \}\}-retry\r?$" `
+            'Coverage upload must retry under a distinct immutable name and keep the retry gating.'
     }
 
     Invoke-Test 'collects GitHub coverage only on Linux .NET 10' {

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -861,6 +861,15 @@ exit 0
     Invoke-Test 'rejects missing and unexpected coverage artifacts' {
         $testCase = New-TestCase
         $expectedArtifacts = Join-Path $testCase.Root 'expected.txt'
+        $reservedExpectedArtifacts = Join-Path $testCase.Root 'reserved-expected.txt'
+        [IO.File]::WriteAllText(
+            $reservedExpectedArtifacts,
+            'test_output_a-Attempt-1',
+            [Text.UTF8Encoding]::new($false)
+        )
+        Assert-Throws `
+            { Invoke-ArtifactValidator $testCase.ReportDirectory $reservedExpectedArtifacts } `
+            'uses the reserved attempt suffix'
         [IO.File]::WriteAllLines(
             $expectedArtifacts,
             @('test_output_a', 'test_output_B'),
@@ -1245,6 +1254,7 @@ exit 0
             'Each selected test job must publish its exact coverage report.'
         Assert-Equal 3 ([regex]::Matches($archiveTestResultsAction, 'uses: actions/upload-artifact@')).Count 'Coverage must have one distinct-name retry.'
         Assert-Equal 1 ([regex]::Matches($archiveTestResultsAction, 'run: Start-Sleep -Seconds 30')).Count 'Coverage upload retry delay count differs.'
+        Assert-Equal 3 ([regex]::Matches($archiveTestResultsAction, "if: steps\.archive-coverage\.outcome == 'failure'")).Count 'Coverage retry steps must depend only on the initial upload outcome.'
         Assert-Equal 0 ([regex]::Matches($archiveTestResultsAction, 'overwrite: true')).Count 'Artifact uploads must not replace an ambiguous partial upload.'
         Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'if-no-files-found: error')).Count 'Both coverage upload attempts must require the report.'
         Assert-Equal 2 ([regex]::Matches($archiveTestResultsAction, 'continue-on-error: true')).Count 'Only diagnostic upload and the initial coverage attempt may remain advisory.'

--- a/.github/scripts/validate-coverage-artifacts.ps1
+++ b/.github/scripts/validate-coverage-artifacts.ps1
@@ -37,6 +37,9 @@ foreach ($line in [IO.File]::ReadAllLines($resolvedExpectedArtifacts)) {
     if ($coverageId -notmatch '^test_output_[A-Za-z0-9_.-]+$') {
         throw "Invalid coverage artifact identity '$coverageId'"
     }
+    if ($coverageId -cmatch '-attempt-[1-9][0-9]*(?:-retry)?$') {
+        throw "Coverage artifact identity '$coverageId' uses the reserved attempt suffix"
+    }
     $artifactName = "coverage_$coverageId"
     if ($expected.ContainsKey($artifactName)) {
         throw "Duplicate coverage artifact identity '$coverageId'"
@@ -53,21 +56,34 @@ $manifestBytes = [Text.UTF8Encoding]::new($false).GetBytes($manifestText)
 $manifestSha256 = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($manifestBytes)).ToLowerInvariant()
 
 $actual = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+$selected = [Collections.Generic.Dictionary[string, object]]::new([StringComparer]::Ordinal)
+$superseded = [Collections.Generic.List[string]]::new()
+$unexpectedArtifactNames = [Collections.Generic.List[string]]::new()
 $testedSha = $null
 foreach ($artifact in Get-ChildItem -LiteralPath $resolvedReportDirectory -Force) {
     Assert-NotReparsePoint $artifact.FullName
     if (-not $artifact.PSIsContainer) {
         throw "Unexpected file '$($artifact.Name)' in the coverage artifact directory"
     }
-    if (-not $actual.Add($artifact.Name)) {
-        throw "Coverage artifact '$($artifact.Name)' appears more than once"
+
+    $artifactName = $artifact.Name
+    $artifactAttempt = 0
+    $artifactIsRetry = $false
+    if ($artifact.Name -cmatch '^(?<name>.+)-attempt-(?<attempt>[1-9][0-9]*)(?<retry>-retry)?$') {
+        $artifactName = $Matches.name
+        if (-not [int]::TryParse($Matches.attempt, [ref] $artifactAttempt)) {
+            throw "Coverage artifact '$($artifact.Name)' has an invalid run attempt"
+        }
+        $artifactIsRetry = $Matches.ContainsKey('retry') -and $Matches.retry -eq '-retry'
     }
-    if (-not $expected.ContainsKey($artifact.Name)) {
+    [void] $actual.Add($artifactName)
+    if (-not $expected.ContainsKey($artifactName)) {
+        $unexpectedArtifactNames.Add($artifact.Name)
         continue
     }
 
     $contents = @(Get-ChildItem -LiteralPath $artifact.FullName -Force)
-    $expectedReport = $expected[$artifact.Name]
+    $expectedReport = $expected[$artifactName]
     $coverageId = $expectedReport.Substring(0, $expectedReport.Length - '.cobertura.xml'.Length)
     $expectedMetadata = "$coverageId.coverage.json"
     $expectedContents = @($expectedMetadata, $expectedReport) | Sort-Object
@@ -75,7 +91,7 @@ foreach ($artifact in Get-ChildItem -LiteralPath $resolvedReportDirectory -Force
     if ($contents.Where({ $_.PSIsContainer }, 'First').Count -gt 0 -or
         $actualContents.Count -ne $expectedContents.Count -or
         (Compare-Object $expectedContents $actualContents)) {
-        throw "Coverage artifact '$($artifact.Name)' must contain only '$expectedReport' and '$expectedMetadata'"
+        throw "Coverage artifact '$artifactName' must contain only '$expectedReport' and '$expectedMetadata'"
     }
     foreach ($content in $contents) {
         Assert-NotReparsePoint $content.FullName
@@ -83,33 +99,52 @@ foreach ($artifact in Get-ChildItem -LiteralPath $resolvedReportDirectory -Force
 
     $metadataPath = Join-Path $artifact.FullName $expectedMetadata
     if ((Get-Item -LiteralPath $metadataPath -Force).Length -gt 1MB) {
-        throw "Coverage artifact '$($artifact.Name)' metadata exceeds the 1 MB parsing limit"
+        throw "Coverage artifact '$artifactName' metadata exceeds the 1 MB parsing limit"
     }
     try {
         $metadata = Get-Content -Raw -LiteralPath $metadataPath | ConvertFrom-Json
     } catch {
-        throw "Coverage artifact '$($artifact.Name)' contains invalid metadata: $($_.Exception.Message)"
+        throw "Coverage artifact '$artifactName' contains invalid metadata: $($_.Exception.Message)"
     }
     $metadataProperties = @($metadata.PSObject.Properties.Name | Sort-Object)
     $expectedMetadataProperties = @('artifact_name', 'commit_sha', 'coverage_id', 'format_version')
     if (Compare-Object $expectedMetadataProperties $metadataProperties) {
-        throw "Coverage artifact '$($artifact.Name)' contains unexpected metadata fields"
+        throw "Coverage artifact '$artifactName' contains unexpected metadata fields"
     }
     if ($metadata.format_version -ne 1 -or
-        $metadata.artifact_name -ne $artifact.Name -or
+        $metadata.artifact_name -ne $artifactName -or
         $metadata.coverage_id -ne $coverageId -or
         $metadata.commit_sha -notmatch '^[0-9a-f]{40}$') {
-        throw "Coverage artifact '$($artifact.Name)' contains inconsistent metadata"
+        throw "Coverage artifact '$artifactName' contains inconsistent metadata"
     }
     if ($null -eq $testedSha) {
         $testedSha = $metadata.commit_sha
     } elseif ($testedSha -ne $metadata.commit_sha) {
         throw "Coverage artifacts reference multiple tested commits: '$testedSha' and '$($metadata.commit_sha)'"
     }
+
+    $existingArtifact = $null
+    if (-not $selected.TryGetValue($artifactName, [ref] $existingArtifact)) {
+        $selected.Add($artifactName, [pscustomobject]@{
+            Attempt = $artifactAttempt
+            IsRetry = $artifactIsRetry
+            Path = $artifact.FullName
+        })
+    } elseif ($artifactAttempt -gt $existingArtifact.Attempt -or
+        ($artifactAttempt -eq $existingArtifact.Attempt -and $artifactIsRetry -and -not $existingArtifact.IsRetry)) {
+        $superseded.Add($existingArtifact.Path)
+        $selected[$artifactName] = [pscustomobject]@{
+            Attempt = $artifactAttempt
+            IsRetry = $artifactIsRetry
+            Path = $artifact.FullName
+        }
+    } else {
+        $superseded.Add($artifact.FullName)
+    }
 }
 
 $missing = @($expected.Keys.Where({ -not $actual.Contains($_) }) | Sort-Object)
-$unexpected = @($actual.Where({ -not $expected.ContainsKey($_) }) | Sort-Object)
+$unexpected = @($unexpectedArtifactNames | Sort-Object)
 if ($missing.Count -gt 0 -or $unexpected.Count -gt 0) {
     $details = @()
     if ($missing.Count -gt 0) {
@@ -119,6 +154,11 @@ if ($missing.Count -gt 0 -or $unexpected.Count -gt 0) {
         $details += "Unexpected: $($unexpected -join ', ')"
     }
     throw "Coverage artifact set differs from the expected CI matrix. $($details -join ' ')"
+}
+
+foreach ($path in $superseded) {
+    # Aggregation recursively discovers reports, so retain only the selected run attempt.
+    Remove-Item -LiteralPath $path -Recurse -Force
 }
 
 $summary = [ordered]@{

--- a/.github/scripts/validate-coverage-artifacts.ps1
+++ b/.github/scripts/validate-coverage-artifacts.ps1
@@ -78,7 +78,7 @@ foreach ($artifact in Get-ChildItem -LiteralPath $resolvedReportDirectory -Force
     }
     [void] $actual.Add($artifactName)
     if (-not $expected.ContainsKey($artifactName)) {
-        $unexpectedArtifactNames.Add($artifact.Name)
+        [void] $unexpectedArtifactNames.Add($artifact.Name)
         continue
     }
 
@@ -132,14 +132,14 @@ foreach ($artifact in Get-ChildItem -LiteralPath $resolvedReportDirectory -Force
         })
     } elseif ($artifactAttempt -gt $existingArtifact.Attempt -or
         ($artifactAttempt -eq $existingArtifact.Attempt -and $artifactIsRetry -and -not $existingArtifact.IsRetry)) {
-        $superseded.Add($existingArtifact.Path)
+        [void] $superseded.Add($existingArtifact.Path)
         $selected[$artifactName] = [pscustomobject]@{
             Attempt = $artifactAttempt
             IsRetry = $artifactIsRetry
             Path = $artifact.FullName
         }
     } else {
-        $superseded.Add($artifact.FullName)
+        [void] $superseded.Add($artifact.FullName)
     }
 }
 

--- a/.github/scripts/validate-coverage-artifacts.ps1
+++ b/.github/scripts/validate-coverage-artifacts.ps1
@@ -91,7 +91,7 @@ foreach ($artifact in Get-ChildItem -LiteralPath $resolvedReportDirectory -Force
     if ($contents.Where({ $_.PSIsContainer }, 'First').Count -gt 0 -or
         $actualContents.Count -ne $expectedContents.Count -or
         (Compare-Object $expectedContents $actualContents)) {
-        throw "Coverage artifact '$artifactName' must contain only '$expectedReport' and '$expectedMetadata'"
+        throw "Coverage artifact '$($artifact.Name)' must contain only '$expectedReport' and '$expectedMetadata'"
     }
     foreach ($content in $contents) {
         Assert-NotReparsePoint $content.FullName
@@ -99,23 +99,23 @@ foreach ($artifact in Get-ChildItem -LiteralPath $resolvedReportDirectory -Force
 
     $metadataPath = Join-Path $artifact.FullName $expectedMetadata
     if ((Get-Item -LiteralPath $metadataPath -Force).Length -gt 1MB) {
-        throw "Coverage artifact '$artifactName' metadata exceeds the 1 MB parsing limit"
+        throw "Coverage artifact '$($artifact.Name)' metadata exceeds the 1 MB parsing limit"
     }
     try {
         $metadata = Get-Content -Raw -LiteralPath $metadataPath | ConvertFrom-Json
     } catch {
-        throw "Coverage artifact '$artifactName' contains invalid metadata: $($_.Exception.Message)"
+        throw "Coverage artifact '$($artifact.Name)' contains invalid metadata: $($_.Exception.Message)"
     }
     $metadataProperties = @($metadata.PSObject.Properties.Name | Sort-Object)
     $expectedMetadataProperties = @('artifact_name', 'commit_sha', 'coverage_id', 'format_version')
     if (Compare-Object $expectedMetadataProperties $metadataProperties) {
-        throw "Coverage artifact '$artifactName' contains unexpected metadata fields"
+        throw "Coverage artifact '$($artifact.Name)' contains unexpected metadata fields"
     }
     if ($metadata.format_version -ne 1 -or
         $metadata.artifact_name -ne $artifactName -or
         $metadata.coverage_id -ne $coverageId -or
         $metadata.commit_sha -notmatch '^[0-9a-f]{40}$') {
-        throw "Coverage artifact '$artifactName' contains inconsistent metadata"
+        throw "Coverage artifact '$($artifact.Name)' contains inconsistent metadata"
     }
     if ($null -eq $testedSha) {
         $testedSha = $metadata.commit_sha

--- a/.github/scripts/validate-coverage-artifacts.ps1
+++ b/.github/scripts/validate-coverage-artifacts.ps1
@@ -37,7 +37,7 @@ foreach ($line in [IO.File]::ReadAllLines($resolvedExpectedArtifacts)) {
     if ($coverageId -notmatch '^test_output_[A-Za-z0-9_.-]+$') {
         throw "Invalid coverage artifact identity '$coverageId'"
     }
-    if ($coverageId -cmatch '-attempt-[1-9][0-9]*(?:-retry)?$') {
+    if ($coverageId -match '-attempt-[1-9][0-9]*(?:-retry)?$') {
         throw "Coverage artifact identity '$coverageId' uses the reserved attempt suffix"
     }
     $artifactName = "coverage_$coverageId"


### PR DESCRIPTION
Closes #11203.

Coverage artifact uploads can report `Upload progress stalled` after provider tests and coverage generation complete, failing an otherwise successful provider job. A same-name retry is unsafe because a failed upload can leave an invisible immutable artifact reservation, causing the retry to mask the original error with a 409 conflict.

Retry failed coverage uploads once after a short delay under a run-attempt-qualified immutable name. The trusted coverage validator normalizes those names, validates every candidate against the canonical metadata and tested commit, and retains only the newest run attempt before recursive aggregation. This also keeps workflow reruns collision-free while preserving strict matrix validation and a gating final upload.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11215)