### PR TITLE
fix: report exact ring cardinality and cover range boundaries

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -995,7 +995,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             yield break;
         }
 
-        var totalSize = GetRangeCoverageSize(range);
+        var totalSize = range.Size;
         queryRangeCount = (int)Math.Min((ulong)queryRangeCount, totalSize);
         if (queryRangeCount == 1)
         {
@@ -1011,18 +1011,6 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             var end = unchecked((uint)((ulong)start + size));
             yield return RingRange.Create(start, end);
             start = end;
-        }
-
-        static ulong GetRangeCoverageSize(RingRange range)
-        {
-            if (range.IsFull)
-            {
-                return (ulong)uint.MaxValue + 1;
-            }
-
-            return range.IsWrapped
-                ? (ulong)uint.MaxValue - range.Start + range.End + 1
-                : range.Size;
         }
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/RingRange.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRange.cs
@@ -52,9 +52,9 @@ internal readonly struct RingRange : IEquatable<RingRange>, ISpanFormattable, IC
     public static RingRange FromPoint(uint point) => new(unchecked(point - 1), point);
 
     /// <summary>
-    /// Gets the size of the range.
+    /// Gets the number of points covered by the range, from zero to 2^32 for a full ring.
     /// </summary>
-    public uint Size
+    public ulong Size
     {
         get
         {
@@ -64,14 +64,14 @@ internal readonly struct RingRange : IEquatable<RingRange>, ISpanFormattable, IC
                 if (_start == 0) return 0;
 
                 // Full
-                return uint.MaxValue;
+                return (ulong)uint.MaxValue + 1;
             }
 
             // Normal
             if (_end > _start) return _end - _start;
 
             // Wrapped
-            return uint.MaxValue - _start + _end + 1;
+            return (ulong)uint.MaxValue - _start + _end + 1;
         }
     }
 
@@ -136,7 +136,7 @@ internal readonly struct RingRange : IEquatable<RingRange>, ISpanFormattable, IC
         return num > Start || num <= End;
     }
 
-    public float SizePercent => Size * (100.0f / uint.MaxValue);
+    public float SizePercent => Size * (100.0f / Full.Size);
 
     public bool Equals(RingRange other) => _start == other._start && _end == other._end;
 

--- a/src/Orleans.Runtime/GrainDirectory/RingRange.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRange.cs
@@ -71,7 +71,7 @@ internal readonly struct RingRange : IEquatable<RingRange>, ISpanFormattable, IC
             if (_end > _start) return _end - _start;
 
             // Wrapped
-            return uint.MaxValue - _start + _end;
+            return uint.MaxValue - _start + _end + 1;
         }
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
@@ -62,33 +62,12 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public bool IsEmpty => Ranges.IsDefaultOrEmpty || Ranges.All(static r => r.IsEmpty);
 
-    public bool IsFull
-    {
-        get
-        {
-            if (Ranges.IsDefaultOrEmpty)
-            {
-                return false;
-            }
+    public bool IsFull => Size == RingRange.Full.Size;
 
-            if (Ranges.Length == 1)
-            {
-                return Ranges[0].IsFull;
-            }
-
-            for (var i = 0; i < Ranges.Length - 1; i++)
-            {
-                if (Ranges[i].End != Ranges[i + 1].Start)
-                {
-                    return false;
-                }
-            }
-
-            return Ranges[^1].End == Ranges[0].Start;
-        }
-    }
-
-    public uint Size
+    /// <summary>
+    /// Gets the total number of points covered by the non-overlapping ranges, from zero to 2^32.
+    /// </summary>
+    public ulong Size
     {
         get
         {
@@ -97,17 +76,17 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
                 return 0;
             }
 
-            long sum = 0;
+            ulong sum = 0;
             foreach (var range in Ranges)
             {
                 sum += range.Size;
             }
 
-            return sum >= uint.MaxValue ? uint.MaxValue : (uint)sum;
+            return sum;
         }
     }
 
-    public float SizePercent => Size * (100.0f / uint.MaxValue);
+    public float SizePercent => Size * (100.0f / RingRange.Full.Size);
 
     public bool Contains(GrainId grainId) => Contains(grainId.GetUniformHashCode());
 
@@ -247,20 +226,22 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public override int GetHashCode()
     {
-        var result = new HashCode();
-        result.Add(Ranges.IsDefault ? 0 : Ranges.Length);
-        if (!Ranges.IsDefaultOrEmpty)
+        if (IsEmpty)
         {
-            foreach (var range in Ranges)
-            {
-                result.Add(range);
-            }
+            return 0;
+        }
+
+        var result = new HashCode();
+        result.Add(Ranges.Length);
+        foreach (var range in Ranges)
+        {
+            result.Add(range);
         }
 
         return result.ToHashCode();
     }
 
-    public ImmutableArray<RingRange>.Enumerator GetEnumerator() => Ranges.IsDefault ? default : Ranges.GetEnumerator();
+    public ImmutableArray<RingRange>.Enumerator GetEnumerator() => Ranges.IsDefault ? ImmutableArray<RingRange>.Empty.GetEnumerator() : Ranges.GetEnumerator();
 
     public override string ToString() => $"{this}";
     string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();

--- a/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
@@ -62,9 +62,9 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public bool IsEmpty => Ranges.Length == 0 || Ranges.All(r => r.IsEmpty);
 
-    public bool IsFull => !IsEmpty && Ranges.Sum(r => r.Size) == uint.MaxValue;
+    public bool IsFull => !IsEmpty && Ranges.Sum(static r => (long)r.Size) >= uint.MaxValue;
 
-    public uint Size => (uint)Ranges.Sum(static r => r.Size);
+    public uint Size => Ranges.Sum(static r => (long)r.Size) >= uint.MaxValue ? uint.MaxValue : (uint)Ranges.Sum(static r => (long)r.Size);
 
     public float SizePercent => Size * (100.0f / uint.MaxValue);
 

--- a/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
@@ -62,7 +62,7 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public bool IsEmpty => Ranges.IsDefaultOrEmpty || Ranges.All(static r => r.IsEmpty);
 
