### PR TITLE
docs: remove unrelated POCO grains section from migration guide

### DIFF
--- a/docs/site/src/content/docs/grains/reminders.md
+++ b/docs/site/src/content/docs/grains/reminders.md
@@ -74,8 +74,6 @@ The reminder table is part of silo startup. Provider availability and consistenc
 
 Grains implementing <xref:Orleans.IGrainBase> directly use the same <xref:Orleans.GrainReminderExtensions> APIs. Inject <xref:Orleans.Timers.IReminderRegistry> when infrastructure code needs lower-level access through the current grain context.
 
-See [POCO grains](../migration-guide.md#poco-grains-and-igrainbase) for the interface-only grain model.
-
 ## Troubleshoot reminders
 
 | Observed behavior | Runtime behavior and action |

--- a/docs/site/src/content/docs/grains/timers.md
+++ b/docs/site/src/content/docs/grains/timers.md
@@ -64,8 +64,6 @@ The callback's <xref:System.Threading.CancellationToken> signals timer disposal 
 
 Grains implementing <xref:Orleans.IGrainBase> directly use <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. Inject <xref:Orleans.Timers.ITimerRegistry> when infrastructure code needs lower-level registration through the current <xref:Orleans.Runtime.IGrainContext>.
 
-See [POCO grains](../migration-guide.md#poco-grains-and-igrainbase) for the interface-only grain model.
-
 ## Troubleshoot grain timers
 
 | Observed behavior | Runtime behavior and action |

--- a/docs/site/src/content/docs/migration-guide.md
+++ b/docs/site/src/content/docs/migration-guide.md
@@ -33,10 +33,6 @@ Before changing packages, record the following compatibility contract:
 
 See [Upgrade deployment and rollback](migration/deployment-and-rollback.md) before choosing a deployment strategy.
 
-## POCO grains and <xref:Orleans.IGrainBase> <a name="poco-grains-and-igrainbase"></a>
-
-POCO grains remain supported. A grain that doesn't inherit from <xref:Orleans.Grain> implements <xref:Orleans.IGrainBase> and receives its <xref:Orleans.Runtime.IGrainContext> through dependency injection. This also enables grain extension methods such as timers, reminders, streaming, deactivation, and migration.
-
 ## Package version policy
 
 Keep all `Microsoft.Orleans.*` packages on the same 10.x patch. For solutions that use NuGet Central Package Management, declare the versions in `Directory.Packages.props` and omit versions from project-level `PackageReference` items. Don't copy old provider dependency versions from migration examples; select a current version that is supported by your target runtime and provider.


### PR DESCRIPTION
Remove the POCO grains and `IGrainBase` section from the migration guide so the page stays focused on upgrade paths and compatibility requirements.

Also remove the two links to that section from the timer and reminder pages, preserving their existing POCO-specific API guidance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/11240)