### PR TITLE
feat(streaming): configure memory stream dequeue limits

### DIFF
--- a/docs/site/src/content/docs/streaming/stream-providers.md
+++ b/docs/site/src/content/docs/streaming/stream-providers.md
@@ -30,6 +30,8 @@ Kafka and Azure Service Bus aren't built-in Orleans stream providers. Integrate 
 
 Register memory streams with <xref:Orleans.Hosting.SiloBuilderMemoryStreamExtensions.AddMemoryStreams*>. They use silo memory for queues and cache, so events don't survive cluster loss. Rewind works only while the relevant event remains in the live in-memory cache. Use this provider for local development, tests, and workloads where loss is explicitly acceptable.
 
+See [Tune memory stream dequeue batches](streaming-operations.md#tune-memory-stream-dequeue-batches) to configure per-provider batch counts and balance call overhead against response size.
+
 ## Azure Queue Storage
 
 <a id="azure-queue-aq-stream-provider"></a>

--- a/docs/site/src/content/docs/streaming/streaming-operations.md
+++ b/docs/site/src/content/docs/streaming/streaming-operations.md
@@ -1,7 +1,7 @@
 ---
 title: Operate and tune Orleans streams
 description: Apply backpressure, tune persistent providers, and observe Orleans streaming health.
-ms.date: 08/17/2026
+ms.date: 09/10/2026
 ms.topic: concept-article
 ---
 
@@ -48,6 +48,14 @@ Persistent providers expose common configuration through their stream configurat
 Provider-specific controls matter as much as common controls: <xref:Orleans.Configuration.AzureQueueOptions.QueueNames>, Event Hubs partitions and cache-pressure settings, Redis `ReadCount` and retention, NATS `BatchSize` and `PartitionCount`, and ADO.NET visibility, expiry, and dead-letter settings.
 
 Change one bottleneck at a time. More queues can increase parallelism but also broker cost, polling load, cache memory, and rebalance work. Reducing polling delay can lower latency while increasing empty reads.
+
+### Tune memory stream dequeue batches
+
+For each named memory stream provider, <xref:Orleans.Configuration.MemoryStreamCacheOptions.MaxAddCount> bounds the number of queue records requested in a single dequeue operation. The default is `100`, and options validation requires a value greater than zero. Configure it on the silo using <xref:Orleans.Hosting.MemoryStreamConfiguratorExtensions.ConfigureCache*> in the provider's `AddMemoryStreams` callback. For configuration-based provider registration, set `MaxAddCount` in the named memory provider's configuration section.
+
+Each record contains one published batch of events. A value such as `25` reduces the number of records combined into each queue-grain response, at the cost of more dequeue calls for the same throughput. Larger values amortize call overhead across more records and can increase serialization work, response size, and memory usage per call.
+
+The bound is measured in records. The aggregate byte size depends on the serialized payloads in those records, including all events in each published batch. Size producer batches and payloads so that a complete dequeue response fits the configured Orleans message-body limit. The queue grain removes records before its response is serialized; an oversized response can therefore lose those records when serialization fails. Tune the count alongside measured response sizes and queue lag.
 
 ## Observe health
 

--- a/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
@@ -27,6 +27,7 @@ namespace Orleans.Providers
         where TSerializer : class, IMemoryMessageBodySerializer
     {
         private readonly StreamCacheEvictionOptions cacheOptions;
+        private readonly MemoryStreamCacheOptions memoryCacheOptions;
         private readonly StreamStatisticOptions statisticOptions;
         private readonly HashRingStreamQueueMapperOptions queueMapperOptions;
         private readonly IGrainFactory grainFactory;
@@ -102,6 +103,7 @@ namespace Orleans.Providers
             this.logger = loggerFactory.CreateLogger<ILogger<MemoryAdapterFactory<TSerializer>>>();
             this.serializer = MemoryMessageBodySerializerFactory<TSerializer>.GetOrCreateSerializer(serviceProvider);
             this.orleansInstruments = serviceProvider.GetRequiredService<OrleansInstruments>();
+            this.memoryCacheOptions = serviceProvider.GetOptionsByName<MemoryStreamCacheOptions>(providerName);
 
             var nameBytes = BitConverter.IsLittleEndian ? MemoryMarshal.AsBytes(Name.AsSpan()) : Encoding.Unicode.GetBytes(Name);
             XxHash64.Hash(nameBytes, MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _nameHash, 1)));