-    public bool IsFull => !IsEmpty && Size == uint.MaxValue;
+    public bool IsFull => Size == uint.MaxValue;
 
     public uint Size
     {

--- a/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
@@ -62,7 +62,31 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public bool IsEmpty => Ranges.IsDefaultOrEmpty || Ranges.All(static r => r.IsEmpty);
 
-    public bool IsFull => Size == uint.MaxValue;
+    public bool IsFull
+    {
+        get
+        {
+            if (Ranges.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            if (Ranges.Length == 1)
+            {
+                return Ranges[0].IsFull;
+            }
+
+            for (var i = 0; i < Ranges.Length - 1; i++)
+            {
+                if (Ranges[i].End != Ranges[i + 1].Start)
+                {
+                    return false;
+                }
+            }
+
+            return Ranges[^1].End == Ranges[0].Start;
+        }
+    }
 
     public uint Size
     {

--- a/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
@@ -62,9 +62,26 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public bool IsEmpty => Ranges.Length == 0 || Ranges.All(r => r.IsEmpty);
 
-    public bool IsFull => !IsEmpty && Ranges.Sum(static r => (long)r.Size) >= uint.MaxValue;
+    public bool IsFull => !IsEmpty && Size == uint.MaxValue;
 
-    public uint Size => Ranges.Sum(static r => (long)r.Size) >= uint.MaxValue ? uint.MaxValue : (uint)Ranges.Sum(static r => (long)r.Size);
+    public uint Size
+    {
+        get
+        {
+            if (Ranges.IsDefaultOrEmpty)
+            {
+                return 0;
+            }
+
+            long sum = 0;
+            foreach (var range in Ranges)
+            {
+                sum += range.Size;
+            }
+
+            return sum >= uint.MaxValue ? uint.MaxValue : (uint)sum;
+        }
+    }
 
     public float SizePercent => Size * (100.0f / uint.MaxValue);
 

--- a/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRangeCollection.cs
@@ -60,7 +60,7 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public bool IsDefault => Ranges.IsDefault;
 
-    public bool IsEmpty => Ranges.Length == 0 || Ranges.All(r => r.IsEmpty);
+    public bool IsEmpty => Ranges.IsDefaultOrEmpty || Ranges.All(static r => r.IsEmpty);
 
     public bool IsFull => !IsEmpty && Size == uint.MaxValue;
 
@@ -89,6 +89,11 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
 
     public bool Contains(uint value)
     {
+        if (Ranges.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
         return SearchAlgorithms.RingRangeBinarySearch(
             Ranges.Length,
             Ranges,
@@ -152,10 +157,13 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
         // Corresponding ranges in left and right have the same starting points.
         // The number of ranges in both 'Ranges' or 'previous.Ranges' is either zero or the configured number of ranges,
         // i.e., if both collections have more than zero ranges, the both have the same number of ranges.
-        if (Ranges.Length == previous.Ranges.Length)
+        var currentLength = Ranges.IsDefault ? 0 : Ranges.Length;
+        var previousLength = previous.Ranges.IsDefault ? 0 : previous.Ranges.Length;
+
+        if (currentLength == previousLength)
         {
-            var result = ImmutableArray.CreateBuilder<RingRange>(Ranges.Length);
-            for (var i = 0; i < Ranges.Length; i++)
+            var result = ImmutableArray.CreateBuilder<RingRange>(currentLength);
+            for (var i = 0; i < currentLength; i++)
             {
                 var c = Ranges[i];
                 var p = previous.Ranges[i];
@@ -179,14 +187,14 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
         }
         else
         {
-            if (Ranges.Length > previous.Ranges.Length)
+            if (currentLength > previousLength)
             {
-                Debug.Assert(previous.Ranges.Length == 0);
+                Debug.Assert(previousLength == 0);
                 return this;
             }
             else
             {
-                Debug.Assert(Ranges.Length == 0 ^ previous.Ranges.Length == 0);
+                Debug.Assert(currentLength == 0 || previousLength == 0);
                 return Empty;
             }
         }
@@ -216,7 +224,7 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
     public override int GetHashCode()
     {
         var result = new HashCode();
-        result.Add(Ranges.Length);
+        result.Add(Ranges.IsDefault ? 0 : Ranges.Length);
         if (!Ranges.IsDefaultOrEmpty)
         {
             foreach (var range in Ranges)
@@ -228,13 +236,13 @@ internal readonly struct RingRangeCollection : IEquatable<RingRangeCollection>, 
         return result.ToHashCode();
     }
 
-    public ImmutableArray<RingRange>.Enumerator GetEnumerator() => Ranges.GetEnumerator();
+    public ImmutableArray<RingRange>.Enumerator GetEnumerator() => Ranges.IsDefault ? default : Ranges.GetEnumerator();
 
     public override string ToString() => $"{this}";
     string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
 
     bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
-        => destination.TryWrite($"({Ranges.Length} subranges), {SizePercent:0.00}%", out charsWritten);
-    IEnumerator<RingRange> IEnumerable<RingRange>.GetEnumerator() => ((IEnumerable<RingRange>)Ranges).GetEnumerator();
-    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Ranges).GetEnumerator();
+        => destination.TryWrite($"({(Ranges.IsDefault ? 0 : Ranges.Length)} subranges), {SizePercent:0.00}%", out charsWritten);
+    IEnumerator<RingRange> IEnumerable<RingRange>.GetEnumerator() => Ranges.IsDefault ? Enumerable.Empty<RingRange>().GetEnumerator() : ((IEnumerable<RingRange>)Ranges).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<RingRange>)this).GetEnumerator();
 }

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -171,11 +171,11 @@ public sealed class DirectoryMembershipSnapshotTests
         GenDirectoryMembershipSnapshot.Where(s => s.Members.Length > 0)
             .Sample(snapshot =>
             {
-                uint sum = 0;
+                ulong sum = 0;
                 var allRanges = new List<RingRange>();
                 foreach (var member in snapshot.Members)
                 {
-                    Assert.Equal(snapshot.GetMemberRanges(member).Sum(range => range.Size), snapshot.GetMemberRangesByPartition(member).Sum(range => range.Size));
+                    Assert.Equal(snapshot.GetMemberRanges(member).Sum(range => (long)range.Size), snapshot.GetMemberRangesByPartition(member).Sum(range => (long)range.Size));
                     foreach (var range in snapshot.GetMemberRanges(member))
                     {
                         allRanges.Add(range);
@@ -183,8 +183,7 @@ public sealed class DirectoryMembershipSnapshotTests
                     }
                 }
 
-
-                Assert.Equal(uint.MaxValue, sum);
+                Assert.True(sum >= uint.MaxValue);
 
                 var allRangesCollection = RingRangeCollection.Create(allRanges);
 
@@ -203,7 +202,7 @@ public sealed class DirectoryMembershipSnapshotTests
         GenDirectoryMembershipSnapshot.Where(s => s.Members.Length > 0)
             .Sample(snapshot =>
             {
-                uint sum = 0;
+                ulong sum = 0;
                 var allRanges = new List<RingRange>();
                 foreach (var member in snapshot.Members)
                 {
@@ -214,7 +213,7 @@ public sealed class DirectoryMembershipSnapshotTests
                     }
                 }
 
-                Assert.Equal(uint.MaxValue, sum);
+                Assert.True(sum >= uint.MaxValue);
                 var allRangesCollection = RingRangeCollection.Create(allRanges);
                 Assert.Equal(uint.MaxValue, allRangesCollection.Size);
                 Assert.Equal(100f, allRangesCollection.SizePercent);

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -187,7 +187,6 @@ public sealed class DirectoryMembershipSnapshotTests
 
                 var allRangesCollection = RingRangeCollection.Create(allRanges);
 
-                Assert.Equal(uint.MaxValue, allRangesCollection.Size);
                 Assert.Equal(100f, allRangesCollection.SizePercent);
                 Assert.False(allRangesCollection.IsEmpty);
                 Assert.False(allRangesCollection.IsDefault);
@@ -215,7 +214,6 @@ public sealed class DirectoryMembershipSnapshotTests
 
                 Assert.True(sum >= uint.MaxValue);
                 var allRangesCollection = RingRangeCollection.Create(allRanges);
-                Assert.Equal(uint.MaxValue, allRangesCollection.Size);
                 Assert.Equal(100f, allRangesCollection.SizePercent);
                 Assert.False(allRangesCollection.IsEmpty);
                 Assert.False(allRangesCollection.IsDefault);

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -175,7 +175,9 @@ public sealed class DirectoryMembershipSnapshotTests
                 var allRanges = new List<RingRange>();
                 foreach (var member in snapshot.Members)
                 {
-                    Assert.Equal(snapshot.GetMemberRanges(member).Sum(range => (long)range.Size), snapshot.GetMemberRangesByPartition(member).Sum(range => (long)range.Size));
+                    Assert.Equal(
+                        snapshot.GetMemberRanges(member).Aggregate(0UL, static (sum, range) => sum + range.Size),
+                        snapshot.GetMemberRangesByPartition(member).Aggregate(0UL, static (sum, range) => sum + range.Size));
                     foreach (var range in snapshot.GetMemberRanges(member))
                     {
                         allRanges.Add(range);
@@ -183,10 +185,11 @@ public sealed class DirectoryMembershipSnapshotTests
                     }
                 }
 
-                Assert.True(sum >= uint.MaxValue);
+                Assert.Equal(1UL << 32, sum);
 
                 var allRangesCollection = RingRangeCollection.Create(allRanges);
 
+                Assert.Equal(1UL << 32, allRangesCollection.Size);
                 Assert.Equal(100f, allRangesCollection.SizePercent);
                 Assert.False(allRangesCollection.IsEmpty);
                 Assert.False(allRangesCollection.IsDefault);
@@ -212,8 +215,9 @@ public sealed class DirectoryMembershipSnapshotTests
                     }
                 }
 
-                Assert.True(sum >= uint.MaxValue);
+                Assert.Equal(1UL << 32, sum);
                 var allRangesCollection = RingRangeCollection.Create(allRanges);
+                Assert.Equal(1UL << 32, allRangesCollection.Size);
                 Assert.Equal(100f, allRangesCollection.SizePercent);
                 Assert.False(allRangesCollection.IsEmpty);
                 Assert.False(allRangesCollection.IsDefault);

--- a/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
@@ -324,13 +324,24 @@ public sealed class RingRangeCollectionTests
     [Fact]
     public void BoundaryValueAnalysis_SizingAndOverflow()
     {
+        // Single range excluding 1 point: Size is uint.MaxValue, but IsFull must be false
+        var almostFull = Create(RingRange.Create(1, 0));
+        Assert.Equal(uint.MaxValue, almostFull.Size);
+        Assert.False(almostFull.IsFull);
+
         // Combination of non-overlapping ranges that exactly covers the ring
         var half1 = RingRange.Create(0, 2_147_483_647u);
         var half2 = RingRange.Create(2_147_483_647u, 0);
 
         var fullCombined = Create(half1, half2);
         Assert.True(fullCombined.IsFull);
-        Assert.Equal((ulong)uint.MaxValue + 1, (ulong)half1.Size + half2.Size);
+        Assert.Equal(uint.MaxValue, fullCombined.Size);
+
+        // Multiple ranges with a gap: IsFull must be false
+        var withGap1 = RingRange.Create(0, 100);
+        var withGap2 = RingRange.Create(105, 0);
+        var collectionWithGap = Create(withGap1, withGap2);
+        Assert.False(collectionWithGap.IsFull);
     }
 
     [Fact]

--- a/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
@@ -43,17 +43,17 @@ public sealed class RingRangeCollectionTests
         Assert.False(empty.IsDefault);
         Assert.True(empty.IsEmpty);
         Assert.False(empty.IsFull);
-        Assert.Equal(0u, empty.Size);
+        Assert.Equal(0UL, empty.Size);
         Assert.Equal(0f, empty.SizePercent);
 
         Assert.False(full.IsEmpty);
         Assert.True(full.IsFull);
-        Assert.Equal(uint.MaxValue, full.Size);
+        Assert.Equal(1UL << 32, full.Size);
         Assert.Equal(100f, full.SizePercent);
 
         Assert.False(partial.IsEmpty);
         Assert.False(partial.IsFull);
-        Assert.Equal(20u, partial.Size);
+        Assert.Equal(20UL, partial.Size);
     }
 
     [Fact]
@@ -150,6 +150,19 @@ public sealed class RingRangeCollectionTests
     }
 
     [Fact]
+    public void Difference_ReturnsMissingPointWhenRangeBecomesFull()
+    {
+        var previous = Create(RingRange.Create(0, uint.MaxValue));
+        var current = Create(RingRange.Full);
+
+        var growth = current.Difference(previous);
+
+        Assert.Equal(RingRange.FromPoint(0), Assert.Single(growth));
+        Assert.Equal(1UL, growth.Size);
+        Assert.True(previous.Difference(current).IsEmpty);
+    }
+
+    [Fact]
     public void Difference_PreservesSortOrderWhenWrappedRangeGrowthMovesToTheFront()
     {
         var previous = Create(RingRange.Create(10, 20), RingRange.Create(100, 5));
@@ -198,6 +211,36 @@ public sealed class RingRangeCollectionTests
 
         Assert.Equal(RingRangeCollection.Empty, emptyWithExplicitRange);
         Assert.NotEqual(first, RingRangeCollection.Empty);
+    }
+
+    [Fact]
+    public void Equality_EmptyRepresentationsShareHashCode()
+    {
+        RingRangeCollection[] collections =
+        [
+            default,
+            RingRangeCollection.Empty,
+            new(ImmutableArray.Create(RingRange.Empty))
+        ];
+
+        foreach (var collection in collections)
+        {
+            Assert.Equal(RingRangeCollection.Empty, collection);
+            Assert.Equal(RingRangeCollection.Empty.GetHashCode(), collection.GetHashCode());
+        }
+
+        Assert.Single(new HashSet<RingRangeCollection>(collections));
+    }
+
+    [Fact]
+    public void Enumeration_DefaultCollectionIsEmpty()
+    {
+        var collection = default(RingRangeCollection);
+        var enumerator = collection.GetEnumerator();
+
+        Assert.False(enumerator.MoveNext());
+        Assert.Empty((IEnumerable<RingRange>)collection);
+        Assert.Empty((IEnumerable)collection);
     }
 
     [Fact]
@@ -282,7 +325,7 @@ public sealed class RingRangeCollectionTests
         Assert.True(defaultCol.IsDefault);
         Assert.True(defaultCol.IsEmpty);
         Assert.False(defaultCol.IsFull);
-        Assert.Equal(0u, defaultCol.Size);
+        Assert.Equal(0UL, defaultCol.Size);
         Assert.Equal(0.0f, defaultCol.SizePercent);
         Assert.False(defaultCol.Contains(0));
         Assert.False(defaultCol.Contains(uint.MaxValue));
@@ -295,7 +338,7 @@ public sealed class RingRangeCollectionTests
         Assert.False(emptyCol.IsDefault);
         Assert.True(emptyCol.IsEmpty);
         Assert.False(emptyCol.IsFull);
-        Assert.Equal(0u, emptyCol.Size);
+        Assert.Equal(0UL, emptyCol.Size);
         Assert.Equal(0.0f, emptyCol.SizePercent);
         Assert.False(emptyCol.Contains(0));
         Assert.False(emptyCol.Intersects(RingRange.Full));
@@ -308,7 +351,7 @@ public sealed class RingRangeCollectionTests
         Assert.False(fullCol.IsDefault);
         Assert.False(fullCol.IsEmpty);
         Assert.True(fullCol.IsFull);
-        Assert.Equal(uint.MaxValue, fullCol.Size);
+        Assert.Equal(1UL << 32, fullCol.Size);
         Assert.Equal(100.0f, fullCol.SizePercent);
 
         uint[] samplePoints = [0, 1, 2, uint.MaxValue - 1, uint.MaxValue];
@@ -324,24 +367,50 @@ public sealed class RingRangeCollectionTests
     [Fact]
     public void BoundaryValueAnalysis_SizingAndOverflow()
     {
-        // Single range excluding 1 point: Size is uint.MaxValue, but IsFull must be false
+        // The almost-full range covers every point except 1.
         var almostFull = Create(RingRange.Create(1, 0));
-        Assert.Equal(uint.MaxValue, almostFull.Size);
+        Assert.Equal((ulong)uint.MaxValue, almostFull.Size);
         Assert.False(almostFull.IsFull);
 
-        // Combination of non-overlapping ranges that exactly covers the ring
+        // Together, the two non-overlapping ranges cover all 2^32 points.
         var half1 = RingRange.Create(0, 2_147_483_647u);
         var half2 = RingRange.Create(2_147_483_647u, 0);
 
         var fullCombined = Create(half1, half2);
         Assert.True(fullCombined.IsFull);
-        Assert.Equal(uint.MaxValue, fullCombined.Size);
+        Assert.Equal(1UL << 32, half1.Size + half2.Size);
+        Assert.Equal(1UL << 32, fullCombined.Size);
 
-        // Multiple ranges with a gap: IsFull must be false
+        // A five-point gap reduces the covered point count by five.
         var withGap1 = RingRange.Create(0, 100);
         var withGap2 = RingRange.Create(105, 0);
         var collectionWithGap = Create(withGap1, withGap2);
+        Assert.Equal((1UL << 32) - 5, collectionWithGap.Size);
         Assert.False(collectionWithGap.IsFull);
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(1u)]
+    [InlineData(2u)]
+    [InlineData((1u << 31) - 1)]
+    [InlineData(1u << 31)]
+    [InlineData(uint.MaxValue - 1)]
+    [InlineData(uint.MaxValue)]
+    public void Size_CountsComplementaryRangesAtBoundaries(uint point)
+    {
+        var singlePoint = RingRange.FromPoint(point);
+        var almostFull = Create(singlePoint.Complement());
+        var full = Create(singlePoint, singlePoint.Complement());
+
+        Assert.Equal(1UL, Create(singlePoint).Size);
+        Assert.Equal((1UL << 32) - 1, almostFull.Size);
+        Assert.False(almostFull.IsFull);
+        Assert.False(almostFull.Contains(point));
+        Assert.Equal(1UL << 32, full.Size);
+        Assert.True(full.IsFull);
+        Assert.True(full.Contains(point));
+        Assert.Equal(100f, full.SizePercent);
     }
 
     [Fact]
@@ -412,23 +481,38 @@ public sealed class RingRangeCollectionTests
     {
         GenRingRangeCollection.Sample(collection =>
         {
-            if (collection.IsEmpty)
-            {
-                Assert.Equal(0u, collection.Size);
-                Assert.False(collection.IsFull);
-            }
-            else
-            {
-                long expectedSum = 0;
-                foreach (var r in collection.Ranges)
-                {
-                    expectedSum += r.Size;
-                }
+            var expectedSize = collection.Ranges.Aggregate(0UL, static (sum, range) => sum + RingRangeTests.GetExpectedSize(range));
 
-                uint expectedSize = expectedSum >= uint.MaxValue ? uint.MaxValue : (uint)expectedSum;
-                Assert.Equal(expectedSize, collection.Size);
-                Assert.Equal(expectedSize == uint.MaxValue, collection.IsFull);
-            }
+            Assert.InRange(expectedSize, 0UL, 1UL << 32);
+            Assert.Equal(expectedSize, collection.Size);
+            Assert.Equal(expectedSize == 1UL << 32, collection.IsFull);
+            Assert.Equal(expectedSize * (100.0f / (1UL << 32)), collection.SizePercent);
+        });
+    }
+
+    [Fact]
+    public void Property_SizeCountsFullPartitionsAndSinglePointGaps()
+    {
+        Gen.Select(RingRangeTests.GenBoundaryPoint.Array[Gen.Int[0, 12]], RingRangeTests.GenBoundaryPoint).Sample((points, missingPoint) =>
+        {
+            var boundaries = points.Append(0u).Distinct().Order().ToArray();
+            var ranges = boundaries.Length == 1
+                ? new[] { RingRange.Full }
+                : boundaries.Select((start, index) => RingRange.Create(start, boundaries[(index + 1) % boundaries.Length])).ToArray();
+            var full = Create(ranges);
+
+            Assert.Equal(1UL << 32, ranges.Aggregate(0UL, static (sum, range) => sum + range.Size));
+            Assert.Equal(1UL << 32, full.Size);
+            Assert.True(full.IsFull);
+            Assert.True(full.Contains(missingPoint));
+
+            var gap = RingRange.FromPoint(missingPoint);
+            var almostFull = Create(ranges.SelectMany(range => range.Difference(gap)).ToArray());
+
+            Assert.Equal((1UL << 32) - 1, almostFull.Size);
+            Assert.False(almostFull.IsFull);
+            Assert.False(almostFull.Contains(missingPoint));
+            Assert.Equal(1UL, full.Size - almostFull.Size);
         });
     }
 

--- a/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
@@ -324,13 +324,13 @@ public sealed class RingRangeCollectionTests
     [Fact]
     public void BoundaryValueAnalysis_SizingAndOverflow()
     {
-        // Combination of non-overlapping ranges that exactly equals uint.MaxValue
-        var half1 = RingRange.Create(0, 2_147_483_648u);
-        var half2 = RingRange.Create(2_147_483_648u, 0);
+        // Combination of non-overlapping ranges that exactly covers the ring
+        var half1 = RingRange.Create(0, 2_147_483_647u);
+        var half2 = RingRange.Create(2_147_483_647u, 0);
 
         var fullCombined = Create(half1, half2);
         Assert.True(fullCombined.IsFull);
-        Assert.Equal(uint.MaxValue, fullCombined.Size);
+        Assert.Equal((ulong)uint.MaxValue + 1, (ulong)half1.Size + half2.Size);
     }
 
     [Fact]

--- a/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeCollectionTests.cs
@@ -1,5 +1,10 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using CsCheck;
+using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
 using Xunit;
 
@@ -229,6 +234,223 @@ public sealed class RingRangeCollectionTests
         Span<char> shortBuffer = stackalloc char[1];
         Assert.False(((ISpanFormattable)collection).TryFormat(shortBuffer, out charsWritten, default, null));
         Assert.Equal(0, charsWritten);
+    }
+
+    internal static Gen<RingRangeCollection> GenRingRangeCollection =>
+        Gen.Select(Gen.UInt.Array[Gen.Int[0, 12]], Gen.Bool).Select(static (points, includeFull) =>
+        {
+            if (includeFull && points.Length == 0)
+            {
+                return Create(RingRange.Full);
+            }
+
+            Array.Sort(points);
+            var distinctPoints = points.Distinct().ToArray();
+            if (distinctPoints.Length < 2)
+            {
+                return RingRangeCollection.Empty;
+            }
+
+            var list = new List<RingRange>();
+            for (int i = 0; i < distinctPoints.Length - 1; i += 2)
+            {
+                var r = RingRange.Create(distinctPoints[i], distinctPoints[i + 1]);
+                if (!r.IsEmpty)
+                {
+                    list.Add(r);
+                }
+            }
+
+            if (list.Count > 1 && list[0].Intersects(list[^1]))
+            {
+                list.RemoveAt(list.Count - 1);
+            }
+
+            return Create(list.ToArray());
+        });
+
+    [Fact]
+    public void Create_NullArgument_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => RingRangeCollection.Create<List<RingRange>>(null!));
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_DefaultAndEmptyCollections()
+    {
+        var defaultCol = default(RingRangeCollection);
+        Assert.True(defaultCol.IsDefault);
+        Assert.True(defaultCol.IsEmpty);
+        Assert.False(defaultCol.IsFull);
+        Assert.Equal(0u, defaultCol.Size);
+        Assert.Equal(0.0f, defaultCol.SizePercent);
+        Assert.False(defaultCol.Contains(0));
+        Assert.False(defaultCol.Contains(uint.MaxValue));
+        Assert.False(defaultCol.Intersects(RingRange.Full));
+        Assert.False(defaultCol.Intersects(RingRangeCollection.Empty));
+        Assert.True(defaultCol.Equals(RingRangeCollection.Empty));
+        Assert.Equal(defaultCol.GetHashCode(), RingRangeCollection.Empty.GetHashCode());
+
+        var emptyCol = RingRangeCollection.Empty;
+        Assert.False(emptyCol.IsDefault);
+        Assert.True(emptyCol.IsEmpty);
+        Assert.False(emptyCol.IsFull);
+        Assert.Equal(0u, emptyCol.Size);
+        Assert.Equal(0.0f, emptyCol.SizePercent);
+        Assert.False(emptyCol.Contains(0));
+        Assert.False(emptyCol.Intersects(RingRange.Full));
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_FullCollection()
+    {
+        var fullCol = Create(RingRange.Full);
+        Assert.False(fullCol.IsDefault);
+        Assert.False(fullCol.IsEmpty);
+        Assert.True(fullCol.IsFull);
+        Assert.Equal(uint.MaxValue, fullCol.Size);
+        Assert.Equal(100.0f, fullCol.SizePercent);
+
+        uint[] samplePoints = [0, 1, 2, uint.MaxValue - 1, uint.MaxValue];
+        foreach (var p in samplePoints)
+        {
+            Assert.True(fullCol.Contains(p));
+        }
+
+        Assert.True(fullCol.Intersects(RingRange.Create(10, 20)));
+        Assert.True(fullCol.Intersects(Create(RingRange.Create(10, 20))));
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_SizingAndOverflow()
+    {
+        // Combination of non-overlapping ranges that exactly equals uint.MaxValue
+        var half1 = RingRange.Create(0, 2_147_483_648u);
+        var half2 = RingRange.Create(2_147_483_648u, 0);
+
+        var fullCombined = Create(half1, half2);
+        Assert.True(fullCombined.IsFull);
+        Assert.Equal(uint.MaxValue, fullCombined.Size);
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_DifferenceScenarios()
+    {
+        var c1 = Create(RingRange.Create(10, 20));
+        var c2 = Create(RingRange.Create(10, 20), RingRange.Create(30, 40));
+
+        // Difference when previous has fewer ranges (0 vs 1)
+        Assert.Equal(c1, c1.Difference(RingRangeCollection.Empty));
+
+        // Difference when current is empty vs non-empty previous (0 vs 1)
+        Assert.True(RingRangeCollection.Empty.Difference(c1).IsEmpty);
+    }
+
+    [Fact]
+    public void Property_Contains_MatchesIndividualRanges()
+    {
+        Gen.Select(GenRingRangeCollection, Gen.UInt).Sample((collection, point) =>
+        {
+            var expected = collection.Ranges.IsDefaultOrEmpty ? false : collection.Ranges.Any(r => r.Contains(point));
+            Assert.Equal(expected, collection.Contains(point));
+        });
+    }
+
+    [Fact]
+    public void Property_IntersectsRange_MatchesIndividualRanges()
+    {
+        Gen.Select(GenRingRangeCollection, RingRangeTests.GenRingRange).Sample((collection, range) =>
+        {
+            var actual = collection.Intersects(range);
+            if (collection.IsEmpty || range.IsEmpty)
+            {
+                Assert.False(actual);
+            }
+            else
+            {
+                var expected = collection.Contains(range.End) || collection.Ranges.Any(r => range.Contains(r.End));
+                Assert.Equal(expected, actual);
+            }
+        });
+    }
+
+    [Fact]
+    public void Property_IntersectsCollection_SymmetricAndMatchesRanges()
+    {
+        Gen.Select(GenRingRangeCollection, GenRingRangeCollection).Sample((c1, c2) =>
+        {
+            var actual1 = c1.Intersects(c2);
+            var actual2 = c2.Intersects(c1);
+
+            Assert.Equal(actual1, actual2);
+
+            if (c1.IsEmpty || c2.IsEmpty)
+            {
+                Assert.False(actual1);
+            }
+            else
+            {
+                var expected = c1.Ranges.Any(r1 => c2.Ranges.Any(r2 => r1.Intersects(r2)));
+                Assert.Equal(expected, actual1);
+            }
+        });
+    }
+
+    [Fact]
+    public void Property_SizeAndIsFull()
+    {
+        GenRingRangeCollection.Sample(collection =>
+        {
+            if (collection.IsEmpty)
+            {
+                Assert.Equal(0u, collection.Size);
+                Assert.False(collection.IsFull);
+            }
+            else
+            {
+                long expectedSum = 0;
+                foreach (var r in collection.Ranges)
+                {
+                    expectedSum += r.Size;
+                }
+
+                uint expectedSize = expectedSum >= uint.MaxValue ? uint.MaxValue : (uint)expectedSum;
+                Assert.Equal(expectedSize, collection.Size);
+                Assert.Equal(expectedSize == uint.MaxValue, collection.IsFull);
+            }
+        });
+    }
+
+    [Fact]
+    public void Property_EqualityAndHashing()
+    {
+        Gen.Select(GenRingRangeCollection, GenRingRangeCollection, GenRingRangeCollection).Sample((c1, c2, c3) =>
+        {
+            var c1Same = c1;
+            // Reflexivity
+            Assert.True(c1 == c1Same);
+            Assert.True(c1.Equals(c1));
+            Assert.True(c1.Equals((object)c1));
+            Assert.False(c1 != c1Same);
+
+            // Symmetry
+            Assert.Equal(c1 == c2, c2 == c1);
+            Assert.Equal(c1.Equals(c2), c2.Equals(c1));
+
+            // Transitivity
+            if (c1 == c2 && c2 == c3)
+            {
+                Assert.True(c1 == c3);
+            }
+
+            // HashCode consistency
+            if (c1 == c2)
+            {
+                Assert.Equal(c1.GetHashCode(), c2.GetHashCode());
+            }
+
+            Assert.Equal(c1 != c2, !(c1 == c2));
+        });
     }
 
     private static RingRangeCollection Create(params RingRange[] ranges) => RingRangeCollection.Create(ranges);

--- a/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
@@ -638,4 +638,247 @@ public sealed class RingRangeTests
             }
         });
     }
