### PR TITLE
fix(docs): tolerate transient GitHub link throttling

### DIFF
--- a/docs/site/scripts/lib/link-audit.mjs
+++ b/docs/site/scripts/lib/link-audit.mjs
@@ -17,8 +17,8 @@ const contentRoute = `${deploymentBase}/docs`;
 const learnContentRoot = '/dotnet/orleans';
 const redirectStatuses = new Set([301, 302, 303, 307, 308]);
 const transientStatuses = new Set([408, 425, 429, 500, 502, 503, 504]);
-const transientStatusesByHost = new Map([
-  ['github.com', new Set([403])],
+const throttlingStatusesByHost = new Map([
+  ['github.com', new Set([403, 429])],
 ]);
 const headFallbackStatuses = new Set([405, 501]);
 const headFallbackStatusesByHost = new Map([
@@ -993,7 +993,9 @@ export function createPinnedRequestOptions(url, { method, destination }) {
     autoSelectFamily: false,
     headers: {
       Host: url.host,
-      'User-Agent': 'dotnet-orleans-docs-link-audit/1.0 (+https://github.com/dotnet/orleans)',
+      ...(url.hostname.toLowerCase() === 'github.com'
+        ? { 'User-Agent': 'dotnet-orleans-docs-link-audit/1.0 (+https://github.com/dotnet/orleans)' }
+        : {}),
       ...(method === 'GET' ? { Range: 'bytes=0-0' } : {}),
     },
     lookup: (_hostname, options, callback) => {
@@ -1121,11 +1123,17 @@ async function probeOnce(url, options) {
   return head;
 }
 
-function hasTransientStatus(result) {
+function isHostThrottlingStatus(result) {
   const hostname = new URL(result.finalUrl).hostname.toLowerCase();
   return (
+    throttlingStatusesByHost.get(hostname)?.has(result.response.status) === true
+  );
+}
+
+function hasTransientStatus(result) {
+  return (
     transientStatuses.has(result.response.status) ||
-    transientStatusesByHost.get(hostname)?.has(result.response.status) === true
+    isHostThrottlingStatus(result)
   );
 }
 
@@ -1198,7 +1206,10 @@ export async function probeExternalTargets({
             maxRedirects,
           });
           error = undefined;
-          if (!transientStatuses.has(result.response.status)) break;
+          if (
+            !transientStatuses.has(result.response.status) ||
+            isHostThrottlingStatus(result)
+          ) break;
         } catch (caught) {
           error = caught;
           if (!caught.transient) break;

--- a/docs/site/scripts/lib/link-audit.mjs
+++ b/docs/site/scripts/lib/link-audit.mjs
@@ -17,6 +17,9 @@ const contentRoute = `${deploymentBase}/docs`;
 const learnContentRoot = '/dotnet/orleans';
 const redirectStatuses = new Set([301, 302, 303, 307, 308]);
 const transientStatuses = new Set([408, 425, 429, 500, 502, 503, 504]);
+const transientStatusesByHost = new Map([
+  ['github.com', new Set([403])],
+]);
 const headFallbackStatuses = new Set([405, 501]);
 const headFallbackStatusesByHost = new Map([
   ['azure.microsoft.com', new Set([404])],
@@ -990,6 +993,7 @@ export function createPinnedRequestOptions(url, { method, destination }) {
     autoSelectFamily: false,
     headers: {
       Host: url.host,
+      'User-Agent': 'dotnet-orleans-docs-link-audit/1.0 (+https://github.com/dotnet/orleans)',
       ...(method === 'GET' ? { Range: 'bytes=0-0' } : {}),
     },
     lookup: (_hostname, options, callback) => {
@@ -1117,6 +1121,14 @@ async function probeOnce(url, options) {
   return head;
 }
 
+function hasTransientStatus(result) {
+  const hostname = new URL(result.finalUrl).hostname.toLowerCase();
+  return (
+    transientStatuses.has(result.response.status) ||
+    transientStatusesByHost.get(hostname)?.has(result.response.status) === true
+  );
+}
+
 export async function probeExternalTargets({
   externalTargets,
   allowlist = { urls: {} },
@@ -1214,9 +1226,9 @@ export async function probeExternalTargets({
         }
       } else if (status === 404 || status === 410) {
         failures.push(`${url} (${provenance}): returned ${status}.`);
-      } else if (status >= 400 && !transientStatuses.has(status)) {
+      } else if (status >= 400 && !hasTransientStatus(result)) {
         failures.push(`${url} (${provenance}): returned ${status}; add a reasoned exact-URL allowlist entry only if the target cannot be probed reliably.`);
-      } else if (transientStatuses.has(status)) {
+      } else if (hasTransientStatus(result)) {
         warnings.push(`Transient external status ${status}: ${url} (${provenance}).`);
       }
     }

--- a/docs/site/tests/link-audit.test.mjs
+++ b/docs/site/tests/link-audit.test.mjs
@@ -731,27 +731,29 @@ describe('external link audit', () => {
   });
 
   test('reports GitHub throttling without amplifying requests', async () => {
-    let requests = 0;
-    const result = await probeExternalTargets({
-      externalTargets: new Map([
-        [
-          'https://github.com/dotnet/orleans/edit/main/docs/README.md',
-          [{ relativeFile: 'guide.md', line: 5 }],
-        ],
-      ]),
-      retries: 1,
-      lookupImpl: publicLookup,
-      requestImpl: async () => {
-        requests += 1;
-        return response(403);
-      },
-    });
+    for (const status of [403, 429]) {
+      let requests = 0;
+      const result = await probeExternalTargets({
+        externalTargets: new Map([
+          [
+            'https://github.com/dotnet/orleans/edit/main/docs/README.md',
+            [{ relativeFile: 'guide.md', line: 5 }],
+          ],
+        ]),
+        retries: 1,
+        lookupImpl: publicLookup,
+        requestImpl: async () => {
+          requests += 1;
+          return response(status);
+        },
+      });
 
-    expect(result.failures).toEqual([]);
-    expect(result.warnings).toEqual([
-      expect.stringContaining('Transient external status 403'),
-    ]);
-    expect(requests).toBe(1);
+      expect(result.failures).toEqual([]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining(`Transient external status ${status}`),
+      ]);
+      expect(requests).toBe(1);
+    }
   });
 
   test('uses the final host to classify redirected GitHub throttling', async () => {
@@ -961,7 +963,6 @@ describe('external link audit', () => {
     );
     expect(options.headers).toEqual({
       Host: 'docs.example',
-      'User-Agent': 'dotnet-orleans-docs-link-audit/1.0 (+https://github.com/dotnet/orleans)',
       Range: 'bytes=0-0',
     });
     expect(options.servername).toBe('docs.example');
@@ -975,6 +976,25 @@ describe('external link audit', () => {
           resolve();
         }
       });
+    });
+  });
+
+  test('identifies the probe only to GitHub', () => {
+    const options = createPinnedRequestOptions(
+      new URL('https://github.com/dotnet/orleans'),
+      {
+        method: 'HEAD',
+        destination: {
+          hostname: 'github.com',
+          address: '8.8.8.8',
+          family: 4,
+        },
+      },
+    );
+
+    expect(options.headers).toEqual({
+      Host: 'github.com',
+      'User-Agent': 'dotnet-orleans-docs-link-audit/1.0 (+https://github.com/dotnet/orleans)',
     });
   });
 

--- a/docs/site/tests/link-audit.test.mjs
+++ b/docs/site/tests/link-audit.test.mjs
@@ -730,6 +730,75 @@ describe('external link audit', () => {
     expect(rateRequests).toBe(2);
   });
 
+  test('reports GitHub throttling without amplifying requests', async () => {
+    let requests = 0;
+    const result = await probeExternalTargets({
+      externalTargets: new Map([
+        [
+          'https://github.com/dotnet/orleans/edit/main/docs/README.md',
+          [{ relativeFile: 'guide.md', line: 5 }],
+        ],
+      ]),
+      retries: 1,
+      lookupImpl: publicLookup,
+      requestImpl: async () => {
+        requests += 1;
+        return response(403);
+      },
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining('Transient external status 403'),
+    ]);
+    expect(requests).toBe(1);
+  });
+
+  test('uses the final host to classify redirected GitHub throttling', async () => {
+    let requests = 0;
+    const result = await probeExternalTargets({
+      externalTargets: new Map([
+        [
+          'https://public.example/github',
+          [{ relativeFile: 'guide.md', line: 5 }],
+        ],
+      ]),
+      retries: 0,
+      lookupImpl: publicLookup,
+      requestImpl: async (url) => {
+        requests += 1;
+        return url.hostname === 'github.com'
+          ? response(403)
+          : response(302, 'https://github.com/dotnet/orleans');
+      },
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining('Transient external status 403'),
+    ]);
+    expect(requests).toBe(2);
+  });
+
+  test('fails definitive missing GitHub targets', async () => {
+    const result = await probeExternalTargets({
+      externalTargets: new Map([
+        [
+          'https://github.com/dotnet/orleans/blob/main/missing.md',
+          [{ relativeFile: 'guide.md', line: 5 }],
+        ],
+      ]),
+      retries: 0,
+      lookupImpl: publicLookup,
+      requestImpl: async () => response(404),
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.failures).toEqual([
+      expect.stringContaining('returned 404'),
+    ]);
+  });
+
   test('fails permanent DNS or TLS-style network errors', async () => {
     const error = new TypeError('fetch failed', {
       cause: Object.assign(new Error('not found'), { code: 'ENOTFOUND' }),
@@ -892,6 +961,7 @@ describe('external link audit', () => {
     );
     expect(options.headers).toEqual({
       Host: 'docs.example',
+      'User-Agent': 'dotnet-orleans-docs-link-audit/1.0 (+https://github.com/dotnet/orleans)',
       Range: 'bytes=0-0',
     });
     expect(options.servername).toBe('docs.example');


### PR DESCRIPTION
## Problem

The documentation external-link audit intermittently receives HTTP 403 responses for varying public `github.com` URLs. Re-running the same audit succeeds, indicating provider throttling rather than dead links. The audit currently treats those responses as permanent failures and blocks unrelated documentation changes.

## Solution

Identify the link checker with a descriptive `User-Agent` and classify final `github.com` HTTP 403 responses as host-specific transient diagnostics. The audit does not retry or add ranged GET requests for this response, avoiding request amplification while GitHub is throttling. Definitive HTTP 404 and 410 responses continue to fail, including for GitHub targets, and redirects are classified using their final host.

Fixes #11208.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11229)