@@ -193,7 +195,7 @@ namespace Orleans.Providers
             var logger = this.loggerFactory.CreateLogger($"{typeof(MemoryPooledCache<TSerializer>).FullName}.{this.Name}.{queueId}");
             var cacheMonitorFactory = this.CacheMonitorFactory!; // Set during Init().
             var monitor = cacheMonitorFactory(new CacheMonitorDimensions(queueId.ToString(), this.blockPoolMonitorDimensions.BlockPoolId));
-            return new MemoryPooledCache<TSerializer>(bufferPool, purgePredicate, logger, this.serializer, monitor, this.statisticOptions.StatisticMonitorWriteInterval, this.cacheOptions.MetadataMinTimeInCache);
+            return new MemoryPooledCache<TSerializer>(bufferPool, purgePredicate, logger, this.serializer, monitor, this.statisticOptions.StatisticMonitorWriteInterval, this.cacheOptions.MetadataMinTimeInCache, this.memoryCacheOptions.MaxAddCount);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -20,6 +21,7 @@ namespace Orleans.Providers
         private readonly TSerializer serializer;
         private readonly IEvictionStrategy evictionStrategy;
         private readonly PooledQueueCache cache;
+        private readonly int maxAddCount;
 
         private FixedSizeBuffer? currentBuffer;
 
@@ -41,7 +43,34 @@ namespace Orleans.Providers
             ICacheMonitor? cacheMonitor,
             TimeSpan? monitorWriteInterval,
             TimeSpan? purgeMetadataInterval)
+            : this(bufferPool, purgePredicate, logger, serializer, cacheMonitor, monitorWriteInterval, purgeMetadataInterval, MemoryStreamCacheOptions.DefaultMaxAddCount)
         {
+        }
+
+        /// <summary>
+        /// Creates a pooled cache for a memory stream provider with a configured dequeue record limit.
+        /// </summary>
+        /// <param name="bufferPool">The buffer pool.</param>
+        /// <param name="purgePredicate">The purge predicate.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="serializer">The serializer.</param>
+        /// <param name="cacheMonitor">The cache monitor.</param>
+        /// <param name="monitorWriteInterval">The monitor write interval.</param>
+        /// <param name="purgeMetadataInterval">The interval between cache purge metadata updates.</param>
+        /// <param name="maxAddCount">The positive maximum number of queue records requested in each dequeue operation.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxAddCount"/> is zero or negative.</exception>
+        public MemoryPooledCache(
+            IObjectPool<FixedSizeBuffer> bufferPool,
+            TimePurgePredicate purgePredicate,
+            ILogger logger,
+            TSerializer serializer,
+            ICacheMonitor? cacheMonitor,
+            TimeSpan? monitorWriteInterval,
+            TimeSpan? purgeMetadataInterval,
+            int maxAddCount)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxAddCount);
+            this.maxAddCount = maxAddCount;
             this.bufferPool = bufferPool;
             this.serializer = serializer;
             this.cache = new PooledQueueCache(this, logger, cacheMonitor, monitorWriteInterval, purgeMetadataInterval);
@@ -179,7 +208,7 @@ namespace Orleans.Providers
         /// <inheritdoc/>
         public int GetMaxAddCount()
         {
-            return 100;
+            return maxAddCount;
         }
 
         /// <inheritdoc/>

--- a/src/Orleans.Streaming/MemoryStreams/MemoryStreamBuilder.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryStreamBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers;
 
@@ -24,6 +25,16 @@ namespace Orleans.Hosting
         {
             configurator.Configure<HashRingStreamQueueMapperOptions>(ob => ob.Configure(options => options.TotalQueueCount = numOfQueues));
         }
+
+        /// <summary>
+        /// Configures cache options for a named memory stream provider.
+        /// </summary>
+        /// <param name="configurator">The configuration builder.</param>
+        /// <param name="configureOptions">The configuration delegate.</param>
+        public static void ConfigureCache(this ISiloMemoryStreamConfigurator configurator, Action<OptionsBuilder<MemoryStreamCacheOptions>> configureOptions)
+        {
+            configurator.Configure(configureOptions);
+        }
     }
 
     /// <summary>