+
+    [Fact]
+    public void BoundaryValueAnalysis_RangeCreationAndProperties()
+    {
+        // 1. Empty range boundary
+        var empty = RingRange.Create(0, 0);
+        Assert.True(empty.IsEmpty);
+        Assert.False(empty.IsFull);
+        Assert.False(empty.IsWrapped);
+        Assert.Equal(0u, empty.Start);
+        Assert.Equal(0u, empty.End);
+        Assert.Equal(0u, empty.Size);
+        Assert.Equal(0.0f, empty.SizePercent);
+
+        // 2. Full range boundaries (Start == End > 0)
+        var fullBoundary1 = RingRange.Create(1, 1);
+        var fullBoundary2 = RingRange.Create(2, 2);
+        var fullBoundaryMax = RingRange.Create(uint.MaxValue, uint.MaxValue);
+        Assert.Equal(RingRange.Full, fullBoundary1);
+        Assert.Equal(RingRange.Full, fullBoundary2);
+        Assert.Equal(RingRange.Full, fullBoundaryMax);
+
+        foreach (var full in new[] { RingRange.Full, fullBoundary1, fullBoundary2, fullBoundaryMax })
+        {
+            Assert.False(full.IsEmpty);
+            Assert.True(full.IsFull);
+            Assert.True(full.IsWrapped);
+            Assert.Equal(0u, full.Start);
+            Assert.Equal(0u, full.End);
+            Assert.Equal(uint.MaxValue, full.Size);
+            Assert.Equal(100.0f, full.SizePercent);
+        }
+
+        // 3. FromPoint boundary cases (0, 1, 2, uint.MaxValue - 1, uint.MaxValue)
+        var p0 = RingRange.FromPoint(0);
+        Assert.Equal(uint.MaxValue, p0.Start);
+        Assert.Equal(0u, p0.End);
+        Assert.Equal(1u, p0.Size);
+        Assert.True(p0.IsWrapped);
+
+        var p1 = RingRange.FromPoint(1);
+        Assert.Equal(0u, p1.Start);
+        Assert.Equal(1u, p1.End);
+        Assert.Equal(1u, p1.Size);
+        Assert.False(p1.IsWrapped);
+
+        var pMax = RingRange.FromPoint(uint.MaxValue);
+        Assert.Equal(uint.MaxValue - 1, pMax.Start);
+        Assert.Equal(uint.MaxValue, pMax.End);
+        Assert.Equal(1u, pMax.Size);
+        Assert.False(pMax.IsWrapped);
+
+        // 4. Normal range boundaries
+        var minNormal = RingRange.Create(0, 1);
+        Assert.Equal(0u, minNormal.Start);
+        Assert.Equal(1u, minNormal.End);
+        Assert.Equal(1u, minNormal.Size);
+        Assert.False(minNormal.IsWrapped);
+
+        var maxNormal0 = RingRange.Create(0, uint.MaxValue);
+        Assert.Equal(0u, maxNormal0.Start);
+        Assert.Equal(uint.MaxValue, maxNormal0.End);
+        Assert.Equal(uint.MaxValue, maxNormal0.Size);
+        Assert.False(maxNormal0.IsWrapped);
+
+        var minNormalAtEnd = RingRange.Create(uint.MaxValue - 1, uint.MaxValue);
+        Assert.Equal(uint.MaxValue - 1, minNormalAtEnd.Start);
+        Assert.Equal(uint.MaxValue, minNormalAtEnd.End);
+        Assert.Equal(1u, minNormalAtEnd.Size);
+        Assert.False(minNormalAtEnd.IsWrapped);
+
+        // 5. Wrapped range boundaries
+        var minWrapped = RingRange.Create(uint.MaxValue, 0);
+        Assert.Equal(uint.MaxValue, minWrapped.Start);
+        Assert.Equal(0u, minWrapped.End);
+        Assert.Equal(1u, minWrapped.Size);
+        Assert.True(minWrapped.IsWrapped);
+
+        var maxWrapped1 = RingRange.Create(1, 0);
+        Assert.Equal(1u, maxWrapped1.Start);
+        Assert.Equal(0u, maxWrapped1.End);
+        Assert.Equal(uint.MaxValue, maxWrapped1.Size);
+        Assert.True(maxWrapped1.IsWrapped);
+
+        var maxWrapped2 = RingRange.Create(uint.MaxValue - 1, 0);
+        Assert.Equal(uint.MaxValue - 1, maxWrapped2.Start);
+        Assert.Equal(0u, maxWrapped2.End);
+        Assert.Equal(2u, maxWrapped2.Size);
+        Assert.True(maxWrapped2.IsWrapped);
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_ContainsAndCompareTo()
+    {
+        uint[] points = [0, 1, 2, 10, 11, 20, 21, 100, uint.MaxValue - 1, uint.MaxValue];
+
+        // Empty range
+        foreach (var p in points)
+        {
+            Assert.False(RingRange.Empty.Contains(p));
+            if (p == 0)
+                Assert.Equal(1, RingRange.Empty.CompareTo(p));
+            else
+                Assert.Equal(-1, RingRange.Empty.CompareTo(p));
+        }
+
+        // Full range
+        foreach (var p in points)
+        {
+            Assert.True(RingRange.Full.Contains(p));
+            Assert.Equal(0, RingRange.Full.CompareTo(p));
+        }
+
+        // Normal range (10, 20]
+        var normal = RingRange.Create(10, 20);
+        Assert.False(normal.Contains(10)); // Start is exclusive
+        Assert.True(normal.Contains(11));
+        Assert.True(normal.Contains(20));  // End is inclusive
+        Assert.False(normal.Contains(21));
+        Assert.Equal(1, normal.CompareTo(0));
+        Assert.Equal(1, normal.CompareTo(10));
+        Assert.Equal(0, normal.CompareTo(11));
+        Assert.Equal(0, normal.CompareTo(20));
+        Assert.Equal(-1, normal.CompareTo(21));
+        Assert.Equal(-1, normal.CompareTo(uint.MaxValue));
+
+        // Wrapped range (uint.MaxValue - 1, 1]
+        var wrapped = RingRange.Create(uint.MaxValue - 1, 1);
+        Assert.False(wrapped.Contains(uint.MaxValue - 1)); // Start is exclusive
+        Assert.True(wrapped.Contains(uint.MaxValue));
+        Assert.True(wrapped.Contains(0));
+        Assert.True(wrapped.Contains(1));                  // End is inclusive
+        Assert.False(wrapped.Contains(2));
+        Assert.Equal(0, wrapped.CompareTo(0));
+        Assert.Equal(0, wrapped.CompareTo(1));
+        Assert.Equal(0, wrapped.CompareTo(uint.MaxValue));
+        Assert.Equal(-1, wrapped.CompareTo(2));
+        Assert.Equal(-1, wrapped.CompareTo(100));
+        Assert.Equal(-1, wrapped.CompareTo(uint.MaxValue - 1));
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_TwoWrappedRangesIntersections()
+    {
+        // Double intersection when two wrapped ranges overlap in two distinct segments
+        // w1: (1000, 500] covers 1001..uint.MaxValue and 0..500
+        // w2: (2000, 1200] covers 2001..uint.MaxValue and 0..1200
+        var w1 = RingRange.Create(1000, 500);
+        var w2 = RingRange.Create(2000, 1200);
+
+        var intersections = w1.Intersections(w2).ToArray();
+        Assert.Equal(2, intersections.Length);
+        Assert.Equal(RingRange.Create(2000, 500), intersections[0]);
+        Assert.Equal(RingRange.Create(1000, 1200), intersections[1]);
+
+        // Symmetric check
+        var reversedIntersections = w2.Intersections(w1).ToArray();
+        Assert.Equal(2, reversedIntersections.Length);
+        Assert.Equal(RingRange.Create(2000, 500), reversedIntersections[0]);
+        Assert.Equal(RingRange.Create(1000, 1200), reversedIntersections[1]);
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_TryFormat()
+    {
+        Span<char> smallBuffer = stackalloc char[1];
+        Span<char> largeBuffer = stackalloc char[128];
+
+        // Empty
+        Assert.False(((ISpanFormattable)RingRange.Empty).TryFormat(smallBuffer, out var written, default, null));
+        Assert.Equal(0, written);
+        Assert.True(((ISpanFormattable)RingRange.Empty).TryFormat(largeBuffer, out written, default, null));
+        Assert.Equal("(0, 0) 0.00%", largeBuffer[..written].ToString());
+
+        // Full
+        Assert.False(((ISpanFormattable)RingRange.Full).TryFormat(smallBuffer, out written, default, null));
+        Assert.Equal(0, written);
+        Assert.True(((ISpanFormattable)RingRange.Full).TryFormat(largeBuffer, out written, default, null));
+        Assert.Equal("(0, 0] (100.00%)", largeBuffer[..written].ToString());
+
+        // Normal
+        var normal = RingRange.Create(0, 1);
+        Assert.False(((ISpanFormattable)normal).TryFormat(smallBuffer, out written, default, null));
+        Assert.Equal(0, written);
+        Assert.True(((ISpanFormattable)normal).TryFormat(largeBuffer, out written, default, null));
+
+        // Wrapped
+        var wrapped = RingRange.Create(uint.MaxValue, 0);
+        Assert.False(((ISpanFormattable)wrapped).TryFormat(smallBuffer, out written, default, null));
+        Assert.Equal(0, written);
+        Assert.True(((ISpanFormattable)wrapped).TryFormat(largeBuffer, out written, default, null));
+    }
+
+    [Fact]
+    public void BoundaryValueAnalysis_CsCheckAllBoundaries()
+    {
+        var genBoundaryUint = Gen.OneOf(
+            Gen.Const(0u),
+            Gen.Const(1u),
+            Gen.Const(2u),
+            Gen.Const(uint.MaxValue - 1),
+            Gen.Const(uint.MaxValue),
+            Gen.UInt
+        );
+
+        var genBoundaryRange = Gen.Select(genBoundaryUint, genBoundaryUint, RingRange.Create);
+
+        Gen.Select(genBoundaryRange, genBoundaryUint).Sample((range, point) =>
+        {
+            // Verify size is correct and non-negative
+            Assert.True(range.Size <= uint.MaxValue);
+
+            // Verify contains logic matches boundary definition
+            var contains = range.Contains(point);
+            if (range.IsEmpty)
+            {
+                Assert.False(contains);
+            }
+            else if (range.IsFull)
+            {
+                Assert.True(contains);
+            }
+            else if (range.Start < range.End)
+            {
+                Assert.Equal(point > range.Start && point <= range.End, contains);
+            }
+            else
+            {
+                Assert.Equal(point > range.Start || point <= range.End, contains);
+            }
+
+            // Verify CompareTo contract
+            var cmp = range.CompareTo(point);
+            if (contains)
+            {
+                Assert.Equal(0, cmp);
+            }
+            else
+            {
+                Assert.NotEqual(0, cmp);
+            }
+        });
+    }
 }

--- a/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
@@ -1,3 +1,4 @@
+using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
 using CsCheck;
 using Xunit;
@@ -172,7 +173,8 @@ public sealed class RingRangeTests
             previous = range;
         }
 
-        Assert.Equal(uint.MaxValue, sum);
+        var expectedSum = count == 1 ? uint.MaxValue : (ulong)uint.MaxValue + 1;
+        Assert.Equal(expectedSum, sum);
     }
 
     private static RingRange CreateEquallyDividedRange(int count, int index)
