### PR TITLE
test(s3): use SeaweedFS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ env:
   CONSUL_IMAGE: public.ecr.aws/hashicorp/consul:1.19
   DYNAMODB_IMAGE: amazon/dynamodb-local:latest
   ELASTICMQ_IMAGE: softwaremill/elasticmq-native:latest
-  # Keep in sync with S3JournalStorageTests and S3JournalStoragePersistenceTestKitTests
+  # Keep in sync with SeaweedFSTestContainer
   # so the fixtures use the pre-pulled image.
-  MINIO_IMAGE: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+  SEAWEEDFS_IMAGE: ghcr.io/chrislusf/seaweedfs:4.46@sha256:08d516132314207d10c8e37cbffc1f32b147d870169688734cc61c6231625b62
   MINISTACK_IMAGE: ministackorg/ministack:1.4.11@sha256:8b05715b9effc23d998d4a4e0c0a0c4af7f9435f0ff076a30cf27a77326f14b1
   MSSQL_IMAGE: mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89
   NATS_IMAGE: nats:latest
@@ -596,7 +596,7 @@ jobs:
         set -euo pipefail
 
         bash .github/scripts/docker-pull-with-retry.sh "$TESTCONTAINERS_RYUK_IMAGE"
-        bash .github/scripts/docker-pull-with-retry.sh "$MINIO_IMAGE"
+        bash .github/scripts/docker-pull-with-retry.sh "$SEAWEEDFS_IMAGE"
     - name: Test
       uses: ./.github/actions/run-tests
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   ELASTICMQ_IMAGE: softwaremill/elasticmq-native:latest
   # Keep in sync with S3JournalStorageTests and S3JournalStoragePersistenceTestKitTests
   # so the fixtures use the pre-pulled image.
-  MINIO_IMAGE: minio/minio:RELEASE.2025-09-07T16-13-09Z
+  MINIO_IMAGE: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
   MINISTACK_IMAGE: ministackorg/ministack:1.4.11@sha256:8b05715b9effc23d998d4a4e0c0a0c4af7f9435f0ff076a30cf27a77326f14b1
   MSSQL_IMAGE: mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89
   NATS_IMAGE: nats:latest

--- a/src/AWS/Orleans.Journaling.S3/README.md
+++ b/src/AWS/Orleans.Journaling.S3/README.md
@@ -2,7 +2,9 @@
 
 `Microsoft.Orleans.Journaling.S3` provides an `IJournalStorage` implementation backed by Amazon S3 Express One Zone directory buckets.
 
-The provider uses S3 Express append writes (`WriteOffsetBytes`) for WAL appends. For local development and tests against S3-compatible emulators such as MinIO, set `UseS3ExpressAppend = false`, `UseConditionalDelete = false`, and `StorageClass = null` to use portable conditional writes and deletes.
+The provider uses S3 Express append writes (`WriteOffsetBytes`) for WAL appends. For local development and tests against S3-compatible services such as SeaweedFS, set `UseS3ExpressAppend = false`, `UseConditionalDelete = false`, and `StorageClass = null` to use portable conditional writes and deletes.
+
+The S3 integration tests run SeaweedFS in a container and exercise conditional-rewrite appends, ETag-conditional deletes, metadata updates, and concurrent writes. The CI pre-pull and both test fixtures use the same digest-pinned official image.
 
 Buckets should be created ahead of time for AWS S3 Express One Zone. `CreateBucketIfNotExists` is intended for local emulators.
 

--- a/src/AWS/Orleans.Journaling.S3/S3JournalStorageOptions.cs
+++ b/src/AWS/Orleans.Journaling.S3/S3JournalStorageOptions.cs
@@ -68,7 +68,7 @@ public sealed class S3JournalStorageOptions
     /// Gets or sets a value indicating whether appends use S3 Express <see cref="Amazon.S3.Model.PutObjectRequest.WriteOffsetBytes"/>.
     /// </summary>
     /// <remarks>
