### PR TITLE
feat(runtime): add hash-range-aware concurrent dictionary

### DIFF
--- a/docs/site/src/content/docs/implementation/grain-directory.md
+++ b/docs/site/src/content/docs/implementation/grain-directory.md
@@ -82,6 +82,14 @@ Requests and responses carry view information. A range cannot serve a request un
 
 API: <xref:Orleans.Hosting.CoreHostingExtensions.AddDistributedGrainDirectory*?displayProperty=nameWithType> and <xref:Orleans.Configuration.GrainDirectoryOptions>. Implementation: [hosting registration](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs) and [`DistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs).
 
+### Range-aware activation storage
+
+The activation directory uses a concurrent hash table whose buckets cover contiguous portions of the 32-bit hash ring. Point lookup, insertion, replacement, expected-value removal, and range enumeration access the same entries. A concrete struct implementing `IConsistentHashComparer<GrainId>` supplies key equality and the stable unsigned `GrainId.GetUniformHashCode()` hash shared by silos. The JIT can specialize comparer calls for that struct. Hashes are inexpensive to compute from the grain type and key's cached hashes, so each table entry stores its key, value, and next link. Internal callers can reuse a precomputed comparer hash for point lookup or enumerate every entry at a hash coordinate.
+
+Recovery enumerates buckets intersecting the requested range and computes hashes only for entries in boundary buckets, using the exclusive-start, inclusive-end convention. Fully covered buckets contribute all their entries. Wrapped ranges visit each bucket once. The table grows by splitting hash prefixes, refining range selection as the activation population increases. For uniformly distributed activations, selective queries examine matching entries plus entries from at most two boundary buckets. A concentrated hash distribution increases boundary scanning and write contention within the affected buckets.
+
+Enumeration captures one table generation and observes concurrent changes to that table. Resizing publishes a new table after copying entries under the writer locks, while readers can finish traversing the prior generation. Writers check the table generation after acquiring their bucket's lock and retry when it changes. The recovery membership watermark advances before enumeration, and the activation-registration protocol ensures that registrations racing with recovery complete at an appropriate membership version. Expected-value removal preserves a newer context when an older context finishes deactivating. Ownership handoff transfers registration records; running contexts continue through their activation lifecycle.
+
 ## Tradeoffs
 
 | Property | Default `LocalGrainDirectory` | Experimental `DistributedGrainDirectory` |

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Utilities;
 
 namespace Orleans.Runtime;
 
@@ -11,7 +12,7 @@ internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IG
 {
     private int _activationsCount;
 
-    private readonly ConcurrentDictionary<GrainId, IGrainContext> _activations = new();
+    private readonly ConcurrentHashRangeDictionary<GrainId, IGrainContext, GrainIdUniformHashComparer> _activations = new(default);
 
     public ActivationDirectory(CatalogInstruments catalogInstruments)
     {
@@ -45,8 +46,11 @@ internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IG
         return false;
     }
 
-    public IEnumerator<KeyValuePair<GrainId, IGrainContext>> GetEnumerator() => _activations.GetEnumerator();
+    public ConcurrentHashRangeDictionary<GrainId, IGrainContext, GrainIdUniformHashComparer>.Enumerator GetEnumerator() => _activations.GetEnumerator();
 
+    public ConcurrentHashRangeDictionary<GrainId, IGrainContext, GrainIdUniformHashComparer>.RangeEnumerable EnumerateRange(RingRange range) => _activations.EnumerateRange(range);
+
+    IEnumerator<KeyValuePair<GrainId, IGrainContext>> IEnumerable<KeyValuePair<GrainId, IGrainContext>>.GetEnumerator() => GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     async ValueTask IAsyncDisposable.DisposeAsync()

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -402,18 +402,13 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         var skippedActivationCount = 0;
         var stopwatch = CoarseStopwatch.StartNew();
 
-        foreach (var (grainId, activation) in _localActivations)
+        foreach (var (_, activation) in _localActivations.EnumerateRange(range))
         {
             cancellationToken.ThrowIfCancellationRequested();
             var directory = GetGrainDirectory(activation, _grainDirectoryResolver!);
             if (directory == this)
             {
                 var address = activation.Address;
-                if (!range.Contains(address.GrainId))
-                {
-                    continue;
-                }
-
                 if (address.MembershipVersion == MembershipVersion.MinValue
                     || activation is ActivationData { State: ActivationState.Deactivating or ActivationState.Invalid })
                 {

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -32,7 +32,7 @@ internal sealed class LocalGrainDirectoryClientCompatibility : SystemTarget, IGr
         cancellationToken.ThrowIfCancellationRequested();
         var grainDirectoryResolver = _grainDirectoryResolver ??= ActivationServices.GetRequiredService<GrainDirectoryResolver>();
         List<GrainAddress> result = [];
-        foreach (var (_, activation) in _localActivations)
+        foreach (var (_, activation) in _localActivations.EnumerateRange(range))
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (!UsesLocalGrainDirectory(activation, grainDirectoryResolver))
@@ -45,11 +45,7 @@ internal sealed class LocalGrainDirectoryClientCompatibility : SystemTarget, IGr
                 continue;
             }
 
-            var address = activation.Address;
-            if (range.Contains(address.GrainId))
-            {
-                result.Add(address);
-            }
+            result.Add(activation.Address);
         }
 
         return new(result.AsImmutable());

--- a/src/Orleans.Runtime/Utilities/ConcurrentHashRangeDictionary.cs
+++ b/src/Orleans.Runtime/Utilities/ConcurrentHashRangeDictionary.cs
@@ -1,0 +1,590 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Adapted from dotnet/runtime ConcurrentDictionary.cs at b5881242dc356bd8c464026387545f2684079d30.
+// See ConcurrentHashRangeDictionary.md for provenance and the adaptation/maintenance contract.
+
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Orleans.Runtime.GrainDirectory;
+
+namespace Orleans.Runtime.Utilities;
+
+/// <summary>
+/// A concurrent hash table whose buckets cover contiguous portions of a stable 32-bit hash ring.
+/// Point and range operations access the same nodes and bucket array.
+/// </summary>
+/// <remarks>
+/// The equality comparer defines both key equality and the table's hash coordinate.
+/// Hash coordinates are the comparer's unsigned 32-bit hash codes.
+/// Keys retain their hash and equality identity while stored. The comparer supports concurrent calls.
+/// Point operations use lock-free reads and striped writes. Enumeration captures one table generation and
+/// observes concurrent changes to that table, with the same consistency model as ConcurrentDictionary.
+/// Callers requiring a point-in-time snapshot quiesce mutations while materializing the enumeration.
+/// </remarks>
+internal sealed class ConcurrentHashRangeDictionary<TKey, TValue, TComparer> : IEnumerable<KeyValuePair<TKey, TValue>>
+    where TKey : notnull
+    where TComparer : IConsistentHashComparer<TKey>
+{
+    private const int MaxCapacity = 1 << 30;
+    private const int MaxLockCount = 1024;
+    private readonly TComparer _comparer;
+    private readonly bool _growLocks;
+    private volatile Tables _tables;
+    private int _budget;
+
+    public ConcurrentHashRangeDictionary(
+        TComparer comparer,
+        int capacity = 32,
+        int concurrencyLevel = -1)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+        ArgumentOutOfRangeException.ThrowIfNegative(capacity);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(capacity, MaxCapacity);
+        _growLocks = concurrencyLevel == -1;
+        if (_growLocks)
+        {
+            concurrencyLevel = Environment.ProcessorCount;
+        }
+
+        ArgumentOutOfRangeException.ThrowIfLessThan(concurrencyLevel, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(concurrencyLevel, MaxCapacity);
+        var lockCount = (int)BitOperations.RoundUpToPowerOf2((uint)concurrencyLevel);
+        // Leave room for uneven lock occupancy before the requested entry count triggers a resize.
+        var initialCapacity = (int)Math.Min(MaxCapacity, (4L * capacity + 2) / 3);
+        var bucketCount = (int)BitOperations.RoundUpToPowerOf2((uint)Math.Max(2, Math.Max(initialCapacity, lockCount)));
+        var locks = new object[lockCount];
+        locks[0] = locks;
+        for (var i = 1; i < locks.Length; i++)
+        {
+            locks[i] = new object();
+        }
+
+        _comparer = comparer;
+        _tables = new Tables(new VolatileNode[bucketCount], locks, new int[lockCount]);
+        _budget = Math.Max(1, bucketCount / lockCount);
+    }
+
+    public TValue this[TKey key]
+    {
+        get => TryGetValue(key, out var value) ? value : throw new KeyNotFoundException();
+        set => TryAddInternal(key, value, updateIfExists: true);
+    }
+
+    public TComparer Comparer => _comparer;
+
+    /// <summary>Gets the entry count while holding all writer locks.</summary>
+    public int Count
+    {
+        get
+        {
+            var locksAcquired = 0;
+            try
+            {
+                var tables = AcquireAllLocks(ref locksAcquired);
+                var count = 0;
+                foreach (var item in tables.CountPerLock)
+                {
+                    count = checked(count + item);
+                }
+
+                return count;
+            }
+            finally
+            {
+                ReleaseLocks(locksAcquired);
+            }
+        }
+    }
+
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return TryGetValueCore(key, GetRangeHash(key), out value);
+    }
+
+    /// <summary>
+    /// Looks up a key using its precomputed comparer hash.
+    /// Key equality distinguishes entries sharing the hash.
+    /// </summary>
+    public bool TryGetValue(TKey key, uint rangeHash, [MaybeNullWhen(false)] out TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return TryGetValueCore(key, rangeHash, out value);
+    }
+
+    private bool TryGetValueCore(TKey key, uint rangeHash, [MaybeNullWhen(false)] out TValue value)
+    {
+        var tables = _tables;
+        for (var node = tables.Buckets[rangeHash >> tables.Shift].Node; node is not null; node = node.Next)
+        {
+            if (KeyEquals(node.Key, key))
+            {
+                value = node.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool TryAdd(TKey key, TValue value) => TryAddInternal(key, value, updateIfExists: false);
+
+    public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var rangeHash = GetRangeHash(key);
+        var tables = _tables;
+        while (true)
+        {
+            ref var bucket = ref GetBucketAndLock(tables, rangeHash, out var lockIndex);
+            lock (tables.Locks[lockIndex])
+            {
+                // A resize can change the bucket's lock. Retry against the published table after taking the lock.
+                if (tables != _tables)
+                {
+                    tables = _tables;
+                    continue;
+                }
+
+                Node? previous = null;
+                for (var node = bucket; node is not null; node = node.Next)
+                {
+                    if (KeyEquals(node.Key, key))
+                    {
+                        if (!EqualityComparer<TValue>.Default.Equals(node.Value, comparisonValue))
+                        {
+                            return false;
+                        }
+
+                        SetValue(ref bucket, previous, node, newValue);
+                        return true;
+                    }
+
+                    previous = node;
+                }
+
+                return false;
+            }
+        }
+    }
+
+    public bool TryRemove(TKey key, [MaybeNullWhen(false)] out TValue value)
+        => TryRemoveInternal(key, out value, matchValue: false, default);
+
+    /// <summary>Removes the key only when its current value equals the supplied value.</summary>
+    public bool TryRemove(KeyValuePair<TKey, TValue> item)
+        => TryRemoveInternal(item.Key, out _, matchValue: true, item.Value);
+
+    private bool TryRemoveInternal(TKey key, [MaybeNullWhen(false)] out TValue value, bool matchValue, TValue? comparisonValue)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var rangeHash = GetRangeHash(key);
+        var tables = _tables;
+        while (true)
+        {
+            ref var bucket = ref GetBucketAndLock(tables, rangeHash, out var lockIndex);
+            lock (tables.Locks[lockIndex])
+            {
+                if (tables != _tables)
+                {
+                    tables = _tables;
+                    continue;
+                }
+
+                Node? previous = null;
+                for (var node = bucket; node is not null; node = node.Next)
+                {
+                    if (KeyEquals(node.Key, key))
+                    {
+                        if (matchValue && !EqualityComparer<TValue>.Default.Equals(node.Value, comparisonValue))
+                        {
+                            value = default;
+                            return false;
+                        }
+
+                        if (previous is null)
+                        {
+                            Volatile.Write(ref bucket, node.Next);
+                        }
+                        else
+                        {
+                            previous.Next = node.Next;
+                        }
+
+                        value = node.Value;
+                        tables.CountPerLock[lockIndex]--;
+                        return true;
+                    }
+
+                    previous = node;
+                }
+
+                value = default;
+                return false;
+            }
+        }
+    }
+
+    private bool TryAddInternal(TKey key, TValue value, bool updateIfExists)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var rangeHash = GetRangeHash(key);
+        var tables = _tables;
+        while (true)
+        {
+            var resize = false;
+            ref var bucket = ref GetBucketAndLock(tables, rangeHash, out var lockIndex);
+            lock (tables.Locks[lockIndex])
+            {
+                if (tables != _tables)
+                {
+                    tables = _tables;
+                    continue;
+                }
+
+                Node? previous = null;
+                for (var node = bucket; node is not null; node = node.Next)
+                {
+                    if (KeyEquals(node.Key, key))
+                    {
+                        if (updateIfExists)
+                        {
+                            SetValue(ref bucket, previous, node, value);
+                        }
+
+                        return false;
+                    }
+
+                    previous = node;
+                }
+
+                var newCount = checked(tables.CountPerLock[lockIndex] + 1);
+                var newNode = new Node(key, value, bucket);
+                Volatile.Write(ref bucket, newNode);
+                tables.CountPerLock[lockIndex] = newCount;
+                resize = newCount > _budget;
+            }
+
+            // GrowTable acquires locks in order, starting at lock zero, after releasing the insertion lock.
+            if (resize)
+            {
+                GrowTable(tables);
+            }
+
+            return true;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetValue(ref Node? bucket, Node? previous, Node node, TValue value)
+    {
+        if (!typeof(TValue).IsValueType || ConcurrentHashRangeDictionaryValue<TValue>.IsWriteAtomic)
+        {
+            node.Value = value;
+        }
+        else
+        {
+            // Readers can still be using this node. Publish a replacement to keep multiword values intact.
+            var replacement = new Node(node.Key, value, node.Next);
+            if (previous is null)
+            {
+                Volatile.Write(ref bucket, replacement);
+            }
+            else
+            {
+                previous.Next = replacement;
+            }
+        }
+    }
+
+    /// <summary>Enumerates matching entries from one table generation, hashing entries in boundary buckets.</summary>
+    public RangeEnumerable EnumerateRange(RingRange range) => new(this, range);
+
+    /// <summary>Enumerates every entry at a hash coordinate, including distinct keys which collide.</summary>
+    public RangeEnumerable EnumerateHash(uint rangeHash) => new(this, RingRange.FromPoint(rangeHash));
+
+    /// <summary>
+    /// Visits entries synchronously outside collection locks. Callbacks may perform point operations.
+    /// Callback exceptions stop visitation and propagate to the caller.
+    /// </summary>
+    public void VisitRange<TState>(RingRange range, TState state, Action<TState, TKey, TValue> visitor)
+    {
+        ArgumentNullException.ThrowIfNull(visitor);
+        foreach (var (key, value) in EnumerateRange(range))
+        {
+            visitor(state, key, value);
+        }
+    }
+
+    /// <summary>
+    /// Materializes candidates, then conditionally removes them, appending successfully removed entries to
+    /// <paramref name="removed"/>. Quiescing writers for the range makes this a complete extraction.
+    /// </summary>
+    /// <remarks>
+    /// Each removal is atomic. Candidate collection and result capacity allocation finish before removal begins.
+    /// If hashing or comparison throws during removal, prior removals remain available in the caller-owned result.
+    /// Expected-value matching follows ordinary key/value removal semantics, including equal replacement values.
+    /// </remarks>
+    public void RemoveRange(RingRange range, List<KeyValuePair<TKey, TValue>> removed)
+    {
+        ArgumentNullException.ThrowIfNull(removed);
+        var candidates = new List<KeyValuePair<TKey, TValue>>(EnumerateRange(range));
+        removed.EnsureCapacity(checked(removed.Count + candidates.Count));
+        foreach (var entry in candidates)
+        {
+            if (TryRemove(entry))
+            {
+                removed.Add(entry);
+            }
+        }
+    }
+
+    public Enumerator GetEnumerator() => new(this, RingRange.Full);
+
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public readonly struct RangeEnumerable(ConcurrentHashRangeDictionary<TKey, TValue, TComparer> dictionary, RingRange range)
+        : IEnumerable<KeyValuePair<TKey, TValue>>
+    {
+        public Enumerator GetEnumerator() => new(dictionary, range);
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
+    {
+        private readonly ConcurrentHashRangeDictionary<TKey, TValue, TComparer> _dictionary;
+        private readonly RingRange _range;
+        private Tables? _tables;
+        private Node? _node;
+        private int _nextBucket;
+        private int _remainingBuckets;
+        private int _firstBucket;
+        private int _lastBucket;
+        private bool _filterBucket;
+
+        internal Enumerator(ConcurrentHashRangeDictionary<TKey, TValue, TComparer> dictionary, RingRange range)
+        {
+            _dictionary = dictionary;
+            _range = range;
+        }
+
+        public KeyValuePair<TKey, TValue> Current { get; private set; }
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            if (_tables is null)
+            {
+                _tables = _dictionary._tables;
+                (_nextBucket, _remainingBuckets) = GetRangeBuckets(_tables, _range);
+                _firstBucket = _nextBucket;
+                _lastBucket = (int)(_range.End >> _tables.Shift);
+            }
+
+            while (true)
+            {
+                while (_node is { } node)
+                {
+                    _node = node.Next;
+                    if (!_filterBucket || _range.Contains(_dictionary.GetRangeHash(node.Key)))
+                    {
+                        Current = KeyValuePair.Create(node.Key, node.Value);
+                        return true;
+                    }
+                }
+
+                if (_remainingBuckets == 0)
+                {
+                    return false;
+                }
+
+                _node = _tables.Buckets[_nextBucket].Node;
+                _filterBucket = !_range.IsFull && (_nextBucket == _firstBucket || _nextBucket == _lastBucket);
+                _nextBucket = (_nextBucket + 1) & (_tables.Buckets.Length - 1);
+                _remainingBuckets--;
+            }
+        }
+
+        public void Reset()
+        {
+            _tables = null;
+            _node = null;
+            _nextBucket = 0;
+            _remainingBuckets = 0;
+            _firstBucket = 0;
+            _lastBucket = 0;
+            _filterBucket = false;
+            Current = default;
+        }
+
+        public void Dispose() { }
+    }
+
+    private static (int First, int Count) GetRangeBuckets(Tables tables, RingRange range)
+    {
+        if (range.IsEmpty)
+        {
+            return (0, 0);
+        }
+
+        if (range.IsFull)
+        {
+            return (0, tables.Buckets.Length);
+        }
+
+        var firstHash = unchecked(range.Start + 1);
+        var bucketSize = 1UL << tables.Shift;
+        var length = unchecked(range.End - range.Start);
+        // A wrapped range can intersect the same boundary bucket at both ends. Visit it once.
+        var count = (int)Math.Min(
+            (ulong)tables.Buckets.Length,
+            ((firstHash & (bucketSize - 1)) + length + bucketSize - 1) >> tables.Shift);
+        return ((int)(firstHash >> tables.Shift), count);
+    }
+
+    private void GrowTable(Tables tables)
+    {
+        var locksAcquired = 0;
+        try
+        {
+            Monitor.Enter(_tables.Locks[0]);
+            locksAcquired = 1;
+            if (tables != _tables)
+            {
+                return;
+            }
+
+            long count = 0;
+            foreach (var item in tables.CountPerLock)
+            {
+                count += item;
+            }
+
+            if (count < tables.Buckets.Length / 4)
+            {
+                _budget = (int)Math.Min(int.MaxValue, 2L * _budget);
+                return;
+            }
+
+            if (tables.Buckets.Length == MaxCapacity)
+            {
+                _budget = int.MaxValue;
+                return;
+            }
+
+            var locks = tables.Locks;
+            if (_growLocks && locks.Length < MaxLockCount)
+            {
+                locks = new object[tables.Locks.Length * 2];
+                Array.Copy(tables.Locks, locks, tables.Locks.Length);
+                for (var i = tables.Locks.Length; i < locks.Length; i++)
+                {
+                    locks[i] = new object();
+                }
+            }
+
+            var newTables = new Tables(new VolatileNode[tables.Buckets.Length * 2], locks, new int[locks.Length]);
+            AcquireRemainingLocks(tables, ref locksAcquired);
+            foreach (var bucket in tables.Buckets)
+            {
+                for (var node = bucket.Node; node is not null; node = node.Next)
+                {
+                    ref var newBucket = ref GetBucketAndLock(newTables, GetRangeHash(node.Key), out var lockIndex);
+                    newBucket = new Node(node.Key, node.Value, newBucket);
+                    newTables.CountPerLock[lockIndex]++;
+                }
+            }
+
+            _budget = Math.Max(1, newTables.Buckets.Length / locks.Length);
+            _tables = newTables;
+        }
+        finally
+        {
+            ReleaseLocks(locksAcquired);
+        }
+    }
+
+    private Tables AcquireAllLocks(ref int locksAcquired)
+    {
+        Monitor.Enter(_tables.Locks[0]);
+        locksAcquired = 1;
+        var tables = _tables;
+        AcquireRemainingLocks(tables, ref locksAcquired);
+        return tables;
+    }
+
+    private static void AcquireRemainingLocks(Tables tables, ref int locksAcquired)
+    {
+        for (var i = 1; i < tables.Locks.Length; i++)
+        {
+            Monitor.Enter(tables.Locks[i]);
+            locksAcquired++;
+        }
+    }
+
+    private void ReleaseLocks(int locksAcquired)
+    {
+        var locks = _tables.Locks;
+        for (var i = 0; i < locksAcquired; i++)
+        {
+            Monitor.Exit(locks[i]);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private uint GetRangeHash(TKey key)
+        => _comparer.GetHashCode(key);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool KeyEquals(TKey left, TKey right)
+        => _comparer.Equals(left, right);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ref Node? GetBucketAndLock(Tables tables, uint rangeHash, out int lockIndex)
+    {
+        var bucketIndex = (int)(rangeHash >> tables.Shift);
+        lockIndex = bucketIndex & (tables.Locks.Length - 1);
+        return ref tables.Buckets[bucketIndex].Node;
+    }
+
+    private struct VolatileNode
+    {
+        // A struct wrapper avoids the array covariance check on each volatile reference load.
+        internal volatile Node? Node;
+    }
+
+    private sealed class Node(TKey key, TValue value, Node? next)
+    {
+        internal readonly TKey Key = key;
+        internal TValue Value = value;
+        internal volatile Node? Next = next;
+    }
+
+    private sealed class Tables(VolatileNode[] buckets, object[] locks, int[] countPerLock)
+    {
+        internal readonly VolatileNode[] Buckets = buckets;
+        internal readonly object[] Locks = locks;
+        internal readonly int[] CountPerLock = countPerLock;
+        internal readonly int Shift = 32 - BitOperations.Log2((uint)buckets.Length);
+    }
+}
+
+internal static class ConcurrentHashRangeDictionaryValue<T>
+{
+    internal static readonly bool IsWriteAtomic = !typeof(T).IsValueType
+        || typeof(T) == typeof(IntPtr)
+        || typeof(T) == typeof(UIntPtr)
+        || Type.GetTypeCode(typeof(T)) switch
+        {
+            TypeCode.Boolean or TypeCode.Byte or TypeCode.Char or TypeCode.Int16 or TypeCode.Int32
+                or TypeCode.SByte or TypeCode.Single or TypeCode.UInt16 or TypeCode.UInt32 => true,
+            TypeCode.Double or TypeCode.Int64 or TypeCode.UInt64 => IntPtr.Size == 8,
+            _ => false,
+        };
+}

--- a/src/Orleans.Runtime/Utilities/ConcurrentHashRangeDictionary.md
+++ b/src/Orleans.Runtime/Utilities/ConcurrentHashRangeDictionary.md
@@ -1,0 +1,98 @@
+# Concurrent hash-range dictionary
+
+`ConcurrentHashRangeDictionary<TKey, TValue, TComparer>` is an Orleans-owned adaptation of
+`ConcurrentDictionary<TKey, TValue>` with a range-aware primary hash table.
+Point operations, prehashed lookup, hash-only enumeration, and range operations
+use the same nodes and bucket array.
+
+## Provenance and maintenance
+
+The starting implementation is
+[`ConcurrentDictionary.cs` at dotnet/runtime revision b5881242dc356bd8c464026387545f2684079d30](https://github.com/dotnet/runtime/blob/b5881242dc356bd8c464026387545f2684079d30/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentDictionary.cs).
+The source file retains the .NET Foundation MIT license header.
+
+The adaptation retains the runtime's linked nodes, volatile bucket publication,
+striped writer locks, table-generation retry after taking a writer lock,
+copy-and-publish resizing, increasing lock acquisition order, and replacement
+nodes for values requiring multiword writes. It implements the internal
+operations used by Orleans and the accompanying benchmarks.
+
+Intentional layout changes:
+
+- `IConsistentHashComparer<TKey>` supplies equality and unsigned 32-bit hashes,
+  following the structure of `IEqualityComparer<TKey>`. A concrete `TComparer`
+  allows the JIT to specialize calls for struct comparers.
+- The readonly `GrainIdUniformHashComparer` struct supplies
+  `GrainId.GetUniformHashCode()` for cluster-wide grain coordinates. That hash
+  combines values already cached in the grain type and key.
+- Power-of-two bucket arrays use the hash's high bits. Doubling the table splits
+  each hash prefix into two narrower prefixes.
+- Initial sizing targets at most 75% occupancy before rounding to a power of two.
+  This accommodates per-lock variation while filling a presized collection.
+- Lock arrays also have power-of-two lengths. Bucket indices select striped
+  locks using a mask.
+- Nodes store the key, value, and next link. Resizing recomputes hashes; range
+  traversal hashes keys only in boundary buckets. Fully covered buckets are
+  traversed directly.
+- Struct enumerators support allocation-free direct `foreach` and visitation.
+- The maximum bucket count is `1 << 30`, preserving power-of-two addressing.
+
+When updating the runtime baseline, compare the upstream insertion, update,
+removal, resize, enumeration, and atomic-write implementations against this
+file. Port relevant correctness and memory-ordering fixes explicitly. Review
+every bucket calculation against stable-hash addressing and rerun boundary,
+collision, generation-race, multiword-value, and recovery coverage on supported
+runtime targets. Update this revision after completing that review. Performance
+changes should retain side-by-side baselines.
+
+## Hash and range contracts
+
+The consistent comparer contract gives equal keys equal hash codes. Keys retain
+their hash and equality identity while stored. The comparer supports concurrent
+calls; equality comparisons run under writer locks during mutations. A prehashed
+lookup's coordinate is `Comparer.GetHashCode(key)`. Comparers supply inexpensive,
+deterministic hashes, stable across processes when coordinates are shared by silos.
+
+Point lookup selects a bucket using the hash and compares keys. Hash-only enumeration
+returns all entries at the coordinate, including distinct colliding keys.
+Range enumeration implements the existing exclusive-start, inclusive-end ring
+semantics, including explicit empty/full ranges and wrap-around. The first and
+last buckets are calculated directly. When a wrapped interval intersects the
+same bucket at both ends, that bucket is visited once.
+
+Range work is proportional to intersecting buckets and their entries. For a
+uniform hash distribution, growth keeps boundary buckets small. Concentrated
+prefixes or identical hashes increase chain traversal, boundary filtering, and
+writer contention. Like the runtime implementation, the growth budget expands
+instead of repeatedly enlarging an underutilized table.
+
+## Concurrency and extraction
+
+Point reads traverse volatile node links without writer locks. Point mutations
+take one lock and verify that their captured table is still current before
+changing it. Resizing first takes lock zero, allocates the new table, then takes
+the remaining locks in increasing order and copies nodes. The new table is
+published after copying; old nodes stay available to readers. Rehashing or
+allocation failures preserve the original table, including the insertion which
+triggered growth. New lock arrays
+retain the old lock objects. A writer waiting on an old table retries against
+the published generation.
+
+An enumerator captures one table on its first `MoveNext`. It can observe
+concurrent mutations to that table and continues safely across resizing.
+Quiescing writers while materializing an enumeration gives a point-in-time
+snapshot. Synchronous visitors execute outside the collection's locks and may
+perform point operations; visitor exceptions propagate.
+
+`RemoveRange` materializes candidates and reserves result capacity before the
+first removal. It then performs expected-value removal for each candidate and
+appends each successfully removed entry to the caller-owned result list.
+Each removal is atomic. Quiescing writers in the range gives complete
+extraction; with concurrent writers, changed values survive and the result
+records successful removals. Equal replacement values follow the ordinary
+key/value removal contract. If hashing or equality throws during removal,
+completed removals remain in the supplied list.
+
+The activation directory uses selective enumeration for recovery. Its existing
+membership watermark, registration-publication protocol, expected-context
+removal, and activation count tracking govern lifecycle consistency.

--- a/src/Orleans.Runtime/Utilities/GrainIdUniformHashComparer.cs
+++ b/src/Orleans.Runtime/Utilities/GrainIdUniformHashComparer.cs
@@ -1,0 +1,11 @@
+namespace Orleans.Runtime.Utilities;
+
+/// <summary>Compares grain identities using their stable, cluster-wide hash-ring coordinate.</summary>
+internal readonly struct GrainIdUniformHashComparer : IConsistentHashComparer<GrainId>
+{
+    public static GrainIdUniformHashComparer Instance { get; } = new();
+
+    public bool Equals(GrainId x, GrainId y) => x.Equals(y);
+
+    public uint GetHashCode(GrainId value) => value.GetUniformHashCode();
+}

--- a/src/Orleans.Runtime/Utilities/IConsistentHashComparer.cs
+++ b/src/Orleans.Runtime/Utilities/IConsistentHashComparer.cs
@@ -1,0 +1,14 @@
+namespace Orleans.Runtime.Utilities;
+
+/// <summary>Defines key equality and a consistent unsigned hash-ring coordinate.</summary>
+/// <remarks>
+/// Equal keys have equal hashes. Keys retain their hash and equality identity while stored.
+/// Implementations support concurrent calls and keep hashing and equality independent of collection mutations.
+/// Hashes shared between silos are stable across processes.
+/// </remarks>
+internal interface IConsistentHashComparer<in T>
+{
+    bool Equals(T? x, T? y);
+
+    uint GetHashCode(T value);
+}

--- a/test/Benchmarks/Collections/HashRangePointBenchmarks.cs
+++ b/test/Benchmarks/Collections/HashRangePointBenchmarks.cs
@@ -1,0 +1,112 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Orleans.Runtime;
+using Orleans.Runtime.Utilities;
+using Entry = System.Collections.Generic.KeyValuePair<Orleans.Runtime.GrainId, int>;
+
+namespace Benchmarks.Collections;
+
+[MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory), CategoriesColumn]
+public class HashRangePointBenchmarks
+{
+    private Entry[] _entries = null!;
+    private ConcurrentDictionary<GrainId, int> _concurrent = null!;
+    private ConcurrentHashRangeDictionary<GrainId, int, GrainIdUniformHashComparer> _native = null!;
+    private Entry _hit;
+    private GrainId _miss;
+    private uint _hitHash;
+    private uint _missHash;
+
+    [Params(16_384, 262_144)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _entries = HashRangeData.Create(Count);
+        _concurrent = (ConcurrentDictionary<GrainId, int>)ConcurrentConstructAndGrow(false);
+        _native = (ConcurrentHashRangeDictionary<GrainId, int, GrainIdUniformHashComparer>)NativeConstructAndGrow(false);
+        _hit = _entries[_entries.Length / 2];
+        _miss = GrainId.Create("hash-range-missing", "0");
+        _hitHash = _hit.Key.GetUniformHashCode();
+        _missHash = _miss.GetUniformHashCode();
+        for (var i = 0; i < 2; i++)
+        {
+            if (ConcurrentHit() != _hit.Value || NativeHit() != _hit.Value || NativePrehashedHit() != _hit.Value
+                || ConcurrentMiss() || NativeMiss() || NativePrehashedMiss()
+                || !ConcurrentUpdateAndRestore() || !NativeUpdateAndRestore()
+                || !ConcurrentRemoveAndRefill() || !NativeRemoveAndRefill())
+            {
+                throw new InvalidOperationException("Point operation or restoration failed.");
+            }
+        }
+
+        HashRangeData.Validate(_entries, _concurrent);
+        HashRangeData.Validate(_entries, _native);
+        HashRangeData.Validate(_entries, (IEnumerable<Entry>)ConcurrentConstructAndGrow(true));
+        HashRangeData.Validate(_entries, (IEnumerable<Entry>)NativeConstructAndGrow(true));
+    }
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Hit")]
+    public int ConcurrentHit() => _concurrent.TryGetValue(_hit.Key, out var value) ? value : -1;
+
+    [Benchmark, BenchmarkCategory("Hit")]
+    public int NativeHit() => _native.TryGetValue(_hit.Key, out var value) ? value : -1;
+
+    [Benchmark, BenchmarkCategory("Hit")]
+    public int NativePrehashedHit() => _native.TryGetValue(_hit.Key, _hitHash, out var value) ? value : -1;
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Miss")]
+    public bool ConcurrentMiss() => _concurrent.TryGetValue(_miss, out _);
+
+    [Benchmark, BenchmarkCategory("Miss")]
+    public bool NativeMiss() => _native.TryGetValue(_miss, out _);
+
+    [Benchmark, BenchmarkCategory("Miss")]
+    public bool NativePrehashedMiss() => _native.TryGetValue(_miss, _missHash, out _);
+
+    [Benchmark(Baseline = true), BenchmarkCategory("UpdateAndRestore")]
+    public bool ConcurrentUpdateAndRestore()
+        => _concurrent.TryUpdate(_hit.Key, -1, _hit.Value) & _concurrent.TryUpdate(_hit.Key, _hit.Value, -1);
+
+    [Benchmark, BenchmarkCategory("UpdateAndRestore")]
+    public bool NativeUpdateAndRestore()
+        => _native.TryUpdate(_hit.Key, -1, _hit.Value) & _native.TryUpdate(_hit.Key, _hit.Value, -1);
+
+    [Benchmark(Baseline = true), BenchmarkCategory("ConditionalRemoveAndRefill")]
+    public bool ConcurrentRemoveAndRefill()
+        => ((ICollection<Entry>)_concurrent).Remove(_hit) & _concurrent.TryAdd(_hit.Key, _hit.Value);
+
+    [Benchmark, BenchmarkCategory("ConditionalRemoveAndRefill")]
+    public bool NativeRemoveAndRefill()
+        => _native.TryRemove(_hit) & _native.TryAdd(_hit.Key, _hit.Value);
+
+    // These measure cumulative construction/growth allocation, not the retained size of a populated collection.
+    [Benchmark(Baseline = true), BenchmarkCategory("ConstructAndGrow")]
+    [Arguments(false), Arguments(true)]
+    public object ConcurrentConstructAndGrow(bool presize)
+    {
+        var result = new ConcurrentDictionary<GrainId, int>(Environment.ProcessorCount, presize ? Count : 32);
+        foreach (var entry in _entries)
+        {
+            result.TryAdd(entry.Key, entry.Value);
+        }
+
+        return result;
+    }
+
+    [Benchmark, BenchmarkCategory("ConstructAndGrow")]
+    [Arguments(false), Arguments(true)]
+    public object NativeConstructAndGrow(bool presize)
+    {
+        var result = new ConcurrentHashRangeDictionary<GrainId, int, GrainIdUniformHashComparer>(
+            GrainIdUniformHashComparer.Instance, capacity: presize ? Count : 32, concurrencyLevel: Environment.ProcessorCount);
+        foreach (var entry in _entries)
+        {
+            result.TryAdd(entry.Key, entry.Value);
+        }
+
+        return result;
+    }
+}

--- a/test/Benchmarks/Collections/HashRangeScanBenchmarks.cs
+++ b/test/Benchmarks/Collections/HashRangeScanBenchmarks.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Utilities;
+using Entry = System.Collections.Generic.KeyValuePair<Orleans.Runtime.GrainId, int>;
+
+namespace Benchmarks.Collections;
+
+public enum HashRangeScenario
+{
+    Empty, Tiny, Sparse, Moderate, Full, Wrapped, Skewed, Colliding, TinyLarge, SparseLarge, FullLarge
+}
+
+[MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory), CategoriesColumn]
+public class HashRangeScanBenchmarks
+{
+    private ConcurrentDictionary<GrainId, int> _concurrent = null!;
+    private ConcurrentHashRangeDictionary<GrainId, int, ScenarioComparer> _native = null!;
+    private ScenarioComparer _comparer;
+    private RingRange _range;
+
+    // Bounded profiles keep the expensive large/collision populations focused on their distinct behaviors.
+    [ParamsAllValues]
+    public HashRangeScenario Scenario { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Bound the deliberately quadratic collision lifecycle; ordinary profiles use the same larger population.
+        var entries = HashRangeData.Create(Scenario switch
+        {
+            HashRangeScenario.Colliding => 1_024,
+            HashRangeScenario.TinyLarge or HashRangeScenario.SparseLarge or HashRangeScenario.FullLarge => 262_144,
+            _ => 16_384
+        });
+        _comparer = new(Scenario);
+        _range = Scenario switch
+        {
+            HashRangeScenario.Empty => RingRange.Empty,
+            HashRangeScenario.Tiny or HashRangeScenario.TinyLarge => RingRange.FromPoint(Hash(entries[0].Key)),
+            HashRangeScenario.Full or HashRangeScenario.FullLarge => RingRange.Full,
+            HashRangeScenario.Wrapped => RingRange.Create(0xf0000000, 0x0fffffff),
+            HashRangeScenario.Moderate => RingRange.Create(0x80000000, 0x9fffffff),
+            HashRangeScenario.Colliding => RingRange.FromPoint(0x80000001),
+            _ => RingRange.Create(0x80000000, 0x80000000 + uint.MaxValue / 1000)
+        };
+        _concurrent = new();
+        _native = new(_comparer);
+        foreach (var entry in entries)
+        {
+            _concurrent.TryAdd(entry.Key, entry.Value);
+            _native.TryAdd(entry.Key, entry.Value);
+        }
+
+        var expected = entries.Where(entry => _range.Contains(Hash(entry.Key))).ToArray();
+        HashRangeData.Validate(expected, ConcurrentMaterialize());
+        HashRangeData.Validate(expected, NativeMaterialize());
+        if (ConcurrentScan() != NativeScan())
+        {
+            throw new InvalidOperationException("Range scan checksums differ.");
+        }
+        for (var i = 0; i < 2; i++)
+        {
+            HashRangeData.Validate(expected, ConcurrentRemoveAndRefill());
+            HashRangeData.Validate(expected, NativeRemoveAndRefill());
+            HashRangeData.Validate(entries, _concurrent);
+            HashRangeData.Validate(entries, _native);
+        }
+    }
+
+    [Benchmark(Baseline = true), BenchmarkCategory("MapMaterialize")]
+    public Entry[] ConcurrentMaterialize() => _concurrent.Where(entry => _range.Contains(Hash(entry.Key))).ToArray();
+
+    [Benchmark, BenchmarkCategory("MapMaterialize")]
+    public Entry[] NativeMaterialize() => _native.EnumerateRange(_range).ToArray();
+
+    [Benchmark(Baseline = true), BenchmarkCategory("MapScan")]
+    public long ConcurrentScan()
+    {
+        var result = 0L;
+        foreach (var entry in _concurrent)
+        {
+            if (_range.Contains(Hash(entry.Key)))
+            {
+                result += entry.Value;
+            }
+        }
+
+        return result;
+    }
+
+    [Benchmark, BenchmarkCategory("MapScan")]
+    public long NativeScan()
+    {
+        var result = 0L;
+        foreach (var entry in _native.EnumerateRange(_range))
+        {
+            result += entry.Value;
+        }
+
+        return result;
+    }
+
+    // Both lifecycles include candidate materialization, conditional removal, result allocation and refill.
+    [Benchmark(Baseline = true), BenchmarkCategory("RangeRemoveAndRefill")]
+    public List<Entry> ConcurrentRemoveAndRefill()
+    {
+        var candidates = _concurrent.Where(entry => _range.Contains(Hash(entry.Key))).ToList();
+        var removed = new List<Entry>(candidates.Count);
+        foreach (var entry in candidates)
+        {
+            if (((ICollection<Entry>)_concurrent).Remove(entry))
+            {
+                removed.Add(entry);
+            }
+        }
+
+        foreach (var entry in removed)
+        {
+            _concurrent.TryAdd(entry.Key, entry.Value);
+        }
+
+        return removed;
+    }
+
+    [Benchmark, BenchmarkCategory("RangeRemoveAndRefill")]
+    public List<Entry> NativeRemoveAndRefill()
+    {
+        var removed = new List<Entry>();
+        _native.RemoveRange(_range, removed);
+        foreach (var entry in removed)
+        {
+            _native.TryAdd(entry.Key, entry.Value);
+        }
+
+        return removed;
+    }
+
+    private uint Hash(GrainId key) => _comparer.GetHashCode(key);
+
+    private readonly struct ScenarioComparer(HashRangeScenario scenario) : IConsistentHashComparer<GrainId>
+    {
+        public bool Equals(GrainId x, GrainId y) => x.Equals(y);
+
+        public uint GetHashCode(GrainId value) => scenario switch
+        {
+            HashRangeScenario.Skewed => 0x80000000 + (value.GetUniformHashCode() >> 8),
+            HashRangeScenario.Colliding => 0x80000001,
+            _ => value.GetUniformHashCode()
+        };
+    }
+}
+
+internal static class HashRangeData
+{
+    internal static Entry[] Create(int count)
+    {
+        var random = new Random(7451);
+        return Enumerable.Range(0, count)
+            .Select(i => new Entry(GrainId.Create("hash-range", $"{i:x8}-{random.NextInt64():x16}"), i + 1)).ToArray();
+    }
+
+    internal static void Validate(IEnumerable<Entry> expected, IEnumerable<Entry> actual)
+    {
+        if (!expected.OrderBy(entry => entry.Value).SequenceEqual(actual.OrderBy(entry => entry.Value)))
+        {
+            throw new InvalidOperationException("Hash-range results or restored population differ.");
+        }
+    }
+}

--- a/test/Benchmarks/Collections/HashRangeWorkloadBenchmarks.cs
+++ b/test/Benchmarks/Collections/HashRangeWorkloadBenchmarks.cs
@@ -1,0 +1,253 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Utilities;
+using Entry = System.Collections.Generic.KeyValuePair<Orleans.Runtime.GrainId, int>;
+
+namespace Benchmarks.Collections;
+
+public enum HashRangeWorkload
+{
+    ReadHeavy,
+    Mixed,
+    HotMixed,
+    Recovery,
+    Churn
+}
+
+// Persistent workers keep thread creation outside measurement. OperationsPerInvoke counts the
+// total work across all workers; each recovery batch includes exactly 32 range scans at every concurrency.
+[ThreadingDiagnoser, OperationsPerSecond]
+public class HashRangeWorkloadBenchmarks
+{
+    private const int Operations = 1_048_576;
+    private const int RangeCadence = Operations / 32;
+    private const int Population = 262_144;
+    private Entry[] _entries = null!;
+    private ConcurrentDictionary<GrainId, int> _concurrent = null!;
+    private ConcurrentHashRangeDictionary<GrainId, int, GrainIdUniformHashComparer> _native = null!;
+    private Barrier _barrier = null!;
+    private long[] _results = null!;
+    private Thread[] _workers = null!;
+    private RingRange _range;
+    private bool _useNative;
+    private bool _stop;
+    private int _round;
+    private Exception? _workerError;
+
+    [Params(1, 8, 32)]
+    public int WorkerCount { get; set; }
+
+    [ParamsAllValues]
+    public HashRangeWorkload Workload { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _entries = HashRangeData.Create(Population);
+        _concurrent = new();
+        _native = new(default);
+        foreach (var entry in _entries)
+        {
+            _concurrent.TryAdd(entry.Key, entry.Value);
+            _native.TryAdd(entry.Key, entry.Value);
+        }
+
+        _range = RingRange.Create(0x80000000, 0x80000000 + uint.MaxValue / 1000);
+        _barrier = new(WorkerCount + 1);
+        _results = new long[WorkerCount];
+        _workers = Enumerable.Range(0, WorkerCount)
+            .Select(id => new Thread(() => Worker(id)) { IsBackground = true })
+            .ToArray();
+        foreach (var worker in _workers)
+        {
+            worker.Start();
+        }
+
+        try
+        {
+            var expected = ExpectedChecksum(round: 1);
+            if (ConcurrentThroughput() != expected)
+            {
+                throw new InvalidOperationException("ConcurrentDictionary workload checksum differs from the model.");
+            }
+
+            _round = 0;
+            if (NativeThroughput() != expected)
+            {
+                throw new InvalidOperationException("Native dictionary workload checksum differs from the model.");
+            }
+
+            HashRangeData.Validate(_entries, _concurrent);
+            HashRangeData.Validate(_entries, _native);
+        }
+        catch
+        {
+            Cleanup();
+            throw;
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = Operations)]
+    public long ConcurrentThroughput() => Run(native: false);
+
+    [Benchmark(OperationsPerInvoke = Operations)]
+    public long NativeThroughput() => Run(native: true);
+
+    private long Run(bool native)
+    {
+        _useNative = native;
+        _round = (_round + 1) & (Population - 1);
+        _barrier.SignalAndWait();
+        _barrier.SignalAndWait();
+        if (_workerError is { } error)
+        {
+            throw new InvalidOperationException("Throughput worker failed.", error);
+        }
+
+        var result = 0L;
+        foreach (var value in _results)
+        {
+            result += value;
+        }
+
+        return result;
+    }
+
+    private long Execute(int worker)
+    {
+        var checksum = 0L;
+        var writesMask = Workload == HashRangeWorkload.ReadHeavy ? 31 : 3;
+        var start = _round * 17;
+        for (var i = 0; i < Operations / WorkerCount; i++)
+        {
+            var index = Workload == HashRangeWorkload.HotMixed
+                ? (i * 17 + worker * 13) & 63
+                : (start + i * WorkerCount + worker) & (Population - 1);
+            var entry = _entries[index];
+            if ((i & writesMask) == 0)
+            {
+                if (Workload == HashRangeWorkload.Churn)
+                {
+                    var removed = _useNative ? _native.TryRemove(entry) : _concurrent.TryRemove(entry);
+                    var added = _useNative ? _native.TryAdd(entry.Key, entry.Value) : _concurrent.TryAdd(entry.Key, entry.Value);
+                    if (!removed || !added)
+                    {
+                        throw new InvalidOperationException("An exclusively assigned lifecycle update failed.");
+                    }
+                }
+                else if (_useNative)
+                {
+                    _native[entry.Key] = entry.Value;
+                }
+                else
+                {
+                    _concurrent[entry.Key] = entry.Value;
+                }
+            }
+            else
+            {
+                var found = _useNative ? _native.TryGetValue(entry.Key, out var value) : _concurrent.TryGetValue(entry.Key, out value);
+                if (!found || value != entry.Value)
+                {
+                    throw new InvalidOperationException("A published entry changed during an idempotent refresh workload.");
+                }
+
+                checksum += value;
+            }
+
+            if (Workload == HashRangeWorkload.Recovery && (i & (RangeCadence - 1)) == 0)
+            {
+                if (_useNative)
+                {
+                    foreach (var item in _native.EnumerateRange(_range))
+                    {
+                        checksum += item.Value;
+                    }
+                }
+                else
+                {
+                    foreach (var item in _concurrent)
+                    {
+                        if (_range.Contains(item.Key.GetUniformHashCode()))
+                        {
+                            checksum += item.Value;
+                        }
+                    }
+                }
+            }
+        }
+
+        return checksum;
+    }
+
+    private long ExpectedChecksum(int round)
+    {
+        var result = 0L;
+        var writesMask = Workload == HashRangeWorkload.ReadHeavy ? 31 : 3;
+        for (var worker = 0; worker < WorkerCount; worker++)
+        {
+            for (var i = 0; i < Operations / WorkerCount; i++)
+            {
+                if ((i & writesMask) != 0)
+                {
+                    var index = Workload == HashRangeWorkload.HotMixed
+                        ? (i * 17 + worker * 13) & 63
+                        : (round * 17 + i * WorkerCount + worker) & (Population - 1);
+                    result += _entries[index].Value;
+                }
+            }
+        }
+
+        if (Workload == HashRangeWorkload.Recovery)
+        {
+            result += (Operations / RangeCadence) * _entries.Where(entry => _range.Contains(entry.Key.GetUniformHashCode())).Sum(static entry => (long)entry.Value);
+        }
+
+        return result;
+    }
+
+    private void Worker(int id)
+    {
+        while (true)
+        {
+            _barrier.SignalAndWait();
+            if (_stop)
+            {
+                return;
+            }
+
+            try
+            {
+                _results[id] = Execute(id);
+            }
+            catch (Exception error)
+            {
+                Interlocked.CompareExchange(ref _workerError, error, null);
+            }
+            finally
+            {
+                _barrier.SignalAndWait();
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        if (_stop)
+        {
+            return;
+        }
+
+        _stop = true;
+        _barrier.SignalAndWait();
+        foreach (var worker in _workers)
+        {
+            worker.Join();
+        }
+
+        _barrier.Dispose();
+    }
+}

--- a/test/Benchmarks/Collections/README.md
+++ b/test/Benchmarks/Collections/README.md
@@ -1,0 +1,106 @@
+# Concurrent hash-range collection benchmarks
+
+These benchmarks compare `ConcurrentDictionary<GrainId, int>` with
+`ConcurrentHashRangeDictionary<GrainId, int, GrainIdUniformHashComparer>`.
+Both use identical seeded grain identities and values. The native map's concrete
+struct comparer supplies consistent hashes and key equality.
+
+## Concurrent throughput
+
+`HashRangeWorkloadBenchmarks` uses 1, 8, and 32 persistent worker threads over
+262,144 entries. Both maps grow from their default initial sizes, allowing their
+normal lock-array growth. Each invocation completes 1,048,576 logical work items
+across all workers, amortizing two barrier rendezvous while keeping total work
+constant across concurrency levels. Reported operations per second represent
+aggregate work-item throughput.
+
+| Profile | Work |
+| --- | --- |
+| ReadHeavy | 31 lookups per idempotent refresh write |
+| Mixed | Three lookups per refresh write over the complete population |
+| HotMixed | The same mix shared across 64 hot keys |
+| Recovery | Mixed point traffic plus 32 selective range scans per invocation, distributed evenly across workers |
+| Churn | Three lookups per conditional remove-and-reinsert lifecycle update; workers own disjoint keys during each batch |
+
+Point traffic rotates over the population. Setup compares worker checksums with
+an independent model and verifies the complete populations. Worker exceptions
+propagate to the controller. Threads start before measurement and are joined
+during cleanup. Threading diagnostics include lock contention. Allocation
+measurements for construction live in the point benchmark class, since worker
+allocations span multiple threads.
+
+## Supporting comparisons
+
+`HashRangePointBenchmarks` covers hits, misses, prehashed lookup, conditional
+update/removal, and construction with and without presizing at 16,384 and 262,144
+entries. Construction reports cumulative allocation, including resizing.
+
+`HashRangeScanBenchmarks` separates traversal checksums, result materialization,
+and remove/refill lifecycles. Bounded profiles cover empty, tiny, sparse, moderate,
+full, wrapped, concentrated-prefix, and colliding hashes. Large profiles contain
+262,144 entries; the deliberate all-collision profile contains 1,024 entries.
+Each destructive invocation restores the complete starting population.
+
+## Running on .NET 10
+
+Build the benchmark assembly, then invoke its `suite` entry point directly to
+keep repository test-runner arguments separate from BenchmarkDotNet arguments.
+`BuildExternalAssets=false` scopes collection measurements to managed code when
+BenchmarkDotNet rebuilds its harness.
+
+```powershell
+$env:BuildExternalAssets = 'false'
+dotnet build test\Benchmarks\Benchmarks.csproj -c Release -f net10.0
+dotnet test\Benchmarks\bin\Release\net10.0\Benchmarks.dll suite --filter '*HashRangeWorkloadBenchmarks*' --job Dry --buildTimeout 600 --noOverwrite
+dotnet test\Benchmarks\bin\Release\net10.0\Benchmarks.dll suite --filter '*HashRangeWorkloadBenchmarks*' --job Short --outliers DontRemove --buildTimeout 600 --noOverwrite
+```
+
+`--inProcess` supports rapid comparisons using the already-built assembly; record
+that toolchain with the results. Out-of-process runs give each case a separate
+process. Inspect reports for successful execution: BenchmarkDotNet can exit
+successfully after a harness build failure and produce a report containing `NA`.
+
+## Recorded results and interpretation
+
+Development measurements on September 8, 2026 used .NET 10.0.11, SDK 10.0.400,
+BenchmarkDotNet 0.15.6, and its in-process emit toolchain on Windows 11 / Hyper-V
+(AMD EPYC 7763, 32 logical processors). Outliers were retained. The initial matrix
+covered all three concurrency levels. A separate repeat used two launches,
+five warmups, and ten measured iterations per launch at 32 workers. After
+improving initial sizing, the final Short job used three warmups and three
+measured iterations.
+
+Final 32-worker results, in millions of logical work items per second:
+
+| Profile | ConcurrentDictionary | Native | Time standard deviation, baseline/native |
+| --- | ---: | ---: | ---: |
+| ReadHeavy | 111.5 | 99.3 | 1.018 / 0.677 ns |
+| Mixed | 80.1 | 87.1 | 0.215 / 0.589 ns |
+| HotMixed | 116.0 | 123.0 | 0.093 / 0.096 ns |
+| Recovery | 19.1 | 84.6 | 1.620 / 0.347 ns |
+| Churn | 59.3 | 58.9 | 0.460 / 0.498 ns |
+
+The 32-worker recovery improvement repeated at approximately 4.4-4.7x.
+Point-only results varied around the baseline: read-heavy native throughput was
+about 2-11% lower across these runs, while mixed results changed direction.
+The earlier eight-worker read-heavy comparison showed about 20% lower native
+throughput. These tradeoffs matter for point-dominated workloads.
+
+For 262,144 entries, cumulative construction allocation was approximately
+54.7 MB native versus 38.4 MB baseline when growing from default capacity.
+Initial sizing headroom reduced presized native allocation from 37.6 MB to
+20.0 MB. Baseline presized allocation varied from 18.1 MB to 38.3 MB between runs.
+These figures include obsolete nodes and tables created during growth.
+
+Range traversal visits intersecting hash-prefix buckets. Concentrated prefixes
+and identical hashes can produce long chains and contention; full scans and
+construction have their own costs. The default BCL baseline and native map use
+different hash/comparer configurations, so these are storage-configuration
+comparisons rather than an isolated attribution to bucket arithmetic.
+
+The host is a shared VM. Retain outliers, report dispersion, and repeat
+representative high-concurrency cases in separate runs. Keep agent-initiated
+builds and tests outside measured intervals. Treat small differences with
+overlapping uncertainty as inconclusive. Reproduce deployment-representative
+workloads on the target hardware before interpreting these microbenchmarks as
+application-level throughput gains.

--- a/test/Orleans.Core.Tests/Utilities/ActivationDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Utilities/ActivationDirectoryTests.cs
@@ -1,0 +1,314 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Xunit;
+
+namespace NonSilo.Tests.Utilities;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+public sealed class ActivationDirectoryTests : IDisposable
+{
+    private readonly ServiceProvider _services;
+    private readonly OrleansInstruments _instruments;
+    private readonly ActivationDirectory _directory;
+
+    public ActivationDirectoryTests()
+    {
+        _services = new ServiceCollection().AddMetrics().BuildServiceProvider();
+        _instruments = new OrleansInstruments(_services.GetRequiredService<IMeterFactory>());
+        _directory = new ActivationDirectory(new CatalogInstruments(_instruments));
+    }
+
+    [Fact]
+    public void RecordNewTarget_DuplicateGrainIdPreservesOriginalIdentityAndCount()
+    {
+        var target = Target("original");
+        var duplicate = Target("original");
+        var neighbor = Target("neighbor");
+        Assert.Null(_directory.FindTarget(target.GrainId));
+        Assert.Equal(0, _directory.Count);
+
+        _directory.RecordNewTarget(target);
+        _directory.RecordNewTarget(target);
+        _directory.RecordNewTarget(duplicate);
+        Assert.Same(target, _directory.FindTarget(target.GrainId));
+        Assert.Equal(1, _directory.Count);
+        Assert.False(_directory.RemoveTarget(duplicate));
+        _directory.RecordNewTarget(neighbor);
+        AssertContents([target, neighbor]);
+        Assert.Same(target, _directory.FindTarget(target.GrainId));
+        Assert.Same(neighbor, _directory.FindTarget(neighbor.GrainId));
+    }
+
+    [Fact]
+    public void RemoveTarget_StaleActivationCannotRemoveReplacementOrDecrementCount()
+    {
+        var original = Target("replaced");
+        var replacement = Target("replaced");
+        var neighbor = Target("neighbor");
+        Assert.False(_directory.RemoveTarget(original));
+        Assert.Equal(0, _directory.Count);
+        _directory.RecordNewTarget(original);
+        _directory.RecordNewTarget(neighbor);
+        Assert.True(_directory.RemoveTarget(original));
+        Assert.Null(_directory.FindTarget(original.GrainId));
+        AssertContents([neighbor]);
+        _directory.RecordNewTarget(replacement);
+        Assert.False(_directory.RemoveTarget(original));
+        Assert.False(_directory.RemoveTarget(original));
+        Assert.Same(replacement, _directory.FindTarget(original.GrainId));
+        AssertContents([replacement, neighbor]);
+
+        Assert.True(_directory.RemoveTarget(replacement));
+        Assert.False(_directory.RemoveTarget(replacement));
+        Assert.Null(_directory.FindTarget(replacement.GrainId));
+        AssertContents([neighbor]);
+        Assert.True(_directory.RemoveTarget(neighbor));
+        AssertContents([]);
+    }
+
+    [Theory]
+    [InlineData("Empty")]
+    [InlineData("Full")]
+    [InlineData("Point")]
+    [InlineData("Nonwrapped")]
+    [InlineData("Wrapped")]
+    public void EnumerateRange_UsesStableGrainCoordinateAndRetainsContextIdentity(string scenario)
+    {
+        var targets = Enumerable.Range(0, 64).Select(index => Target($"range-{index}"))
+            .OrderBy(target => target.GrainId.GetUniformHashCode()).ToArray();
+        foreach (var target in targets)
+        {
+            _directory.RecordNewTarget(target);
+        }
+
+        var lower = targets[8].GrainId.GetUniformHashCode();
+        var upper = targets[40].GrainId.GetUniformHashCode();
+        Assert.True(lower < upper);
+        var (range, expected) = scenario switch
+        {
+            "Empty" => (RingRange.Empty, Array.Empty<IGrainContext>()),
+            "Full" => (RingRange.Full, targets),
+            "Point" => (RingRange.FromPoint(lower), targets.Where(target => Hash(target) == lower).ToArray()),
+            "Nonwrapped" => (RingRange.Create(lower, upper), targets.Where(target => Hash(target) > lower && Hash(target) <= upper).ToArray()),
+            "Wrapped" => (RingRange.Create(upper, lower), targets.Where(target => Hash(target) > upper || Hash(target) <= lower).ToArray()),
+            _ => throw new ArgumentOutOfRangeException(nameof(scenario))
+        };
+
+        var actual = _directory.EnumerateRange(range).ToArray();
+        AssertEntries(expected, actual);
+        if (scenario == "Nonwrapped")
+        {
+            Assert.DoesNotContain(actual, pair => pair.Key == targets[8].GrainId);
+            Assert.Same(targets[40], Assert.Single(actual, pair => pair.Key == targets[40].GrainId).Value);
+        }
+        else if (scenario == "Wrapped")
+        {
+            Assert.DoesNotContain(actual, pair => pair.Key == targets[40].GrainId);
+            Assert.Same(targets[8], Assert.Single(actual, pair => pair.Key == targets[8].GrainId).Value);
+        }
+
+        AssertContents(targets);
+        static uint Hash(IGrainContext target) => target.GrainId.GetUniformHashCode();
+    }
+
+    [Fact]
+    public void ActivationCountGauge_TracksSuccessfulRegistrationAndConditionalRemoval()
+    {
+        var measurements = new List<int>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (ReferenceEquals(instrument.Meter, _instruments.Meter) && instrument.Name == InstrumentNames.CATALOG_ACTIVATION_COUNT)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<int>((_, value, _, _) => measurements.Add(value));
+        listener.Start();
+        AssertGauge(0);
+        var target = Target("measured");
+        var stale = Target("measured");
+        _directory.RecordNewTarget(target);
+        _directory.RecordNewTarget(stale);
+        AssertGauge(1);
+        Assert.False(_directory.RemoveTarget(stale));
+        Assert.Same(target, _directory.FindTarget(target.GrainId));
+        AssertGauge(1);
+        Assert.True(_directory.RemoveTarget(target));
+        Assert.Null(_directory.FindTarget(target.GrainId));
+        AssertGauge(0);
+
+        void AssertGauge(int expected)
+        {
+            measurements.Clear();
+            listener.RecordObservableInstruments();
+            Assert.Equal(expected, Assert.Single(measurements));
+            Assert.Equal(expected, _directory.Count);
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentRegistrationRemovalAndReplacement_PreserveIdentityAndCountAtEveryCompletedPhase()
+    {
+        const int workersCount = 4;
+        const int entriesCount = 128;
+        var originals = Enumerable.Range(0, entriesCount).Select(index => Target($"concurrent-{index}")).ToArray();
+        var replacements = Enumerable.Range(0, entriesCount).Select(index => Target($"concurrent-{index}")).ToArray();
+        var extras = Enumerable.Range(0, entriesCount).Select(index => Target($"extra-{index}")).ToArray();
+        var originalRemovals = new int[workersCount];
+        var finalRemovals = new int[workersCount];
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        using var phases = new Barrier(workersCount, barrier =>
+        {
+            switch (barrier.CurrentPhaseNumber)
+            {
+                case 0:
+                case 2:
+                case 6:
+                    AssertContents([]);
+                    break;
+                case 1:
+                    AssertContents(originals);
+                    break;
+                case 3:
+                case 4:
+                    AssertContents(replacements);
+                    break;
+                case 5:
+                    AssertContents(replacements.Where((_, index) => index % 2 == 1).Concat(extras.Where((_, index) => index % 2 == 1)));
+                    break;
+            }
+
+            if (barrier.CurrentPhaseNumber == 2)
+            {
+                Assert.Equal(entriesCount, originalRemovals.Sum());
+            }
+            else if (barrier.CurrentPhaseNumber == 6)
+            {
+                Assert.Equal(entriesCount, finalRemovals.Sum());
+            }
+        });
+
+        var workers = Enumerable.Range(0, workersCount).Select(worker => Task.Factory.StartNew(() =>
+        {
+            try
+            {
+                Meet("all registration workers armed");
+                foreach (var target in originals)
+                {
+                    _directory.RecordNewTarget(target);
+                }
+
+                Meet("competing duplicate registrations completed");
+                foreach (var target in originals)
+                {
+                    if (_directory.RemoveTarget(target))
+                    {
+                        originalRemovals[worker]++;
+                    }
+                }
+
+                Meet("competing removals completed");
+                foreach (var target in replacements)
+                {
+                    _directory.RecordNewTarget(target);
+                }
+
+                Meet("replacement registrations completed");
+                foreach (var stale in originals)
+                {
+                    Assert.False(_directory.RemoveTarget(stale));
+                    _directory.RecordNewTarget(stale);
+                }
+
+                Meet("stale removal and registration attempts completed");
+                for (var index = worker; index < entriesCount; index += workersCount)
+                {
+                    if (index % 2 == 0)
+                    {
+                        Assert.True(_directory.RemoveTarget(replacements[index]));
+                    }
+                    else
+                    {
+                        _directory.RecordNewTarget(extras[index]);
+                    }
+                }
+
+                Meet("disjoint additions and removals completed");
+                for (var index = 1; index < entriesCount; index += 2)
+                {
+                    if (_directory.RemoveTarget(replacements[index]))
+                    {
+                        finalRemovals[worker]++;
+                    }
+
+                    if (_directory.RemoveTarget(extras[index]))
+                    {
+                        finalRemovals[worker]++;
+                    }
+                }
+
+                Meet("final competing removals completed");
+            }
+            catch
+            {
+                cancellation.Cancel();
+                throw;
+            }
+        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray();
+
+        await Task.WhenAll(workers);
+        Assert.Equal(entriesCount, originalRemovals.Sum());
+        Assert.Equal(entriesCount, finalRemovals.Sum());
+        AssertContents([]);
+        foreach (var target in originals.Concat(extras))
+        {
+            Assert.Null(_directory.FindTarget(target.GrainId));
+            Assert.False(_directory.RemoveTarget(target));
+        }
+
+        Assert.Equal(0, _directory.Count);
+
+        void Meet(string description)
+            => Assert.True(phases.SignalAndWait(TimeSpan.FromSeconds(30), cancellation.Token),
+                $"ActivationDirectory phase {phases.CurrentPhaseNumber}: {description}; remaining workers {phases.ParticipantsRemaining}, count {_directory.Count}.");
+    }
+
+    public void Dispose() => _services.Dispose();
+
+    private static IGrainContext Target(string key)
+    {
+        var target = Substitute.For<IGrainContext>();
+        target.GrainId.Returns(GrainId.Create("hash-range-tests", key));
+        // IGrainContext is IEquatable<IGrainContext>; use activation identity, not default substitute bool values.
+        target.Equals(Arg.Any<IGrainContext>()).Returns(call => ReferenceEquals(target, call.Arg<IGrainContext>()));
+        return target;
+    }
+
+    private void AssertContents(IEnumerable<IGrainContext> expected)
+    {
+        var targets = expected.ToArray();
+        Assert.Equal(targets.Length, _directory.Count);
+        AssertEntries(targets, _directory.ToArray());
+        foreach (var target in targets)
+        {
+            Assert.Same(target, _directory.FindTarget(target.GrainId));
+        }
+    }
+
+    private static void AssertEntries(IGrainContext[] expected, KeyValuePair<GrainId, IGrainContext>[] actual)
+    {
+        Assert.Equal(expected.Select(target => target.GrainId.ToString()).Order(StringComparer.Ordinal),
+            actual.Select(pair => pair.Key.ToString()).Order(StringComparer.Ordinal));
+        foreach (var target in expected)
+        {
+            Assert.Same(target, Assert.Single(actual, pair => pair.Key == target.GrainId).Value);
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Utilities/ConcurrentHashRangeDictionaryConcurrencyTests.cs
+++ b/test/Orleans.Core.Tests/Utilities/ConcurrentHashRangeDictionaryConcurrencyTests.cs
@@ -1,0 +1,382 @@
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Utilities;
+using Xunit;
+
+namespace NonSilo.Tests.Utilities;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+public sealed class ConcurrentHashRangeDictionaryConcurrencyTests
+{
+    private static readonly TimeSpan PhaseTimeout = TimeSpan.FromSeconds(30);
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(-1)]
+    public async Task ConcurrentFirstInsertionAndGrowth_PreserveLongLivedKeysAndExactQuiescentCounts(int concurrencyLevel)
+    {
+        const int writers = 4;
+        const int batchSize = 128;
+        const int rounds = 4;
+        static uint Hash(int key) => key < writers || key % 31 == 0 ? 0x08000011 : unchecked((uint)key * 2654435761);
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(Hash), capacity: 2, concurrencyLevel: concurrencyLevel);
+        var expected = new Dictionary<int, int>();
+        static int Value(int key) => key * 17 + 1;
+        static int Key(int round, int worker, int offset) => writers + (round * writers + worker) * batchSize + offset;
+
+        await RunWorkers(writers + 1, (worker, phases, cancellation) =>
+        {
+            Meet(phases, cancellation, "first insertion armed");
+            if (worker < writers)
+            {
+                Assert.True(dictionary.TryAdd(worker, Value(worker)));
+            }
+
+            Meet(phases, cancellation, "long-lived collision keys published");
+            for (var round = 0; round < rounds; round++)
+            {
+                if (worker < writers)
+                {
+                    for (var offset = 0; offset < batchSize; offset++)
+                    {
+                        var key = Key(round, worker, offset);
+                        Assert.True(dictionary.TryAdd(key, Value(key)));
+                    }
+                }
+                else
+                {
+                    ReadLongLivedKeys();
+                }
+
+                Meet(phases, cancellation, $"round {round} insertions complete");
+                if (worker < writers)
+                {
+                    for (var offset = 1; offset < batchSize; offset += 2)
+                    {
+                        var key = Key(round, worker, offset);
+                        Assert.True(dictionary.TryRemove(key, out var value));
+                        Assert.Equal(Value(key), value);
+                    }
+                }
+                else
+                {
+                    ReadLongLivedKeys();
+                }
+
+                Meet(phases, cancellation, $"round {round} removals complete");
+            }
+        }, phases =>
+        {
+            var phase = (int)phases.CurrentPhaseNumber;
+            if (phase == 1)
+            {
+                for (var key = 0; key < writers; key++)
+                {
+                    expected.Add(key, Value(key));
+                }
+            }
+            else if (phase >= 2)
+            {
+                var round = (phase - 2) / 2;
+                for (var worker = 0; worker < writers; worker++)
+                {
+                    for (var offset = 0; offset < batchSize; offset++)
+                    {
+                        var key = Key(round, worker, offset);
+                        if (phase % 2 == 0)
+                        {
+                            expected.Add(key, Value(key));
+                        }
+                        else if (offset % 2 == 1)
+                        {
+                            Assert.True(expected.Remove(key));
+                        }
+                    }
+                }
+            }
+
+            // The barrier's post-phase action executes while every worker is quiescent.
+            Assert.Equal(expected.Count, dictionary.Count);
+            Assert.Equal(expected.OrderBy(pair => pair.Key), dictionary.OrderBy(pair => pair.Key));
+        });
+
+        Assert.Equal(writers + rounds * writers * batchSize / 2, dictionary.Count);
+        ReadLongLivedKeys();
+        foreach (var (key, value) in expected)
+        {
+            Assert.True(dictionary.TryGetValue(key, out var actual));
+            Assert.Equal(value, actual);
+        }
+
+        void ReadLongLivedKeys()
+        {
+            for (var iteration = 0; iteration < 256; iteration++)
+            {
+                for (var key = 0; key < writers; key++)
+                {
+                    Assert.True(dictionary.TryGetValue(key, out var value), $"Long-lived key {key} disappeared during growth/removal.");
+                    Assert.Equal(Value(key), value);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void Enumerator_RetainsOriginalKeysAcrossTableGrowth()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key => unchecked((uint)key * 2654435761)), capacity: 2, concurrencyLevel: 1);
+        for (var key = 0; key < 4; key++)
+        {
+            dictionary[key] = key + 17;
+        }
+
+        var enumerator = dictionary.GetEnumerator();
+        Assert.True(enumerator.MoveNext());
+        var captured = new List<KeyValuePair<int, int>> { enumerator.Current };
+        for (var key = 4; key < 1024; key++)
+        {
+            dictionary[key] = key + 17;
+        }
+
+        while (enumerator.MoveNext())
+        {
+            captured.Add(enumerator.Current);
+        }
+
+        Assert.Equal(captured.Count, captured.Select(pair => pair.Key).Distinct().Count());
+        Assert.Equal(Enumerable.Range(0, 4).Select(key => KeyValuePair.Create(key, key + 17)),
+            captured.Where(pair => pair.Key < 4).OrderBy(pair => pair.Key));
+        Assert.All(captured, pair => Assert.Equal(pair.Key + 17, pair.Value));
+        Assert.Equal(1024, dictionary.Count);
+        enumerator.Reset();
+        var afterReset = new List<KeyValuePair<int, int>>();
+        while (enumerator.MoveNext())
+        {
+            afterReset.Add(enumerator.Current);
+        }
+
+        enumerator.Dispose();
+        Assert.Equal(Enumerable.Range(0, 1024).Select(key => KeyValuePair.Create(key, key + 17)),
+            afterReset.OrderBy(pair => pair.Key));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task MultiwordValues_RemainWholeDuringSetterOrConditionalUpdatesAndGrowth(bool useTryUpdate, bool updateHead)
+    {
+        const int rounds = 8;
+        const int writesPerHalf = 128;
+        const int readsPerHalf = 256;
+        const int growthPerHalf = 64;
+        const int totalWrites = rounds * 2 * writesPerHalf;
+        const uint collisionHash = 0x40000000;
+        static uint Hash(int key) => key < 2 ? collisionHash : unchecked((uint)key * 2654435761);
+        var dictionary = new ConcurrentHashRangeDictionary<int, WideValue, TestHashComparer<int>>(new(Hash), capacity: 32, concurrencyLevel: 1);
+        dictionary[0] = WideValue.Create(0);
+        dictionary[1] = WideValue.Create(0);
+        // Before growth, key 1 is the chain head and key 0 is an interior node.
+        var target = updateHead ? 1 : 0;
+        var neighbor = 1 - target;
+        var observations = new int[2];
+        var writes = 0;
+
+        await RunWorkers(4, (worker, phases, cancellation) =>
+        {
+            var current = WideValue.Create(0);
+            for (var round = 0; round < rounds; round++)
+            {
+                Meet(phases, cancellation, $"struct round {round} ready");
+                for (var half = 0; half < 2; half++)
+                {
+                    switch (worker)
+                    {
+                        case 0:
+                            for (var i = 0; i < writesPerHalf; i++)
+                            {
+                                var next = WideValue.Create(current.Version + 1);
+                                if (useTryUpdate)
+                                {
+                                    Assert.True(dictionary.TryUpdate(target, next, current));
+                                }
+                                else
+                                {
+                                    dictionary[target] = next;
+                                }
+
+                                current = next;
+                                writes++;
+                            }
+
+                            break;
+                        case 1:
+                        case 2:
+                            for (var i = 0; i < readsPerHalf; i++)
+                            {
+                                Assert.True(dictionary.TryGetValue(target, out var value));
+                                AssertWhole(value);
+                                var values = dictionary.EnumerateHash(collisionHash).ToArray();
+                                Assert.Equal(2, values.Length);
+                                AssertWhole(Assert.Single(values, pair => pair.Key == target).Value);
+                                Assert.Equal(WideValue.Create(0), Assert.Single(values, pair => pair.Key == neighbor).Value);
+                                observations[worker - 1]++;
+                            }
+
+                            break;
+                        case 3 when round >= 2:
+                            // The first two rounds exercise both original chain positions without resizing.
+                            for (var i = 0; i < growthPerHalf; i++)
+                            {
+                                var key = 2 + ((round - 2) * 2 + half) * growthPerHalf + i;
+                                Assert.True(dictionary.TryAdd(key, WideValue.Create(key)));
+                            }
+
+                            break;
+                    }
+
+                    Meet(phases, cancellation, $"struct round {round}, half {half} complete");
+                }
+            }
+        }, phases =>
+        {
+            var phase = (int)phases.CurrentPhaseNumber;
+            var round = phase / 3;
+            var completedHalves = round * 2 + phase % 3;
+            Assert.Equal(completedHalves * writesPerHalf, writes);
+            Assert.All(observations, count => Assert.Equal(completedHalves * readsPerHalf, count));
+        });
+
+        Assert.Equal(totalWrites, writes);
+        Assert.Equal(WideValue.Create(totalWrites), dictionary[target]);
+        Assert.Equal(WideValue.Create(0), dictionary[neighbor]);
+        var growthCount = (rounds - 2) * 2 * growthPerHalf;
+        Assert.Equal(2 + growthCount, dictionary.Count);
+        Assert.Equal(Enumerable.Range(0, 2 + growthCount), dictionary.Select(pair => pair.Key).Order());
+        for (var key = 2; key < 2 + growthCount; key++)
+        {
+            Assert.Equal(WideValue.Create(key), dictionary[key]);
+        }
+
+        static void AssertWhole(WideValue value)
+        {
+            Assert.InRange(value.Version, 0, totalWrites);
+            Assert.Equal(WideValue.Create(value.Version), value);
+        }
+    }
+
+    [Fact]
+    public async Task ConditionalRemove_PreservesReplacementPublishedBeforeRemoval()
+    {
+        using var removeMayContinue = new ManualResetEventSlim();
+        var removalReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var armed = 0;
+        var cancellation = TestContext.Current.CancellationToken;
+        var dictionary = new ConcurrentHashRangeDictionary<int, string, TestHashComparer<int>>(new(_ =>
+        {
+            if (Interlocked.Exchange(ref armed, 0) == 1)
+            {
+                removalReady.SetResult();
+                Assert.True(removeMayContinue.Wait(PhaseTimeout, cancellation), "Conditional removal was not released after replacement publication.");
+            }
+
+            return 17;
+        }));
+        dictionary[1] = "original";
+        armed = 1;
+        var removal = Task.Run(() => dictionary.TryRemove(KeyValuePair.Create(1, "original")), cancellation);
+        var removed = true;
+        try
+        {
+            await removalReady.Task.WaitAsync(PhaseTimeout, cancellation);
+            dictionary[1] = "replacement";
+        }
+        finally
+        {
+            removeMayContinue.Set();
+            removed = await removal.WaitAsync(PhaseTimeout, cancellation);
+        }
+
+        Assert.False(removed);
+        Assert.Equal("replacement", dictionary[1]);
+        Assert.Equal(1, dictionary.Count);
+        Assert.True(dictionary.TryRemove(KeyValuePair.Create(1, "replacement")));
+        Assert.Empty(dictionary);
+        Assert.Equal(0, dictionary.Count);
+    }
+
+    [Fact]
+    public async Task VisitRange_AllowsAnotherThreadToMutateTheVisitedBucket()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key => (uint)key), capacity: 2, concurrencyLevel: 1);
+        dictionary[1] = 17;
+        using var mutationComplete = new ManualResetEventSlim();
+        var cancellation = TestContext.Current.CancellationToken;
+        Task mutation = Task.CompletedTask;
+        var visited = new List<KeyValuePair<int, int>>();
+        try
+        {
+            dictionary.VisitRange(RingRange.FromPoint(1), visited, (state, key, value) =>
+            {
+                state.Add(KeyValuePair.Create(key, value));
+                mutation = Task.Run(() =>
+                {
+                    try
+                    {
+                        Assert.True(dictionary.TryUpdate(key, 29, value));
+                        Assert.True(dictionary.TryRemove(key, out var removed));
+                        Assert.Equal(29, removed);
+                        Assert.True(dictionary.TryAdd(2, 41));
+                    }
+                    finally
+                    {
+                        mutationComplete.Set();
+                    }
+                }, cancellation);
+                Assert.True(mutationComplete.Wait(PhaseTimeout, cancellation),
+                    "Visitor retained a writer lock: the worker could not update/remove the visited key and insert its neighbor.");
+            });
+        }
+        finally
+        {
+            await mutation.WaitAsync(PhaseTimeout, cancellation);
+        }
+
+        Assert.Equal(KeyValuePair.Create(1, 17), Assert.Single(visited));
+        Assert.Equal(KeyValuePair.Create(2, 41), Assert.Single(dictionary));
+        Assert.Equal(1, dictionary.Count);
+        Assert.False(dictionary.TryGetValue(1, out _));
+    }
+
+    private static async Task RunWorkers(int count, Action<int, Barrier, CancellationToken> work, Action<Barrier>? checkpoint = null)
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        using var phases = new Barrier(count, checkpoint);
+        var workers = Enumerable.Range(0, count).Select(worker => Task.Factory.StartNew(() =>
+        {
+            try
+            {
+                work(worker, phases, cancellation.Token);
+            }
+            catch
+            {
+                cancellation.Cancel();
+                throw;
+            }
+        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray();
+        await Task.WhenAll(workers);
+    }
+
+    private static void Meet(Barrier phases, CancellationToken cancellation, string description)
+        => Assert.True(phases.SignalAndWait(PhaseTimeout, cancellation),
+            $"Timed out at phase {phases.CurrentPhaseNumber}: {description}; remaining participants {phases.ParticipantsRemaining}.");
+
+    private readonly record struct WideValue(long Version, long Complement, long Product, long Checksum, long Negative, long Offset)
+    {
+        public static WideValue Create(long version)
+            => new(version, ~version, unchecked(version * 0x123456789ABCDEF), version ^ 0x5A5A5A5A5A5A5A5A, -version, version + 0x1234567800000000);
+    }
+}

--- a/test/Orleans.Core.Tests/Utilities/ConcurrentHashRangeDictionaryTests.cs
+++ b/test/Orleans.Core.Tests/Utilities/ConcurrentHashRangeDictionaryTests.cs
@@ -1,0 +1,727 @@
+using System.Collections;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Utilities;
+using Xunit;
+
+namespace NonSilo.Tests.Utilities;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+public sealed class ConcurrentHashRangeDictionaryTests
+{
+    private static readonly uint[] Hashes =
+    [
+        0, 1, 2, 9, 10, 11, 19, 20, 21,
+        0x07FFFFFE, 0x07FFFFFF, 0x08000000, 0x08000001,
+        0x08000010, 0x08000011, 0x0800001F, 0x08000020, 0x08000021,
+        0x0FFFFFFF, 0x10000000, 0x17FFFFFF, 0x18000000, 0x18000001,
+        uint.MaxValue - 2, uint.MaxValue - 1, uint.MaxValue, 20, 0
+    ];
+
+    [Fact]
+    public void ConstructorAndPointOperations_RejectInvalidArguments()
+    {
+        Assert.Throws<ArgumentNullException>("comparer", () => new ConcurrentHashRangeDictionary<string, int, TestHashComparer<string>>(null!));
+        Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new ConcurrentHashRangeDictionary<string, int, TestHashComparer<string>>(new(_ => 0), capacity: -1));
+        Assert.Throws<ArgumentOutOfRangeException>("capacity", () => new ConcurrentHashRangeDictionary<string, int, TestHashComparer<string>>(new(_ => 0), capacity: int.MaxValue));
+        Assert.Throws<ArgumentOutOfRangeException>("concurrencyLevel", () => new ConcurrentHashRangeDictionary<string, int, TestHashComparer<string>>(new(_ => 0), concurrencyLevel: 0));
+        Assert.Throws<ArgumentOutOfRangeException>("concurrencyLevel", () => new ConcurrentHashRangeDictionary<string, int, TestHashComparer<string>>(new(_ => 0), concurrencyLevel: -2));
+        Assert.Throws<ArgumentOutOfRangeException>("concurrencyLevel", () => new ConcurrentHashRangeDictionary<string, int, TestHashComparer<string>>(new(_ => 0), concurrencyLevel: int.MaxValue));
+
+        var dictionary = new ConcurrentHashRangeDictionary<string, int, TestHashComparer<string>>(new(_ => 0), capacity: 0);
+        Assert.Throws<ArgumentNullException>("key", () => dictionary.TryAdd(null!, 1));
+        Assert.Throws<ArgumentNullException>("key", () => dictionary.TryGetValue(null!, out _));
+        Assert.Throws<ArgumentNullException>("key", () => dictionary.TryGetValue(null!, 0, out _));
+        Assert.Throws<ArgumentNullException>("key", () => dictionary.TryUpdate(null!, 2, 1));
+        Assert.Throws<ArgumentNullException>("key", () => dictionary.TryRemove(null!, out _));
+        Assert.Throws<ArgumentNullException>("key", () => dictionary.TryRemove(KeyValuePair.Create<string, int>(null!, 1)));
+        Assert.Throws<ArgumentNullException>("key", () => dictionary[null!] = 1);
+        Assert.Throws<ArgumentNullException>("visitor", () => dictionary.VisitRange<object>(RingRange.Full, new(), null!));
+        Assert.Throws<ArgumentNullException>("removed", () => dictionary.RemoveRange(RingRange.Full, null!));
+        Assert.Equal(0, dictionary.Count);
+        Assert.Empty(dictionary);
+        Assert.True(dictionary.TryAdd("valid", 17));
+        Assert.Equal(17, dictionary["valid"]);
+        Assert.Equal(1, dictionary.Count);
+    }
+
+    [Fact]
+    public void TryAddAndIndexer_DistinguishInsertionDuplicateAndReplacement()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, string, TestHashComparer<int>>(new(key => (uint)key));
+        Assert.False(dictionary.TryGetValue(1, out var missing));
+        Assert.Null(missing);
+        Assert.Throws<KeyNotFoundException>(() => dictionary[1]);
+        Assert.True(dictionary.TryAdd(1, "original"));
+        Assert.False(dictionary.TryAdd(1, "duplicate"));
+        Assert.True(dictionary.TryGetValue(1, out var original));
+        Assert.Equal("original", original);
+        Assert.Equal(1, dictionary.Count);
+
+        dictionary[1] = "replacement";
+        Assert.Equal("replacement", dictionary[1]);
+        Assert.Equal(1, dictionary.Count);
+        dictionary[2] = "inserted";
+        Assert.Equal(2, dictionary.Count);
+        AssertEntries([KeyValuePair.Create(1, "replacement"), KeyValuePair.Create(2, "inserted")], dictionary);
+    }
+
+    [Fact]
+    public void TryUpdate_UsesExpectedValueEqualityWithoutChangingCount()
+    {
+        var original = new Payload(17);
+        var equalButDistinct = new Payload(17);
+        var replacement = new Payload(29);
+        var dictionary = new ConcurrentHashRangeDictionary<int, Payload, TestHashComparer<int>>(new(_ => 7));
+        Assert.True(dictionary.TryAdd(1, original));
+        Assert.False(dictionary.TryUpdate(2, replacement, original));
+        Assert.False(dictionary.TryUpdate(1, replacement, new Payload(18)));
+        Assert.Same(original, dictionary[1]);
+        Assert.NotSame(original, equalButDistinct);
+        Assert.True(dictionary.TryUpdate(1, replacement, equalButDistinct));
+        Assert.Same(replacement, dictionary[1]);
+        Assert.Equal(1, dictionary.Count);
+        Assert.False(dictionary.TryUpdate(1, original, equalButDistinct));
+        Assert.Same(replacement, Assert.Single(dictionary).Value);
+    }
+
+    [Fact]
+    public void TryRemove_ReturnsActualValueAndConditionallyPreservesReplacement()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, Payload, TestHashComparer<int>>(new(_ => 7));
+        var original = new Payload(17);
+        var replacement = new Payload(29);
+        dictionary[1] = original;
+        dictionary[2] = new Payload(41);
+        dictionary[1] = replacement;
+
+        Assert.False(dictionary.TryRemove(KeyValuePair.Create(1, original)));
+        Assert.Same(replacement, dictionary[1]);
+        Assert.Equal(2, dictionary.Count);
+        Assert.True(dictionary.TryRemove(KeyValuePair.Create(1, new Payload(29))));
+        Assert.False(dictionary.TryRemove(KeyValuePair.Create(1, replacement)));
+        Assert.False(dictionary.TryGetValue(1, out var missing));
+        Assert.Null(missing);
+        Assert.Equal(1, dictionary.Count);
+        Assert.True(dictionary.TryRemove(2, out var removed));
+        Assert.Equal(new Payload(41), removed);
+        Assert.False(dictionary.TryRemove(2, out missing));
+        Assert.Null(missing);
+        Assert.Empty(dictionary);
+        Assert.Equal(0, dictionary.Count);
+    }
+
+    [Theory]
+    [InlineData(false, 0)]
+    [InlineData(false, 1)]
+    [InlineData(false, 2)]
+    [InlineData(true, 0)]
+    [InlineData(true, 1)]
+    [InlineData(true, 2)]
+    public void TryRemove_CollisionChainHeadMiddleOrTailPreservesEveryNeighbor(bool conditional, int removedKey)
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(_ => 17), capacity: 32, concurrencyLevel: 1);
+        for (var key = 0; key < 3; key++)
+        {
+            Assert.True(dictionary.TryAdd(key, key + 41));
+        }
+
+        if (conditional)
+        {
+            Assert.True(dictionary.TryRemove(KeyValuePair.Create(removedKey, removedKey + 41)));
+        }
+        else
+        {
+            Assert.True(dictionary.TryRemove(removedKey, out var removedValue));
+            Assert.Equal(removedKey + 41, removedValue);
+        }
+
+        Assert.False(dictionary.TryGetValue(removedKey, out var missing));
+        Assert.Equal(0, missing);
+        Assert.Equal(2, dictionary.Count);
+        var expected = Enumerable.Range(0, 3).Where(key => key != removedKey).Select(key => KeyValuePair.Create(key, key + 41)).ToArray();
+        AssertEntries(expected, dictionary);
+        AssertEntries(expected, dictionary.EnumerateHash(17));
+        foreach (var (key, value) in expected)
+        {
+            Assert.Equal(value, dictionary[key]);
+        }
+    }
+
+    [Fact]
+    public void NullValue_IsPresentAndParticipatesInConditionalUpdateAndRemoval()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, string?, TestHashComparer<int>>(new(_ => 17));
+        Assert.True(dictionary.TryAdd(1, null));
+        Assert.True(dictionary.TryGetValue(1, out var value));
+        Assert.Null(value);
+        Assert.False(dictionary.TryGetValue(2, out _));
+        Assert.False(dictionary.TryAdd(1, "duplicate"));
+        Assert.Equal(1, dictionary.Count);
+        Assert.False(dictionary.TryRemove(KeyValuePair.Create<int, string?>(1, "not-null")));
+        Assert.True(dictionary.TryUpdate(1, "replacement", null));
+        Assert.Equal("replacement", dictionary[1]);
+        Assert.False(dictionary.TryUpdate(1, "wrong", null));
+        Assert.True(dictionary.TryUpdate(1, null, "replacement"));
+        Assert.True(dictionary.TryRemove(KeyValuePair.Create<int, string?>(1, null)));
+        Assert.False(dictionary.TryGetValue(1, out _));
+        Assert.Empty(dictionary);
+        Assert.Equal(0, dictionary.Count);
+    }
+
+    [Fact]
+    public void KeyEquality_IsIndependentOfRangeCoordinateAndOrdinaryHash()
+    {
+        var comparer = new KeyComparer();
+        var dictionary = new ConcurrentHashRangeDictionary<Key, string, TestHashComparer<Key>>(new(key => key.Hash, comparer));
+        var key = new Key(1, 0x80000000);
+        var equalKey = new Key(1, 0x80000000);
+        var collision = new Key(2, 0x80000000);
+        var outsider = new Key(3, 0x10000000);
+        Assert.True(dictionary.TryAdd(key, "first"));
+        Assert.False(dictionary.TryAdd(equalKey, "duplicate"));
+        Assert.True(dictionary.TryAdd(collision, "collision"));
+        Assert.True(dictionary.TryAdd(outsider, "outside"));
+        Assert.Equal("first", dictionary[equalKey]);
+        Assert.True(dictionary.TryUpdate(equalKey, "updated", "first"));
+        Assert.Equal("updated", dictionary[key]);
+        var range = dictionary.EnumerateHash(key.Hash).OrderBy(pair => pair.Key.Id).ToArray();
+        Assert.Equal(new[] { "updated", "collision" }, range.Select(pair => pair.Value));
+        Assert.Same(key, range[0].Key);
+        Assert.Same(collision, range[1].Key);
+        Assert.True(dictionary.TryRemove(equalKey, out var removed));
+        Assert.Equal("updated", removed);
+        Assert.Equal("collision", dictionary[collision]);
+        Assert.Equal("outside", dictionary[outsider]);
+        Assert.Equal(2, dictionary.Count);
+        // KeyComparer.GetHashCode throws: every point operation above must use the stable coordinate.
+    }
+
+    [Fact]
+    public void PrehashedLookup_DoesNotRecomputeHashAndDistinguishesCollisions()
+    {
+        var calls = 0;
+        var dictionary = new ConcurrentHashRangeDictionary<int, string, TestHashComparer<int>>(new(_ =>
+        {
+            calls++;
+            return 17;
+        }));
+        dictionary[1] = "one";
+        dictionary[2] = "two";
+        calls = 0;
+        Assert.True(dictionary.TryGetValue(2, 17, out var value));
+        Assert.Equal("two", value);
+        Assert.False(dictionary.TryGetValue(3, 17, out var missing));
+        Assert.Null(missing);
+        Assert.Equal(0, calls);
+        Assert.True(dictionary.TryGetValue(1, out value));
+        Assert.Equal("one", value);
+        Assert.Equal(1, calls);
+        Assert.Equal(2, dictionary.Count);
+    }
+
+    [Theory]
+    [InlineData("Empty")]
+    [InlineData("Full")]
+    [InlineData("EqualEndpointsFull")]
+    [InlineData("Zero")]
+    [InlineData("Max")]
+    [InlineData("Ordinary")]
+    [InlineData("Wrapped")]
+    [InlineData("SamePrefixWrapped")]
+    [InlineData("InteriorBuckets")]
+    [InlineData("PrefixBoundary")]
+    public void RangeApis_RespectExclusiveStartInclusiveEndAndRetainCollisions(string scenario)
+    {
+        var (range, contains) = GetRangeCase(scenario);
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key => Hashes[key]), capacity: 32, concurrencyLevel: 1);
+        var all = Hashes.Select((_, key) => KeyValuePair.Create(key, key * 13 + 7)).ToArray();
+        foreach (var (key, value) in all)
+        {
+            Assert.True(dictionary.TryAdd(key, value));
+        }
+
+        var expected = all.Where(pair => contains(Hashes[pair.Key])).ToArray();
+        AssertEntries(expected, dictionary.EnumerateRange(range));
+        var visited = new List<KeyValuePair<int, int>>();
+        dictionary.VisitRange(range, visited, static (state, key, value) => state.Add(KeyValuePair.Create(key, value)));
+        AssertEntries(expected, visited);
+        AssertEntries(all, dictionary);
+        Assert.Equal(all.Length, dictionary.Count);
+
+        var sentinel = KeyValuePair.Create(-1, -71);
+        var removed = new List<KeyValuePair<int, int>> { sentinel };
+        // Writers are quiescent: this is a complete extraction, not a concurrent snapshot promise.
+        dictionary.RemoveRange(range, removed);
+        Assert.Equal(sentinel, removed[0]);
+        AssertEntries(expected, removed.Skip(1));
+        AssertEntries(all.Where(pair => !contains(Hashes[pair.Key])), dictionary);
+        Assert.Equal(all.Length - expected.Length, dictionary.Count);
+        dictionary.RemoveRange(range, removed);
+        AssertEntries(expected, removed.Skip(1));
+    }
+
+    [Fact]
+    public void RangeOperations_HashOnlyIntersectingBoundaryBucketsAndSkipFullyCoveredInteriors()
+    {
+        var calls = new List<int>();
+        var armed = false;
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key =>
+        {
+            if (armed)
+            {
+                calls.Add(key);
+            }
+
+            return Hashes[key];
+        }), capacity: 24, concurrencyLevel: 1);
+        for (var i = 0; i < Hashes.Length; i++)
+        {
+            dictionary[i] = i + 17;
+        }
+
+        var range = RingRange.Create(10, 20);
+        var expected = Enumerable.Range(0, Hashes.Length)
+            .Where(key => Hashes[key] > 10 && Hashes[key] <= 20)
+            .Select(key => KeyValuePair.Create(key, key + 17)).ToArray();
+        armed = true;
+        AssertEntries(expected, dictionary.EnumerateRange(range));
+        var visited = new List<KeyValuePair<int, int>>();
+        dictionary.VisitRange(range, visited, static (state, key, value) => state.Add(KeyValuePair.Create(key, value)));
+        AssertEntries(expected, visited);
+        AssertEntries(expected.Where(pair => Hashes[pair.Key] == 20), dictionary.EnumerateHash(20));
+        // Capacity 24 yields 32 buckets with initial occupancy headroom.
+        Assert.All(calls, key => Assert.Equal(0u, Hashes[key] >> 27));
+        calls.Clear();
+
+        var interiorRange = RingRange.Create(0x07FFFFFE, 0x18000001);
+        var interiorExpected = Enumerable.Range(0, Hashes.Length)
+            .Where(key => Hashes[key] > 0x07FFFFFE && Hashes[key] <= 0x18000001)
+            .Select(key => KeyValuePair.Create(key, key + 17)).ToArray();
+        AssertEntries(interiorExpected, dictionary.EnumerateRange(interiorRange));
+        Assert.All(calls, key => Assert.True((Hashes[key] >> 27) is 0 or 3,
+            $"Key {key} in prefix {Hashes[key] >> 27} was hashed even though it is outside the range or in a fully covered interior bucket."));
+        calls.Clear();
+        AssertEntries(Enumerable.Range(0, Hashes.Length).Select(key => KeyValuePair.Create(key, key + 17)), dictionary);
+        Assert.Empty(calls);
+
+        var removed = new List<KeyValuePair<int, int>>();
+        dictionary.RemoveRange(range, removed);
+        armed = false;
+        AssertEntries(expected, removed);
+        Assert.All(calls, key => Assert.Equal(0u, Hashes[key] >> 27));
+        foreach (var candidate in expected)
+        {
+            Assert.Contains(candidate.Key, calls);
+        }
+
+        Assert.Equal(Hashes.Length - expected.Length, dictionary.Count);
+        AssertEntries(Enumerable.Range(0, Hashes.Length).Where(key => Hashes[key] <= 10 || Hashes[key] > 20)
+            .Select(key => KeyValuePair.Create(key, key + 17)), dictionary);
+    }
+
+    [Fact]
+    public async Task GrowthHashFailurePreservesPublishedTableAndCommittedInsertion()
+    {
+        var fail = false;
+        var failure = new InvalidOperationException("controlled growth hash fault");
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key =>
+        {
+            if (fail && key == 1)
+            {
+                throw failure;
+            }
+
+            return unchecked((uint)key << 30);
+        }), capacity: 1, concurrencyLevel: 1);
+        dictionary[1] = 17;
+        dictionary[2] = 29;
+        var enumerator = dictionary.GetEnumerator();
+        Assert.True(enumerator.MoveNext());
+        var observed = new List<KeyValuePair<int, int>> { enumerator.Current };
+
+        fail = true;
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => dictionary.TryAdd(3, 41)));
+        fail = false;
+        AssertEntries([KeyValuePair.Create(1, 17), KeyValuePair.Create(2, 29), KeyValuePair.Create(3, 41)], dictionary);
+        Assert.Equal(3, dictionary.Count);
+        while (enumerator.MoveNext())
+        {
+            observed.Add(enumerator.Current);
+        }
+
+        Assert.Contains(KeyValuePair.Create(1, 17), observed);
+        Assert.Contains(KeyValuePair.Create(2, 29), observed);
+        Assert.Equal(observed.Count, observed.Select(static entry => entry.Key).Distinct().Count());
+        await Task.Run(() =>
+        {
+            Assert.True(dictionary.TryUpdate(3, 43, 41));
+            Assert.True(dictionary.TryAdd(4, 53));
+        }, TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        AssertEntries(
+            [KeyValuePair.Create(1, 17), KeyValuePair.Create(2, 29), KeyValuePair.Create(3, 43), KeyValuePair.Create(4, 53)],
+            dictionary);
+        Assert.Equal(4, dictionary.Count);
+    }
+
+    [Fact]
+    public void PresizingAccommodatesUniformPopulationWithoutRehashing()
+    {
+        const int count = 16_384;
+        var hashes = 0;
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key =>
+        {
+            hashes++;
+            return unchecked((uint)key * 2654435761);
+        }), capacity: count, concurrencyLevel: 32);
+        for (var i = 0; i < count; i++)
+        {
+            Assert.True(dictionary.TryAdd(i, i));
+        }
+
+        Assert.Equal(count, hashes);
+        Assert.Equal(count, dictionary.Count);
+        Assert.Equal(Enumerable.Range(0, count), dictionary.Select(static entry => entry.Key).Order());
+    }
+
+    [Fact]
+    public void Enumeration_CapturesAtFirstMoveAndSupportsResetAndAdapters()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key => (uint)key));
+        var enumerator = dictionary.GetEnumerator();
+        dictionary[1] = 17;
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(KeyValuePair.Create(1, 17), enumerator.Current);
+        Assert.False(enumerator.MoveNext());
+        dictionary[2] = 29;
+        enumerator.Reset();
+        var results = new List<KeyValuePair<int, int>>();
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        enumerator.Dispose();
+        var expected = new[] { KeyValuePair.Create(1, 17), KeyValuePair.Create(2, 29) };
+        AssertEntries(expected, results);
+        AssertEntries(expected, (IEnumerable<KeyValuePair<int, int>>)dictionary);
+        AssertEntries(expected, ((IEnumerable)dictionary).Cast<KeyValuePair<int, int>>());
+        AssertEntries(expected, ((IEnumerable)dictionary.EnumerateRange(RingRange.Full)).Cast<KeyValuePair<int, int>>());
+        Assert.Equal(2, dictionary.Count);
+    }
+
+    [Fact]
+    public void RemoveRange_MaterializesAllCandidatesAndReservesCapacityBeforeFirstRemoval()
+    {
+        Action? onHash = null;
+        var dictionary = new ConcurrentHashRangeDictionary<int, Payload, TestHashComparer<int>>(new(key =>
+        {
+            onHash?.Invoke();
+            return (uint)key << 28;
+        }), capacity: 32, concurrencyLevel: 1);
+        for (var key = 1; key <= 4; key++)
+        {
+            dictionary[key] = new Payload(key * 17);
+        }
+
+        // Use observed order only to place a fault/mutation, not as an ordering contract.
+        var candidates = dictionary.EnumerateRange(RingRange.Full).ToArray();
+        var sentinel = KeyValuePair.Create(-1, new Payload(-1));
+        var removed = new List<KeyValuePair<int, Payload>>(1) { sentinel };
+        var replacements = candidates.Skip(1).ToDictionary(pair => pair.Key, pair => new Payload(pair.Value.Number + 1000));
+        var checkpoints = 0;
+        onHash = () =>
+        {
+            onHash = null;
+            checkpoints++;
+            Assert.Equal(sentinel, Assert.Single(removed));
+            Assert.True(removed.Capacity >= candidates.Length + 1);
+            AssertEntries(candidates, dictionary);
+            Assert.Equal(candidates.Length, dictionary.Count);
+            // If enumeration were lazy, these later nodes would yield their NEW values and be removed.
+            foreach (var (key, replacement) in replacements)
+            {
+                dictionary[key] = replacement;
+            }
+        };
+
+        dictionary.RemoveRange(RingRange.Full, removed);
+        Assert.Equal(1, checkpoints);
+        Assert.Equal(sentinel, removed[0]);
+        Assert.Equal(candidates[0], Assert.Single(removed.Skip(1)));
+        Assert.False(dictionary.TryGetValue(candidates[0].Key, out _));
+        Assert.Equal(3, dictionary.Count);
+        foreach (var (key, replacement) in replacements)
+        {
+            Assert.Same(replacement, dictionary[key]);
+        }
+
+        AssertEntries(replacements, dictionary);
+    }
+
+    [Fact]
+    public void RemoveRange_HashFaultDuringCandidateEnumerationRemovesNothing()
+    {
+        var armed = false;
+        var calls = 0;
+        var failure = new InvalidOperationException("controlled candidate enumeration fault");
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key =>
+        {
+            if (armed && ++calls == 3)
+            {
+                throw failure;
+            }
+
+            return (uint)key;
+        }), capacity: 32, concurrencyLevel: 1);
+        var expected = Enumerable.Range(1, 4).Select(key => KeyValuePair.Create(key, key * 17)).ToArray();
+        foreach (var (key, value) in expected)
+        {
+            dictionary[key] = value;
+        }
+
+        var sentinel = KeyValuePair.Create(-1, -71);
+        var removed = new List<KeyValuePair<int, int>> { sentinel };
+        armed = true;
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(
+            () => dictionary.RemoveRange(RingRange.Create(0, 4), removed)));
+        armed = false;
+        Assert.Equal(3, calls);
+        Assert.Equal(sentinel, Assert.Single(removed));
+        Assert.Equal(4, dictionary.Count);
+        AssertEntries(expected, dictionary);
+        dictionary.RemoveRange(RingRange.Create(0, 4), removed);
+        Assert.Equal(sentinel, removed[0]);
+        AssertEntries(expected, removed.Skip(1));
+        Assert.Empty(dictionary);
+        Assert.Equal(0, dictionary.Count);
+    }
+
+    [Theory]
+    [InlineData(false, 0)]
+    [InlineData(false, 2)]
+    [InlineData(true, 0)]
+    [InlineData(true, 2)]
+    public async Task RemoveRange_HashOrComparerFaultRetainsEveryCompletedRemoval(bool comparerFault, int failureIndex)
+    {
+        Action? checkpoint = null;
+        var comparer = new CallbackComparer(() =>
+        {
+            if (comparerFault)
+            {
+                checkpoint?.Invoke();
+            }
+        });
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key =>
+        {
+            if (!comparerFault)
+            {
+                checkpoint?.Invoke();
+            }
+
+            return (uint)key << 28;
+        }, comparer), capacity: 32, concurrencyLevel: 1);
+        for (var key = 1; key <= 4; key++)
+        {
+            dictionary[key] = key * 17;
+        }
+
+        var candidates = dictionary.EnumerateRange(RingRange.Full).ToArray();
+        var sentinel = KeyValuePair.Create(-1, -71);
+        var removed = new List<KeyValuePair<int, int>>(1) { sentinel };
+        var failure = new InvalidOperationException("controlled removal fault");
+        var attempts = 0;
+        checkpoint = () =>
+        {
+            Assert.Equal(sentinel, removed[0]);
+            Assert.Equal(candidates.Take(attempts), removed.Skip(1));
+            Assert.True(removed.Capacity >= candidates.Length + 1);
+            if (attempts++ == failureIndex)
+            {
+                throw failure;
+            }
+        };
+
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() => dictionary.RemoveRange(RingRange.Full, removed)));
+        checkpoint = null;
+        Assert.Equal(failureIndex + 1, attempts);
+        Assert.Equal(sentinel, removed[0]);
+        AssertEntries(candidates.Take(failureIndex), removed.Skip(1));
+        AssertEntries(candidates.Skip(failureIndex), dictionary);
+        Assert.Equal(4 - failureIndex, dictionary.Count);
+
+        // A different thread proves a throwing comparer did not leave a writer lock held.
+        await Task.Run(() =>
+        {
+            Assert.True(dictionary.TryAdd(9, 153));
+            Assert.True(dictionary.TryUpdate(9, 154, 153));
+            Assert.True(dictionary.TryRemove(9, out var value));
+            Assert.Equal(154, value);
+        }, TestContext.Current.CancellationToken).WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        dictionary.RemoveRange(RingRange.Full, removed);
+        AssertEntries(candidates, removed.Skip(1));
+        Assert.Empty(dictionary);
+        Assert.Equal(0, dictionary.Count);
+    }
+
+    [Fact]
+    public async Task VisitRange_PropagatesCallbackExceptionAndPreservesCompletedMutation()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(key => (uint)key));
+        dictionary[1] = 17;
+        dictionary[2] = 29;
+        var failure = new InvalidOperationException("controlled visitor fault");
+        var visited = new List<KeyValuePair<int, int>>();
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() =>
+            dictionary.VisitRange(RingRange.Full, visited, (state, key, value) =>
+            {
+                state.Add(KeyValuePair.Create(key, value));
+                dictionary[key] = value + 100;
+                throw failure;
+            })));
+
+        var first = Assert.Single(visited);
+        var originals = new Dictionary<int, int> { [1] = 17, [2] = 29 };
+        Assert.Equal(originals[first.Key], first.Value);
+        Assert.Equal(first.Value + 100, dictionary[first.Key]);
+        var neighbor = first.Key == 1 ? 2 : 1;
+        Assert.Equal(originals[neighbor], dictionary[neighbor]);
+        Assert.Equal(2, dictionary.Count);
+        await Task.Run(() => Assert.True(dictionary.TryUpdate(first.Key, first.Value + 200, first.Value + 100)), TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        AssertEntries([KeyValuePair.Create(first.Key, first.Value + 200), KeyValuePair.Create(neighbor, originals[neighbor])], dictionary);
+    }
+
+    [Theory]
+    [InlineData(0x51A7)]
+    [InlineData(0xC0FFEE)]
+    public void SeededOperations_MatchIndependentDictionaryAndRingModel(int seed)
+    {
+        var random = new Random(seed);
+        static uint Hash(int key) => key % 17 == 0 ? 0 : key % 19 == 0 ? uint.MaxValue : key % 7 == 0 ? 0x08000011 : unchecked((uint)key * 2654435761);
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, TestHashComparer<int>>(new(Hash), capacity: 2, concurrencyLevel: 1);
+        var model = new Dictionary<int, int>();
+        for (var operation = 0; operation < 1000; operation++)
+        {
+            var key = random.Next(128);
+            var value = random.Next(1, 10000);
+            var oldValue = model.GetValueOrDefault(key);
+            var comparison = random.Next(2) == 0 ? oldValue : -1;
+            var start = (uint)random.NextInt64(1L << 32);
+            var end = (uint)random.NextInt64(1L << 32);
+            var range = RingRange.Create(start, end);
+            bool Contains(uint hash) => start == end ? start != 0 : start < end ? hash > start && hash <= end : hash > start || hash <= end;
+            switch (random.Next(9))
+            {
+                case 0:
+                    Assert.Equal(model.TryAdd(key, value), dictionary.TryAdd(key, value));
+                    break;
+                case 1:
+                    model[key] = value;
+                    dictionary[key] = value;
+                    break;
+                case 2:
+                    Assert.Equal(model.TryGetValue(key, out var expected), dictionary.TryGetValue(key, out var actual));
+                    Assert.Equal(expected, actual);
+                    break;
+                case 3:
+                    var updated = model.ContainsKey(key) && oldValue == comparison;
+                    Assert.Equal(updated, dictionary.TryUpdate(key, value, comparison));
+                    if (updated)
+                    {
+                        model[key] = value;
+                    }
+
+                    break;
+                case 4:
+                    Assert.Equal(model.Remove(key, out expected), dictionary.TryRemove(key, out actual));
+                    Assert.Equal(expected, actual);
+                    break;
+                case 5:
+                    var matched = model.ContainsKey(key) && oldValue == comparison;
+                    Assert.Equal(matched, dictionary.TryRemove(KeyValuePair.Create(key, comparison)));
+                    if (matched)
+                    {
+                        model.Remove(key);
+                    }
+
+                    break;
+                case 6:
+                    var selected = model.Where(pair => Contains(Hash(pair.Key))).ToArray();
+                    AssertEntries(selected, dictionary.EnumerateRange(range));
+                    var visited = new List<KeyValuePair<int, int>>();
+                    dictionary.VisitRange(range, visited, static (state, k, v) => state.Add(KeyValuePair.Create(k, v)));
+                    AssertEntries(selected, visited);
+                    break;
+                case 7:
+                    selected = model.Where(pair => Contains(Hash(pair.Key))).ToArray();
+                    var removed = new List<KeyValuePair<int, int>>();
+                    dictionary.RemoveRange(range, removed);
+                    AssertEntries(selected, removed);
+                    foreach (var entry in selected)
+                    {
+                        model.Remove(entry.Key);
+                    }
+
+                    break;
+                default:
+                    AssertEntries(model.Where(pair => Hash(pair.Key) == Hash(key)), dictionary.EnumerateHash(Hash(key)));
+                    break;
+            }
+
+            Assert.True(model.Count == dictionary.Count, $"Seed {seed}, operation {operation}, key {key}: expected count {model.Count}, actual {dictionary.Count}.");
+            if (operation % 16 == 0)
+            {
+                AssertEntries(model, dictionary);
+            }
+        }
+
+        AssertEntries(model, dictionary);
+    }
+
+    private static (RingRange Range, Func<uint, bool> Contains) GetRangeCase(string scenario) => scenario switch
+    {
+        "Empty" => (RingRange.Empty, _ => false),
+        "Full" => (RingRange.Full, _ => true),
+        "EqualEndpointsFull" => (RingRange.Create(7, 7), _ => true),
+        "Zero" => (RingRange.FromPoint(0), hash => hash == 0),
+        "Max" => (RingRange.FromPoint(uint.MaxValue), hash => hash == uint.MaxValue),
+        "Ordinary" => (RingRange.Create(10, 20), hash => hash > 10 && hash <= 20),
+        "Wrapped" => (RingRange.Create(uint.MaxValue - 2, 2), hash => hash > uint.MaxValue - 2 || hash <= 2),
+        "SamePrefixWrapped" => (RingRange.Create(0x08000020, 0x08000010), hash => hash > 0x08000020 || hash <= 0x08000010),
+        "InteriorBuckets" => (RingRange.Create(0x07FFFFFE, 0x18000001), hash => hash > 0x07FFFFFE && hash <= 0x18000001),
+        "PrefixBoundary" => (RingRange.Create(0x07FFFFFF, 0x08000000), hash => hash == 0x08000000),
+        _ => throw new ArgumentOutOfRangeException(nameof(scenario))
+    };
+
+    private static void AssertEntries<T>(IEnumerable<KeyValuePair<int, T>> expected, IEnumerable<KeyValuePair<int, T>> actual)
+        => Assert.Equal(expected.OrderBy(pair => pair.Key).ToArray(), actual.OrderBy(pair => pair.Key).ToArray());
+
+    private sealed record Payload(int Number);
+    private sealed record Key(int Id, uint Hash);
+
+    private sealed class KeyComparer : IEqualityComparer<Key>
+    {
+        public bool Equals(Key? x, Key? y) => x?.Id == y?.Id;
+        public int GetHashCode(Key obj) => throw new InvalidOperationException("Ordinary equality hashing is not the range coordinate.");
+    }
+
+    private sealed class CallbackComparer(Action checkpoint) : IEqualityComparer<int>
+    {
+        public bool Equals(int x, int y)
+        {
+            checkpoint();
+            return x == y;
+        }
+
+        public int GetHashCode(int obj) => obj;
+    }
+}
+
+internal sealed class TestHashComparer<TKey>(Func<TKey, uint> hash, IEqualityComparer<TKey>? equality = null) : IConsistentHashComparer<TKey>
+{
+    public uint GetHashCode(TKey value) => hash(value);
+    public bool Equals(TKey? x, TKey? y) => (equality ?? EqualityComparer<TKey>.Default).Equals(x, y);
+}

--- a/test/Orleans.Core.Tests/Utilities/GrainIdUniformHashComparerTests.cs
+++ b/test/Orleans.Core.Tests/Utilities/GrainIdUniformHashComparerTests.cs
@@ -1,0 +1,65 @@
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Utilities;
+using Xunit;
+
+namespace NonSilo.Tests.Utilities;
+
+[TestCategory("BVT")]
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("GrainDirectory")]
+public sealed class GrainIdUniformHashComparerTests
+{
+    [Fact]
+    public void ComparerPreservesGrainIdentityAndUnsignedRingHash()
+    {
+        var comparer = GrainIdUniformHashComparer.Instance;
+        var dictionary = new ConcurrentHashRangeDictionary<GrainId, int, GrainIdUniformHashComparer>(comparer);
+
+        for (var i = 0; i < 128; i++)
+        {
+            var key = i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var grainId = GrainId.Create("range-comparer", key);
+            var equivalent = GrainId.Create("range-comparer", key);
+            var differentType = GrainId.Create("other-type", key);
+            var hash = comparer.GetHashCode(grainId);
+
+            Assert.Equal(grainId.GetUniformHashCode(), hash);
+            Assert.True(comparer.Equals(grainId, equivalent));
+            Assert.False(comparer.Equals(grainId, differentType));
+            Assert.Equal(comparer.GetHashCode(grainId), comparer.GetHashCode(equivalent));
+            Assert.True(dictionary.TryAdd(grainId, i));
+            Assert.True(dictionary.TryGetValue(equivalent, hash, out var value));
+            Assert.Equal(i, value);
+        }
+
+        Assert.Equal(128, dictionary.Count);
+    }
+
+    [Fact]
+    public void ConcreteComparerMapsSignedKeysToUnsignedCoordinates()
+    {
+        var dictionary = new ConcurrentHashRangeDictionary<int, int, IntComparer>(default);
+        var keys = new[] { int.MinValue, -1, 0, 1, int.MaxValue };
+        foreach (var key in keys)
+        {
+            Assert.True(dictionary.TryAdd(key, key));
+            Assert.True(dictionary.TryGetValue(key, unchecked((uint)key), out var value));
+            Assert.Equal(key, value);
+            Assert.Equal(KeyValuePair.Create(key, key), Assert.Single(dictionary.EnumerateHash(unchecked((uint)key))));
+        }
+
+        Assert.Equal(
+            new[] { -1, 0, 1 },
+            dictionary.EnumerateRange(RingRange.Create(uint.MaxValue - 1, 1)).Select(static entry => entry.Key).Order());
+        Assert.Empty(dictionary.EnumerateRange(RingRange.Empty));
+        Assert.Equal(keys.Order(), dictionary.EnumerateRange(RingRange.Full).Select(static entry => entry.Key).Order());
+    }
+
+    private readonly struct IntComparer : IConsistentHashComparer<int>
+    {
+        public bool Equals(int x, int y) => x == y;
+        public uint GetHashCode(int value) => unchecked((uint)value);
+    }
+}

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRangeRecoveryTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRangeRecoveryTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace UnitTests.GrainDirectory;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("GrainDirectory")]
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class GrainDirectoryRangeRecoveryTests
+{
+    [Fact]
+    public async Task RecoveryEnumeratesExactRangesAndPreservesPublishedActivations()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var builder = new InProcessTestClusterBuilder(1);
+#pragma warning disable ORLEANSEXP003
+        builder.Options.UseDistributedGrainDirectory = true;
+#pragma warning restore ORLEANSEXP003
+        await using var cluster = builder.Build();
+        await cluster.DeployAsync(cancellationToken);
+
+        var grains = Enumerable.Range(0, 64)
+            .Select(index => cluster.Client.GetGrain<IMyDirectoryTestGrain>(index))
+            .ToArray();
+        await Task.WhenAll(grains.Select(grain => grain.Ping().AsTask()));
+
+        var services = cluster.Silos[0].ServiceProvider;
+        var activations = services.GetRequiredService<ActivationDirectory>();
+        var directory = services.GetRequiredService<DistributedGrainDirectory>();
+        var membership = services.GetRequiredService<DirectoryMembershipService>();
+        var contexts = grains.Select(grain => activations.FindTarget(grain.GetGrainId())!).ToArray();
+        Assert.All(contexts, static context => Assert.NotNull(context));
+        var addresses = contexts.Select(static context => context.Address).ToArray();
+        var ids = addresses.Select(static address => address.GrainId).ToHashSet();
+        var hashes = ids.Select(static id => id.GetUniformHashCode()).Order().ToArray();
+        var range = RingRange.Create(hashes[15], hashes[47]);
+        var recoveryVersion = new MembershipVersion(Math.Max(
+            membership.CurrentView.Version.Value,
+            directory.RecoveryMembershipVersion + 1));
+
+        foreach (var query in new[] { range, range.Complement(), RingRange.FromPoint(hashes[0]), RingRange.Empty, RingRange.Full })
+        {
+            var result = await directory.GetRegisteredActivations(recoveryVersion, query, isValidation: false, cancellationToken);
+            Assert.All(result.Value, address => Assert.True(query.Contains(address.GrainId)));
+            var expected = addresses.Where(address => query.Contains(address.GrainId)).OrderBy(static address => address.GrainId).ToArray();
+            var actual = result.Value.Where(address => ids.Contains(address.GrainId)).OrderBy(static address => address.GrainId).ToArray();
+
+            Assert.Equal(expected.Length, actual.Length);
+            for (var i = 0; i < expected.Length; i++)
+            {
+                Assert.Same(expected[i], actual[i]);
+                Assert.Equal(expected[i].MembershipVersion, actual[i].MembershipVersion);
+            }
+
+            Assert.Equal(recoveryVersion.Value, directory.RecoveryMembershipVersion);
+            Assert.All(contexts, context => Assert.Same(context, activations.FindTarget(context.GrainId)));
+        }
+
+        await directory.GetRegisteredActivations(new MembershipVersion(recoveryVersion.Value - 1), range, isValidation: false, cancellationToken);
+        Assert.Equal(recoveryVersion.Value, directory.RecoveryMembershipVersion);
+    }
+}


### PR DESCRIPTION
## Problem

Activation recovery filters the complete activation directory for each requested hash range. Batched recovery therefore repeatedly scans unrelated activations, even when the requested range is small.

## Solution

Add an internal `ConcurrentHashRangeDictionary<TKey, TValue, TComparer>` adapted from the .NET runtime's concurrent dictionary. Its power-of-two buckets cover contiguous portions of the consistent hash ring, allowing range traversal to visit intersecting buckets directly.

- Use a concrete `IConsistentHashComparer<TKey>` and a struct `GrainIdUniformHashComparer` for stable unsigned coordinates and specialization.
- Support point operations, prehashed lookup, hash-only enumeration, typed range visitation, and conditional range removal with explicit consistency and quiescence contracts.
- Retain striped writes, lock-free reads, table-generation retry during resizing, and atomic handling of multiword values.
- Adopt selective enumeration in `ActivationDirectory` recovery and rolling-upgrade compatibility recovery, preserving publication barriers, membership watermarks, expected-context removal, and counting.
- Include deterministic coverage, side-by-side point/range/concurrency benchmarks, runtime-source provenance, and architecture guidance.

## Performance and scope

Recorded .NET 10 recovery mixes at 32 workers improved approximately 4.4–4.7x on the shared Hyper-V host. Point-only results are workload-dependent, and construction, memory, skew, and contention costs are documented with reproduction instructions in the benchmark README. Prefix-concentrated populations remain a trade-off of this layout.

This is the concurrent-collection portion of #11207. The adaptive single-writer dictionary and partition-storage work are reserved for a separate PR.

Repository-wide restore is currently blocked by the SourceLink advisory tracked in #11213. The separate fix is #11216; that dependency update is not included here.

Fixes: #11207
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11219)