@@ -308,5 +310,332 @@ public sealed class RingRangeTests
         }
 
         return RingRange.Create(unchecked(start - 1), end);
+    }
+
+    [Fact]
+    public void FromPoint_UnitTests()
+    {
+        // Point 0 (wraps around: Start = uint.MaxValue, End = 0)
+        var range0 = RingRange.FromPoint(0);
+        Assert.Equal(uint.MaxValue, range0.Start);
+        Assert.Equal(0u, range0.End);
+        Assert.Equal(1u, range0.Size);
+        Assert.False(range0.IsEmpty);
+        Assert.False(range0.IsFull);
+        Assert.True(range0.IsWrapped);
+        Assert.True(range0.Contains(0));
+        Assert.False(range0.Contains(1));
+        Assert.False(range0.Contains(uint.MaxValue));
+
+        // Point 1 (Start = 0, End = 1)
+        var range1 = RingRange.FromPoint(1);
+        Assert.Equal(0u, range1.Start);
+        Assert.Equal(1u, range1.End);
+        Assert.Equal(1u, range1.Size);
+        Assert.False(range1.IsEmpty);
+        Assert.False(range1.IsFull);
+        Assert.False(range1.IsWrapped);
+        Assert.True(range1.Contains(1));
+        Assert.False(range1.Contains(0));
+        Assert.False(range1.Contains(2));
+
+        // Arbitrary point 42 (Start = 41, End = 42)
+        var range42 = RingRange.FromPoint(42);
+        Assert.Equal(41u, range42.Start);
+        Assert.Equal(42u, range42.End);
+        Assert.Equal(1u, range42.Size);
+        Assert.True(range42.Contains(42));
+        Assert.False(range42.Contains(41));
+        Assert.False(range42.Contains(43));
+
+        // Point uint.MaxValue (Start = uint.MaxValue - 1, End = uint.MaxValue)
+        var rangeMax = RingRange.FromPoint(uint.MaxValue);
+        Assert.Equal(uint.MaxValue - 1, rangeMax.Start);
+        Assert.Equal(uint.MaxValue, rangeMax.End);
+        Assert.Equal(1u, rangeMax.Size);
+        Assert.True(rangeMax.Contains(uint.MaxValue));
+        Assert.False(rangeMax.Contains(uint.MaxValue - 1));
+        Assert.False(rangeMax.Contains(0));
+    }
+
+    [Fact]
+    public void FromPoint_GrainId()
+    {
+        var grainId = GrainId.Create("testGrainType", "testGrainKey");
+        var range = RingRange.FromPoint(grainId.GetUniformHashCode());
+        Assert.True(range.Contains(grainId));
+    }
+
+    [Fact]
+    public void FromPoint_CsCheckProperty()
+    {
+        Gen.Select(Gen.UInt, Gen.UInt).Sample((point, other) =>
+        {
+            var range = RingRange.FromPoint(point);
+            Assert.Equal(1u, range.Size);
+            Assert.False(range.IsEmpty);
+            Assert.False(range.IsFull);
+            Assert.True(range.Contains(point));
+            Assert.Equal(unchecked(point - 1), range.Start);
+            Assert.Equal(point, range.End);
+            Assert.Equal(point == 0, range.IsWrapped);
+
+            Assert.Equal(other == point, range.Contains(other));
+            Assert.Equal(0, range.CompareTo(point));
+
+            var complement = range.Complement();
+            Assert.False(complement.Contains(point));
+            Assert.Equal(uint.MaxValue, complement.Size);
+        });
+    }
+
+    [Fact]
+    public void RingRange_CreateAndNormalization()
+    {
+        var empty = RingRange.Create(0, 0);
+        Assert.True(empty.IsEmpty);
+        Assert.False(empty.IsFull);
+        Assert.Equal(0u, empty.Start);
+        Assert.Equal(0u, empty.End);
+
+        var full1 = RingRange.Create(1, 1);
+        Assert.False(full1.IsEmpty);
+        Assert.True(full1.IsFull);
+        Assert.Equal(0u, full1.Start);
+        Assert.Equal(0u, full1.End);
+
+        var full2 = RingRange.Create(2, 2);
+        Assert.False(full2.IsEmpty);
+        Assert.True(full2.IsFull);
+        Assert.Equal(0u, full2.Start);
+        Assert.Equal(0u, full2.End);
+
+        var fullMax = RingRange.Create(uint.MaxValue, uint.MaxValue);
+        Assert.False(fullMax.IsEmpty);
+        Assert.True(fullMax.IsFull);
+
+        Assert.True(RingRange.Empty.IsEmpty);
+        Assert.True(RingRange.Full.IsFull);
+    }
+
+    [Fact]
+    public void RingRange_SizeAndPercent_CsCheckProperty()
+    {
+        Gen.Select(Gen.UInt, Gen.UInt).Sample((start, end) =>
+        {
+            var range = RingRange.Create(start, end);
+            ulong expectedSize;
+            if (start == end)
+            {
+                expectedSize = start == 0 ? 0UL : uint.MaxValue;
+            }
+            else if (start < end)
+            {
+                expectedSize = (ulong)end - start;
+            }
+            else
+            {
+                expectedSize = (ulong)uint.MaxValue - start + end + 1;
+            }
+
+            Assert.Equal((uint)expectedSize, range.Size);
+            Assert.Equal((float)(expectedSize * (100.0f / uint.MaxValue)), range.SizePercent);
+            Assert.Equal(start == 0 && end == 0, range.IsEmpty);
+            Assert.Equal(start == end && start != 0, range.IsFull);
+            Assert.Equal(start >= end && start != 0, range.IsWrapped);
+        });
+    }
+
+    [Fact]
+    public void RingRange_Contains_CsCheckProperty()
+    {
+        Gen.Select(GenRingRange, Gen.UInt).Sample((range, point) =>
+        {
+            bool expected;
+            if (range.IsEmpty)
+            {
+                expected = false;
+            }
+            else if (range.IsFull)
+            {
+                expected = true;
+            }
+            else if (range.Start < range.End)
+            {
+                expected = point > range.Start && point <= range.End;
+            }
+            else
+            {
+                expected = point > range.Start || point <= range.End;
+            }
+
+            Assert.Equal(expected, range.Contains(point));
+        });
+    }
+
+    [Fact]
+    public void RingRange_CompareTo_UnitTests()
+    {
+        // Full range
+        Assert.Equal(0, RingRange.Full.CompareTo(0));
+        Assert.Equal(0, RingRange.Full.CompareTo(42));
+        Assert.Equal(0, RingRange.Full.CompareTo(uint.MaxValue));
+
+        // Empty range
+        Assert.Equal(1, RingRange.Empty.CompareTo(0));
+        Assert.Equal(-1, RingRange.Empty.CompareTo(1));
+        Assert.Equal(-1, RingRange.Empty.CompareTo(100));
+
+        // Normal range (10, 20]
+        var normal = RingRange.Create(10, 20);
+        Assert.Equal(0, normal.CompareTo(11));
+        Assert.Equal(0, normal.CompareTo(15));
+        Assert.Equal(0, normal.CompareTo(20));
+        Assert.Equal(1, normal.CompareTo(10));
+        Assert.Equal(1, normal.CompareTo(5));
+        Assert.Equal(-1, normal.CompareTo(21));
+        Assert.Equal(-1, normal.CompareTo(100));
+
+        // Wrapped range (100, 10]
+        var wrapped = RingRange.Create(100, 10);
+        Assert.Equal(0, wrapped.CompareTo(0));
+        Assert.Equal(0, wrapped.CompareTo(5));
+        Assert.Equal(0, wrapped.CompareTo(10));
+        Assert.Equal(0, wrapped.CompareTo(101));
+        Assert.Equal(0, wrapped.CompareTo(uint.MaxValue));
+        Assert.Equal(-1, wrapped.CompareTo(11));
+        Assert.Equal(-1, wrapped.CompareTo(50));
+        Assert.Equal(-1, wrapped.CompareTo(100));
+    }
+
+    [Fact]
+    public void RingRange_CompareTo_CsCheckProperty()
+    {
+        Gen.Select(GenRingRange, Gen.UInt).Sample((range, point) =>
+        {
+            var cmp = range.CompareTo(point);
+            if (range.Contains(point))
+            {
+                Assert.Equal(0, cmp);
+            }
+            else
+            {
+                Assert.NotEqual(0, cmp);
+                if (range.IsWrapped)
+                {
+                    if (point <= range.Start)
+                    {
+                        Assert.Equal(-1, cmp);
+                    }
+                    else
+                    {
+                        Assert.Equal(1, cmp);
+                    }
+                }
+                else
+                {
+                    if (point <= range.Start)
+                    {
+                        Assert.Equal(1, cmp);
+                    }
+                    else
+                    {
+                        Assert.Equal(-1, cmp);
+                    }
+                }
+            }
+        });
+    }
+
+    [Fact]
+    public void RingRange_EqualityAndHashing_UnitTests()
+    {
+        var r1 = RingRange.Create(10, 20);
+        var r1Copy = RingRange.Create(10, 20);
+        var r2 = RingRange.Create(10, 21);
+
+        Assert.True(r1.Equals(r1Copy));
+        Assert.True(r1.Equals((object)r1Copy));
+        Assert.False(r1.Equals(r2));
+        Assert.False(r1.Equals(null));
+        Assert.False(r1.Equals("not a range"));
+
+        Assert.True(r1 == r1Copy);
+        Assert.False(r1 != r1Copy);
+        Assert.False(r1 == r2);
+        Assert.True(r1 != r2);
+
+        Assert.Equal(r1.GetHashCode(), r1Copy.GetHashCode());
+    }
+
+    [Fact]
+    public void RingRange_EqualityAndHashing_CsCheckProperty()
+    {
+        Gen.Select(GenRingRange, GenRingRange, GenRingRange).Sample((r1, r2, r3) =>
+        {
+            var r1Same = r1;
+            // Reflexivity
+            Assert.True(r1 == r1Same);
+            Assert.True(r1.Equals(r1));
+            Assert.True(r1.Equals((object)r1));
+            Assert.False(r1 != r1Same);
+
+            // Symmetry
+            Assert.Equal(r1 == r2, r2 == r1);
+            Assert.Equal(r1.Equals(r2), r2.Equals(r1));
+
+            // Transitivity
+            if (r1 == r2 && r2 == r3)
+            {
+                Assert.True(r1 == r3);
+            }
+
+            // HashCode consistency
+            if (r1 == r2)
+            {
+                Assert.Equal(r1.GetHashCode(), r2.GetHashCode());
+            }
+
+            Assert.Equal(r1 != r2, !(r1 == r2));
+        });
+    }
+
+    [Fact]
+    public void RingRange_Formatting_UnitTests()
+    {
+        Assert.Equal("(0, 0) 0.00%", RingRange.Empty.ToString());
+        Assert.Equal("(0, 0] (100.00%)", RingRange.Full.ToString());
+
+        var range = RingRange.Create(1, 10);
+        var formatted = range.ToString();
+        Assert.Contains("0x00000001", formatted);
+        Assert.Contains("0x0000000A", formatted);
+
+        Assert.Equal(formatted, ((IFormattable)range).ToString(null, null));
+
+        Span<char> buffer = stackalloc char[64];
+        Assert.True(((ISpanFormattable)range).TryFormat(buffer, out var charsWritten, default, null));
+        Assert.Equal(formatted, buffer[..charsWritten].ToString());
+
+        Span<char> smallBuffer = stackalloc char[1];
+        Assert.False(((ISpanFormattable)range).TryFormat(smallBuffer, out charsWritten, default, null));
+        Assert.Equal(0, charsWritten);
+    }
+
+    [Fact]
+    public void RingRange_Complement_CsCheckProperty()
+    {
+        Gen.Select(GenRingRange, Gen.UInt).Sample((r, p) =>
+        {
+            var comp = r.Complement();
+            Assert.Equal(r, comp.Complement());
+
+            if (!r.IsEmpty && !r.IsFull)
+            {
+                Assert.True(r.Contains(p) ^ comp.Contains(p));
+                Assert.Equal((ulong)uint.MaxValue + 1, (ulong)r.Size + comp.Size);
+                Assert.False(r.Intersects(comp));
+            }
+        });
     }
 }

