### PR TITLE
ci: retry transient NuGet metadata restore failures

### DIFF
--- a/.github/actions/dotnet-test/action.yml
+++ b/.github/actions/dotnet-test/action.yml
@@ -32,6 +32,9 @@ runs:
         'DOTNET_DbgMiniDumpName=${{ github.workspace }}/TestResults/dotnet-test.%p.dmp'
         'DOTNET_CreateDumpDiagnostics=1'
       ) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+  - name: Restore
+    shell: pwsh
+    run: ./.github/scripts/invoke-restore.ps1
   - name: Prepare coverage report
     if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)))
     shell: pwsh

--- a/.github/actions/dotnet-test/action.yml
+++ b/.github/actions/dotnet-test/action.yml
@@ -39,7 +39,7 @@ runs:
   - name: Test
     if: inputs.coverage != 'true' || (github.event_name != 'pull_request' && (github.event_name != 'push' || github.ref != format('refs/heads/{0}', github.event.repository.default_branch)))
     shell: pwsh
-    run: dotnet test --solution Orleans.slnx --framework "${{ inputs.framework }}" --filter-query "${{ inputs.filter-query }}" --minimum-expected-tests 1 --hangdump --hangdump-timeout 10m --crashdump --crashdump-type Full --hangdump-type Full --report-trx --report-trx-filename "test_results_${{ inputs.result-id }}_{asm}_{tfm}_{arch}.trx" --max-parallel-test-modules 1
+    run: dotnet test --solution Orleans.slnx --framework "${{ inputs.framework }}" --no-restore --filter-query "${{ inputs.filter-query }}" --minimum-expected-tests 1 --hangdump --hangdump-timeout 10m --crashdump --crashdump-type Full --hangdump-type Full --report-trx --report-trx-filename "test_results_${{ inputs.result-id }}_{asm}_{tfm}_{arch}.trx" --max-parallel-test-modules 1
   - name: Test with coverage
     if: inputs.coverage == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)))
     shell: pwsh
@@ -51,6 +51,7 @@ runs:
         'Orleans.slnx'
         '--framework'
         '${{ inputs.framework }}'
+        '--no-restore'
         '--filter-query'
         '${{ inputs.filter-query }}'
         '--minimum-expected-tests'

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -31,23 +31,6 @@ runs:
   - uses: ./.github/actions/setup-test-environment
     with:
       coverage: ${{ runner.os == 'Linux' && inputs.framework == 'net10.0' }}