-    /// Set this to <see langword="false"/> for S3-compatible emulators such as MinIO which do not support S3 Express append writes.
+    /// Set this to <see langword="false"/> to use conditional-rewrite appends with S3-compatible services such as SeaweedFS.
     /// </remarks>
     public bool UseS3ExpressAppend { get; set; } = true;
 

--- a/test/Orleans.Journaling.Tests/S3JournalStoragePersistenceTestKitTests.cs
+++ b/test/Orleans.Journaling.Tests/S3JournalStoragePersistenceTestKitTests.cs
@@ -188,7 +188,7 @@ public sealed class S3JournalStoragePersistenceTestKitFixture : IAsyncLifetime
     {
         if (DockerSkipReason.Value is null)
         {
-            _container = new ContainerBuilder("minio/minio:RELEASE.2025-09-07T16-13-09Z")
+            _container = new ContainerBuilder("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
                 .WithEnvironment("MINIO_ROOT_USER", AccessKey)
                 .WithEnvironment("MINIO_ROOT_PASSWORD", SecretKey)
                 .WithCommand("server", "/data")

--- a/test/Orleans.Journaling.Tests/S3JournalStoragePersistenceTestKitTests.cs
+++ b/test/Orleans.Journaling.Tests/S3JournalStoragePersistenceTestKitTests.cs
@@ -8,7 +8,6 @@ using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Docker.DotNet;
-using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -176,9 +175,6 @@ public sealed class S3JournalStoragePersistenceTestKitTests
 
 public sealed class S3JournalStoragePersistenceTestKitFixture : IAsyncLifetime
 {
-    private const int MinioPort = 9000;
-    private const string AccessKey = "minioadmin";
-    private const string SecretKey = "minioadmin";
     private static readonly Lazy<string?> DockerSkipReason = new(GetDockerSkipReason);
     private readonly IContainer? _container;
     private AmazonS3Client? _client;
@@ -188,15 +184,7 @@ public sealed class S3JournalStoragePersistenceTestKitFixture : IAsyncLifetime
     {
         if (DockerSkipReason.Value is null)
         {
-            _container = new ContainerBuilder("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
-                .WithEnvironment("MINIO_ROOT_USER", AccessKey)
-                .WithEnvironment("MINIO_ROOT_PASSWORD", SecretKey)
-                .WithCommand("server", "/data")
-                .WithPortBinding(MinioPort, true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request
-                    .ForPort(MinioPort)
-                    .ForPath("/minio/health/ready")))
-                .Build();
+            _container = SeaweedFSTestContainer.Create();
         }
     }
 
@@ -223,10 +211,10 @@ public sealed class S3JournalStoragePersistenceTestKitFixture : IAsyncLifetime
 
         await _container!.StartAsync(TestContext.Current.CancellationToken);
         _client = new AmazonS3Client(
-            new BasicAWSCredentials(AccessKey, SecretKey),
+            new BasicAWSCredentials(SeaweedFSTestContainer.AccessKey, SeaweedFSTestContainer.SecretKey),
             new AmazonS3Config
             {
-                ServiceURL = $"http://127.0.0.1:{_container.GetMappedPublicPort(MinioPort)}",
+                ServiceURL = $"http://127.0.0.1:{_container.GetMappedPublicPort(SeaweedFSTestContainer.Port)}",
                 ForcePathStyle = true,
                 AuthenticationRegion = RegionEndpoint.USEast1.SystemName,
             });

--- a/test/Orleans.Journaling.Tests/S3JournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/S3JournalStorageTests.cs
@@ -42,7 +42,7 @@ public sealed class S3JournalStorageTests : IAsyncLifetime
     {
         if (DockerSkipReason.Value is null)
         {
-            _container = new ContainerBuilder("minio/minio:RELEASE.2025-09-07T16-13-09Z")
+            _container = new ContainerBuilder("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
                 .WithEnvironment("MINIO_ROOT_USER", AccessKey)
                 .WithEnvironment("MINIO_ROOT_PASSWORD", SecretKey)
                 .WithCommand("server", "/data")

--- a/test/Orleans.Journaling.Tests/S3JournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/S3JournalStorageTests.cs
@@ -6,7 +6,6 @@ using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Docker.DotNet;
-using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using Microsoft.Extensions.Configuration;
@@ -29,10 +28,7 @@ namespace Orleans.Journaling.Tests;
 [TestArea("Journaling")]
 public sealed class S3JournalStorageTests : IAsyncLifetime
 {
-    private const int MinioPort = 9000;
     private const string BucketName = "journaling-tests";
-    private const string AccessKey = "minioadmin";
-    private const string SecretKey = "minioadmin";
     private static readonly Lazy<string?> DockerSkipReason = new(GetDockerSkipReason);
     private readonly IContainer? _container;
     private AmazonS3Client? _client;
@@ -42,15 +38,7 @@ public sealed class S3JournalStorageTests : IAsyncLifetime
     {
         if (DockerSkipReason.Value is null)
         {
-            _container = new ContainerBuilder("quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z")
-                .WithEnvironment("MINIO_ROOT_USER", AccessKey)
-                .WithEnvironment("MINIO_ROOT_PASSWORD", SecretKey)
-                .WithCommand("server", "/data")
-                .WithPortBinding(MinioPort, true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request
-                    .ForPort(MinioPort)
-                    .ForPath("/minio/health/ready")))
-                .Build();
+            _container = SeaweedFSTestContainer.Create();
         }
     }
 
@@ -1481,10 +1469,10 @@ public sealed class S3JournalStorageTests : IAsyncLifetime
 
         await _container!.StartAsync(TestContext.Current.CancellationToken);
         _client = new AmazonS3Client(
-            new BasicAWSCredentials(AccessKey, SecretKey),
+            new BasicAWSCredentials(SeaweedFSTestContainer.AccessKey, SeaweedFSTestContainer.SecretKey),
             new AmazonS3Config
             {
-                ServiceURL = $"http://127.0.0.1:{_container.GetMappedPublicPort(MinioPort)}",
+                ServiceURL = $"http://127.0.0.1:{_container.GetMappedPublicPort(SeaweedFSTestContainer.Port)}",
                 ForcePathStyle = true,
                 AuthenticationRegion = RegionEndpoint.USEast1.SystemName,
             });
@@ -1504,7 +1492,7 @@ public sealed class S3JournalStorageTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task AppendReadReplaceAndDelete_RoundTripsThroughMinio()
+    public async Task AppendReadReplaceAndDelete_RoundTripsThroughSeaweedFS()
     {
         EnsureDockerAvailable();
         var storage = CreateStorage("journals/test", journalFormatKey: "json-lines");
@@ -1724,7 +1712,7 @@ public sealed class S3JournalStorageTests : IAsyncLifetime
             var endpointAuthConfig = TestcontainersSettings.OS?.DockerEndpointAuthConfig;
             if (endpointAuthConfig is null)
             {
-                return "Docker is unavailable, so MinIO S3 journal storage tests are skipped.";
+                return "Docker is unavailable, so SeaweedFS S3 journal storage tests are skipped.";
             }
 
             using var dockerClient = endpointAuthConfig
@@ -1733,31 +1721,31 @@ public sealed class S3JournalStorageTests : IAsyncLifetime
             var dockerInfo = dockerClient.System.GetSystemInfoAsync().GetAwaiter().GetResult();
             if (string.IsNullOrWhiteSpace(dockerInfo.OSType))
             {
-                return "Docker is unavailable, so MinIO S3 journal storage tests are skipped.";
+                return "Docker is unavailable, so SeaweedFS S3 journal storage tests are skipped.";
             }
 
             if (string.Equals(dockerInfo.OSType, "windows", StringComparison.OrdinalIgnoreCase))
             {
-                return "Docker is running in Windows container mode, so MinIO S3 journal storage tests are skipped.";
+                return "Docker is running in Windows container mode, so SeaweedFS S3 journal storage tests are skipped.";
             }
 
             return null;
         }
         catch (HttpRequestException)
         {
-            return "Docker is unavailable, so MinIO S3 journal storage tests are skipped.";
+            return "Docker is unavailable, so SeaweedFS S3 journal storage tests are skipped.";
         }
         catch (OperationCanceledException)
         {
-            return "Docker is unavailable, so MinIO S3 journal storage tests are skipped.";
+            return "Docker is unavailable, so SeaweedFS S3 journal storage tests are skipped.";
         }
         catch (DockerApiException)
         {
-            return "Docker is unavailable, so MinIO S3 journal storage tests are skipped.";
+            return "Docker is unavailable, so SeaweedFS S3 journal storage tests are skipped.";
         }
         catch (InvalidOperationException)
         {
-            return "Docker is unavailable, so MinIO S3 journal storage tests are skipped.";
+            return "Docker is unavailable, so SeaweedFS S3 journal storage tests are skipped.";
         }
     }
 

--- a/test/Orleans.Journaling.Tests/SeaweedFSTestContainer.cs
+++ b/test/Orleans.Journaling.Tests/SeaweedFSTestContainer.cs
@@ -1,0 +1,34 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace Orleans.Journaling.Tests;
+
+internal static class SeaweedFSTestContainer
+{
+    internal const int Port = 8333;
+    internal const string AccessKey = "orleans-test";
+    internal const string SecretKey = "orleans-test-secret";
+
+    // Keep in sync with SEAWEEDFS_IMAGE in .github/workflows/ci.yml.
+    private const string Image = "ghcr.io/chrislusf/seaweedfs:4.46@sha256:08d516132314207d10c8e37cbffc1f32b147d870169688734cc61c6231625b62";
+
+    internal static IContainer Create() =>
+        new ContainerBuilder(Image)
+            .WithEnvironment("AWS_ACCESS_KEY_ID", AccessKey)
+            .WithEnvironment("AWS_SECRET_ACCESS_KEY", SecretKey)
+            .WithCommand(
+                "mini",
+                "-dir=/data",
+                "-ip=127.0.0.1",
+                "-ip.bind=0.0.0.0",
+                "-master.telemetry=false",
+                "-admin.ui=false",
+                "-webdav=false",
+                "-s3.port.iceberg=0",
+                "-s3.port.lance=0")
+            .WithPortBinding(Port, true)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request
+                .ForPort(Port)
+                .ForPath("/readyz")))
+            .Build();
+}


### PR DESCRIPTION
Anonymous Docker Hub pulls of the pinned MinIO image are denied, blocking both S3 provider jobs before their tests execute. MinIO's community repository is also archived. Replace the test backend with maintained, Apache-2.0-licensed SeaweedFS.

Use the official `ghcr.io/chrislusf/seaweedfs:4.46` image, pinned to multi-platform digest `sha256:08d516132314207d10c8e37cbffc1f32b147d870169688734cc61c6231625b62`. Its Cosign signature was verified against issuer `https://token.actions.githubusercontent.com` and identity `https://github.com/seaweedfs/seaweedfs/.github/workflows/container_release_unified.yml@refs/tags/4.46`, including the transparency-log entry. The [upstream release workflow](https://github.com/seaweedfs/seaweedfs/blob/4.46/.github/workflows/container_release_unified.yml) publishes and signs this image.

Share the SeaweedFS container configuration between the journaling and persistence-test-kit fixtures: single-process `mini`, test credentials, an ephemeral S3 port, and HTTP readiness. Disable telemetry and ancillary web interfaces/catalog endpoints. Keep the CI pre-pull on the same digest and retain its existing retry helper.

Both fixtures continue using conditional-rewrite appends and ETag-conditional deletes with `UseS3ExpressAppend = false`, `UseConditionalDelete = false`, and `StorageClass = null`. Existing persistence, metadata, conflict, and concurrent-write assertions remain intact. SeaweedFS's ordinary S3 operations provide this coverage; AWS S3 Express supplies the native offset-append contract. Update the related provider guidance and test naming accordingly.

This expands the original registry-only repair into the requested MinIO-to-SeaweedFS migration.

Fixes #11250.