--- a/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
@@ -16,6 +16,14 @@ public sealed class RingRangeTests
 {
     internal static Gen<RingRange> GenRingRange => Gen.Select(Gen.UInt, Gen.UInt, RingRange.Create);
 
+    internal static Gen<uint> GenBoundaryPoint => Gen.OneOf(
+        Gen.Const(0u),
+        Gen.Const(1u),
+        Gen.Const(2u),
+        Gen.Const(uint.MaxValue - 1),
+        Gen.Const(uint.MaxValue),
+        Gen.UInt);
+
     [Fact]
     public void RingRangeDifference_EquallyDividedRange()
     {
@@ -173,8 +181,7 @@ public sealed class RingRangeTests
             previous = range;
         }
 
-        var expectedSum = count == 1 ? uint.MaxValue : (ulong)uint.MaxValue + 1;
-        Assert.Equal(expectedSum, sum);
+        Assert.Equal(1UL << 32, sum);
     }
 
     private static RingRange CreateEquallyDividedRange(int count, int index)
@@ -302,6 +309,9 @@ public sealed class RingRangeTests
         }
     }
 
+    internal static ulong GetExpectedSize(RingRange range) =>
+        ToIntervals(range).Aggregate(0UL, static (sum, interval) => sum + ((ulong)interval.End - interval.Start + 1));
+
     private static RingRange FromInclusiveInterval(uint start, uint end)
     {
         if (start == 0 && end == uint.MaxValue)
@@ -319,7 +329,7 @@ public sealed class RingRangeTests
         var range0 = RingRange.FromPoint(0);
         Assert.Equal(uint.MaxValue, range0.Start);
         Assert.Equal(0u, range0.End);
-        Assert.Equal(1u, range0.Size);
+        Assert.Equal(1UL, range0.Size);
         Assert.False(range0.IsEmpty);
         Assert.False(range0.IsFull);
         Assert.True(range0.IsWrapped);
@@ -331,7 +341,7 @@ public sealed class RingRangeTests
         var range1 = RingRange.FromPoint(1);
         Assert.Equal(0u, range1.Start);
         Assert.Equal(1u, range1.End);
-        Assert.Equal(1u, range1.Size);
+        Assert.Equal(1UL, range1.Size);
         Assert.False(range1.IsEmpty);
         Assert.False(range1.IsFull);
         Assert.False(range1.IsWrapped);
@@ -343,7 +353,7 @@ public sealed class RingRangeTests
         var range42 = RingRange.FromPoint(42);
         Assert.Equal(41u, range42.Start);
         Assert.Equal(42u, range42.End);
-        Assert.Equal(1u, range42.Size);
+        Assert.Equal(1UL, range42.Size);
         Assert.True(range42.Contains(42));
         Assert.False(range42.Contains(41));
         Assert.False(range42.Contains(43));
@@ -352,7 +362,7 @@ public sealed class RingRangeTests
         var rangeMax = RingRange.FromPoint(uint.MaxValue);
         Assert.Equal(uint.MaxValue - 1, rangeMax.Start);
         Assert.Equal(uint.MaxValue, rangeMax.End);
-        Assert.Equal(1u, rangeMax.Size);
+        Assert.Equal(1UL, rangeMax.Size);
         Assert.True(rangeMax.Contains(uint.MaxValue));
         Assert.False(rangeMax.Contains(uint.MaxValue - 1));
         Assert.False(rangeMax.Contains(0));
@@ -372,7 +382,7 @@ public sealed class RingRangeTests
         Gen.Select(Gen.UInt, Gen.UInt).Sample((point, other) =>
         {
             var range = RingRange.FromPoint(point);
-            Assert.Equal(1u, range.Size);
+            Assert.Equal(1UL, range.Size);
             Assert.False(range.IsEmpty);
             Assert.False(range.IsFull);
             Assert.True(range.Contains(point));
@@ -385,7 +395,7 @@ public sealed class RingRangeTests
 
             var complement = range.Complement();
             Assert.False(complement.Contains(point));
-            Assert.Equal(uint.MaxValue, complement.Size);
+            Assert.Equal((ulong)uint.MaxValue, complement.Size);
         });
     }
 