@@ -47,7 +58,14 @@ namespace Orleans.Hosting
             string name, Action<Action<IServiceCollection>> configureServicesDelegate)
             : base(name, configureServicesDelegate, MemoryAdapterFactory<TSerializer>.Create)
         {
-            this.ConfigureDelegate(services => services.ConfigureNamedOptionForLogging<HashRingStreamQueueMapperOptions>(name));
+            this.ConfigureDelegate(services => services
+                .ConfigureNamedOptionForLogging<HashRingStreamQueueMapperOptions>(name)
+                .ConfigureNamedOptionForLogging<MemoryStreamCacheOptions>(name));
+            this.Configure<MemoryStreamCacheOptions>(options => options
+                .Validate(
+                    static value => value.MaxAddCount > 0,
+                    $"{nameof(MemoryStreamCacheOptions.MaxAddCount)} must be greater than zero.")
+                .ValidateOnStart());
         }
     }
 

--- a/src/Orleans.Streaming/MemoryStreams/MemoryStreamCacheOptions.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryStreamCacheOptions.cs
@@ -1,0 +1,23 @@
+namespace Orleans.Configuration;
+
+/// <summary>
+/// Configures the cache for a named memory stream provider.
+/// </summary>
+public class MemoryStreamCacheOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum number of queue records requested in each dequeue operation.
+    /// </summary>
+    /// <remarks>
+    /// The value must be greater than zero. Each record contains one published batch of events.
+    /// Smaller values reduce the number of records serialized into a dequeue response, while larger
+    /// values amortize the cost of queue calls over more records. The limit is measured in records;
+    /// response size in bytes depends on the serialized size of those records.
+    /// </remarks>
+    public int MaxAddCount { get; set; } = DefaultMaxAddCount;
+
+    /// <summary>
+    /// The default value of <see cref="MaxAddCount"/>.
+    /// </summary>
+    public const int DefaultMaxAddCount = 100;
+}

--- a/src/Orleans.Streaming/MemoryStreams/MemoryStreamProviderBuilder.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryStreamProviderBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Hosting;
 using Orleans.Providers;
@@ -11,7 +12,8 @@ internal sealed class MemoryStreamProviderBuilder : IProviderBuilder<ISiloBuilde
 {
     public void Configure(ISiloBuilder builder, string? name, IConfigurationSection configurationSection)
     {
-        builder.AddMemoryStreams(name!); // Streaming providers are configured from named subsections.
+        // Streaming providers are configured from named subsections.
+        builder.AddMemoryStreams(name!, stream => stream.ConfigureCache(options => options.Bind(configurationSection)));
     }
 
     public void Configure(IClientBuilder builder, string? name, IConfigurationSection configurationSection)

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -90,6 +90,12 @@ namespace Orleans.Configuration
         public System.TimeSpan LeaseRenewPeriod { get { throw null; } set { } }
     }
 
