### PR TITLE
fix(streaming): satisfy checkpoint state analyzer

### DIFF
--- a/src/Orleans.Streaming/Checkpointers/StreamCheckpointStoreState.cs
+++ b/src/Orleans.Streaming/Checkpointers/StreamCheckpointStoreState.cs
@@ -5,7 +5,7 @@ namespace Orleans.Streams;
 /// <summary>
 /// Represents a persisted stream checkpoint and its backend version.
 /// </summary>
-public readonly struct StreamCheckpointStoreState
+public readonly struct StreamCheckpointStoreState : IEquatable<StreamCheckpointStoreState>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="StreamCheckpointStoreState"/> struct.
@@ -29,4 +29,20 @@ public readonly struct StreamCheckpointStoreState
     /// Gets the backend version or entity tag.
     /// </summary>
     public string Version { get; }
+
+    /// <inheritdoc />
+    public bool Equals(StreamCheckpointStoreState other)
+        => string.Equals(Checkpoint, other.Checkpoint, StringComparison.Ordinal)
+        && string.Equals(Version, other.Version, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is StreamCheckpointStoreState other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(Checkpoint, Version);
+
+    public static bool operator ==(StreamCheckpointStoreState left, StreamCheckpointStoreState right) => left.Equals(right);
+
+    public static bool operator !=(StreamCheckpointStoreState left, StreamCheckpointStoreState right) => !left.Equals(right);
 }

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -2208,7 +2208,7 @@ namespace Orleans.Streams
         public System.Threading.Tasks.ValueTask<string> Update(string offset, string expectedCheckpoint, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 
-    public readonly partial struct StreamCheckpointStoreState
+    public readonly partial struct StreamCheckpointStoreState : System.IEquatable<StreamCheckpointStoreState>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -2217,6 +2217,16 @@ namespace Orleans.Streams
         public string Checkpoint { get { throw null; } }
 
         public string Version { get { throw null; } }
+
+        public readonly bool Equals(StreamCheckpointStoreState other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(StreamCheckpointStoreState left, StreamCheckpointStoreState right) { throw null; }
+
+        public static bool operator !=(StreamCheckpointStoreState left, StreamCheckpointStoreState right) { throw null; }
     }
 
     [GenerateSerializer]

--- a/test/Orleans.Streaming.Tests/Checkpointers/ReusableStreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/ReusableStreamQueueCheckpointerTests.cs
@@ -15,6 +15,17 @@ public sealed class ReusableStreamQueueCheckpointerTests : StreamQueueCheckpoint
 {
     protected override OffsetRegressionPolicy RegressionPolicy => OffsetRegressionPolicy.Ignore;
 
+    [Fact]
+    public void StreamCheckpointStoreState_UsesValueEquality()
+    {
+        var state = new StreamCheckpointStoreState("10", "version-1");
+
+        Assert.Equal(state, new StreamCheckpointStoreState("10", "version-1"));
+        Assert.True(state == new StreamCheckpointStoreState("10", "version-1"));
+        Assert.False(state != new StreamCheckpointStoreState("10", "version-1"));
+        Assert.NotEqual(state, new StreamCheckpointStoreState("20", "version-1"));
+    }
+
     protected override Task<IStreamQueueCheckpointer<string>> CreateCheckpointer(
         ControllableCheckpointStore store)
         => Task.FromResult<IStreamQueueCheckpointer<string>>(


### PR DESCRIPTION
## Problem
The daily `dotnet-orleans` pipeline failed during the build/package stage because the new public `StreamCheckpointStoreState` readonly struct triggered CA1815.

## Solution
Implement value equality (`IEquatable<T>`, `Equals`, `GetHashCode`, and `==`/`!=`) using the checkpoint and backend version, and add a focused regression test. Regenerate the Orleans.Streaming API surface.

Closes #11226

## Evidence
- Failed build: https://dnceng.visualstudio.com/internal/_build/results?buildId=3071511&view=results
- Source commit: https://github.com/dotnet/orleans/commit/bfef5e641629db33dcad34f3190ce87010359cb6

## Targeted validation
- `dotnet build src\Orleans.Streaming\Orleans.Streaming.csproj --framework net10.0 --no-restore`
- API regeneration and Release `net8.0` build passed.
- Focused equality test passed with the existing obsolete API warnings allowed.

The full streaming test project still emits pre-existing obsolete API diagnostics in `EncodedOffsetPooledQueueCacheTests`; those are unrelated to this analyzer fix.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11227)