@@ -421,29 +431,39 @@ public sealed class RingRangeTests
     [Fact]
     public void RingRange_SizeAndPercent_CsCheckProperty()
     {
-        Gen.Select(Gen.UInt, Gen.UInt).Sample((start, end) =>
+        Gen.Select(GenBoundaryPoint, GenBoundaryPoint).Sample((start, end) =>
         {
             var range = RingRange.Create(start, end);
-            ulong expectedSize;
-            if (start == end)
-            {
-                expectedSize = start == 0 ? 0UL : uint.MaxValue;
-            }
-            else if (start < end)
-            {
-                expectedSize = (ulong)end - start;
-            }
-            else
-            {
-                expectedSize = (ulong)uint.MaxValue - start + end + 1;
-            }
+            var expectedSize = GetExpectedSize(range);
 
-            Assert.Equal((uint)expectedSize, range.Size);
-            Assert.Equal((float)(expectedSize * (100.0f / uint.MaxValue)), range.SizePercent);
+            Assert.Equal(expectedSize, range.Size);
+            Assert.Equal(expectedSize * (100.0f / (1UL << 32)), range.SizePercent);
             Assert.Equal(start == 0 && end == 0, range.IsEmpty);
             Assert.Equal(start == end && start != 0, range.IsFull);
             Assert.Equal(start >= end && start != 0, range.IsWrapped);
         });
+    }
+
+    [Theory]
+    [InlineData(0u, 0u, 0UL)]
+    [InlineData(1u, 1u, 1UL << 32)]
+    [InlineData(uint.MaxValue, uint.MaxValue, 1UL << 32)]
+    [InlineData(0u, 1u, 1UL)]
+    [InlineData(uint.MaxValue, 0u, 1UL)]
+    [InlineData(uint.MaxValue - 1, 0u, 2UL)]
+    [InlineData(0u, 1u << 31, 1UL << 31)]
+    [InlineData(1u << 31, 0u, 1UL << 31)]
+    [InlineData(0u, uint.MaxValue - 1, (1UL << 32) - 2)]
+    [InlineData(2u, 0u, (1UL << 32) - 2)]
+    [InlineData(0u, uint.MaxValue, (1UL << 32) - 1)]
+    [InlineData(1u, 0u, (1UL << 32) - 1)]
+    public void Size_CountsCoveredPointsAtBoundaries(uint start, uint end, ulong expectedSize)
+    {
+        var range = RingRange.Create(start, end);
+
+        Assert.Equal(expectedSize, range.Size);
+        Assert.Equal((1UL << 32) - expectedSize, range.Complement().Size);
+        Assert.Equal(expectedSize == 1UL << 32, range.IsFull);
     }
 
     [Fact]
@@ -625,17 +645,14 @@ public sealed class RingRangeTests
     [Fact]
     public void RingRange_Complement_CsCheckProperty()
     {
-        Gen.Select(GenRingRange, Gen.UInt).Sample((r, p) =>
+        var genRange = Gen.Select(GenBoundaryPoint, GenBoundaryPoint, RingRange.Create);
+        Gen.Select(genRange, GenBoundaryPoint).Sample((r, p) =>
         {
             var comp = r.Complement();
             Assert.Equal(r, comp.Complement());
-
-            if (!r.IsEmpty && !r.IsFull)
-            {
-                Assert.True(r.Contains(p) ^ comp.Contains(p));
-                Assert.Equal((ulong)uint.MaxValue + 1, (ulong)r.Size + comp.Size);
-                Assert.False(r.Intersects(comp));
-            }
+            Assert.True(r.Contains(p) ^ comp.Contains(p));
+            Assert.Equal(1UL << 32, r.Size + comp.Size);
+            Assert.False(r.Intersects(comp));
         });
     }
 
@@ -649,7 +666,7 @@ public sealed class RingRangeTests
         Assert.False(empty.IsWrapped);
         Assert.Equal(0u, empty.Start);
         Assert.Equal(0u, empty.End);
-        Assert.Equal(0u, empty.Size);
+        Assert.Equal(0UL, empty.Size);
         Assert.Equal(0.0f, empty.SizePercent);
 
         // 2. Full range boundaries (Start == End > 0)
@@ -667,7 +684,7 @@ public sealed class RingRangeTests
             Assert.True(full.IsWrapped);
             Assert.Equal(0u, full.Start);
             Assert.Equal(0u, full.End);
-            Assert.Equal(uint.MaxValue, full.Size);
+            Assert.Equal(1UL << 32, full.Size);
             Assert.Equal(100.0f, full.SizePercent);
         }
 
@@ -675,57 +692,57 @@ public sealed class RingRangeTests
         var p0 = RingRange.FromPoint(0);
         Assert.Equal(uint.MaxValue, p0.Start);
         Assert.Equal(0u, p0.End);
-        Assert.Equal(1u, p0.Size);
+        Assert.Equal(1UL, p0.Size);
         Assert.True(p0.IsWrapped);
 
         var p1 = RingRange.FromPoint(1);
         Assert.Equal(0u, p1.Start);
         Assert.Equal(1u, p1.End);
-        Assert.Equal(1u, p1.Size);
+        Assert.Equal(1UL, p1.Size);
         Assert.False(p1.IsWrapped);
 
         var pMax = RingRange.FromPoint(uint.MaxValue);
         Assert.Equal(uint.MaxValue - 1, pMax.Start);
         Assert.Equal(uint.MaxValue, pMax.End);
-        Assert.Equal(1u, pMax.Size);
+        Assert.Equal(1UL, pMax.Size);
         Assert.False(pMax.IsWrapped);
 
         // 4. Normal range boundaries
         var minNormal = RingRange.Create(0, 1);
         Assert.Equal(0u, minNormal.Start);
         Assert.Equal(1u, minNormal.End);
-        Assert.Equal(1u, minNormal.Size);
+        Assert.Equal(1UL, minNormal.Size);
         Assert.False(minNormal.IsWrapped);
 
         var maxNormal0 = RingRange.Create(0, uint.MaxValue);
         Assert.Equal(0u, maxNormal0.Start);
         Assert.Equal(uint.MaxValue, maxNormal0.End);
-        Assert.Equal(uint.MaxValue, maxNormal0.Size);
+        Assert.Equal((ulong)uint.MaxValue, maxNormal0.Size);
         Assert.False(maxNormal0.IsWrapped);
 
         var minNormalAtEnd = RingRange.Create(uint.MaxValue - 1, uint.MaxValue);
         Assert.Equal(uint.MaxValue - 1, minNormalAtEnd.Start);
         Assert.Equal(uint.MaxValue, minNormalAtEnd.End);
-        Assert.Equal(1u, minNormalAtEnd.Size);
+        Assert.Equal(1UL, minNormalAtEnd.Size);
         Assert.False(minNormalAtEnd.IsWrapped);
 
         // 5. Wrapped range boundaries
         var minWrapped = RingRange.Create(uint.MaxValue, 0);
         Assert.Equal(uint.MaxValue, minWrapped.Start);
         Assert.Equal(0u, minWrapped.End);
-        Assert.Equal(1u, minWrapped.Size);
+        Assert.Equal(1UL, minWrapped.Size);
         Assert.True(minWrapped.IsWrapped);
 
         var maxWrapped1 = RingRange.Create(1, 0);
         Assert.Equal(1u, maxWrapped1.Start);
         Assert.Equal(0u, maxWrapped1.End);
-        Assert.Equal(uint.MaxValue, maxWrapped1.Size);
+        Assert.Equal((ulong)uint.MaxValue, maxWrapped1.Size);
         Assert.True(maxWrapped1.IsWrapped);
 
         var maxWrapped2 = RingRange.Create(uint.MaxValue - 1, 0);
         Assert.Equal(uint.MaxValue - 1, maxWrapped2.Start);
         Assert.Equal(0u, maxWrapped2.End);
-        Assert.Equal(2u, maxWrapped2.Size);
+        Assert.Equal(2UL, maxWrapped2.Size);
         Assert.True(maxWrapped2.IsWrapped);
     }
 