-  - name: Restore
-    shell: pwsh
-    run: |
-      & dotnet restore Orleans.slnx 2>&1 | Tee-Object -Variable restoreOutput
-      $exitCode = $LASTEXITCODE
-
-      if ($exitCode -eq 0) {
-        exit 0
-      }
-
-      if (($restoreOutput | Out-String) -notmatch 'Failed to retrieve information about .+ from remote source') {
-        exit $exitCode
-      }
-
-      Write-Warning 'Retrying restore after a remote package metadata retrieval failure.'
-      & dotnet restore Orleans.slnx
-      exit $LASTEXITCODE
   - name: Test
     id: test
     continue-on-error: ${{ env.ORLEANS_TEST_RETRY == 'true' }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -31,6 +31,23 @@ runs:
   - uses: ./.github/actions/setup-test-environment
     with:
       coverage: ${{ runner.os == 'Linux' && inputs.framework == 'net10.0' }}
+  - name: Restore
+    shell: pwsh
+    run: |
+      & dotnet restore Orleans.slnx 2>&1 | Tee-Object -Variable restoreOutput
+      $exitCode = $LASTEXITCODE
+
+      if ($exitCode -eq 0) {
+        exit 0
+      }
+
+      if (($restoreOutput | Out-String) -notmatch 'Failed to retrieve information about .+ from remote source') {
+        exit $exitCode
+      }
+
+      Write-Warning 'Retrying restore after a remote package metadata retrieval failure.'
+      & dotnet restore Orleans.slnx
+      exit $LASTEXITCODE
   - name: Test
     id: test
     continue-on-error: ${{ env.ORLEANS_TEST_RETRY == 'true' }}

--- a/.github/scripts/invoke-restore.ps1
+++ b/.github/scripts/invoke-restore.ps1
@@ -26,9 +26,6 @@ function Test-IsRemoteMetadataFailure {
     return $text.Contains(
         'Failed to retrieve information about ',
         [StringComparison]::Ordinal
-    ) -and $text.Contains(
-        ' from remote source ',
-        [StringComparison]::Ordinal
     )
 }
 

--- a/.github/scripts/invoke-restore.ps1
+++ b/.github/scripts/invoke-restore.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    [string] $RestoreCommand = 'dotnet'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-SolutionRestore {
+    $messages = [Collections.Generic.List[string]]::new()
+    & $RestoreCommand restore Orleans.slnx 2>&1 | ForEach-Object {
+        $messages.Add($_.ToString())
+        $_ | Out-Host
+    }
+
+    return [pscustomobject] @{
+        ExitCode = $LASTEXITCODE
+        Messages = $messages.ToArray()
+    }
+}
+
+function Test-IsRemoteMetadataFailure {
+    param([string[]] $Messages)
+
+    $text = [string]::Join([Environment]::NewLine, $Messages)
+    return $text.Contains(
+        'Failed to retrieve information about ',
+        [StringComparison]::Ordinal
+    ) -and $text.Contains(
+        ' from remote source ',
+        [StringComparison]::Ordinal
+    )
+}
+
+$result = Invoke-SolutionRestore
+if ($result.ExitCode -eq 0 -or -not (Test-IsRemoteMetadataFailure $result.Messages)) {
+    exit $result.ExitCode
+}
+
+Write-Warning 'Retrying restore after a remote package metadata retrieval failure.'
+$result = Invoke-SolutionRestore
+exit $result.ExitCode

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -754,8 +754,13 @@ $attempt = if (Test-Path -LiteralPath $env:ORLEANS_RESTORE_ATTEMPT_FILE) {
 
 $attempt++
 Set-Content -LiteralPath $env:ORLEANS_RESTORE_ATTEMPT_FILE -Value $attempt
-if ($env:ORLEANS_RESTORE_FAILURE -eq 'metadata' -and $attempt -eq 1) {
+if ($env:ORLEANS_RESTORE_FAILURE -eq 'metadata-remote-source' -and $attempt -eq 1) {
     Write-Output "Failed to retrieve information about 'Aspire.AppHost.Sdk' from remote source 'https://feed/index.json'."
+    exit 1
+}
+
+if ($env:ORLEANS_RESTORE_FAILURE -eq 'metadata-configured-feed' -and $attempt -eq 1) {
+    Write-Output "Failed to retrieve information about 'Aspire.AppHost.Sdk' from the configured Azure DevOps feed."
     exit 1
 }
 
@@ -781,12 +786,14 @@ exit 0
         $previousFailure = $env:ORLEANS_RESTORE_FAILURE
         try {
             $env:ORLEANS_RESTORE_ATTEMPT_FILE = $attemptFile
-            $env:ORLEANS_RESTORE_FAILURE = 'metadata'
-            & $invokeRestoreScriptPath -RestoreCommand $fakeRestore
-            Assert-Equal 0 $LASTEXITCODE 'A transient metadata failure should succeed on retry.'
-            Assert-Equal 2 ([int] (Get-Content -Raw -LiteralPath $attemptFile)) 'The transient metadata restore attempt count differs.'
+            foreach ($failure in 'metadata-remote-source', 'metadata-configured-feed') {
+                $env:ORLEANS_RESTORE_FAILURE = $failure
+                & $invokeRestoreScriptPath -RestoreCommand $fakeRestore
+                Assert-Equal 0 $LASTEXITCODE "The $failure failure should succeed on retry."
+                Assert-Equal 2 ([int] (Get-Content -Raw -LiteralPath $attemptFile)) "The $failure restore attempt count differs."
+                Remove-Item -LiteralPath $attemptFile
+            }
 
-            Remove-Item -LiteralPath $attemptFile
             $env:ORLEANS_RESTORE_FAILURE = 'deterministic'
             & $invokeRestoreScriptPath -RestoreCommand $fakeRestore
             Assert-Equal 1 $LASTEXITCODE 'A deterministic restore failure should be preserved.'

--- a/.github/scripts/test-summarize-coverage.ps1
+++ b/.github/scripts/test-summarize-coverage.ps1
@@ -16,6 +16,7 @@ $azureBuildTemplatePath = Join-Path $PSScriptRoot '../../.azure/pipelines/templa
 $azureVariablesPath = Join-Path $PSScriptRoot '../../.azure/pipelines/templates/vars.yaml'
 $dotnetTestActionPath = Join-Path $PSScriptRoot '../actions/dotnet-test/action.yml'
 $invokeCoverageScriptPath = Join-Path $PSScriptRoot 'invoke-coverage.ps1'
+$invokeRestoreScriptPath = Join-Path $PSScriptRoot 'invoke-restore.ps1'
 $runTestsActionPath = Join-Path $PSScriptRoot '../actions/run-tests/action.yml'
 $selectCoverageBaselineScriptPath = Join-Path $PSScriptRoot 'select-coverage-baseline.ps1'
 $setupCoverageScriptPath = Join-Path $PSScriptRoot 'setup-coverage.ps1'
@@ -724,6 +725,76 @@ try {
             $setupTestEnvironmentAction `
             "inputs\.coverage == 'true'.*?github\.event_name == 'push'.*?github\.event\.repository\.default_branch" `
             'Selected current-main test jobs must install the coverage collector.'
+    }
+
+    Invoke-Test 'retries only remote metadata restore failures' {
+        $testCase = New-TestCase
+        $dotnetTestAction = Get-Content -Raw -LiteralPath $dotnetTestActionPath
+        $runTestsAction = Get-Content -Raw -LiteralPath $runTestsActionPath
+        $attemptFile = Join-Path $testCase.Root 'restore-attempt.txt'
+        $fakeRestore = Join-Path $testCase.Root 'fake-restore.ps1'
+        [IO.File]::WriteAllText(
+            $fakeRestore,
+            @'
+param(
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]] $Command
+)
+
+if (($Command -join ' ') -cne 'restore Orleans.slnx') {
+    Write-Output "Unexpected restore command: $Command"
+    exit 2
+}
+
+$attempt = if (Test-Path -LiteralPath $env:ORLEANS_RESTORE_ATTEMPT_FILE) {
+    [int] (Get-Content -Raw -LiteralPath $env:ORLEANS_RESTORE_ATTEMPT_FILE)
+} else {
+    0
+}
+
+$attempt++
+Set-Content -LiteralPath $env:ORLEANS_RESTORE_ATTEMPT_FILE -Value $attempt
+if ($env:ORLEANS_RESTORE_FAILURE -eq 'metadata' -and $attempt -eq 1) {
+    Write-Output "Failed to retrieve information about 'Aspire.AppHost.Sdk' from remote source 'https://feed/index.json'."
+    exit 1
+}
+
+if ($env:ORLEANS_RESTORE_FAILURE -eq 'deterministic') {
+    Write-Output 'A deterministic restore failure occurred.'
+    exit 1
+}
+
+Write-Output 'Restore succeeded.'
+exit 0
+'@,
+            [Text.UTF8Encoding]::new($false)
+        )
+
+        Assert-Matches `
+            $dotnetTestAction `
+            '(?ms)^  - name: Restore\r?\n    shell: pwsh\r?\n    run: \./\.github/scripts/invoke-restore\.ps1\r?\n  - name: Prepare coverage report' `
+            'Restore must run inside the replaceable test action before coverage preparation.'
+        Assert-Equal 0 ([regex]::Matches($runTestsAction, '(?m)^  - name: Restore\r?$')).Count 'The test coordinator must not restore outside the replaceable test action.'
+        Assert-Equal 2 ([regex]::Matches($dotnetTestAction, '''--no-restore''| --no-restore ')).Count 'Both test launch paths must reuse the explicit restore.'
+
+        $previousAttemptFile = $env:ORLEANS_RESTORE_ATTEMPT_FILE
+        $previousFailure = $env:ORLEANS_RESTORE_FAILURE
+        try {
+            $env:ORLEANS_RESTORE_ATTEMPT_FILE = $attemptFile
+            $env:ORLEANS_RESTORE_FAILURE = 'metadata'
+            & $invokeRestoreScriptPath -RestoreCommand $fakeRestore
+            Assert-Equal 0 $LASTEXITCODE 'A transient metadata failure should succeed on retry.'
+            Assert-Equal 2 ([int] (Get-Content -Raw -LiteralPath $attemptFile)) 'The transient metadata restore attempt count differs.'
+
+            Remove-Item -LiteralPath $attemptFile
+            $env:ORLEANS_RESTORE_FAILURE = 'deterministic'
+            & $invokeRestoreScriptPath -RestoreCommand $fakeRestore
+            Assert-Equal 1 $LASTEXITCODE 'A deterministic restore failure should be preserved.'
+            Assert-Equal 1 ([int] (Get-Content -Raw -LiteralPath $attemptFile)) 'The deterministic restore attempt count differs.'
+        } finally {
+            $env:ORLEANS_RESTORE_ATTEMPT_FILE = $previousAttemptFile
+            $env:ORLEANS_RESTORE_FAILURE = $previousFailure
+        }
     }
 
     Invoke-Test 'retries only the uninitialized coverage handle failure' {

--- a/.github/workflows/test-action-retry.yml
+++ b/.github/workflows/test-action-retry.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .github/actions/run-tests/**
       - .github/actions/dotnet-test/**
+      - .github/scripts/invoke-restore.ps1
       - .github/workflows/test-action-retry.yml
   push:
     branches:
@@ -14,6 +15,7 @@ on:
     paths:
       - .github/actions/run-tests/**
       - .github/actions/dotnet-test/**
+      - .github/scripts/invoke-restore.ps1
       - .github/workflows/test-action-retry.yml
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #11185.

Provider test lanes evaluate and restore the full solution, including Aspire AppHost projects. A transient CFS upstream metadata failure for `Aspire.AppHost.Sdk` can therefore stop an unrelated provider lane before tests begin, even after NuGet exhausts its per-request retries.

The replaceable `dotnet-test` action now performs an explicit restore and retries it once only when NuGet reports a remote package metadata retrieval failure. The restore runs within each test attempt, inherits test-attempt environment such as `BuildExternalAssets`, and remains intercepted by the retry contract’s recording fixture. Test execution reuses that restore through `--no-restore`.

Focused contracts exercise transient and deterministic restore failures, assert the retry boundary, and require both test launch paths to disable implicit restore. Deterministic restore failures continue to fail on the first attempt, while the repository feed, pinned SDK, package auditing, and test failure behavior remain unchanged.