### PR TITLE
fix(ci): update SourceLink packages flagged by NU1902

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -79,8 +79,8 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="10.0.111" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.111" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="2.4.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.4.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.4.0" />


### PR DESCRIPTION
## Problem

NuGet auditing reports GHSA-23fw-v26w-5fgq for `Microsoft.Build.Tasks.Git` and `Microsoft.SourceLink.AzureRepos.Git` 8.0.0. Restore treats these diagnostics as errors and blocks CI before compilation.

## Solution

Update the central `Microsoft.SourceLink.AzureRepos.Git` and `Microsoft.SourceLink.GitHub` versions to `10.0.111`, the earliest patched NuGet release identified by the [advisory](https://github.com/advisories/GHSA-23fw-v26w-5fgq). Both providers depend on matching `Microsoft.Build.Tasks.Git` and `Microsoft.SourceLink.Common` versions, keeping the SourceLink toolchain aligned.

The packages work with the repository's .NET 10 SDK and preserve SourceLink generation for `net8.0`, `net10.0`, and `netstandard2.0`. Existing NuGet auditing, warnings-as-errors, private build dependencies, and package compatibility validation remain enabled.

Closes #11213.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11216)