@@ -834,21 +851,12 @@ public sealed class RingRangeTests
     [Fact]
     public void BoundaryValueAnalysis_CsCheckAllBoundaries()
     {
-        var genBoundaryUint = Gen.OneOf(
-            Gen.Const(0u),
-            Gen.Const(1u),
-            Gen.Const(2u),
-            Gen.Const(uint.MaxValue - 1),
-            Gen.Const(uint.MaxValue),
-            Gen.UInt
-        );
+        var genBoundaryRange = Gen.Select(GenBoundaryPoint, GenBoundaryPoint, RingRange.Create);
 
-        var genBoundaryRange = Gen.Select(genBoundaryUint, genBoundaryUint, RingRange.Create);
-
-        Gen.Select(genBoundaryRange, genBoundaryUint).Sample((range, point) =>
+        Gen.Select(genBoundaryRange, GenBoundaryPoint).Sample((range, point) =>
         {
-            // Verify size is correct and non-negative
-            Assert.True(range.Size <= uint.MaxValue);
+            Assert.InRange(range.Size, 0UL, 1UL << 32);
+            Assert.Equal(GetExpectedSize(range), range.Size);
 
             // Verify contains logic matches boundary definition
             var contains = range.Contains(point);

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionBatchingTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionBatchingTests.cs
@@ -60,6 +60,7 @@ public sealed class GrainDirectoryPartitionBatchingTests
         var ranges = GrainDirectoryPartition.GetActivationQueryRanges(RingRange.Full).ToArray();
 
         Assert.True(ranges.Length > 1);
+        Assert.Equal(1UL << 32, ranges.Aggregate(0UL, static (sum, range) => sum + range.Size));
         AssertRangePartition(RingRange.Full, ranges);
         AssertBalancedRanges(ranges);
     }
@@ -70,7 +71,7 @@ public sealed class GrainDirectoryPartitionBatchingTests
         Assert.All(ranges, static candidate => Assert.False(candidate.IsEmpty));
         Assert.Equal(range.Start, ranges[0].Start);
         Assert.Equal(range.End, ranges[^1].End);
-        Assert.Equal(GetRangeSize(range), ranges.Aggregate(0UL, static (sum, range) => sum + GetRangeSize(range)));
+        Assert.Equal(range.Size, ranges.Aggregate(0UL, static (sum, range) => sum + range.Size));
 
         for (var i = 1; i < ranges.Length; i++)
         {
@@ -80,20 +81,8 @@ public sealed class GrainDirectoryPartitionBatchingTests
 
     private static void AssertBalancedRanges(RingRange[] ranges)
     {
-        var sizes = ranges.Select(GetRangeSize).ToArray();
+        var sizes = ranges.Select(static range => range.Size).ToArray();
 
         Assert.True(sizes.Max() - sizes.Min() <= 1);
-    }
-
-    private static ulong GetRangeSize(RingRange range)
-    {
-        if (range.IsFull)
-        {
-            return (ulong)uint.MaxValue + 1;
-        }
-
-        return range.IsWrapped
-            ? (ulong)uint.MaxValue - range.Start + range.End + 1
-            : range.Size;
     }
 }


### PR DESCRIPTION
## Motivation

Grain directory partitioning depends on accurate range boundaries and point counts. A 32-bit ring contains 2^32 points, so both full-ring cardinality and almost-full ranges need distinct, exact sizes. Exact counts preserve the size-conservation invariant used during membership updates, including transitions between full and partial ownership.

This PR corrects the sizing contract and adds unit, CsCheck property-based, and boundary-value coverage for `RingRange` and `RingRangeCollection`.

## Summary of Changes

- Return exact `ulong` point counts from both `Size` properties, including 2^32 for a full ring. Include zero when counting wrapped ranges and sum non-overlapping collection ranges in one pass.
- Derive collection fullness from exact cardinality, calculate percentages against the full-ring count, and reuse `RingRange.Size` for directory query batching. Range endpoints remain `uint` and serialized fields retain their existing IDs.
- Exercise construction, single-point ranges, containment, comparison, intersections, complements, differences, equality, hashing, enumeration, and formatting using unit tests, CsCheck properties, and boundary values.
- Compare generated sizes with an independent inclusive-interval model. Cover full partitions, single-point gaps, and boundary cardinalities; assert exactly 2^32 covered points in directory membership tests.
- Give equal empty collection representations matching hash codes and make default collections enumerate as empty through both the struct enumerator and interface-based enumeration. Add regressions for both behaviors.