+    public partial class MemoryStreamCacheOptions
+    {
+        public const int DefaultMaxAddCount = 100;
+        public int MaxAddCount { get { throw null; } set { } }
+    }
+
     public partial class SimpleQueueCacheOptions
     {
         public const int DEFAULT_CACHE_SIZE = 4096;
@@ -230,6 +236,8 @@ namespace Orleans.Hosting
 
     public static partial class MemoryStreamConfiguratorExtensions
     {
+        public static void ConfigureCache(this ISiloMemoryStreamConfigurator configurator, System.Action<Microsoft.Extensions.Options.OptionsBuilder<Configuration.MemoryStreamCacheOptions>> configureOptions) { }
+
         public static void ConfigurePartitioning(this IMemoryStreamConfigurator configurator, int numOfQueues = 8) { }
     }
 
@@ -450,6 +458,8 @@ namespace Orleans.Providers
 
     public partial class MemoryPooledCache<TSerializer> : Orleans.Streams.IQueueCache, Orleans.Streams.IQueueFlowController, Streams.Common.ICacheDataAdapter where TSerializer : class, IMemoryMessageBodySerializer
     {
+        public MemoryPooledCache(Streams.Common.IObjectPool<Streams.Common.FixedSizeBuffer> bufferPool, Streams.Common.TimePurgePredicate purgePredicate, Microsoft.Extensions.Logging.ILogger logger, TSerializer serializer, Streams.Common.ICacheMonitor? cacheMonitor, System.TimeSpan? monitorWriteInterval, System.TimeSpan? purgeMetadataInterval, int maxAddCount) { }
+
         public MemoryPooledCache(Streams.Common.IObjectPool<Streams.Common.FixedSizeBuffer> bufferPool, Streams.Common.TimePurgePredicate purgePredicate, Microsoft.Extensions.Logging.ILogger logger, TSerializer serializer, Streams.Common.ICacheMonitor? cacheMonitor, System.TimeSpan? monitorWriteInterval, System.TimeSpan? purgeMetadataInterval) { }
 
         public void AddToCache(System.Collections.Generic.IList<Orleans.Streams.IBatchContainer> messages) { }

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/MemoryStreamCacheOptionsTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/MemoryStreamCacheOptionsTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Providers;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace UnitTests.OrleansRuntime.Streams;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Streaming")]
+[TestCategory("BVT"), TestCategory("Streaming")]
+public sealed class MemoryStreamCacheOptionsTests
+{
+    [Fact]
+    public void DefaultMaxAddCountIs100()
+    {
+        using var host = CreateHost(builder => builder.AddMemoryStreams("default"));
+        var options = host.Services.GetOptionsByName<MemoryStreamCacheOptions>("default");
+        IQueueFlowController controller = CreateCache(host.Services, "default");
+
+        Assert.Equal(100, new MemoryStreamCacheOptions().MaxAddCount);
+        Assert.Equal(100, options.MaxAddCount);
+        Assert.Equal(100, controller.GetMaxAddCount());
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(25)]
+    [InlineData(int.MaxValue)]
+    public void ConfiguredMaxAddCountFlowsToCache(int maxAddCount)
+    {
+        using var host = CreateHost(builder => builder.AddMemoryStreams("configured", stream =>
+            stream.ConfigureCache(options => options.Configure(value => value.MaxAddCount = maxAddCount))));
+
+        host.Services.GetRequiredService<IStartupValidator>().Validate();
+        IQueueFlowController controller = CreateCache(host.Services, "configured");
+
+        Assert.Equal(maxAddCount, controller.GetMaxAddCount());
+    }
+
+    [Fact]
+    public void NamedProvidersHaveIndependentMaxAddCounts()
+    {
+        using var host = CreateHost(builder => builder
+            .AddMemoryStreams("small", stream =>
+                stream.ConfigureCache(options => options.Configure(value => value.MaxAddCount = 25)))
+            .AddMemoryStreams("large", stream =>
+                stream.ConfigureCache(options => options.Configure(value => value.MaxAddCount = 200)))
+            .AddMemoryStreams("default"));
+
+        Assert.Equal(25, CreateCache(host.Services, "small").GetMaxAddCount());
+        Assert.Equal(200, CreateCache(host.Services, "large").GetMaxAddCount());
+        Assert.Equal(100, CreateCache(host.Services, "default").GetMaxAddCount());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void InvalidMaxAddCountIsRejectedDuringStartupValidation(int maxAddCount)
+    {
+        var services = new ServiceCollection();
+        var configurator = new SiloMemoryStreamConfigurator<DefaultMemoryMessageBodySerializer>(
+            "invalid", configure => configure(services));
+        configurator.ConfigureCache(options => options.Configure(value => value.MaxAddCount = maxAddCount));
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            serviceProvider.GetRequiredService<IStartupValidator>().Validate);
+
+        Assert.Equal("invalid", exception.OptionsName);
+        Assert.Equal(typeof(MemoryStreamCacheOptions), exception.OptionsType);
+        Assert.Contains(nameof(MemoryStreamCacheOptions.MaxAddCount), Assert.Single(exception.Failures), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConfigurationBasedProviderBindsMaxAddCount()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["memory:MaxAddCount"] = "25",
+            })
+            .Build();
+        using var host = CreateHost(builder =>
+            new MemoryStreamProviderBuilder().Configure(builder, "memory", configuration.GetSection("memory")));
+
+        Assert.Equal(25, CreateCache(host.Services, "memory").GetMaxAddCount());
+    }
+
+    [Fact]
+    public async Task ConfiguredCountBoundsReceiverDequeue()
+    {
+        using var host = CreateHost(builder => builder.AddMemoryStreams("small", stream =>
+            stream.ConfigureCache(options => options.Configure(value => value.MaxAddCount = 25))));
+        IQueueFlowController controller = CreateCache(host.Services, "small");
+        var serializer = MemoryMessageBodySerializerFactory<DefaultMemoryMessageBodySerializer>.GetOrCreateSerializer(host.Services);
+        var queue = new MemoryStreamQueueGrain();
+        var streamId = StreamId.Create("namespace", "stream");
+        var cancellationToken = TestContext.Current.CancellationToken;
+        for (var i = 0; i < 26; i++)
+        {
+            var payload = serializer.Serialize(new MemoryMessageBody([i], requestContext: null));
+            await queue.Enqueue(MemoryMessageData.Create(streamId, payload), cancellationToken);
+        }
+
+        IQueueAdapterReceiver receiver = new MemoryAdapterReceiver<DefaultMemoryMessageBodySerializer>(
+            queue, NullLogger.Instance, serializer, Substitute.For<IQueueAdapterReceiverMonitor>());
+
+        var first = await receiver.GetQueueMessagesAsync(controller.GetMaxAddCount(), cancellationToken);
+        var second = await receiver.GetQueueMessagesAsync(controller.GetMaxAddCount(), cancellationToken);
+
+        Assert.Equal(25, first.Count);
+        Assert.Equal(Enumerable.Range(0, 25), first.SelectMany(batch => batch.GetEvents<int>()).Select(item => item.Item1));
+        Assert.Equal(25, Assert.Single(Assert.Single(second).GetEvents<int>()).Item1);
+        Assert.Empty(await receiver.GetQueueMessagesAsync(controller.GetMaxAddCount(), cancellationToken));
+    }
+
+    [Fact]
+    public void OriginalCacheConstructorPreservesDefaultMaxAddCount()
+    {
+        IQueueFlowController controller = new MemoryPooledCache<IMemoryMessageBodySerializer>(
+            Substitute.For<IObjectPool<FixedSizeBuffer>>(),
+            new TimePurgePredicate(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(5)),
+            NullLogger.Instance,
+            serializer: Substitute.For<IMemoryMessageBodySerializer>(),
+            cacheMonitor: null,
+            monitorWriteInterval: null,
+            purgeMetadataInterval: null);
+
+        Assert.Equal(100, controller.GetMaxAddCount());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void CacheConstructorRejectsInvalidMaxAddCount(int maxAddCount)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new MemoryPooledCache<IMemoryMessageBodySerializer>(
+                Substitute.For<IObjectPool<FixedSizeBuffer>>(),
+                new TimePurgePredicate(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(5)),
+                NullLogger.Instance,
+                serializer: Substitute.For<IMemoryMessageBodySerializer>(),
+                cacheMonitor: null,
+                monitorWriteInterval: null,
+                purgeMetadataInterval: null,
+                maxAddCount));
+
+        Assert.Equal("maxAddCount", exception.ParamName);
+    }
+
+    private static IHost CreateHost(Action<ISiloBuilder> configure)
+        => new HostBuilder()
+            .UseOrleans(builder =>
+            {
+                builder.UseLocalhostClustering().AddMemoryGrainStorage("PubSubStore");
+                configure(builder);
+            })
+            .Build();
+
+    private static IQueueCache CreateCache(IServiceProvider services, string providerName)
+    {
+        var factory = services.GetRequiredKeyedService<IQueueAdapterFactory>(providerName);
+        var queueId = factory.GetStreamQueueMapper().GetAllQueues().First();
+        return factory.GetQueueAdapterCache().CreateQueueCache(queueId);
+    }
+}


### PR DESCRIPTION
## Problem

Memory streams request a fixed 100 queue records per dequeue. Combining large records into one queue-grain response can exceed the configured message-body limit after those records have been removed from the queue. Applications need a per-provider record limit to tune response sizes and queue-call overhead.

## Solution

Add named `MemoryStreamCacheOptions.MaxAddCount`, defaulting to 100, with positive-value validation at startup. Configure it through `ConfigureCache` on the silo memory-stream configurator or through the named provider's configuration section.

Pass the configured count from `MemoryAdapterFactory` into `MemoryPooledCache` and expose it through `IQueueFlowController.GetMaxAddCount()`. Preserve the existing cache constructor and its default behavior, and add an overload for direct cache construction.

Document the throughput/response-size tradeoff and the record-count semantics: aggregate response bytes depend on serialized record payloads. Include coverage for defaults, custom values, named-provider isolation, validation, configuration binding, receiver dequeue bounds, and constructor compatibility, plus the regenerated public API surface.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11238)